### PR TITLE
Execute queries nightly

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,25 +1,28 @@
-((clojure-mode . (eval . (progn
-                           (put 'defhook 'clojure-doc-string-elt 2)
-                           (put 'defsetting 'clojure-doc-string-elt 2)
-                           ;; Define custom indentation for functions inside metabase.
-                           ;; This list isn't complete; add more forms as we come across them.
-                           (define-clojure-indent
-                             (api-let 2)
-                             (auto-parse 1)
-                             (catch-api-exceptions 0)
-                             (check 1)
-                             (context 2)
-                             (execute-query 1)
-                             (expect 1)
-                             (expect-eval-actual-first 1)
-                             (expect-let 1)
-                             (ins 1)
-                             (let-400 1)
-                             (let-404 1)
-                             (let-500 1)
-                             (match 1)
-                             (match-$ 1)
-                             (macrolet 1)
-                             (org-perms-case 1)
-                             (upd 2)
-                             (with-credentials 1))))))
+((clojure-mode . ((eval . (progn
+                            ;; Specify which arg is the docstring for certain macros
+                            ;; (Add more as needed)
+                            (put 'defhook 'clojure-doc-string-elt 2)
+                            (put 'defsetting 'clojure-doc-string-elt 2)
+
+                            ;; Define custom indentation for functions inside metabase.
+                            ;; This list isn't complete; add more forms as we come across them.
+                            (define-clojure-indent
+                              (api-let 2)
+                              (auto-parse 1)
+                              (catch-api-exceptions 0)
+                              (check 1)
+                              (context 2)
+                              (execute-query 1)
+                              (expect 1)
+                              (expect-eval-actual-first 1)
+                              (expect-let 1)
+                              (ins 1)
+                              (let-400 1)
+                              (let-404 1)
+                              (let-500 1)
+                              (match 1)
+                              (match-$ 1)
+                              (macrolet 1)
+                              (org-perms-case 1)
+                              (upd 2)
+                              (with-credentials 1)))))))

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -7,6 +7,7 @@
                               (catch-api-exceptions 0)
                               (check 1)
                               (context 2)
+                              (execute-query 1)
                               (expect 1)
                               (expect-eval-actual-first 1)
                               (expect-let 1)

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,23 +1,25 @@
-((clojure-mode . ((eval . (progn
-                            ;; Define custom indentation for functions inside metabase.
-                            ;; This list isn't complete; add more forms as we come across them.
-                            (define-clojure-indent
-                              (api-let 2)
-                              (auto-parse 1)
-                              (catch-api-exceptions 0)
-                              (check 1)
-                              (context 2)
-                              (execute-query 1)
-                              (expect 1)
-                              (expect-eval-actual-first 1)
-                              (expect-let 1)
-                              (ins 1)
-                              (let-400 1)
-                              (let-404 1)
-                              (let-500 1)
-                              (match 1)
-                              (match-$ 1)
-                              (macrolet 1)
-                              (org-perms-case 1)
-                              (upd 2)
-                              (with-credentials 1)))))))
+((clojure-mode . (eval . (progn
+                           (put 'defhook 'clojure-doc-string-elt 2)
+                           (put 'defsetting 'clojure-doc-string-elt 2)
+                           ;; Define custom indentation for functions inside metabase.
+                           ;; This list isn't complete; add more forms as we come across them.
+                           (define-clojure-indent
+                             (api-let 2)
+                             (auto-parse 1)
+                             (catch-api-exceptions 0)
+                             (check 1)
+                             (context 2)
+                             (execute-query 1)
+                             (expect 1)
+                             (expect-eval-actual-first 1)
+                             (expect-let 1)
+                             (ins 1)
+                             (let-400 1)
+                             (let-404 1)
+                             (let-500 1)
+                             (match 1)
+                             (match-$ 1)
+                             (macrolet 1)
+                             (org-perms-case 1)
+                             (upd 2)
+                             (with-credentials 1))))))

