### PR TITLE
hydrate 2.0

### DIFF
--- a/src/metabase/api/annotation.clj
+++ b/src/metabase/api/annotation.clj
@@ -35,7 +35,7 @@
         (sel :many Annotation :organization_id org :object_type_id object_model :object_id object_id (korma/order :start :DESC))
         ;; default is to return all annotations
         (sel :many Annotation :organization_id org (korma/order :start :DESC)))
-      (simple-batched-hydrate User :author_id :author)))
+      (hydrate :author)))
 
 
 (defendpoint POST "/" [:as {{:keys [organization start end title body annotation_type object_model object_id]

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -5,7 +5,7 @@
             [medley.core :refer [mapply]]
             [metabase.api.common :refer :all]
             [metabase.db :refer :all]
-            (metabase.models [hydrate :refer [hydrate simple-batched-hydrate]]
+            (metabase.models [hydrate :refer [hydrate]]
                              [card :refer [Card]]
                              [card-favorite :refer [CardFavorite]]
                              [org :refer [Org]]
@@ -25,7 +25,7 @@
                        (hydrate :card))
                    (map :card)
                    (sort-by :name)))
-      (simple-batched-hydrate User :creator_id :creator)))
+      (hydrate :creator)))
 
 (defendpoint POST "/" [:as {{:keys [dataset_query description display name organization public_perms visualization_settings]} :body}]
   {name         [Required NonEmptyString]

--- a/src/metabase/api/meta/db.clj
+++ b/src/metabase/api/meta/db.clj
@@ -8,7 +8,7 @@
             [metabase.db :refer :all]
             [metabase.driver :as driver]
             (metabase.models common
-                             [hydrate :refer [hydrate simple-batched-hydrate]]
+                             [hydrate :refer [hydrate]]
                              [database :refer [Database]]
                              [field :refer [Field]]
                              [org :refer [Org org-can-read org-can-write]]
@@ -22,7 +22,7 @@
   {org Required}
   (read-check Org org)
   (-> (sel :many Database :organization_id org (order :name))
-      (simple-batched-hydrate Org :organization_id :organization)))
+      (hydrate :organization)))
 
 (defendpoint POST "/" [:as {{:keys [org name engine details] :as body} :body}]
   {org     Required
@@ -94,7 +94,7 @@
   (read-check Database id)
   (let [table_ids (sel :many :id Table :db_id id)]
     (-> (sel :many Field :table_id [in table_ids] :special_type "id")
-        (simple-batched-hydrate Table :table_id :table))))
+        (hydrate :table))))
 
 (defendpoint POST "/:id/sync" [id]
   (let-404 [db (sel :one Database :id id)]

--- a/src/metabase/api/meta/table.clj
+++ b/src/metabase/api/meta/table.clj
@@ -19,7 +19,7 @@
   {org Required}
   (let [db-ids (sel :many :id Database :organization_id org)]
     (-> (sel :many Table :db_id [in db-ids] (order :name :ASC))
-        (simple-batched-hydrate Database :db_id :db))))
+        (hydrate :db))))
 
 
 (defendpoint GET "/:id" [id]

--- a/src/metabase/models/hydrate.clj
+++ b/src/metabase/models/hydrate.clj
@@ -2,59 +2,19 @@
   (:require [clojure.data.json :as json]
             [clojure.walk :as walk]
             [metabase.db :refer [sel]]
-            [metabase.util :as util]))
+            [metabase.db.internal :refer [entity->korma]]
+            [metabase.util :as u]))
 
 (declare hydrate
-         hydrate-one
-         hydrate-many
-         hydrate-one-key)
+         hydrate-1)
 
