### PR TITLE
`sel`, API unit test improvements

### DIFF
--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -8,7 +8,8 @@
                    [db :refer :all])
             [medley.core :refer [filter-vals]]
             [metabase.config :refer [app-defaults]]
-            [metabase.db.internal :refer :all]))
+            [metabase.db.internal :refer :all]
+            [metabase.util :as u]))
 
 (declare post-select)
 
@@ -101,6 +102,17 @@
     (sel :one User :id 1)          -> returns the User (or nil) whose id is 1
     (sel :many OrgPerm :user_id 1) -> returns sequence of OrgPerms whose user_id is 1
 
+  OPTION, if specified, is one of `:field`, `:fields`, or `:id`.
+
+    ;; Only return IDs of objects.
+    (sel :one :id User :email \"cam@metabase.com\")  -> 120
+
+    ;; Only return the specified field.
+    (sel :many :field [User :first_name])            -> (\"Cam\" \"Sameer\" ...)
+
+    ;; Return map(s) that only contain the specified fields.
+    (sel :one :fields [User :id :first_name])        -> ({:id 1 :first_name \"Cam\"}, {:id 2 :first_name \"Sameer\"} ...)
+
   ENTITY may be either an entity like `User` or a vector like `[entity & field-keys]`.
   If just an entity is passed, `sel` will return `default-fields` for ENTITY.
   Otherwise is a vector is passed `sel` will return the fields specified by FIELD-KEYS.
@@ -118,13 +130,20 @@
 
     (sel :many Table :db_id 1)                    -> (select User (where {:id 1}))
     (sel :many Table :db_id 1 (order :name :ASC)) -> (select User (where {:id 1}) (order :name ASC))"
-  [one-or-many entity & forms]
-  {:pre [(contains? #{:one :many} one-or-many)]}
-  `(->> (-sel-select ~entity ~@forms ~@(when (= one-or-many :one) `((limit 1))))
-        (map (partial post-select (entity->korma ~entity)))
-        ~(case one-or-many
-           :one `first
-           :many `identity)))
+  [one-or-many & args]
+  {:arglists ([one-or-many option? entity & forms])
+   :pre [(contains? #{:one :many} one-or-many)]}
+  (if (= one-or-many :one)
+    `(first (sel :many ~@args (limit 1)))
+    (let [[option [entity & forms]] (u/optional keyword? args)]
+      (case option
+        :field  `(map ~(second entity)
+                      (sel :many ~entity ~@forms))
+        :id      `(sel :many :field [~entity :id] ~@forms)
+        :fields `(map #(select-keys % [~@(rest entity)])
+                      (sel :many ~entity ~@forms))
+        nil     `(map (partial post-select (entity->korma ~entity))
+                      (-sel-select ~entity ~@forms))))))
 
 (def ^:dynamic *entity-overrides*
   "The entity passed to `-sel-select` gets merged with this dictionary right before `select` gets called. This lets you override some of the korma

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -137,11 +137,13 @@
     `(first (sel :many ~@args (limit 1)))
     (let [[option [entity & forms]] (u/optional keyword? args)]
       (case option
-        :field  `(map ~(second entity)
-                      (sel :many ~entity ~@forms))
-        :id      `(sel :many :field [~entity :id] ~@forms)
-        :fields `(map #(select-keys % [~@(rest entity)])
-                      (sel :many ~entity ~@forms))
+        :field  `(let [[entity# field#] ~entity]
+                   (map field#
+                        (sel :many [entity# field#] ~@forms)))
+        :id     `(sel :many :field [~entity :id] ~@forms)
+        :fields `(let [[~'_ & fields# :as entity#] ~entity]
+                   (map #(select-keys % fields#)
+                        (sel :many entity# ~@forms)))
         nil     `(-sel-select ~entity ~@forms)))))
 
 (def ^:dynamic *entity-overrides*

--- a/src/metabase/db/internal.clj
+++ b/src/metabase/db/internal.clj
@@ -27,8 +27,12 @@
   [default-fields-fn entity]
   (let [[entity & field-keys] (if (vector? entity) entity
                                   [entity])
+        _ (println "FIELD KEYS: " field-keys)
+        _ (println "ENTITY: " entity)
+        _ (println "ENTITY TYPE: " (type entity))
         field-keys (or field-keys
-                       (default-fields-fn entity))]
+                       (default-fields-fn (entity->korma entity)))
+        _ (println "FIELD KEYS: " field-keys)]
     [entity field-keys]))
 
 (defn sel-apply-fields

--- a/src/metabase/db/internal.clj
+++ b/src/metabase/db/internal.clj
@@ -2,6 +2,8 @@
   "Internal functions and macros used by the public-facing functions in `metabase.db`."
   (:require [korma.core :refer :all]))
 
+(declare entity->korma)
+
 (defn- pull-kwargs
   "Where FORMS is a sequence like `[:id 1 (limit 3)]`, return a map of kwarg pairs and sequence of remaining forms.
 
@@ -21,25 +23,11 @@
     (if-not (empty? kwargs-map) (conj forms `(where ~kwargs-map))
             forms)))
 
-(defn entity-field-keys
-  "Lookup default field keys for ENTITY or destucture entity to get overriden defaults.
-   Note DEFAULT-FIELDS-FN is passed as an argument to avoid circular dependencies with `metabase.db`."
-  [default-fields-fn entity]
-  (let [[entity & field-keys] (if (vector? entity) entity
-                                  [entity])
-        _ (println "FIELD KEYS: " field-keys)
-        _ (println "ENTITY: " entity)
-        _ (println "ENTITY TYPE: " (type entity))
-        field-keys (or field-keys
-                       (default-fields-fn (entity->korma entity)))
-        _ (println "FIELD KEYS: " field-keys)]
-    [entity field-keys]))
-
-(defn sel-apply-fields
-  "When field-keys are specified, add `fields` clause to forms."
-  [field-keys forms]
-  (if-not (empty? field-keys) (conj forms `(fields ~@field-keys))
-          forms))
+(defn destructure-entity
+  "Take an ENTITY of the form `entity` or `[entity & field-keys]` and return a pair like `[entity field-keys]`."
+  [entity]
+  (if-not (vector? entity) [entity nil]
+          [(first entity) (vec (rest entity))]))
 
 (defn entity->korma
   "Convert an ENTITY argument to `sel`/`sel-fn` into the form we should pass to korma `select` and to various multi-methods such as
@@ -50,10 +38,11 @@
        and requires their namespace if needed."
   [entity]
   {:post [(= (type %) :korma.core/Entity)]}
-  (if (vector? entity) (entity->korma (first entity))
-      (if (string? entity) (let [ns (-> (.split ^String entity "/")
-                                        first
-                                        symbol)]
-                             (require ns)
+  (cond (vector? entity) (entity->korma (first entity))
+        (string? entity) (do (-> (.split ^String entity "/")
+                                 first
+                                 symbol
+                                 require)
                              (eval (symbol entity)))
-          entity)))
+        (symbol? entity) (eval entity)
+        :else entity))

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -1,73 +1,52 @@
 (ns metabase.api.user-test
   "Tests for /api/user endpoints."
   (:require [expectations :refer :all]
-            [medley.core :as medley]
             [metabase.db :refer :all]
             (metabase.models [org-perm :refer [OrgPerm]])
-            [metabase.test-data :refer :all]
-            [metabase.util :as u]))
+            (metabase [test-data :refer :all]
+                      [test-utils :refer [deserialize-dates match-$]])))
 
 (def rasta-org-perm-id (delay (sel :one :id OrgPerm :organization_id @org-id :user_id (user->id :rasta))))
 
-(defn- $->prop
-  "If FORM is a symbol starting with a `$`, convert it to the form `(PROP-FN form-keyword)`.
-
-    ($->prop my-fn 'fish)  -> 'fish
-    ($->prop my-fn '$fish) -> '(my-fn :fish)"
-  [prop-fn form]
-  (if-not (symbol? form) form
-          (let [[first-char & rest-chars] (name form)]
-            (if-not (= first-char \$) form
-                    (let [form (->> rest-chars
-                                    (apply str)
-                                    keyword)]
-                      `(~prop-fn ~form))))))
-
-(defmacro with-$-props
-  "Replace symbols like `$symbol` with ones like `(:symbol OBJ)` in BODY.
-
-    (with-$-props (sel :one User :id 1)
-      {:name $first_name})
-    ->
-    ({:name (:first_name <user>)}) ; <user> being the instance that came back from `sel`"
-  [obj & body]
-  (let [obj## (gensym)]
-    `(let [~obj## ~obj]
-       ~@(map (partial clojure.walk/prewalk (partial $->prop obj##))
-              body))))
 
 
-(defn deserialize-dates
-  "Deserialize date strings with KEYS returned in RESPONSE."
-  [response & [k & ks]]
-  {:pre [(map? response)
-         (keyword? k)]}
-  (let [response (medley/update response k #(some->> (u/parse-iso8601 %)
-                                                     .getTime
-                                                     java.sql.Timestamp.))]
-    (if (empty? ks) response
-        (apply deserialize-dates response ks))))
+;; ## GET /api/user/current
+;; Check that fetching current user will return extra fields like `is_active` and will return OrgPerms
+(expect (match-$ (fetch-user :rasta)
+                 {:email "rasta@metabase.com"
+                  :first_name "Rasta"
+                  :last_name "Toucan"
+                  :common_name "Rasta Toucan"
+                  :date_joined $
+                  :last_login $
+                  :is_active true
+                  :is_staff true
+                  :is_superuser false
+                  :id $
+                  :org_perms [{:organization {:inherits true
+                                              :logo_url nil
+                                              :description nil
+                                              :name "Test Organization"
+                                              :slug "test"
+                                              :id @org-id}
+                               :organization_id @org-id
+                               :user_id $id
+                               :admin true
+                               :id @rasta-org-perm-id}]})
+  (-> ((user->client :rasta) :get 200 "user/current")
+      (deserialize-dates :last_login :date_joined)))
 
-(expect (with-$-props (fetch-user :rasta)
-          {:email "rasta@metabase.com"
-           :first_name "Rasta"
-           :last_name "Toucan"
-           :common_name "Rasta Toucan"
-           :date_joined $date_joined
-           :last_login $last_login
-           :is_active true
-           :is_staff true
-           :is_superuser false
-           :id $id
-           :org_perms [{:organization {:inherits true
-                                       :logo_url nil
-                                       :description nil
-                                       :name "Test Organization"
-                                       :slug "test"
-                                       :id @org-id}
-                        :organization_id @org-id
-                        :user_id $id
-                        :admin true
-                        :id @rasta-org-perm-id}]})
-        (-> ((user->client :rasta) :get 200 "user/current")
-            (deserialize-dates :last_login :date_joined)))
+
+;; ## GET /api/user/:id
+;; Should return a smaller set of fields, and should *not* return OrgPerms
+(expect (match-$ (fetch-user :rasta)
+                 {:email "rasta@metabase.com"
+                  :first_name "Rasta"
+                  :last_login $
+                  :is_superuser false
+                  :id $
+                  :last_name "Toucan"
+                  :date_joined $
+                  :common_name "Rasta Toucan"})
+  (-> ((user->client :rasta) :get 200 (str "user/" (user->id :rasta)))
+      (deserialize-dates :last_login :date_joined)))

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -9,7 +9,6 @@
 (def rasta-org-perm-id (delay (sel :one :id OrgPerm :organization_id @org-id :user_id (user->id :rasta))))
 
 
-
 ;; ## GET /api/user/current
 ;; Check that fetching current user will return extra fields like `is_active` and will return OrgPerms
 (expect (match-$ (fetch-user :rasta)

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -1,0 +1,73 @@
+(ns metabase.api.user-test
+  "Tests for /api/user endpoints."
+  (:require [expectations :refer :all]
+            [medley.core :as medley]
+            [metabase.db :refer :all]
+            (metabase.models [org-perm :refer [OrgPerm]])
+            [metabase.test-data :refer :all]
+            [metabase.util :as u]))
+
+(def rasta-org-perm-id (delay (sel :one :id OrgPerm :organization_id @org-id :user_id (user->id :rasta))))
+
+(defn- $->prop
+  "If FORM is a symbol starting with a `$`, convert it to the form `(PROP-FN form-keyword)`.
+
+    ($->prop my-fn 'fish)  -> 'fish
+    ($->prop my-fn '$fish) -> '(my-fn :fish)"
+  [prop-fn form]
+  (if-not (symbol? form) form
+          (let [[first-char & rest-chars] (name form)]
+            (if-not (= first-char \$) form
+                    (let [form (->> rest-chars
+                                    (apply str)
+                                    keyword)]
+                      `(~prop-fn ~form))))))
+
+(defmacro with-$-props
+  "Replace symbols like `$symbol` with ones like `(:symbol OBJ)` in BODY.
+
+    (with-$-props (sel :one User :id 1)
+      {:name $first_name})
+    ->
+    ({:name (:first_name <user>)}) ; <user> being the instance that came back from `sel`"
+  [obj & body]
+  (let [obj## (gensym)]
+    `(let [~obj## ~obj]
+       ~@(map (partial clojure.walk/prewalk (partial $->prop obj##))
+              body))))
+
+
+(defn deserialize-dates
+  "Deserialize date strings with KEYS returned in RESPONSE."
+  [response & [k & ks]]
+  {:pre [(map? response)
+         (keyword? k)]}
+  (let [response (medley/update response k #(some->> (u/parse-iso8601 %)
+                                                     .getTime
+                                                     java.sql.Timestamp.))]
+    (if (empty? ks) response
+        (apply deserialize-dates response ks))))
+
+(expect (with-$-props (fetch-user :rasta)
+          {:email "rasta@metabase.com"
+           :first_name "Rasta"
+           :last_name "Toucan"
+           :common_name "Rasta Toucan"
+           :date_joined $date_joined
+           :last_login $last_login
+           :is_active true
+           :is_staff true
+           :is_superuser false
+           :id $id
+           :org_perms [{:organization {:inherits true
+                                       :logo_url nil
+                                       :description nil
+                                       :name "Test Organization"
+                                       :slug "test"
+                                       :id @org-id}
+                        :organization_id @org-id
+                        :user_id $id
+                        :admin true
+                        :id @rasta-org-perm-id}]})
+        (-> ((user->client :rasta) :get 200 "user/current")
+            (deserialize-dates :last_login :date_joined)))

--- a/test/metabase/test_utils.clj
+++ b/test/metabase/test_utils.clj
@@ -78,7 +78,7 @@
         (apply deserialize-dates response ks))))
 
 
-;; ## $$$ Macro
+;; ## match-$
 
 (defmacro match-$
   "Walk over map DEST-OBJECT and replace values of the form `$` or `$key` as follows:


### PR DESCRIPTION
## Improvements to `sel`
-  Cleaned up implementation a bit
-   Fetching an object and calling `select-keys` or pulling a single key from it are common patterns throughout our app. `sel` now handles optional `option` argument, which many be one of `:field`, `:fields`, or `:id`.
  -  `:id` will return just the ID(s) of the object(s) selected.
  -  `:field` will return just one given field from the object(s) selected
  -  `:fields` will return a map containing only the given keys from the object(s) selected.
  -  examples:
    
    ```
    (sel :one :id User :first_name "Rasta") -> 1
    (sel :one :field [User :last_name] :id 1) -> "Toucan"
    (sel :one :fields [User :first_name :last_name] :id 1) -> {:first_name "Rasta", :last_name "Toucan"}
    ```
-  Fixed issues where `default-fields` would not be called.
-  Fixed issues where `sel` complained about using local variables. E.g., the following now works as expected:
  
  ```
  (let [entity (apply vector User [:first_name :last_name])]
    (sel :one entity :id 1))
  ```
-  `sel` now handles symbols such as `'metabase.models.user/User` 
-  Clearer DB logging format
## API Utils
-  `deserialize-dates` deserializes string dates in an API response to a format that can be compared by expectations
-  `match-$` makes it easier to write an expected API response with values from a DB object
  
  ```
  (match-$ (sel :one User :first_name "Rasta")
    {:first_name "Rasta"
     :last_login $                  ; $ expands to (:last_login rasta)
     :org {:id $organization_id}    ; $organization_id expands to (:organization_id rasta)
     :common_name "Rasta Toucan"})) 
  ```
## Additional Tests
-  Added unit test for `GET api/users/:id`
