### PR TITLE
Fix navbar state issues

### DIFF
--- a/resources/frontend_client/app/controllers.js
+++ b/resources/frontend_client/app/controllers.js
@@ -133,15 +133,11 @@ CorvusControllers.controller('Nav', ['$scope', '$routeParams', '$location', 'App
     }
 
     var setNavContext = function(context) {
-        if(context === 'org-admin') {
-            $scope.nav = 'admin';
-        } else if (context === 'setup') {
-            $scope.nav = 'setup';
-        } else if (context === 'site-admin') {
-            $scope.nav = 'superadmin';
-        } else {
-            // this covers 'org', 'auth', and 'unknown' contexts
-            $scope.nav = 'main';
+        switch(context) {
+            case "site-admin": $scope.nav = 'superadmin'; break;
+            case "setup":      $scope.nav = 'setup'; break;
+            case "org-admin":  $scope.nav = 'admin'; break;
+            default:           $scope.nav = 'main';
         }
     }
 

--- a/resources/frontend_client/app/controllers.js
+++ b/resources/frontend_client/app/controllers.js
@@ -123,8 +123,8 @@ CorvusControllers.controller('Unauthorized', ['$scope', '$location', function($s
 }]);
 
 
-CorvusControllers.controller('Nav', ['$scope', '$routeParams', '$location', function($scope, $routeParams, $location) {
-    $scope.nav = 'main';
+CorvusControllers.controller('Nav', ['$scope', '$routeParams', '$location', 'AppState', function($scope, $routeParams, $location, AppState) {
+
     $scope.activeClass = 'is--selected';
 
     $scope.isActive = function (location) {
@@ -132,15 +132,23 @@ CorvusControllers.controller('Nav', ['$scope', '$routeParams', '$location', func
         return active;
     }
 
-    $scope.$on('$routeChangeSuccess', function () {
-        if($routeParams.orgSlug && $location.path().indexOf('admin') > 0) {
+    var setNavContext = function(context) {
+        if(context === 'org-admin') {
             $scope.nav = 'admin';
-        } else if ($location.path().indexOf('setup') > 0) {
+        } else if (context === 'setup') {
             $scope.nav = 'setup';
-        } else if ($location.path().indexOf('superadmin') > 0) {
+        } else if (context === 'site-admin') {
             $scope.nav = 'superadmin';
         } else {
+            // this covers 'org', 'auth', and 'unknown' contexts
             $scope.nav = 'main';
         }
+    }
+
+    $scope.$on('appstate:context-changed', function (event, newAppContext) {
+        setNavContext(newAppContext);
     });
+
+    // initialize our state from the current AppState model, which we expect to have resolved already
+    setNavContext(AppState.model.appContext);
 }]);


### PR DESCRIPTION
underlying problem was that the $scope.on() listener on our NavController doesn't get setup until after the initial view loads some times, so we could get in a state where we never set our navbar the way we wanted on page load.

fixed the issue by:
- moving the app context management into the AppState service so that it's tied to $rootScope.on() and it's guaranteed to initialize at the very beginning of the app lifecycle.
- updated the NavController to use the new AppState code providing an `appContext` to remove the url parsing code and leave that stuff in AppState.
