### PR TITLE
fix dataset ordering

### DIFF
--- a/resources/frontend_client/app/admin/datasets/datasets.controllers.js
+++ b/resources/frontend_client/app/admin/datasets/datasets.controllers.js
@@ -66,6 +66,7 @@ AdminDatasetsControllers.controller('AdminDatasetEdit', ['$scope', '$routeParams
         'tableId': $routeParams.tableId
     }, function(result) {
         $scope.table = result;
+        $scope.fields = $scope.table.fields;
         $scope.getIdFields();
         $scope.decorateWithTargets();
     }, function(error) {
@@ -93,7 +94,6 @@ AdminDatasetsControllers.controller('AdminDatasetEdit', ['$scope', '$routeParams
     };
 
     $scope.decorateWithTargets = function() {
-        console.log($scope.table);
         $scope.table.fields.forEach(function(field) {
             if (field.target) {
                 field.target_id = field.target.id;

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -327,6 +327,12 @@
   [symb value :nillable]
   (checkp-with map? symb value "value must be a dictionary."))
 
+(defannotation ArrayOfIntegers
+  "Check that param is an array or Integers (this does *not* cast the param!)"
+  [symb value :nillable]
+  (checkp-with vector? symb value "value must be an array.")
+  (map (fn [v] (checkp-with integer? symb v "array value must be an integer.")) value))
+
 (defannotation NonEmptyString
   "Check that param is a non-empty string (strings that only contain whitespace are considered empty)."
   [symb value :nillable]

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -16,8 +16,8 @@
 
 (defmethod post-select Table [_ {:keys [id db db_id description] :as table}]
   (u/assoc* table
-               :db          (or db (delay (sel :one db/Database :id db_id))) ; Check to see if `:db` is already set. In some cases we add a korma transform fn to `Table`
-               :fields      (delay (sel :many Field :table_id id))           ; and assoc :db if the DB has already been fetched, so we can re-use its DB connections.
+               :db          (or db (delay (sel :one db/Database :id db_id)))
+               :fields      (delay (sel :many Field :table_id id (order :position :ASC) (order :name :ASC)))
                :description (u/jdbc-clob->str description)
                :pk_field    (delay (:id (sel :one :fields [Field :id] :table_id id (where {:special_type "id"}))))
                :can_read    (delay @(:can_read @(:db <>)))

--- a/test/metabase/api/meta/table_test.clj
+++ b/test/metabase/api/meta/table_test.clj
@@ -97,21 +97,7 @@
               :organization_id @org-id
               :description nil})
        :name "CATEGORIES"
-       :fields [(match-$ (sel :one Field :id (field->id :categories :name))
-                  {:description nil
-                   :table_id (table->id :categories)
-                   :special_type nil
-                   :name "NAME"
-                   :updated_at $
-                   :active true
-                   :id $
-                   :field_type "info"
-                   :position 0
-                   :target nil
-                   :preview_display true
-                   :created_at $
-                   :base_type "TextField"})
-                (match-$ (sel :one Field :id (field->id :categories :id))
+       :fields [(match-$ (sel :one Field :id (field->id :categories :id))
                   {:description nil
                    :table_id (table->id :categories)
                    :special_type "id"
@@ -124,7 +110,21 @@
                    :target nil
                    :preview_display true
                    :created_at $
-                   :base_type "BigIntegerField"})]
+                   :base_type "BigIntegerField"})
+                (match-$ (sel :one Field :id (field->id :categories :name))
+                  {:description nil
+                   :table_id (table->id :categories)
+                   :special_type nil
+                   :name "NAME"
+                   :updated_at $
+                   :active true
+                   :id $
+                   :field_type "info"
+                   :position 0
+                   :target nil
+                   :preview_display true
+                   :created_at $
+                   :base_type "TextField"})]
        :rows 75
        :updated_at $
        :entity_name nil

--- a/test/metabase/api/meta/table_test.clj
+++ b/test/metabase/api/meta/table_test.clj
@@ -227,3 +227,20 @@
                                 :db_id $
                                 :created_at $})})})]
   ((user->client :rasta) :get 200 (format "meta/table/%d/fks" (table->id :users))))
+
+
+;; ## POST /api/meta/table/:id/reorder
+(expect-eval-actual-first
+  {:result "success"}
+  (let [categories-id-field (sel :one Field :table_id (table->id :categories) :name "ID")
+        categories-name-field (sel :one Field :table_id (table->id :categories) :name "NAME")
+        api-response ((user->client :rasta) :post 200 (format "meta/table/%d/reorder" (table->id :categories))
+                       {:new_order [(:id categories-name-field) (:id categories-id-field)]})]
+    ;; check the modified values (have to do it here because the api response tells us nothing)
+    (assert (= 0 (:position (sel :one :fields [Field :position] :id (:id categories-name-field)))))
+    (assert (= 1 (:position (sel :one :fields [Field :position] :id (:id categories-id-field)))))
+    ;; put the values back to their previous state
+    (upd Field (:id categories-name-field) :position 0)
+    (upd Field (:id categories-id-field) :position 0)
+    ;; return our origin api response for validation
+    api-response))


### PR DESCRIPTION
- implemented POST /api/meta/table/:id/reorder endpoint
- added unit test for new endpoint
- updated GET /api/meta/table/:id/query_metadata so that the :fields attribute will be ordered by position then name
- small tweak on the frontend to make sure $scope.fields has the right values for the template.
