### PR TITLE
Need to keep a connection open in order to unCLOB-er CLOBs

### DIFF
--- a/src/metabase/driver/generic_sql/util.clj
+++ b/src/metabase/driver/generic_sql/util.clj
@@ -17,7 +17,7 @@
     (-> database
         database->connection-details
         connection-details->connection-spec
-        (assoc :make-pool? true))))     ; need to make a pool or the connection will be closed before we get a change to unCLOB-er the results during JSON serialization
+        (assoc :make-pool? true))))     ; need to make a pool or the connection will be closed before we get a chance to unCLOB-er the results during JSON serialization
 
 (def ^{:arglists '([database])}
   db->korma-db

--- a/src/metabase/driver/generic_sql/util.clj
+++ b/src/metabase/driver/generic_sql/util.clj
@@ -29,9 +29,7 @@
                                 :ttl/threshold (* 60 1000))]
     ;; only :engine and :details are needed for driver/connection so just pass those so memoization works as expected
     (fn [database]
-      (let [r (-db->korma-db (select-keys database [:engine :details]))]
-        (println "R:\n" (metabase.util/pprint-to-str 'green r))
-        r))))
+      (-db->korma-db (select-keys database [:engine :details])))))
 
 (def ^:dynamic ^java.sql.DatabaseMetaData *jdbc-metadata*
   "JDBC metadata object for a database. This is set by `with-jdbc-metadata`."

--- a/test/metabase/test/data/h2.clj
+++ b/test/metabase/test/data/h2.clj
@@ -33,10 +33,11 @@
 
 (defn- connection-details
   "Return a Metabase `Database.details` for H2 database defined by DATABASE-DEFINITION."
-  [^DatabaseDefinition database-definition]
-  {:db (format (if (:short-lived? database-definition) "file:%s" ; for short-lived connections don't create a server thread and don't use a keep-alive connection
+  [^DatabaseDefinition {:keys [short-lived?], :as database-definition}]
+  {:db (format (if short-lived? "file:%s" ; for short-lived connections don't create a server thread and don't use a keep-alive connection
                    "file:%s;AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1")
-               (filename database-definition))})
+               (filename database-definition))
+   :short-lived? short-lived?})
 
 (defn- korma-connection-pool
   "Return an H2 korma connection pool to H2 database defined by DATABASE-DEFINITION."

--- a/test/metabase/test/data/postgres.clj
+++ b/test/metabase/test/data/postgres.clj
@@ -23,9 +23,10 @@
    :TextField       "TEXT"
    :TimeField       "TIME"})
 
-(defn- pg-connection-details [^DatabaseDefinition database-definition]
-  (merge {:host "localhost"
-          :port 5432}
+(defn- pg-connection-details [^DatabaseDefinition {:keys [short-lived?]}]
+  (merge {:host         "localhost"
+          :port         5432
+          :short-lived? short-lived?}
          ;; HACK
          (when (env :circleci)
            {:user "ubuntu"})))


### PR DESCRIPTION
This was a dumb error on my part. I was requesting that Korma make connection pools at the wrong point in the GenericSQL QP internals. This meant we'd occasionally get dumb bugs like "Object already closed" when the API went to JSON-serialize H2 CLOBs and Postgres PGObjects or whatever they're called because the DB connection was closed before we got a chance to pull the data from the DB (on a lighter note, this is proof the QP pulls data lazily :smirk:)

Not sure how long ago I messed this up but it might be responsible for some of the CSV download errors or whatever we've been seeing. I'll take a look at those tix and if it looks like this was the issue we should consider a :fire:fix
