### PR TITLE
async tasks

### DIFF
--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -10,6 +10,7 @@
             [metabase.models.user :refer [User]]
             [metabase.routes :as routes]
             [metabase.setup :as setup]
+            [metabase.task :as task]
             [ring.adapter.jetty :as ring-jetty]
             (ring.middleware [cookies :refer [wrap-cookies]]
                              [gzip :refer [wrap-gzip]]
@@ -61,9 +62,13 @@
                      setup-url
                      "\n\n"))))
 
+  ;; Now start the task runner
+  (task/start-task-runner!)
+
   (log/info "Metabase Initialization COMPLETE")
   true)
 
+;; TODO - uh, when do we *stop* the task runner ?
 
 ;; ## Jetty (Web) Server
 

--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -1,0 +1,147 @@
+;; -*- comment-column: 60; -*-
+(ns metabase.task
+  (:require [clojure.tools.logging :as log]
+            [metabase.util :as u])
+  (:import java.util.Calendar))
+
+;; # HOOKS
+;; [Just like in Emacs Lisp](http://www.gnu.org/software/emacs/manual/html_node/elisp/Hooks.html) (well, almost) <3
+;;
+;; Define a hook with `defhook`, add functions to it with `add-hook!`, and run those functions later with `run-hook`:
+;;
+;;     (defhook hourly-tasks-hook \"Tasks to run hourly\") ; define a new hook.
+;;     (add-hook! #'hourly-tasks-hook my-fn-to-run-hourly) ; add a function to the hook
+;;     (run-hook #'hourly-tasks-hook :parallel)            ; run the functions associated with a hook
+;;
+;; See the docstrs of these functions below for further discussion.
+;;
+;; ### Robert Hooke
+;; Yes, I known [`robert-hooke`](https://github.com/technomancy/robert-hooke) exists.
+;; This library is actually bascially an implementation of Emacs Lisp [`advice`](http://www.gnu.org/software/emacs/manual/html_node/elisp/Advising-Functions.html),
+;; not `add-hook`. Which is what we want here. Also, the implementation below is only like ~20 LOC so no need to pull in a 3rd-party library IMO.
+;;
+;; ### Differences from Emacs Lisp
+;;
+;;     (defun add-hook (hook function &optional append local)
+;;       ...)
+;;     (add-hook 'my-wacky-hook #'some-fun t t)
+;;
+;; 1.  In Elisp, calling `add-hook` with an undefined hook will just create the hook for you. We're not allowing that here so we can do
+;;     some safety checking.
+;; 2.  You can't define a `buffer-local` hook because there's no such thing in Clojure
+;; 3.  Excution order of *hook functions* here are indeterminate since they're stored in a set
+;; 4.  We can run our *hook functions* in parallel <3
+;;
+(defmacro defhook
+  "Define a new hook.
+
+    (defhook hourly-tasks-hook \"Tasks to run hourly\")
+
+  A hook is simply an atom storing a set of functions that you can run at any time with `run-hook`."
+  [hook-name & [docstr?]]
+  {:arglists '([hook-name docstr?])}
+  `(do (def ~hook-name
+            (atom #{}))
+       (alter-meta! #'~hook-name merge {:doc ~docstr?
+                                        :type ::hook})))
+
+;; TODO Should we require that F be a var so as to avoid duplicate lambdas being added ?
+(defn add-hook!
+  "Add function F to HOOK (hereafter, known as one of HOOK's *hook functions*).
+   Calling `(run-hook #'hook)` at a later time will call this function.
+
+    (add-hook! #'hourly-tasks-hook my-fn-to-run-hourly)
+
+  Note that you are expected to pass the var literal of HOOK; this is so we can check its metadata.
+  Hooks are tagged with `:type -> :metabase.task/hook` which is checked as a precondition so you
+  don't accidentally use this function the wrong way."
+  [hook f]
+  {:pre [(var? hook)
+         (= (:type (meta hook)) ::hook)
+         (fn? f)]}
+  (swap! (var-get hook) conj f))
+
+;; TODO - remove-hook! function
+
+(defn run-hook
+  "Run the *hook functions* associated with HOOK sequentially (by default) or in parallel if `:parallel` is
+   passed as the first arg. All subsequent args will be passed directly to the *hook functions* themselves.
+
+    (run-hook #'hourly-tasks-hook :parallel)
+
+  Like `add-hook!`, you are expected to pass the var literal of HOOK so we can do some safety checks for you."
+  {:arglists '([hook parallel? & args])}
+  [hook & args]
+  {:pre [(var? hook)
+         (= (:type (meta hook)) ::hook)]}
+  (let [[parallel args] (u/optional (partial = :parallel) args)
+        map-fn (if parallel pmap #(dorun (map %1 %2)))]
+    (map-fn (u/rpartial apply args)
+            @(var-get hook))))
+
+
+;; # TASK RUNNER
+;; The task runner is a set of hooks like `hourly-tasks-hook` that get called at certain intervals on a background thread.
+;; Just add functions to these hooks with `add-hook!` and they'll be ran at the appropriate time.
+
+;; ## STANDARD TASK RUNNER HOOKS
+
+(defhook hourly-tasks-hook
+  "Tasks to run hourly.
+   Functions will be passed a single function: the current hour (according to the system calendar) in 24-hour time.
+
+    (defn some-task [hour]
+        do-something ...)
+    (add-hook! #'hourly-tasks-hook some-task) ; now some-task will be called on a background thread every hour")
+
+(defhook nightly-tasks-hook
+  "Tasks to run nightly at midnight (according to the system calendar).
+   Functions will be passed no arguments.")
+
+(def ^:private hourly-task-delay
+  "Number of milliseconds to wait before running hourly tasks a second time around.
+   (Provided here so the unit tests can replace this value so we can actually test the scheduling mechanism)."
+  (* 1000 60 60))
+
+;; TODO: Does it matter whether we run at the top of each hour or just once per hour?
+(defn- run-hourly-tasks
+  "Run the `hourly-tasks-hook` in parallel, then sleep for an hour."
+  []
+  ;; Sleep first, that way we're not trying to run a ton of tasks as soon as Metabase spins up
+  (Thread/sleep hourly-task-delay)
+  (log/info "Running hourly tasks...")
+  (run-hook #'hourly-tasks-hook :parallel (.get (Calendar/getInstance) Calendar/HOUR))
+  (recur))
+
+(defn- run-nightly-tasks
+  "Run the `nightly-tasks-hook` (in parallel).
+   This is acutally just a *hook function* added to the `hourly-tasks-hook`;
+   it just checks whether the system hour is `0`, and, if so, runs the `nightly-tasks-hook`."
+  [hour]
+  (when (= hour 0)
+    (log/info "Running nightly tasks...")
+    (run-hook #'nightly-tasks-hook :parallel)))
+(add-hook! #'hourly-tasks-hook run-nightly-tasks)
+
+(defonce ^:private task-runner
+  (atom nil))
+
+(defn start-task-runner!
+  "Start a background thread that will run tasks on the `hourly-tasks-hook` and `nightly-tasks-hook` every hour / every night, respectively. "
+  []
+  (when-not @task-runner
+    (log/info "Starting task runner...")
+    (reset! task-runner (future (run-hourly-tasks)))))
+
+(defn stop-task-runner!
+  "Stop the task runner."
+  []
+  (when @task-runner
+    (log/info "Stopping task runner...")
+    (future-cancel @task-runner)
+    (reset! task-runner nil)))
+
+;; Now start up the task runner
+
+
+;; TODO -

--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -124,7 +124,6 @@
   []
   (* 1000 60 (minutes-until-next-hour)))
 
-;; TODO: Does it matter whether we run at the top of each hour or just once per hour?
 (defn- run-hourly-tasks
   "Run the `hourly-tasks-hook` in parallel, then sleep for an hour."
   []
@@ -161,8 +160,3 @@
     (log/info "Stopping task runner...")
     (future-cancel @task-runner)
     (reset! task-runner nil)))
-
-;; Now start up the task runner
-
-
-;; TODO -

--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -118,14 +118,14 @@
 
    This is the number of milliseconds until the top of the next hour; e.g., if the test runner is started
    with `(start-task-runner!)` at 8:23 PM, this function will return the number of milliseconds until 9:00 PM,
-   which will be first time we'd want
+   which will be first time we'd want to run the `hourly-task-hook` functions.
 
    (This is provided here so the unit tests can replace this fn so we can test the scheduling mechanism.)"
   []
   (* 1000 60 (minutes-until-next-hour)))
 
 (defn- run-hourly-tasks
-  "Run the `hourly-tasks-hook` in parallel, then sleep for an hour."
+  "Sleep until the top of the next hour, then run the `hourly-tasks-hook` in parallel."
   []
   ;; Sleep first, that way we're not trying to run a ton of tasks as soon as Metabase spins up
   (Thread/sleep (hourly-task-delay))

--- a/test/metabase/task_test.clj
+++ b/test/metabase/task_test.clj
@@ -1,0 +1,92 @@
+(ns metabase.task-test
+  (:require [expectations :refer :all]
+            (metabase [task :refer :all]
+                      [test-setup :refer :all]))
+  (:import java.util.Calendar))
+
+(defhook task-test-hook "Hook for test purposes.")
+
+(def task-test-atom
+  (atom 0))
+
+(defn- inc-task-test-atom []
+  (swap! task-test-atom inc))
+
+(defn- inc-task-test-atom-twice []
+  (swap! task-test-atom (partial + 2)))
+
+;; ## HOOK TESTS
+
+(expect
+    [0  ; (1)
+     1  ; (2)
+     3  ; (3)
+     6  ; (4)
+     9] ; (5)
+  [;; (1) get initial value
+   (do (reset! task-test-atom 0)   ; reset back to 0
+       (run-hook #'task-test-hook)
+       @task-test-atom)
+
+   ;; (2) now add a hook function. Should increment the counter once
+   (do (add-hook! #'task-test-hook inc-task-test-atom)
+       (run-hook #'task-test-hook)
+       @task-test-atom)
+
+   ;; (3) ok, run the hook twice. Should increment counter twice
+   (do (run-hook #'task-test-hook)
+       (run-hook #'task-test-hook)
+       @task-test-atom)
+
+   ;; (4) add another hook function that increments counter twice on each call (for a total of + 3)
+   (do (add-hook! #'task-test-hook inc-task-test-atom-twice)
+       (run-hook #'task-test-hook)
+       @task-test-atom)
+
+   ;; (5) check that we can't add duplicate hooks - should still be just +3
+   (do (add-hook! #'task-test-hook inc-task-test-atom-twice)
+       (run-hook #'task-test-hook)
+       @task-test-atom)])
+
+
+;; ## TASK RUNNER TESTS
+
+(defn- system-hour []
+  (.get (Calendar/getInstance) Calendar/HOUR))
+
+(defn- inc-task-test-atom-by-system-hour [hour]
+  (swap! task-test-atom (partial + (system-hour))))
+
+;; we'll temporarily swap out the `hourly-tasks-hook` functions
+;; so the tests don't cause some crazy database analysis or w/e to start up
+(def ^:private original-hourly-tasks-hook-functions
+  (atom nil))
+(defn- stash-original-hourly-tasks-hook-functions!   [] (reset! original-hourly-tasks-hook-functions @hourly-tasks-hook))
+(defn- restore-original-hourly-tasks-hook-functions! [] (reset! hourly-tasks-hook @original-hourly-tasks-hook-functions))
+
+(expect [0
+         (system-hour)       ; we can also check that the `hourly-tasks-hook` is passing the correct param to its functions
+         (* 3 (system-hour))
+         :ok]
+  (do
+    ;; stop the task runner and set the internal interval to 30 ms.
+    ;; Add `inc-task-test-atom-by-system-hour` to the `hourly-tasks-hook` and restart
+    (stop-task-runner!)
+    (stash-original-hourly-tasks-hook-functions!)
+    (intern 'metabase.task 'hourly-task-delay 30)
+    (add-hook! #'hourly-tasks-hook inc-task-test-atom-by-system-hour)
+    (reset! task-test-atom 0)
+    (start-task-runner!)
+
+    [@task-test-atom       ; should be 0, since not enough time has elaspsed for the hook to be executed
+     (do (Thread/sleep 45)
+         @task-test-atom)  ; should have been called once (~15ms ago)
+     (do (Thread/sleep 60)
+         @task-test-atom)  ; should have been called two more times
+
+     ;; no put things back how we found them
+     (do (stop-task-runner!)
+         (intern 'metabase.task 'hourly-task-delay (* 1000 60 60))
+         (restore-original-hourly-tasks-hook-functions!)
+         (start-task-runner!)
+         :ok)]))

--- a/test/metabase/test_setup.clj
+++ b/test/metabase/test_setup.clj
@@ -5,6 +5,7 @@
             [expectations :refer :all]
             (metabase [core :as core]
                       [db :as db]
+                      [task :as task]
                       [test-data :refer :all])))
 
 (declare clear-test-db)
@@ -29,13 +30,16 @@
   ;; this causes the test data to be loaded
   @test-db
   ;; startup test web server
-  (core/start-jetty))
+  (core/start-jetty)
+  ;; start the task runner
+  (task/start-task-runner!))
 
 
 (defn test-teardown
   {:expectations-options :after-run}
   []
   (log/info "Shutting down Metabase unit test runner")
+  (task/stop-task-runner!)
   (core/stop-jetty))
 
 


### PR DESCRIPTION
Implemented aspect-oriented function hooks [à la Emacs Lisp](http://www.gnu.org/software/emacs/manual/html_node/elisp/Hooks.html) and a background task runner.

``` clojure
(require '[metabase.tasks :refer :all])
(defn vacuum-databases []
  ...)
(add-hook #'nightly-task-hook vacuum-databases)
```

Then start the task runner with:

``` clojure
(start-task-runner!)
```

And _voilà_, `vacuum-databases` will be called once per day at midnight on a background thread.

For you convenience there's also an `hourly-task-hook` for hourly tasks, and it's trivial enough to add others if we need them.
