### PR TITLE
Run unit tests against Postgres

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,5 +11,5 @@ test:
     # 2) runs Eastwood linter + Bikeshed linter
     # 3) runs JS linter + JS test
     # 4) runs lein uberjar
-    - case $CIRCLE_NODE_INDEX in 0) MB_TEST_DATASETS=generic-sql,mongo lein test ;; 1) MB_DB_TYPE=postgres MB_DB_DBNAME=circle_test MB_DB_PORT=5432 MB_DB_USER=ubuntu MB_DB_HOST=localhost lein test ;; 2) lein eastwood && lein bikeshed --max-line-length 240 ;; 3) npm run lint && npm run build && npm run test ;; 4) CI_DISABLE_WEBPACK_MINIFICATION=1 lein uberjar ;; esac:
+    - case $CIRCLE_NODE_INDEX in 0) MB_TEST_DATASETS=generic-sql,mongo,postgres lein test ;; 1) MB_DB_TYPE=postgres MB_DB_DBNAME=circle_test MB_DB_PORT=5432 MB_DB_USER=ubuntu MB_DB_HOST=localhost lein test ;; 2) lein eastwood && lein bikeshed --max-line-length 240 ;; 3) npm run lint && npm run build && npm run test ;; 4) CI_DISABLE_WEBPACK_MINIFICATION=1 lein uberjar ;; esac:
         parallel: true

--- a/circle.yml
+++ b/circle.yml
@@ -11,5 +11,5 @@ test:
     # 2) runs Eastwood linter + Bikeshed linter
     # 3) runs JS linter + JS test
     # 4) runs lein uberjar
-    - case $CIRCLE_NODE_INDEX in 0) MB_TEST_DATASETS=generic-sql,mongo,postgres lein test ;; 1) MB_DB_TYPE=postgres MB_DB_DBNAME=circle_test MB_DB_PORT=5432 MB_DB_USER=ubuntu MB_DB_HOST=localhost lein test ;; 2) lein eastwood && lein bikeshed --max-line-length 240 ;; 3) npm run lint && npm run build && npm run test ;; 4) CI_DISABLE_WEBPACK_MINIFICATION=1 lein uberjar ;; esac:
+    - case $CIRCLE_NODE_INDEX in 0) MB_TEST_DATASETS=h2,mongo,postgres lein test ;; 1) MB_DB_TYPE=postgres MB_DB_DBNAME=circle_test MB_DB_PORT=5432 MB_DB_USER=ubuntu MB_DB_HOST=localhost lein test ;; 2) lein eastwood && lein bikeshed --max-line-length 240 ;; 3) npm run lint && npm run build && npm run test ;; 4) CI_DISABLE_WEBPACK_MINIFICATION=1 lein uberjar ;; esac:
         parallel: true

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -100,7 +100,6 @@
     :connection-details->connection-spec          connection-details->connection-spec
     :database->connection-details                 database->connection-details
     :sql-string-length-fn                         :LENGTH
-    :timezone->set-timezone-sql                   nil
     :cast-timestamp-seconds-field-to-date-fn      cast-timestamp-seconds-field-to-date-fn
     :cast-timestamp-milliseconds-field-to-date-fn cast-timestamp-milliseconds-field-to-date-fn
     :uncastify-timestamp-regex                    uncastify-timestamp-regex}))

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -111,15 +111,16 @@
 (defn- cast-timestamp-seconds-field-to-date-fn [table-name field-name]
   {:pre [(string? table-name)
          (string? field-name)]}
-  (format "CAST(TO_TIMESTAMP(\"%s\".\"%s\") AS DATE)" table-name field-name))
+  (format "(TIMESTAMP WITH TIME ZONE 'epoch' + (\"%s\".\"%s\" * INTERVAL '1 second'))::date" table-name field-name))
 
 (defn- cast-timestamp-milliseconds-field-to-date-fn [table-name field-name]
   {:pre [(string? table-name)
          (string? field-name)]}
-  (format "CAST(TO_TIMESTAMP(\"%s\".\"%s\" / 1000) AS DATE)" table-name field-name))
+  (format "(TIMESTAMP WITH TIME ZONE 'epoch' + (\"%s\".\"%s\" * INTERVAL '1 millisecond'))::date" table-name field-name))
 
 (def ^:private ^:const uncastify-timestamp-regex
-  #"CAST\(TO_TIMESTAMP\([^.\s]+\.([^.\s]+)(?: / 1000)?\) AS DATE\)")
+  ;; TODO - this doesn't work
+  #"TO_TIMESTAMP\([^.\s]+\.([^.\s]+)(?: / 1000)?\)::date")
 
 ;; ## DRIVER
 

--- a/src/metabase/driver/query_processor.clj
+++ b/src/metabase/driver/query_processor.clj
@@ -342,9 +342,11 @@
                      (= col-kw :count)                       {:base_type    :IntegerField
                                                               :special_type :number}
                      ;; Otherwise something went wrong !
-                     :else                                   (throw (Exception. (format "Annotation failed: don't know what to do with Field '%s'.\nExpected these Fields:\n%s"
-                                                                                        col-kw
-                                                                                        (u/pprint-to-str field-kw->field))))))))
+                     :else                                   (do (log/error (u/format-color 'red "Annotation failed: don't know what to do with Field '%s'.\nExpected these Fields:\n%s"
+                                                                                            col-kw
+                                                                                            (u/pprint-to-str field-kw->field)))
+                                                                 {:base_type    :UnknownField
+                                                                  :special_type nil})))))
          ;; Add FK info the the resulting Fields
          add-fields-extra-info)))
 

