### PR TITLE
Limit max # of result rows returned to 10000 :smiling_imp:

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -72,7 +72,7 @@
                              [lein-expectations "0.0.8"]              ; run unit tests with 'lein expectations'
                              [lein-instant-cheatsheet "2.1.1"]        ; use awesome instant cheatsheet created by yours truly w/ 'lein instant-cheatsheet'
                              [lein-marginalia "0.8.0"]                ; generate documentation with 'lein marg'
-                             [refactor-nrepl "1.0.5"]]                ; support for advanced refactoring in Emacs/LightTable
+                             [refactor-nrepl "1.1.0-SNAPSHOT"]]       ; support for advanced refactoring in Emacs/LightTable
                    :global-vars {*warn-on-reflection* true}           ; Emit warnings on all reflection calls
                    :jvm-opts ["-Dlogfile.path=target/log"
                               "-Xms1024m"                             ; give JVM a decent heap size to start with

--- a/src/metabase/driver/query_processor.clj
+++ b/src/metabase/driver/query_processor.clj
@@ -170,7 +170,7 @@
   [results]
   {:pre [(map? results)
          (sequential? (:rows results))]}
-  (assoc results :rows (take max-result-rows (:rows results))))
+  (update-in results [:rows] (partial take max-result-rows)))
 
 
 ;; ### ADD-ROW-COUNT-AND-STATUS

--- a/src/metabase/driver/query_processor.clj
+++ b/src/metabase/driver/query_processor.clj
@@ -197,7 +197,7 @@
          (sequential? (:cols results))
          (sequential? (:rows results))]}
   (let [num-results (count (:rows results))]
-    (cond-> {:row_count (count (:rows results))
+    (cond-> {:row_count num-results
              :status    :completed
              :data      results}
       (= num-results max-result-rows) (assoc :num_results_over_limit true)))) ; so the front-end can let the user know why they're being arbitarily limited

--- a/test/metabase/driver/generic_sql/query_processor_test.clj
+++ b/test/metabase/driver/generic_sql/query_processor_test.clj
@@ -11,7 +11,7 @@
 ;; Check that we get an error response formatted the way we'd expect
 (expect
     {:status :failed
-     :error "Column \"CHECKINS.NAME\" not found; SQL statement:\nSELECT \"CHECKINS\".* FROM \"CHECKINS\" WHERE (\"CHECKINS\".\"NAME\" = ?)"}
+     :error "Column \"CHECKINS.NAME\" not found; SQL statement:\nSELECT \"CHECKINS\".* FROM \"CHECKINS\" WHERE (\"CHECKINS\".\"NAME\" = ?) LIMIT 10000"}
   ;; This will print a stacktrace. Better to reassure people that that's on purpose than to make people question whether the tests are working
   (do (log/info (color/green "NOTE: The following stacktrace is expected <3"))
       (driver/process-query {:database @db-id

--- a/test/metabase/driver/generic_sql/query_processor_test.clj
+++ b/test/metabase/driver/generic_sql/query_processor_test.clj
@@ -4,6 +4,7 @@
             [colorize.core :as color]
             [expectations :refer :all]
             [metabase.driver :as driver]
+            [metabase.driver.query-processor :refer [max-result-rows]]
             [metabase.test-data :refer [db-id table->id field->id]]))
 
 ;; # ERROR RESPONSES
@@ -11,7 +12,7 @@
 ;; Check that we get an error response formatted the way we'd expect
 (expect
     {:status :failed
-     :error "Column \"CHECKINS.NAME\" not found; SQL statement:\nSELECT \"CHECKINS\".* FROM \"CHECKINS\" WHERE (\"CHECKINS\".\"NAME\" = ?) LIMIT 10000"}
+     :error (format "Column \"CHECKINS.NAME\" not found; SQL statement:\nSELECT \"CHECKINS\".* FROM \"CHECKINS\" WHERE (\"CHECKINS\".\"NAME\" = ?) LIMIT %d" max-result-rows)}
   ;; This will print a stacktrace. Better to reassure people that that's on purpose than to make people question whether the tests are working
   (do (log/info (color/green "NOTE: The following stacktrace is expected <3"))
       (driver/process-query {:database @db-id

--- a/test/metabase/driver/query_processor_test.clj
+++ b/test/metabase/driver/query_processor_test.clj
@@ -3,6 +3,7 @@
   (:require [expectations :refer :all]
             [metabase.db :refer :all]
             [metabase.driver :as driver]
+            [metabase.driver.query-processor :refer :all]
             (metabase.models [table :refer [Table]])
             [metabase.test.data.datasets :as datasets :refer [*dataset* expect-with-all-datasets]]))
 
@@ -518,6 +519,14 @@
 
 
 ;; # POST PROCESSING TESTS
+
+;; ## LIMIT-MAX-RESULT-ROWS
+;; Apply limit-max-result-rows to an infinite sequence and make sure it gets capped at `max-result-rows`
+(expect max-result-rows
+  (count (->> {:rows (repeat [:ok])}
+              limit-max-result-rows
+              :rows)))
+
 
 ;; ## CUMULATIVE SUM
 


### PR DESCRIPTION
Add an implict `limit` clause to the query for `rows` aggregations and enforce a hard limit of the number of rows to return in the response
