### PR TITLE
fix 'result' type dataset queries

### DIFF
--- a/test/metabase/driver/result_test.clj
+++ b/test/metabase/driver/result_test.clj
@@ -16,7 +16,7 @@
     (match-$ (sel :one QueryExecution :additional_info addtl-info)
       {:id $
        :uuid $
-       :status "completed"
+       :status :completed
        :row_count 1
        :data {:rows [[100]]
               :columns ["count"]


### PR DESCRIPTION
convert :status of QueryExecution as a keyword.  this fixes a bug in dataset query api endpoint where we were falsly thinking the query failed because we were expecting a keyword instead of a string.
