### PR TITLE
:bird: Add H2 driver support for new-style connection details

### DIFF
--- a/resources/frontend_client/app/services.js
+++ b/resources/frontend_client/app/services.js
@@ -604,21 +604,21 @@ CorvusServices.service('CorvusCore', ['$resource', 'User', function($resource, U
             name: 'H2',
             fields: [{
                 displayName: "Connection String",
-                fieldName: "connectionString",
+                fieldName: "db",
                 placeholder: "file:/Users/camsaul/bird_sightings/toucans;AUTO_SERVER=TRUE"
             }],
             parseDetails: function(details) {
                 // Check for new-style details
-                if (details.connectionString) return details;
+                if (details.db) return details;
 
                 // Otherwise parse legacy details
                 return {
-                    connectionString: details.conn_str
+                    db: details.conn_str
                 };
             },
             buildDetails: function(details) {
                 // add conn_str for backwards-compatibility
-                details.conn_str = details.connectionString;
+                details.conn_str = details.db;
                 return details;
             }
         },

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -1,6 +1,5 @@
 (ns metabase.driver.h2
-  (:require [clojure.set :as set]
-            [korma.db :as kdb]
+  (:require [korma.db :as kdb]
             [metabase.driver :as driver]
             [metabase.driver.generic-sql :as generic-sql]))
 
@@ -11,8 +10,9 @@
                       :db-type :h2          ; what are we using this for again (?)
                       :make-pool? false)))
 
-(defn- database->connection-details [database]
-  (set/rename-keys (:details database) {:conn_str :db}))
+(defn- database->connection-details [{:keys [details]}]
+  {:db (or (:db details)          ; new-style connection details call it 'db'
+           (:conn_str details))}) ; legacy instead calls is 'conn_str'
 
 
 ;; ## SYNCING

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -1,0 +1,16 @@
+(ns metabase.driver.h2-test
+  (:require [expectations :refer :all]
+            [metabase.driver.h2 :refer :all]
+            [metabase.test.util :refer [resolve-private-fns]]))
+
+(resolve-private-fns metabase.driver.h2 database->connection-details)
+
+;; # Check that database->connection-details works with both new-style and legacy details
+;; ## new-style
+(expect {:db
+         "file:/Users/cam/birdly/bird_sightings.db;AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1"}
+    {:details {:db "file:/Users/cam/birdly/bird_sightings.db;AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1"}})
+
+;; ## legacy
+(expect {:db "file:/Users/cam/birdly/bird_sightings.db;AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1"}
+  {:details {:conn_str "file:/Users/cam/birdly/bird_sightings.db;AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1"}})

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -9,8 +9,8 @@
 ;; ## new-style
 (expect {:db
          "file:/Users/cam/birdly/bird_sightings.db;AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1"}
-    {:details {:db "file:/Users/cam/birdly/bird_sightings.db;AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1"}})
+  (database->connection-details {:details {:db "file:/Users/cam/birdly/bird_sightings.db;AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1"}}))
 
 ;; ## legacy
 (expect {:db "file:/Users/cam/birdly/bird_sightings.db;AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1"}
-  {:details {:conn_str "file:/Users/cam/birdly/bird_sightings.db;AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1"}})
+  (database->connection-details {:details {:conn_str "file:/Users/cam/birdly/bird_sightings.db;AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1"}}))

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -114,6 +114,9 @@
       field-avg-length field-percent-urls)"
   {:arglists '([namespace-symb & fn-symbs])}
   [namespc fn-name & more]
+  {:pre [(symbol? namespc)
+         (symbol? fn-name)
+         (every? symbol? more)]}
   `(do (def ~fn-name (ns-resolve '~namespc '~fn-name))
        ~(when (seq more)
           `(resolve-private-fns ~namespc ~(first more) ~@(rest more)))))


### PR DESCRIPTION
- Add some sweet unit tests.

Use 'db' instead of 'connectionString' in the H2 details map since that's what JDBC calls it