-(defn hydrate
-  "Hydrate a single object or sequence of objects.
-
-  Hydration simply evaluates functions associated with the keys you specify, e.g.
-
-     (hydrate {:a (fn [] 100)} :a) -> {:a 100}
-
-   You can also specify nested keys to do recursive hydration:
-
-     (hydrate {:a (fn [] {:b (fn [] 20)})}
-               [:a :b]) -> {:a {:b 20}}"
-  [object & ks]
-  (apply (if (map? object) hydrate-one
-             hydrate-many)
-         object ks))
-
-(defn- hydrate-one
-  "Hydrate a single object."
-  [object & [first-key & rest-keys]]
-  (let [object (hydrate-one-key object first-key)]
-    (if-not rest-keys object
-            (apply hydrate object rest-keys))))
-
-(defn- hydrate-many
-  "Hydrate a sequence of several objects."
-  [objects & ks]
-  (map #(apply hydrate % ks) objects))
-
-(defn- hydrate-one-key
-  "Hydrate a single key for an object."
-  [object k]
-  (let [[k & sub-keys] (if (vector? k) k [k])
-        hydration-fn (k object)]
-    (if-not hydration-fn object
-            (let [hydrated-val (if (fn? hydration-fn) (hydration-fn)
-                                   (if (delay? hydration-fn) @hydration-fn
-                                       (throw (Exception. (str "Error: hydration-fn for '" k "' is not a function or delay")))))
-                  hydrated-val (if sub-keys (apply hydrate hydrated-val sub-keys)
-                                   hydrated-val)]
-              (assoc object k hydrated-val)))))
+;; ## REALIZE-JSON
 
 (defn- read-json-str-or-clob
   "If STR is a JDBC Clob, convert to a String. Then call `json/read-str`."
   [str]
   (when-let [str (if-not (= (type str) org.h2.jdbc.JdbcClob) str
-                         (util/jdbc-clob->str str))]
+                         (u/jdbc-clob->str str))]
     (json/read-str str)))
 
 (defn realize-json
@@ -70,7 +30,10 @@
         (if (empty? rest-keys) result                                               ; if there are remaining keys recurse to realize those
             (recur result rest-keys)))))
 
-(defn simple-batched-hydrate
+
+;; ## SIMPLE-BATCHED-HYDRATE (DEPRECATED)
+
+(defn- simple-batched-hydrate
   "Similiar in functionality to `hydrate`, but instead aggregates the values of SOURCE-KEY for all RESULTS,
    does a single select, and maps the corresponding objects to DEST-KEY.
 
@@ -87,3 +50,151 @@
                 (let [source-id (result source-key)
                       obj (objs source-id)]
                   (assoc result dest-key obj)))))))
