### PR TITLE
Allow setting report timezone at Organization level

### DIFF
--- a/resources/frontend_client/app/admin/admin.controllers.js
+++ b/resources/frontend_client/app/admin/admin.controllers.js
@@ -21,6 +21,11 @@ AdminControllers.controller('AdminHome', ['$scope', 'Organization', function($sc
         });
     };
 
+    Organization.form_input(function (result) {
+        $scope.form_input = result;
+    }, function (error) {
+        console.log('error getting form input', error);
+    });
 }]);
 
 AdminControllers.controller('TestLoginForm', ['$scope', function($scope) {

--- a/resources/frontend_client/app/admin/home.html
+++ b/resources/frontend_client/app/admin/home.html
@@ -24,6 +24,15 @@
                     <label for="id_logo">Logo Url:</label>
                     <input class="input block full" id="id_logo" type="text" ng-model="currentOrg.logo_url"/>
                 </div>
+
+                <div class="py1">
+                    <label>Report Timezone:</label>
+                    <label class="Select">
+                        <select ng-model="currentOrg.report_timezone" ng-options="tz for tz in form_input['timezones']">
+                            <option value="">Select a Timezone</option>
+                        </select>
+                    </label>
+                </div>
             </div>
             <div class="py3 px4 border-top clearfix">
                 <input class="Button Button--primary float-right" type="button" value="Save" ng-click="updateOrg(currentOrg)"/>

--- a/resources/frontend_client/app/services.js
+++ b/resources/frontend_client/app/services.js
@@ -741,6 +741,10 @@ CoreServices.factory('User', ['$resource', '$cookies', function($resource, $cook
 
 CoreServices.factory('Organization', ['$resource', '$cookies', function($resource, $cookies) {
     return $resource('/api/org/:orgId', {}, {
+        form_input: {
+            url:'/api/org/form_input',
+            method:'GET'
+        },
         list: {
             url: '/api/org/',
             method: 'GET',

--- a/resources/frontend_client/app/superadmin/organization/organization.controllers.js
+++ b/resources/frontend_client/app/superadmin/organization/organization.controllers.js
@@ -96,5 +96,12 @@ OrganizationControllers.controller('OrganizationDetailController', ['$scope', '$
                     });
             };
         }
+
+        // always get our form input
+        Organization.form_input(function (result) {
+            $scope.form_input = result;
+        }, function (error) {
+            console.log('error getting form input', error);
+        });
     }
 ]);

--- a/resources/frontend_client/app/superadmin/organization/partials/org_detail.html
+++ b/resources/frontend_client/app/superadmin/organization/partials/org_detail.html
@@ -26,6 +26,15 @@
                 <label for="id_logo">Logo Url:</label>
                 <input class="input block full" id="id_logo" type="text" ng-model="organization.logo_url"/>
             </div>
+
+            <div class="py1">
+                <label>Report Timezone:</label>
+                <label class="Select">
+                    <select ng-model="organization.report_timezone" ng-options="tz for tz in form_input['timezones']">
+                        <option value="">Select a Timezone</option>
+                    </select>
+                </label>
+            </div>
         </div>
 
         <div class="py2 border-top">

--- a/resources/migrations/005_add_org_report_tz_column.json
+++ b/resources/migrations/005_add_org_report_tz_column.json
@@ -1,0 +1,25 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "5",
+        "author": "agilliland",
+        "changes": [
+          {
+            "addColumn": {
+              "tableName": "core_organization",
+              "columns": [
+                {
+                  "column": {
+                    "name": "report_timezone",
+                    "type": "varchar(254)"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/resources/migrations/liquibase.json
+++ b/resources/migrations/liquibase.json
@@ -2,6 +2,7 @@
   "databaseChangeLog": [
       {"include": {"file": "migrations/001_initial_schema.json"}},
       {"include": {"file": "migrations/002_add_session_table.json"}},
-      {"include": {"file": "migrations/004_add_setting_table.json"}}
+      {"include": {"file": "migrations/004_add_setting_table.json"}},
+      {"include": {"file": "migrations/005_add_org_report_tz_column.json"}}
   ]
 }

--- a/src/metabase/driver/generic_sql/native.clj
+++ b/src/metabase/driver/generic_sql/native.clj
@@ -51,12 +51,14 @@
          (integer? database-id)]}
   (log/debug "QUERY: \n"
              (with-out-str (clojure.pprint/pprint query)))
-  (try (let [db (-> (sel :one Database :id database-id)
+  (try (let [database (sel :one Database :id database-id)
+             db (-> database
                     korma-db
                     korma.db/get-connection)
              [columns & [first-row :as rows]] (jdbc/with-db-transaction [conn db :read-only? true]
                                                 ;; If timezone is specified in the Query and the driver supports setting the timezone then execute SQL to set it
-                                                (when-let [timezone (-> query :native :timezone)]
+                                                (when-let [timezone (or (-> query :native :timezone)
+                                                                        (-> @(:organization database) :report_timezone))]
                                                   (when-let [set-timezone-sql (*timezone->set-timezone-sql* timezone)]
                                                     (log/debug "Setting timezone to:" timezone)
                                                     (jdbc/db-do-prepared conn set-timezone-sql)))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -81,6 +81,7 @@
          :organization_id @org-id
          :name card-name
          :organization {:inherits true
+                        :report_timezone nil
                         :logo_url nil
                         :description nil
                         :name "Test Organization"

--- a/test/metabase/api/dash_test.clj
+++ b/test/metabase/api/dash_test.clj
@@ -41,21 +41,22 @@
 (expect-let [dash (create-dash (random-name))]
   {:dashboard
    (match-$ dash
-     {:description nil
-      :can_read true
-      :ordered_cards []
-      :creator (-> (sel :one User :id (user->id :rasta))
-                   (select-keys [:email :first_name :last_login :is_superuser :id :last_name :date_joined :common_name]))
-      :can_write true
+     {:description     nil
+      :can_read        true
+      :ordered_cards   []
+      :creator         (-> (sel :one User :id (user->id :rasta))
+                         (select-keys [:email :first_name :last_login :is_superuser :id :last_name :date_joined :common_name]))
+      :can_write       true
       :organization_id @org-id
-      :name $
-      :organization (-> @test-org
-                        (select-keys [:inherits :logo_url :description :name :slug :id]))
-      :creator_id (user->id :rasta)
-      :updated_at $
-      :id $
-      :public_perms 0
-      :created_at $})}
+      :name            $
+      :organization    (-> @test-org
+                         (select-keys [:inherits :report_timezone :logo_url :description :name :slug :id
+                                       ]))
+      :creator_id      (user->id :rasta)
+      :updated_at      $
+      :id              $
+      :public_perms    0
+      :created_at      $})}
   ((user->client :rasta) :get 200 (format "dash/%d" (:id dash))))
 
 ;; Check that only the creator of a Dashboard sees it when it isn't public

--- a/test/metabase/api/emailreport_test.clj
+++ b/test/metabase/api/emailreport_test.clj
@@ -162,6 +162,7 @@
                       :name "Test Organization"
                       :description nil
                       :logo_url nil
+                      :report_timezone nil
                       :inherits true}
        :creator_id (user->id :rasta)
        :updated_at $

--- a/test/metabase/api/meta/db_test.clj
+++ b/test/metabase/api/meta/db_test.clj
@@ -47,6 +47,7 @@
                       :name "Test Organization"
                       :description nil
                       :logo_url nil
+                      :report_timezone nil
                       :inherits true}
        :name "Test Database"
        :organization_id @org-id
@@ -120,6 +121,7 @@
                          :name "Test Organization"
                          :description nil
                          :logo_url nil
+                         :report_timezone nil
                          :inherits true}
           :name $
           :organization_id @org-id
@@ -135,6 +137,7 @@
                          :name "Test Organization"
                          :description nil
                          :logo_url nil
+                         :report_timezone nil
                          :inherits true}
           :name "Test Database"
           :organization_id @org-id

--- a/test/metabase/api/org_test.clj
+++ b/test/metabase/api/org_test.clj
@@ -44,6 +44,7 @@
       :name "Test Organization"
       :description nil
       :logo_url nil
+      :report_timezone nil
       :inherits true}]
     (do
       ;; Delete all the random test Orgs we've created
@@ -61,6 +62,7 @@
         :name "Test Organization"
         :description nil
         :logo_url nil
+        :report_timezone nil
         :inherits true}
        (match-$ (sel :one Org :name org-name)
          {:id $
@@ -68,6 +70,7 @@
           :name $
           :description nil
           :logo_url nil
+          :report_timezone nil
           :inherits false})]
     (do
       ;; Delete all the random test Orgs we've created
@@ -94,6 +97,7 @@
        :name org-name
        :description nil
        :logo_url nil
+       :report_timezone nil
        :inherits false})
     (let [new-org (create-org org-name)
           org-perm (sel :one OrgPerm :organization_id (:id new-org))]
@@ -118,6 +122,7 @@
      :name "Test Organization"
      :description nil
      :logo_url nil
+     :report_timezone nil
      :inherits true}
   ((user->client :rasta) :get 200 (format "org/%d" @org-id)))
 
@@ -138,6 +143,7 @@
      :name "Test Organization"
      :description nil
      :logo_url nil
+     :report_timezone nil
      :inherits true}
   ((user->client :rasta) :get 200 (format "org/slug/%s" (:slug @test-org))))
 
@@ -162,6 +168,7 @@
    :name upd-name
    :description upd-name
    :logo_url upd-name
+   :report_timezone nil
    :inherits false}
   ;; we try setting `slug` & `inherits` which should both remain unmodified
   ((user->client :crowberto) :put 200 (format "org/%d" id) {:slug upd-name
@@ -293,6 +300,7 @@
                         :name test-org-name
                         :description nil
                         :logo_url nil
+                        :report_timezone nil
                         :inherits false}
          :user {:common_name (:common_name my-user)
                 :date_joined (:date_joined my-user)
@@ -389,11 +397,12 @@
               :first_name "Lucky"
               :email "lucky@metabase.com"})
      :organization (match-$ (sel :one Org :id @org-id)
-                     {:id $,
-                      :slug "test",
-                      :name "Test Organization",
-                      :description nil,
-                      :logo_url nil,
+                     {:id $
+                      :slug "test"
+                      :name "Test Organization"
+                      :description nil
+                      :logo_url nil
+                      :report_timezone nil
                       :inherits true})})
   ((user->client :crowberto) :get 200 (format "org/%d/members/%d" @org-id (user->id :lucky))))
 

--- a/test/metabase/api/org_test.clj
+++ b/test/metabase/api/org_test.clj
@@ -35,6 +35,21 @@
 
 ;; # GENERAL ORG ENDPOINTS
 
+;; ## GET /api/org/form_input
+;; this endpoint is available to any user that is authentic, so no security check here
+(expect-eval-actual-first
+  {:timezones ["GMT"
+               "UTC"
+               "US/Alaska"
+               "US/Arizona"
+               "US/Central"
+               "US/Eastern"
+               "US/Hawaii"
+               "US/Mountain"
+               "US/Pacific"
+               "America/Costa_Rica"]}
+  ((user->client :rasta) :get 200 "org/form_input"))
+
 ;; ## GET /api/org
 ;; Non-superusers should only be able to see Orgs they are members of
 (let [org-name (random-name)]
@@ -168,13 +183,14 @@
    :name upd-name
    :description upd-name
    :logo_url upd-name
-   :report_timezone nil
+   :report_timezone "US/Eastern"
    :inherits false}
   ;; we try setting `slug` & `inherits` which should both remain unmodified
   ((user->client :crowberto) :put 200 (format "org/%d" id) {:slug upd-name
                                                             :name upd-name
                                                             :description upd-name
                                                             :logo_url upd-name
+                                                            :report_timezone "US/Eastern"
                                                             :inherits true}))
 
 ;; Check that non-superusers can't modify orgs they don't have permissions to

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -86,6 +86,7 @@
            :is_superuser false
            :id $
            :org_perms [{:organization {:inherits true
+                                       :report_timezone nil
                                        :logo_url nil
                                        :description nil
                                        :name "Test Organization"


### PR DESCRIPTION
this was a quick decision made to allow the application of a timezone when running SQL queries from a card, which isn't possible currently.  this choice was preferred over the alternative option of allowing a timezone selection on the card builder page directly.
### How it Works
- each Organization now has a property called :report_timezone which can be set if desired.  the default value is null.
- when the Org :report_timezone is set then any SQL query executed will apply the specified timezone on the database connection.
- if a timezone is set on the SQL query directly (only possible via the old SQL Query interface) then that timezone will take precedence over the Org :report_timezone
