### PR TITLE
give defhook defonce semantics so we don't lose any functions when

### DIFF
--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -44,7 +44,7 @@
   A hook is simply an atom storing a set of functions that you can run at any time with `run-hook`."
   [hook-name & [docstr?]]
   {:arglists '([hook-name docstr?])}
-  `(defonce ~(vary-meta hook-name
+  `(defonce ~(vary-meta hook-name assoc
                         :doc docstr?
                         :type ::hook)
      (atom #{})))

--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -44,10 +44,10 @@
   A hook is simply an atom storing a set of functions that you can run at any time with `run-hook`."
   [hook-name & [docstr?]]
   {:arglists '([hook-name docstr?])}
-  `(do (def ~hook-name
-            (atom #{}))
-       (alter-meta! #'~hook-name merge {:doc ~docstr?
-                                        :type ::hook})))
+  `(defonce ~(vary-meta hook-name
+                        :doc docstr?
+                        :type ::hook)
+     (atom #{})))
 
 ;; TODO Should we require that F be a var so as to avoid duplicate lambdas being added ?
 (defn add-hook!


### PR DESCRIPTION
reloading relevant namespace. Cleaner implementation of defhook macro
