### PR TITLE
greatest refactor part 2 - eliminate 100 LOC

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -72,7 +72,8 @@
                               "-Xmx2048m"                             ; hard limit of 2GB so we stop hitting the 4GB container limit on CircleCI
                               "-XX:+CMSClassUnloadingEnabled"         ; let Clojure's dynamically generated temporary classes be GC'ed from PermGen
                               "-XX:+UseConcMarkSweepGC"]}             ; Concurrent Mark Sweep GC needs to be used for Class Unloading (above)
-             :expectations {:resource-paths ["test_resources"]
+             :expectations {:injections [(require 'metabase.test-setup)]
+                            :resource-paths ["test_resources"]
                             :jvm-opts ["-Dmb.db.file=target/metabase-test"
                                        "-Dmb.jetty.join=false"
                                        "-Dmb.jetty.port=3001"

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -172,9 +172,6 @@
 ;; TODO - It would be good to allow custom types by just inserting the `{:in fn :out fn}` inline with the
 ;; entity definition
 
-;; TODO - It would be nice to be able to say an entity is "timestamped" and have created_at / updated_at taken
-;; care of automatically
-
 ;; TODO - hydration-keys should be an entity function for the sake of prettiness
 
 

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -178,6 +178,20 @@
 ;; TODO - hydration-keys should be an entity function for the sake of prettiness
 
 
+;; ## TIMESTAMPED
+
+(defn timestamped
+  "Mark ENTITY as having `:created_at` *and* `:updated_at` fields.
+
+    (defentity Card
+      timestamped)
+
+   *  When a new object is created via `ins`, values for both fields will be generated.
+   *  When an object is updated via `upd`, `:updated_at` will be updated."
+  [entity]
+  (assoc entity ::timestamped true))
+
+
 ;; ## UPD
 
 (defmulti pre-update
@@ -214,6 +228,8 @@
                  (pre-update entity)
                  (#(dissoc % :id))
                  (apply-type-fns :in (seq (::types entity))))
+        obj (cond-> obj
+              (::timestamped entity) (assoc :updated_at (u/new-sql-timestamp)))
         result (-> (update entity (set-fields obj) (where {:id entity-id}))
                    (> 0))]
     (when result
@@ -370,6 +386,9 @@
   (let [vals (->> kwargs
                   (pre-insert entity)
                   (apply-type-fns :in (seq (::types entity))))
+        vals (cond-> vals
+               (::timestamped entity) (assoc :created_at (u/new-sql-timestamp)
+                                             :updated_at (u/new-sql-timestamp)))
         {:keys [id]} (-> (insert entity (values vals))
                          (clojure.set/rename-keys {(keyword "scope_identity()") :id}))]
     (->> (sel :one entity :id id)

--- a/src/metabase/models/annotation.clj
+++ b/src/metabase/models/annotation.clj
@@ -3,8 +3,7 @@
             [metabase.db :refer :all]
             (metabase.models [common :refer :all]
                              [org :refer [Org]]
-                             [user :refer [User]])
-            [metabase.util :as util]))
+                             [user :refer [User]])))
 
 
 (def annotation-general 0)

--- a/src/metabase/models/annotation.clj
+++ b/src/metabase/models/annotation.clj
@@ -12,18 +12,8 @@
 
 
 (defentity Annotation
-  (table :annotation_annotation))
-
-
-(defmethod pre-insert Annotation [_ annotation]
-  (let [defaults {:created_at (util/new-sql-timestamp)
-                  :updated_at (util/new-sql-timestamp)}]
-    (merge defaults annotation)))
-
-
-(defmethod pre-update Annotation [_ annotation]
-  (assoc annotation :updated_at (util/new-sql-timestamp)))
-
+  (table :annotation_annotation)
+  timestamped)
 
 (defmethod post-select Annotation [_ {:keys [organization_id author_id] :as annotation}]
   (assoc annotation

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -6,7 +6,7 @@
             (metabase.models [common :refer :all]
                              [org :refer [Org]]
                              [user :refer [User]])
-            [metabase.util :as util]))
+            [metabase.util :as u]))
 
 (def ^:const display-types
   "Valid values of `Card.display_type`."
@@ -26,16 +26,8 @@
   (types {:dataset_query          :json
           :display                :keyword
           :visualization_settings :json})
+  timestamped
   (assoc :hydration-keys #{:card}))
-
-(defmethod pre-insert Card [_ {:keys [display] :as card}]
-  (assert (contains? display-types (keyword display)))
-  (let [defaults {:created_at (util/new-sql-timestamp)
-                  :updated_at (util/new-sql-timestamp)}]
-    (merge defaults card)))
-
-(defmethod pre-update Card [_ {:keys [dataset_query visualization_settings display] :as card}]
-  (assoc card :updated_at (util/new-sql-timestamp)))
 
 (defmethod post-select Card [_ {:keys [organization_id creator_id] :as card}]
   (-> (assoc card

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -5,8 +5,7 @@
             [metabase.db :refer :all]
             (metabase.models [common :refer :all]
                              [org :refer [Org]]
-                             [user :refer [User]])
-            [metabase.util :as u]))
+                             [user :refer [User]])))
 
 (def ^:const display-types
   "Valid values of `Card.display_type`."

--- a/src/metabase/models/card_favorite.clj
+++ b/src/metabase/models/card_favorite.clj
@@ -2,8 +2,7 @@
   (:require [korma.core :refer :all]
             [metabase.db :refer :all]
             (metabase.models [card :refer [Card]]
-                             [user :refer [User]])
-            [metabase.util :refer [new-sql-timestamp]]))
+                             [user :refer [User]])))
 
 (defentity CardFavorite
   (table :report_cardfavorite)

--- a/src/metabase/models/card_favorite.clj
+++ b/src/metabase/models/card_favorite.clj
@@ -6,14 +6,10 @@
             [metabase.util :refer [new-sql-timestamp]]))
 
 (defentity CardFavorite
-  (table :report_cardfavorite))
+  (table :report_cardfavorite)
+  timestamped)
 
 (defmethod post-select CardFavorite [_ {:keys [card_id owner_id] :as card-favorite}]
   (assoc card-favorite
          :owner (delay (sel :one User :id owner_id))
          :card  (delay (sel :one Card :id card_id))))
