### PR TITLE
Faster tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,7 @@ You can make API calls from the REPL using `metabase.http-client`:
     lein ancient                   # list all out-of-date dependencies
     lein ancient latest lein-ring  # list latest version of artifact lein-ring
 
-Will give you a list of out-of-date dependencies. This requires leiningen version 2.4.0 or higher so run `lein upgrade` first if needed.
-This doesn't seem to check plugins, so you'll have to do that manually using `lein ancient latest`.
+Will give you a list of out-of-date dependencies.
 
 Once's this repo is made public, this Clojars badge will work and show the status as well:
 

--- a/circle.yml
+++ b/circle.yml
@@ -2,9 +2,9 @@ machine:
   java:
     version:
       oraclejdk8
-dependencies:    # We can skip inferred `npm install` since we're not running browser tests (yet).
-  override:      # We can also skip `lein deps` since the test commands will install them if needed.
-    - echo "ok." # No need to spin up Clojure twice
+dependencies:
+  override:
+    - lein deps # We can skip inferred `npm install` since we're not running browser tests (yet)
 test:
   override:
     - case $CIRCLE_NODE_INDEX in 0) lein eastwood ;; 1) lein test ;; esac:

--- a/circle.yml
+++ b/circle.yml
@@ -2,9 +2,9 @@ machine:
   java:
     version:
       oraclejdk8
-dependencies:
-  override:
-    - echo "ok." # skip lein deps since the test commands will install them if needed. No need to spin up Clojure twice
+dependencies:    # We can skip inferred `npm install` since we're not running browser tests (yet).
+  override:      # We can also skip `lein deps` since the test commands will install them if needed.
+    - echo "ok." # No need to spin up Clojure twice
 test:
   override:
     - case $CIRCLE_NODE_INDEX in 0) lein eastwood ;; 1) lein test ;; esac:

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,9 @@
+machine:
+  java:
+    oraclejdk8
+dependencies:
+  override:
+    ## Nothing, `lein eastwood`/`lein test` will load dependencies as needed so don't waste time booting Clojure twice
 test:
   override:
     - case $CIRCLE_NODE_INDEX in 0) lein eastwood ;; 1) lein test ;; esac:

--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,10 @@
 machine:
   java:
-    oraclejdk8
+    version:
+      oraclejdk8
 dependencies:
   override:
-    ## Nothing, `lein eastwood`/`lein test` will load dependencies as needed so don't waste time booting Clojure twice
+    echo "ok!" ## Nothing, `lein eastwood`/`lein test` will load dependencies as needed so don't waste time booting Clojure twice
 test:
   override:
     - case $CIRCLE_NODE_INDEX in 0) lein eastwood ;; 1) lein test ;; esac:

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
       oraclejdk8
 dependencies:
   override:
-    - lein deps # no need to run npm install for non-browser tests
+    - echo 'ok!' # skip lein deps since the test commands will install them if needed. No need to spin up Clojure twice
 test:
   override:
     - case $CIRCLE_NODE_INDEX in 0) lein eastwood ;; 1) lein test ;; esac:

--- a/circle.yml
+++ b/circle.yml
@@ -4,14 +4,8 @@ machine:
       oraclejdk8
 dependencies:
   override:
-    - echo "ok!" # Nothing, `lein eastwood`/`lein test` will load dependencies as needed so don't waste time booting Clojure twice
-database:
-  override:
-    - echo "ok!" # We aren't using the test DB
+    - lein deps # no need to run npm install for non-browser tests
 test:
   override:
     - case $CIRCLE_NODE_INDEX in 0) lein eastwood ;; 1) lein test ;; esac:
         parallel: true
-teardown:
-  override:
-    - echo "ok!" # don't waste 10 seconds looking for junit xml files or cucumber json files. There are none

--- a/circle.yml
+++ b/circle.yml
@@ -4,8 +4,14 @@ machine:
       oraclejdk8
 dependencies:
   override:
