### PR TITLE
Actual Email Reports

### DIFF
--- a/src/metabase/api/emailreport.clj
+++ b/src/metabase/api/emailreport.clj
@@ -12,7 +12,7 @@
                              [emailreport-executions :refer [EmailReportExecutions]]
                              [org :refer [Org]]
                              [user :refer [users-for-org]])
-            [metabase.tasks.email-report :as report]
+            [metabase.task.email-report :as report]
             [metabase.util :as util]))
 
 (defannotation EmailReportFilterOption [symb value :nillable]

--- a/src/metabase/api/emailreport.clj
+++ b/src/metabase/api/emailreport.clj
@@ -12,6 +12,7 @@
                              [emailreport-executions :refer [EmailReportExecutions]]
                              [org :refer [Org]]
                              [user :refer [users-for-org]])
+            [metabase.tasks.email-report :as report]
             [metabase.util :as util]))
 
 (defannotation EmailReportFilterOption [symb value :nillable]
@@ -100,9 +101,10 @@
   (del EmailReport :id id))
 
 
-;; TODO
-;; (defendpoint POST "/:id" [id]
-;;   {:TODO "TODO"})
+(defendpoint POST "/:id" [id]
+  (read-check EmailReport id)
+  (->> (report/execute-and-send id)
+       (sel :one EmailReportExecutions :id)))
 
 
 (defendpoint GET "/:id/executions" [id]

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -1,0 +1,38 @@
+(ns metabase.email.messages
+  "Convenience functions for sending templated email messages.  Each function here should represent a single email.
+   NOTE: we want to keep this about email formatting, so don't put heavy logic here RE: building data for emails."
+  (:require [hiccup.core :refer [html]]
+            [metabase.email :as email]))
+
+
+;;; ### Public Interface
+
+(defn send-email-report
+  "Format and Send an `EmailReport` email."
+  [subject recipients query-result]
+  {:pre [(string? subject)
+         (vector? recipients)
+         (map? query-result)]}
+  (let [html-header-row (fn [cols]
+                          (into [:tr {:style "background-color: #f4f4f4;"}]
+                            (map (fn [col]
+                                   [:td {:style "text-align: left; padding: 0.5em; border: 1px solid #ddd; font-size: 12px;"} col]) cols)))
+        html-data-row (fn [row]
+                        (into [:tr]
+                          (map (fn [cell]
+                                 ;; TODO - format cell
+                                 ;; {{ cell|default_if_none:"N/A"|floatformat:"-2"|default:cell  }}
+                                 [:td {:style "border: 1px solid #ddd; padding: 0.5em;"} cell]) row)))]
+    (email/send-message
+      subject
+      (into {} (map (fn [email] {email email}) recipients))
+      :html (html [:html
+                   [:head]
+                   [:body {:style "font-family: Helvetica Neue, Helvetica, sans-serif; width: 100%; margin: 0 auto; max-width: 800px; font-size: 12px;"}
+                    [:div {:class "wrapper" :style "padding: 10px; background-color: #ffffff;"}
+                     (into [:table {:style "border: 1px solid #cccccc; width: 100%; border-collapse: collapse;"}]
+                       (vector
+                         ;; table header row
+                         (html-header-row (get-in query-result [:data :columns]))
+                         ;; actual data rows
+                         (map (fn [row] (html-data-row row)) (get-in query-result [:data :rows]))))]]]))))

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -22,17 +22,20 @@
                           (map (fn [cell]
                                  ;; TODO - format cell
                                  ;; {{ cell|default_if_none:"N/A"|floatformat:"-2"|default:cell  }}
-                                 [:td {:style "border: 1px solid #ddd; padding: 0.5em;"} cell]) row)))]
+                                 [:td {:style "border: 1px solid #ddd; padding: 0.5em;"} cell]) row)))
+        message-body (html [:html
+                            [:head]
+                            [:body {:style "font-family: Helvetica Neue, Helvetica, sans-serif; width: 100%; margin: 0 auto; max-width: 800px; font-size: 12px;"}
+                             [:div {:class "wrapper" :style "padding: 10px; background-color: #ffffff;"}
+                              (into [:table {:style "border: 1px solid #cccccc; width: 100%; border-collapse: collapse;"}]
+                                (vector
+                                  ;; table header row
+                                  (html-header-row (get-in query-result [:data :columns]))
+                                  ;; actual data rows
+                                  (map (fn [row] (html-data-row row)) (get-in query-result [:data :rows]))))]]])]
     (email/send-message
       subject
       (into {} (map (fn [email] {email email}) recipients))
-      :html (html [:html
-                   [:head]
-                   [:body {:style "font-family: Helvetica Neue, Helvetica, sans-serif; width: 100%; margin: 0 auto; max-width: 800px; font-size: 12px;"}
-                    [:div {:class "wrapper" :style "padding: 10px; background-color: #ffffff;"}
-                     (into [:table {:style "border: 1px solid #cccccc; width: 100%; border-collapse: collapse;"}]
-                       (vector
-                         ;; table header row
-                         (html-header-row (get-in query-result [:data :columns]))
-                         ;; actual data rows
-                         (map (fn [row] (html-data-row row)) (get-in query-result [:data :rows]))))]]]))))
+      :html message-body)
+    ;; return the message body we sent
+    message-body))

