### PR TITLE
Open H2 DB connections in `AUTO_SERVER` mode, so we can have multiple

### DIFF
--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -20,6 +20,14 @@
                :naming {:keys str/lower-case
                         :fields str/upper-case}}))
 
+;; Tell the DB to open an "AUTO_SERVER" connection so multiple processes can connect to it (e.g. web server + REPL)
+;; Do this by appending `;AUTO_SERVER=TRUE` to the JDBC URL (see http://h2database.com/html/features.html#auto_mixed_mode)
+(when (get-in db [:options :subprotocol])
+  (let [datasource (:datasource @(:pool db))
+        url (.getJdbcUrl datasource)]
+    (when-not (.contains ^String url ";AUTO_SERVER=TRUE")
+      (.setJdbcUrl datasource (str url ";AUTO_SERVER=TRUE")))))
+
 (defn migrate
   "Migrate the database :up or :down."
   [direction]


### PR DESCRIPTION
connections to it (e.g. Web Server + REPL)