+
+
+;; ## HYDRATE 2.0
+
+;; TODO: this would be nicer if these were instead defined in the entity files
+;; with multimethods for each key?
+;; or for each entity (reflect to "discover" all the metabase entities and then call multimethods)
+(def ^:private hydration-key->entity
+  {:author       'metabase.models.user/User
+   :card         'metabase.models.card/Card
+   :creator      'metabase.models.user/User
+   :database     'metabase.models.database/Database
+   :db           'metabase.models.database/Database
+   :destination  'metabase.models.field/Field
+   :organization 'metabase.models.org/Org
+   :origin       'metabase.models.field/Field
+   :table        'metabase.models.table/Table
+   :user         'metabase.models.user/User
+   :query        'metabase.models.query/Query})
+
+(def ^:private hydration-keys
+  (set (keys hydration-key->entity)))
+
+
+(def ^:private hydration-key->korma
+  (memoize
+   (fn [k]
+     (->> k hydration-key->entity entity->korma))))
+
+(defn- k->k_id [k]
+  (keyword (str (name k) "_id")))
+
+(defn- can-batched-hydrate? [results k]
+  (and (contains? hydration-keys k)
+       (every? (u/rpartial contains? (k->k_id k)) results)))
+
+(defn- valid-hydration-form? [k]
+  (or (keyword? k)
+      (and (sequential? k)
+           (keyword? (first k))
+           (every? valid-hydration-form? (rest k)))))
+
+(defn- simple-hydrate [results k]
+  {:pre [(keyword? k)]}
+  (map (fn [result]
+         (let [v (k result)]
+           (when (fn? v)
+             (throw (Exception. (format "Warning: '%s' is a function. Hydration via functions is deprecated; please use a delay instead. In: %s" k result))))
+           (if-not (delay? v) result      ; if v isn't a delay it's either already hydrated or nil.
+                   (assoc result k @v)))) ; don't barf on nil; just no-op
+       results))
+
+(defn- batched-hydrate [results k]
+  {:pre [(keyword? k)]}
+  (simple-batched-hydrate results (hydration-key->korma k) (k->k_id k) k))
+
+(defn- hydrate-kw [results k]
+  (if (can-batched-hydrate? results k) (batched-hydrate results k)
+      (simple-hydrate results k)))
+
+(defn counts-of
+  "Return a sequence of:
+   -  `(count (k x))` for each item `x` in COLL where `(sequential? (k x))`;
+   -  `:atom` for all values of `(k x)` that are non-nil;
+   -  `:nil`  if `k` is present in `x` but is nil
+   -  `nil`   if `x` is nil.
+
+    (counts-of [{:f [:a :b]}, {:f {:c 1}}, {:f nil}] :f)
+      -> [2 :atom nil]"
+  [coll k]
+  (map (fn [x]
+         (cond
+           (sequential? (k x)) (count (k x))
+           (k x)               :atom
+           (contains? x k)     :nil
+           :else               nil))
+       coll))
+
+(defn counts-flatten [coll k]
+  {:pre [(sequential? coll)
+         (keyword? k)]}
+  (->> coll
+       (map k)
+       (mapcat (fn [x]
+                 (if (sequential? x)  x
+                     [x])))))
+
+(defn counts-unflatten-1 [coll count]
+  (condp = count
+    nil   [nil (rest coll)]
+    :atom [(first coll) (rest coll)]
+    :nil  [:nil (rest coll)]
+    (split-at count coll)))
+
+(defn counts-unflatten
+  ([coll k counts]
+   (counts-unflatten [] coll k counts))
+  ([acc coll k [count & more]]
+   (let [[unflattend coll] (counts-unflatten-1 coll count)
+         acc (conj acc unflattend)]
+     (if-not (seq more) (map (fn [x]
+                               (when x
+                                 {k (when-not (= x :nil) x)}))
+                             acc)
+             (recur acc coll k more)))))
+
+(defn counts-apply [coll k f]
+  (let [counts (counts-of coll k)
+        new-vals (-> coll
+                     (counts-flatten k)
+                     f
+                     (counts-unflatten k counts))]
+    (map merge coll new-vals)))
+
+(defn- hydrate-vector [results [k & more]]
+  (let [results (hydrate results k)]
+    (if-not (seq more) results
+            (counts-apply results k #(apply hydrate % more)))))
+
+(defn- hydrate-1 [results k]
+  (if (keyword? k) (hydrate-kw results k)
+      (hydrate-vector results k)))
+
+(defn- hydrate-many
+  [results k & more]
+  (let [results (hydrate-1 results k)]
+    (if-not (seq more) results
+            (recur results (first more) (rest more)))))
+
+(defn hydrate
+  "Hydrate a single object or sequence of objects.
+
+  Hydration looks for keys like `:user` and fetches values corresponding
+  Hydration simply evaluates functions associated with the keys you specify, e.g.
+
+     (hydrate {:a (fn [] 100)} :a) -> {:a 100}
+
+   You can also specify nested keys to do recursive hydration:
+
+     (hydrate {:a (fn [] {:b (fn [] 20)})}
+               [:a :b]) -> {:a {:b 20}}"
+  [results k & ks]
+  {:pre [(valid-hydration-form? k)
+         (every? valid-hydration-form? ks)]}
+  (when results
+    (if (sequential? results) (if (empty? results) results
+                                  (apply hydrate-many results k ks))
+        (first (apply hydrate-many [results] k ks)))))

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -2,8 +2,7 @@
   (:require [cemerick.friend.credentials :as creds]
             [korma.core :refer :all]
             [metabase.db :refer :all]
-            (metabase.models [hydrate :refer :all]
-                             [org-perm :refer [OrgPerm]])
+            (metabase.models [org-perm :refer [OrgPerm]])
             [metabase.util :as util]))
 
 (defentity User

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -3,10 +3,10 @@
   (:require [clojure.tools.logging :as log]
             [medley.core :refer :all]
             [clj-time.format :as time]
-            [clj-time.coerce :as coerce]))
-  (import  '(java.net Socket)
-           '(java.net InetSocketAddress)
-           '(java.net InetAddress))
+            [clj-time.coerce :as coerce])
+  (:import (java.net Socket
+                     InetSocketAddress
+                     InetAddress)))
 
 (defn contains-many? [m & ks]
   (every? true? (map #(contains? m %) ks)))

--- a/test/metabase/models/hydrate_test.clj
+++ b/test/metabase/models/hydrate_test.clj
@@ -2,44 +2,421 @@
   (:require [expectations :refer :all]
             [metabase.models.hydrate :refer :all]))
 
-(def obj1 {:a 1
-           :b (fn [] 100)})
+(def d1 (delay 1))
+(def d2 (delay 2))
+(def d3 (delay 3))
+(def d4 (delay 4))
+(def d5 (delay 5))
+(def d6 (delay 6))
+
+;; ## TESTS FOR HYDRATION HELPER FNS
+
+;; ### k->k_id
+(def k->k_id (ns-resolve 'metabase.models.hydrate 'k->k_id))
+
+(expect :user_id
+  (k->k_id :user))
+
+(expect :toucan_id
+  (k->k_id :toucan))
+
+;; ### can-batched-hydrate?
+(def can-batched-hydrate? (ns-resolve 'metabase.models.hydrate 'can-batched-hydrate?))
+
+;; should fail for unknown keys
+(expect false
+  (can-batched-hydrate? [{:a_id 1} {:a_id 2}] :a))
+
+;; should work for known keys if k_id present in every map
+(expect true
+  (can-batched-hydrate? [{:user_id 1} {:user_id 2}] :user))
+
+;; should fail for known keys if k_id isn't present in every map
+(expect false
+  (can-batched-hydrate? [{:user_id 1} {:user_id 2} {:x 3}] :user))
+
+;; ### valid-hydration-form?
+(def valid-hydration-form? (ns-resolve 'metabase.models.hydrate 'valid-hydration-form?))
+(expect true  (valid-hydration-form? :k))
+(expect true  (valid-hydration-form? [:k]))
+(expect true  (valid-hydration-form? [:k :k2]))
+(expect true  (valid-hydration-form? [:k [:k2]]))
+(expect true  (valid-hydration-form? [:k [:k2] :k3]))
+(expect true  (valid-hydration-form? [:k [:k2 :k3] :k4]))
+(expect true  (valid-hydration-form? [:k [:k2 [:k3]] :k4]))
+(expect false (valid-hydration-form? 'k))
+(expect false (valid-hydration-form? [[:k]]))
+(expect false (valid-hydration-form? [:k [[:k2]]]))
+(expect false (valid-hydration-form? [:k 'k2]))
+(expect false (valid-hydration-form? ['k :k2]))
+(expect false (valid-hydration-form? "k"))
+
+
+;; ### counts-of
+
+(expect [:atom :atom]
+  (counts-of [{:f d1}
+              {:f d2}]
+             :f))
+
+(expect [2 2]
+  (counts-of [{:f [d1 d2]}
+              {:f [d3 d4]}]
+             :f))
+
+(expect [3 2]
+  (counts-of [{:f [{:g {:i d1}}
+                   {:g {:i d2}}
+                   {:g {:i d3}}]}
+              {:f [{:g {:i d4}}
+                   {:g {:i d5}}]}]
+             :f))
+
+(expect [2 :atom :nil]
+  (counts-of [{:f [:a :b]}
+              {:f {:c 1}}
+              {:f nil}]
+             :f))
+
+(expect [:atom
+         :atom
+         :nil
+         :atom]
+    (counts-of [{:f {:g d1}}
+                {:f {:g d2}}
+                {:f nil}
+                {:f {:g d4}}]
+               :f))
+
+(expect [:atom nil :nil :atom]
+    (counts-of [{:h {:i d1}}
+                {}
+                {:h nil}
+                {:h {:i d3}}]
+               :h))
+
+;; ### counts-flatten
+
+(expect [{:g {:i d1}}
+         {:g {:i d2}}
+         {:g {:i d3}}
+         {:g {:i d4}}
+         {:g {:i d5}}]
+  (counts-flatten [{:f [{:g {:i d1}}
+                        {:g {:i d2}}
+                        {:g {:i d3}}]}
+                   {:f [{:g {:i d4}}
+                        {:g {:i d5}}]}]
+                  :f))
+
+(expect [1 2 nil]
+  (counts-flatten [{:f 1}
+                   {:f 2}
+                   nil]
+                  :f))
+
+(expect [{:g 1} {:g 2} nil {:g 4}]
+  (counts-flatten [{:f {:g 1}}
+                   {:f {:g 2}}
+                   nil
+                   {:f {:g 4}}]
+                  :f))
+
+;; ### counts-unflatten
+
+(expect [{:f [{:g {:i d1}}
+              {:g {:i d2}}
+              {:g {:i d3}}]}
+         {:f [{:g {:i d4}}
+              {:g {:i d5}}]}]
+  (counts-unflatten [{:g {:i d1}}
+                     {:g {:i d2}}
+                     {:g {:i d3}}
+                     {:g {:i d4}}
+                     {:g {:i d5}}] :f [3 2]))
+
+(expect [{:f {:g 1}}
+                   {:f {:g 2}}
+                   nil
+                   {:f {:g 4}}]
+  (counts-unflatten [{:g 1} {:g 2} nil {:g 4}]
+                    :f
+                    [:atom :atom nil :atom]))
+
+;; ### counts-apply
+
+(expect [{:f d1}
+         {:f d2}]
+  (counts-apply [{:f d1}
+                 {:f d2}]
+                :f
+                identity))
+
+(expect [{:f [d1 d2]}
+         {:f [d3 d4]}]
+  (counts-apply [{:f [d1 d2]}
+                 {:f [d3 d4]}]
+                :f
+                identity))
+
+(expect [{:f [{:g {:i d1}}
+              {:g {:i d2}}
+              {:g {:i d3}}]}
+         {:f [{:g {:i d4}}
+              {:g {:i d5}}]}]
+  (counts-apply [{:f [{:g {:i d1}}
+                      {:g {:i d2}}
+                      {:g {:i d3}}]}
+                 {:f [{:g {:i d4}}
+                      {:g {:i d5}}]}]
+                :f
+                identity))
+
+(expect [{:f {:g 1}}
+         {:f {:g 2}}
+         {:f nil}
+         nil
+         {:f {:g 3}}]
+  (counts-apply [{:f {:g 1}}
+                 {:f {:g 2}}
+                 {:f nil}
+                 nil
+                 {:f {:g 3}}]
+                :f
+                identity))
+
+;; ## TESTS FOR HYDRATE INTERNAL FNS
+
+;; ### hydrate-vector (nested hydration)
+(def hydrate-vector (ns-resolve 'metabase.models.hydrate 'hydrate-vector))
+
+;; check with a nested hydration that returns one result
+(expect [{:f {:g 1}}]
+    (hydrate-vector [{:f (delay {:g d1})}]
+                    [:f :g]))
+
+(expect [{:f {:g 1}}
+         {:f {:g 2}}]
+  (hydrate-vector [{:f (delay {:g d1})}
+                   {:f (delay {:g d2})}]
+                  [:f :g]))
+
+;; check with a nested hydration that returns multiple results
+(expect [{:f [{:g 1}
+              {:g 2}
+              {:g 3}]}]
+  (hydrate-vector [{:f (delay [{:g d1}
+                               {:g d2}
+                               {:g d3}])}]
+                  [:f :g]))
+
+;; ### hydrate-kw
+(def hydrate-kw (ns-resolve 'metabase.models.hydrate 'hydrate-kw))
+(expect [{:g 1}
+         {:g 2}
+         {:g 3}]
+    (hydrate-kw [{:g d1}
+                 {:g d2}
+                 {:g d3}] :g))
+
+;; ### batched-hydrate
+
+;; ### hydrate - tests for overall functionality
 
 ;; make sure we can do basic hydration
-(expect {:a 1 :b 100}
-        (hydrate obj1 :b))
+(expect {:a 1 :b 2}
+        (hydrate {:a 1
+                  :b d2}
+                 :b))
 
 ;; specifying "nested" hydration with no "nested" keys should still work
-(expect {:a 1 :b 100}
-        (hydrate obj1 [:b]))
+(expect {:a 1 :b 2}
+        (hydrate {:a 1
+                  :b d2}
+                 [:b]))
 
 ;; check that returning an array works correctly
-(def obj2 {:c (fn [] [1 2 3])})
 (expect {:c [1 2 3]}
-        (hydrate obj2 :c))
-
-
-(defn fn-that-returns-1 [] 1)
-(def obj3 {:d (fn [] {:e fn-that-returns-1})})
+        (hydrate {:c (delay [1 2 3])} :c))
 
 ;; check that nested keys aren't hydrated if we don't ask for it
-(expect {:d {:e fn-that-returns-1}}
-        (hydrate obj3 :d))
+(expect {:d {:e d1}}
+  (hydrate {:d (delay {:e d1})}
+           :d))
 
 ;; check that nested keys can be hydrated if we DO ask for it
 (expect {:d {:e 1}}
-        (hydrate obj3 [:d :e]))
-
-
-(def obj4 {:f (fn [] [{:g (fn [] 1)}
-                     {:g (fn [] 2)}
-                     {:g (fn [] 3)}])})
+  (hydrate {:d (delay {:e d1})}
+           [:d :e]))
 
 ;; check that nested hydration also works if one step returns multiple results
 (expect {:f [{:g 1}
              {:g 2}
              {:g 3}]}
-  (hydrate obj4 [:f :g]))
+  (hydrate {:f (delay [{:g d1}
+                       {:g d2}
+                       {:g d3}])}
+           [:f :g]))
+
+;; check nested hydration with nested maps
+(expect [{:f {:g 1}}
+         {:f {:g 2}}
+         {:f {:g 3}}
+         {:f {:g 4}}]
+  (hydrate [{:f {:g d1}}
+            {:f {:g d2}}
+            {:f {:g d3}}
+            {:f {:g d4}}] [:f :g]))
+
+;; check with a nasty mix of maps and seqs
+(expect [{:f [{:g 1} {:g 2} {:g 3}]}
+         {:f {:g 1}}
+         {:f [{:g 4} {:g 5} {:g 6}]}]
+  (hydrate [{:f [{:g d1}
+                 {:g d2}
+                 {:g d3}]}
+            {:f {:g d1}}
+            {:f [{:g d4}
+                 {:g d5}
+                 {:g d6}]}] [:f :g]))
+
+;; check that hydration works with top-level nil values
+(expect [{:f 1}
+         {:f 2}
+         nil
+         {:f 4}]
+    (hydrate [{:f d1}
+              {:f d2}
+              nil
+              {:f d4}] :f))
+
+;; check nested hydration with top-level nil values
+(expect [{:f {:g 1}}
+         {:f {:g 2}}
+         nil
+         {:f {:g 4}}]
+  (hydrate [{:f {:g d1}}
+            {:f {:g d2}}
+            nil
+            {:f {:g d4}}] [:f :g]))
+
+;; check that nested hydration w/ nested nil values
+(expect [{:f {:g 1}}
+         {:f {:g 2}}
+         {:f nil}
+         {:f {:g 4}}]
+  (hydrate [{:f {:g d1}}
+            {:f {:g d2}}
+            {:f nil}
+            {:f {:g d4}}] [:f :g]))
+
+(expect [{:f {:g 1}}
+         {:f {:g 2}}
+         {:f {:g nil}}
+         {:f {:g 4}}]
+  (hydrate [{:f {:g d1}}
+            {:f {:g d2}}
+            {:f {:g nil}}
+            {:f {:g d4}}] [:f :g]))
+
+;; check that it works with some objects missing the key
+(expect [{:f [{:g 1} {:g 2} {:h d3}]}
+         {:f {:g 1}}
+         {:f [{:g 4} {:h d5} {:g 6}]}]
+    (hydrate [{:f [{:g d1}
+                   {:g d2}
+                   {:h d3}]}
+              {:f  {:g d1}}
+              {:f [{:g d4}
+                   {:h d5}
+                   {:g d6}]}] [:f :g]))
+
+;; check that we can handle wonky results: :f is [sequence, map sequence] respectively
+(expect [{:f [{:g 1, :h 1} {:g 2} {:g 3, :h 3}]}
+         {:f {:g 1, :h 1}}
+         {:f [{:g 4} {:g 5, :h 5} {:g 6}]}]
+  (hydrate [{:f [{:g d1 :h d1}
+                 {:g d2}
+                 {:g d3 :h d3}]}
+            {:f  {:g d1 :h d1}}
+            {:f [{:g d4}
+                 {:g d5 :h d5}
+                 {:g d6}]}] [:f :g :h]))
+
+;; nested-nested hydration
+(expect [{:f [{:g {:i 1}}
+              {:g {:i 2}}
+              {:g {:i 3}}]}
+         {:f [{:g {:i 4}}
+              {:g {:i 5}}]}]
+  (hydrate [{:f [{:g {:i d1}}
+                 {:g {:i d2}}
+                 {:g {:i d3}}]}
+            {:f [{:g {:i d4}}
+                 {:g {:i d5}}]}]
+           [:f [:g :i]]))
+
+;; nested + nested-nested hydration
+(expect [{:f [{:g 1 :h {:i 1}}]}
+         {:f [{:g 2 :h {:i 4}}
+              {:g 3 :h {:i 5}}]}]
+  (hydrate [{:f [{:g d1 :h {:i d1}}]}
+            {:f [{:g d2 :h {:i d4}}
+                 {:g d3 :h {:i d5}}]}]
+           [:f :g [:h :i]]))
+
+;; make sure nested-nested hydration doesn't accidentally return maps where there were none
+(expect {:f [{:h {:i 1}}
+             {}
+             {:h {:i 3}}]}
+  (hydrate {:f [{:h {:i d1}}
+                {}
+                {:h {:i d3}}]}
+           [:f [:h :i]]))
+
+;; check nested hydration with several keys
+(expect [{:f [{:g 1
+               :h {:i 1, :j 1}}]}
+         {:f [{:g 2
+               :h {:i 4, :j 2}}
+              {:g 3
+               :h {:i 5, :j 3}}]}]
+  (hydrate [{:f [{:g d1 :h {:i d1 :j d1}}]}
+            {:f [{:g d2 :h {:i d4 :j d2}}
+                 {:g d3 :h {:i d5 :j d3}}]}]
+           [:f :g [:h :i :j]]))
+
+;; multiple nested-nested hydrations
+(expect [{:f [{:g {:k 1}
+               :h {:i {:j 1}}}]}
+         {:f [{:g {:k 2}
+               :h {:i {:j 2}}}
+              {:g {:k 3}
+               :h {:i {:j 3}}}]}]
+  (hydrate [{:f [{:g {:k d1}
+                  :h (delay {:i {:j d1}})}]}
+            {:f [{:g {:k d2}
+                  :h (delay {:i {:j d2}})}
+                 {:g {:k d3}
+                  :h (delay {:i {:j d3}})}]}]
+           [:f [:g :k] [:h [:i :j]]]))
+
+;; *nasty* nested-nested hydration
+(expect [{:f [{:g 1 :h {:i 1}}
+              {:g 2}
+              {:g 3 :h {:i 3}}]}
+         {:f  {:g 1 :h {:i 1}}}
+         {:f [{:g 4}
+              {:g 5 :h {:i 5}}
+              {:g 6}]}]
+  (hydrate [{:f [{:g d1 :h {:i d1}}
+                 {:g d2}
+                 {:g d3 :h {:i d3}}]}
+            {:f  {:g d1 :h {:i d1}}}
+            {:f [{:g d4}
+                 {:g d5 :h {:i d5}}
+                 {:g d6}]}]
+           [:f :g [:h :i]]))
 
 ;; check that hydration doesn't barf if we ask it to hydrate an object that's not there
 (expect {:f [:a 100]}


### PR DESCRIPTION
new implementation of `hydrate` automatically determines when hydrations
can be batched for most common keys and does so automatically. 

Batched hydration now works recursively (i.e. nested hydration).

Eliminate need for separate `simple-batched-hydrate` function.

Eliminate the need for associating most delays in `post-select`.
