### PR TITLE
use `(into {})` instead of `(reduce merge {})` or `(apply merge {})` --

### DIFF
--- a/src/metabase/api/meta/db.clj
+++ b/src/metabase/api/meta/db.clj
@@ -50,7 +50,7 @@
         table-id->name (->> (sel :many [Table :id :name] :db_id id)                                             ; fetch all name + ID of all Tables for this DB
                             (map (fn [{:keys [id name]}]                                                         ; make a map of Table ID -> Table Name
                                    {id name}))
-                            (apply merge {}))
+                            (into {}))
         matching-tables (->> (vals table-id->name)                                                              ; get all Table names that start with PREFIX
                              (filter (fn [^String table-name]
                                        (= prefix (.substring table-name 0 prefix-len))))

--- a/src/metabase/driver/generic_sql/query_processor/annotate.clj
+++ b/src/metabase/driver/generic_sql/query_processor/annotate.clj
@@ -35,7 +35,7 @@
                                                               :id [in field-ids])     ; Fetch names of fields from `fields` clause
                                                          (map (fn [{:keys [id name]}]  ; build map of field-id -> field-name
                                                                 {id (keyword name)}))
-                                                         (reduce merge {}))]
+                                                         (into {}))]
                                  (map field-id->name field-ids)))                     ; now get names in same order as the IDs
         other-fields (->> (first results)
                           keys                                                        ; Get the names of any other fields that were returned (i.e., `sum`)
@@ -52,7 +52,7 @@
                           :table_id table-id :name [in (set column-names)])
                      (map (fn [{:keys [name] :as column}]                                          ; build map of column-name -> column
                             {name (select-keys column [:id :table_id :name :description :base_type :special_type])}))
-                     (apply merge {}))]
+                     (into {}))]
     (->> column-names
          (map (fn [column-name]
                 (or (columns column-name)                             ; try to get matching column from the map we build earlier

--- a/src/metabase/models/hydrate.clj
+++ b/src/metabase/models/hydrate.clj
@@ -81,7 +81,7 @@
         objs (->> (sel :many entity :id [in ids])
                   (map (fn [obj]
                          {(:id obj) obj}))
-                  (reduce merge {}))]
+                  (into {}))]
     (->> results
          (map (fn [result]
                 (let [source-id (result source-key)

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -130,7 +130,7 @@
     (reset! cached-setting-values (->> (sel :many Setting)
                                        (map (fn [{k :key v :value}]
                                               {(keyword k) v}))
-                                       (reduce merge {})))))
+                                       (into {})))))
 
 (def ^:private cached-setting-values
   (atom nil))

--- a/test/metabase/http_client.clj
+++ b/test/metabase/http_client.clj
@@ -146,5 +146,5 @@
                                     {k (if (contains? auto-deserialize-dates-keys k)
                                          (deserialize-date v)
                                          (auto-deserialize-dates v))}))
-                             (reduce merge {}))
+                             (into {}))
         :else response))

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -23,7 +23,7 @@
                          (map (fn [[k v]]
                                 {k (if (= v '$) `(~k ~source##)
                                        v)}))
-                         (reduce merge {}))]
+                         (into {}))]
     `(let [~source## ~source-obj]
        ~(clojure.walk/prewalk (partial $->prop source##)
                               dest-object))))

--- a/test/metabase/test_data.clj
+++ b/test/metabase/test_data.clj
@@ -167,7 +167,7 @@
   (->> [:users :venues :checkins :categories]
        (map (fn [table-kw]
               {table-kw (f table-kw)}))
-       (reduce merge {})))
+       (into {})))
 
 (def
   ^{:doc "A map of Table name keywords -> Table IDs.
@@ -201,7 +201,7 @@
                                      (integer? id)
                                      (not (zero? id))]}
                               {(keyword (.toLowerCase name)) id}))
-                       (reduce merge {}))))))
+                       (into {}))))))
 
 ;; ## Users
 


### PR DESCRIPTION
it's a lot faster
