### PR TITLE
fix issue with using <base> tag in html doc

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,7 @@
         "angular-sanitize": "1.2.26",
         "angular-xeditable": "0.1.8",
         "angular-bootstrap": "0.11.0",
+        "angular-cookie": "4.0.6",
         "jquery": "2.1.1",
         "angular-animate": "1.2.26",
         "underscore": "1.7.0",

--- a/frontend_client/index.html
+++ b/frontend_client/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en" ng-app="corvus" class="no-js">
 <head>
-  <base href="/">
   <meta charset="utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, minimal-ui" />
@@ -107,6 +106,7 @@
   <script src="/app/bower_components/angular-animate/angular-animate.min.js"></script>
   <script src="/app/bower_components/angular-sanitize/angular-sanitize.min.js"></script>
   <script src="/app/bower_components/angular-xeditable/dist/js/xeditable.js"></script>
+  <script src="/app/bower_components/angular-cookie/angular-cookie.min.js"></script>
   <script src="/app/bower_components/javascript-detect-element-resize/detect-element-resize.js"></script>
   <script src="/app/bower_components/angular-gridster/src/angular-gridster.js"></script>
   <script src="/app/bower_components/angular-bootstrap/ui-bootstrap-tpls.min.js"></script>


### PR DESCRIPTION
use 3rd party angular-cookie library instead of the built-in $cookies because we need to control setting cookie options like path and secure.  we were only using the <base> tag as a work around for applying some kind of path to the cookies set by $cookies, but this is a better way.
