### PR TITLE
Reenable parallelism in sync :heart_eyes:

### DIFF
--- a/src/metabase/driver/sync.clj
+++ b/src/metabase/driver/sync.clj
@@ -110,7 +110,7 @@
   ;; Now sync all active fields
   (let [tables-count (count active-tables)
         finished-tables-count (atom 0)]
-    (doseq [table active-tables]
+    (u/pdoseq [table active-tables]
       (log/debug (color/green (format "Syncing metadata for %s.%s..." (:name @(:db table)) (:name table))))
       (sync-table-fields-metadata! driver table)
       (swap! finished-tables-count inc)


### PR DESCRIPTION
I had turned this off for a while because it made the refactored sync code from the implement-a-Mongo-driver era a little harder to debug. But now that sync is working nicely and stable we can speed it up dramatically by turning it back on
