### PR TITLE
log GET params when logging API call

### DIFF
--- a/src/metabase/api/meta/db.clj
+++ b/src/metabase/api/meta/db.clj
@@ -76,7 +76,8 @@
                             (into {}))
         matching-tables (->> (vals table-id->name)                                                              ; get all Table names that start with PREFIX
                              (filter (fn [^String table-name]
-                                       (= prefix (.substring table-name 0 prefix-len))))
+                                       (and (>= (count table-name) prefix-len)
+                                            (= prefix (.substring table-name 0 prefix-len)))))
                              (map (fn [table-name]                                                               ; return them in the format [table_name "Table"]
                                     [table-name "Table"])))
         fields (->> (sel :many [Field :name :base_type :special_type :table_id]                                 ; get all Fields with names that start with PREFIX

--- a/src/metabase/middleware/log_api_call.clj
+++ b/src/metabase/middleware/log_api_call.clj
@@ -56,8 +56,10 @@
   (and (>= (count uri) 4)
        (= (.substring uri 0 4) "/api")))
 
-(defn- log-request [{:keys [uri request-method body]}]
-  (log/debug (color/blue (format "%s %s " (.toUpperCase (name request-method)) uri)
+(defn- log-request [{:keys [uri request-method body query-string]}]
+  (log/debug (color/blue (format "%s %s " (.toUpperCase (name request-method)) (str uri
+                                                                                    (when-not (empty? query-string)
+                                                                                      (str "?" query-string))))
                          (when (or (string? body) (coll? body))
                            (str "\n" (with-out-str (pprint (scrub-sensitive-fields body))))))))
 


### PR DESCRIPTION
-  log GET params when logging API call
-  fix issue where autocomplete_suggestions would barf if length of autocomplete str > length of table name
