### PR TITLE
Fix People Admin

### DIFF
--- a/resources/frontend_client/app/admin/people/partials/people.html
+++ b/resources/frontend_client/app/admin/people/partials/people.html
@@ -15,6 +15,7 @@
                 <a class="link" cv-org-href="/admin/people/{{perm.user.id}}/modify">{{perm.user.common_name}}</a>
             </h4>
             <span class="User-perms inline-block" ng-if="perm.admin">Admin</span>
+            <span class="User-perms inline-block" ng-if="!perm.admin">Member</span>
         </li>
     </ul>
 </div>

--- a/resources/frontend_client/app/admin/people/partials/user_edit.html
+++ b/resources/frontend_client/app/admin/people/partials/user_edit.html
@@ -21,8 +21,8 @@
                 <div class="py2">
                     <a class="Button" ng-if="user.is_superuser" ng-click="revokeAdmin()">Revoke Admin</a>
                     <a class="Button" ng-if="!user.is_superuser" ng-click="grantAdmin()">Grant Admin</a>
-                    <a class="Button" cv-org-href="/admin/people/{{perm.user.id}}/change_password" >Change password</a>
-                    <a class="Button" ng-click="removeMember(perm.user.id)" delete-confirm>Delete user</a>
+                    <a class="Button" cv-org-href="/admin/people/{{user.id}}/change_password" >Change Password</a>
+                    <a class="Button" ng-click="removeMember(perm.user.id)" delete-confirm>Delete User</a>
                 </div>
             </div>
             <div ng-cloak>

--- a/resources/frontend_client/app/admin/people/partials/user_edit.html
+++ b/resources/frontend_client/app/admin/people/partials/user_edit.html
@@ -19,10 +19,10 @@
                     <input class="input block" ng-model="user.email" type="email" name="email" placeholder="Email address" required>
                 </div>
                 <div class="py2">
-                    <a class="Button" ng-if="user.is_superuser" ng-click="revokeAdmin()">Revoke Admin</a>
-                    <a class="Button" ng-if="!user.is_superuser" ng-click="grantAdmin()">Grant Admin</a>
+                    <a class="Button" ng-if="perm.admin" ng-click="revokeAdmin()">Revoke Admin</a>
+                    <a class="Button" ng-if="!perm.admin" ng-click="grantAdmin()">Grant Admin</a>
                     <a class="Button" cv-org-href="/admin/people/{{user.id}}/change_password" >Change Password</a>
-                    <a class="Button" ng-click="removeMember(perm.user.id)" delete-confirm>Delete User</a>
+                    <a class="Button" ng-click="removeMember(user.id)" delete-confirm>Delete User</a>
                 </div>
             </div>
             <div ng-cloak>

--- a/resources/frontend_client/app/admin/people/partials/user_edit.html
+++ b/resources/frontend_client/app/admin/people/partials/user_edit.html
@@ -4,7 +4,7 @@
     </div>
 
     <div class="bg-white bordered rounded shadowed">
-        <form name="editUserAdmin" novalidate ng-submit="submit()">
+        <form name="editUserAdmin" novalidate ng-submit="submit()" cv-form="uer">
             <div class="p4">
                 <div class="py2">
                     <label class="block mb1" for="first_name">First name:</label>

--- a/resources/frontend_client/app/admin/people/partials/user_password_edit.html
+++ b/resources/frontend_client/app/admin/people/partials/user_password_edit.html
@@ -1,24 +1,29 @@
-<div>
-    <div class="Form-group border-bottom clearfix">
-        <h3 class="text-normal">Change password for {{user.first_name}} {{user.last_name}}</h3>
+<section class="wrapper">
+    <div class="py2">
+        <h2 class="text-normal">Change password for {{user.common_name}}</h2>
     </div>
-    <div ng-cloak>
-        <alert class="alert" ng-repeat="alert in alerts" type="{{alert.type}}" close="closeAlert($index)" ng-animate=" 'animate' " cv-delayed-call="closeAlert($index)">{{alert.msg}}</alert>
-    </div>
-    <form name="editPasswordAdmin" novalidate ng-submit="resetPassword()" cv-form="user">
-    {{errors}}
-        <div class="Form-group" cv-error-flag="password">
-            <input class="input block full" ng-model="password" type="password" name="password" placeholder="New Password" autofocus>
-            <fielderrors for="password">{{errors.password}}</fielderrors>
-        </div>
 
