### PR TITLE
Group together frequently-used requires

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -43,6 +43,7 @@
             ]
   :java-source-paths ["src/java"]
   :main ^:skip-aot metabase.core
+  :aot [metabase.require]
   :target-path "target/%s"
   :ring {:handler metabase.core/app}
   :profiles {:dev {:dependencies [[expectations "2.0.12"]   ; unit tests

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -1,11 +1,5 @@
-(ns metabase.api.card
-  (:require [compojure.core :refer [GET DELETE]]
-            [korma.core :refer :all]
-            [metabase.api.common :refer :all]
-            [metabase.db :refer :all]
-            (metabase.models [hydrate :refer [hydrate]]
-                             [card :refer :all]
-                             [card-favorite :refer :all])))
+(ns metabase.api.card)
+(metabase.require/api)
 
 (defendpoint GET "/" [org f] ; TODO - need to do something with the `f` param
   (-> (sel :many Card :organization_id org (order :name :ASC))

--- a/src/metabase/api/dash.clj
+++ b/src/metabase/api/dash.clj
@@ -1,10 +1,6 @@
 (ns metabase.api.dash
-  "/api/meta/dash endpoints."
-  (:require [compojure.core :refer [GET]]
-            [metabase.api.common :refer :all]
-            [metabase.db :refer :all]
-            (metabase.models [hydrate :refer [hydrate]]
-                             [dashboard :refer [Dashboard]])))
+  "/api/meta/dash endpoints.")
+(metabase.require/api)
 
 (defendpoint GET "/" [org f] ; TODO - what to do with f ?
   (-> (sel :many Dashboard :organization_id org)

--- a/src/metabase/api/meta_db.clj
+++ b/src/metabase/api/meta_db.clj
@@ -1,11 +1,6 @@
 (ns metabase.api.meta-db
-  "/api/meta/db endpoints."
-  (:require [compojure.core :refer [GET]]
-            [metabase.api.common :refer :all]
-            [metabase.db :refer :all]
-            (metabase.models [hydrate :refer [hydrate]]
-                             [database :refer [Database]]
-                             [table :refer [Table]])))
+  "/api/meta/db endpoints.")
+(metabase.require/api)
 
 (defendpoint GET "/" [org]
   (sel :many Database :organization_id org))

--- a/src/metabase/api/meta_table.clj
+++ b/src/metabase/api/meta_table.clj
@@ -1,13 +1,6 @@
 (ns metabase.api.meta-table
-  "/api/meta/table endpoints."
-  (:require [compojure.core :refer [GET]]
-            [korma.core :refer :all]
-            [metabase.api.common :refer :all]
-            [metabase.db :refer :all]
-            (metabase.models [hydrate :refer :all]
-                             [database :refer [Database]]
-                             [field :refer [Field]]
-                             [table :refer [Table]])))
+  "/api/meta/table endpoints.")
+(metabase.require/api)
 
 (defendpoint GET "/:id" [id]
   (->404 (sel :one Table :id id)

--- a/src/metabase/api/org.clj
+++ b/src/metabase/api/org.clj
@@ -1,8 +1,5 @@
-(ns metabase.api.org
-  (:require [compojure.core :refer [defroutes GET PUT POST DELETE]]
-            [metabase.api.common :refer :all]
-            [metabase.db :refer :all]
-            [metabase.models.org :refer [Org]]))
+(ns metabase.api.org)
+(metabase.require/api)
 
 (def org-list
   (GET "/" request

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -1,7 +1,5 @@
-(ns metabase.api.session
-  (:require [metabase.api.common :refer :all]
-            [compojure.core :refer [defroutes GET POST]]))
-
+(ns metabase.api.session)
+(metabase.require/api)
 
 (def session-login
   (POST "/login" [:as {body :body}]

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -1,10 +1,5 @@
-(ns metabase.api.user
-  (:require [metabase.api.common :refer :all]
-            [compojure.core :refer [defroutes GET PUT]]
-            [metabase.db :refer [sel upd]]
-            [metabase.models.hydrate :refer [hydrate]]
-            [metabase.models.user :refer [User]]))
-
+(ns metabase.api.user)
+(metabase.require/api)
 
 (def user-list
   (GET "/" []

--- a/src/metabase/require.clj
+++ b/src/metabase/require.clj
@@ -1,0 +1,27 @@
+(ns metabase.require)
+
+(gen-class
+ :name metabase.require
+ :prefix nil
+ :methods [#^{:static true} [api [] void]])
+
+(defn- require-all [forms]
+  (dorun (map require forms)))
+
+(def api-requires
+  ^:private
+  '[[compojure.core :refer [GET POST PUT DELETE defroutes context]]
+    [korma.core :refer :all]
+    [metabase.api.common :refer :all]
+    [metabase.db :refer :all]
+    (metabase.models [hydrate :refer [hydrate simple-batched-hydrate]]
+                     [card :refer [Card]]
+                     [card-favorite :refer [CardFavorite]]
+                     [field :refer [Field]]
+                     [database :refer [Database]]
+                     [dashboard :refer [Dashboard]]
+                     [org :refer [Org]]
+                     [table :refer [Table]]
+                     [user :refer [User]])])
+
+(defn api [] (require-all api-requires))


### PR DESCRIPTION
I'm not 100% sure I'm sold on this. But it simplifies our code a lot. We can create a set of functions like
`(metabase.require/api)`  that will require the things we use in basically every file of type X (for API files, `compojure.core/GET`, etc.)

_PROS_
- Simplifies our code a lot
- Don't have to waste time adding the same things to `:require` over and over

_CONS_
- Probably slightly slower than just doing the bare minimum `:require` clauses for each file
- Obscures things slightly
