### PR TITLE
allow saving a card with a failed query

### DIFF
--- a/resources/frontend_client/app/card/card.controllers.js
+++ b/resources/frontend_client/app/card/card.controllers.js
@@ -711,7 +711,10 @@ CardControllers.controller('CardDetail', [
                 updateAvailableDisplayTypes(result);
                 var display = $scope.card.display;
                 if (typeof display === 'undefined' || display === 'none' || (!$scope.displayTypes[display].available)) {
-                    $scope.card.display = getDefaultDisplayType($scope.displayTypes, result);
+                    var new_display = getDefaultDisplayType($scope.displayTypes, result);
+                    if (new_display) {
+                        $scope.card.display = new_display;
+                    }
                 } else {
                     assignColumns(result);
                 }


### PR DESCRIPTION
fix logic around setting card.display so that we ensure we always have a valid value.  previous code had a condition where a failed card query would result in setting the card.display to null.
