### PR TITLE
only ask for confirmation when leaving the QB if a card has already been saved

### DIFF
--- a/resources/frontend_client/app/card/card.controllers.js
+++ b/resources/frontend_client/app/card/card.controllers.js
@@ -383,10 +383,14 @@ CardControllers.controller('CardDetail', [
         };
 
         $scope.$on('$locationChangeStart', function (event) {
-            if (cardJson !== JSON.stringify(card) && queryResult !== null) {
-                if (!confirm('You have unsaved changes!  Click OK to discard changes and leave the page.')) {
-                    event.preventDefault();
-                    return;
+            // only ask for a confirmation on unsaved changes if the question is
+            // saved already, indicated by a cardId
+            if($routeParams.cardId) {
+                if (cardJson !== JSON.stringify(card) && queryResult !== null) {
+                    if (!confirm('You have unsaved changes!  Click OK to discard changes and leave the page.')) {
+                        event.preventDefault();
+                        return;
+                    }
                 }
             }
 


### PR DESCRIPTION
per the conversation between myself @salsakran and @agilliland, make the confirmation a little less intrusive for ad-hoc queries and only ask for confirmation if the card has already been saved.