-
-(defmethod pre-insert CardFavorite [_ card-favorite]
-  (let [defaults {:created_at (new-sql-timestamp)
-                  :updated_at (new-sql-timestamp)}]
-    (merge defaults card-favorite)))

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -8,16 +8,8 @@
             [metabase.util :as util]))
 
 (defentity Dashboard
-  (table :report_dashboard))
-
-(defmethod pre-insert Dashboard [_ dashboard]
-  (let [defaults {:created_at (util/new-sql-timestamp)
-                  :updated_at (util/new-sql-timestamp)}]
-    (merge defaults dashboard)))
-
-(defmethod pre-update Dashboard [_ dashboard]
-  (assoc dashboard
-         :updated_at (util/new-sql-timestamp)))
+  (table :report_dashboard)
+  timestamped)
 
 (defmethod post-select Dashboard [_ {:keys [id creator_id organization_id description] :as dash}]
   (-> dash
@@ -26,5 +18,3 @@
              :organization  (delay (sel :one Org :id organization_id))
              :ordered_cards (delay (sel :many DashboardCard :dashboard_id id (order :created_at :asc))))
       assoc-permissions-sets))
-
-; TODO - ordered_cards

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -5,7 +5,7 @@
                              [dashboard-card :refer [DashboardCard]]
                              [org :refer [Org]]
                              [user :refer [User]])
