### PR TITLE
upgrade angular gridster to 0.11.7

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "angular-animate": "1.2.26",
     "underscore": "1.8.2",
     "angularytics": "0.3.0",
-    "angular-gridster": "git://github.com/psalami/angular-gridster.git#v0.10.8.4",
+    "angular-gridster": "0.11.7",
     "angular-http-auth": "1.2.1",
     "ace-builds": "1.1.7",
     "angular-ui-ace": "0.1.1",


### PR DESCRIPTION
- gets us past an issue where the 'gridster-item-initialized' event wasn't being triggered for some reason.
- also removes the dependency we had on fork of angular gridster that was being hosted by psalami
