### PR TITLE
Return a better 404 for missing API routes

### DIFF
--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -22,7 +22,10 @@
 ;; placeholder until we actually define real API routes
 (defroutes api-routes
   ;; call /api/test to see this
-  (GET "/test" [] {:status 200 :body {:message "We can serialize JSON <3"}}))
+  (GET "/test" [] {:status 200 :body {:message "We can serialize JSON <3"}})
+  (route/not-found (fn [{:keys [request-method uri]}]
+                        {:status 404
+                         :body (str (.toUpperCase (name request-method)) " " uri " is not yet implemented.")})))
 
 (letfn [(serve-index [_] (resp/file-response "frontend_client/index.html"))]
   (defroutes routes


### PR DESCRIPTION
More useful when looking at the JS console for the angular app.
