### PR TITLE
"data migration" to convert databases to new-style connection strings

### DIFF
--- a/src/metabase/db/migrate_details.clj
+++ b/src/metabase/db/migrate_details.clj
@@ -17,7 +17,7 @@
 
 (def ^:private ^:const convert-legacy-connection-details
   {:postgres (fn [details]
-               (merge details) (postgres/parse-legacy-conn-str (:conn_str details)))
+               (merge details (postgres/parse-legacy-conn-str (:conn_str details))))
    :h2       (fn [details]
                (assoc details :db (:conn_str details)))
    :mongo    (fn [details]

--- a/src/metabase/db/migrate_details.clj
+++ b/src/metabase/db/migrate_details.clj
@@ -1,0 +1,51 @@
+(ns metabase.db.migrate-details
+  (:require [clojure.pprint :refer [pprint]]
+            [clojure.tools.logging :as log]
+            [medley.core :as m]
+            [metabase.db :refer :all]
+            (metabase.driver [postgres :as postgres])
+            [metabase.models.database :refer :all]))
+
+;; # Convert old-style DB connection details to new-style ones
+
+(def ^:private ^:const is-legacy-connection-details?
+  {:postgres postgres/is-legacy-conn-details?
+   :h2       (fn [details]
+               (not (:db details)))
+   :mongo    (fn [details]
+               (not (:dbname details)))})
+
+(def ^:private ^:const convert-legacy-connection-details
+  {:postgres (fn [details]
+               (merge details) (postgres/parse-legacy-conn-str (:conn_str details)))
+   :h2       (fn [details]
+               (assoc details :db (:conn_str details)))
+   :mongo    (fn [details]
+               (let [[_ user pass host port dbname] (re-matches #"^mongodb:\/\/(?:([^@:]+)(?::([^@:]+))?@)?([^\/:@]+)(?::([\d]+))?\/([^\/]+)$" (:conn_str details))]
+                 (m/filter-vals identity (assoc details
+                                                :user     user
+                                                :pass     pass
+                                                :host     host
+                                                :port     (when port
+                                                            (Integer/parseInt port))
+                                                :dbname   dbname))))})
+
+(defn convert-details-when-legacy
+  "When DETAILS are legacy, return updated map, otherwise return `nil`."
+  [engine details]
+  {:pre [(keyword? engine)
+         (map? details)]}
+  (when ((is-legacy-connection-details? engine) details)
+    ((convert-legacy-connection-details engine) details)))
+
+
+(defn convert-legacy-database-connection-details
+  "Convert the connection `details` of databases in the DB to [backwards-compatible] new-style ones when applicable."
+  []
+  (doseq [{:keys [id details engine]} (sel :many :fields [Database :id :details :engine])]
+    (when-let [updated-details (convert-details-when-legacy engine details)]
+      (log/info (format "Database %d (%s) has legacy connection details: " id engine)
+                (with-out-str (clojure.pprint/pprint details))
+                "Updated these to: "
+                (with-out-str (clojure.pprint/pprint updated-details)))
+      (upd Database id :details updated-details))))

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -100,12 +100,13 @@
   "Parse a legacy `database.details.conn_str` CONNECTION-STRING and return a new-style map."
   [connection-string]
   {:pre [(string? connection-string)]}
-  (-<>> connection-string
-        (s/split <> #" ")               ; split into k=v pairs
-        (map (fn [pair]                  ; convert to {:k v} pairs
-               (let [[k v] (s/split pair #"=")]
-                 {(keyword k) v})))
-        (reduce conj {})))
+  (let [details (-<>> connection-string
+                      (s/split <> #" ")            ; split into k=v pairs
+                      (map (fn [pair]               ; convert to {:k v} pairs
+                             (let [[k v] (s/split pair #"=")]
+                               {(keyword k) v})))
+                      (reduce conj {}))]
+    (assoc details :port (Integer/parseInt (:port details)))))
 
 (defn- database->connection-details [{:keys [details]}]
   (let [{:keys [host port] :as details} (if (is-legacy-conn-details? details) (parse-legacy-conn-str (:conn_str details))

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -107,7 +107,7 @@
                                                   {(keyword k) v})))
                                          (reduce conj {}))]
     (cond-> details
-      (string? port) (update-in :port (Integer/parseInt port)))))
+      (string? port) (assoc :port (Integer/parseInt port)))))
 
 (defn- database->connection-details [{:keys [details]}]
   (let [{:keys [host port] :as details} (if (is-legacy-conn-details? details) (parse-legacy-conn-str (:conn_str details))

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -90,14 +90,14 @@
       (rename-keys {:dbname :db})
       kdb/postgres))
 
-(defn- is-legacy-conn-details?
+(defn is-legacy-conn-details?
   "Is DETAILS-MAP a legacy map (i.e., does it only contain `conn_str`)?"
   [details-map]
   {:pre [(map? details-map)]}
   (not (:dbname details-map)))
 
-(defn- parse-legacy-conn-str
-  "Parse a legacy `database.details.conn_str` CONNECTION-STRING."
+(defn parse-legacy-conn-str
+  "Parse a legacy `database.details.conn_str` CONNECTION-STRING and return a new-style map."
   [connection-string]
   {:pre [(string? connection-string)]}
   (-<>> connection-string

--- a/test/metabase/db/migrate_details_test.clj
+++ b/test/metabase/db/migrate_details_test.clj
@@ -1,0 +1,75 @@
+(ns metabase.db.migrate-details-test
+  (:require [expectations :refer :all]
+            [metabase.db.migrate-details :refer :all]))
+
+;; # tests for convert-details-when-legacy
+
+;; ## legacy postgres
+(expect {:user "cam"
+         :dbname "fakedb"
+         :port "5432"
+         :host "localhost"
+         :timezone "US/Pacific"}
+  (convert-details-when-legacy
+   :postgres
+   {:conn_str "host=localhost port=5432 dbname=fakedb user=cam"
+    :timezone "US/Pacific"}))
+
+;; ## new-style postgres
+(expect nil
+  (convert-details-when-legacy
+   :postgres
+   {:ssl false
+    :host "localhost"
+    :port "5432"
+    :dbname "ryde"
+    :user "cam"
+    :conn_str "host=localhost port=5432 dbname=ryde user=cam"}))
+
+;; ## legacy h2
+(expect {:timezone "US/Pacific",
+         :db "host=localhost port=5432 dbname=fakedb user=rastacan"
+         :conn_str "host=localhost port=5432 dbname=fakedb user=rastacan"}
+  (convert-details-when-legacy
+   :h2
+   {:timezone "US/Pacific"
+    :conn_str "host=localhost port=5432 dbname=fakedb user=rastacan"}))
+
+;; ## new-style h2
+(expect nil
+  (convert-details-when-legacy
+   :h2
+   {:timezone "US/Pacific"
+    :db "host=localhost port=5432 dbname=fakedb user=rastacan"
+    :conn_str "host=localhost port=5432 dbname=fakedb user=rastacan"}))
+
+;; ## legacy mongo
+(expect {:timezone "US/Pacific"
+         :conn_str "mongodb://localhost:27017/test"
+         :port 27017
+         :dbname "test"
+         :host "localhost"}
+  (convert-details-when-legacy
+   :mongo
+   {:timezone "US/Pacific", :conn_str "mongodb://localhost:27017/test"}))
+
+(expect {:timezone "US/Pacific"
+         :conn_str "mongodb://cam:password@localhost:27017/test"
+         :port 27017
+         :dbname "test"
+         :host "localhost"
+         :pass "password"
+         :user "cam"}
+  (convert-details-when-legacy
+   :mongo
+   {:timezone "US/Pacific",
+    :conn_str "mongodb://cam:password@localhost:27017/test"}))
+
+(expect nil
+  (convert-details-when-legacy
+   :mongo
+   {:timezone "US/Pacific"
+    :conn_str "mongodb://localhost:27017/test"
+    :port 27017
+    :dbname "test"
+    :host "localhost"}))

--- a/test/metabase/db/migrate_details_test.clj
+++ b/test/metabase/db/migrate_details_test.clj
@@ -7,9 +7,10 @@
 ;; ## legacy postgres
 (expect {:user "cam"
          :dbname "fakedb"
-         :port "5432"
+         :port 5432
          :host "localhost"
-         :timezone "US/Pacific"}
+         :timezone "US/Pacific"
+         :conn_str "host=localhost port=5432 dbname=fakedb user=cam"}
   (convert-details-when-legacy
    :postgres
    {:conn_str "host=localhost port=5432 dbname=fakedb user=cam"
@@ -21,7 +22,7 @@
    :postgres
    {:ssl false
     :host "localhost"
-    :port "5432"
+    :port 5432
     :dbname "ryde"
     :user "cam"
     :conn_str "host=localhost port=5432 dbname=ryde user=cam"}))


### PR DESCRIPTION
:unamused:

Basically this just loops through all the DBs at startup and converts their `details` if needed. 
This is kinda hacky but:
1.  The sooner we can remove all the nasty "legacy" connection-string parsing code the better
2.  This will save us from having to manually fix things everywhere
3.  This is a pre-1.0 release so I don't want to waste too much time doing over-engineering this
4.  I still wrote a bunch of tests to make sure it works correctly

We'll be able to remove it as soon as 
1.  Everyone has ran it at least once
2.  The Django code is updated (WIP)

And then yay, no more legacy stuff