--- a/src/metabase/models/emailreport.clj
+++ b/src/metabase/models/emailreport.clj
@@ -56,6 +56,20 @@
 (defentity EmailReport
   (table :report_emailreport))
 
+(def execution-details-fields [EmailReport
+                               :id
+                               :organization_id
+                               :creator_id
+                               :name
+                               :description
+                               :mode
+                               :public_perms
+                               :version
+                               :dataset_query
+                               :schedule
+                               :created_at
+                               :updated_at
+                               :email_addresses])
 
 (defmethod pre-insert EmailReport [_ {:keys [dataset_query schedule] :as report}]
   (let [defaults {:public_perms perms-none

--- a/src/metabase/models/emailreport.clj
+++ b/src/metabase/models/emailreport.clj
@@ -50,6 +50,12 @@
    {:id "evening" :name "Evening" :realhour 20},
    {:id "midnight" :name "Midnight" :realhour 0}])
 
+(defn time-of-day->realhour
+  "Time-of-day to realhour"
+  [time-of-day]
+  (-> (filter (fn [tod] (= time-of-day (:id tod))) times-of-day)
+      (first)
+      (:realhour)))
 
 ;; ## Entity
 

--- a/src/metabase/models/emailreport.clj
+++ b/src/metabase/models/emailreport.clj
@@ -35,6 +35,10 @@
    {:id (mode->id :disabled), :name (mode->name :disabled)}])
 
 (def days-of-week
+  "Simple `vector` of the days in the week used for reference and lookups.
+
+   NOTE: order is important here!!
+         these indexes match the values from clj-time `day-of-week` function (0 = Sunday, 6 = Saturday)"
   [{:id "sun" :name "Sun"},
    {:id "mon" :name "Mon"},
    {:id "tue" :name "Tue"},

--- a/src/metabase/models/emailreport_executions.clj
+++ b/src/metabase/models/emailreport_executions.clj
@@ -1,5 +1,5 @@
 (ns metabase.models.emailreport-executions
-  (:require [clojure.data.json :as json]
+  (:require [cheshire.core :as json]
             [korma.core :refer :all]
             [metabase.api.common :refer [check]]
             [metabase.db :refer :all]
@@ -21,3 +21,7 @@
     (util/assoc*
       :organization (delay
                       (sel :one Org :id organization_id)))))
+
+(defmethod pre-insert EmailReportExecutions [_ {:keys [details] :as execution}]
+  (assoc execution :details (if (string? details) details
+                                                  (json/encode details))))

--- a/src/metabase/task/email_report.clj
+++ b/src/metabase/task/email_report.clj
@@ -1,4 +1,4 @@
-(ns metabase.tasks.email-report
+(ns metabase.task.email-report
   "Tasks related to running `EmailReports`."
   (:require [clojure.tools.logging :as log]
             [clj-time.core :as time]

--- a/src/metabase/tasks/email_report.clj
+++ b/src/metabase/tasks/email_report.clj
@@ -1,0 +1,73 @@
+(ns metabase.tasks.email-report
+  "Tasks related to running `EmailReports`."
+  (:require [clojure.tools.logging :as log]
+            [korma.core :refer :all]
+            [metabase.db :refer :all]
+            [metabase.driver :as driver]
+            [metabase.email.messages :refer [send-email-report]]
+            (metabase.models [emailreport :refer [EmailReport execution-details-fields]]
+                             [emailreport-executions :refer [EmailReportExecutions]]
+                             [emailreport-recipients :refer [EmailReportRecipients]]
+                             [hydrate :refer :all])
+            [metabase.util :as u]))
+
+
+(declare execute report-fail report-complete)
+
+(defn execute-and-send
+  "Execute and Send an `EmailReport`.  This includes running the data query behind the report, formatting the email,
+   and sending the email to any specified recipients."
+  [report-id]
+  {:pre [(integer? report-id)]}
+  (let [email-report (-> (sel :one :fields execution-details-fields :id report-id)
+                         ;; TODO - this feels heavy handed.  need to check `sel` macro about clob handling
+                         (u/assoc* :description (u/jdbc-clob->str (:description <>))
+                                   :email_addresses (u/jdbc-clob->str (:email_addresses <>))
+                                   :recipients (sel :many :fields ['metabase.models.user/User :id :email]
+                                                 (where {:id [in (subselect EmailReportRecipients
+                                                                   (fields :user_id)
+                                                                   (where {:emailreport_id report-id}))]}))))
+        query-execution (ins EmailReportExecutions
+                          :report_id report-id
+                          :organization_id (:organization_id email-report)
+                          :details email-report
+                          :status "running"
+                          :created_at (u/new-sql-timestamp)
+                          :started_at (u/new-sql-timestamp)
+                          :error ""
+                          :sent_email "")]
+    (log/debug (format "Starting EmailReport Execution: %d" (:id query-execution)))
+    (execute query-execution)
+    (log/debug (format "Finished EmailReport Execution: %d" (:id query-execution)))))
+
+
+(defn- execute
+  "Internal handling of EmailReport sending."
+  [{execution-id :id {:keys [name creator_id dataset_query recipients email_addresses]} :details}]
+  (let [email-subject (str (or name "Your Email Report") " - " (u/now-with-format "MMMM dd, YYYY"))
+        email-recipients (->> (filter identity (map (fn [recip] (:email recip)) recipients))
+                              (into (clojure.string/split email_addresses #","))
+                              (filter u/is-email?)
+                              (into []))
+        email-data (driver/dataset-query dataset_query {:executed_by creator_id
+                                                        :synchronously true})]
+    (if (= :completed (:status email-data))
+      (->> (send-email-report email-subject email-recipients email-data)
+           (report-complete execution-id))
+      (report-fail execution-id (format "dataset_query() failed for email report (%d): %s" execution-id (:error email-data))))))
+
+(defn- report-fail
+  "Record report failure"
+  [execution-id msg]
+  (upd EmailReportExecutions execution-id
+    :status "failed"
+    :error msg
+    :finished_at (u/new-sql-timestamp)))
+
+(defn- report-complete
+  "Record report completion"
+  [execution-id sent-email]
+  (upd EmailReportExecutions execution-id
+    :status "completed"
+    :finished_at (u/new-sql-timestamp)
+    :sent_email (or sent-email "")))

--- a/src/metabase/tasks/email_report.clj
+++ b/src/metabase/tasks/email_report.clj
@@ -27,18 +27,20 @@
                                                  (where {:id [in (subselect EmailReportRecipients
                                                                    (fields :user_id)
                                                                    (where {:emailreport_id report-id}))]}))))
-        query-execution (ins EmailReportExecutions
-                          :report_id report-id
-                          :organization_id (:organization_id email-report)
-                          :details email-report
-                          :status "running"
-                          :created_at (u/new-sql-timestamp)
-                          :started_at (u/new-sql-timestamp)
-                          :error ""
-                          :sent_email "")]
-    (log/debug (format "Starting EmailReport Execution: %d" (:id query-execution)))
-    (execute query-execution)
-    (log/debug (format "Finished EmailReport Execution: %d" (:id query-execution)))))
+        report-execution (ins EmailReportExecutions
+                           :report_id report-id
+                           :organization_id (:organization_id email-report)
+                           :details email-report
+                           :status "running"
+                           :created_at (u/new-sql-timestamp)
+                           :started_at (u/new-sql-timestamp)
+                           :error ""
+                           :sent_email "")]
+    (log/debug (format "Starting EmailReport Execution: %d" (:id report-execution)))
+    (execute report-execution)
+    (log/debug (format "Finished EmailReport Execution: %d" (:id report-execution)))
+    ;; return the id of the report-execution
+    (:id report-execution)))
 
 
 (defn- execute

--- a/src/metabase/tasks/email_report.clj
+++ b/src/metabase/tasks/email_report.clj
@@ -6,22 +6,17 @@
             [metabase.db :refer :all]
             [metabase.driver :as driver]
             [metabase.email.messages :refer [send-email-report]]
-            (metabase.models [emailreport :refer [EmailReport execution-details-fields mode->id time-of-day->realhour]]
+            (metabase.models [emailreport :refer [EmailReport
+                                                  days-of-week
+                                                  execution-details-fields
+                                                  mode->id
+                                                  time-of-day->realhour]]
                              [emailreport-executions :refer [EmailReportExecutions]]
                              [emailreport-recipients :refer [EmailReportRecipients]]
                              [hydrate :refer :all])
             [metabase.task :as task]
             [metabase.util :as u]))
 
