### PR TITLE
`defapi` helper macro and a few helper macros similar to `with-or-404`

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -1,0 +1,8 @@
+(ns metabase.api.card
+  (:require [metabase.api.common :refer :all]
+            [metabase.db :refer :all]
+            [metabase.models.card :refer :all]
+            [metabase.models.hydrate :refer [hydrate]]))
+
+(defapi by-id [id]
+  (or-404-> (sel :one Card :id (Integer/parseInt id))))

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -10,9 +10,57 @@
   (constantly nil)) ; default binding is fn that always returns nil
 
 (defmacro with-or-404
-  "Evaluate BODY if TEST is not-nil. Otherwise return a 404."
+  "Evaluate BODY if TEST is not-nil. Otherwise return a 404.
+
+   `(with-or-404 (*current-user*)
+      ...)`"
   [test & body]
   `(if-not ~test
      {:status 404
       :body "Not found."} ; TODO - let this message be customizable ?
      (do ~@body)))
+
+(defmacro let-or-404
+  "If TEST is true, bind in to BINDING and evaluate BODY. Otherwise return a 404.
+
+  `(let-or-404 [user (*current-user*)]
+     (:id user))`"
+  [[binding test] & body]
+  `(let [~binding ~test]
+     (with-or-404 ~binding
+       ~@body)))
+
+(defmacro or-404->
+  "If TEST is true, thread the result using `->` through BODY.
+
+  `(or-404-> (*current-user*)
+     :id)`"
+  [test & body]
+  `(let-or-404 [result# ~test]
+     (-> result#
+         ~@body)))
+
+(defmacro or-404->>
+  "Like or-404->, but threads result using `->>`."
+  [test & body]
+  `(let-or-404 [result# ~test]
+     (->> result#
+          ~@body)))
+
+(defn wrap-response-if-needed
+  "If RESPONSE isn't already a map with keys :status and :body, wrap it in one (using status 200)."
+  [response]
+  (letfn [(is-wrapped? [resp] (and (map? resp)
+                                   (:status resp)
+                                   (:body resp)))]
+    (if (is-wrapped? response) response
+        {:status 200
+         :body response})))
+
+(defmacro defapi
+  "Define an API function that implicitly calls wrap-response-if-needed."
+  [& forms]
+  (let [[forms last-form] [(butlast forms) (last forms)]]
+    `(defn ~@forms
+       (-> ~last-form
+           wrap-response-if-needed))))

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -21,7 +21,7 @@
      (do ~@body)))
 
 (defmacro let-or-404
-  "If TEST is true, bind in to BINDING and evaluate BODY. Otherwise return a 404.
+  "If TEST is true, bind it to BINDING and evaluate BODY. Otherwise return a 404.
 
   `(let-or-404 [user (*current-user*)]
      (:id user))`"
@@ -41,7 +41,7 @@
          ~@body)))
 
 (defmacro or-404->>
-  "Like or-404->, but threads result using `->>`."
+  "Like `or-404->`, but threads result using `->>`."
   [test & body]
   `(let-or-404 [result# ~test]
      (->> result#

--- a/src/metabase/api/routes.clj
+++ b/src/metabase/api/routes.clj
@@ -1,12 +1,14 @@
 (ns metabase.api.routes
   (:require [compojure.core :refer [defroutes GET]]
             [compojure.route :as route]
-            (metabase.api [user :as user])))
+            (metabase.api [card :as card]
+                          [user :as user])))
 
 ;; placeholder until we actually define real API routes
 (defroutes routes
   ;; call /api/test to see this
   (GET "/test" [] {:status 200 :body {:message "We can serialize JSON <3"}})
+  (GET "/card/:id" [id] (card/by-id id))
   (GET "/user/current" [] user/current)
   (route/not-found (fn [{:keys [request-method uri]}]
                         {:status 404

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -2,8 +2,6 @@
   (:require [metabase.api.common :refer :all]
             [metabase.models.hydrate :refer [hydrate]]))
 
-(defn current [_]
-  (with-or-404 (*current-user*)
-    {:status 200
-     :body (-> (*current-user*)
-               (hydrate [:org_perms :organization]))}))
+(defapi current [_]
+  (or-404-> (*current-user*)
+            (hydrate [:org_perms :organization])))

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -4,4 +4,4 @@
 
 (defapi current [_]
   (or-404-> (*current-user*)
-            (hydrate [:org_perms :organization])))
+    (hydrate [:org_perms :organization])))

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -14,15 +14,9 @@
                    (:database-file app-defaults))))
 (log/info (str "Using H2 database file: " db-file))
 
-;; (defdb db (h2 {:db db-file
-;;                :naming {:keys str/lower-case
-;;                         :fields str/upper-case}}))
-
-(defdb db (postgres {:db "corvus"
-                     :port 15432
-                     :user "corvus"
-                     :password ""
-                     :host "localhost"}))
+(defdb db (h2 {:db db-file
+               :naming {:keys str/lower-case
+                        :fields str/upper-case}}))
 
 (defn migrate
   "Migrate the database :up or :down."

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -14,9 +14,15 @@
                    (:database-file app-defaults))))
 (log/info (str "Using H2 database file: " db-file))
 
