### PR TITLE
set default order on dashboard 'ordered_cards' to be by :created_at :asc...

### DIFF
--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -24,7 +24,7 @@
       (assoc :creator       (delay (sel :one User :id creator_id))
              :description   (util/jdbc-clob->str description)
              :organization  (delay (sel :one Org :id organization_id))
-             :ordered_cards (delay (sel :many DashboardCard :dashboard_id id)))
+             :ordered_cards (delay (sel :many DashboardCard :dashboard_id id (order :created_at :asc))))
       assoc-permissions-sets))
 
 ; TODO - ordered_cards


### PR DESCRIPTION
... so it matches the django app.  this realistically only affects the card order when no explicit order has been set by repositioning them.
