### PR TITLE
fix table description styles on the homepage

### DIFF
--- a/resources/frontend_client/app/css/home.css
+++ b/resources/frontend_client/app/css/home.css
@@ -100,3 +100,8 @@
     box-shadow: 1px 1px 1px rgba(0, 0, 0, .12);
     color: #ddd;
 }
+
+.TableDescription {
+    max-width: 42rem;
+    line-height: 1.4;
+}

--- a/resources/frontend_client/app/home/home.html
+++ b/resources/frontend_client/app/home/home.html
@@ -96,7 +96,7 @@
                     <a class="no-decoration py2 border-bottom flex align-center" href="/card/create?db={{currentDB.id}}&table={{table.id}}">
                         <div class="flex flex-column pr3 lg-pr0">
                             <h2 class="text-dark text-brand-hover break-word">{{table.name}}</h2>
-                            {{table.description}}
+                            <h4 class="TableDescription text-grey-4 text-normal mt1">{{table.description}}</h4>
                         </div>
                         <div class="flex flex-align-right align-center">
                             <div class="text-right text-brand text-brand-darken-hover mr2">


### PR DESCRIPTION
add readable line length, line-height and add a better color to desciptions of tables on /

New:
![screen shot 2015-07-06 at 7 46 39 pm](https://cloud.githubusercontent.com/assets/5248953/8537737/fa76166a-2417-11e5-8f81-df1b948f128b.png)

Old:
![screen shot 2015-07-06 at 7 49 23 pm](https://cloud.githubusercontent.com/assets/5248953/8537749/3522461c-2418-11e5-8cf7-bff23651f848.png)
