### PR TITLE
QP orders all results based on value of Field.position

### DIFF
--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -116,8 +116,11 @@
   field)
 
 (defmethod post-update Field [_ {:keys [id] :as field}]
-  (future
-    (create-field-values-if-needed (sel :one Field :id id))))
+  ;; if base_type or special_type were affected then we should asynchronously create corresponding FieldValues objects if need be
+  (when (or (contains? field :base_type)
+            (contains? field :special_type))
+    (future
+      (create-field-values-if-needed (sel :one [Field :id :table_id :base_type :special_type] :id id)))))
 
 (defmethod pre-cascade-delete Field [_ {:keys [id]}]
   (cascade-delete ForeignKey (where (or (= :origin_id id)

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -31,6 +31,8 @@
   "Should this `Field` be backed by a corresponding `FieldValues` object?"
   {:arglists '([field])}
   [{:keys [base_type special_type]}]
+  {:pre [base_type
+         special_type]}
   (or (contains? #{:category :city :state :country} (keyword special_type))
       (= (keyword base_type) :BooleanField)))
 

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -30,9 +30,9 @@
 (defn field-should-have-field-values?
   "Should this `Field` be backed by a corresponding `FieldValues` object?"
   {:arglists '([field])}
-  [{:keys [base_type special_type]}]
-  {:pre [base_type
-         special_type]}
+  [{:keys [base_type special_type] :as field}]
+  {:pre [(contains? field :base_type)
+         (contains? field :special_type)]}
   (or (contains? #{:category :city :state :country} (keyword special_type))
       (= (keyword base_type) :BooleanField)))
 

--- a/test/metabase/driver/generic_sql/query_processor/annotate_test.clj
+++ b/test/metabase/driver/generic_sql/query_processor/annotate_test.clj
@@ -1,0 +1,72 @@
+(ns metabase.driver.generic-sql.query-processor.annotate-test
+  (:require [expectations :refer :all]
+            [metabase.driver.generic-sql.query-processor.annotate :refer :all]
+            [metabase.test.util :refer [resolve-private-fns]]))
+
+(resolve-private-fns metabase.driver.generic-sql.query-processor.annotate -order-columns)
+
+;; ## TESTS FOR -ORDER-COLUMNS
+
+(def ^:const ^:private mock-fields
+  [{:position 0, :name "id", :id 224}
+   {:position 1, :name "name", :id 341}
+   {:position 2, :name "author_name", :id 453}
+   {:position 3, :name "allows_suggestions", :id 433}
+   {:position 4, :name "author_url", :id 455}
+   {:position 5, :name "content_creator_id", :id 446}
+   {:position 6, :name "created_at", :id 263}
+   {:position 7, :name "description", :id 375}
+   {:position 8, :name "external_url", :id 424}
+   {:position 9, :name "updated_at", :id 284}])
+
+(def ^:const ^:private mock-castified-field-names
+  [:allows_suggestions
+   :description
+   :author_url
+   :name
+   (keyword "CAST(updated_at AS DATE)")
+   :id
+   :author_name
+   :external_url
+   :content_creator_id
+   (keyword "CAST(created_at AS DATE)")])
+
+;; Check that `Field.order` is respected. No breakout fields
+(expect [:id
+         :name
+         :author_name
+         :allows_suggestions
+         :author_url
+         :content_creator_id
+         (keyword "CAST(created_at AS DATE)")
+         :description
+         :external_url
+         (keyword "CAST(updated_at AS DATE)")]
+  (-order-columns mock-fields [] mock-castified-field-names))
+
+;; Check that breakout fields are returned first, in order, before other fields
+(expect [:description
+         :allows_suggestions
+         :id
+         :name
+         :author_name
+         :author_url
+         :content_creator_id
+         (keyword "CAST(created_at AS DATE)")
+         :external_url
+         (keyword "CAST(updated_at AS DATE)")]
+  (-order-columns mock-fields [375 433] mock-castified-field-names))
+
+;; Check that aggregate fields are returned ahead of other fields
+(expect [:allows_suggestions
+         :description
+         :count
+         :id
+         :name
+         :author_name
+         :author_url
+         :content_creator_id
+         (keyword "CAST(created_at AS DATE)")
+         :external_url
+         (keyword "CAST(updated_at AS DATE)")]
+  (-order-columns mock-fields [433 375] (concat [:count] mock-castified-field-names)))

--- a/test/metabase/driver/generic_sql/sync_test.clj
+++ b/test/metabase/driver/generic_sql/sync_test.clj
@@ -6,14 +6,8 @@
                                          [util :refer [korma-entity]])
             (metabase.models [field :refer [Field]]
                              [table :refer [Table]])
-            [metabase.test-data :refer :all]))
-
-
-;; TODO  - This is fairly useful, should probably move to metabase.test.util
-(defmacro resolve-private-fns [namespc fn-name & more]
-  `(do (def ~fn-name (ns-resolve '~namespc '~fn-name))
-       ~(when (seq more)
-          `(resolve-private-fns ~namespc ~(first more) ~@(rest more)))))
+            [metabase.test-data :refer :all]
+            [metabase.test.util :refer [resolve-private-fns]]))
 
 (resolve-private-fns metabase.driver.generic-sql.sync field-avg-length field-percent-urls)
 

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -103,3 +103,17 @@
                           (throw e#)))]
        (delete-fn#)
        result#)))
+
+
+;; ## resolve-private-fns
+
+(defmacro resolve-private-fns
+  "Have your cake and eat it too. This Macro adds private functions from another namespace to the current namespace so we can test them.
+
+    (resolve-private-fns metabase.driver.generic-sql.sync
+      field-avg-length field-percent-urls)"
+  {:arglists '([namespace-symb & fn-symbs])}
+  [namespc fn-name & more]
+  `(do (def ~fn-name (ns-resolve '~namespc '~fn-name))
+       ~(when (seq more)
+          `(resolve-private-fns ~namespc ~(first more) ~@(rest more)))))


### PR DESCRIPTION
-  QP orders result columns based on:
  1.  breakout columns
  2.  aggregate columns like `count`
  3.  `Field.position` for all other columns
-  New unit tests for column ordering.
-  Try to be a little smarter about firing off async tasks to check if we need to create `FieldValues`. Don't need to do this _every_ time a `Field` is updated