--- a/README.md
+++ b/README.md
@@ -80,8 +80,10 @@ Will give you a list of all tables + fields in the Metabase DB.
 To quickly get your dev environment set up, use the `bootstrap` function to create a new User and Organization.
 Open a REPL in Emacs or with `lein repl` and enter the following:
 
-    (use 'metabase.bootstrap)
-    (bootstrap)
+```clojure
+(use 'metabase.bootstrap)
+(bootstrap)
+```
 
 You'll be walked through the steps to get started.
 
@@ -89,15 +91,31 @@ You'll be walked through the steps to get started.
 
 You can make API calls from the REPL using `metabase.http-client`:
 
-    (use 'metabase.http-client)
-    (defn cl [& args]
-      (-> (apply client {:email "crowberto@metabase.com", :password "blackjet"} args)
-          clojure.pprint/pprint))
-    (cl :get "user/current")
-    ;; -> {:email "crowbetro@metabase.com",
-    ;;     :first_name "Crowbero",
-    ;;     :last_login #inst "2015-03-13T22:55:05.390000000-00:00",
-    ;;     ...}
+```clojure
+(use 'metabase.http-client)
+(defn cl [& args]
+  (-> (apply client {:email "crowberto@metabase.com", :password "blackjet"} args)
+      clojure.pprint/pprint))
+(cl :get "user/current")
+;; -> {:email "crowbetro@metabase.com",
+;;     :first_name "Crowbero",
+;;     :last_login #inst "2015-03-13T22:55:05.390000000-00:00",
+;;     ...}
+```
+
+## Developing with Emacs
+
+`.dir-locals.el` contains some Emacs Lisp that tells `clojure-mode` how to indent Metabase macros and which arguments are docstrings. Whenever this file is updated,
+Emacs will ask you if the code is safe to load. You can answer `!` to save it as safe.
+
+By default, Emacs will insert this code as a customization at the bottom of your `init.el`.
+You'll probably want to tell Emacs to store customizations in a different file. Add the following to your `init.el`:
+
+```emacs-lisp
+(setq custom-file (concat user-emacs-directory ".custom.el")) ; tell Customize to save customizations to ~/.emacs.d/.custom.el
+(ignore-errors                                                ; load customizations from ~/.emacs.d/.custom.el
+  (load-file custom-file))
+```
 
 ## Checking for Out-of-Date Dependencies
 

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -86,8 +86,7 @@
   [query {:keys [executed_by synchronously saved_query]
           :or {synchronously true}
           :as caller-options}]
-  {:pre [(integer? executed_by)
-         (map? saved_query)]}
+  {:pre [(integer? executed_by)]}
   (let [options (merge {:cache_result false} caller-options)
         query-execution {:uuid (.toString (java.util.UUID/randomUUID))
                          :executor_id executed_by

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -82,9 +82,12 @@
      :synchronously [true|false]      (default true)
      :cache_result [true|false]       (default false)
   "
+  {:arglists '([query caller-options])}
   [query {:keys [executed_by synchronously saved_query]
           :or {synchronously true}
           :as caller-options}]
+  {:pre [(integer? executed_by)
+         (map? saved_query)]}
   (let [options (merge {:cache_result false} caller-options)
         query-execution {:uuid (.toString (java.util.UUID/randomUUID))
                          :executor_id executed_by

--- a/src/metabase/models/hydrate.clj
+++ b/src/metabase/models/hydrate.clj
@@ -181,8 +181,7 @@
          results    (map (fn [{dest-obj dest-key :as result}]   ; if there are realized delays for `dest-key`
                            (if (and (delay? dest-obj)          ; in any of the objects replace delay with its value
                                     (realized? dest-obj))
-                             (do (println "HERE!" @dest-obj)
-                                 (assoc result dest-key @dest-obj))
+                             (assoc result dest-key @dest-obj)
                              result))
                          results)
          ids        (->> results

--- a/src/metabase/models/query_execution.clj
+++ b/src/metabase/models/query_execution.clj
@@ -4,10 +4,10 @@
             [metabase.api.common :refer [check]]
             [metabase.db :refer :all]
             (metabase.models [common :refer :all]
-              [hydrate :refer [realize-json]]
-              [user :refer [User]]
-              [database :refer [Database]]
-              [query :refer [Query]])
+                             [hydrate :refer [realize-json]]
+                             [user :refer [User]]
+                             [database :refer [Database]]
+                             [query :refer [Query]])
             [metabase.util :refer :all]))
 
 
@@ -49,14 +49,13 @@
   (assoc query-execution :json_query (if (string? json_query) json_query
                                         (json/write-str json_query))))
 
-(defmethod post-select QueryExecution [_ {:keys [query_id] :as query-execution}]
+(defmethod post-select QueryExecution [_ {:keys [query_id result_rows] :as query-execution}]
   (-> query-execution
-    (assoc :row_count (get query-execution :result_rows 0))  ;; sadly we have 2 ways to reference the row count :(
-    (realize-json :json_query)
-    (realize-json :result_data)
-    (assoc* :query (delay
-                     (check query_id 500 "Can't get execution: QueryExecution doesn't have a :query_id.")
-                     (sel :one Query :id query_id)))))
+    (realize-json :json_query :result_data)
+    (assoc* :row_count (or result_rows 0) ; sadly we have 2 ways to reference the row count :(
+            :query (delay
+                    (check query_id 500 "Can't get execution: QueryExecution doesn't have a :query_id.")
+                    (sel :one Query :id query_id)))))
 
 
 (defn build-response

--- a/src/metabase/task/execute_queries.clj
+++ b/src/metabase/task/execute_queries.clj
@@ -1,8 +1,8 @@
 (ns metabase.task.execute-queries
-  (require (metabase [db :refer :all]
-                     [driver :as driver]
-                     [task :refer :all])
-           [metabase.models.query :refer [Query]]))
+  (:require (metabase [db :refer :all]
+                      [driver :as driver]
+                      [task :refer :all])
+            [metabase.models.query :refer [Query]]))
 
 (defn execute-queries []
   "Execute all `Querys` in the database, one-at-a-time."

--- a/src/metabase/task/execute_queries.clj
+++ b/src/metabase/task/execute_queries.clj
@@ -1,0 +1,24 @@
+(ns metabase.task.execute-queries
+  (require (metabase [db :refer :all]
+                     [driver :as driver]
+                     [task :refer :all])
+           [metabase.models.query :refer [Query]]))
+
+(defn execute-queries []
+  "Execute all `Querys` in the database, one-at-a-time."
+  (->> (sel :many Query)
+       (map (fn [{database-id :database_id
+                 creator-id :creator_id
+                 {:keys [sql timezone]} :details :as query}]
+              (let [dataset-query {:type :native                 ; TODO: this code looks too much like the code in POST /api/query/:id
+                                   :database database-id         ; it would make me happier if there was a nice way to de-duplicate it
+                                   :native {:query sql
+                                            :timezone timezone}}
+                    options {:executed_by creator-id             ; HACK: Technically, creator *isn't* executing this `Query`, but this is a required field
+                             :saved_query query
+                             :synchronously true                 ; probably makes sense to run these one-at-a-time to avoid putting too much stress on the DB
+                             :cache_result true}]
+                (driver/dataset-query dataset-query options))))
+       dorun))
+
+(add-hook! #'nightly-tasks-hook execute-queries)

--- a/src/metabase/task/execute_queries.clj
+++ b/src/metabase/task/execute_queries.clj
@@ -4,8 +4,9 @@
                       [task :refer :all])
             [metabase.models.query :refer [Query]]))
 
-(defn execute-queries []
+(defn execute-queries
   "Execute all `Querys` in the database, one-at-a-time."
+  []
   (->> (sel :many Query)
        (map (fn [{database-id :database_id
                  creator-id :creator_id


### PR DESCRIPTION
-  Automatically load `metabase.task.*` namespaces when starting the task runner. 
-  Add task to execute all queryies on the `nightly-task-hook`
