### PR TITLE
Defendpoint

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -1,8 +1,11 @@
 (ns metabase.api.card
-  (:require [metabase.api.common :refer :all]
+  (:require [compojure.core :refer [GET]]
+            [metabase.api.common :refer :all]
             [metabase.db :refer :all]
             [metabase.models.card :refer :all]
             [metabase.models.hydrate :refer [hydrate]]))
 
-(defapi by-id [id]
-  (or-404-> (sel :one Card :id (Integer/parseInt id))))
+(defendpoint GET "/:id" [id]
+  (or-404-> (sel :one Card :id id)))
+
+(define-routes)

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -1,5 +1,7 @@
 (ns metabase.api.common
-  "Dynamic variables and utility functions/macros for writing API functions.")
+  "Dynamic variables and utility functions/macros for writing API functions."
+  (:require [compojure.core :refer [defroutes]]
+            [medley.core :refer :all]))
 
 (def ^:dynamic *current-user-id*
   "Int ID or nil of user associated with current API call."
@@ -64,3 +66,48 @@
     `(defn ~@forms
        (-> ~last-form
            wrap-response-if-needed))))
+
+(defn route-fn-name
+  "Generate a symbol suitable for use as the name of an API endpoint fn.
+   Name is just METHOD + ROUTE with slashes replaced by underscores.
+   `(route-fn-name GET \"/:id\") -> GET_:id`"
+  [method route]
+  (-> (str (name method) route)
+      (^String .replace "/" "_")
+      symbol))
+
+(def ^:dynamic *auto-parse-types*
+  "Map of symbol -> parse-fn.
+   Symbols that should automatically be parsed by given functions when passed as parameters to the API."
+  {'id 'Integer/parseInt})
+
+(defmacro auto-parse
+  "Create a `let` form that applies corresponding parse-fn for any symbols in ARGS that are present in `*auto-parse-types*`."
+  [args & body]
+  (let [let-forms (->> args
+                       (mapcat (fn [arg]
+                                 (if (contains? *auto-parse-types* arg) [arg `(~(*auto-parse-types* arg) ~arg)])))
+                       (filter identity))]
+    `(let [~@let-forms]
+       ~@body)))
+
+(defmacro defendpoint
+  "Define an API function that implicitly calls wrap-response-if-needed.
+   The function's metadata is tagged in a way that subsequent calls to `define-routes` (see below)
+   will automatically include the function in the generated `defroutes` form."
+  [method route args & body]
+  (let [name (route-fn-name method route)]
+    `(do (def ~name
+           (~method ~route ~args
+                    (-> (auto-parse ~args ~@body)
+                        wrap-response-if-needed)))
+         (alter-meta! #'~name assoc :is-endpoint? true))))
+
+(defmacro define-routes
+  "Create a `(defroutes routes ...)` form that automatically includes all functions created with
+   `defendpoint` in the current namespace."
+  [& additional-routes]
+  (let [api-routes (->> (ns-publics *ns*)
+                        (filter-vals #(:is-endpoint? (meta %)))
+                        (map first))]
+    `(defroutes ~'routes ~@api-routes ~@additional-routes)))

--- a/src/metabase/api/routes.clj
+++ b/src/metabase/api/routes.clj
@@ -10,10 +10,10 @@
 (defroutes routes
   ;; call /api/test to see this
   (GET "/test" [] {:status 200 :body {:message "We can serialize JSON <3"}})
+  (context "/card" [] card/routes)
   (context "/org" [] org/routes)
   (context "/session" [] session/routes)
   (context "/user" [] user/routes)
-  (GET "/card/:id" [id] (card/by-id id))
   (route/not-found (fn [{:keys [request-method uri]}]
                         {:status 404
                          :body (str (.toUpperCase (name request-method)) " " uri " is not yet implemented.")})))

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -15,10 +15,9 @@
        {:status 200
         :body {}}))
 
-(def user-current
-  (GET "/current" []
-       (or-404-> (*current-user*)
-                 (hydrate [:org_perms :organization]))))
+(defendpoint GET "/current" []
+  (or-404-> (*current-user*)
+    (hydrate [:org_perms :organization])))
 
 (def user-update
   (PUT "/:user-id" [user-id :as {body :body}]
@@ -33,12 +32,11 @@
         :body {}}))
 
 
-(defroutes routes
-           ;; TODO - this feels bleh.  is it better to put the actual route data here
-           ;;        and just have the endpoints be plain functions?
-           ;;        best way to automate building this list?
-           user-list
-           user-current
-           user-get
-           user-update
-           user-update-password)
+(define-routes
+  ;; TODO - this feels bleh.  is it better to put the actual route data here
+  ;;        and just have the endpoints be plain functions?
+  ;;        best way to automate building this list?
+  user-list
+  user-get
+  user-update
+  user-update-password)

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -1,0 +1,18 @@
+(ns metabase.util
+  "Common utility functions useful throughout the codebase."
+  (:require [medley.core :refer :all]))
+
+(defn select-non-nil-keys
+  "Like `select-keys` but filters out key-value pairs whose value is nil."
+  [m & keys]
+  (->> (select-keys m keys)
+       (filter-vals identity)))
+
+(defn apply-kwargs
+  "Like `apply`, but takes a map as the last argument, and applies its key-value pairs as keyword args.
+
+  `(apply-kwargs assoc {} {:c 3 :d 4}) -> (apply assoc {} :c 3 :d 4)`"
+  [fn & args]
+  (apply fn (concat (butlast args) (->> (last args)
+                                        (apply vector)
+                                        (reduce concat)))))

--- a/test/metabase/test_util.clj
+++ b/test/metabase/test_util.clj
@@ -1,0 +1,16 @@
+(ns metabase.test-util
+  (:require [expectations :refer :all]
+            [metabase.util :refer :all]))
+
+;;; tests for select-non-nil-keys
+
+(expect {:a 100 :b 200}
+  (select-non-nil-keys {:a 100 :b 200 :c nil :d 300} :a :b :c))
+
+;;; tests for apply-kwargs
+
+(expect {:a 1 :c 3 :d 4}
+  (apply-kwargs assoc {:a 1} {:c 3 :d 4})) ; should work like (assoc {:a 1} :c 3 :d 4)
+
+(expect {:a 1 :b 2 :c 3 :d 4}
+    (apply-kwargs assoc {:a 1} :b 2 {:c 3 :d 4})) ; should work like (assoc {:a 1} :b 2 :c 3 :d 4)


### PR DESCRIPTION
Added previously mentioned utility functions and tests,

and the new `defendpoint` and `define-routes` macros.

This version of `defendpoint` is improved slightly from the one we discussed previously: it automatically generates an name for the endpoint function and automatically parses certain predefined arguments as a certain type (currently just `id`). i.e. `id` is _always_ passed to an API as an int so this is saving a step and doing the parsing for us. The relevant `param` -> `parse-fn` mappings are bound to `*auto-parse-types*` so they can be overriden or added to as needed and we can add more automatic parse functions whenever we want
