### PR TITLE
fix the mongo connection error

### DIFF
--- a/test/metabase/test/data/mongo.clj
+++ b/test/metabase/test/data/mongo.clj
@@ -22,8 +22,8 @@
   (create-physical-db! [_ _])
 
   (drop-physical-db! [this database-definition]
-    (mg/drop-db (mg/connect (database->connection-details this database-definition))
-                (escaped-name database-definition)))
+    (with-open [mongo-connection (mg/connect (database->connection-details this database-definition))]
+      (mg/drop-db mongo-connection (escaped-name database-definition))))
 
   ;; Nothing to do here, collection is created when we add documents to it
   (create-physical-table! [_ _ _])


### PR DESCRIPTION
Finally fixed the mongo open connection error messages! Was forgetting to close a connection that's opened when syncing a Mongo DB. 

I forgot that Java destructors don't do that for you like they do in C++ :sweat: :unamused: 