-            [metabase.util :as util]))
+            [metabase.util :as u]))
 
 (defentity Dashboard
   (table :report_dashboard)
@@ -14,7 +14,7 @@
 (defmethod post-select Dashboard [_ {:keys [id creator_id organization_id description] :as dash}]
   (-> dash
       (assoc :creator       (delay (sel :one User :id creator_id))
-             :description   (util/jdbc-clob->str description)
+             :description   (u/jdbc-clob->str description)
              :organization  (delay (sel :one Org :id organization_id))
              :ordered_cards (delay (sel :many DashboardCard :dashboard_id id (order :created_at :asc))))
       assoc-permissions-sets))

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -5,7 +5,8 @@
             [metabase.util :as util]))
 
 (defentity DashboardCard
-  (table :report_dashboardcard))
+  (table :report_dashboardcard)
+  timestamped)
 
 ;; #### fields:
 ;; *  `id`
@@ -27,12 +28,6 @@
              :dashboard (delay (sel :one 'metabase.models.dashboard/Dashboard :id dashboard_id)))))
 
 (defmethod pre-insert DashboardCard [_ dashcard]
-  (let [defaults {:created_at (util/new-sql-timestamp)
-                  :updated_at (util/new-sql-timestamp)
-                  :sizeX 2
+  (let [defaults {:sizeX 2
                   :sizeY 2}]
     (merge defaults dashcard)))
-
-(defmethod pre-update DashboardCard [_ dashcard]
-  (assoc dashcard
-         :updated_at (util/new-sql-timestamp))) ; is this useful in any way whatsoever???

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -1,8 +1,7 @@
 (ns metabase.models.dashboard-card
   (:require [korma.core :refer :all]
             [metabase.db :refer :all]
-            (metabase.models [card :refer [Card]])
-            [metabase.util :as util]))
+            (metabase.models [card :refer [Card]])))
 
 (defentity DashboardCard
   (table :report_dashboardcard)

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -9,6 +9,7 @@
   (table :metabase_database)
   (types {:details :json
           :engine  :keyword})
+  timestamped
   (assoc :hydration-keys #{:database
                            :db}))
 
@@ -17,14 +18,6 @@
          :organization (delay (sel :one Org :id organization_id))
          :can_read     (delay (org-can-read organization_id))
          :can_write    (delay (org-can-write organization_id))))
-
-(defmethod pre-insert Database [_ {:keys [details engine] :as database}]
-  (assoc database
-         :created_at (u/new-sql-timestamp)
-         :updated_at (u/new-sql-timestamp)))
-
-(defmethod pre-update Database [_ database]
-  (assoc database :updated_at (u/new-sql-timestamp)))
 
 (defmethod pre-cascade-delete Database [_ {:keys [id]}]
   (cascade-delete 'metabase.models.table/Table :db_id id)

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -1,8 +1,7 @@
 (ns metabase.models.database
   (:require [korma.core :refer :all]
             [metabase.db :refer :all]
-            [metabase.models.org :refer [Org org-can-read org-can-write]]
-            [metabase.util :as u]))
+            [metabase.models.org :refer [Org org-can-read org-can-write]]))
 
 
 (defentity Database

--- a/src/metabase/models/emailreport.clj
+++ b/src/metabase/models/emailreport.clj
@@ -65,7 +65,8 @@
 (defentity EmailReport
   (table :report_emailreport)
   (types {:dataset_query :json
-          :schedule      :json}))
+          :schedule      :json})
+  timestamped)
 
 (def execution-details-fields [EmailReport
                                :id
@@ -85,14 +86,8 @@
 (defmethod pre-insert EmailReport [_ report]
   (let [defaults {:public_perms perms-none
                   :mode         (mode->id :active)
-                  :version      1
-                  :created_at   (u/new-sql-timestamp)
-                  :updated_at   (u/new-sql-timestamp)}]
+                  :version      1}]
     (merge defaults report)))
