### PR TITLE
Backend implementation for timestamp special type

### DIFF
--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -142,14 +142,10 @@
     [_ field-id & _] {(field-id->kw field-id)
                       ;; If the field in question is a date field we need to cast the YYYY-MM-DD string that comes back from the UI to a SQL date
                       (let [cast-value-if-needed (cond
-                                                   (date-field-id? field-id)
-                                                   (fn [value]
-                                                     `(raw ~(format "CAST('%s' AS DATE)" value)))
-
-                                                   (= (field-id->special-type field-id) :timestamp_seconds)
-                                                   u/date-yyyy-mm-dd->unix-timestamp
-
-                                                   :else identity)]
+                                                   (date-field-id? field-id)            u/parse-date-yyyy-mm-dd
+                                                   (= (field-id->special-type field-id)
+                                                      :timestamp_seconds)               u/date-yyyy-mm-dd->unix-timestamp
+                                                   :else                                identity)]
                         (match subclause
                           ["NOT_NULL" _]        ['not= nil]
                           ["IS_NULL" _]         ['=    nil]

--- a/src/metabase/driver/mongo/query_processor.clj
+++ b/src/metabase/driver/mongo/query_processor.clj
@@ -307,9 +307,10 @@
                      `(ObjectId. ~value))]
     (memoize
      (fn [field-id]
-       (let [{base-type :base_type, field-name :name} (sel :one [Field :base_type :name] :id field-id)]
+       (let [{base-type :base_type, field-name :name, special-type :special_type} (sel :one [Field :base_type :name :special_type] :id field-id)]
          (cond
            (contains? #{:DateField :DateTimeField} base-type) u/parse-date-yyyy-mm-dd
+           (= special-type :timestamp_seconds)                u/date-yyyy-mm-dd->unix-timestamp
            (and (= field-name "_id")
                 (= base-type  :UnknownField))                 ->ObjectId
            :else                                              identity))))))

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -24,27 +24,29 @@
     :name
     :number
     :state
+    :timestamp_seconds
     :url
     :zip_code})
 
 (def ^:const special-type->name
   "User-facing names for the `Field` special types."
-  {:avatar "Avatar Image URL"
-   :category "Category"
-   :city "City"
-   :country "Country"
-   :desc "Description"
-   :fk "Foreign Key"
-   :id "Entity Key"
-   :image "Image URL"
-   :json "Field containing JSON"
-   :latitude "Latitude"
-   :longitude "Longitude"
-   :name "Entity Name"
-   :number "Number"
-   :state "State"
-   :url "URL"
-   :zip_code "Zip Code"})
+  {:avatar            "Avatar Image URL"
+   :category          "Category"
+   :city              "City"
+   :country           "Country"
+   :desc              "Description"
+   :fk                "Foreign Key"
+   :id                "Entity Key"
+   :image             "Image URL"
+   :json              "Field containing JSON"
+   :latitude          "Latitude"
+   :longitude         "Longitude"
+   :name              "Entity Name"
+   :number            "Number"
+   :state             "State"
+   :timestamp_seconds "Timestamp - seconds since 1970"
+   :url               "URL"
+   :zip_code          "Zip Code"})
 
 (def ^:const base-types
   "Possible values for `Field` `:base_type`."

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -100,18 +100,26 @@
 (defn parse-iso8601
   "Parse a string value expected in the iso8601 format into a `java.sql.Date`."
   ^java.sql.Date
-  [datetime]
+  [^String datetime]
   (some->> datetime
            (time/parse (time/formatters :date-time))
            (coerce/to-long)
            (java.sql.Date.)))
 
 
-(def ^{:arglists '([date])} parse-date-yyyy-mm-dd
+(def ^{:arglists '([date])} ^java.util.Date parse-date-yyyy-mm-dd
   "Parse a date in the `yyyy-mm-dd` format and return a `java.util.Date`."
   (let [sdf (java.text.SimpleDateFormat. "yyyy-MM-dd")]
-    (fn [date]
+    (fn [^String date]
       (.parse sdf date))))
+
+(defn date-yyyy-mm-dd->unix-timestamp
+  "Convert a string DATE in the `YYYY-MM-DD` format to a Unix timestamp in seconds."
+  ^Float [^String date]
+  (-> date
+      parse-date-yyyy-mm-dd
+      .getTime
+      (/ 1000)))
 
 (defn now-iso8601
   "format the current time as iso8601 date/time string."

--- a/test/metabase/driver/query_processor_test.clj
+++ b/test/metabase/driver/query_processor_test.clj
@@ -797,7 +797,7 @@
                               :type     :query
                               :query    {:source_table (:id &events)
                                          :aggregation  ["count"]
-                                         :filter       ["<" (:id &events.timestamp) (metabase.util/date-yyyy-mm-dd->unix-timestamp "1765-01-01")]}})
+                                         :filter       ["<" (:id &events.timestamp) "1765-01-01"]}})
        :data
        :rows
        first

--- a/test/metabase/driver/query_processor_test.clj
+++ b/test/metabase/driver/query_processor_test.clj
@@ -823,7 +823,7 @@
                                  :type     :query
                                  :query    {:source_table (:id &events)
                                             :aggregation  ["count"]
-                                            :filter       ["<" (:id &events.timestamp) (metabase.util/date-yyyy-mm-dd->unix-timestamp "1765-01-01")]}})
+                                            :filter       ["<" (:id &events.timestamp) "1765-01-01"]}})
           :data
           :rows
           first

