### PR TITLE
don't force 4 space indentation for all editor defaults, clojure for examp...

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,12 +6,14 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 
 [Makefile]
 indent_style = tab
+
+[*.js]
+indent_size = 4
 
 [*.css]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,8 +12,14 @@ trim_trailing_whitespace = true
 [Makefile]
 indent_style = tab
 
-[*.js]
-indent_size = 4
+[*.clj]
+indent_size = 2
 
 [*.css]
 indent_size = 2
+
+[*.html]
+indent_size = 4
+
+[*.js]
+indent_size = 4


### PR DESCRIPTION
...le doesn't make sense for 4 spaces.  add explict definition for *.js at 4 space indentation.
