### PR TITLE
cruft removal: remove unused/barely-used functions in metabase.util

### DIFF
--- a/src/metabase/api/common/internal.clj
+++ b/src/metabase/api/common/internal.clj
@@ -163,7 +163,8 @@
     (route-arg-keywords \"/:id/cards\") -> [:id]"
   [route]
   (->> (re-seq #":([\w-]+)" route)
-       (map (u/fn-> second keyword))))
+       (map second)
+       (map keyword)))
 
 (defn typify-args
   "Given a sequence of keyword ARGS, return a sequence of `[:arg pattern :arg pattern ...]`

--- a/src/metabase/driver/query_processor.clj
+++ b/src/metabase/driver/query_processor.clj
@@ -5,7 +5,8 @@
             [korma.core :refer :all]
             [metabase.db :refer :all]
             [metabase.driver.interface :as i]
-            [metabase.models.field :refer [Field field->fk-table]]))
+            [metabase.models.field :refer [Field field->fk-table]]
+            [metabase.util :as u]))
 
 (declare add-implicit-breakout-order-by
          add-implicit-limit
@@ -181,11 +182,8 @@
   (if-not cum-sum-field results
           (let [ ;; Determine the index of the field we need to cumulative sum
                 cum-sum-field-index (->> cols
-                                         (map-indexed (fn [i {field-name :name, field-id :id}]
-                                                        (when (or (= field-name "sum")
-                                                                  (= field-id cum-sum-field))
-                                                          i)))
-                                         (filter identity)
+                                         (u/indecies-satisfying #(or (= (:name %) "sum")
+                                                                     (= (:id %) cum-sum-field)))
                                          first)
                 _                   (assert (integer? cum-sum-field-index))
                 ;; Now make a sequence of cumulative sum values for each row

--- a/src/metabase/driver/sync.clj
+++ b/src/metabase/driver/sync.clj
@@ -402,7 +402,7 @@
                                          [#"^zipcode$"      int-or-text :zip_code]]]
     ;; Check that all the pattern tuples are valid
     (doseq [[name-pattern base-types special-type] pattern+base-types+special-type]
-      (assert (u/regex? name-pattern))
+      (assert (= (type name-pattern) java.util.regex.Pattern))
       (assert (every? (partial contains? field/base-types) base-types))
       (assert (contains? field/special-types special-type)))
 

--- a/src/metabase/models/hydrate.clj
+++ b/src/metabase/models/hydrate.clj
@@ -211,7 +211,7 @@
               (mapcat ns-publics)
               vals
               (map var-get)
-              (filter (u/fn-> type (= :korma.core/Entity)))
+              (filter #(= (type %) :korma.core/Entity))
               (filter :hydration-keys)
               (mapcat (fn [{:keys [hydration-keys] :as entity}]
                         (assert (and (set? hydration-keys) (every? keyword? hydration-keys))

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -2,73 +2,12 @@
   "Common utility functions useful throughout the codebase."
   (:require [clojure.tools.logging :as log]
             [colorize.core :as color]
-            [medley.core :refer :all]
+            [medley.core :as m]
             [clj-time.format :as time]
             [clj-time.coerce :as coerce])
   (:import (java.net Socket
                      InetSocketAddress
                      InetAddress)))
-
-(defn contains-many?
-  "Does M contain every key in KS?"
-  [m & ks]
-  (every? (partial contains? m) ks))
-
-(defn select-non-nil-keys
-  "Like `select-keys` but filters out key-value pairs whose value is nil.
-   Unlike `select-keys`, KEYS are rest args (should not be wrapped in a vector).
-   TODO: Why?"
-  [m & ks]
-  {:pre [(map? m)
-         (every? keyword? ks)]}
-  (->> (select-keys m ks)
-       (filter-vals identity)))
-
-(defmacro fn->
-  "Returns a function that threads arguments to it through FORMS via `->`."
-  [& forms]
-  `(fn [x#]
-     (-> x#
-         ~@forms)))
-
-(defmacro fn->>
-  "Returns a function that threads arguments to it through FORMS via `->>`."
-  [& forms]
-  `(fn [x#]
-     (->> x#
-          ~@forms)))
-
-(defn regex?
-  "Is ARG a regular expression?"
-  [arg]
-  (= (type arg)
-     java.util.regex.Pattern))
-
-(defn regex=
-  "Returns `true` if the literal string representations of REGEXES are exactly equal.
-
-    (= #\"[0-9]+\" #\"[0-9]+\")           -> false
-    (regex= #\"[0-9]+\" #\"[0-9]+\")      -> true
-    (regex= #\"[0-9]+\" #\"[0-9][0-9]*\") -> false (although it's theoretically true)"
-  [& regexes]
-  (->> regexes
-       (map #(.toString ^java.util.regex.Pattern %))
-       (apply =)))
-
-(defn self-mapping
-  "Given a function F that takes a single arg, return a function that will call `(f arg)` when
-  passed a non-sequential ARG, or `(map f arg)` when passed a sequential ARG.
-
-    (def f (self-mapping (fn [x] (+ 1 x))))
-    (f 2)       -> 3
-    (f [1 2 3]) -> (2 3 4)"
-  [f & args]
-  (fn [arg]
-    (if (sequential? arg) (map f arg)
-        (f arg))))
-
-;; looking for `apply-kwargs`?
-;; turns out `medley.core/mapply` does the same thingx
 
 (defmacro -assoc*
   "Internal. Don't use this directly; use `assoc*` instead."
@@ -106,12 +45,13 @@
            (coerce/to-long)
            (java.sql.Date.)))
 
+(def ^:private ^java.text.SimpleDateFormat simple-date-format
+  (java.text.SimpleDateFormat. "yyyy-MM-dd"))
 
-(def ^{:arglists '([date])} ^java.util.Date parse-date-yyyy-mm-dd
+(defn parse-date-yyyy-mm-dd
   "Parse a date in the `yyyy-mm-dd` format and return a `java.util.Date`."
-  (let [sdf (java.text.SimpleDateFormat. "yyyy-MM-dd")]
-    (fn [^String date]
-      (.parse sdf date))))
+  ^java.util.Date [^String date]
+  (.parse simple-date-format date))
 
 (defn date-yyyy-mm-dd->unix-timestamp
   "Convert a string DATE in the `YYYY-MM-DD` format to a Unix timestamp in seconds."
@@ -287,5 +227,17 @@
        (log/error (color/red ~(format "Caught exception in %s:" f)
                              (or (.getMessage e#) e#)
                              (with-out-str (.printStackTrace e#)))))))
+
+(defn indecies-satisfying
+  "Return a set of indencies in COLL that satisfy PRED.
+
+    (indecies-satisfying keyword? ['a 'b :c 3 :e])
+      -> #{2 4}"
+  [pred coll]
+  (->> (for [[i item] (m/indexed coll)]
+         (when (pred item)
+           i))
+       (filter identity)
+       set))
 
 (require-dox-in-this-namespace)

--- a/test/metabase/api/common_test.clj
+++ b/test/metabase/api/common_test.clj
@@ -3,8 +3,7 @@
             [metabase.api.common :refer :all]
             [metabase.api.common.internal :refer :all]
             [metabase.test.data :refer :all]
-            [metabase.test.util :refer :all]
-            [metabase.util :refer [regex= regex?]])
+            [metabase.test.util :refer :all])
   (:import com.metabase.corvus.api.ApiException))
 
 

--- a/test/metabase/test_util.clj
+++ b/test/metabase/test_util.clj
@@ -5,22 +5,6 @@
             [metabase.util :refer :all]))
 
 
-;; tests for CONTAINS-MANY?
-
-(let [m {:a 1 :b 1 :c 2}]
-  (expect true (contains-many? m :a))
-  (expect true (contains-many? m :a :b))
-  (expect true (contains-many? m :a :b :c))
-  (expect false (contains-many? m :a :d))
-  (expect false (contains-many? m :a :b :d)))
-
-
-;;; ## tests for SELECT-NON-NIL-KEYS
-
-(expect {:a 100 :b 200}
-  (select-non-nil-keys {:a 100 :b 200 :c nil :d 300} :a :b :c))
-
-
 ;;; ## tests for ASSOC*
 
 (expect {:a 100


### PR DESCRIPTION
Several fancy functions I wrote half a year ago that we're not using anymore
