### PR TITLE
 QP don't barf on FKs with no destination_id #574

### DIFF
--- a/src/metabase/driver/query_processor.clj
+++ b/src/metabase/driver/query_processor.clj
@@ -313,10 +313,11 @@
         ;; Look up the Foreign keys info if applicable.
         ;; Build a map of FK Field IDs -> Destination Field IDs
         field-id->dest-field-id (when (seq fk-field-ids)
-                                  (sel :many :field->field [ForeignKey :origin_id :destination_id], :origin_id [in fk-field-ids]))
+                                  (sel :many :field->field [ForeignKey :origin_id :destination_id], :origin_id [in fk-field-ids], :destination_id [not= nil]))
 
         ;; Build a map of Destination Field IDs -> Destination Fields
-        dest-field-id->field    (when (seq fk-field-ids)
+        dest-field-id->field    (when (and (seq fk-field-ids)
+                                           (seq (vals field-id->dest-field-id)))
                                   (sel :many :id->fields [Field :id :name :table_id :description :base_type :special_type], :id [in (vals field-id->dest-field-id)]))]
 
     ;; Add the :extra_info + :target to every Field. For non-FK Fields, these are just {} and nil, respectively.


### PR DESCRIPTION
Fixes #574.

So the problem here is that people were running around marking up Fields as foreign keys without setting the destination Fields.

QP contained code that assumed `ForeignKeys` would have a non-null `destination_id`, which caused it to barf when it encountered ones that did.

I really don't like to have to write all this hairy special case code all over the place; this really should have been a DB constraint to begin with. 

At any rate there's no need to do a hotfix here since you can just go fix manually fix the offending foreign keys in admin.
