### PR TITLE
*current-user* is now a delay rather than a memoized function

### DIFF
--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -23,7 +23,7 @@
                     :body (select-keys user [:id :email :first_name :last_name :last_login :is_superuser])})))
 
 (defendpoint GET "/current" []
-  (->404 (*current-user*)
+  (->404 @*current-user*
          (hydrate [:org_perms :organization])))
 
 (def user-update

--- a/src/metabase/middleware/current_user.clj
+++ b/src/metabase/middleware/current_user.clj
@@ -1,7 +1,7 @@
 (ns metabase.middleware.current-user
   "Middleware to make accessing user associated with a request easier."
   (:require [korma.core :refer :all]
-            [metabase.db :refer [sel-fn]]
+            [metabase.db :refer [sel]]
             [metabase.api.common :refer [*current-user-id* *current-user*]]
             [metabase.models.user :refer [User]]))
 
@@ -9,11 +9,11 @@
   "Middleware that binds `metabase.api.common/*current-user*` and `*current-user-id*`
 
    *current-user-id* int ID or nil of user associated with request
-   *current-user*    memoized fn that returns current user (or nil) from DB"
+   *current-user*    delay that returns current user (or nil) from DB"
   [handler]
   (fn [request]
     (let [current-user-id 1] ; TODO - Placeholder value
          (binding [*current-user-id* current-user-id
-                   *current-user* (if-not current-user-id (constantly nil)
-                                          (sel-fn :one User :id current-user-id))]
+                   *current-user* (if-not current-user-id (atom nil)
+                                          (delay (sel :one User :id current-user-id)))]
            (handler request)))))

--- a/test/metabase/api/common_test.clj
+++ b/test/metabase/api/common_test.clj
@@ -10,14 +10,14 @@
 
 (defn my-mock-api-fn [_]
   (catch-api-exceptions
-   (check-404 (*current-user*))
+   (check-404 @*current-user*)
    {:status 200
-    :body (*current-user*)}))
+    :body @*current-user*}))
 
 ; check that `check-404` doesn't throw an exception if TEST is true
 (expect {:status 200
          :body "Cam Saul"}
-  (binding [*current-user* (constantly "Cam Saul")]
+  (binding [*current-user* (atom "Cam Saul")]
     (my-mock-api-fn nil)))
 
 ; check that 404 is returned otherwise


### PR DESCRIPTION
So to get current User you do `@*current-user*` instead of `(*current-user*)`. Basically has the same functionality but slightly easier to write and nicer looking. IMO `((:perms-for-org @*current-user*) ~org-id))` is easier to read than `((:perms-for-org (*current-user*)) ~org-id))`
