### PR TITLE
Mongo support for new-style conn details :relaxed:

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -20,6 +20,7 @@
                               (expect-expansion 0)
                               (expect-let 1)
                               (expect-when-testing-against-dataset 1)
+                              (expect-when-testing-mongo 1)
                               (expect-with-all-drivers 1)
                               (ins 1)
                               (let-400 1)

--- a/src/metabase/driver/mongo.clj
+++ b/src/metabase/driver/mongo.clj
@@ -13,7 +13,7 @@
             [metabase.driver :as driver]
             [metabase.driver.interface :refer :all]
             (metabase.driver.mongo [query-processor :as qp]
-                                   [util :refer [*mongo-connection* with-mongo-connection values->base-type details-map->connection-string]])))
+                                   [util :refer [*mongo-connection* with-mongo-connection values->base-type]])))
 
 (declare driver)
 

--- a/src/metabase/driver/mongo.clj
+++ b/src/metabase/driver/mongo.clj
@@ -13,7 +13,7 @@
             [metabase.driver :as driver]
             [metabase.driver.interface :refer :all]
             (metabase.driver.mongo [query-processor :as qp]
-                                   [util :refer [*mongo-connection* with-mongo-connection values->base-type]])))
+                                   [util :refer [*mongo-connection* with-mongo-connection values->base-type details-map->connection-string]])))
 
 (declare driver)
 
@@ -50,20 +50,8 @@
              :ok)
          1.0)))
 
-  (can-connect-with-details? [this {:keys [user password host port dbname]}]
-    (assert (and host
-                 dbname))
-    (can-connect? this (str "mongodb://"
-                            user
-                            (when password
-                              (assert user "Can't have a password without a user!")
-                              (str ":" password))
-                            (when user "@")
-                            host
-                            (when port
-                              (str ":" port))
-                            "/"
-                            dbname)))
+  (can-connect-with-details? [this details]
+    (can-connect? this {:details details}))
 
 ;;; ### QP
   (process-query [_ query]

--- a/test/metabase/driver/mongo_test.clj
+++ b/test/metabase/driver/mongo_test.clj
@@ -64,8 +64,17 @@
 
 ;; ## Tests for connection functions
 
+;; legacy
 (expect-when-testing-mongo true
-  (driver/can-connect? @mongo-test-db))
+  (driver/can-connect? {:engine  :mongo
+                        :details {:conn_str "mongodb://localhost:27017/metabase-test"}}))
+
+;; new-style
+(expect-when-testing-mongo true
+  (driver/can-connect? {:engine  :mongo
+                        :details {:host   "localhost"
+                                  :dbname "metabase-test"
+                                  :port   27017}}))
 
 (expect-when-testing-mongo false
   (driver/can-connect? {:engine :mongo


### PR DESCRIPTION
So at this point just need add support to Django and no more `conn_str`.
(well, at least no more `conn_str` going forward; existing DBs will have to be re-saved) :disappointed_relieved: 

But after that we can remove all the crazy code to parse/build `conn_str` :sweat_smile: 
