### PR TITLE
Endpoint for notifications from django ETL Server

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -75,6 +75,7 @@
              :expectations {:resource-paths ["test_resources"]
                             :jvm-opts ["-Dmb.db.file=target/metabase-test"
                                        "-Dmb.jetty.join=false"
-                                       "-Dmb.jetty.port=3001"]}
+                                       "-Dmb.jetty.port=3001"
+                                       "-Dmb.api.key=test-api-key"]}
              :uberjar {:aot :all
                        :prep-tasks ["npm" "gulp" "javac" "compile"]}})

--- a/src/metabase/api/notify.clj
+++ b/src/metabase/api/notify.clj
@@ -1,0 +1,24 @@
+(ns metabase.api.notify
+  "/api/notify/* endpoints which receive inbound etl server notifications."
+  (:require [compojure.core :refer [POST]]
+            [metabase.api.common :refer :all]
+            [metabase.db :refer :all]
+            [metabase.driver :as driver]
+            (metabase.models [database :refer [Database]]
+                             [table :refer [Table]])))
+
+
+(defendpoint POST "/db/:id"
+  "Notification about a potential schema change to one of our `Databases`.
+  Caller can optionally specify a `:table_id` or `:table_name` in the body to limit updates to a single `Table`."
+  [id :as {{:keys [table_id table_name] :as body} :body}]
+  (let-404 [database (sel :one Database :id id)]
+    (cond
+      table_id (when-let [table (sel :one Table :database_id id :id (int table_id))]
+                 (future (driver/sync-table table)))
+      table_name (when-let [table (sel :one Table :database_id id :name table_name)]
+                   (future (driver/sync-table table)))
+      :else (future (driver/sync-database database)))))
+
+
+(define-routes)

--- a/src/metabase/api/notify.clj
+++ b/src/metabase/api/notify.clj
@@ -14,11 +14,12 @@
   [id :as {{:keys [table_id table_name] :as body} :body}]
   (let-404 [database (sel :one Database :id id)]
     (cond
-      table_id (when-let [table (sel :one Table :database_id id :id (int table_id))]
+      table_id (when-let [table (sel :one Table :db_id id :id (int table_id))]
                  (future (driver/sync-table table)))
-      table_name (when-let [table (sel :one Table :database_id id :name table_name)]
+      table_name (when-let [table (sel :one Table :db_id id :name table_name)]
                    (future (driver/sync-table table)))
-      :else (future (driver/sync-database database)))))
+      :else (future (driver/sync-database database))))
+  {:success true})
 
 
 (define-routes)

--- a/src/metabase/api/routes.clj
+++ b/src/metabase/api/routes.clj
@@ -5,6 +5,7 @@
                           [card :as card]
                           [dash :as dash]
                           [emailreport :as emailreport]
+                          [notify :as notify]
                           [org :as org]
                           [qs :as qs]
                           [query :as query]
@@ -20,6 +21,12 @@
                                [field :as field]
                                [table :as table])
             [metabase.middleware.auth :as auth]))
+
+(defn- +apikey
+  "Wrap API-ROUTES so they may only be accessed with proper apikey credentials."
+  [api-routes]
+  (-> api-routes
+      auth/enforce-apikey))
 
 (defn- +auth
   "Wrap API-ROUTES so they may only be accessed with proper authentiaction credentials."
@@ -38,6 +45,7 @@
   (context "/meta/db"      [] (+auth db/routes))
   (context "/meta/field"   [] (+auth field/routes))
   (context "/meta/table"   [] (+auth table/routes))
+  (context "/notify"       [] (+apikey notify/routes))
   (context "/org"          [] (+auth org/routes))
   (context "/qs"           [] (+auth qs/routes))
   (context "/query"        [] (+auth query/routes))

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -31,6 +31,7 @@
       wrap-json-response      ; middleware to automatically serialize suitable objects as JSON in responses
       wrap-keyword-params     ; converts string keys in :params to keyword keys
       wrap-params             ; parses GET and POST params as :query-params/:form-params and both as :params
+      auth/wrap-apikey        ; looks for a Metabase API Key on the request and assocs as :metabase-apikey
       auth/wrap-sessionid     ; looks for a Metabase sessionid and assocs as :metabase-sessionid
       wrap-cookies            ; Parses cookies in the request map and assocs as :cookies
       wrap-session            ; reads in current HTTP session and sets :session/key

--- a/test/metabase/api/notify_test.clj
+++ b/test/metabase/api/notify_test.clj
@@ -1,0 +1,27 @@
+(ns metabase.api.notify-test
+  (:require [clj-http.lite.client :as client]
+            [expectations :refer :all]
+            [metabase.http-client :as http]
+            [metabase.middleware.auth :as auth]))
+
+
+;; ## /api/notify/* AUTHENTICATION Tests
+;; We assume that all endpoints for a given context are enforced by the same middleware, so we don't run the same
+;; authentication test on every single individual endpoint
+
+(expect (get auth/response-forbidden :body) (http/client :post 403 "notify/db/100"))
+
+
+;; ## POST /api/notify/db/:id
+;; database must exist or we get a 404
+(expect
+  {:status 404
+   :body "Not found."}
+  (try (client/post (http/build-url "notify/db/100" {}) {:accept :json
+                                                         :headers {"X-METABASE-APIKEY" "test-api-key"}})
+       (catch clojure.lang.ExceptionInfo e
+         (-> (.getData ^clojure.lang.ExceptionInfo e)
+             (:object)
+             (select-keys [:status :body])))))
+
+;; TODO - how can we validate the normal scenario given that it just kicks off a background job?

--- a/test/metabase/http_client.clj
+++ b/test/metabase/http_client.clj
@@ -113,7 +113,7 @@
     (catch Exception e
       (log/error "Failed to authenticate with email:" email "and password:" password ". Does user exist?"))))
 
-(defn- build-url [url url-param-kwargs]
+(defn build-url [url url-param-kwargs]
   {:pre [(string? url)
          (or (nil? url-param-kwargs)
              (map? url-param-kwargs))]}


### PR DESCRIPTION
- new api context for /api/notify/\* which is specifically for handling notifications from our ETL Server
- new middleware and authorization mechanism using a static API Key which only enables access to the /api/notify/\* endpoints.
- server configured API Key is currently set via env variable `:mb-api-key` and matched on request by looking for http header `X-METABASE-APIKEY`
- simple api endpoint which allows caller to run sync-database or sync-table depending on the input
