### PR TITLE
Faster tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,4 @@
 test:
   override:
-    - lein eastwood
-    - lein expectations
+    - case $CIRCLE_NODE_INDEX in 0) lein eastwood ;; 1) lein expectations ;; esac:
+        parallel: true

--- a/resources/log4j.properties
+++ b/resources/log4j.properties
@@ -15,5 +15,6 @@ log4j.appender.file.layout=org.apache.log4j.PatternLayout
 log4j.appender.file.layout.ConversionPattern=%d [%t] %-5p%c - %m%n
 
 # customizations to logging by package
-log4j.logger.metabase=DEBUG
+log4j.logger.com.mchange=WARN
 log4j.logger.liquibase=WARN
+log4j.logger.metabase=DEBUG

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -73,11 +73,15 @@
       :print (com.metabase.corvus.migrations.LiquibaseMigrations/genSqlDatabase conn))))
 
 
+(def ^:private setup-db-has-been-called?
+  (atom false))
+
 (defn setup-db
   "Do general perparation of database by validating that we can connect.
    Caller can specify if we should run any pending database migrations."
   [& {:keys [auto-migrate]
       :or {auto-migrate true}}]
+  (reset! setup-db-has-been-called? true)
   (let [jdbc-db (setup-jdbc-db)
         korma-db (setup-korma-db)]
     ;; Test DB connection and throw exception if we have any troubles connecting
@@ -99,6 +103,10 @@
     (log/info "Database Migrations Current ... CHECK")
     ;; Establish our 'default' Korma DB Connection
     (default-connection (create-db korma-db))))
+
+(defn setup-db-if-needed [& args]
+  (when-not @setup-db-has-been-called?
+    (apply setup-db args)))
 
 
 ;;; # UTILITY FUNCTIONS

--- a/src/metabase/middleware/log_api_call.clj
+++ b/src/metabase/middleware/log_api_call.clj
@@ -17,7 +17,13 @@
               (do
                 (when log-request?
                   (log-request request))
-                (let [response (time (handler request))]
+                (let [start-time (System/nanoTime)
+                      response (handler request)]
+                  (when log-request?
+                    (let [elapsed-time (-> (- (System/nanoTime) start-time)
+                                           double
+                                           (/ 1000000.0))]
+                      (log/debug (str "Elapsed time: " elapsed-time " msecs"))))
                   (when log-response?
                     (log/debug (with-out-str (pprint response))))
                   response))))))

--- a/test/metabase/http_client.clj
+++ b/test/metabase/http_client.clj
@@ -78,7 +78,7 @@
         ;; Now perform the HTTP request
         {:keys [status body]} (try (request-fn url request-map)
                                    (catch clojure.lang.ExceptionInfo e
-                                     (log/info method-name url)
+                                     (log/debug method-name url)
                                      (-> (.getData ^clojure.lang.ExceptionInfo e)
                                          :object)))]
 

--- a/test/metabase/middleware/auth_test.clj
+++ b/test/metabase/middleware/auth_test.clj
@@ -8,13 +8,7 @@
             [metabase.util :as util]
             [ring.mock.request :as mock]))
 
-
-;; make sure test db is setup
-@test-db
-
-
 ;;;;  ===========================  TEST wrap-sessionid middleware  ===========================
-
 
 ;; create a simple example of our middleware wrapped around a handler that simply returns the request
 ;; this works in this case because the only impact our middleware has is on the request

