### PR TITLE
fully qualify the names of fields in QP korma forms

### DIFF
--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -13,7 +13,7 @@
                       database->connection-details
                       sql-string-length-fn
                       timezone->set-timezone-sql
-                      ;; These functions take a string name of a Field and return the raw SQL to select it as a DATE
+                      ;; These functions take a string name of a Table and a string name of a Field and return the raw SQL to select it as a DATE
                       cast-timestamp-seconds-field-to-date-fn
                       cast-timestamp-milliseconds-field-to-date-fn
                       ;; This should be a regex that will match the column returned by the driver when unix timestamp -> date casting occured

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -87,13 +87,13 @@
 
 (extend-protocol IGenericSQLFormattable
   Field
-  (formatted [{:keys [field-name base-type special-type]}]
+  (formatted [{:keys [table-name field-name base-type special-type]}]
     ;; TODO - add Table names
     (cond
-      (contains? #{:DateField :DateTimeField} base-type) `(raw ~(format "CAST(\"%s\" AS DATE)" field-name))
-      (= special-type :timestamp_seconds)                `(raw ~((:cast-timestamp-seconds-field-to-date-fn qp/*driver*) field-name))
-      (= special-type :timestamp_milliseconds)           `(raw ~((:cast-timestamp-milliseconds-field-to-date-fn qp/*driver*) field-name))
-      :else                                              (keyword field-name)))
+      (contains? #{:DateField :DateTimeField} base-type) `(raw ~(format "CAST(\"%s\".\"%s\" AS DATE)" table-name field-name))
+      (= special-type :timestamp_seconds)                `(raw ~((:cast-timestamp-seconds-field-to-date-fn qp/*driver*) table-name field-name))
+      (= special-type :timestamp_milliseconds)           `(raw ~((:cast-timestamp-milliseconds-field-to-date-fn qp/*driver*) table-name field-name))
+      :else                                              (keyword (format "%s.%s" table-name field-name))))
 
   ;; e.g. the ["aggregation" 0] fields we allow in order-by
   OrderByAggregateField

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -26,7 +26,7 @@
     (uncastify \"CAST(DATE AS DATE)\") -> \"DATE\""
   [column-name]
   (let [column-name (name column-name)]
-    (keyword (or (second (re-find #"CAST\(([^\s]+) AS [\w]+\)" column-name))
+    (keyword (or (second (re-find #"CAST\([^.\s]+\.([^.\s]+) AS [\w]+\)" column-name))
                  (second (re-find (:uncastify-timestamp-regex qp/*driver*) column-name))
                  column-name))))
 

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -83,14 +83,14 @@
 
 ;; ## QP Functions
 
-(defn- cast-timestamp-seconds-field-to-date-fn [field-name]
-  (format "CAST(TIMESTAMPADD('SECOND', \"%s\", DATE '1970-01-01') AS DATE)" field-name))
+(defn- cast-timestamp-seconds-field-to-date-fn [table-name field-name]
+  (format "CAST(TIMESTAMPADD('SECOND', \"%s\".\"%s\", DATE '1970-01-01') AS DATE)" table-name field-name))
 
-(defn- cast-timestamp-milliseconds-field-to-date-fn [field-name]
-  (format "CAST(TIMESTAMPADD('MILLISECOND', \"%s\", DATE '1970-01-01') AS DATE)" field-name))
+(defn- cast-timestamp-milliseconds-field-to-date-fn [table-name field-name]
+  (format "CAST(TIMESTAMPADD('MILLISECOND', \"%s\".\"%s\", DATE '1970-01-01') AS DATE)" table-name field-name))
 
 (def ^:private ^:const uncastify-timestamp-regex
-  #"CAST\(TIMESTAMPADD\('(?:MILLI)?SECOND', ([^\s]+), DATE '1970-01-01'\) AS DATE\)")
+  #"CAST\(TIMESTAMPADD\('(?:MILLI)?SECOND', [^.\s]+\.([^.\s]+), DATE '1970-01-01'\) AS DATE\)")
 
 ;; ## DRIVER
 

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -108,16 +108,18 @@
 (defn- timezone->set-timezone-sql [timezone]
   (format "SET LOCAL timezone TO '%s';" timezone))
 
-(defn- cast-timestamp-seconds-field-to-date-fn [field-name]
-  {:pre [(string? field-name)]}
-  (format "CAST(TO_TIMESTAMP(\"%s\") AS DATE)" field-name))
+(defn- cast-timestamp-seconds-field-to-date-fn [table-name field-name]
+  {:pre [(string? table-name)
+         (string? field-name)]}
+  (format "CAST(TO_TIMESTAMP(\"%s\".\"%s\") AS DATE)" table-name field-name))
 
-(defn- cast-timestamp-milliseconds-field-to-date-fn [field-name]
-  {:pre [(string? field-name)]}
-  (format "CAST(TO_TIMESTAMP(\"%s\" / 1000) AS DATE)" field-name))
+(defn- cast-timestamp-milliseconds-field-to-date-fn [table-name field-name]
+  {:pre [(string? table-name)
+         (string? field-name)]}
+  (format "CAST(TO_TIMESTAMP(\"%s\".\"%s\" / 1000) AS DATE)" table-name field-name))
 
 (def ^:private ^:const uncastify-timestamp-regex
-  #"CAST\(TO_TIMESTAMP\(([^\s+])(?: / 1000)?\) AS DATE\)")
+  #"CAST\(TO_TIMESTAMP\([^.\s]+\.([^.\s]+)(?: / 1000)?\) AS DATE\)")
 
 ;; ## DRIVER
 

--- a/test/metabase/driver/generic_sql/query_processor_test.clj
+++ b/test/metabase/driver/generic_sql/query_processor_test.clj
@@ -16,7 +16,7 @@
               ;; column should look like "null.NAME" because the Field will have no associated Table name from expansion and will get
               ;; pased to korma as :null.NAME
               "Column \"null.NAME\" not found; SQL statement:\nSELECT \"CHECKINS\".\"ID\", CAST(\"DATE\" AS DATE), "
-              "\"CHECKINS\".\"VENUE_ID\", \"CHECKINS\".\"USER_ID\" FROM \"CHECKINS\" WHERE (\"CHECKINS\".\"NAME\" = ?) LIMIT "
+              "\"CHECKINS\".\"VENUE_ID\", \"CHECKINS\".\"USER_ID\" FROM \"CHECKINS\" WHERE (\"null\".\"NAME\" = ?) LIMIT "
               max-result-bare-rows)}
   ;; This will print a stacktrace. Better to reassure people that that's on purpose than to make people question whether the tests are working
   (do (log/info (color/green "NOTE: The following stacktrace is expected <3"))

--- a/test/metabase/driver/generic_sql/query_processor_test.clj
+++ b/test/metabase/driver/generic_sql/query_processor_test.clj
@@ -15,7 +15,7 @@
      :error  (str
               ;; column should look like "null.NAME" because the Field will have no associated Table name from expansion and will get
               ;; pased to korma as :null.NAME
-              "Column \"null.NAME\" not found; SQL statement:\nSELECT \"CHECKINS\".\"ID\", CAST(\"DATE\" AS DATE), "
+              "Column \"null.NAME\" not found; SQL statement:\nSELECT \"CHECKINS\".\"ID\", CAST(\"CHECKINS\".\"DATE\" AS DATE), "
               "\"CHECKINS\".\"VENUE_ID\", \"CHECKINS\".\"USER_ID\" FROM \"CHECKINS\" WHERE (\"null\".\"NAME\" = ?) LIMIT "
               max-result-bare-rows)}
   ;; This will print a stacktrace. Better to reassure people that that's on purpose than to make people question whether the tests are working

--- a/test/metabase/driver/generic_sql/query_processor_test.clj
+++ b/test/metabase/driver/generic_sql/query_processor_test.clj
@@ -12,9 +12,12 @@
 ;; Check that we get an error response formatted the way we'd expect
 (expect
     {:status :failed
-     :error (str "Column \"CHECKINS.NAME\" not found; SQL statement:\nSELECT \"CHECKINS\".\"ID\", CAST(\"DATE\" AS DATE), "
-                 "\"CHECKINS\".\"VENUE_ID\", \"CHECKINS\".\"USER_ID\" FROM \"CHECKINS\" WHERE (\"CHECKINS\".\"NAME\" = ?) LIMIT "
-                 max-result-bare-rows)}
+     :error  (str
+              ;; column should look like "null.NAME" because the Field will have no associated Table name from expansion and will get
+              ;; pased to korma as :null.NAME
+              "Column \"null.NAME\" not found; SQL statement:\nSELECT \"CHECKINS\".\"ID\", CAST(\"DATE\" AS DATE), "
+              "\"CHECKINS\".\"VENUE_ID\", \"CHECKINS\".\"USER_ID\" FROM \"CHECKINS\" WHERE (\"CHECKINS\".\"NAME\" = ?) LIMIT "
+              max-result-bare-rows)}
   ;; This will print a stacktrace. Better to reassure people that that's on purpose than to make people question whether the tests are working
   (do (log/info (color/green "NOTE: The following stacktrace is expected <3"))
       (datasets/with-dataset :generic-sql


### PR DESCRIPTION
so the generated sql will look like `"SIGHTINGS"."TIMESTAMP"` instead of just `"TIMESTAMP"`. This is needed to disambiguate the column names when a query accesses multiple tables
