### PR TITLE
More dox

### DIFF
--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -1,6 +1,7 @@
 (ns metabase.api.common
   "Dynamic variables and utility functions/macros for writing API functions."
   (:require [clojure.data.json :as json]
+            [clojure.tools.logging :as log]
             [compojure.core :refer [defroutes]]
             [korma.core :refer :all :exclude [update]]
             [medley.core :refer :all]
@@ -249,7 +250,9 @@
 (defmacro defannotation
   "Convenience for defining a new `defendpoint` arg annotation.
 
-    (defannotation Required [symb value]
+    (defannotation Required
+      \"Param must be non-nil.\"
+      [symb value]
       (when-not value
         (throw (ApiException. 400 (format \"'%s' is a required param.\" symb))))
       value)
@@ -275,7 +278,10 @@
 
     (defannotation PublicPerm [symb value :nillable]
       (annotation:Integer symb value]
-      (checkp-contains? #{0 1 2} symb value))"
+      (checkp-contains? #{0 1 2} symb value))
+
+   Try to add a docstr for all annotations. When they exist, they'll be included in the API documentation for
+   all parameters that use them. A good annotation docstr should explain what the valid values for the param are."
   {:arglists '([annotation-name docstr? [symbol-binding value-binding nillable?] & body])}
   [annotation-name & args]
   {:pre [(symbol? annotation-name)]}
@@ -284,6 +290,8 @@
     (assert (symbol? value-binding))
     (assert (or (nil? nillable?)
                 (= nillable? :nillable)))
+    (when-not docstr
+      (log/warn (format "Warning: annotation %s/%s does not have a docstring." (.getName *ns*) annotation-name)))
     (let [fn-name (symbol (str "annotation:" annotation-name))]
       `(do
          (defn ~fn-name ~@(when docstr [docstr]) [~symbol-binding ~value-binding]
@@ -299,7 +307,7 @@
 ;; ### common annotation definitions
 
 (defannotation Required
-  "Throw a 400 if param is `nil`."
+  "Param may not be `nil`."
   [symb value]
   (when-not value
     (throw (ApiException. (int 400) (format "'%s' is a required param." symb))))
@@ -313,60 +321,64 @@
           (catch Throwable _
             (throw (ApiException. (int 400) (format "'%s' is not a valid date." symb))))))
 
-(defannotation String->Integer [symb value :nillable]
+(defannotation String->Integer
+  "Param is converted from a string to an integer."
+  [symb value :nillable]
   (try (Integer/parseInt value)
        (catch java.lang.NumberFormatException _
          (format "Invalid value '%s' for '%s': cannot parse as an integer." value symb))))
 
-(defannotation String->Dict [symb value :nillable]
+(defannotation String->Dict
+  "Param is converted from a JSON string to a dictionary."
+  [symb value :nillable]
   (try (clojure.walk/keywordize-keys (json/read-str value))
        (catch java.lang.Exception _
          (format "Invalid value '%s' for '%s': cannot parse as json." value symb))))
 
 (defannotation Integer
-  "Check that a param is an integer (this does *not* cast the param!)"
+  "Param must be an integer (this does *not* cast the param)."
   [symb value :nillable]
   (checkp-with integer? symb value "value must be an integer."))
 
 (defannotation Boolean
-  "Check that param is a boolean (this does *not* cast the param!)"
+  "Param must be a boolean (this does *not* cast the param)."
   [symb value :nillable]
   (checkp-with boolean? symb value "value must be a boolean."))
 
 (defannotation Dict
-  "Check that param is a dictionary (this does *not* cast the param!)"
+  "Param must be a dictionary (this does *not* cast the param)."
   [symb value :nillable]
   (checkp-with map? symb value "value must be a dictionary."))
 
 (defannotation ArrayOfIntegers
-  "Check that param is an array or Integers (this does *not* cast the param!)"
+  "Param must be an array of integers (this does *not* cast the param)."
   [symb value :nillable]
   (checkp-with vector? symb value "value must be an array.")
   (map (fn [v] (checkp-with integer? symb v "array value must be an integer.")) value))
 
 (defannotation NonEmptyString
-  "Check that param is a non-empty string (strings that only contain whitespace are considered empty)."
+  "Param must be a non-empty string (strings that only contain whitespace are considered empty)."
   [symb value :nillable]
   (checkp-with (complement clojure.string/blank?) symb value "value must be a non-empty string."))
 
 (defannotation PublicPerms
-  "check that perms is `int` in `#{0 1 2}`"
+  "Param must be an integer and either `0` (no public permissions), `1` (public may read), or `2` (public may read and write)."
   [symb value :nillable]
   (annotation:Integer symb value)
   (checkp-contains? #{0 1 2} symb value))
 
 (defannotation Email
-  "Check that param is a valid email address."
+  "Param must be a valid email address."
   [symb value :nillable]
   (checkp-with u/is-email? symb value "Not a valid email address."))
 
 (defannotation ComplexPassword
-  "Check that a password is complex enough."
+  "Param must be a complex password (*what does this mean?*)"
   [symb value]
   (checkp-with password/is-complex? symb value "Insufficient password strength"))
 
 (defannotation FilterOptionAllOrMine
-  "Option must be either 'all' or 'mine'."
+  "Param must be either `all` or `mine`."
   [symb value :nillable]
   (checkp-contains? #{:all :mine} symb (keyword value)))
 
@@ -388,11 +400,13 @@
   [method route & more]
   {:pre [(or (string? route)
              (vector? route))]}
-  (let [name (route-fn-name method route)
-        route (typify-route route)
+  (let [fn-name               (route-fn-name method route)
+        route                  (typify-route route)
         [docstr [args & more]] (u/optional string? more)
+        _                      (when-not docstr
+                                 (log/warn (format "Warning: endpoint %s/%s does not have a docstring." (.getName *ns*) fn-name)))
         [arg-annotations body] (u/optional #(and (map? %) (every? symbol? (keys %))) more)]
-    `(def ~(vary-meta name assoc
+    `(def ~(vary-meta fn-name assoc
                       :doc (route-dox method route docstr args arg-annotations)
                       :is-endpoint? true)
        (~method ~route ~args

--- a/src/metabase/api/dash.clj
+++ b/src/metabase/api/dash.clj
@@ -11,15 +11,22 @@
                              [org :refer [Org]])
             [metabase.util :as u]))
 
-(defendpoint GET "/" [org f]
+(defendpoint GET "/"
+  "Get `Dashboards` for an `Org`. With filter option `f` (default `all`), restrict results as follows:
+
+  *  `all` - Return all `Dashboards` for `Org`.
+  *  `mine` - Return `Dashboards` created by the current user for `Org`."
+  [org f]
   {org Required, f FilterOptionAllOrMine}
   (read-check Org org)
-  (-> (case (or f :all) ; default value for f is `all`
+  (-> (case (or f :all)
         :all  (sel :many Dashboard :organization_id org)
         :mine (sel :many Dashboard :organization_id org :creator_id *current-user-id*))
       (hydrate :creator :organization)))
 
-(defendpoint POST "/" [:as {{:keys [organization name public_perms] :as body} :body}]
+(defendpoint POST "/"
+  "Create a new `Dashboard`."
+  [:as {{:keys [organization name public_perms] :as body} :body}]
   {name         Required
    organization Required
    public_perms Required}
@@ -30,14 +37,17 @@
     :public_perms public_perms
     :creator_id *current-user-id*))
 
-(defendpoint GET "/:id" [id]
+(defendpoint GET "/:id"
+  "Get `Dashboard` with ID."
+  [id]
   (let-404 [db (-> (sel :one Dashboard :id id)
                    (hydrate :creator :organization [:ordered_cards [:card :creator]] :can_read :can_write))]
     {:dashboard db})) ; why is this returned with this {:dashboard} wrapper?
 
-(defendpoint PUT "/:id" [id :as {{:keys [description name public_perms]} :body}]
-  {name         NonEmptyString
-   public_perms PublicPerms}
+(defendpoint PUT "/:id"
+  "Update a `Dashboard`."
+  [id :as {{:keys [description name public_perms]} :body}]
+  {name NonEmptyString, public_perms PublicPerms}
   (write-check Dashboard id)
   (check-500 (upd-non-nil-keys Dashboard id
                                :description description
@@ -45,22 +55,36 @@
                                :public_perms public_perms))
   (sel :one Dashboard :id id))
 
-(defendpoint DELETE "/:id" [id]
+(defendpoint DELETE "/:id"
+  "Delete a `Dashboard`."
+  [id]
   (write-check Dashboard id)
   (del Dashboard :id id))
 
-(defendpoint POST "/:id/cards" [id :as {{:keys [cardId]} :body}]
+(defendpoint POST "/:id/cards"
+  "Add a `Card` to a `Dashboard`."
+  [id :as {{:keys [cardId]} :body}]
   {cardId [Required Integer]}
   (write-check Dashboard id)
   (check-400 (exists? Card :id cardId))
   (ins DashboardCard :card_id cardId :dashboard_id id))
 
-(defendpoint DELETE "/:id/cards" [id dashcardId]
+(defendpoint DELETE "/:id/cards"
+  "Remove a `Card` from a `Dashboard`."
+  [id dashcardId]
   {dashcardId [Required String->Integer]}
   (write-check Dashboard id)
   (del DashboardCard :id dashcardId :dashboard_id id))
 
-(defendpoint POST "/:id/reposition" [id :as {{:keys [cards]} :body}]
+(defendpoint POST "/:id/reposition"
+  "Reposition `Cards` on a `Dashboard`. Request body should have the form:
+
+    {:cards [{:card_id ...
+              :sizeX ...
+              :sizeY ...
+              :row ...
+              :col} ...]}"
+  [id :as {{:keys [cards]} :body}]
   (write-check Dashboard id)
   (dorun (map (fn [{:keys [card_id sizeX sizeY row col]}]
                 (let [{dashcard-id :id} (sel :one [DashboardCard :id] :card_id card_id :dashboard_id id)]

--- a/src/metabase/api/org.clj
+++ b/src/metabase/api/org.clj
@@ -10,15 +10,17 @@
                              [org-perm :refer [OrgPerm grant-org-perm]])
             [metabase.util :as util]))
 
-(defendpoint GET "/" []
+(defendpoint GET "/"
+  "Fetch a list of all `Orgs`. Superusers get all organizations; normal users simpliy see the orgs they are members of."
+  []
   (if (:is_superuser @*current-user*)
-    ;; superusers get all organizations
     (sel :many Org)
-    ;; normal users simply see the orgs they are members of
     (sel :many Org (where {:id [in (subselect OrgPerm (fields :organization_id) (where {:user_id *current-user-id*}))]}))))
 
 
-(defendpoint POST "/" [:as {{:keys [name slug] :as body} :body}]
+(defendpoint POST "/"
+  "Create a new `Org`. You must be a superuser to do this."
+  [:as {{:keys [name slug] :as body} :body}]
   {name [Required NonEmptyString]
    slug [Required NonEmptyString]} ; TODO - check logo_url ?
   (check-superuser)
@@ -27,17 +29,23 @@
     (grant-org-perm id *current-user-id* true) ; now that the Org exists, add the creator as the first admin member
     new-org))                                  ; make sure the api response is still the newly created org
 
-(defendpoint GET "/:id" [id]
+(defendpoint GET "/:id"
+  "Fetch `Org` with ID."
+  [id]
   (->404 (sel :one Org :id id)
          read-check))
 
 
-(defendpoint GET "/slug/:slug" [slug]
+(defendpoint GET "/slug/:slug"
+  "Fetch `Org` with given SLUG."
+  [slug]
   (->404 (sel :one Org :slug slug)
          read-check))
 
 
-(defendpoint PUT "/:id" [id :as {{:keys [name description logo_url]} :body}]
+(defendpoint PUT "/:id"
+  "Update an `Org`."
+  [id :as {{:keys [name description logo_url]} :body}]
   {name NonEmptyString}
   (write-check Org id)
   (check-500 (upd-non-nil-keys Org id
@@ -47,14 +55,18 @@
   (sel :one Org :id id))
 
 
-(defendpoint GET "/:id/members" [id]
+(defendpoint GET "/:id/members"
+  "Get a list of `Users` who are members of (i.e., have `OrgPerms` for) `Org`."
+  [id]
   (read-check Org id)
   (-> (sel :many OrgPerm :organization_id id)
       (hydrate :user)))
 
 
-(defendpoint POST "/:id/members" [id :as {{:keys [first_name last_name email admin]
-                                           :or {admin false}} :body}]
+(defendpoint POST "/:id/members"
+  "Add a `User` to an `Org`. If user already exists, they'll simply be granted `OrgPerms`;
+   otherwise, a new `User` will be created."
+  [id :as {{:keys [first_name last_name email admin] :or {admin false}} :body}]
   {admin      Boolean
    first_name [Required NonEmptyString]
    last_name  [Required NonEmptyString]
@@ -71,14 +83,19 @@
         (hydrate :user :organization))))
 
 
-(defendpoint GET "/:id/members/:user-id" [id user-id]
+(defendpoint GET "/:id/members/:user-id"
+  "Get the `OrgPerm` for `Org` with ID and `User` with USER-ID, if it exists.
+   `User` is returned along with the `OrgPerm`."
+  [id user-id]
   (read-check Org id)
   (check-exists? User user-id)
   (-> (sel :one OrgPerm :user_id user-id :organization_id id)
       (hydrate :user :organization)))
 
 
-(defendpoint POST "/:id/members/:user-id" [id user-id :as {{:keys [admin]} :body}]
+(defendpoint POST "/:id/members/:user-id"
+  "Add an existing `User` to an `Org` (i.e., create an `OrgPerm` for them)."
+  [id user-id :as {{:keys [admin]} :body}]
   {admin Boolean}
   (write-check Org id)
   (check-exists? User user-id)
@@ -87,7 +104,9 @@
 
 ;; TODO `POST` and `PUT` endpoints are exactly the same. Do we need both?
 
-(defendpoint PUT "/:id/members/:user-id" [id user-id :as {{:keys [admin]} :body}]
+(defendpoint PUT "/:id/members/:user-id"
+  "Add an existing `User` to an `Org` (i.e., create an `OrgPerm` for them)."
+  [id user-id :as {{:keys [admin]} :body}]
   {admin Boolean}
   (write-check Org id)
   (check-exists? User user-id)
@@ -95,7 +114,9 @@
   {:success true})
 
 
-(defendpoint DELETE "/:id/members/:user-id" [id user-id :as {body :body}]
+(defendpoint DELETE "/:id/members/:user-id"
+  "Remove a `User` from an `Org` (i.e., delete the `OrgPerm`)"
+  [id user-id :as {body :body}]
   (write-check Org id)
   (check-exists? User user-id)
   (del OrgPerm :user_id user-id :organization_id id))


### PR DESCRIPTION
`defendpoint`/`defannotation` warn at compile time when they're missing a docstr.

Write docstrs for about half of the API.