--- a/test/metabase/models/org_perm_test.clj
+++ b/test/metabase/models/org_perm_test.clj
@@ -1,14 +1,14 @@
 (ns metabase.models.org-perm-test
   (:require [clojure.tools.logging :as log]
-            [metabase.test-utils :refer [setup-test-db]]
-            [metabase.db :refer :all]
-            [metabase.models.org-perm :refer [OrgPerm]]
-            [metabase.models.org :refer [Org]]
-            [metabase.models.user :refer [User]]
-            [korma.core :refer :all]
-            [expectations :refer :all]
+            [clj-time.coerce :as tc]
             [clj-time.core :as time]
-            [clj-time.coerce :as tc]))
+            [expectations :refer :all]
+            [korma.core :refer :all]
+            (metabase [db :refer :all]
+                      test-utils)
+            (metabase.models [org-perm :refer [OrgPerm]]
+                             [org :refer [Org]]
+                             [user :refer [User]])))
 
 
 ;(defn insert-org []

--- a/test/metabase/models/org_test.clj
+++ b/test/metabase/models/org_test.clj
@@ -1,10 +1,10 @@
 (ns metabase.models.org-test
   (:require [clojure.tools.logging :as log]
-            [metabase.test-utils :refer [setup-test-db]]
-            [metabase.db :refer :all]
-            [metabase.models.org :refer [Org]]
+            [expectations :refer :all]
             [korma.core :refer :all]
-            [expectations :refer :all]))
+            (metabase [db :refer :all]
+                      test-utils)
+            [metabase.models.org :refer [Org]]))
 
 
 ;(defn count-orgs []

--- a/test/metabase/models/user_test.clj
+++ b/test/metabase/models/user_test.clj
@@ -1,12 +1,12 @@
 (ns metabase.models.user-test
   (:require [clojure.tools.logging :as log]
-            [metabase.test-utils :refer [setup-test-db]]
-            [metabase.db :refer :all]
-            [metabase.models.user :refer [User]]
-            [korma.core :refer :all]
-            [expectations :refer :all]
+            [clj-time.coerce :as tc]
             [clj-time.core :as time]
-            [clj-time.coerce :as tc]))
+            [expectations :refer :all]
+            [korma.core :refer :all]
+            (metabase [db :refer :all]
+                      test-utils)
+            [metabase.models.user :refer [User]]))
 
 
 ;(defn count-users []

--- a/test/metabase/test_data.clj
+++ b/test/metabase/test_data.clj
@@ -45,8 +45,7 @@
 
 (def test-db
   "The test `Database` object."
-  (delay (setup-db :auto-migrate true)
-         (load/test-db)))
+  (delay (load/test-db)))
 
 (def db-id
   "The ID of the test `Database`."
@@ -79,8 +78,7 @@
 
 (def test-org
   "The test Organization."
-  (delay (setup-db :auto-migrate true)
-         (load/test-org)))
+  (delay (load/test-org)))
 
 (def org-id
   "The ID of the test Organization."

--- a/test/metabase/test_data.clj
+++ b/test/metabase/test_data.clj
@@ -2,8 +2,8 @@
   "Functions relating to using the test data, Database, Organization, and Users."
   (:require [cemerick.friend.credentials :as creds]
             [medley.core :as medley]
-            [metabase.db :refer :all]
-            [metabase.http-client :as http]
+            (metabase [db :refer :all]
+                      [http-client :as http])
             (metabase.models [field :refer [Field]]
                              [org-perm :refer [OrgPerm]]
                              [table :refer [Table]]
@@ -45,7 +45,8 @@
 
 (def test-db
   "The test `Database` object."
-  (delay (load/test-db)))
+  (delay (setup-db-if-needed :auto-migrate true)
+         (load/test-db)))
 
 (def db-id
   "The ID of the test `Database`."
@@ -78,7 +79,8 @@
 
 (def test-org
   "The test Organization."
-  (delay (load/test-org)))
+  (delay (setup-db-if-needed :auto-migrate true)
+         (load/test-org)))
 
 (def org-id
   "The ID of the test Organization."

--- a/test/metabase/test_utils.clj
+++ b/test/metabase/test_utils.clj
@@ -23,18 +23,10 @@
 (defn test-setup
   {:expectations-options :before-run}
   []
-  (set-test-logging-level)
+  ;; Disable debug logging since it clutters up our output
+  (.setLevel (org.apache.log4j.Logger/getLogger "metabase") org.apache.log4j.Level/INFO)
   (setup-test-db)
   (start-jetty))
-
-
-;; ## Logging Setup
-
-(defn set-test-logging-level
-  "Disable debug logging since it clutters up our output."
-  []
-  (.setLevel (org.apache.log4j.Logger/getLogger "metabase") org.apache.log4j.Level/INFO))
-
 
 ;; ## DB Setup
 ;; WARNING: BY RUNNING ANY UNIT TESTS THAT REQUIRE THIS FILE OR BY RUNNING YOUR ENTIRE TEST SUITE YOU WILL EFFECTIVELY BE WIPING OUT YOUR DATABASE.

--- a/test/metabase/test_utils.clj
+++ b/test/metabase/test_utils.clj
@@ -20,7 +20,6 @@
 
 ;; Disable debug logging since it clutters up our output
 (.setLevel (org.apache.log4j.Logger/getLogger "metabase") org.apache.log4j.Level/INFO)
-(println "OK!")
 
 (defn setup-test-db
   "setup database schema"

--- a/test/metabase/test_utils.clj
+++ b/test/metabase/test_utils.clj
@@ -5,7 +5,6 @@
             [ring.adapter.jetty :as ring]
             (metabase [core :as core]
                       [db :refer :all]
-                      test-utils
                       [test-data :refer :all])))
 
 (declare load-test-data

--- a/test/metabase/test_utils.clj
+++ b/test/metabase/test_utils.clj
@@ -18,6 +18,10 @@
 ;; it's pretty annoying to have our DB reset all the time
 (expectations/disable-run-on-shutdown)
 
+;; Disable debug logging since it clutters up our output
+(.setLevel (org.apache.log4j.Logger/getLogger "metabase") org.apache.log4j.Level/INFO)
+(println "OK!")
+
 (defn setup-test-db
   "setup database schema"
   {:expectations-options :before-run}


### PR DESCRIPTION
-  parallelize tests on Circle CI
-  turn off Debug logging when running unit tests
-  HTTP client uses logging instead of println
