### PR TITLE
include fields with "dimension" field_type in our breakout list in query builder

### DIFF
--- a/resources/frontend_client/app/explore/explore.services.js
+++ b/resources/frontend_client/app/explore/explore.services.js
@@ -36,7 +36,7 @@ ExploreServices.service('CorvusFormGenerator', [function() {
     }
 
     function isDimension(field) {
-        return isDate(field) || isCategory(field);
+        return isDate(field) || isCategory(field) || isInTypes(field.field_type, ['dimension']);
     }
 
 


### PR DESCRIPTION
include a `Field` with a :field_type of "dimension" in our frontend check for isDimension() that builds our breakout list in the query builder.
