### PR TITLE
fix bug with redirect on non-authenticated pages when loading the app

### DIFF
--- a/resources/frontend_client/app/services.js
+++ b/resources/frontend_client/app/services.js
@@ -73,7 +73,7 @@ CorvusServices.factory('AppState', ['$rootScope', '$q', '$location', '$timeout',
 
             refreshSiteSettings: function() {
 
-                var settingsRefresh = Settings.list(function(result) {
+                var settingsRefresh = Session.properties(function(result) {
 
                     var settings = _.indexBy(result, 'key');
 
@@ -782,23 +782,18 @@ CoreServices.factory('Session', ['$resource', '$cookies', function($resource, $c
         delete: {
             method: 'DELETE'
         },
+        properties: {
+            url: '/api/session/properties',
+            method: 'GET',
+            isArray: true
+        },
         forgot_password: {
             url: '/api/session/forgot_password',
-            method: 'POST',
-            headers: {
-                'X-CSRFToken': function() {
-                    return $cookies.csrftoken;
-                }
-            }
+            method: 'POST'
         },
         reset_password: {
             url: '/api/session/reset_password',
-            method: 'POST',
-            headers: {
-                'X-CSRFToken': function() {
-                    return $cookies.csrftoken;
-                }
-            }
+            method: 'POST'
         }
     });
 }]);
@@ -854,7 +849,7 @@ CoreServices.factory('Settings', ['$resource', function($resource) {
         list: {
             url: '/api/setting',
             method: 'GET',
-            isArray: true
+            isArray: true,
         },
 
         // POST endpoint handles create + update in this case

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -1,14 +1,15 @@
 (ns metabase.api.session
   "/api/session endpoints"
   (:require [clojure.tools.logging :as log]
-            [compojure.core :refer [defroutes POST DELETE]]
+            [compojure.core :refer [defroutes GET POST DELETE]]
             [hiccup.core :refer [html]]
             [korma.core :as korma]
             [metabase.api.common :refer :all]
             [metabase.db :refer :all]
             [metabase.email.messages :as email]
             (metabase.models [user :refer [User set-user-password]]
-                             [session :refer [Session]])
+                             [session :refer [Session]]
+                             [setting :as setting])
             [metabase.util.password :as pass]))
 
 
@@ -70,5 +71,12 @@
       (symbol "token") "Reset token has expired")
     (set-user-password (:id user) password)
     {:success true}))
+
+
+(defendpoint GET "/properties"
+  "Get all global properties and their values. These are the specific `Settings` which are meant to be public."
+  []
+  (filter #(= (:key %) :site-name) (setting/all-with-descriptions)))
+
 
 (define-routes)

--- a/src/metabase/api/setting.clj
+++ b/src/metabase/api/setting.clj
@@ -7,10 +7,8 @@
 (defendpoint GET "/"
   "Get all `Settings` and their values. Superusers get all settings, normal users get public settings only."
   []
-  (if (:is_superuser @*current-user*)
-    (setting/all-with-descriptions)
-    ;; TODO - we could make this a little more dynamic
-    (filter #(= (:key %) :site-name) (setting/all-with-descriptions))))
+  (check-superuser)
+  (setting/all-with-descriptions))
 
 (defendpoint GET "/:key"
   "Fetch a single `Setting`. You must be a superuser to do this."

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -112,3 +112,13 @@
     (upd User (user->id :rasta) :reset_token token :reset_triggered 0)
     (client :post 400 "session/reset_password" {:token token
                                                 :password "whateverUP12!!"})))
+
+
+;; GET /session/properties
+;; Check that a non-superuser can't read settings
+(expect
+  [{:value nil
+    :key "site-name"
+    :description "The name used for this instance of Metabase."
+    :default "Metabase"}]
+  ((user->client :rasta) :get 200 "session/properties"))

--- a/test/metabase/api/setting_test.clj
+++ b/test/metabase/api/setting_test.clj
@@ -26,13 +26,9 @@
     (do (set-settings nil "FANCY")
         (fetch-all-settings)))
 
-;; Check that a non-superuser can't read settings
-(expect
-  [{:value nil
-    :key "site-name"
-    :description "The name used for this instance of Metabase."
-    :default "Metabase"}]
-  ((user->client :rasta) :get 200 "setting"))
+;; Check that non-superusers are denied access
+(expect "You don't have permissions to do that."
+  ((user->client :rasta) :get 403 "setting"))
 
 
 ;; ## GET /api/setting/:key


### PR DESCRIPTION
create a new api endpoint for /session/properties for accessing publicly accessible app properties instead of trying to get them via /settings which has the problem of not being available to non-authentic users.  this fixes https://app.asana.com/0/37641057717421/37653988022906
