### PR TITLE
`defendpoint` accepts optional docstr. 

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,6 +1,8 @@
 ((clojure-mode . ((eval . (progn
                             ;; Specify which arg is the docstring for certain macros
                             ;; (Add more as needed)
+                            (put 'defannotation 'clojure-doc-string-elt 2)
+                            (put 'defendpoint 'clojure-doc-string-elt 3)
                             (put 'defhook 'clojure-doc-string-elt 2)
                             (put 'defsetting 'clojure-doc-string-elt 2)
 

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -17,6 +17,7 @@
                               (execute-query 1)
                               (expect 1)
                               (expect-eval-actual-first 1)
+                              (expect-expansion 0)
                               (expect-let 1)
                               (ins 1)
                               (let-400 1)

--- a/src/metabase/api/annotation.clj
+++ b/src/metabase/api/annotation.clj
@@ -71,7 +71,9 @@
     (hydrate annotation :author)))
 
 
-(defendpoint PUT "/:id" [id :as {{:keys [start end title body]} :body}]
+(defendpoint PUT "/:id"
+  "Update an existing `Annotation`."
+  [id :as {{:keys [start end title body]} :body}]
   {start [Required Date]
    end   [Required Date]
    title [Required NonEmptyString]

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -48,7 +48,7 @@
          (hydrate :can_read :can_write :organization)))
 
 (defendpoint PUT "/:id" [id :as {{:keys [dataset_query description display name public_perms visualization_settings]} :body}]
-  {name         NonEmptyString, public_perms PublicPerms}
+  {name NonEmptyString, public_perms PublicPerms}
   (write-check Card id)
   (check-500 (upd-non-nil-keys Card id
                                :dataset_query dataset_query
@@ -67,10 +67,14 @@
   {:favorite (boolean (some->> *current-user-id*
                                (exists? CardFavorite :card_id id :owner_id)))})
 
-(defendpoint POST "/:card-id/favorite" [card-id]
+(defendpoint POST "/:card-id/favorite"
+  "Favorite a Card."
+  [card-id]
   (ins CardFavorite :card_id card-id :owner_id *current-user-id*))
 
-(defendpoint DELETE "/:card-id/favorite" [card-id]
+(defendpoint DELETE "/:card-id/favorite"
+  "Unfavorite a Card."
+  [card-id]
   (let-404 [{:keys [id] :as card-favorite} (sel :one CardFavorite :card_id card-id :owner_id *current-user-id*)]
     (del CardFavorite :id id)))
 

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -377,7 +377,8 @@
    -  executes BODY inside a `try-catch` block that handles `ApiExceptions`
    -  automatically calls `wrap-response-if-needed` on the result of BODY
    -  tags function's metadata in a way that subsequent calls to `define-routes` (see below)
-      will automatically include the function in the generated `defroutes` form."
+      will automatically include the function in the generated `defroutes` form.
+   -  Generates a super-sophisticated Markdown-formatted docstring"
   {:arglists '([method route docstr? args annotations-map? & body])}
   [method route & more]
   {:pre [(or (string? route)

--- a/test/metabase/api/common_test.clj
+++ b/test/metabase/api/common_test.clj
@@ -142,16 +142,14 @@
 ;; replace regex `#"[0-9]+"` with str `"#[0-9]+" so expectations doesn't barf
 (binding [*auto-parse-types* (update-in *auto-parse-types* [:int :route-param-regex] (partial str "#"))]
   (expect-expansion
-   (do
-     (def GET_:id
-       (GET ["/:id" :id "#[0-9]+"] [id]
-         (metabase.api.common.internal/catch-api-exceptions
-           (metabase.api.common.internal/auto-parse [id]
-             (metabase.api.common.internal/let-annotated-args
-              {id Required}
-              (clojure.core/-> (do (->404 (sel :one Card :id id)))
-                               metabase.api.common.internal/wrap-response-if-needed))))))
-     (clojure.core/alter-meta! #'GET_:id clojure.core/assoc :is-endpoint? true))
-   (defendpoint GET "/:id" [id]
-     {id Required}
-     (->404 (sel :one Card :id id)))))
+    (def GET_:id
+      (GET ["/:id" :id "#[0-9]+"] [id]
+        (metabase.api.common.internal/catch-api-exceptions
+          (metabase.api.common.internal/auto-parse [id]
+            (metabase.api.common.internal/let-annotated-args
+             {id Required}
+             (clojure.core/-> (do (->404 (sel :one Card :id id)))
+                              metabase.api.common.internal/wrap-response-if-needed))))))
+    (defendpoint GET "/:id" [id]
+      {id Required}
+      (->404 (sel :one Card :id id)))))


### PR DESCRIPTION
Automagically generate fancy documentation for all API endpoints based on params + annotations
