### PR TITLE
fix card saving error in safari where 'display' was unset

### DIFF
--- a/resources/frontend_client/app/card/card.controllers.js
+++ b/resources/frontend_client/app/card/card.controllers.js
@@ -1181,7 +1181,7 @@ CardControllers.controller('CardDetail', [
                         'public_perms': 0,
                         'can_read': true,
                         'can_write': true,
-                        'display': 'none',
+                        'display': 'table',
                         'dataset_query': {
                             'type': 'native',
                             'native': {}


### PR DESCRIPTION
fix bug in frontend_client where 'display' was unset in safari and caused card saving to fail.  now explicitly setting default card 'display' to 'table'.
