### PR TITLE
Pretty print failed unit tests. 1000x more readable

### DIFF
--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -1,6 +1,7 @@
 (ns metabase.util
   "Common utility functions useful throughout the codebase."
-  (:require [clojure.tools.logging :as log]
+  (:require [clojure.pprint :refer [pprint]]
+            [clojure.tools.logging :as log]
             [colorize.core :as color]
             [medley.core :as m]
             [clj-time.format :as time]
@@ -239,5 +240,25 @@
            i))
        (filter identity)
        set))
+
+(defn format-color
+  "Like `format`, but uses a function in `colorize.core` to colorize the output.
+   COLOR-SYMB should be a symbol like `green`.
+
+     (format-color 'red \"Fatal error: %s\" error-message)"
+  [color-symb format-string & args]
+  ((ns-resolve 'colorize.core color-symb) (apply format format-string args)))
+
+(defn pprint-to-str
+  "Returns the output of pretty-printing X as a string.
+   Optionally accepts COLOR-SYMB, which colorizes the output with the corresponding
+   function from `colorize.core`.
+
+     (pprint-to-str 'green some-obj)"
+  ([x]
+   (when x
+     (with-out-str (pprint x))))
+  ([color-symb x]
+   ((ns-resolve 'colorize.core color-symb) (pprint-to-str x))))
 
 (require-dox-in-this-namespace)


### PR DESCRIPTION
This should make fixing broken unit tests a little nicer.
Swapped out the method `expectations` uses to print the differences between two maps in a failed test.
### BEFORE

![screen shot 2015-06-16 at 2 03 35 pm](https://cloud.githubusercontent.com/assets/1455846/8194436/8758c73c-1430-11e5-9f0e-6a509286c282.png)
### AFTER

![screen shot 2015-06-16 at 2 03 20 pm](https://cloud.githubusercontent.com/assets/1455846/8194445/8feb82fe-1430-11e5-834b-f55ba1f4604f.png)