-(defdb db (h2 {:db db-file
-               :naming {:keys str/lower-case
-                        :fields str/upper-case}}))
+;; (defdb db (h2 {:db db-file
+;;                :naming {:keys str/lower-case
+;;                         :fields str/upper-case}}))
+
+(defdb db (postgres {:db "corvus"
+                     :port 15432
+                     :user "corvus"
+                     :password ""
+                     :host "localhost"}))
 
 (defn migrate
   "Migrate the database :up or :down."

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -1,5 +1,11 @@
 (ns metabase.models.card
-  (:use korma.core))
+  (:require [korma.core :refer :all]
+            [metabase.db :refer :all]
+            [metabase.models.hydrate :refer [realize-json]]))
 
 (defentity Card
   (table :report_card))
+
+(defmethod post-select Card [_ card]
+  (-> card
+      (realize-json :dataset_query :visualization_settings)))

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -17,6 +17,6 @@
    :last_login
    :last_name]) ; don't return :password!
 
-(defmethod post-select User [_ {:keys [id] :as result}]
-  (-> result
+(defmethod post-select User [_ {:keys [id] :as user}]
+  (-> user
       (assoc :org_perms (sel-fn :many OrgPerm :user_id id))))

--- a/test/metabase/api/common_test.clj
+++ b/test/metabase/api/common_test.clj
@@ -2,6 +2,11 @@
   (:require [expectations :refer :all]
             [metabase.api.common :refer :all]))
 
+(def four-oh-four
+  "The expected format of a 404 response."
+  {:status 404
+   :body "Not found."})
+
 (defn my-mock-api-fn [_]
   (with-or-404 (*current-user*)
     {:status 200
@@ -10,10 +15,54 @@
 ; check that with-or-404 executes body if TEST is true
 (expect {:status 200
          :body "Cam Saul"}
-        (binding [*current-user* (constantly "Cam Saul")]
-          (my-mock-api-fn nil)))
+  (binding [*current-user* (constantly "Cam Saul")]
+    (my-mock-api-fn nil)))
 
 ; check that 404 is returned otherwise
+(expect four-oh-four
+  (my-mock-api-fn nil))
+
+;;let-or-404 should return nil if test fails
+(expect four-oh-four
+  (let-or-404 [user nil]
+    {:user user}))
+
+;; otherwise let-or-404 should bind as expected
+(expect {:user {:name "Cam"}}
+  (let-or-404 [user {:name "Cam"}]
+    {:user user}))
+
+;; test the 404 thread versions
+
+(expect four-oh-four
+  (or-404-> nil
+    (- 100)))
+
+(expect -99
+  (or-404-> 1
+    (- 100)))
+
+(expect four-oh-four
+  (or-404->> nil
+    (- 100)))
+
+(expect 99
+  (or-404->> 1
+    (- 100)))
+
+;; test that functions created with defapi automatically wrap responses if needed
+(defapi my-fn []
+  {:a 100})
+
+(expect {:status 200
+         :body {:a 100}}
+  (my-fn))
+
+;; test that they don't wrap responses if you wrap them yourself
+(defapi my-fn2 []
+  {:status 404
+   :body {:status "Not found."}})
+
 (expect {:status 404
-         :body "Not found."}
-        (my-mock-api-fn nil))
+         :body {:status "Not found."}}
+  (my-fn2))


### PR DESCRIPTION
`defapi` will wrap its result in `{:status 200 :body ...}` if you don't wrap it yourself.

Thus

```
(defn current [_]
  (with-or-404 (*current-user*)
    {:status 200
     :body (-> (*current-user*)
               (hydrate [:org_perms :organization]))}))
```

is the same as

```
(defapi current [_]
  (with-or-404 (*current-user*)
    (-> (*current-user*)
        (hydrate [:org_perms :organization]))))
```

Added a few tiny macros similar to `with-or-404` that will be super useful for writing the API code.
The function above can be written:

```
(defapi current [_]
  (or-404-> (*current-user*)
    (hydrate [:org_perms :organization])))
```