-
-(defmethod pre-update EmailReport [_ report]
-  (assoc report :updated_at (u/new-sql-timestamp))) ; don't increment "version" here, we do that in API endpoint (?)
-
 
 (defmethod post-select EmailReport [_ {:keys [id creator_id organization_id] :as report}]
   (-> (u/assoc* report

--- a/src/metabase/models/emailreport_executions.clj
+++ b/src/metabase/models/emailreport_executions.clj
@@ -1,11 +1,8 @@
 (ns metabase.models.emailreport-executions
   (:require [korma.core :refer :all]
-            [metabase.api.common :refer [check]]
             [metabase.db :refer :all]
-            (metabase.models [common :refer [assoc-permissions-sets perms-none]]
-                             [emailreport-recipients :refer [EmailReportRecipients]]
-                             [org :refer [Org org-can-read org-can-write]]
-                             [user :refer [User]])))
+            (metabase.models [emailreport-recipients :refer [EmailReportRecipients]]
+                             [org :refer [Org]])))
 
 
 (defentity EmailReportExecutions

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -68,6 +68,7 @@
 
 (defentity Field
   (table :metabase_field)
+  timestamped
   (types {:base_type    :keyword
           :field_type   :keyword
           :special_type :keyword})
@@ -103,9 +104,7 @@
             :can_write (delay @(:can_write @(:table <>)))))
 
 (defmethod pre-insert Field [_ field]
-  (let [defaults {:created_at      (u/new-sql-timestamp)
-                  :updated_at      (u/new-sql-timestamp)
-                  :active          true
+  (let [defaults {:active          true
                   :preview_display true
                   :field_type      :info
                   :position        0}]

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -9,6 +9,7 @@
 
 (defentity FieldValues
   (table :metabase_fieldvalues)
+  timestamped
   (types {:human_readable_values :json
           :values                :json}))
 
@@ -22,11 +23,6 @@
 
 (defmethod post-select FieldValues [_ field-values]
   (update-in field-values [:human_readable_values] #(or % {}))) ; return an empty map for :human_readable_values in cases where it is nil
-
-(defmethod pre-insert FieldValues [_ {:keys [values human_readable_values] :as field-values}]
-  (assoc field-values
-         :created_at            (u/new-sql-timestamp)
-         :updated_at            (u/new-sql-timestamp)))
 
 
 ;; ## `FieldValues` Helper Functions

--- a/src/metabase/models/foreign_key.clj
+++ b/src/metabase/models/foreign_key.clj
@@ -1,7 +1,6 @@
 (ns metabase.models.foreign-key
   (:require [korma.core :refer :all]
-            [metabase.db :refer :all]
-            [metabase.util :as util]))
+            [metabase.db :refer :all]))
 
 (def relationships
   "Valid values for `ForeginKey.relationship`."
@@ -15,21 +14,12 @@
    :MtM "Many to Many"})
 
 (defentity ForeignKey
-  (table :metabase_foreignkey))
+  (table :metabase_foreignkey)
+  timestamped
+  (types {:relationship :keyword}))
 
 
 (defmethod post-select ForeignKey [_ {:keys [origin_id destination_id] :as fk}]
-  (util/assoc* fk
-    :origin         (delay (sel :one 'metabase.models.field/Field :id origin_id))
-    :destination    (delay (sel :one 'metabase.models.field/Field :id destination_id))))
-
-
-(defmethod pre-insert ForeignKey [_ {:keys [relationship] :as fk}]
-  (let [defaults {:created_at (util/new-sql-timestamp)
-                  :updated_at (util/new-sql-timestamp)}]
-    (merge defaults fk
-           {:relationship (name relationship)})))
-
-(defmethod pre-update ForeignKey [_ {:keys [relationship] :as fk}]
-  (cond-> (assoc fk :updated_at (util/new-sql-timestamp))
-    relationship (assoc :relationship (name relationship))))
+  (assoc fk
+         :origin      (delay (sel :one 'metabase.models.field/Field :id origin_id))
+         :destination (delay (sel :one 'metabase.models.field/Field :id destination_id))))

--- a/src/metabase/models/org.clj
+++ b/src/metabase/models/org.clj
@@ -14,21 +14,21 @@
   "Does `*current-user*` have read permissions for `Org` with ORG-ID?"
   [org-id]
   (org-perms-case org-id
-    :admin true
+    :admin   true
     :default true
-    nil false))
+    nil      false))
 
 (defn org-can-write
   "Does `*current-user*` have write permissions for `Org` with ORG-ID?"
   [org-id]
   (org-perms-case org-id
-    :admin true
+    :admin   true
     :default false
-    nil false))
+    nil      false))
 
 (defmethod post-select Org [_ {:keys [id] :as org}]
   (assoc org
-         :can_read (delay (org-can-read id))
+         :can_read  (delay (org-can-read id))
          :can_write (delay (org-can-write id))))
 
 (defmethod pre-insert Org [_ org]

--- a/src/metabase/models/org_perm.clj
+++ b/src/metabase/models/org_perm.clj
@@ -9,7 +9,7 @@
 
 (defmethod post-select OrgPerm [_ {:keys [organization_id user_id] :as org-perm}]
   (assoc org-perm
-         :organization (delay (sel :one 'metabase.models.org/Org :id organization_id))
+         :organization (delay (sel :one 'metabase.models.org/Org   :id organization_id))
          :user         (delay (sel :one 'metabase.models.user/User :id user_id))))
 
 

--- a/src/metabase/models/query.clj
+++ b/src/metabase/models/query.clj
@@ -5,12 +5,13 @@
             (metabase.models [common :refer :all]
                              [user :refer [User]]
                              [database :refer [Database]])
-            [metabase.util :refer :all]))
+            [metabase.util :as u]))
 
 
 (defentity Query
   (table :query_query)
   (types {:details :json})
+  timestamped
   (assoc :hydration-keys #{:query}))
 
 
@@ -28,24 +29,21 @@
    :database_id])
 
 (defmethod pre-insert Query [_ query]
-  (let [defaults {:created_at (new-sql-timestamp)
-                  :updated_at (new-sql-timestamp)
-                  :version 1}]
+  (let [defaults {:version 1}]
     (merge defaults query)))
 
 (defmethod pre-update Query [_ {:keys [version] :as query}]
   (-> query
-      (select-non-nil-keys :name :database_id :public_perms)
-      (assoc :updated_at (new-sql-timestamp)
-             :version (+ 1 version))))
+      (u/select-non-nil-keys :name :database_id :public_perms)
+      (assoc :version (+ 1 version))))
 
 (defmethod post-select Query [_ {:keys [creator_id database_id] :as query}]
   (-> query
-      (assoc* :creator         (delay (check creator_id 500 "Can't get creator: Query doesn't have a :creator_id.")
-                                      (sel :one User :id creator_id))
-              :database        (delay (check database_id 500 "Can't get database: Query doesn't have a :database_id.")
-                                      (sel :one Database :id database_id))
-              :organization_id (delay (:organization_id @(:database <>))))
+      (u/assoc* :creator         (delay (check creator_id 500 "Can't get creator: Query doesn't have a :creator_id.")
+                                        (sel :one User :id creator_id))
+                :database        (delay (check database_id 500 "Can't get database: Query doesn't have a :database_id.")
+                                        (sel :one Database :id database_id))
+                :organization_id (delay (:organization_id @(:database <>))))
       assoc-permissions-sets))
 
 (defmethod pre-cascade-delete Query [_ {:keys [id]}]

--- a/src/metabase/models/query_execution.clj
+++ b/src/metabase/models/query_execution.clj
@@ -3,7 +3,6 @@
             [metabase.api.common :refer [check]]
             [metabase.db :refer :all]
             (metabase.models [common :refer :all]
-                             [user :refer [User]]
                              [database :refer [Database]]
                              [query :refer [Query]])))
 

--- a/src/metabase/models/session.clj
+++ b/src/metabase/models/session.clj
@@ -3,13 +3,12 @@
             [metabase.db :refer :all]
             (metabase.models [common :refer :all]
                              [user :refer [User]])
-            [metabase.util :as util]))
+            [metabase.util :as u]))
 
 (defentity Session
   (table :core_session)
   (belongs-to User {:fk :user_id}))
 
-
 (defmethod pre-insert Session [_ session]
-  (let [defaults {:created_at (util/new-sql-timestamp)}]
+  (let [defaults {:created_at (u/new-sql-timestamp)}]
     (merge defaults session)))

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -11,6 +11,8 @@
 
 (defentity Table
   (table :metabase_table)
+  timestamped
+  (types {:entity_type :keyword})
   (assoc :hydration-keys #{:table}))
 
 
@@ -23,15 +25,6 @@
                :can_read    (delay @(:can_read @(:db <>)))
                :can_write   (delay @(:can_write @(:db <>)))))
 
-(defmethod pre-insert Table [_ {:keys [entity_type] :as table}]
-  (assoc table
-         :entity_type (when entity_type (name entity_type))
-         :created_at  (u/new-sql-timestamp)
-         :updated_at  (u/new-sql-timestamp)))
-
-(defmethod pre-update Table [_ {:keys [entity_type] :as table}]
-  (cond-> (assoc table :updated_at (u/new-sql-timestamp))
-    entity_type (assoc :entity_type (name entity_type))))
 
 (defmethod pre-cascade-delete Table [_ {:keys [id] :as table}]
   (cascade-delete Field :table_id id))

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -4,7 +4,7 @@
             [metabase.db :refer :all]
             [metabase.email.messages :as email]
             (metabase.models [org-perm :refer [OrgPerm]])
-            [metabase.util :as util]))
+            [metabase.util :as u]))
 
 ;; ## Enity + DB Multimethods
 
@@ -48,14 +48,14 @@
              :common_name   (str (:first_name user) " " (:last_name user)))))
 
 (defmethod pre-insert User [_ {:keys [email password] :as user}]
-  (assert (util/is-email? email))
+  (assert (u/is-email? email))
   (assert (and (string? password)
                (not (clojure.string/blank? password))))
   (assert (not (:password_salt user))
           "Don't try to pass an encrypted password to (ins User). Password encryption is handled by pre-insert.")
   (let [salt (.toString (java.util.UUID/randomUUID))
-        defaults {:date_joined (util/new-sql-timestamp)
-                  :last_login (util/new-sql-timestamp)
+        defaults {:date_joined (u/new-sql-timestamp)
+                  :last_login (u/new-sql-timestamp)
                   :is_staff true
                   :is_active true
                   :is_superuser false}]
@@ -65,7 +65,7 @@
 
 (defmethod pre-update User [_ {:keys [email] :as user}]
   (when email
-    (assert (util/is-email? email)))
+    (assert (u/is-email? email)))
   user)
 
 (defmethod pre-cascade-delete User [_ {:keys [id]}]

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -6,8 +6,7 @@
             (metabase.models [card :refer [Card]]
                              [common :as common])
             [metabase.test.util :refer [match-$ expect-eval-actual-first random-name with-temp]]
-            [metabase.test-data :refer :all]
-            metabase.test-setup))
+            [metabase.test-data :refer :all]))
 
 ;; # CARD LIFECYCLE
 

--- a/test/metabase/api/common_test.clj
+++ b/test/metabase/api/common_test.clj
@@ -5,7 +5,6 @@
             [metabase.api.org-test :refer [create-org]]
             [metabase.test-data :refer :all]
             [metabase.test-data.create :refer [create-user]]
-            metabase.test-setup
             [metabase.test.util :refer :all]
             [metabase.util :refer [regex= regex?]])
   (:import com.metabase.corvus.api.ApiException))

