### PR TITLE
Send out new user email when accounts are created

### DIFF
--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -2,10 +2,31 @@
   "Convenience functions for sending templated email messages.  Each function here should represent a single email.
    NOTE: we want to keep this about email formatting, so don't put heavy logic here RE: building data for emails."
   (:require [hiccup.core :refer [html]]
-            [metabase.email :as email]))
+            [metabase.email :as email]
+            [metabase.util :as u]))
 
 
 ;;; ### Public Interface
+
+(defn send-new-user-email
+  "Format and Send an welcome email for newly created users."
+  [first_name email password-reset-url]
+  {:pre [(string? first_name)
+         (string? email)
+         (u/is-email? email)
+         (string? password-reset-url)]}
+  (let [message-body (html [:html
+                            [:body
+                             [:p (format "Welcome to Metabase %s!" first_name)]
+                             [:p "Your account is setup and ready to go, you just need to set a password so you can login.  Follow the link below to reset your account password."]
+                             [:p [:a {:href password-reset-url} password-reset-url]]]])]
+    (email/send-message
+      "Your new Metabase account is all set up"
+      {email email}
+      :html message-body)
+    ;; return the message body we sent
+    message-body))
+
 
 (defn send-email-report
   "Format and Send an `EmailReport` email."

--- a/test/metabase/email/messages_test.clj
+++ b/test/metabase/email/messages_test.clj
@@ -1,0 +1,8 @@
+(ns metabase.email.messages-test
+  (:require [expectations :refer :all]
+            [metabase.email.messages :refer :all]))
+
+
+(expect
+  "<html><body><p>Welcome to Metabase test!</p><p>Your account is setup and ready to go, you just need to set a password so you can login.  Follow the link below to reset your account password.</p><p><a href=\"http://localhost/some/url\">http://localhost/some/url</a></p></body></html>"
+  (send-new-user-email "test" "test@test.com" "http://localhost/some/url"))

--- a/test/metabase/email/messages_test.clj
+++ b/test/metabase/email/messages_test.clj
@@ -4,5 +4,8 @@
 
 
 (expect
-  "<html><body><p>Welcome to Metabase test!</p><p>Your account is setup and ready to go, you just need to set a password so you can login.  Follow the link below to reset your account password.</p><p><a href=\"http://localhost/some/url\">http://localhost/some/url</a></p></body></html>"
+  (str "<html><body><p>Welcome to Metabase test!</p>"
+    "<p>Your account is setup and ready to go, you just need to set a password so you can login.  "
+    "Follow the link below to reset your account password.</p>"
+    "<p><a href=\"http://localhost/some/url\">http://localhost/some/url</a></p></body></html>")
   (send-new-user-email "test" "test@test.com" "http://localhost/some/url"))


### PR DESCRIPTION
- new email message function for formatting and sending a welcome email to new users
- when users are created via Org member create then send out the welcome email