-        <div class="Form-group" cv-error-flag="password_verify">
-            <input class="input block full" ng-model="password_verify" type="password" name="password_verify" placeholder="Verify Password" ng-disabled="!form.password.$dirty">
-            <fielderrors for="password_verify">{{errors.password_verify}}</fielderrors>
-        </div>
-        <div class="Form-group border-top clearfix">
-            <button class="Button Button--primary float-right" type="submit" ng-disabled="!form.$dirty || form.$invalid">Save changes</button>
-            <button class="Button" type="button" ng-click="sendEmail(user)">Send Password Reset E-Mail</button>
-        </div>
-    </form>
-</div>
+    <div class="bg-white bordered rounded shadowed">
+        <form name="editPasswordAdmin" novalidate ng-submit="submit()" cv-form="user">
+            {{errors}}
+            <div class="p4">
+                <div class="Form-group" cv-error-flag="password">
+                    <input class="input block" ng-model="password" type="password" name="password" placeholder="New Password" autofocus>
+                    <fielderrors for="password">{{errors.password}}</fielderrors>
+                </div>
+
+                <div class="Form-group" cv-error-flag="password_verify">
+                    <input class="input block" ng-model="password_verify" type="password" name="password_verify" placeholder="Verify Password" ng-disabled="!form.password.$dirty">
+                    <fielderrors for="password_verify">{{errors.password_verify}}</fielderrors>
+                </div>
+            </div>
+            <div ng-cloak>
+                <alert class="alert" ng-repeat="alert in alerts" type="{{alert.type}}" close="closeAlert($index)" ng-animate=" 'animate' " cv-delayed-call="closeAlert($index)">{{alert.msg}}</alert>
+            </div>
+            <div class="border-top py2 px4 clearfix">
+                <button class="Button Button--primary" type="submit" ng-disabled="!form.$dirty || form.$invalid">Save changes</button>
+                <button class="Button float-right" type="button" ng-click="sendEmail(user)">Send Password Reset E-Mail</button>
+            </div>
+        </form>
+    </div>
+</section>

--- a/resources/frontend_client/app/admin/people/people.controllers.js
+++ b/resources/frontend_client/app/admin/people/people.controllers.js
@@ -25,12 +25,7 @@ PeopleControllers.controller('PeopleList', ['$scope', '$routeParams', 'Organizat
 }]);
 
 