--- a/test/metabase/api/dash_test.clj
+++ b/test/metabase/api/dash_test.clj
@@ -11,8 +11,7 @@
                              [dashboard-card :refer [DashboardCard]]
                              [user :refer [User]])
             [metabase.test.util :refer [match-$ expect-eval-actual-first random-name with-temp]]
-            [metabase.test-data :refer :all]
-            metabase.test-setup))
+            [metabase.test-data :refer :all]))
 
 ;; # DASHBOARD LIFECYCLE
 

--- a/test/metabase/api/emailreport_test.clj
+++ b/test/metabase/api/emailreport_test.clj
@@ -8,8 +8,7 @@
                              [database :refer [Database]]
                              [emailreport :refer [EmailReport] :as emailreport])
             [metabase.test.util :refer [match-$ expect-eval-actual-first random-name with-temp]]
-            [metabase.test-data :refer :all]
-            metabase.test-setup))
+            [metabase.test-data :refer :all]))
 
 ;; ## Helper Fns
 

--- a/test/metabase/api/meta/field_test.clj
+++ b/test/metabase/api/meta/field_test.clj
@@ -5,7 +5,6 @@
                              [field-values :refer [FieldValues]]
                              [table :refer [Table]])
             [metabase.test-data :refer :all]
-            metabase.test-setup
             [metabase.test.util :refer [match-$ expect-eval-actual-first]]))
 
 

