### PR TITLE
Keep H2 DB connections open for Metabase DB / Test DB until JVM shutdown

### DIFF
--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -18,14 +18,12 @@
   []
   (let [db-file-name (config/config-str :mb-db-file)
         db-file (clojure.java.io/file db-file-name)
-        options ";AUTO_SERVER=TRUE;MV_STORE=FALSE"]
+        options ";AUTO_SERVER=TRUE;MV_STORE=FALSE;DB_CLOSE_DELAY=-1"] ; see http://h2database.com/html/features.html for explanation of optionss
     (if (.isAbsolute db-file)
       ;; when an absolute path is given for the db file then don't mess with it
       (str "file:" db-file-name options)
       ;; if we don't have an absolute path then make sure we start from "user.dir"
       (str "file:" (str (System/getProperty "user.dir") "/" db-file-name options)))))
-;; Tell the DB to open an "AUTO_SERVER" connection so multiple processes can connect to it (e.g. web server + REPL)
-;; Do this by appending `;AUTO_SERVER=TRUE` to the JDBC URL (see http://h2database.com/html/features.html#auto_mixed_mode)
 
 
 (defn setup-jdbc-db

--- a/test/metabase/test_data/load.clj
+++ b/test/metabase/test_data/load.clj
@@ -20,7 +20,7 @@
 (def ^:private test-db-filename
   (delay (format "%s/t.db" (System/getProperty "user.dir"))))
 (def ^:private test-db-connection-string
-  (delay (format "file:%s;AUTO_SERVER=TRUE" @test-db-filename)))
+  (delay (format "file:%s;AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1" @test-db-filename)))
 
 ;; # PUBLIC INTERFACE
 

--- a/test/metabase/test_utils.clj
+++ b/test/metabase/test_utils.clj
@@ -4,7 +4,8 @@
             [expectations :refer :all]
             [ring.adapter.jetty :as ring]
             (metabase [core :as core]
-                      [db :refer :all])))
+                      [db :refer :all]
+                      [test-data :refer :all])))
 
 
 ;; # FUNCTIONS THAT GET RUN ON TEST SUITE START / STOP
@@ -33,7 +34,10 @@
   (migrate (setup-jdbc-db) :down)
   (log/info "setting up database and running all migrations")
   (setup-db :auto-migrate true)
-  (log/info "database setup complete"))
+  (log/info "database setup complete")
+
+  ;; Now load the test data
+  @test-db)
 
 
 ;; ## Jetty (Web) Server


### PR DESCRIPTION
Slight performance improvement + fixes a few issues
