### PR TITLE
remove unused clojure.core/data.json dep

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,6 @@
                  [org.clojure/math.numeric-tower "0.0.4"]             ; math functions like `ceil`
                  [org.clojure/core.memoize "0.5.7"]                   ; needed by core.match; has useful FIFO, LRU, etc. caching mechanisms
                  [org.clojure/data.csv "0.1.2"]                       ; CSV parsing / generation
-                 [org.clojure/data.json "0.2.6"]                      ; JSON parsing / generation
                  [org.clojure/java.classpath "0.2.2"]
                  [org.clojure/java.jdbc "0.3.7"]                      ; basic jdbc access from clojure
                  [org.clojure/tools.logging "0.3.1"]                  ; logging framework


### PR DESCRIPTION
We switched over to using `cheshire` for JSON serialization/deserialization months ago so no point in keeping around unused deps