--- a/test/metabase/api/qs_test.clj
+++ b/test/metabase/api/qs_test.clj
@@ -5,8 +5,7 @@
             [metabase.db :refer :all]
             (metabase.models [query-execution :refer [QueryExecution]])
             [metabase.test.util :refer [match-$ random-name expect-eval-actual-first]]
-            [metabase.test-data :refer :all]
-            metabase.test-setup))
+            [metabase.test-data :refer :all]))
 
 ;; ## Helper Fns
 (defn create-query []

--- a/test/metabase/driver/generic_sql/native_test.clj
+++ b/test/metabase/driver/generic_sql/native_test.clj
@@ -1,8 +1,7 @@
 (ns metabase.driver.generic-sql.native-test
   (:require [expectations :refer :all]
             [metabase.driver.generic-sql.native :refer :all]
-            [metabase.test-data :refer :all]
-            metabase.test-setup))
+            [metabase.test-data :refer :all]))
 
 ;; Just check that a basic query works
 (expect {:status :completed

--- a/test/metabase/driver/generic_sql/query_processor_test.clj
+++ b/test/metabase/driver/generic_sql/query_processor_test.clj
@@ -2,8 +2,7 @@
   (:require [clojure.math.numeric-tower :as math]
             [expectations :refer :all]
             [metabase.driver.generic-sql.query-processor :refer :all]
-            [metabase.test-data :refer [db-id table->id field->id]]
-            metabase.test-setup))
+            [metabase.test-data :refer [db-id table->id field->id]]))
 
 (def venues-columns
   (delay ["ID" "CATEGORY_ID" "PRICE" "LONGITUDE" "LATITUDE" "NAME"]))

