### PR TITLE
add in a quick fix to support ssl connections on postgres db connections...

### DIFF
--- a/src/metabase/driver/postgres/connection.clj
+++ b/src/metabase/driver/postgres/connection.clj
@@ -16,6 +16,7 @@
         {:keys [host dbname port host]} details]
     (-> details
         (assoc :host host                                     ; e.g. "localhost"
+               :make-pool? false
                :db-type :postgres                             ; HACK hardcoded to postgres for time being until API has a way to choose DB type !
                :port (Integer/parseInt port))                 ; convert :port to an Integer
         (cond-> (config/config-bool :mb-postgres-ssl) (assoc :ssl true :sslfactory "org.postgresql.ssl.NonValidatingFactory"))

--- a/src/metabase/driver/postgres/connection.clj
+++ b/src/metabase/driver/postgres/connection.clj
@@ -3,6 +3,7 @@
             [clojure.string :as s]
             [korma.db]
             [swiss.arrows :refer :all]
+            [metabase.config :as config]
             [metabase.driver :refer [connection connection-details]]))
 
 (defmethod connection-details :postgres [database]
@@ -17,6 +18,7 @@
         (assoc :host host                                     ; e.g. "localhost"
                :db-type :postgres                             ; HACK hardcoded to postgres for time being until API has a way to choose DB type !
                :port (Integer/parseInt port))                 ; convert :port to an Integer
+        (cond-> (config/config-bool :mb-postgres-ssl) (assoc :ssl true :sslfactory "org.postgresql.ssl.NonValidatingFactory"))
         (rename-keys {:dbname :db}))))
 
 (defmethod connection :postgres [database]


### PR DESCRIPTION
... if the user sets the :mb-postgres-ssl env value to "true"
