### PR TITLE
Use `reductions` for cumulative sum instead of implementing it manually

### DIFF
--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -219,18 +219,6 @@
            first
            (= "cum_sum")))
 
-(defn- cumulative-sum
-  "Recursively cumulative sum a sequence of VALUES."
-  ([values]
-   {:pre [(sequential? values)
-          (every? number? values)]}
-   (cumulative-sum 0 [] values))
-  ([acc-sum acc-values [value & more]]
-   (let [acc-sum (+ acc-sum value)
-         acc-values (conj acc-values acc-sum)]
-     (if-not (seq? more) acc-values
-             (recur acc-sum acc-values more)))))
-
 (defn- apply-cumulative-sum
   "Apply `cumulative-sum` to values of the aggregate `Field` in RESULTS."
   {:arglists '([query results])}
@@ -238,7 +226,7 @@
   (let [field (field-id->kw field-id)
         values (->> results          ; make a sequence of cumulative sum values for each row
                     (map field)
-                    cumulative-sum)]
+                    (reductions +))]
     (map (fn [row value]              ; replace the value for each row with the cumulative sum value
            (assoc row field value))
          results values)))

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -220,7 +220,7 @@
            (= "cum_sum")))
 
 (defn- apply-cumulative-sum
-  "Apply `cumulative-sum` to values of the aggregate `Field` in RESULTS."
+  "Cumulative sum the values of the aggregate `Field` in RESULTS."
   {:arglists '([query results])}
   [{[_ field-id] :aggregation} results]
   (let [field (field-id->kw field-id)

--- a/test/metabase/driver/generic_sql/query_processor_test.clj
+++ b/test/metabase/driver/generic_sql/query_processor_test.clj
@@ -387,6 +387,7 @@
 ;; # POST PROCESSING TESTS
 
 ;; ## CUMULATIVE SUM
+
 ;; ### Simple cumulative sum w/o any breakout
 (expect {:status :completed
          :row_count 15


### PR DESCRIPTION
Well it turns out cumulative sum in clojure is just

```
(reductions + [1 2 3 4 5]) -> (1 3 6 10 15)
```

I thought I had a very nice recursive implementation but it is pointless :sob:
