### PR TITLE
comment out the call to `(browse-url)` for now because it's causing e…

### DIFF
--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -54,7 +54,8 @@
                            setup-url
                            "\n\n"))
     ;; Attempt to browse URL on user's system; this will just fail silently if we can't do it
-    (browse-url setup-url)))
+    ;(browse-url setup-url)
+    ))
 
 
 (defn init


### PR DESCRIPTION
…lastic beanstalk deployments to fail.