-;; order is important here!!  these indexes match the values from clj-times (day-of-week) function
-;; 0 = Sunday, 6 = Saturday
-(def days-of-week ["sun"
-                   "mon"
-                   "tue"
-                   "wed"
-                   "thu"
-                   "fri"
-                   "sat"])
 
 (declare execute-all-reports
          execute-if-scheduled
@@ -48,7 +43,7 @@
   (log/debug "Processing: " id days_of_week time_of_day timezone)
   (let [now (time/to-time-zone (time/now) (time/time-zone-for-id (or timezone "UTC"))) ; NOTE this is in LOCAL timezone
         curr-hour (time/hour now)
-        curr-weekday (get days-of-week (time/day-of-week now))]
+        curr-weekday (:id (get days-of-week (time/day-of-week now)))]
     ;; report schedule should look like:
     ;;   `{:days_of_week {:mon true :tue true :wed false ...} :time_of_day "morning" :timezone "US/Pacific"}`
     (when (and (get days_of_week (keyword curr-weekday))   ; scheduled weekdays include curr-weekday

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -108,6 +108,11 @@
   []
   (time/unparse (time/formatters :date-time) (coerce/from-long (System/currentTimeMillis))))
 
+(defn now-with-format
+  "format the current time using a custom format."
+  [format]
+  (time/unparse (time/formatter format) (coerce/from-long (System/currentTimeMillis))))
+
 (defn jdbc-clob->str
   "Convert a `JdbcClob` to a `String`."
   (^String


### PR DESCRIPTION
EmailReport sending should now work end to end:
- 'metabase.email.messages/send-email-report function handles the logic of formatting and delivering an email report message given appropriate data input.
- 'metabase.tasks.email-report/execute-and-send function deals with the overall process of executing a report, including running the dataset_query, collecting the necessary data for subject & recipients, and tracking the execution.
- 'metabase.tasks.email-report/execute-all-reports function handles the scheduling logic to determine which reports should be run in a given hour and sends them if appropriate.
- hourly task hook adde in 'metabase.tasks.email-report to run `(execute-all-reports)`
- implemented POST /api/emailreport/:id which synchronously executes a given EmailReport immediately.