--- a/test/metabase/models/emailreport_test.clj
+++ b/test/metabase/models/emailreport_test.clj
@@ -6,7 +6,6 @@
             (metabase.models [emailreport :refer :all]
                              [emailreport-recipients :refer :all])
             [metabase.test-data :refer :all]
-            metabase.test-setup
             [metabase.test.util :as tu]))
 
 ;; ## UPDATE-RECIPIENTS

--- a/test/metabase/models/field_test.clj
+++ b/test/metabase/models/field_test.clj
@@ -3,8 +3,7 @@
             [metabase.db :refer :all]
             (metabase.models [field :refer :all]
                              [field-values :refer :all])
-            [metabase.test-data :refer :all]
-            metabase.test-setup))
+            [metabase.test-data :refer :all]))
 
 ;; Check that setting a Field's special_type to :category will cause a corresponding FieldValues to be created asynchronously
 (expect

--- a/test/metabase/models/hydrate_test.clj
+++ b/test/metabase/models/hydrate_test.clj
@@ -3,7 +3,6 @@
             [medley.core :as m]
             [metabase.models.hydrate :refer :all]
             [metabase.test-data :refer :all]
-            metabase.test-setup
             [metabase.test.util :refer :all]))
 
 (def d1 (delay 1))


### PR DESCRIPTION
new `timestamped` entity function takes care of handling `:created_at` / `:updated_at` timestamps
