### PR TITLE
start tracking 'executor_id' on query executions now that its in the dat...

### DIFF
--- a/src/metabase/api/meta/dataset.clj
+++ b/src/metabase/api/meta/dataset.clj
@@ -5,6 +5,6 @@
             [metabase.driver :as driver]))
 
 (defendpoint POST "/" [:as {:keys [body]}]
-  (driver/dataset-query body {:executor *current-user-id*}))
+  (driver/dataset-query body {:executed_by *current-user-id*}))
 
 (define-routes)

--- a/src/metabase/api/qs.clj
+++ b/src/metabase/api/qs.clj
@@ -21,7 +21,8 @@
                        :database (:database body)
                        :native {:query (:sql body)
                                 :timezone (get body :timezone)}}
-        options {:synchronously false
+        options {:executed_by *current-user-id*
+                 :synchronously false
                  :cache_result true}]
     (driver/dataset-query dataset-query options)))
 

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -36,7 +36,7 @@
           :as caller-options}]
   (let [options (merge {:cache_result false} caller-options)
         query-execution {:uuid (.toString (java.util.UUID/randomUUID))
-                         ;:executor executed_by
+                         :executor_id executed_by
                          :json_query query
                          :version 0
                          :status "starting"


### PR DESCRIPTION
...a model.
