### PR TITLE
fix email reports not sending

### DIFF
--- a/src/metabase/task/email_report.clj
+++ b/src/metabase/task/email_report.clj
@@ -40,7 +40,8 @@
   []
   (log/debug "Executing ALL scheduled EmailReports")
   (->> (sel :many :fields [EmailReport :id :schedule] :mode (mode->id :active))
-       (map execute-if-scheduled)))
+       (map execute-if-scheduled)
+       dorun))
 
 (defn- execute-if-scheduled
   "Test if a given report is scheduled to run at the current time and if so execute it."


### PR DESCRIPTION
I think the problem is the lazy sequence produced by `map` here is never realized:

```
  (->> (sel :many :fields [EmailReport :id :schedule] :mode (mode->id :active))
       (map execute-if-scheduled))
```

Remember Clojure functions like `map` and `filter` return lazy sequences and you need to use `dorun` or an equivalent function to force realization if you're using them purely for side-effects
