### PR TITLE
Several excellent improvements

### DIFF
--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -2,12 +2,11 @@
   "Dynamic variables and utility functions/macros for writing API functions."
   (:require [compojure.core :refer [defroutes]]
             [medley.core :refer :all]
-            [metabase.api.common.internal :refer :all]
+            (metabase.api.common [internal :refer :all])
             [metabase.db :refer [sel-fn]])
   (:import com.metabase.corvus.api.ApiException))
 
-
-;;; ## DYNAMICALLY BOUND REQUEST VARIABLES
+;;; ## DYNAMIC VARIABLES
 ;; These get bound by middleware for each HTTP request.
 
 (def ^:dynamic *current-user-id*
@@ -18,6 +17,9 @@
   "Delay that returns the `User` (or nil) associated with the current API call.
    ex. `@*current-user*`"
   (atom nil)) ; default binding is just something that will return nil when dereferenced
+
+
+;;; ## GENERAL HELPER FNS / MACROS
 
 ;; TODO - move this to something like `metabase.util.debug`
 (defmacro with-current-user
@@ -114,38 +116,25 @@
 
 ;;; ## DEFENDPOINT AND RELATED FUNCTIONS
 
-(def ^:dynamic *auto-parse-types*
-  "Map of `symbol` -> `parse-fn`.
-   Symbols that should automatically be parsed by given functions when passed as parameters to the API."
-  {'id 'Integer/parseInt
-   'org 'Integer/parseInt})
-
-(defmacro auto-parse
-  "Create a `let` form that applies corresponding parse-fn for any symbols in ARGS that are present in `*auto-parse-types*`."
-  [args & body]
-  (let [let-forms (->> args
-                       (mapcat (fn [arg]
-                                 (if (contains? *auto-parse-types* arg) [arg (list (*auto-parse-types* arg) arg)])))
-                       (filter identity))]
-    `(let [~@let-forms]
-       ~@body)))
-
 (defmacro defendpoint
   "Define an API function.
    This automatically does several things:
 
    -  calls `auto-parse` to automatically parse certain args. e.g. `id` is converted from `String` to `Integer` via `Integer/parseInt`
+   -  converts ROUTE from a simple form like `\"/:id\"` to a typed one like `[\"/:id\" :id #\"[0-9]+\"]`
    -  executes BODY inside a `try-catch` block that handles `ApiExceptions`
    -  automatically calls `wrap-response-if-needed` on the result of BODY
    -  tags function's metadata in a way that subsequent calls to `define-routes` (see below)
       will automatically include the function in the generated `defroutes` form."
   [method route args & body]
-  (let [name (route-fn-name method route)]
+  (let [name (route-fn-name method route)
+        route (typify-route route)]
     `(do (def ~name
            (~method ~route ~args
-                    (-> (auto-parse ~args
-                          (catch-api-exceptions ~@body))
-                        wrap-response-if-needed)))
+                    (auto-parse ~args
+                      (catch-api-exceptions
+                        (-> (do ~@body)
+                            wrap-response-if-needed)))))
          (alter-meta! #'~name assoc :is-endpoint? true))))
 
 (defmacro define-routes

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -2,7 +2,7 @@
   "Dynamic variables and utility functions/macros for writing API functions."
   (:require [compojure.core :refer [defroutes]]
             [medley.core :refer :all]
-            (metabase.api.common [internal :refer :all])
+            [metabase.api.common.internal :refer :all]
             [metabase.db :refer [sel-fn]])
   (:import com.metabase.corvus.api.ApiException))
 

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -51,6 +51,14 @@
   ([test status-code message]                            ; (check TEST [CODE MESSAGE]) or (check TEST CODE MESSAGE)
    (check test [status-code message])))                  ; are both acceptable for the sake of flexibility
 
+(defmacro require-params
+  "Checks that a list of params are non-nil or throws a 400."
+  [& params]
+  `(do
+     ~@(map (fn [param]
+              `(check ~param [400 ~(str "'" (name param) "' is a required param.")]))
+            params)))
+
 ;; The following all work exactly like the corresponding Clojure versions
 ;; but take an additional arg at the beginning called RESPONSE-PAIR.
 ;; RESPONSE-PAIR is of the form `[status-code message]`.

--- a/src/metabase/api/common/internal.clj
+++ b/src/metabase/api/common/internal.clj
@@ -96,11 +96,11 @@
   that can be used in a `let` form."
   [arg-symbol]
   (when (symbol? arg-symbol)
-    (some-> (arg-type arg-symbol)            ; :int
-            *auto-parse-types*               ; {:parser ... }
-            :parser                          ; Integer/parseInt
-            (list arg-symbol)                ; (Integer/parseInt id)
-            ((partial vector arg-symbol))))) ; [id (Integer/parseInt id)]
+    (some-> (arg-type arg-symbol)                                    ; :int
+            *auto-parse-types*                                       ; {:parser ... }
+            :parser                                                  ; Integer/parseInt
+            ((fn [parser] `(when ~arg-symbol (~parser ~arg-symbol)))) ; (when id (Integer/parseInt id))
+            ((partial vector arg-symbol)))))                         ; [id (Integer/parseInt id)]
 
 (defmacro auto-parse
   "Create a `let` form that applies corresponding parse-fn for any symbols in ARGS that are present in `auto-*parse-types*`."

--- a/src/metabase/api/common/internal.clj
+++ b/src/metabase/api/common/internal.clj
@@ -1,6 +1,118 @@
 (ns metabase.api.common.internal
   "Internal functions used by `metabase.api.common`."
-    (:import com.metabase.corvus.api.ApiException))
+  (:require [metabase.util :refer [fn-> regex?]])
+  (:import com.metabase.corvus.api.ApiException))
+
+;;; # DEFENDPOINT HELPER FUNCTIONS + MACROS
+
+;;; ## ROUTE NAME
+
+(defn route-fn-name
+  "Generate a symbol suitable for use as the name of an API endpoint fn.
+   Name is just METHOD + ROUTE with slashes replaced by underscores.
+   `(route-fn-name GET \"/:id\") -> GET_:id`"
+  [method route]
+  (let [route (if (vector? route) (first route) route)] ; if we were passed a vector like [":id" :id #"[0-9+]"] only use first part
+    (-> (str (name method) route)
+        (^String .replace "/" "_")
+        symbol)))
+
+
+;;; ## ROUTE TYPING / AUTO-PARSE SHARED FNS
+
+(def ^:dynamic *auto-parse-types*
+  "Map of `param-type` -> map with the following keys:
+
+     :route-param-regex Regex pattern that should be used for params in Compojure route forms
+     :parser            Function that should be used to parse args"
+  {:int {:route-param-regex #"[0-9]+"
+         :parser 'Integer/parseInt}})
+
+(def ^:dynamic *auto-parse-arg-name-patterns*
+  "Sequence of `[param-pattern parse-type]` pairs.
+   A param with name matching PARAM-PATTERN should be considered to be of AUTO-PARSE-TYPE."
+  [[#"[\w-_]*id" :int]
+   [#"org" :int]])
+
+(defn arg-type
+  "Return a key into `*auto-parse-types*` if ARG has a matching pattern in `*auto-parse-arg-name-patterns*`.
+
+  (arg-type :id) -> :int"
+  [arg]
+  (-> *auto-parse-arg-name-patterns*
+      ((fn [[[pattern type] & rest-patterns]]
+         (or (when (re-find pattern (name arg))
+               type)
+             (when rest-patterns
+               (recur rest-patterns)))))))
+
+
+;;; ## TYPIFY-ROUTE
+
+(defn route-param-regex
+  "If keyword ARG has a matching type, return a pair like `[arg route-param-regex]`,
+   where ROUTE-PARAM-REGEX is the regex that this param that arg must match.
+
+    (route-param-regex :id) -> [:id #\"[0-9]+\"]"
+  [arg]
+  (some->> (arg-type arg)
+           *auto-parse-types*
+           :route-param-regex
+           (vector arg)))
+
+(defn route-arg-keywords
+  "Return a sequence of keywords for URL args in string ROUTE.
+
+    (route-arg-keywords \"/:id/cards\") -> [:id]"
+  [route]
+  (->> (re-seq #":([\w-]+)" route)
+       (map (fn-> second keyword))))
+
+(defn typify-args
+  "Given a sequence of keyword ARGS, return a sequence of `[:arg pattern :arg pattern ...]`
+   for args that have matching types."
+  [args]
+  (->> args
+       (mapcat route-param-regex)
+       (filterv identity)))
+
+(defn typify-route
+  "Expand a ROUTE string like \"/:id\" into a Compojure route form that uses regexes to match
+   parameters whose name matches a regex from `*auto-parse-arg-name-patterns*`.
+
+    (typify-route \"/:id/card\") -> [\"/:id/card\" :id #\"[0-9]+\""
+  [route]
+  (if (vector? route) route
+      (let [arg-types (->> (route-arg-keywords route)
+                           typify-args)]
+        (if (empty? arg-types) route
+            (apply vector route arg-types)))))
+
+
+;;; ## ROUTE ARG AUTO PARSING
+
+(defn let-form-for-arg
+  "Given an ARG-SYMBOL like `id`, return a pair like `[id (Integer/parseInt id)]`
+  that can be used in a `let` form."
+  [arg-symbol]
+  (when (symbol? arg-symbol)
+    (some-> (arg-type arg-symbol)            ; :int
+            *auto-parse-types*               ; {:parser ... }
+            :parser                          ; Integer/parseInt
+            (list arg-symbol)                ; (Integer/parseInt id)
+            ((partial vector arg-symbol))))) ; [id (Integer/parseInt id)]
+
+(defmacro auto-parse
+  "Create a `let` form that applies corresponding parse-fn for any symbols in ARGS that are present in `auto-*parse-types*`."
+  [args & body]
+  (let [let-forms (->> args
+                       (mapcat let-form-for-arg)
+                       (filter identity))]
+    `(let [~@let-forms]
+       ~@body)))
+
+
+;;; ## ROUTE BODY WRAPPERS
 
 (defmacro catch-api-exceptions
   "Execute BODY, and if an `ApiException` is thrown, return the appropriate HTTP response."
@@ -19,12 +131,3 @@
     (if (is-wrapped? response) response
         {:status 200
          :body response})))
-
-(defn route-fn-name
-  "Generate a symbol suitable for use as the name of an API endpoint fn.
-   Name is just METHOD + ROUTE with slashes replaced by underscores.
-   `(route-fn-name GET \"/:id\") -> GET_:id`"
-  [method route]
-  (-> (str (name method) route)
-      (^String .replace "/" "_")
-      symbol))

--- a/src/metabase/api/meta_table.clj
+++ b/src/metabase/api/meta_table.clj
@@ -21,6 +21,7 @@
          (hydrate :db :fields)))
 
 (defendpoint GET "/" [org]
+  (require-params org)
   (let [db-ids (->> (sel :many [Database :id] :organization_id org)
                     (map :id))]
     (-> (sel :many Table :db_id [in db-ids] (order :name :ASC))

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -20,6 +20,7 @@
   (sel :many User :is_active true))
 
 (defendpoint GET "/current" []
+  (println "CURRENT USER: " @*current-user*)
   (->404 @*current-user*
          (hydrate [:org_perms :organization])))
 

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -1,52 +1,46 @@
 (ns metabase.api.user
-  (:require [metabase.api.common :refer :all]
-            [compojure.core :refer [defroutes GET PUT]]
-            [metabase.db :refer [sel upd]]
-            [metabase.models.hydrate :refer [hydrate]]
-            [metabase.models.user :refer [User]]))
+  (:require [compojure.core :refer [defroutes GET PUT]]
+            [medley.core :refer [mapply]]
+            [metabase.api.common :refer :all]
+            [metabase.db :refer [sel upd exists?]]
+            (metabase.models [hydrate :refer [hydrate]]
+                             [user :refer [User]])
+            [metabase.util :refer [select-non-nil-keys]]))
 
+;; RE stripping fields and calculating fields:
+;; -  Instead of stripping fields it makes more sense to just not select them in the first place.
+;;    The default fields selected for any entity can be set by implementing `metabase.db/default-fields`.
+;;    In fact, `User` is already doing this inside `metabase.models.user`.
+;; -  Calculating fields can be done with `assoc` in `post-select`. You can give it an actual value, which
+;;    means it will always be returned, or set it to a function or delay, which means it will only be returned
+;;    if specified in a call to `hydrate`.
 
 (defendpoint GET "/" []
   ;; TODO - permissions check
-  ;; TODO - limit the keys available in the response objects
   (sel :many User :is_active true))
-
-
-(defendpoint GET "/:user-id" [user-id]
-  ;; TODO - permissions check
-  ;; TODO - map to serializer.  strip fields (is_active, is_staff).  calculate fields (common_name)
-  (let-404 [user (sel :one User :id user-id)]
-    ;; TODO - we need a reusable way to do something like this for serializing output for responses
-    (select-keys user [:id :email :first_name :last_name :last_login :is_superuser])))
-
 
 (defendpoint GET "/current" []
   (->404 @*current-user*
          (hydrate [:org_perms :organization])))
 
+;; TODO - permissions check
+(defendpoint GET "/:id" [id]
+  (sel :one User :id id))
 
-(defendpoint PUT "/:user-id" [user-id :as {body :body}]
-  ;; TODO - permissions check
-  ;; TODO - validations (email address must be unique)
-  (let-404 [user (sel :one User :id user-id)]
-    (upd User user-id
-      :email (get body :email (:email user))
-      :first_name (get body :first_name (:first_name user))
-      :last_name (get body :last_name (:last_name user)))
-    (let [updated-user (sel :one User :id user-id)]
-      (select-keys updated-user [:id :email :first_name :last_name :last_login :is_superuser]))))
+(defendpoint PUT "/:id" [id :as {:keys [body]}]
+  (check-403 (= id *current-user-id*))                                     ; you can only update yourself (or can admins update other users?)
+  (check-500 (->> (select-non-nil-keys body :email :first_name :last_name)
+                  (mapply upd User id)))                                   ; `upd` returns `false` if no updates occured. So in that case return a 500
+  (sel :one User :id id))                                                  ; return the updated user
 
-
-(defendpoint PUT "/:user-id/password" [user-id :as {body :body}]
-  (if-not (and (:old_password body) (:password body))
-    {:status 400 :body "You must specifby both old_password and password"}
-    (let-404 [user (sel :one User :id user-id)]
-      ;; TODO - match old password against current one
-      ;; TODO - password encryption
-      (upd User user-id
-        :password (get body :password))
-      (let [updated-user (sel :one User :id user-id)]
-        (select-keys updated-user [:id :email :first_name :last_name :last_login :is_superuser])))))
-
+;; TODO: do we want a permissions check here?
+(defendpoint PUT "/:id/password" [id :as {:keys [body]}]
+  (let [{:keys [password old_password]} body]
+    (check (and password old_password) [400 "You must specify both old_password and password"])
+    (check-404 (exists? User :id id))
+    ;; TODO - match old password against current one
+    ;; TODO - password encryption
+    (upd User id :password password)
+    (sel :one User :id id)))
 
 (define-routes)

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -20,7 +20,6 @@
   (sel :many User :is_active true))
 
 (defendpoint GET "/current" []
-  (println "CURRENT USER: " @*current-user*)
   (->404 @*current-user*
          (hydrate [:org_perms :organization])))
 

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -103,7 +103,8 @@
         forms (->> forms
                    sel-apply-kwargs
                    (sel-apply-fields field-keys))]
-    `(select ~entity ~@forms)))
+    `(do (println "DB CALL: " ~(str entity) " " ~(str forms))
+         (select ~entity ~@forms))))
 
 (defmacro sel-fn
   "Returns a memoized fn that calls `sel`.
@@ -122,3 +123,13 @@
             (let [entity# (symbol ~entity)]
               (eval `(sel ~~one-or-many ~entity# ~~@forms))))
           `((sel ~one-or-many ~entity ~@forms))))))
+
+;;
+(defmacro exists?
+  "Easy way to see if something exists in the db.
+   TODO: How can we disable the `post-select` functionality for this call.
+   TODO: Doesn't korma have an `exists` method?
+
+    (exists? User :id 100)"
+  [entity & forms]
+  `(boolean (sel :one [~entity :id] ~@forms)))

--- a/src/metabase/middleware/current_user.clj
+++ b/src/metabase/middleware/current_user.clj
@@ -2,8 +2,12 @@
   "Middleware to make accessing user associated with a request easier."
   (:require [korma.core :refer :all]
             [metabase.db :refer [sel]]
-            [metabase.api.common :refer [*current-user-id* *current-user*]]
-            [metabase.models.user :refer [User]]))
+            [metabase.api.common :refer [*current-user* *current-user-id*]]
+            [metabase.models.user :refer [User current-user-fields]]))
+
+(defmacro sel-current-user [current-user-id]
+  `(sel :one [User ~@current-user-fields]
+        :id ~current-user-id))
 
 (defn bind-current-user
   "Middleware that binds `metabase.api.common/*current-user*` and `*current-user-id*`
@@ -15,5 +19,5 @@
     (let [current-user-id 1] ; TODO - Placeholder value
          (binding [*current-user-id* current-user-id
                    *current-user* (if-not current-user-id (atom nil)
-                                          (delay (sel :one User :id current-user-id)))]
+                                          (delay (sel-current-user current-user-id)))]
            (handler request)))))

--- a/src/metabase/middleware/log_api_call.clj
+++ b/src/metabase/middleware/log_api_call.clj
@@ -16,7 +16,7 @@
               (do
                 (when log-request?
                   (log-request request))
-                (let [response (handler request)]
+                (let [response (time (handler request))]
                   (when log-response?
                     (pprint response))
                   response))))))

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -8,5 +8,48 @@
   (->> (select-keys m keys)
        (filter-vals identity)))
 
+(defmacro fn->
+  "Returns a function that threads arguments to it through FORMS via `->`."
+  [& forms]
+  `(fn [x#]
+     (-> x#
+         ~@forms)))
+
+(defmacro fn->>
+  "Returns a function that threads arguments to it through FORMS via `->>`."
+  [& forms]
+  `(fn [x#]
+     (->> x#
+          ~@forms)))
+
+(defn regex?
+  "Is ARG a regular expression?"
+  [arg]
+  (= (type arg)
+     java.util.regex.Pattern))
+
+(defn regex=
+  "Returns `true` if the literal string representations of REGEXES are exactly equal.
+
+    (= #\"[0-9]+\" #\"[0-9]+\")           -> false
+    (regex= #\"[0-9]+\" #\"[0-9]+\")      -> true
+    (regex= #\"[0-9]+\" #\"[0-9][0-9]*\") -> false (although it's theoretically true)"
+  [& regexes]
+  (->> regexes
+       (map #(.toString ^java.util.regex.Pattern %))
+       (apply =)))
+
+(defn self-mapping
+  "Given a function F that takes a single arg, return a function that will call `(f arg)` when
+  passed a non-sequential ARG, or `(map f arg)` when passed a sequential ARG.
+
+    (def f (self-mapping (fn [x] (+ 1 x))))
+    (f 2)       -> 3
+    (f [1 2 3]) -> (2 3 4)"
+  [f & args]
+  (fn [arg]
+    (if (sequential? arg) (map f arg)
+        (f arg))))
+
 ;; looking for `apply-kwargs`?
 ;; turns out `medley.core/mapply` does the same thingx

--- a/test/metabase/api/common/internal_test.clj
+++ b/test/metabase/api/common/internal_test.clj
@@ -1,7 +1,6 @@
 (ns metabase.api.common.internal-test
   (:require [expectations :refer :all]
-            (metabase.api.common [dynamic :refer :all]
-                                 [internal :refer :all])))
+            (metabase.api.common [internal :refer :all])))
 
 ;;; TESTS FOR ROUTE-FN-NAME
 
@@ -108,16 +107,16 @@
   (no-regex (typify-route "/:id/tables/:card-id")))
 
 ;; don't try to typify route that's already typified
-(expect ["/:id/:crazy-id" :crazy-id #"[0-9]+"]
-  (no-regex (typify-route ["/:id/:crazy-id" :crazy-id #"[0-9]+"])))
+(expect ["/:id/:crazy-id" :crazy-id "#[0-9]+"]
+  (no-regex (typify-route ["/:id/:crazy-id" :crazy-id "#[0-9]+"])))
 
 
 ;; TESTS FOR LET-FORM-FOR-ARG
 
-(expect '[id (Integer/parseInt id)]
+(expect '[id (when id (Integer/parseInt id))]
   (let-form-for-arg 'id))
 
-(expect '[org_id (Integer/parseInt org_id)]
+(expect '[org_id (when org_id (Integer/parseInt org_id))]
   (let-form-for-arg 'org_id))
 
 (expect nil
@@ -129,3 +128,5 @@
 
 (expect nil
   (let-form-for-arg '{body :body}))
+
+;; Tests for AUTO-PARSE presently live in `metabase.api.common-test`

--- a/test/metabase/api/common/internal_test.clj
+++ b/test/metabase/api/common/internal_test.clj
@@ -1,0 +1,131 @@
+(ns metabase.api.common.internal-test
+  (:require [expectations :refer :all]
+            (metabase.api.common [dynamic :refer :all]
+                                 [internal :refer :all])))
+
+;;; TESTS FOR ROUTE-FN-NAME
+
+(expect 'GET_
+  (route-fn-name 'GET "/"))
+
+(expect 'GET_:id_cards
+  (route-fn-name 'GET "/:id/cards"))
+
+;; check that route-fn-name can handle routes with regex conditions
+(expect 'GET_:id
+  (route-fn-name 'GET ["/:id" :id #"[0-9]+"]))
+
+;;; TESTS FOR ARG-TYPE
+
+(expect nil
+  (arg-type :fish))
+
+(expect :int
+  (arg-type :id))
+
+(expect :int
+  (arg-type :card-id))
+
+(expect :int
+  (arg-type 'org))
+
+
+;;; TESTS FOR ROUTE-PARAM-REGEX
+
+;; expectations (internally, `clojure.data/diff`) doesn't think two regexes with the same exact pattern are equal.
+;; so in order to make sure we're getting back the right output we'll just change them to strings, e.g. `#"[0-9]+ -> "#[0-9]+"`
+(defmacro no-regex [& body]
+  `(binding [*auto-parse-types* (update-in *auto-parse-types* [:int :route-param-regex] (partial str "#"))]
+     ~@body))
+
+(expect nil
+  (no-regex (route-param-regex :fish)))
+
+(expect [:id "#[0-9]+"]
+  (no-regex (route-param-regex :id)))
+
+(expect [:card-id "#[0-9]+"]
+  (no-regex (route-param-regex :card-id)))
+
+
+;;; TESTS FOR ROUTE-ARG-KEYWORDS
+
+(expect []
+  (no-regex (route-arg-keywords "/")))
+
+(expect [:id]
+  (no-regex (route-arg-keywords "/:id")))
+
+(expect [:id]
+  (no-regex (route-arg-keywords "/:id/card")))
+
+(expect [:id :org]
+  (no-regex (route-arg-keywords "/:id/etc/:org")))
+
+(expect [:card-id]
+  (no-regex (route-arg-keywords "/:card-id")))
+
+
+;;; TESTS FOR TYPE-ARGS
+
+(expect []
+  (no-regex (typify-args [])))
+
+(expect []
+  (no-regex (typify-args [:fish])))
+
+(expect []
+  (no-regex (typify-args [:fish :fry])))
+
+(expect [:id "#[0-9]+"]
+  (no-regex (typify-args [:id])))
+
+(expect [:id "#[0-9]+"]
+  (no-regex (typify-args [:id :fish])))
+
+(expect [:id "#[0-9]+" :card-id "#[0-9]+"]
+  (no-regex (typify-args [:id :card-id])))
+
+
+;;; TESTS FOR TYPE-ROUTE
+
+(expect "/"
+  (no-regex (typify-route "/")))
+
+(expect ["/:id" :id "#[0-9]+"]
+  (no-regex (typify-route "/:id")))
+
+(expect ["/:id/card" :id "#[0-9]+"]
+  (no-regex (typify-route "/:id/card")))
+
+(expect ["/:card-id" :card-id "#[0-9]+"]
+  (no-regex (typify-route "/:card-id")))
+
+(expect "/:fish"
+  (no-regex (typify-route "/:fish")))
+
+(expect ["/:id/tables/:card-id" :id "#[0-9]+" :card-id "#[0-9]+"]
+  (no-regex (typify-route "/:id/tables/:card-id")))
+
+;; don't try to typify route that's already typified
+(expect ["/:id/:crazy-id" :crazy-id #"[0-9]+"]
+  (no-regex (typify-route ["/:id/:crazy-id" :crazy-id #"[0-9]+"])))
+
+
+;; TESTS FOR LET-FORM-FOR-ARG
+
+(expect '[id (Integer/parseInt id)]
+  (let-form-for-arg 'id))
+
+(expect '[org_id (Integer/parseInt org_id)]
+  (let-form-for-arg 'org_id))
+
+(expect nil
+  (let-form-for-arg 'fish))
+
+;; make sure we don't try to generate let forms for any fancy destructuring
+(expect nil
+  (let-form-for-arg :as))
+
+(expect nil
+  (let-form-for-arg '{body :body}))

--- a/test/metabase/api/common/internal_test.clj
+++ b/test/metabase/api/common/internal_test.clj
@@ -113,10 +113,10 @@
 
 ;; TESTS FOR LET-FORM-FOR-ARG
 
-(expect '[id (when id (Integer/parseInt id))]
+(expect '[id (clojure.core/when id (Integer/parseInt id))]
   (let-form-for-arg 'id))
 
-(expect '[org_id (when org_id (Integer/parseInt org_id))]
+(expect '[org_id (clojure.core/when org_id (Integer/parseInt org_id))]
   (let-form-for-arg 'org_id))
 
 (expect nil


### PR DESCRIPTION
### require-params

Added new `require-params` macro.

```
(defendpoint GET "/" [org f]
  (require-params org f)
  ...)
```

When used in the context of a `defendpoint` it will throw a 400 with customized message `"'org' is a required param"`.
### Regex-based auto-parse

 `auto-parse` now automatically parses args based on matching regexes in `*auto-parse-arg-name-patterns*`. (Previously, only exact name matches were parsed). E.g. any arg that matches `[\w-_]+id` will be auto-parsed as an int. (You can always override this behavior by binding `*auto-parse-arg-name-patterns*` on the off chance you need to).
### typify-route

Similar to `auto-parse`, `defendpoint` now performs a step called `typify-route`. URL-params that match a pattern in `*auto-parse-arg-name-patterns*` will automatically pass a regex to restrict Compojure's route matching.

e.g. route `"/:id/cards"` would match `/1/cards` or `/fish/cards`. Which is obviously not what we want and caused some problems with endpoints with conflicting names like `/user/current` and `/user/:id`.

Compojure can understand routes of the form

```
["/:id/cards" :id #"[0-9]+"]
```

So `typify-route` automatically looks for known param patterns (currently just things like `id` or `user-id`) and generates an appropriate route form like the one above.
### /api/user improvements
-  Rewrote the endpoints using the sophisticated new functionality of `defendpoint`
-  Modified `User`'s `default-fields` to exclude `is_active`, `is_staff`. Tweaked `current-user-middleware` to include these fields when you call `*current-user*` (i.e., they're returned for calls to `/api/user/current`)
-  `post-select` for `User` automatically generates their `common_name`.
### Etc
- Significantly simplified the `auto-parse` macro
-  Cleanup + additional unit tests for `auto-parse`
-  A few additional functions in `util` such as `regex?`
### Bug Fixes
-  fixed the issue where `auto-parse` would barf if a param (e.g. `org` in the example above) was not passed.

So there's definitely a lot going on in this PR, and `defendpoint` is getting pretty sophisticated, but I added dozens of unit tests to make sure everything is working perfectly. 