-PeopleControllers.controller('PeopleView', ['$scope', '$routeParams', 'User', 'CorvusAlert', function($scope, $routeParams, User, CorvusAlert) {
-        if ($routeParams.userId) {
-            $scope.user = User.get({userId:$routeParams.userId});
-        }
-        $scope.password = null;
-        $scope.password_verify = null;
+PeopleControllers.controller('PeopleEdit', ['$scope', '$routeParams', 'User', 'CorvusAlert', function($scope, $routeParams, User, CorvusAlert) {
 
         $scope.grantAdmin = function() {
             if ($scope.user) {
@@ -88,36 +83,67 @@ PeopleControllers.controller('PeopleView', ['$scope', '$routeParams', 'User', 'C
             });
         };
 
-        $scope.sendEmail = function(user) {
-            User.send_password_reset_email({
-                userId: user.id
-            }, function(result) {
-                CorvusAlert.alertInfo("password reset E-mail sent to " + user.email);
-            }, function(errorResponse) {
-                console.log("error while sending password reset email:");
-                console.log(errorResponse.data);
-                CorvusAlert.alertError("Error in sending reset E-mail to " + user.email);
-            });
-        };
+    if ($routeParams.userId) {
+        User.get({
+            userId: $routeParams.userId
+        }, function (user) {
+            $scope.user = user;
+        }, function (error) {
+            console.log('error getting user', error);
+        });
+    }
+}]);
 
-        $scope.resetPassword = function(){
-            if($scope.password != $scope.password_verify){
-                CorvusAlert.alertError("Passwords must match!");
-                return;
+
+PeopleControllers.controller('PeopleChangePassword', ['$scope', '$routeParams', 'User', 'CorvusAlert', function($scope, $routeParams, User, CorvusAlert) {
+
+    $scope.sendEmail = function(user) {
+        User.send_password_reset_email({
+            userId: user.id
+        }, function(result) {
+            CorvusAlert.alertInfo("password reset E-mail sent to " + user.email);
+        }, function(errorResponse) {
+            console.log("error while sending password reset email:");
+            console.log(errorResponse.data);
+            CorvusAlert.alertError("Error in sending reset E-mail to " + user.email);
+        });
+    };
+
+    $scope.submit = function() {
+        if($scope.password !== $scope.password_verify) {
+            CorvusAlert.alertError("Passwords must match!");
+            return;
+        }
+
+        User.update_password({
+            id: $scope.user.id,
+            password: $scope.password
+        }, function (result) {
+            CorvusAlert.alertInfo("Updated password!");
+            console.log(result);
+        }, function (error) {
+            // Check for a specific error
+            if(error.status==400 && error.data.password) {
+                var errorText = error.data.password.join('.');
+                CorvusAlert.alertError(errorText);
+
+            } else{
+                CorvusAlert.alertError("Error resetting password");
+                console.log(error);
             }
-            User.update_password({'id': $scope.user.id, 'password': $scope.password}, function(result) {
-                CorvusAlert.alertInfo("Updated password!");
-                console.log(result);
-            }, function(errorResponse) {
-                // Check for a specific error
-                if(errorResponse.status==400 && errorResponse.data.password){
-                    var errorText = errorResponse.data.password.join('.');
-                    CorvusAlert.alertError(errorText);
+        });
+    };
 
-                }else{
-                    CorvusAlert.alertError("Error resetting password");
-                    console.log(errorResponse);
-                }
-            });
-        };
+    $scope.password = null;
+    $scope.password_verify = null;
+
+    if ($routeParams.userId) {
+        User.get({
+            userId: $routeParams.userId
+        }, function (user) {
+            $scope.user = user;
+        }, function (error) {
+            console.log('error getting user', error);
+        });
+    }
 }]);

--- a/resources/frontend_client/app/admin/people/people.controllers.js
+++ b/resources/frontend_client/app/admin/people/people.controllers.js
@@ -25,17 +25,17 @@ PeopleControllers.controller('PeopleList', ['$scope', '$routeParams', 'Organizat
 }]);
 
 
-PeopleControllers.controller('PeopleEdit', ['$scope', '$routeParams', 'User', 'CorvusAlert', function($scope, $routeParams, User, CorvusAlert) {
+PeopleControllers.controller('PeopleEdit', ['$scope', '$routeParams', '$location', 'User', 'Organization', 'CorvusAlert',
+    function($scope, $routeParams, $location, User, Organization, CorvusAlert) {
 
         $scope.grantAdmin = function() {
             if ($scope.user) {
-                console.log('grant');
                 Organization.member_update({
-                    'orgId': $scope.currentOrg.id,
-                    'userId': $scope.people[index].user.id,
-                    'admin': true
+                    orgId: $scope.currentOrg.id,
+                    userId: $scope.user.id,
+                    admin: true
                 }, function (result) {
-                    $scope.people[index].admin = true;
+                    $scope.perm.admin = true;
                 }, function (error) {
                     console.log('error', error);
                     $scope.alertError('failed to grant admin to user');
@@ -46,11 +46,11 @@ PeopleControllers.controller('PeopleEdit', ['$scope', '$routeParams', 'User', 'C
         $scope.revokeAdmin = function() {
             if ($scope.user) {
                 Organization.member_update({
-                    'orgId': $scope.currentOrg.id,
-                    'userId': $scope.people[index].user.id,
-                    'admin': false
-                }, function(result) {
-                    $scope.people[index].admin = false;
+                    orgId: $scope.currentOrg.id,
+                    userId: $scope.user.id,
+                    admin: false
+                }, function (result) {
+                    $scope.perm.admin = false;
                 }, function (error) {
                     console.log('error', error);
                     $scope.alertError('failed to revoke admin from user');
@@ -61,12 +61,10 @@ PeopleControllers.controller('PeopleEdit', ['$scope', '$routeParams', 'User', 'C
         $scope.removeMember = function() {
             if ($scope.user) {
                 Organization.member_remove({
-                    'orgId': $scope.currentOrg.id,
-                    'userId': userId
+                    orgId: $scope.currentOrg.id,
+                    userId: $scope.user.id
                 }, function(result) {
-                    $scope.people = _.filter($scope.people, function(perm){
-                        return perm.user.id != userId;
-                    });
+                    $location.path('/'+$scope.currentOrg.slug+'/admin/people/');
                 }, function (error) {
                     console.log('error', error);
                     $scope.alertError('failed to remove user from org');
@@ -83,16 +81,23 @@ PeopleControllers.controller('PeopleEdit', ['$scope', '$routeParams', 'User', 'C
             });
         };
 
-    if ($routeParams.userId) {
-        User.get({
-            userId: $routeParams.userId
-        }, function (user) {
-            $scope.user = user;
-        }, function (error) {
-            console.log('error getting user', error);
+        $scope.$watch('currentOrg', function (org) {
+            if(!org) return;
+
+            if ($routeParams.userId) {
+                Organization.member_get({
+                    orgId: $scope.currentOrg.id,
+                    userId: $routeParams.userId
+                }, function (perm) {
+                    $scope.perm = perm;
+                    $scope.user = perm.user;
+                }, function (error) {
+                    console.log('error getting user', error);
+                });
+            }
         });
     }
-}]);
+]);
 
 
 PeopleControllers.controller('PeopleChangePassword', ['$scope', '$routeParams', 'User', 'CorvusAlert', function($scope, $routeParams, User, CorvusAlert) {

--- a/resources/frontend_client/app/admin/people/people.controllers.js
+++ b/resources/frontend_client/app/admin/people/people.controllers.js
@@ -73,7 +73,7 @@ PeopleControllers.controller('PeopleEdit', ['$scope', '$routeParams', '$location
         };
 
         $scope.submit = function() {
-            User.update($scope.user, function(result) {
+            User.update($scope.user, function (result) {
                 CorvusAlert.alertInfo("Successfully updated!");
             }, function(errorResponse) {
                 console.log(errorResponse);

--- a/resources/frontend_client/app/admin/people/people.directives.js
+++ b/resources/frontend_client/app/admin/people/people.directives.js
@@ -49,7 +49,7 @@ AdminPeopleDirectives.directive('cvAdminCreateUser', ['$modal', function ($modal
             });
         };
 
-        element.click(openCreateUserAdminModal);
+        element.bind('click', openCreateUserAdminModal);
 
     }
 

--- a/resources/frontend_client/app/admin/people/people.module.js
+++ b/resources/frontend_client/app/admin/people/people.module.js
@@ -13,12 +13,12 @@ Organization.config(['$routeProvider', function ($routeProvider) {
     });
     $routeProvider.when('/:orgSlug/admin/people/:userId/modify', {
         templateUrl: '/app/admin/people/partials/user_edit.html',
-        controller: 'PeopleView'
+        controller: 'PeopleEdit'
     });
 
     $routeProvider.when('/:orgSlug/admin/people/:userId/change_password', {
         templateUrl: '/app/admin/people/partials/user_password_edit.html',
-        controller: 'PeopleView'
+        controller: 'PeopleChangePassword'
     });
 
 }]);

--- a/resources/frontend_client/app/services.js
+++ b/resources/frontend_client/app/services.js
@@ -814,6 +814,14 @@ CoreServices.factory('Organization', ['$resource', '$cookies', function($resourc
                 }
             }
         },
+        member_get: {
+            url: '/api/org/:orgId/members/:userId',
+            method: 'GET',
+            params: {
+                orgId: '@orgId',
+                userId: '@userId'
+            }
+        },
         member_add: {
             url: '/api/org/:orgId/members/:userId',
             method: 'POST',

--- a/src/metabase/api/org.clj
+++ b/src/metabase/api/org.clj
@@ -71,6 +71,13 @@
         (hydrate :user :organization))))
 
 
+(defendpoint GET "/:id/members/:user-id" [id user-id]
+  (read-check Org id)
+  (check-exists? User user-id)
+  (-> (sel :one OrgPerm :user_id user-id :organization_id id)
+      (hydrate :user :organization)))
+
+
 (defendpoint POST "/:id/members/:user-id" [id user-id :as {{:keys [admin]} :body}]
   {admin Boolean}
   (write-check Org id)


### PR DESCRIPTION
- update user details
- grant admin
- revoke admin
- remove user from org

TODO: it's unclear why there is a 'change password' section on org administration.  doesn't seem like a good idea to let admins set passwords for other users if we can avoid it.  simply triggering the password reset process should be good enough to let the user pick their own password.