--- a/src/metabase/driver/query_processor.clj
+++ b/src/metabase/driver/query_processor.clj
@@ -241,8 +241,8 @@
         fields-ids       (when-not fields-is-implicit fields-ids)
         all-field-ids    (->> fields    ; Sort the Fields.
                               (sort-by (fn [{:keys [position special_type name]}] ; For each field generate a vector of
-                                         [position ; [position special-type-group name]
-                                          (cond ; and Clojure will take care of the rest.
+                                         [position                                ; [position special-type-group name]
+                                          (cond                                   ; and Clojure will take care of the rest.
                                             (= special_type :id)   0
                                             (= special_type :name) 1
                                             :else                  2)

--- a/src/metabase/driver/sync.clj
+++ b/src/metabase/driver/sync.clj
@@ -68,7 +68,7 @@
              (map #(assoc % :db (delay database))) ; replace default delays with ones that reuse database (and don't require a DB call)
              (sync-database-active-tables! driver))
 
-        (log/info (color/blue (format "Finished syncing database %s." (:name database))))))))
+        (log/info (u/format-color 'blue "Finished syncing %s database %s." (name (:engine database)) (:name database)))))))
 
 (defn sync-table!
   "Sync a *single* TABLE by running all the sync steps for it.

--- a/src/metabase/driver/sync.clj
+++ b/src/metabase/driver/sync.clj
@@ -34,7 +34,7 @@
   (binding [qp/*disable-qp-logging* true]
     (sync-in-context driver database
       (fn []
-        (log/info (color/blue (format "Syncing database %s..." (:name database))))
+        (log/info (u/format-color 'blue "Syncing %s database %s..." (name (:engine database)) (:name database)))
 
         (let [active-table-names (active-table-names driver database)
               table-name->id (sel :many :field->id [Table :name] :db_id (:id database) :active true)]

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -19,4 +19,5 @@
          :can_write    (delay (:is_superuser @*current-user*))))
 
 (defmethod pre-cascade-delete Database [_ {:keys [id] :as database}]
+  (println (format "DATABASE %d IS GOING TO BE DESTROYED..." id))
   (cascade-delete 'metabase.models.table/Table :db_id id))

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -18,6 +18,28 @@
          :can_read     (delay true)
          :can_write    (delay (:is_superuser @*current-user*))))
 
+ {:created_at #inst "2015-06-30T19:51:45.294000000-00:00",
+   :engine :h2,
+   :id 3,
+   :details
+   {:db
+    "file:/Users/camsaul/metabase/target/Test_Database;AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1"},
+   :updated_at #inst "2015-06-30T19:51:45.294000000-00:00",
+   :name "Test Database",
+   :organization_id nil,
+   :description nil}
+
+{:description nil,
+   :organization_id nil,
+   :name "Test Database",
+   :updated_at #inst "2015-06-30T19:51:45.294000000-00:00",
+   :details
+   {:db
+    "file:/Users/camsaul/metabase/target/Test_Database;AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1"},
+   :id 3,
+   :engine "h2",
+   :created_at #inst "2015-06-30T19:51:45.294000000-00:00"}
+
+
 (defmethod pre-cascade-delete Database [_ {:keys [id] :as database}]
-  (println (format "DATABASE %d IS GOING TO BE DESTROYED..." id))
   (cascade-delete 'metabase.models.table/Table :db_id id))

--- a/test/metabase/api/meta/db_test.clj
+++ b/test/metabase/api/meta/db_test.clj
@@ -141,10 +141,9 @@
     (do
       ;; Delete all the randomly created Databases we've made so far
       (cascade-delete Database :id [not-in (set (filter identity
-                                                        [(datasets/when-testing-dataset :h2
-                                                           (db-id))
-                                                         (datasets/when-testing-dataset :mongo
-                                                           @mongo-test-data/mongo-test-db-id)]))])
+                                                        (for [dataset (datasets/all-valid-dataset-names)]
+                                                          (datasets/when-testing-dataset dataset
+                                                            (db-id)))))])
       ;; Add an extra DB so we have something to fetch besides the Test DB
       (create-db db-name)
       ;; Now hit the endpoint

--- a/test/metabase/api/meta/db_test.clj
+++ b/test/metabase/api/meta/db_test.clj
@@ -109,7 +109,7 @@
 (let [db-name (str "A" (random-name))] ; make sure this name comes before "Test Database"
   (expect-eval-actual-first
       (set (filter identity
-                   [(datasets/when-testing-dataset :generic-sql
+                   [(datasets/when-testing-dataset :h2
                       (match-$ (sel :one Database :name db-name)
                         {:created_at      $
                          :engine          "postgres"
@@ -141,7 +141,7 @@
     (do
       ;; Delete all the randomly created Databases we've made so far
       (cascade-delete Database :id [not-in (set (filter identity
-                                                        [(datasets/when-testing-dataset :generic-sql
+                                                        [(datasets/when-testing-dataset :h2
                                                            (db-id))
                                                          (datasets/when-testing-dataset :mongo
                                                            @mongo-test-data/mongo-test-db-id)]))])

--- a/test/metabase/api/meta/db_test.clj
+++ b/test/metabase/api/meta/db_test.clj
@@ -109,41 +109,33 @@
 (let [db-name (str "A" (random-name))] ; make sure this name comes before "Test Database"
   (expect-eval-actual-first
       (set (filter identity
-                   [(datasets/when-testing-dataset :h2
-                      (match-$ (sel :one Database :name db-name)
-                        {:created_at      $
-                         :engine          "postgres"
-                         :id              $
-                         :details         {:host "localhost", :port 5432, :dbname "fakedb", :user "cam"}
-                         :updated_at      $
-                         :name            $
-                         :organization_id nil
-                         :description     nil}))
-                    (datasets/when-testing-dataset :mongo
-                      (match-$ @mongo-test-data/mongo-test-db
-                        {:created_at      $
-                         :engine          "mongo"
-                         :id              $
-                         :details         $
-                         :updated_at      $
-                         :name            "Test Database"
-                         :organization_id nil
-                         :description     nil}))
-                    (match-$ (db)
-                      {:created_at      $
-                       :engine          "h2"
-                       :id              $
-                       :details         $
-                       :updated_at      $
-                       :name            "Test Database"
-                       :organization_id nil
-                       :description     nil})]))
+                   (conj (for [dataset-name datasets/all-valid-dataset-names]
+                           (datasets/when-testing-dataset dataset-name
+                             (match-$ (datasets/db (datasets/dataset-name->dataset dataset-name))
+                               {:created_at      $
+                                :engine          (name $engine)
+                                :id              $
+                                :details         $
+                                :updated_at      $
+                                :name            "Test Database"
+                                :organization_id nil
+                                :description     nil})))
+                         (datasets/when-testing-dataset :h2
+                           (match-$ (sel :one Database :name db-name)
+                             {:created_at      $
+                              :engine          "postgres"
+                              :id              $
+                              :details         {:host "localhost", :port 5432, :dbname "fakedb", :user "cam"}
+                              :updated_at      $
+                              :name            $
+                              :organization_id nil
+                              :description     nil})))))
     (do
       ;; Delete all the randomly created Databases we've made so far
       (cascade-delete Database :id [not-in (set (filter identity
-                                                        (for [dataset (datasets/all-valid-dataset-names)]
-                                                          (datasets/when-testing-dataset dataset
-                                                            (db-id)))))])
+                                                        (for [dataset-name datasets/all-valid-dataset-names]
+                                                          (datasets/when-testing-dataset dataset-name
+                                                            (:id (datasets/db (datasets/dataset-name->dataset dataset-name)))))))])
       ;; Add an extra DB so we have something to fetch besides the Test DB
       (create-db db-name)
       ;; Now hit the endpoint

--- a/test/metabase/driver/query_processor_test.clj
+++ b/test/metabase/driver/query_processor_test.clj
@@ -615,7 +615,7 @@
 ;;; SQL-Only for the time being
 
 ;; ## "STDDEV" AGGREGATION
-(qp-expect-with-datasets #{:generic-sql}
+(qp-expect-with-datasets #{:h2 :postgres}
   {:columns ["stddev"]
    :cols    [(aggregate-col :stddev (venues-col :latitude))]
    :rows    [[3.43467255295115]]}
@@ -635,7 +635,7 @@
 ;;; ## order_by aggregate fields (SQL-only for the time being)
 
 ;;; ### order_by aggregate ["count"]
-(qp-expect-with-datasets #{:generic-sql}
+(qp-expect-with-datasets #{:h2 :postgres}
   {:columns [(format-name "price")
              "count"]
    :rows    [[4 6]
@@ -667,7 +667,7 @@
 
 
 ;;; ### order_by aggregate ["distinct" field-id]
-(qp-expect-with-datasets #{:generic-sql}
+(qp-expect-with-datasets #{:h2 :postgres}
   {:columns [(format-name "price")
              "count"]
    :rows    [[4 6]
@@ -683,7 +683,7 @@
 
 
 ;;; ### order_by aggregate ["avg" field-id]
-(qp-expect-with-datasets #{:generic-sql}
+(qp-expect-with-datasets #{:h2 :postgres}
   {:columns [(format-name "price")
              "avg"]
    :rows    [[3 22]
@@ -698,7 +698,7 @@
    :order_by     [[["aggregation" 0] "ascending"]]})
 
 ;;; ### order_by aggregate ["stddev" field-id]
-(qp-expect-with-datasets #{:generic-sql}
+(qp-expect-with-datasets #{:h2 :postgres}
   {:columns [(format-name "price")
              "stddev"]
    :rows    [[3 26.19160170741759]
@@ -782,7 +782,7 @@
                             :query    ~query})))
 
 ;; There were 9 "sad toucan incidents" on 2015-06-02
-(datasets/expect-with-datasets #{:generic-sql :postgres}
+(datasets/expect-with-datasets #{:h2 :postgres}
   9
   (->> (query-with-temp-db defs/sad-toucan-incidents
          :source_table &incidents:id
@@ -803,7 +803,7 @@
                            (map (fn [[^java.util.Date date count]]
                                   [(.toString date) (int count)]))))]
 
-  (datasets/expect-with-dataset :generic-sql
+  (datasets/expect-with-dataset :h2
     [["2015-06-01" 6]
      ["2015-06-02" 9]
      ["2015-06-03" 5]
@@ -839,7 +839,7 @@
 ;; The top 10 cities by number of Tupac sightings
 ;; Test that we can breakout on an FK field
 ;; (Note how the FK Field is returned in the results)
-(datasets/expect-with-datasets #{:generic-sql}
+(datasets/expect-with-datasets #{:h2 :postgres}
   [[16 "Arlington"]
    [15 "Albany"]
    [14 "Portland"]
@@ -862,7 +862,7 @@
 ;; Number of Tupac sightings in the Expa office
 ;; (he was spotted here 60 times)
 ;; Test that we can filter on an FK field
-(datasets/expect-with-datasets #{:generic-sql}
+(datasets/expect-with-datasets #{:h2 :postgres}
   60
   (-> (query-with-temp-db defs/tupac-sightings
         :source_table &sightings:id
@@ -874,7 +874,7 @@
 ;; THE 10 MOST RECENT TUPAC SIGHTINGS (!)
 ;; (What he was doing when we saw him, sighting ID)
 ;; Check that we can include an FK field in the :fields clause
-(datasets/expect-with-datasets #{:generic-sql}
+(datasets/expect-with-datasets #{:h2 :postgres}
   [["In the Park" 772]
    ["Working at a Pet Store" 894]
    ["At the Airport" 684]
@@ -897,7 +897,7 @@
 ;;    (this query targets sightings and orders by cities.name and categories.name)
 ;; 2. Check that we can join MULTIPLE tables in a single query
 ;;    (this query joins both cities and categories)
-(datasets/expect-with-datasets #{:generic-sql}
+(datasets/expect-with-datasets #{:h2 :postgres}
   ;; CITY_ID, CATEGORY_ID, ID
   ;; Cities are already alphabetized in the source data which is why CITY_ID is sorted
   [[1 12 6]

--- a/test/metabase/driver/query_processor_test.clj
+++ b/test/metabase/driver/query_processor_test.clj
@@ -9,6 +9,7 @@
             [metabase.test.data :refer :all]
             (metabase.test.data [dataset-definitions :as defs]
                                 [datasets :as datasets :refer [*dataset*]])
+            [metabase.test.util.mql :refer [Q]]
             [metabase.util :as u]))
 
 
@@ -850,13 +851,13 @@
    [11 "Houston"]
    [11 "Irvine"]
    [11 "Lakeland"]]
-  (-> (query-with-temp-db defs/tupac-sightings
-        :source_table &sightings:id
-        :aggregation  ["count"]
-        :breakout     [["fk->" &sightings.city_id:id &cities.name:id]]
-        :order_by     [[["aggregation" 0] "descending"]]
-        :limit        10)
-      :data :rows))
+  (Q run with db tupac-sightings
+     return :data :rows
+     tbl sightings
+     ag count
+     breakout city_id->cities.name
+     order ag.0-
+     lim 10))
 
 
 ;; Number of Tupac sightings in the Expa office

--- a/test/metabase/driver/query_processor_test.clj
+++ b/test/metabase/driver/query_processor_test.clj
@@ -325,7 +325,7 @@
   :aggregation  ["rows"]
   :page         {:items 5
                  :page 1}
-  :order_by     [[(id :categories :name) "ascending"]]})
+  :order_by     [[(id :categories :id) "ascending"]]})
 
 ;; ### PAGE - Get the second page
 (qp-expect-with-all-datasets
@@ -341,7 +341,7 @@
   :aggregation  ["rows"]
   :page         {:items 5
                  :page 2}
-  :order_by     [[(id :categories :name) "ascending"]]})
+  :order_by     [[(id :categories :id) "ascending"]]})
 
 
 ;; ## "ORDER_BY" CLAUSE

--- a/test/metabase/test/data/datasets.clj
+++ b/test/metabase/test/data/datasets.clj
@@ -67,14 +67,12 @@
   (field-name->id [_ table-name field-name]
     (mongo-data/field-name->id table-name (if (= field-name :id) :_id
                                               field-name)))
-  (fks-supported? [_] false)
-
   (format-name [_ table-or-field-name]
     (if (= table-or-field-name "id") "_id"
         table-or-field-name))
 
-  (id-field-type [_] :IntegerField)
-
+  (fks-supported?       [_] false)
+  (id-field-type        [_] :IntegerField)
   (timestamp-field-type [_] :DateField))
 
 
@@ -160,10 +158,9 @@
 
 (def dataset-name->dataset
   "Map of dataset keyword name -> dataset instance (i.e., an object that implements `IDataset`)."
-  {:mongo       (MongoDriverData.)
-   :generic-sql (H2DriverData. (promise))
-   :postgres    (PostgresDriverData. (promise))})
-;; TODO - :generic-sql should be renamed H2
+  {:mongo    (MongoDriverData.)
+   :h2       (H2DriverData. (promise))
+   :postgres (PostgresDriverData. (promise))})
 
 (def ^:const all-valid-dataset-names
   "Set of names of all valid datasets."
@@ -172,13 +169,13 @@
 
 ;; # Logic for determining which datasets to test against
 
-;; By default, we'll test against against only the :generic-sql (H2) dataset; otherwise, you can specify which
+;; By default, we'll test against against only the :h2 (H2) dataset; otherwise, you can specify which
 ;; datasets to test against by setting the env var `MB_TEST_DATASETS` to a comma-separated list of dataset names, e.g.
 ;;
-;;    # test against :generic-sql and :mongo
+;;    # test against :h2 and :mongo
 ;;    MB_TEST_DATASETS=generic-sql,mongo
 ;;
-;;    # just test against :generic-sql (default)
+;;    # just test against :h2 (default)
 ;;    MB_TEST_DATASETS=generic-sql
 
 (defn- get-test-datasets-from-env
@@ -197,9 +194,9 @@
 
 (def test-dataset-names
   "Delay that returns set of names of drivers we should run tests against.
-   By default, this returns only `:generic-sql`, but can be overriden by setting env var `MB_TEST_DATASETS`."
+   By default, this returns only `:h2` but can be overriden by setting env var `MB_TEST_DATASETS`."
   (delay (let [datasets (or (get-test-datasets-from-env)
-                            #{:generic-sql})]
+                            #{:h2})]
            (log/info (color/green "Running QP tests against these datasets: " datasets))
            datasets)))
 
@@ -208,8 +205,8 @@
 
 (def ^:dynamic *dataset*
   "The dataset we're currently testing against, bound by `with-dataset`.
-   Defaults to `:generic-sql`."
-  (dataset-name->dataset :generic-sql))
+   Defaults to `:h2`."
+  (dataset-name->dataset :h2))
 
 (defmacro with-dataset
   "Bind `*dataset*` to the dataset with DATASET-NAME and execute BODY."

--- a/test/metabase/test/data/generic_sql.clj
+++ b/test/metabase/test/data/generic_sql.clj
@@ -1,0 +1,73 @@
+(ns metabase.test.data.generic-sql
+  "Common functionality for various Generic SQL dataset loaders."
+  (:require [clojure.tools.logging :as log]
+            [korma.core :as k]
+            [metabase.test.data.interface :as i])
+  (:import (metabase.test.data.interface DatabaseDefinition
+                                         TableDefinition)))
+
+(defprotocol IGenericSQLDatasetLoader
+  "Methods that generic SQL dataset loaders should implement so they can use the shared functions in `metabase.test.data.generic-sql`."
+  (execute-sql! [this ^DatabaseDefinition database-definition ^String raw-sql]
+    "Execute RAW-SQL against  database defined by DATABASE-DEFINITION.")
+
+  (korma-entity [this ^DatabaseDefinition database-definition ^TableDefinition table-definition]
+    "Return a Korma entity (e.g., one that can be passed to `select` or `sel` for the table
+     defined by TABLE-DEFINITION in the database defined by DATABASE-DEFINITION.")
+
+  (pk-sql-type ^String [this]
+    "SQL that should be used for creating the PK Table ID, e.g. `SERIAL` or `BIGINT AUTOINCREMENT`.")
+
+  (field-base-type->sql-type ^String [this base-type]
+    "Given a `Field.base_type`, return the SQL type we should use for that column when creating a DB."))
+
+
+(defn create-physical-table! [dataset-loader database-definition {:keys [table-name field-definitions], :as table-definition}]
+  ;; Drop the table if it already exists
+  (i/drop-physical-table! dataset-loader database-definition table-definition)
+
+  ;; Now create the new table
+  (execute-sql! dataset-loader database-definition
+    (format "CREATE TABLE \"%s\" (%s, \"ID\" %s, PRIMARY KEY (\"ID\"));"
+            table-name
+            (->> field-definitions
+                 (map (fn [{:keys [field-name base-type]}]
+                        (format "\"%s\" %s" field-name (field-base-type->sql-type dataset-loader base-type))))
+                 (interpose ", ")
+                 (apply str))
+            (pk-sql-type dataset-loader))))
+
+
+(defn drop-physical-table! [dataset-loader database-definition table-definition]
+  (execute-sql! dataset-loader database-definition
+    (format "DROP TABLE IF EXISTS \"%s\";" (:table-name table-definition))))
+
+
+(defn create-physical-db! [dataset-loader {:keys [table-definitions], :as database-definition}]
+  ;; Create all the Tables
+  (doseq [^TableDefinition table-definition table-definitions]
+    (log/info (format "Creating table '%s'..." (:table-name table-definition)))
+    (i/create-physical-table! dataset-loader database-definition table-definition))
+
+  ;; Now add the foreign key constraints
+  (doseq [{:keys [table-name field-definitions]} table-definitions]
+    (doseq [{dest-table-name :fk, field-name :field-name} field-definitions]
+      (when dest-table-name
+        (execute-sql! dataset-loader database-definition
+          (format "ALTER TABLE \"%s\" ADD CONSTRAINT \"FK_%s_%s\" FOREIGN KEY (\"%s\") REFERENCES \"%s\" (\"ID\");"
+                  table-name
+                  field-name dest-table-name
+                  field-name
+                  (name dest-table-name)))))))
+
+
+(defn load-table-data! [dataset-loader database-definition table-definition]
+  (let [rows              (:rows table-definition)
+        fields-for-insert (map :field-name (:field-definitions table-definition))]
+    (println (korma-entity dataset-loader database-definition table-definition))
+    (-> (korma-entity dataset-loader database-definition table-definition)
+        (k/insert (k/values (->> (for [row rows]
+                                   (for [v row]
+                                     (if (instance? java.util.Date v) (java.sql.Timestamp. (.getTime ^java.util.Date v))
+                                         v)))
+                                 (map (partial zipmap fields-for-insert))))))))

--- a/test/metabase/test/data/h2.clj
+++ b/test/metabase/test/data/h2.clj
@@ -5,54 +5,13 @@
             [clojure.string :as s]
             (korma [core :as k]
                    [db :as kdb])
-            [metabase.test.data.interface :refer :all])
+            (metabase.test.data [generic-sql :as generic]
+                                [interface :refer :all]))
   (:import (metabase.test.data.interface DatabaseDefinition
                                          FieldDefinition
                                          TableDefinition)))
 
-;; ## DatabaseDefinition helper functions
-
-(defn filename
-  "Return filename that should be used for connecting to H2 database defined by DATABASE-DEFINITION.
-   This does not include the `.mv.db` extension."
-  [^DatabaseDefinition database-definition]
-  (format "%s/target/%s" (System/getProperty "user.dir") (escaped-name database-definition)))
-
-(defn connection-details
-  "Return a Metabase `Database.details` for H2 database defined by DATABASE-DEFINITION."
-  [^DatabaseDefinition database-definition]
-  {:db (format (if (:short-lived? database-definition) "file:%s" ; for short-lived connections don't create a server thread and don't use a keep-alive connection
-                   "file:%s;AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1")
-               (filename database-definition))})
-
-(defn korma-connection-pool
-  "Return an H2 korma connection pool to H2 database defined by DATABASE-DEFINITION."
-  [^DatabaseDefinition database-definition]
-  (kdb/create-db (kdb/h2 (assoc (connection-details database-definition)
-                                  :naming {:keys   s/lower-case
-                                           :fields s/upper-case}))))
-
-(defn exec-sql
-  "Execute RAW-SQL against H2 instance of H2 database defined by DATABASE-DEFINITION."
-  [^DatabaseDefinition database-definition ^String raw-sql]
-  (log/info raw-sql)
-  (k/exec-raw (korma-connection-pool database-definition) raw-sql))
-
-
-;; ## TableDefinition helper functions
-
-(defn korma-entity
-  "Return a Korma entity (e.g., one that can be passed to `select` or `sel` for the table
-   defined by TABLE-DEFINITION in the H2 database defined by DATABASE-DEFINITION."
-  [^TableDefinition table-definition ^DatabaseDefinition database-definition]
-  (-> (k/create-entity (:table-name table-definition))
-      (k/database (korma-connection-pool database-definition))))
-
-
-;; ## Internal Stuff
-
 (def ^:private ^:const field-base-type->sql-type
-  "Map of `Field.base_type` to the SQL type we should use for that column when creating a DB."
   {:BigIntegerField "BIGINT"
    :BooleanField    "BOOL"
    :CharField       "VARCHAR(254)"
@@ -64,10 +23,70 @@
    :TextField       "TEXT"
    :TimeField       "TIME"})
 
+;; ## DatabaseDefinition helper functions
+
+(defn- filename
+  "Return filename that should be used for connecting to H2 database defined by DATABASE-DEFINITION.
+   This does not include the `.mv.db` extension."
+  [^DatabaseDefinition database-definition]
+  (format "%s/target/%s" (System/getProperty "user.dir") (escaped-name database-definition)))
+
+(defn- connection-details
+  "Return a Metabase `Database.details` for H2 database defined by DATABASE-DEFINITION."
+  [^DatabaseDefinition database-definition]
+  {:db (format (if (:short-lived? database-definition) "file:%s" ; for short-lived connections don't create a server thread and don't use a keep-alive connection
+                   "file:%s;AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1")
+               (filename database-definition))})
+
+(defn- korma-connection-pool
+  "Return an H2 korma connection pool to H2 database defined by DATABASE-DEFINITION."
+  [^DatabaseDefinition database-definition]
+  (kdb/create-db (kdb/h2 (assoc (connection-details database-definition)
+                                :naming {:keys   s/lower-case
+                                         :fields s/upper-case}))))
+
+;; ## Implementation
+
+(defprotocol IH2DatasetFormat
+  (format-for-h2 [this]
+    "Format dataset definitions for H2, e.g. upcasing `Table` and `Field` names."))
+
+(extend-protocol IH2DatasetFormat
+  DatabaseDefinition
+  (format-for-h2 [this]
+    (update-in this [:table-definitions] (partial map format-for-h2)))
+
+  TableDefinition
+  (format-for-h2 [this]
+    (-> this
+        (update-in [:table-name] s/upper-case)
+        (update-in [:field-definitions] (partial map format-for-h2))))
+
+  FieldDefinition
+  (format-for-h2 [this]
+    (cond-> (update-in this [:field-name] s/upper-case)
+      (:pk this) (update-in [:pk] (comp s/upper-case name)))))
+
+
 ;; ## Public Concrete DatasetLoader instance
 
 ;; For some reason this doesn't seem to work if we define IDatasetLoader methods inline, but does work when we explicitly use extend-protocol
-(defrecord H2DatasetLoader [])
+(defrecord H2DatasetLoader []
+  generic/IGenericSQLDatasetLoader
+  (generic/execute-sql! [_ database-definition raw-sql]
+    (log/info raw-sql)
+    (k/exec-raw (korma-connection-pool database-definition) raw-sql))
+
+  (generic/korma-entity [_ database-definition table-definition]
+    (-> (k/create-entity (:table-name table-definition))
+        (k/database (korma-connection-pool database-definition))))
+
+  (generic/pk-sql-type [_]
+    "BIGINT AUTO_INCREMENT")
+
+  (generic/field-base-type->sql-type [_ field-type]
+    (field-base-type->sql-type field-type)))
+
 (extend-protocol IDatasetLoader
   H2DatasetLoader
   (engine [_]
@@ -82,54 +101,16 @@
         (.delete file))))
 
   (create-physical-table! [this database-definition table-definition]
-    ;; Drop the table if it already exists
-    (drop-physical-table! this database-definition table-definition)
-
-    ;; Now create the new table
-    (exec-sql
-     database-definition
-     (format "CREATE TABLE \"%s\" (%s, \"ID\" BIGINT AUTO_INCREMENT, PRIMARY KEY (\"ID\"));"
-             (s/upper-case (:table-name table-definition))
-             (->> (:field-definitions table-definition)
-                  (map (fn [{:keys [field-name base-type]}]
-                         (format "\"%s\" %s" (s/upper-case field-name) (base-type field-base-type->sql-type))))
-                  (interpose ", ")
-                  (apply str)))))
+    (generic/create-physical-table! this database-definition (format-for-h2 table-definition)))
 
   (create-physical-db! [this database-definition]
-    ;; Create all the Tables
-    (doseq [^TableDefinition table-definition (:table-definitions database-definition)]
-      (log/info (format "Creating table '%s'..." (:table-name table-definition)))
-      (create-physical-table! this database-definition table-definition))
+    (generic/create-physical-db! this (format-for-h2 database-definition)))
 
-    ;; Now add the foreign key constraints
-    (doseq [^TableDefinition table-definition (:table-definitions database-definition)]
-      (let [table-name (s/upper-case (:table-name table-definition))]
-        (doseq [{dest-table-name :fk, field-name :field-name} (:field-definitions table-definition)]
-          (when dest-table-name
-            (let [field-name      (s/upper-case field-name)
-                  dest-table-name (s/upper-case (name dest-table-name))]
-              (exec-sql
-               database-definition
-               (format "ALTER TABLE \"%s\" ADD CONSTRAINT IF NOT EXISTS \"FK_%s_%s\" FOREIGN KEY (\"%s\") REFERENCES \"%s\" (\"ID\");"
-                       table-name
-                       field-name dest-table-name
-                       field-name
-                       dest-table-name))))))))
+  (load-table-data! [this database-definition table-definition]
+    (generic/load-table-data! this database-definition table-definition))
 
-  (load-table-data! [_ database-definition table-definition]
-    (let [rows              (:rows table-definition)
-          fields-for-insert (map :field-name (:field-definitions table-definition))]
-      (-> (korma-entity table-definition database-definition)
-          (k/insert (k/values (map (partial zipmap fields-for-insert)
-                                   rows))))))
-
-  (drop-physical-table! [_ database-definition table-definition]
-    (exec-sql
-     database-definition
-     (format "DROP TABLE IF EXISTS \"%s\";" (s/upper-case (:table-name table-definition))))))
+  (drop-physical-table! [this database-definition table-definition]
+    (generic/drop-physical-table! this database-definition (format-for-h2 table-definition))))
 
 (defn dataset-loader []
-  (let [loader (->H2DatasetLoader)]
-    (assert (satisfies? IDatasetLoader loader))
-    loader))
+  (->H2DatasetLoader))

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -50,10 +50,11 @@
                                                        (s/upper-case (:table-name this))}]))
 
   DatabaseDefinition
-  (metabase-instance [this engine-kw]
+  (metabase-instance [{:keys [database-name]} engine-kw]
+    (assert (string? database-name))
     (assert (keyword? engine-kw))
     (setup-db-if-needed :auto-migrate true)
-    (sel :one Database :name (:database-name this) :engine (name engine-kw))))
+    (sel :one Database :name database-name, :engine (name engine-kw))))
 
 
 ;; ## IDatasetLoader

--- a/test/metabase/test/data/postgres.clj
+++ b/test/metabase/test/data/postgres.clj
@@ -1,0 +1,99 @@
+(ns metabase.test.data.postgres
+  "Code for creating / destroying a Postgres database from a `DatabaseDefinition`."
+  (:require [clojure.java.jdbc :as jdbc]
+            [clojure.tools.logging :as log]
+            [environ.core :refer [env]]
+            (korma [core :as k]
+                   [db :as kdb])
+            (metabase.test.data [generic-sql :as generic]
+                                [interface :refer :all]))
+  (:import (metabase.test.data.interface DatabaseDefinition
+                                         FieldDefinition
+                                         TableDefinition)))
+
+(def ^:private ^:const field-base-type->sql-type
+  {:BigIntegerField "BIGINT"
+   :BooleanField    "BOOL"
+   :CharField       "VARCHAR(254)"
+   :DateField       "DATE"
+   :DateTimeField   "TIMESTAMP"
+   :DecimalField    "DECIMAL"
+   :FloatField      "FLOAT"
+   :IntegerField    "INTEGER"
+   :TextField       "TEXT"
+   :TimeField       "TIME"})
+
+(defn- pg-connection-details [^DatabaseDefinition database-definition]
+  (merge {:host "localhost"
+          :port 5432}
+         ;; HACK
+         (when (env :circleci)
+           {:user "ubuntu"})))
+
+(defn- db-connection-details [^DatabaseDefinition database-definition]
+  (assoc (pg-connection-details database-definition)
+         :db (:database-name database-definition)))
+
+(defn- execute! [scope ^DatabaseDefinition database-definition & format-strings]
+  (jdbc/execute! (-> ((case scope
+                        :pg pg-connection-details
+                        :db db-connection-details) database-definition)
+                     kdb/postgres
+                     (assoc :make-pool? false))
+                 [(apply format format-strings)]
+                 :transaction? false))
+
+
+(defrecord PostgresDatasetLoader []
+  generic/IGenericSQLDatasetLoader
+  (generic/execute-sql! [_ database-definition raw-sql]
+    (log/info raw-sql)
+    (execute! :db database-definition raw-sql))
+
+  (generic/korma-entity [_ database-definition table-definition]
+    (-> (k/create-entity (:table-name table-definition))
+        (k/database (-> (db-connection-details database-definition)
+                        kdb/postgres
+                        (assoc :make-pool? false)
+                        kdb/create-db))))
+
+  (generic/pk-sql-type [_]
+    "SERIAL")
+
+  (generic/field-base-type->sql-type [_ field-type]
+    (field-base-type->sql-type field-type)))
+
+(extend-protocol IDatasetLoader
+  PostgresDatasetLoader
+  (engine [_]
+    :postgres)
+
+  (database->connection-details [_ database-definition]
+    (assoc (db-connection-details database-definition)
+           :timezone :America/Los_Angeles))
+
+  (drop-physical-db! [_ database-definition]
+    (execute! :pg database-definition "DROP DATABASE IF EXISTS \"%s\";" (:database-name database-definition)))
+
+  (drop-physical-table! [this database-definition table-definition]
+    (generic/drop-physical-table! this database-definition table-definition))
+
+  (create-physical-table! [this database-definition table-definition]
+    (generic/create-physical-table! this database-definition table-definition))
+
+  (create-physical-db! [this {:keys [database-name], :as database-definition}]
+    (execute! :pg database-definition "DROP DATABASE IF EXISTS \"%s\";" database-name)
+    (execute! :pg database-definition "CREATE DATABASE \"%s\";" database-name)
+
+    ;; double check that we can connect to the newly created DB
+    (metabase.driver/can-connect-with-details? :postgres (db-connection-details database-definition) :rethrow-exceptions)
+
+    ;; call the generic implementation to create Tables + FKs
+    (generic/create-physical-db! this database-definition))
+
+  (load-table-data! [this database-definition table-definition]
+    (generic/load-table-data! this database-definition table-definition)))
+
+
+(defn dataset-loader []
+  (->PostgresDatasetLoader))

--- a/test/metabase/test/data/postgres.clj
+++ b/test/metabase/test/data/postgres.clj
@@ -57,8 +57,8 @@
                         (assoc :make-pool? false)
                         kdb/create-db))))
 
-  (generic/pk-sql-type [_]
-    "SERIAL")
+  (generic/pk-sql-type   [_] "SERIAL")
+  (generic/pk-field-name [_] "id")
 
   (generic/field-base-type->sql-type [_ field-type]
     (field-base-type->sql-type field-type)))

--- a/test/metabase/test_setup.clj
+++ b/test/metabase/test_setup.clj
@@ -8,6 +8,7 @@
                       [db :as db]
                       [task :as task]
                       [util :as u])
+            (metabase.models [table :refer [Table]])
             [metabase.test.data.datasets :as datasets]))
 
 (declare clear-test-db)
@@ -70,7 +71,12 @@
   []
   (doseq [dataset-name @datasets/test-dataset-names]
     (log/info (format "Loading test data: %s..." (name dataset-name)))
-    (datasets/load-data! (datasets/dataset-name->dataset dataset-name))))
+    (let [dataset (datasets/dataset-name->dataset dataset-name)]
+      (datasets/load-data! dataset)
+
+      ;; Check that dataset is loaded and working
+      (assert (db/sel :one Table :id (datasets/table-name->id dataset :venues))
+              (format "Loading test dataset %s failed: could not find 'venues' Table!" dataset-name)))))
 
 (defn test-startup
   {:expectations-options :before-run}


### PR DESCRIPTION
Very nice!

Extend the magic multiple-dataset unit test magic to run against `:mongo`, `:h2`, _and_ `:postgres`.

Also, fix the Operator timestamp bug (will do a separate patch for the 0.9 branch)
