### PR TITLE
`sel`/`upd`/`del`/`cascade-delete`/`ins` auto-infer namespaces

### DIFF
--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -14,7 +14,7 @@
          qualified-name-components)
 
 (def ^:const special-types
-  "Possible values for `Field` `:special_type`."
+  "Possible values for `Field.special_type`."
   #{:avatar
     :category
     :city
@@ -55,7 +55,7 @@
    :zip_code          "Zip Code"})
 
 (def ^:const base-types
-  "Possible values for `Field` `:base_type`."
+  "Possible values for `Field.base_type`."
   #{:BigIntegerField
     :BooleanField
     :CharField


### PR DESCRIPTION
### BEFORE

For convenience the macros and functions in `metabase.db` have let you pass a quoted symbol for a model _without_ having to `use`/`require` their namespace:

``` clojure
(sel :one 'metabase.models.database/Database)
```

This does a memoized runtime resolution of the var in question so we can:
1. Avoid circular namespace dependencies and 
2. Do interactive REPL development without having to type 

``` clojure
(use 'metabase.models.database)
```

every 2 seconds. But still, there's enough extra typing involved to make it frustrating. :imp: 
### AFTER

So I made the function that implements this behavior a little smarter, and it can figure out the corresponding namespace for you.

``` clojure
(sel :one 'Database)
```

:smiling_imp: 