-    - echo "ok!" ## Nothing, `lein eastwood`/`lein test` will load dependencies as needed so don't waste time booting Clojure twice
+    - echo "ok!" # Nothing, `lein eastwood`/`lein test` will load dependencies as needed so don't waste time booting Clojure twice
+database:
+  override:
+    - echo "ok!" # We aren't using the test DB
 test:
   override:
     - case $CIRCLE_NODE_INDEX in 0) lein eastwood ;; 1) lein test ;; esac:
         parallel: true
+teardown:
+  override:
+    - echo "ok!" # don't waste 10 seconds looking for junit xml files or cucumber json files. There are none

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
       oraclejdk8
 dependencies:
   override:
-    - echo 'ok!' # skip lein deps since the test commands will install them if needed. No need to spin up Clojure twice
+    - echo "ok." # skip lein deps since the test commands will install them if needed. No need to spin up Clojure twice
 test:
   override:
     - case $CIRCLE_NODE_INDEX in 0) lein eastwood ;; 1) lein test ;; esac:

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
       oraclejdk8
 dependencies:
   override:
-    echo "ok!" ## Nothing, `lein eastwood`/`lein test` will load dependencies as needed so don't waste time booting Clojure twice
+    - echo "ok!" ## Nothing, `lein eastwood`/`lein test` will load dependencies as needed so don't waste time booting Clojure twice
 test:
   override:
     - case $CIRCLE_NODE_INDEX in 0) lein eastwood ;; 1) lein test ;; esac:

--- a/project.clj
+++ b/project.clj
@@ -54,8 +54,8 @@
   :eastwood {:exclude-namespaces [:test-paths]
              :add-linters [:unused-private-vars]
              :exclude-linters [:constant-test]}                       ; korma macros generate some formats with if statements that are always logically true or false
-  :profiles {:dev {:dependencies [[org.clojure/tools.nrepl "0.2.7"]   ; REPL <3
-                                  [expectations "2.0.16"]             ; unit tests
+  :profiles {:dev {:dependencies [[org.clojure/tools.nrepl "0.2.8"]   ; REPL <3
+                                  [expectations "2.1.0"]              ; unit tests
                                   [marginalia "0.8.0"]                ; for documentation
                                   [ring/ring-mock "0.2.0"]]
                    :plugins [[cider/cider-nrepl "0.9.0-SNAPSHOT"]     ; Interactive development w/ cider NREPL in Emacs

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
 (defproject metabase "metabase-0.1.0-SNAPSHOT"
   :description "Metabase Community Edition"
   :url "http://metabase.com/"
-  :min-lein-version "2.3.0"
+  :min-lein-version "2.5.0"
   :aliases {"test" ["with-profile" "+expectations" "expectations"]}
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/core.async "LATEST"]                    ; facilities for async programming + communication (using 'LATEST' because this is an alpha library)
@@ -67,8 +67,6 @@
                    :jvm-opts ["-Dlogfile.path=target/log"
                               "-Xms1024m"                             ; give JVM a decent heap size to start with
                               "-Xmx2048m"                             ; hard limit of 2GB so we stop hitting the 4GB container limit on CircleCI
-                              "-XX:PermSize=64m"                      ; start with a little more PermGen space
-                              "-XX:MaxPermSize=128m"                  ; a little more headroom for PermGen
                               "-XX:+CMSClassUnloadingEnabled"         ; let Clojure's dynamically generated temporary classes be GC'ed from PermGen
                               "-XX:+UseConcMarkSweepGC"]}             ; Concurrent Mark Sweep GC needs to be used for Class Unloading (above)
              :expectations {:resource-paths ["test_resources"]


### PR DESCRIPTION
-  Save about ~10 seconds by disabling inferred `npm install` for the time being since we don't have any web tests.
-  Bump versions for `org.clojure/tools.nrepl` and `expectations` to latest releases
-  Tell CircleCI to use Java 8 instead of 7
-  Bump `min-lein-version` now that circle is using 2.5.1