--- a/test/metabase/driver/query_processor_test.clj
+++ b/test/metabase/driver/query_processor_test.clj
@@ -6,7 +6,7 @@
             [metabase.driver.query-processor :refer :all]
             (metabase.models [field :refer [Field]]
                              [table :refer [Table]])
-            [metabase.test.data :refer [with-temp-db temp-get]]
+            [metabase.test.data :refer [with-temp-db]]
             (metabase.test.data [dataset-definitions :refer [us-history-1607-to-1774]]
                                 [datasets :as datasets :refer [*dataset*]])))
 

--- a/test/metabase/driver/query_processor_test.clj
+++ b/test/metabase/driver/query_processor_test.clj
@@ -790,8 +790,8 @@
 
 ;; ## Unix timestamp special type fields <3
 
-(datasets/expect-with-all-datasets
- 4
+;; There are 4 events in us-history-1607-to-1774 whose year is < 1765
+(datasets/expect-with-all-datasets 4
  (with-temp-db [db (dataset-loader) us-history-1607-to-1774]
    (-> (driver/process-query {:database (:id db)
                               :type     :query
@@ -802,29 +802,3 @@
        :rows
        first
        first)))
-
-(defn x []
-  (datasets/with-dataset :generic-sql
-    (with-temp-db [db (dataset-loader) us-history-1607-to-1774]
-      (-> (driver/process-query {:database (:id db)
-                                 :type     :query
-                                 :query    {:source_table (:id &events)
-                                            :aggregation  ["count"]
-                                            :filter       ["<" (:id &events.timestamp) "1765-01-01"]}})
-          :data
-          :rows
-          first
-          first))))
-
-(defn y []
-  (datasets/with-dataset :mongo
-    (with-temp-db [db (dataset-loader) us-history-1607-to-1774]
-      (-> (driver/process-query {:database (:id db)
-                                 :type     :query
-                                 :query    {:source_table (:id &events)
-                                            :aggregation  ["count"]
-                                            :filter       ["<" (:id &events.timestamp) "1765-01-01"]}})
-          :data
-          :rows
-          first
-          first))))

--- a/test/metabase/driver/query_processor_test.clj
+++ b/test/metabase/driver/query_processor_test.clj
@@ -6,7 +6,9 @@
             [metabase.driver.query-processor :refer :all]
             (metabase.models [field :refer [Field]]
                              [table :refer [Table]])
-            [metabase.test.data.datasets :as datasets :refer [*dataset*]]))
+            [metabase.test.data :refer [with-temp-db temp-get]]
+            (metabase.test.data [dataset-definitions :refer [us-history-1607-to-1774]]
+                                [datasets :as datasets :refer [*dataset*]])))
 
 ;; ##  Dataset-Independent Data Fns
 
