### PR TITLE
update database listing endpoint to account of org.inherits

### DIFF
--- a/src/metabase/api/meta/db.clj
+++ b/src/metabase/api/meta/db.clj
@@ -26,12 +26,9 @@
   {org Required}
   (let-404 [{:keys [id inherits] :as org} (sel :one Org :id org)]
     (read-check org)
-    (-> (if inherits
-          ;; orgs which `inherit` get access to ALL databases
-          (sel :many Database (order :name))
-          ;; otherwise we filter to just databases attached to the org
-          (sel :many Database :organization_id id (order :name)))
-      (hydrate :organization))))
+    (-> (sel :many Database (order :name) (where (if inherits {}
+                                                              {:organization_id id})))
+        (hydrate :organization))))
 
 (defendpoint POST "/"
   "Add a new `Database` for `Org`."

--- a/src/metabase/api/meta/db.clj
+++ b/src/metabase/api/meta/db.clj
@@ -24,9 +24,14 @@
   "Fetch all `Databases` for an `Org`."
   [org]
   {org Required}
-  (read-check Org org)
-  (-> (sel :many Database :organization_id org (order :name))
-      (hydrate :organization)))
+  (let-404 [{:keys [id inherits] :as org} (sel :one Org :id org)]
+    (read-check org)
+    (-> (if inherits
+          ;; orgs which `inherit` get access to ALL databases
+          (sel :many Database (order :name))
+          ;; otherwise we filter to just databases attached to the org
+          (sel :many Database :organization_id id (order :name)))
+      (hydrate :organization))))
 
 (defendpoint POST "/"
   "Add a new `Database` for `Org`."

--- a/src/metabase/api/meta/db.clj
+++ b/src/metabase/api/meta/db.clj
@@ -26,8 +26,9 @@
   {org Required}
   (let-404 [{:keys [id inherits] :as org} (sel :one Org :id org)]
     (read-check org)
-    (-> (sel :many Database (order :name) (where (if inherits {}
-                                                              {:organization_id id})))
+    (-> (sel :many Database (order :name) (where (if inherits
+                                                   {}
+                                                   {:organization_id id})))
         (hydrate :organization))))
 
 (defendpoint POST "/"


### PR DESCRIPTION
update database listing endpoint so that if the org 'inherits' we return ALL databases in the system rather than just the dbs for the specified organization.
