### PR TITLE
Defendpoint annotations

### DIFF
--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -206,9 +206,13 @@
   `(defmethod arg-annotation-fn ~(keyword annotation-name) [~'_ ~binding]
      `(do ~~@body)))
 
-
 ;; `required` just calls require-params
 (defannotation required [param]
+  `(require-params ~param)
+  param)
+
+;; `req` is an alias for `required`
+(defannotation req [param]
   `(require-params ~param)
   param)
 

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -193,10 +193,24 @@
 (defmethod arg-annotation-fn :default [annotation-kw arg-symbol]
   (throw (Exception. (format "Don't know what to do with arg annotation '%s' on arg '%s'!" (name annotation-kw) (name arg-symbol)))))
 
+(defmacro defannotation
+  "Convenience for defining a new `defendpoint` arg annotation.
+
+   BINDING is the actual symbol name of the arg being checked; `defannotation` returns form(s)
+   that will be included in the let binding for the annotated arg.
+
+    (defannotation required [param]
+      `(require-params ~param)       ; quasiquoting needed to keep require-params from being evaluated at macroexpansion time
+      param)"
+  [annotation-name [binding] & body]
+  `(defmethod arg-annotation-fn ~(keyword annotation-name) [~'_ ~binding]
+     `(do ~~@body)))
+
+
 ;; `required` just calls require-params
-(defmethod arg-annotation-fn :required [_ arg-symbol]
-  `(do (require-params ~arg-symbol)
-       ~arg-symbol))
+(defannotation required [param]
+  `(require-params ~param)
+  param)
 
 
 ;;; ### defendpoint

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -239,7 +239,7 @@
          (vector? args)]}
   (let [name (route-fn-name method route)
         route (typify-route route)
-        [arg-annotations body] (u/optional map? more)]
+        [arg-annotations body] (u/optional #(and (map? %) (every? symbol? (keys %))) more)]
     `(do (def ~name
            (~method ~route ~args
                     (auto-parse ~args

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -180,9 +180,9 @@
    Dispatches on the arg annotation as a keyword, and is also passed the symbol
    of the argument that should be checked.
 
-    (defendpoint GET ... [id] {id required})
+    (defendpoint GET ... [id] {id Required})
 
-     -> (let [id ~(arg-annotation-fn :required id)]
+     -> (let [id ~(arg-annotation-fn :Required id)]
            ...)
 
      -> (let [id (do (require-params id) id)]

--- a/src/metabase/api/common/internal.clj
+++ b/src/metabase/api/common/internal.clj
@@ -216,11 +216,14 @@
          (symbol? arg-symb)]}
   `[~arg-symb ~((eval 'metabase.api.common/arg-annotation-fn) annotation-kw arg-symb)])
 
-(defn process-arg-annotations [annotations]
-  {:pre [(or (nil? annotations)
-             (map? annotations))]}
-  (some->> annotations
+(defn process-arg-annotations [annotations-map]
+  {:pre [(or (nil? annotations-map)
+             (map? annotations-map))]}
+  (some->> annotations-map
            (mapcat (fn [[arg annotations]]
+                     {:pre [(symbol? arg)
+                            (or (symbol? annotations)
+                                (every? symbol? annotations))]}
                      (if (sequential? annotations) (->> annotations
                                                         (map keyword)
                                                         (map (u/rpartial vector arg)))

--- a/src/metabase/api/common/internal.clj
+++ b/src/metabase/api/common/internal.clj
@@ -149,65 +149,6 @@
 
 ;;; ## ARG ANNOTATION FUNCTIONALITY
 
-;;; ### Args Form Deannotation
-
-;; (defn deannotate-arg
-;;   "If FORM is a symbol, strip off any annotations.
-
-;;     (deannotate-arg 'password.required) -> password"
-;;   [form]
-;;   (if-not (symbol? form) form
-;;           (let [[arg & _] (clojure.string/split (name form) #"\.")]
-;;             (symbol arg))))
-
-;; (defn deannotate-args-form
-;;   "Walk ARGS-FORM and strip off any annotations.
-
-;;     (deannotate-args-form [id :as {{:keys [password.required old_password.required]} :body}])
-;;       -> [id :as {{:keys [password old_password]} :body}]"
-;;   [args-form]
-;;   (if (= args-form []) '[:as _]
-;;       (->> args-form
-;;            (mapv (partial clojure.walk/prewalk deannotate-arg)))))
-
-
-;;; ### Args Form Annotation Gathering
-
-;; (defn args-form->symbols
-;;   "Recursively walk ARGS-FORM and return a sequence of symbols.
-
-;;     (args-form->symbols [id :as {{:keys [password.required old_password.required]} :body}])
-;;       -> (id password.required old_password.required)"
-;;   [args-form]
-;;   {:post [(sequential? %)
-;;           (every? symbol? %)]}
-;;   (cond
-;;     (symbol? args-form) [args-form]
-;;     (map? args-form) (->> args-form
-;;                           (mapcat (fn [[k v]]
-;;                                     [(args-form->symbols k) (args-form->symbols v)]))
-;;                           (mapcat args-form->symbols))
-;;     (sequential? args-form) (mapcat args-form->symbols
-;;                                     args-form)
-;;     :else []))
-
-;; (defn symb->arg+annotations
-;;   "Return a sequence of pairs of `[annotation-kw deannotated-arg-symb]` for an annotated ARG.
-
-;;     (symb->arg+annotations 'password)              -> nil
-;;     (symb->arg+annotations 'password.required)     -> [[:required password]]
-;;     (symb->arg+annotations 'password.required.str) -> [[:required password], [:str password]]"
-;;   [arg]
-;;   {:pre [(symbol? arg)]}
-;;   (let [[arg & annotations] (clojure.string/split (name arg) #"\.")]
-;;     (when (seq annotations)
-;;       (->> annotations
-;;            (map (fn [annotation]
-;;                   [(keyword annotation) (symbol arg)]))))))
-
-
-;;; ### let-annotated-args
-
 (defn arg-annotation-let-binding
   "Return a pair like `[arg-symb arg-annotation-form]`, where `arg-annotation-form` is the result of calling the `arg-annotation-fn` implementation
    for ANNOTATION-KW."

--- a/src/metabase/api/common/internal.clj
+++ b/src/metabase/api/common/internal.clj
@@ -205,13 +205,6 @@
            (map (fn [annotation]
                   [(keyword annotation) (symbol arg)]))))))
 
-(defn args-form->arg+annotations-pairs
-  [annotated-args-form]
-  {:pre [(vector? annotated-args-form)]}
-  (->> annotated-args-form
-       args-form->symbols
-       (mapcat symb->arg+annotations)))
-
 
 ;;; ### let-annotated-args
 

--- a/src/metabase/api/emailreport.clj
+++ b/src/metabase/api/emailreport.clj
@@ -81,9 +81,9 @@
   (del EmailReport :id id))
 
 
-(defendpoint POST "/:id" [id]
-  ;; TODO - implementation (execute a report)
-  {:TODO "TODO"})
+;; TODO
+;; (defendpoint POST "/:id" [id]
+;;   {:TODO "TODO"})
 
 
 (defendpoint GET "/:id/executions" [id]

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -31,7 +31,8 @@
   `(check (is-email? ~email) [400 (format ~(str (name email) " '%s' is not a valid email.") ~email)])
   email)
 
-(defendpoint PUT "/:id" [id :as {{:keys [email.email] :as body} :body}]
+(defendpoint PUT "/:id" [id :as {{:keys [email] :as body} :body}]
+  {email email}
   ;; user must be getting their own details OR they must be a superuser to proceed
   (check-403 (or (= id *current-user-id*) (:is_superuser @*current-user*)))
   ;; can't change email if it's already taken BY ANOTHER ACCOUNT
@@ -45,8 +46,9 @@
   `(check (password/is-complex? ~password) [400 "Insufficient password strength"])
   password)
 
-(defendpoint PUT "/:id/password" [id :as {{:keys [password.req.complex-pw old_password.req]} :body}]
-  (require-params password old_password)
+(defendpoint PUT "/:id/password" [id :as {{:keys [password old_password]} :body}]
+  {password [req complex-pw]
+   old_password req}
   (check-403 (or (= id *current-user-id*)
                  (:is_superuser @*current-user*)))
   (let-404 [user (sel :one [User :password_salt :password] :id id)]

--- a/test/metabase/api/common_test.clj
+++ b/test/metabase/api/common_test.clj
@@ -176,10 +176,10 @@
          (metabase.api.common.internal/auto-parse [id]
            (metabase.api.common.internal/catch-api-exceptions
              (metabase.api.common.internal/let-annotated-args
-              {id required}
+              {id Required}
               (clojure.core/-> (do (->404 (sel :one Card :id id)))
                                metabase.api.common.internal/wrap-response-if-needed))))))
      (clojure.core/alter-meta! #'GET_:id clojure.core/assoc :is-endpoint? true))
    (defendpoint GET "/:id" [id]
-     {id required}
+     {id Required}
      (->404 (sel :one Card :id id)))))

--- a/test/metabase/api/common_test.clj
+++ b/test/metabase/api/common_test.clj
@@ -175,8 +175,11 @@
        (GET ["/:id" :id "#[0-9]+"] [id]
          (metabase.api.common.internal/auto-parse [id]
            (metabase.api.common.internal/catch-api-exceptions
-             (clojure.core/-> (do (->404 (sel :one Card :id id)))
-                              metabase.api.common.internal/wrap-response-if-needed)))))
+             (metabase.api.common.internal/let-annotated-args
+              {id required}
+              (clojure.core/-> (do (->404 (sel :one Card :id id)))
+                               metabase.api.common.internal/wrap-response-if-needed))))))
      (clojure.core/alter-meta! #'GET_:id clojure.core/assoc :is-endpoint? true))
    (defendpoint GET "/:id" [id]
+     {id required}
      (->404 (sel :one Card :id id)))))

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -149,7 +149,7 @@
 
 ;; Check that a non-superuser CANNOT update someone else's user details
 (expect "You don't have permissions to do that."
-  ((user->client :rasta) :put 403 (str "user/" (user->id :trashbird)) {email "toucan@metabase.com"}))
+  ((user->client :rasta) :put 403 (str "user/" (user->id :trashbird)) {:email "toucan@metabase.com"}))
 
 
 ;; ## PUT /api/user/:id/password

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -149,7 +149,7 @@
 
 ;; Check that a non-superuser CANNOT update someone else's user details
 (expect "You don't have permissions to do that."
-  ((user->client :rasta) :put 403 (str "user/" (user->id :trashbird))))
+  ((user->client :rasta) :put 403 (str "user/" (user->id :trashbird)) {email "toucan@metabase.com"}))
 
 
 ;; ## PUT /api/user/:id/password


### PR DESCRIPTION
Args to `defendpoint` can be "annotated" in a way reminiscent of the `@params` decorator from the old Django backend.

This allows us to remove a lot of validation boilerplate such as `require-params`, and compose/reuse more sophisticated parameter checking patterns, ultimately leading to tidier code and better error messages.
#### BEFORE

```
(defendpoint PUT "/:id/password" [id :as {{:keys [password old_password]} :body}]
  (require-params password old_password)
  (check (password/is-complex? password) [400 "Insufficient password strength"])
  ...)
```
#### AFTER

```
(defendpoint PUT "/:id/password" [id :as {{:keys [password.req.complex-pw old_password.req]} :body}]
  ...)
```
#### ANNOTATIONS

Can be defined in an ad-hoc manner with the `defannotation` macro.

```
(defannotation complex-pw [password]
  `(check (password/is-complex? ~password) [400 "Insufficient password strength"])
  password)
```

Annotated args are expanded into simple let-bound forms around the `defendpoint` body. The example above is expanded into a form like

```
(let [password (do (check (password/is-complex? password) [400 "Insufficient password strength"])
                   password)]
  ...)
```