@@ -40,6 +42,9 @@
 
 (defn timestamp-field-type []
   (datasets/timestamp-field-type *dataset*))
+
+(defn dataset-loader []
+  (datasets/dataset-loader *dataset*))
 
 
 ;; ## Dataset-Independent QP Tests
@@ -781,3 +786,45 @@
         :aggregation ["rows"],
         :order_by [[(id :users :id) "ascending"]]}})
      (update-in [:data :rows] (partial mapv (partial filterv #(not (isa? (type %) java.util.Date)))))))
+
+
+;; ## Unix timestamp special type fields <3
+
+(datasets/expect-with-all-datasets
+ 4
+ (with-temp-db [db (dataset-loader) us-history-1607-to-1774]
+   (-> (driver/process-query {:database (:id db)
+                              :type     :query
+                              :query    {:source_table (:id &events)
+                                         :aggregation  ["count"]
+                                         :filter       ["<" (:id &events.timestamp) (metabase.util/date-yyyy-mm-dd->unix-timestamp "1765-01-01")]}})
+       :data
+       :rows
+       first
+       first)))
+
+(defn x []
+  (datasets/with-dataset :generic-sql
+    (with-temp-db [db (dataset-loader) us-history-1607-to-1774]
+      (-> (driver/process-query {:database (:id db)
+                                 :type     :query
+                                 :query    {:source_table (:id &events)
+                                            :aggregation  ["count"]
+                                            :filter       ["<" (:id &events.timestamp) "1765-01-01"]}})
+          :data
+          :rows
+          first
+          first))))
+
+(defn y []
+  (datasets/with-dataset :mongo
+    (with-temp-db [db (dataset-loader) us-history-1607-to-1774]
+      (-> (driver/process-query {:database (:id db)
+                                 :type     :query
+                                 :query    {:source_table (:id &events)
+                                            :aggregation  ["count"]
+                                            :filter       ["<" (:id &events.timestamp) (metabase.util/date-yyyy-mm-dd->unix-timestamp "1765-01-01")]}})
+          :data
+          :rows
+          first
+          first))))

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -175,3 +175,9 @@
          ~@(walk-body-parse-temp-get db-binding body))
        (finally
          (remove-database! loader# dbdef#)))))
+
+(defn x []
+  (driver/process-query {:database @db-id
+                         :type :query
+                         :query {:source_table (table->id :users)
+                                 :aggregation  ["rows"]}}))

--- a/test/metabase/test/data/dataset_definitions.clj
+++ b/test/metabase/test/data/dataset_definitions.clj
@@ -1,0 +1,41 @@
+(ns metabase.test.data.dataset-definitions
+  "Definitions of various datasets for use in tests with `with-temp-db` and the like."
+  (:require [metabase.test.data.interface :refer [def-database-definition]]))
+
+;; ## Helper Functions
+
+(defn create-unix-timestamp
+  "Create a Unix timestamp (in seconds).
+
+     (create-unix-timestamp :year 2012 :month 12 :date 27)"
+  ^Long [& {:keys [year month date hour minute second nano]
+            :or   {year 0, month 1, date 1, hour 0, minute 0, second 0, nano 0}}]
+  (-> (java.sql.Timestamp. (- year 1900) (- month 1) date hour minute second nano)
+      .getTime
+      (/ 1000)
+      long)) ; coerce to long since Korma doesn't know how to insert bigints
+
+
+;; ## Datasets
+
+(def-database-definition us-history-1607-to-1774
+  "us_history_1607_1774"
+  ["events" [{:field-name   "name"
+              :base-type    :CharField}
+             {:field-name   "timestamp"
+              :base-type    :BigIntegerField
+              :special-type :timestamp_seconds}]
+   [["Jamestown Settlement Founded"    (create-unix-timestamp :year 1607 :month  5 :date 14)]
+    ["Mayflower Compact Signed"        (create-unix-timestamp :year 1620 :month 11 :date 11)]
+    ["Ben Franklin's Kite Experiment"  (create-unix-timestamp :year 1752 :month 96 :date 15)]
+    ["French and Indian War Begins"    (create-unix-timestamp :year 1754 :month  5 :date 28)]
+    ["Stamp Act Enacted"               (create-unix-timestamp :year 1765 :month  3 :date 22)]
+    ["Quartering Act Enacted"          (create-unix-timestamp :year 1765 :month  3 :date 24)]
+    ["Stamp Act Congress Meets"        (create-unix-timestamp :year 1765 :month 10 :date 19)]
+    ["Stamp Act Repealed"              (create-unix-timestamp :year 1766 :month  3 :date 18)]
+    ["Townshend Acts Passed"           (create-unix-timestamp :year 1767 :month  6 :date 29)]
+    ["Boston Massacre"                 (create-unix-timestamp :year 1770 :month  3 :date  5)]
+    ["Tea Act Passed"                  (create-unix-timestamp :year 1773 :month  5 :date 10)]
+    ["Boston Tea Party"                (create-unix-timestamp :year 1773 :month 12 :date 16)]
+    ["Boston Port Act Passed"          (create-unix-timestamp :year 1774 :month  3 :date 31)]
+    ["First Continental Congress Held" (create-unix-timestamp :year 1774 :month  9 :date  5)]]])

--- a/test/metabase/test/data/dataset_definitions.clj
+++ b/test/metabase/test/data/dataset_definitions.clj
@@ -1,5 +1,5 @@
 (ns metabase.test.data.dataset-definitions
-  "Definitions of various datasets for use in tests with `with-temp-db` and the like."
+  "Definitions of various datasets for use in tests with `with-temp-db`."
   (:require [metabase.test.data.interface :refer [def-database-definition]]))
 
 ;; ## Helper Functions
@@ -19,7 +19,6 @@
 ;; ## Datasets
 
 (def-database-definition us-history-1607-to-1774
-  "us_history_1607_1774"
   ["events" [{:field-name   "name"
               :base-type    :CharField}
              {:field-name   "timestamp"

--- a/test/metabase/test/data/datasets.clj
+++ b/test/metabase/test/data/datasets.clj
@@ -6,7 +6,9 @@
             [environ.core :refer [env]]
             [expectations :refer :all]
             [metabase.driver.mongo.test-data :as mongo-data]
-            [metabase.test.data :as generic-sql-data]))
+            [metabase.test.data :as generic-sql-data]
+            (metabase.test.data [h2 :as h2]
+                                [mongo :as mongo])))
 
 ;; # IDataset
 
@@ -14,6 +16,8 @@
   "Functions needed to fetch test data for various drivers."
   (load-data! [this]
     "Load the test data for this dataset.")
+  (dataset-loader [this]
+    "Return a dataset loader (an object that implements `IDatasetLoader`) for this dataset/driver.")
   (db [this]
     "Return `Database` containing test data for this driver.")
   (table-name->table [this table-name]
@@ -42,6 +46,8 @@
   (load-data! [_]
     @mongo-data/mongo-test-db
     (assert (integer? @mongo-data/mongo-test-db-id)))
+  (dataset-loader [_]
+    (mongo/dataset-loader))
   (db [_]
     @mongo-data/mongo-test-db)
   (table-name->table [_ table-name]
@@ -69,6 +75,8 @@
   (load-data! [_]
     @generic-sql-data/test-db
     (assert (integer? @generic-sql-data/db-id)))
+  (dataset-loader [_]
+    (h2/dataset-loader))
   (db [this]
     @generic-sql-data/test-db)
   (table-name->table [_ table-name]

--- a/test/metabase/test/data/h2.clj
+++ b/test/metabase/test/data/h2.clj
@@ -21,7 +21,9 @@
 (defn connection-details
   "Return a Metabase `Database.details` for H2 database defined by DATABASE-DEFINITION."
   [^DatabaseDefinition database-definition]
-  {:db (format "file:%s;AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1" (filename database-definition))})
+  {:db (format (if (:short-lived? database-definition) "file:%s" ; for short-lived connections don't create a server thread and don't use a keep-alive connection
+                   "file:%s;AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1")
+               (filename database-definition))})
 
 (defn korma-connection-pool
   "Return an H2 korma connection pool to H2 database defined by DATABASE-DEFINITION."

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -26,15 +26,10 @@
                                ;; for long -- they can adjust connection behavior, e.g. choosing simple connections instead of creating pools.
                                ^Boolean short-lived?])
 
-
-(defprotocol IEscapedName
-  (^String escaped-name [this]
-    "Return escaped version of DATABASE-NAME suitable for use as a filename / database name / etc."))
-
-(extend-protocol IEscapedName
-  DatabaseDefinition
-  (escaped-name [this]
-    (s/replace (:database-name this) #"\s+" "_")))
+(defn escaped-name
+  "Return escaped version of database name suitable for use as a filename / database name / etc."
+  ^String [^DatabaseDefinition database-definition]
+  (s/replace (:database-name database-definition) #"\s+" "_"))
 
 
 (defprotocol IMetabaseInstance

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -119,9 +119,8 @@
 
 (defmacro def-database-definition
   "Convenience for creating a new `DatabaseDefinition` named by the symbol DATASET-NAME."
-  [^clojure.lang.Symbol dataset-name ^String db-name & table-name+field-definition-maps+rows]
-  {:pre [(symbol? dataset-name)
-         (string? db-name)]}
+  [^clojure.lang.Symbol dataset-name & table-name+field-definition-maps+rows]
+  {:pre [(symbol? dataset-name)]}
   `(def ~(vary-meta dataset-name assoc :tag DatabaseDefinition)
-     (create-database-definition ~db-name
+     (create-database-definition ~(name dataset-name)
        ~@table-name+field-definition-maps+rows)))

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -21,7 +21,10 @@
                             rows])
 
 (defrecord DatabaseDefinition [^String database-name
-                               table-definitions])
+                               table-definitions
+                               ;; Optional. Set this to non-nil to let dataset loaders know that we don't intend to keep it
+                               ;; for long -- they can adjust connection behavior, e.g. choosing simple connections instead of creating pools.
+                               ^Boolean short-lived?])
 
 
 (defprotocol IEscapedName

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -106,8 +106,7 @@
   ^TableDefinition [^String table-name field-definition-maps rows]
   (map->TableDefinition {:table-name          table-name
                          :rows                rows
-                         :field-definitions   (mapv create-field-definition field-definition-maps)
-                         :database-definition (promise)}))
+                         :field-definitions   (mapv create-field-definition field-definition-maps)}))
 
 (defn create-database-definition
   "Convenience for creating a new `DatabaseDefinition`."
@@ -117,3 +116,12 @@
   (map->DatabaseDefinition {:database-name     database-name
                             :table-definitions (mapv (partial apply create-table-definition)
                                                      table-name+field-definition-maps+rows)}))
+
+(defmacro def-database-definition
+  "Convenience for creating a new `DatabaseDefinition` named by the symbol DATASET-NAME."
+  [^clojure.lang.Symbol dataset-name ^String db-name & table-name+field-definition-maps+rows]
+  {:pre [(symbol? dataset-name)
+         (string? db-name)]}
+  `(def ~(vary-meta dataset-name assoc :tag DatabaseDefinition)
+     (create-database-definition ~db-name
+       ~@table-name+field-definition-maps+rows)))


### PR DESCRIPTION
Big improvements to the `with-temp-table` macro. You can now use `&table` and `&table.field` forms to refer temporary `Tables` and `Fields` within its body:

``` clojure
(with-temp-db [db (dataset-loader) us-history-1607-to-1774]
  (driver/process-query {:database (:id db)
                         :type     :query
                         :query    {:source_table (:id &events)
                                    :aggregation  ["count"]
                                    :filter       ["<" (:id &events.timestamp) "1765-01-01"]}}))
```

Added `def-database-definition` macro to simplify defining temporary datasets and added namespace `metabase.test.data.dataset-definitions` for them to live in.

Added additional support for switching out dataset loaders for writing unit tests that work across multiple drivers.

Some cleanup in the H2 dataset loader -- switched a few internal methods to plain functions which are a bit better behaved when reloading big parts of the codebase.
