### PR TITLE
fix mongo driver connection w/ passwords :unamused:

### DIFF
--- a/src/metabase/driver/mongo/util.clj
+++ b/src/metabase/driver/mongo/util.clj
@@ -6,14 +6,14 @@
             [metabase.driver :as driver]))
 
 (defn- details-map->connection-string
-  [{:keys [user password host port dbname]}]
+  [{:keys [user pass host port dbname]}]
   {:pre [host
          dbname]}
   (str "mongodb://"
        user
-       (when password
+       (when pass
          (assert user "Can't have a password without a user!")
-         (str ":" password))
+         (str ":" pass))
        (when user "@")
        host
        (when port

--- a/src/metabase/driver/sync.clj
+++ b/src/metabase/driver/sync.clj
@@ -122,9 +122,12 @@
   "Update the row count of TABLE if it has changed."
   [table]
   {:pre [(integer? (:id table))]}
-  (let [table-row-count (queries/table-row-count table)]
-    (when-not (= (:rows table) table-row-count)
-      (upd Table (:id table) :rows table-row-count))))
+  (try
+    (let [table-row-count (queries/table-row-count table)]
+      (when-not (= (:rows table) table-row-count)
+        (upd Table (:id table) :rows table-row-count)))
+    (catch Throwable e
+      (log/error (color/red (format "Unable to update row_count for %s: %s" (:name table) (.getMessage e)))))))
 
 
 ;; ### 2) sync-table-active-fields-and-pks!


### PR DESCRIPTION
just a typo in the code that looked for the key `password` when it was being saved as `pass`.

Also tweak sync to catch exceptions thrown by `update-table-row-count!`
