### PR TITLE
remove button to 'Create Card' from a saved SQL Query

### DIFF
--- a/resources/frontend_client/app/admin/query/partials/query_view.html
+++ b/resources/frontend_client/app/admin/query/partials/query_view.html
@@ -17,7 +17,6 @@
 
           <input class="Button Button--primary" type="button" value='Execute Now' ng-click="runQuery(query.id)"/>
           <a class="Button" href="/api/result/{{queryResult.id}}/csv" target="_self" ng-if="queryResultData">Download Results</a>
-          <a class="Button" cv-org-href="/card/create/{{query.id}}">Create Card</a>
         </div>
     </div>
 


### PR DESCRIPTION
This should only be merged after the new query builder (https://github.com/metabase/metabase-init/pull/373) is fully merged and deployed.

This will remove the button which allows for the creation of 'result' type cards which are backed by saved sql queries.
