### PR TITLE
Rewrite QP column ordering (annotation) stage w/ core.logic

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -27,7 +27,7 @@
                               (expect-with-all-drivers 1)
                               (expect-with-dataset 1)
                               (expect-with-datasets 1)
-                              (fpred-conda 2)
+                              (fpred-conda 1)
                               (ins 1)
                               (let-400 1)
                               (let-404 1)

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -33,6 +33,7 @@
                               (let-500 1)
                               (match 1)
                               (match-$ 1)
+                              (matche 1)
                               (macrolet 1)
                               (org-perms-case 1)
                               (pdoseq 1)

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -17,6 +17,7 @@
                               (auto-parse 1)
                               (catch-api-exceptions 0)
                               (check 1)
+                              (conda 0)
                               (context 2)
                               (create-database-definition 1)
                               (execute-query 1)

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -4,6 +4,8 @@
                             (put 'defannotation 'clojure-doc-string-elt 2)
                             (put 'defendpoint 'clojure-doc-string-elt 3)
                             (put 'defhook 'clojure-doc-string-elt 2)
+                            (put 'defna 'clojure-doc-string-elt 2)
+                            (put 'defne 'clojure-doc-string-elt 2)
                             (put 'defsetting 'clojure-doc-string-elt 2)
 
                             ;; Define custom indentation for functions inside metabase.
@@ -34,7 +36,9 @@
                               (let-500 1)
                               (match 1)
                               (match-$ 1)
+                              (matcha 1)
                               (matche 1)
+                              (matchu 1)
                               (macrolet 1)
                               (org-perms-case 1)
                               (pdoseq 1)

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -36,6 +36,7 @@
                               (macrolet 1)
                               (org-perms-case 1)
                               (pdoseq 1)
+                              (project 1)
                               (qp-expect-with-datasets 1)
                               (query-with-temp-db 1)
                               (resolve-private-fns 1)

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -30,7 +30,6 @@
                               (expect-with-all-drivers 1)
                               (expect-with-dataset 1)
                               (expect-with-datasets 1)
-                              (fpred-conda 1)
                               (ins 1)
                               (let-400 1)
                               (let-404 1)

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -27,6 +27,7 @@
                               (expect-with-all-drivers 1)
                               (expect-with-dataset 1)
                               (expect-with-datasets 1)
+                              (fpred-conda 2)
                               (ins 1)
                               (let-400 1)
                               (let-404 1)

--- a/project.clj
+++ b/project.clj
@@ -84,7 +84,7 @@
                             :env {:mb-test-setting-1 "ABCDEFG"}
                             :jvm-opts ["-Dmb.db.file=target/metabase-test"
                                        "-Dmb.jetty.join=false"
-                                       "-Dmb.jetty.port=3001"
+                                       "-Dmb.jetty.port=3010"
                                        "-Dmb.api.key=test-api-key"
                                        "-Xverify:none"]}              ; disable bytecode verification when running tests so they start slightly faster
              :uberjar {:aot :all

--- a/project.clj
+++ b/project.clj
@@ -7,12 +7,13 @@
   :min-lein-version "2.5.0"
   :aliases {"test" ["with-profile" "+expectations" "expectations"]}
   :dependencies [[org.clojure/clojure "1.7.0"]
+                 [org.clojure/core.logic "0.8.10"]
                  [org.clojure/core.match "0.3.0-alpha4"]              ; optimized pattern matching library for Clojure
-                 [org.clojure/math.numeric-tower "0.0.4"]             ; math functions like `ceil`
                  [org.clojure/core.memoize "0.5.7"]                   ; needed by core.match; has useful FIFO, LRU, etc. caching mechanisms
                  [org.clojure/data.csv "0.1.2"]                       ; CSV parsing / generation
                  [org.clojure/java.classpath "0.2.2"]
                  [org.clojure/java.jdbc "0.3.7"]                      ; basic jdbc access from clojure
+                 [org.clojure/math.numeric-tower "0.0.4"]             ; math functions like `ceil`
                  [org.clojure/tools.logging "0.3.1"]                  ; logging framework
                  [org.clojure/tools.macro "0.1.5"]                    ; tools for writing macros
                  [org.clojure/tools.namespace "0.2.10"]

--- a/project.clj
+++ b/project.clj
@@ -58,7 +58,8 @@
   :eastwood {:exclude-namespaces [:test-paths]
              :add-linters [:unused-private-vars]
              :exclude-linters [:constant-test                         ; korma macros generate some forms with if statements that are always logically true or false
-                               :suspicious-expression]}               ; core.match macros generate some forms like (and expr) which is "suspicious"
+                               :suspicious-expression                 ; core.match macros generate some forms like (and expr) which is "suspicious"
+                               :unused-ret-vals]}                     ; gives too many false positives for functions with side-effects like conj!
   :profiles {:dev {:dependencies [[org.clojure/tools.nrepl "0.2.10"]  ; REPL <3
                                   [expectations "2.1.2"]              ; unit tests
                                   [marginalia "0.8.0"]                ; for documentation

--- a/src/metabase/api/common/internal.clj
+++ b/src/metabase/api/common/internal.clj
@@ -227,8 +227,7 @@
                       ;; If status code was specified but other data wasn't, it's something like a 404. Return message as the body.
                       status-code            message
                       ;; Otherwise it's a 500. Return a body that includes exception & filtered stacktrace for debugging purposes
-                      :else                  (let [stacktrace (->> (map str (.getStackTrace e))
-                                                                   (filter (partial re-find #"metabase")))]
+                      :else                  (let [stacktrace (u/filtered-stacktrace e)]
                                                (log/debug message "\n" (u/pprint-to-str stacktrace))
                                                (assoc other-info
                                                       :message message

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -23,10 +23,7 @@
                       timezone->set-timezone-sql
                       ;; These functions take a string name of a Table and a string name of a Field and return the raw SQL to select it as a DATE
                       cast-timestamp-seconds-field-to-date-fn
-                      cast-timestamp-milliseconds-field-to-date-fn
-                      ;; This should be a regex that will match the column returned by the driver when unix timestamp -> date casting occured
-                      ;; e.g. #"CAST\(TIMESTAMPADD\('(?:MILLI)?SECOND', ([^\s]+), DATE '1970-01-01'\) AS DATE\)" for H2
-                      uncastify-timestamp-regex]
+                      cast-timestamp-milliseconds-field-to-date-fn]
   IDriver
   ;; Features
   (supports? [_ feature]

--- a/src/metabase/driver/generic_sql/native.clj
+++ b/src/metabase/driver/generic_sql/native.clj
@@ -34,6 +34,7 @@
                                                     (log/debug "Setting timezone to:" timezone)
                                                     (jdbc/db-do-prepared conn (timezone->set-timezone-sql timezone))))
                                                 (jdbc/query conn sql :as-arrays? true))]
+         ;; TODO - Why don't we just use annotate?
          {:rows    rows
           :columns columns
           :cols    (map (fn [column first-value]

--- a/src/metabase/driver/generic_sql/util.clj
+++ b/src/metabase/driver/generic_sql/util.clj
@@ -24,10 +24,9 @@
   db->korma-db
   "Return a Korma database definition for DATABASE.
    This does a little bit of smart caching (for 60 seconds) to avoid creating new connections when unneeded."
-  (let [-db->korma-db (memo/ttl (fn [database]
-                                  (log/debug (color/red "Creating a new DB connection..."))
-                                  (kdb/create-db (db->connection-spec database)))
-                                :ttl/threshold (* 60 1000))]
+  (let [-db->korma-db (memoize (fn [database]
+                                 (log/debug (color/red "Creating a new DB connection..."))
+                                 (kdb/create-db (db->connection-spec database))))]
     ;; only :engine and :details are needed for driver/connection so just pass those so memoization works as expected
     (fn [database]
       (-db->korma-db (select-keys database [:engine :details])))))

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -89,9 +89,6 @@
 (defn- cast-timestamp-milliseconds-field-to-date-fn [table-name field-name]
   (format "CAST(TIMESTAMPADD('MILLISECOND', \"%s\".\"%s\", DATE '1970-01-01') AS DATE)" table-name field-name))
 
-(def ^:private ^:const uncastify-timestamp-regex
-  #"CAST\(TIMESTAMPADD\('(?:MILLI)?SECOND', [^.\s]+\.([^.\s]+), DATE '1970-01-01'\) AS DATE\)")
-
 ;; ## DRIVER
 
 (def driver
@@ -101,5 +98,4 @@
     :database->connection-details                 database->connection-details
     :sql-string-length-fn                         :LENGTH
     :cast-timestamp-seconds-field-to-date-fn      cast-timestamp-seconds-field-to-date-fn
-    :cast-timestamp-milliseconds-field-to-date-fn cast-timestamp-milliseconds-field-to-date-fn
-    :uncastify-timestamp-regex                    uncastify-timestamp-regex}))
+    :cast-timestamp-milliseconds-field-to-date-fn cast-timestamp-milliseconds-field-to-date-fn}))

--- a/src/metabase/driver/mongo/query_processor.clj
+++ b/src/metabase/driver/mongo/query_processor.clj
@@ -45,10 +45,10 @@
                                             (->> generated-query
                                                  (walk/postwalk #(if (symbol? %) (symbol (name %)) %)) ; strip namespace qualifiers from Monger form
                                                  u/pprint-to-str) "\n"))) ; so it's easier to read
-                {:results (eval generated-query)})
+                (eval generated-query))
       :native (let [results (eval-raw-command (:query (:native query)))]
-                {:results (if (sequential? results) results
-                              [results])}))))
+                (if (sequential? results) results
+                              [results])))))
 
 
 ;; # NATIVE QUERY PROCESSOR

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -118,10 +118,6 @@
          (string? field-name)]}
   (format "(TIMESTAMP WITH TIME ZONE 'epoch' + (\"%s\".\"%s\" * INTERVAL '1 millisecond'))::date" table-name field-name))
 
-(def ^:private ^:const uncastify-timestamp-regex
-  ;; TODO - this doesn't work
-  #"TO_TIMESTAMP\([^.\s]+\.([^.\s]+)(?: / 1000)?\)::date")
-
 ;; ## DRIVER
 
 (def ^:const driver
@@ -133,5 +129,4 @@
     :sql-string-length-fn                         :CHAR_LENGTH
     :timezone->set-timezone-sql                   timezone->set-timezone-sql
     :cast-timestamp-seconds-field-to-date-fn      cast-timestamp-seconds-field-to-date-fn
-    :cast-timestamp-milliseconds-field-to-date-fn cast-timestamp-milliseconds-field-to-date-fn
-    :uncastify-timestamp-regex                    uncastify-timestamp-regex}))
+    :cast-timestamp-milliseconds-field-to-date-fn cast-timestamp-milliseconds-field-to-date-fn}))

--- a/src/metabase/driver/query_processor.clj
+++ b/src/metabase/driver/query_processor.clj
@@ -64,7 +64,6 @@
         (= num-results max-result-rows) (assoc-in [:data :rows_truncated] max-result-rows)))))
 
 (defn- should-add-implicit-fields? [{{:keys [fields breakout], {ag-type :aggregation-type} :aggregation} :query}]
-  (println "AG-TYPE:" ag-type)
   (and (or (not ag-type)
            (= ag-type :rows))
        (not breakout)

--- a/src/metabase/driver/query_processor.clj
+++ b/src/metabase/driver/query_processor.clj
@@ -8,7 +8,8 @@
             [swiss.arrows :refer [<<-]]
             [metabase.db :refer :all]
             [metabase.driver.interface :as i]
-            [metabase.driver.query-processor.expand :as expand]
+            (metabase.driver.query-processor [annotate :as annotate]
+                                             [expand :as expand])
             (metabase.models [field :refer [Field], :as field]
                              [foreign-key :refer [ForeignKey]])
             [metabase.util :as u]))
@@ -195,219 +196,6 @@
     (qp query)))
 
 
-;; +----------------------------------------------------------------------------------------------------+
-;; |                                             ANNOTATION                                             |
-;; +----------------------------------------------------------------------------------------------------+
-
-;; ## Ordering
-;;
-;; Fields should be returned in the following order:
-;; 1.  Breakout Fields
-;;
-;; 2.  Aggregation Fields (e.g. sum, count)
-;;
-;; 3.  Fields clause Fields, if they were added explicitly
-;;
-;; 4.  All other Fields, sorted by:
-;;     A.  :position (ascending)
-;;         Users can manually specify default Field ordering for a Table in the Metadata admin. In that case, return Fields in the specified
-;;         order; most of the time they'll have the default value of 0, in which case we'll compare...
-;;
-;;     B.  :special_type "group" -- :id Fields, then :name Fields, then everyting else
-;;         Attempt to put the most relevant Fields first. Order the Fields as follows:
-;;         1.  :id Fields
-;;         2.  :name Fields
-;;         3.  all other Fields
-;;
-;;     C.  Field Name
-;;         When two Fields have the same :position and :special_type "group", fall back to sorting Fields alphabetically by name.
-;;         This is arbitrary, but it makes the QP deterministic by keeping the results in a consistent order, which makes it testable.
-(defn- order-cols
-  "Construct a sequence of column keywords that should be used for pulling ordered rows from RESULTS.
-   FIELDS should be a sequence of all `Fields` for the `Table` associated with QUERY."
-  [{{breakout-fields :breakout, {ag-type :aggregation-type} :aggregation, fields-fields :fields, fields-is-implicit :fields-is-implicit} :query} results fields]
-  (let [;; Get all the column name keywords returned by the results
-        result-kws       (set (keys (first results)))
-        valid-kw?        (partial contains? result-kws)
-
-        breakout-ids     (map :field-id breakout-fields)
-
-        breakout-kws     (->> (for [field breakout-fields]
-                                (->> (rest (expand/qualified-name-components field)) ; TODO - this "qualified name for results" should be calculated in the Query expander
-                                     (interpose ".")
-                                     (apply str)
-                                     keyword))
-                              (filter valid-kw?))
-
-        fields-ids       (map :field-id fields-fields)
-
-        field-id->field  (zipmap (map :id fields) fields)
-
-        ;; Get IDs from Fields clause *if* it was added explicitly and other all other Field IDs for Table.
-        fields-ids       (when-not fields-is-implicit fields-ids)
-        all-field-ids    (->> fields    ; Sort the Fields.
-                              (sort-by (fn [{:keys [position special_type name]}] ; For each field generate a vector of
-                                         [position ; [position special-type-group name]
-                                          (cond ; and Clojure will take care of the rest.
-                                            (= special_type :id)   0
-                                            (= special_type :name) 1
-                                            :else                  2)
-                                          name]))
-                              (map :id)) ; Return the sorted IDs
-
-        ;; Get the aggregate column if any
-        ag-kws           (when (and ag-type
-                                    (not= ag-type :rows))
-                           (let [ag (if (= ag-type :distinct) :count
-                                        ag-type)]
-                             [ag]))
-
-        ;; Make a helper function that will take a sequence of Field IDs and convert them to corresponding column name keywords.
-        ;; Don't include names that aren't part of RESULT-KWS: we fetch *all* the Fields for a Table regardless of the Query, so
-        ;; there are likely some unused ones.
-        ids->kws         (fn [field-ids]
-                           (some->> (map field-id->field field-ids)
-                                    (map :name)
-                                    (map keyword)
-                                    (filter valid-kw?)))
-
-        ;; Concat the Fields clause IDs + the sequence of all Fields ID for the Table.
-        ;; Then filter out ones that appear in breakout clause and remove duplicates
-        ;; which effectively gives us parts #3 and #4 from above.
-        non-breakout-ids (->> (concat fields-ids all-field-ids)
-                              (filter (complement (partial contains? (set breakout-ids))))
-                              distinct)
-
-        ;; Use fn above to get the keyword column names of other non-aggregation fields [#3 and #4]
-        non-breakout-kws (->> (ids->kws non-breakout-ids)
-                              (filter (complement (partial contains? (set ag-kws)))))
-
-        ;; Collect all other Fields
-        other-kws        (->> result-kws
-                              (filter (complement (partial contains? (set (concat breakout-kws non-breakout-kws ag-kws)))))
-                              sort)] ; sort by name so results are deterministic
-
-    (when (seq other-kws)
-      (log/warn (u/format-color 'red "Warning: not 100%% sure how to order these columns: %s" (vec other-kws))))
-
-    ;; Now combine the breakout [#1] + aggregate [#2] + "non-breakout" [#3 &  #4] column name keywords into a single sequence
-    (when-not *disable-qp-logging*
-      (log/debug (u/format-color 'magenta "Using this ordering: breakout: %s, ag: %s, non-breakout: %s, other: %s"
-                                 (vec breakout-kws) (vec ag-kws) (vec non-breakout-kws) (vec other-kws))))
-
-    (let [ordered-kws (concat breakout-kws ag-kws non-breakout-kws other-kws)]
-      (assert (and (= (set ordered-kws) result-kws)
-                   (= (count ordered-kws) (count result-kws)))
-        (format "Order-cols returned invalid results: expected %s, got %s\nbreakout: %s, ag: %s, non-breakout: %s, other: %s" result-kws (vec ordered-kws)
-                (vec breakout-kws) (vec ag-kws) (vec non-breakout-kws) (vec other-kws)))
-      ordered-kws)))
-
-(defn- add-fields-extra-info
-  "Add `:extra_info` about `ForeignKeys` to `Fields` whose `special_type` is `:fk`."
-  [fields]
-  ;; Get a sequence of add Field IDs that have a :special_type of FK
-  (let [fk-field-ids            (->> fields
-                                     (filter #(= (:special_type %) :fk))
-                                     (map :id)
-                                     (filter identity))
-        ;; Look up the Foreign keys info if applicable.
-        ;; Build a map of FK Field IDs -> Destination Field IDs
-        field-id->dest-field-id (when (seq fk-field-ids)
-                                  (sel :many :field->field [ForeignKey :origin_id :destination_id], :origin_id [in fk-field-ids], :destination_id [not= nil]))
-
-        ;; Build a map of Destination Field IDs -> Destination Fields
-        dest-field-id->field    (when (and (seq fk-field-ids)
-                                           (seq (vals field-id->dest-field-id)))
-                                  (sel :many :id->fields [Field :id :name :table_id :description :base_type :special_type], :id [in (vals field-id->dest-field-id)]))]
-
-    ;; Add the :extra_info + :target to every Field. For non-FK Fields, these are just {} and nil, respectively.
-    (for [{field-id :id, :as field} fields]
-      (let [dest-field (when (seq fk-field-ids)
-                         (some->> field-id
-                                  field-id->dest-field-id
-                                  dest-field-id->field))]
-        (assoc field
-               :target     dest-field
-               :extra_info (if-not dest-field {}
-                                   {:target_table_id (:table_id dest-field)}))))))
-
-(defn- get-cols-info
-  "Get column info for the `:cols` part of the QP results."
-  [{{{ag-type :aggregation-type, ag-field :field} :aggregation} :query} fields ordered-col-kws join-table-ids]
-  (let [field-kw->field (zipmap (map #(keyword (:name %)) fields)
-                                fields)
-        field-id->field (delay (zipmap (map :id fields) ; a delay since we probably won't need it
-                                       fields))]
-    (->> (for [col-kw ordered-col-kws]
-           (or
-            ;; If col-kw is a known Field return that
-            (field-kw->field col-kw)
-
-            ;; Otherwise if this Query included any joins then attempt to lookup a matching Field from one of the join tables
-            (and (seq join-table-ids)
-                 (sel :one :fields [Field :id :table_id :name :description :base_type :special_type], :name (name col-kw), :table_id [in join-table-ids]))
-
-            ;; Otherwise if this is a nested Field recursively find the appropriate info
-            (let [name-components (s/split (name col-kw) #"\.")]
-              (when (> (count name-components) 1)
-                ;; Find the nested Field by recursing through each Field's :children
-                (loop [field-kw->field field-kw->field, [component & more] (map keyword name-components)]
-                  (when-let [f (field-kw->field component)]
-                    (if-not (seq more)
-                      ;; If the are no more components to recurse through give the resulting Field a qualified name like "source.service" and return it
-                      (assoc f :name (apply str (interpose "." name-components)))
-                      ;; Otherwise recurse with a map of child-name-kw -> child and the rest of the name components
-                      (recur (zipmap (map (comp keyword :name) (:children f))
-                                     (:children f))
-                             more))))))
-
-            ;; Otherwise it is an aggregation column like :sum, build a map of information to return
-            (merge (assert ag-type)
-                   {:name        (name col-kw)
-                    :id          nil
-                    :table_id    nil
-                    :description nil}
-                   (cond
-                     ;; avg, stddev, and sum should inherit the base_type and special_type from the Field they're aggregating
-                     (contains? #{:avg :stddev :sum} col-kw) {:base_type    (:base-type ag-field)
-                                                              :special_type (:special-type ag-field)}
-                     ;; count should always be IntegerField/number
-                     (= col-kw :count)                       {:base_type    :IntegerField
-                                                              :special_type :number}
-
-                     ;; Otherwise something went wrong !
-                     :else                                   (do (log/error (u/format-color 'red "Annotation failed: don't know what to do with Field '%s'.\nExpected these Fields:\n%s"
-                                                                                            col-kw
-                                                                                            (u/pprint-to-str field-kw->field)))
-                                                                 {:base_type    :UnknownField
-                                                                  :special_type nil})))))
-         ;; Add FK info the the resulting Fields
-         add-fields-extra-info
-
-         ;; Remove extra data from the resulting Fields
-         (map (u/rpartial dissoc :children :parent_id)))))
-
-(defn- post-annotate
-  "Take a sequence of RESULTS of executing QUERY and return the \"annotated\" results we pass to postprocessing -- the map with `:cols`, `:columns`, and `:rows`.
-   RESULTS should be a sequence of *maps*, keyed by result column -> value."
-  [qp]
-  (fn [{{:keys [join-tables] {source-table-id :id} :source-table} :query, :as query}]
-    (let [{:keys [results uncastify-fn]} (qp query)
-          results                        (if-not uncastify-fn results
-                                                 (for [row results]
-                                                   (m/map-keys uncastify-fn row)))
-          _                              (when-not *disable-qp-logging*
-                                           (log/debug (u/format-color 'magenta "Driver QP returned results with keys: %s." (vec (keys (first results))))))
-          join-table-ids                 (set (map :table-id join-tables))
-          fields                         (field/unflatten-nested-fields (sel :many :fields [Field :id :table_id :name :description :base_type :special_type :parent_id], :table_id source-table-id, :active true))
-          ordered-col-kws                (order-cols query results fields)]
-
-      {:rows    (for [row results]
-                  (mapv row ordered-col-kws))                                                      ; might as well return each row and col info as vecs because we're not worried about making
-       :columns (mapv name ordered-col-kws)                                                        ; making them lazy, and results are easier to play with in the REPL / paste into unit tests
-       :cols    (vec (get-cols-info query fields ordered-col-kws join-table-ids))})))  ; as vecs. Make sure :rows stays lazy!
-
-
 ;; +------------------------------------------------------------------------------------------------------------------------+
 ;; |                                                     QUERY PROCESSOR                                                    |
 ;; +------------------------------------------------------------------------------------------------------------------------+
@@ -460,7 +248,7 @@
           post-convert-unix-timestamps-to-dates
           cumulative-sum
           limit
-          post-annotate
+          annotate/post-annotate
           pre-log-query
           wrap-guard-multiple-calls
           driver-process-query) query)))

--- a/src/metabase/driver/query_processor.clj
+++ b/src/metabase/driver/query_processor.clj
@@ -67,14 +67,17 @@
   "Add an implicit `fields` clause to queries with `rows` aggregations."
   [qp]
   (fn [{{:keys [fields breakout source-table], {source-table-id :id} :source-table, {ag-type :aggregation-type} :aggregation} :query, :as query}]
-    (qp (if (or (not (= ag-type :rows)) breakout fields) query
-            (-> query
-                (assoc-in [:query :fields-is-implicit] true)
-                (assoc-in [:query :fields] (->> (sel :many :fields [Field :name :base_type :special_type :table_id :id :position :description], :table_id source-table-id, :active true,
-                                                     :preview_display true, :field_type [not= "sensitive"], :parent_id nil, (k/order :position :asc), (k/order :id :desc))
-                                                (map expand/rename-mb-field-keys)
-                                                (map expand/map->Field)
-                                                (map #(expand/resolve-table % {source-table-id source-table})))))))))
+    (qp (if (or (and ag-type
+                     (not (= ag-type :rows)))
+                breakout
+                fields)  query
+                (-> query
+                    (assoc-in [:query :fields-is-implicit] true)
+                    (assoc-in [:query :fields] (->> (sel :many :fields [Field :name :base_type :special_type :table_id :id :position :description], :table_id source-table-id, :active true,
+                                                         :preview_display true, :field_type [not= "sensitive"], :parent_id nil, (k/order :position :asc), (k/order :id :desc))
+                                                    (map expand/rename-mb-field-keys)
+                                                    (map expand/map->Field)
+                                                    (map #(expand/resolve-table % {source-table-id source-table})))))))))
 
 
 (defn- pre-add-implicit-breakout-order-by

--- a/src/metabase/driver/query_processor.clj
+++ b/src/metabase/driver/query_processor.clj
@@ -43,7 +43,8 @@
            (.printStackTrace e)
            {:status     :failed
             :error      (.getMessage e)
-            :stacktrace (u/filtered-stacktrace e)}))))
+            :stacktrace (u/filtered-stacktrace e)
+            :query      (dissoc query :database)}))))
 
 
 (defn- pre-expand [qp]

--- a/src/metabase/driver/query_processor.clj
+++ b/src/metabase/driver/query_processor.clj
@@ -70,7 +70,7 @@
     (qp (if (or (not (= ag-type :rows)) breakout fields) query
             (-> query
                 (assoc-in [:query :fields-is-implicit] true)
-                (assoc-in [:query :fields] (->> (sel :many :fields [Field :name :base_type :special_type :table_id :id], :table_id source-table-id, :active true,
+                (assoc-in [:query :fields] (->> (sel :many :fields [Field :name :base_type :special_type :table_id :id :position], :table_id source-table-id, :active true,
                                                      :preview_display true, :field_type [not= "sensitive"], :parent_id nil, (k/order :position :asc), (k/order :id :desc))
                                                 (map expand/rename-mb-field-keys)
                                                 (map expand/map->Field)

--- a/src/metabase/driver/query_processor.clj
+++ b/src/metabase/driver/query_processor.clj
@@ -44,7 +44,9 @@
            {:status     :failed
             :error      (.getMessage e)
             :stacktrace (u/filtered-stacktrace e)
-            :query      (dissoc query :database)}))))
+            :query      (dissoc query :database :driver)
+            :expanded-query (try (dissoc (expand/expand query) :database :driver)
+                                 (catch Throwable _))}))))
 
 
 (defn- pre-expand [qp]

--- a/src/metabase/driver/query_processor.clj
+++ b/src/metabase/driver/query_processor.clj
@@ -70,7 +70,7 @@
     (qp (if (or (not (= ag-type :rows)) breakout fields) query
             (-> query
                 (assoc-in [:query :fields-is-implicit] true)
-                (assoc-in [:query :fields] (->> (sel :many :fields [Field :name :base_type :special_type :table_id :id :position], :table_id source-table-id, :active true,
+                (assoc-in [:query :fields] (->> (sel :many :fields [Field :name :base_type :special_type :table_id :id :position :description], :table_id source-table-id, :active true,
                                                      :preview_display true, :field_type [not= "sensitive"], :parent_id nil, (k/order :position :asc), (k/order :id :desc))
                                                 (map expand/rename-mb-field-keys)
                                                 (map expand/map->Field)

--- a/src/metabase/driver/query_processor/annotate.clj
+++ b/src/metabase/driver/query_processor/annotate.clj
@@ -1,0 +1,217 @@
+(ns metabase.driver.query-processor.annotate
+  (:require [clojure.string :as s]
+            [clojure.tools.logging :as log]
+            [medley.core :as m]
+            [metabase.db :refer [sel]]
+            [metabase.driver.query-processor.expand :as expand]
+            (metabase.models [field :refer [Field], :as field]
+                             [foreign-key :refer [ForeignKey]])
+            [metabase.util :as u]))
+
+;; ## Ordering
+;;
+;; Fields should be returned in the following order:
+;; 1.  Breakout Fields
+;;
+;; 2.  Aggregation Fields (e.g. sum, count)
+;;
+;; 3.  Fields clause Fields, if they were added explicitly
+;;
+;; 4.  All other Fields, sorted by:
+;;     A.  :position (ascending)
+;;         Users can manually specify default Field ordering for a Table in the Metadata admin. In that case, return Fields in the specified
+;;         order; most of the time they'll have the default value of 0, in which case we'll compare...
+;;
+;;     B.  :special_type "group" -- :id Fields, then :name Fields, then everyting else
+;;         Attempt to put the most relevant Fields first. Order the Fields as follows:
+;;         1.  :id Fields
+;;         2.  :name Fields
+;;         3.  all other Fields
+;;
+;;     C.  Field Name
+;;         When two Fields have the same :position and :special_type "group", fall back to sorting Fields alphabetically by name.
+;;         This is arbitrary, but it makes the QP deterministic by keeping the results in a consistent order, which makes it testable.
+(defn- order-cols
+  "Construct a sequence of column keywords that should be used for pulling ordered rows from RESULTS.
+   FIELDS should be a sequence of all `Fields` for the `Table` associated with QUERY."
+  [{{breakout-fields :breakout, {ag-type :aggregation-type} :aggregation, fields-fields :fields, fields-is-implicit :fields-is-implicit} :query} results fields]
+  (let [;; Get all the column name keywords returned by the results
+        result-kws       (set (keys (first results)))
+        valid-kw?        (partial contains? result-kws)
+
+        breakout-ids     (map :field-id breakout-fields)
+
+        breakout-kws     (->> (for [field breakout-fields]
+                                (->> (rest (expand/qualified-name-components field)) ; TODO - this "qualified name for results" should be calculated in the Query expander
+                                     (interpose ".")
+                                     (apply str)
+                                     keyword))
+                              (filter valid-kw?))
+
+        fields-ids       (map :field-id fields-fields)
+
+        field-id->field  (zipmap (map :id fields) fields)
+
+        ;; Get IDs from Fields clause *if* it was added explicitly and other all other Field IDs for Table.
+        fields-ids       (when-not fields-is-implicit fields-ids)
+        all-field-ids    (->> fields    ; Sort the Fields.
+                              (sort-by (fn [{:keys [position special_type name]}] ; For each field generate a vector of
+                                         [position ; [position special-type-group name]
+                                          (cond ; and Clojure will take care of the rest.
+                                            (= special_type :id)   0
+                                            (= special_type :name) 1
+                                            :else                  2)
+                                          name]))
+                              (map :id)) ; Return the sorted IDs
+
+        ;; Get the aggregate column if any
+        ag-kws           (when (and ag-type
+                                    (not= ag-type :rows))
+                           (let [ag (if (= ag-type :distinct) :count
+                                        ag-type)]
+                             [ag]))
+
+        ;; Make a helper function that will take a sequence of Field IDs and convert them to corresponding column name keywords.
+        ;; Don't include names that aren't part of RESULT-KWS: we fetch *all* the Fields for a Table regardless of the Query, so
+        ;; there are likely some unused ones.
+        ids->kws         (fn [field-ids]
+                           (some->> (map field-id->field field-ids)
+                                    (map :name)
+                                    (map keyword)
+                                    (filter valid-kw?)))
+
+        ;; Concat the Fields clause IDs + the sequence of all Fields ID for the Table.
+        ;; Then filter out ones that appear in breakout clause and remove duplicates
+        ;; which effectively gives us parts #3 and #4 from above.
+        non-breakout-ids (->> (concat fields-ids all-field-ids)
+                              (filter (complement (partial contains? (set breakout-ids))))
+                              distinct)
+
+        ;; Use fn above to get the keyword column names of other non-aggregation fields [#3 and #4]
+        non-breakout-kws (->> (ids->kws non-breakout-ids)
+                              (filter (complement (partial contains? (set ag-kws)))))
+
+        ;; Collect all other Fields
+        other-kws        (->> result-kws
+                              (filter (complement (partial contains? (set (concat breakout-kws non-breakout-kws ag-kws)))))
+                              sort)] ; sort by name so results are deterministic
+
+    (when (seq other-kws)
+      (log/warn (u/format-color 'red "Warning: not 100%% sure how to order these columns: %s" (vec other-kws))))
+
+    ;; Now combine the breakout [#1] + aggregate [#2] + "non-breakout" [#3 &  #4] column name keywords into a single sequence
+    (when-not @(ns-resolve 'metabase.driver.query-processor '*disable-qp-logging*)
+      (log/debug (u/format-color 'magenta "Using this ordering: breakout: %s, ag: %s, non-breakout: %s, other: %s"
+                                 (vec breakout-kws) (vec ag-kws) (vec non-breakout-kws) (vec other-kws))))
+
+    (let [ordered-kws (concat breakout-kws ag-kws non-breakout-kws other-kws)]
+      (assert (and (= (set ordered-kws) result-kws)
+                   (= (count ordered-kws) (count result-kws)))
+        (format "Order-cols returned invalid results: expected %s, got %s\nbreakout: %s, ag: %s, non-breakout: %s, other: %s" result-kws (vec ordered-kws)
+                (vec breakout-kws) (vec ag-kws) (vec non-breakout-kws) (vec other-kws)))
+      ordered-kws)))
+
+(defn- add-fields-extra-info
+  "Add `:extra_info` about `ForeignKeys` to `Fields` whose `special_type` is `:fk`."
+  [fields]
+  ;; Get a sequence of add Field IDs that have a :special_type of FK
+  (let [fk-field-ids            (->> fields
+                                     (filter #(= (:special_type %) :fk))
+                                     (map :id)
+                                     (filter identity))
+        ;; Look up the Foreign keys info if applicable.
+        ;; Build a map of FK Field IDs -> Destination Field IDs
+        field-id->dest-field-id (when (seq fk-field-ids)
+                                  (sel :many :field->field [ForeignKey :origin_id :destination_id], :origin_id [in fk-field-ids], :destination_id [not= nil]))
+
+        ;; Build a map of Destination Field IDs -> Destination Fields
+        dest-field-id->field    (when (and (seq fk-field-ids)
+                                           (seq (vals field-id->dest-field-id)))
+                                  (sel :many :id->fields [Field :id :name :table_id :description :base_type :special_type], :id [in (vals field-id->dest-field-id)]))]
+
+    ;; Add the :extra_info + :target to every Field. For non-FK Fields, these are just {} and nil, respectively.
+    (for [{field-id :id, :as field} fields]
+      (let [dest-field (when (seq fk-field-ids)
+                         (some->> field-id
+                                  field-id->dest-field-id
+                                  dest-field-id->field))]
+        (assoc field
+               :target     dest-field
+               :extra_info (if-not dest-field {}
+                                   {:target_table_id (:table_id dest-field)}))))))
+
+(defn- get-cols-info
+  "Get column info for the `:cols` part of the QP results."
+  [{{{ag-type :aggregation-type, ag-field :field} :aggregation} :query} fields ordered-col-kws join-table-ids]
+  (let [field-kw->field (zipmap (map #(keyword (:name %)) fields)
+                                fields)
+        field-id->field (delay (zipmap (map :id fields) ; a delay since we probably won't need it
+                                       fields))]
+    (->> (for [col-kw ordered-col-kws]
+           (or
+            ;; If col-kw is a known Field return that
+            (field-kw->field col-kw)
+
+            ;; Otherwise if this Query included any joins then attempt to lookup a matching Field from one of the join tables
+            (and (seq join-table-ids)
+                 (sel :one :fields [Field :id :table_id :name :description :base_type :special_type], :name (name col-kw), :table_id [in join-table-ids]))
+
+            ;; Otherwise if this is a nested Field recursively find the appropriate info
+            (let [name-components (s/split (name col-kw) #"\.")]
+              (when (> (count name-components) 1)
+                ;; Find the nested Field by recursing through each Field's :children
+                (loop [field-kw->field field-kw->field, [component & more] (map keyword name-components)]
+                  (when-let [f (field-kw->field component)]
+                    (if-not (seq more)
+                      ;; If the are no more components to recurse through give the resulting Field a qualified name like "source.service" and return it
+                      (assoc f :name (apply str (interpose "." name-components)))
+                      ;; Otherwise recurse with a map of child-name-kw -> child and the rest of the name components
+                      (recur (zipmap (map (comp keyword :name) (:children f))
+                                     (:children f))
+                             more))))))
+
+            ;; Otherwise it is an aggregation column like :sum, build a map of information to return
+            (merge (assert ag-type)
+                   {:name        (name col-kw)
+                    :id          nil
+                    :table_id    nil
+                    :description nil}
+                   (cond
+                     ;; avg, stddev, and sum should inherit the base_type and special_type from the Field they're aggregating
+                     (contains? #{:avg :stddev :sum} col-kw) {:base_type    (:base-type ag-field)
+                                                              :special_type (:special-type ag-field)}
+                     ;; count should always be IntegerField/number
+                     (= col-kw :count)                       {:base_type    :IntegerField
+                                                              :special_type :number}
+
+                     ;; Otherwise something went wrong !
+                     :else                                   (do (log/error (u/format-color 'red "Annotation failed: don't know what to do with Field '%s'.\nExpected these Fields:\n%s"
+                                                                                            col-kw
+                                                                                            (u/pprint-to-str field-kw->field)))
+                                                                 {:base_type    :UnknownField
+                                                                  :special_type nil})))))
+         ;; Add FK info the the resulting Fields
+         add-fields-extra-info
+
+         ;; Remove extra data from the resulting Fields
+         (map (u/rpartial dissoc :children :parent_id)))))
+
+(defn post-annotate
+  "Take a sequence of RESULTS of executing QUERY and return the \"annotated\" results we pass to postprocessing -- the map with `:cols`, `:columns`, and `:rows`.
+   RESULTS should be a sequence of *maps*, keyed by result column -> value."
+  [qp]
+  (fn [{{:keys [join-tables] {source-table-id :id} :source-table} :query, :as query}]
+    (let [{:keys [results uncastify-fn]} (qp query)
+          results                        (if-not uncastify-fn results
+                                                 (for [row results]
+                                                   (m/map-keys uncastify-fn row)))
+          _                              (when-not @(ns-resolve 'metabase.driver.query-processor '*disable-qp-logging*)
+                                           (log/debug (u/format-color 'magenta "Driver QP returned results with keys: %s." (vec (keys (first results))))))
+          join-table-ids                 (set (map :table-id join-tables))
+          fields                         (field/unflatten-nested-fields (sel :many :fields [Field :id :table_id :name :description :base_type :special_type :parent_id], :table_id source-table-id, :active true))
+          ordered-col-kws                (order-cols query results fields)]
+
+      {:rows    (for [row results]
+                  (mapv row ordered-col-kws))                                          ; might as well return each row and col info as vecs because we're not worried about making
+       :columns (mapv name ordered-col-kws)                                            ; making them lazy, and results are easier to play with in the REPL / paste into unit tests
+       :cols    (vec (get-cols-info query fields ordered-col-kws join-table-ids))})))  ; as vecs. Make sure :rows stays lazy!

--- a/src/metabase/driver/query_processor/annotate.clj
+++ b/src/metabase/driver/query_processor/annotate.clj
@@ -210,7 +210,7 @@
 
 (defn post-annotate [qp]
   (fn [query]
-    (let [{:keys [results uncastify-fn]} (qp query)
+    (let [results (qp query)
           cols    (time (->> (query-add-info (:query query) results)
                              resolve+order-cols
                              (map format-col)

--- a/src/metabase/driver/query_processor/annotate.clj
+++ b/src/metabase/driver/query_processor/annotate.clj
@@ -115,13 +115,16 @@
     {:source_table 371, :aggregation ["rows"], :breakout [], :filter []}}))
 
 ;; (require '[metabase.test.data :refer [db-id id]])
-;; (defn x []
-;;   (@(ns-resolve 'metabase.driver 'process-query)
-;;    {:type :query,
-;;     :database (db-id),
-;;     :query
-;;     {:source_table (id :users),
-;;      :aggregation ["cum_sum" (id :users :id)]}}))
+(defn x []
+  (@(ns-resolve 'metabase.driver 'process-query)
+   {:database 339,
+    :type "query",
+    :query
+    {:source_table 820,
+     :aggregation ["count"],
+     :breakout [["fk->" 8896 8855]]}}))
+
+
 
 (defn y* [n]
   (dorun (repeatedly n y)))
@@ -213,37 +216,8 @@
                                                    (name< f1 f2)))
               ((clause-pos< f1 f2)))))))))
 
-
-
-(defn- resolve+order-cols [{:keys [result-keys], :as query}]
-  {:pre  [(seq result-keys)]
-   :post [(sequential? %)]}
-  (first (let [fields       (vec (lvars (count result-keys)))
-               known-field° (field° query)]
-           (run 1 [q]
-             (everyg (fn [[result-key field]]
-                       (conda
-                         ((known-field°   result-key field))
-                         ((unknown-field° result-key field))))
-                     (zipmap result-keys fields))
-             (sorted-permutation° (fields-sorted° query) fields q)))))
-
-
-;;; # ---------------------------------------- COLUMN DETAILS  ----------------------------------------
-
-;; Format the results in the way the front-end expects.
-
-(defn- format-col [col]
-  (merge {:description nil
-          :id          nil
-          :table_id    nil}
-         (-> col
-             (set/rename-keys  {:base-type    :base_type
-                                :field-id     :id
-                                :field-name   :name
-                                :special-type :special_type
-                                :table-id     :table_id})
-             (dissoc :position))))
+(defn- fk-info-added° [field]
+  )
 
 (defn- add-fields-extra-info
   "Add `:extra_info` about `ForeignKeys` to `Fields` whose `special_type` is `:fk`."
@@ -273,6 +247,35 @@
                     :target     dest-field
                     :extra_info (if-not dest-field {}
                                         {:target_table_id (:table_id dest-field)})))))))
+
+(defn- resolve+order-cols [{:keys [result-keys], :as query}]
+  (when (seq result-keys)
+    (first (let [fields       (vec (lvars (count result-keys)))
+                 known-field° (field° query)]
+             (run 1 [q]
+               (everyg (fn [[result-key field]]
+                         (conda
+                           ((known-field°   result-key field))
+                           ((unknown-field° result-key field))))
+                       (zipmap result-keys fields))
+               (sorted-permutation° (fields-sorted° query) fields q))))))
+
+
+;;; # ---------------------------------------- COLUMN DETAILS  ----------------------------------------
+
+;; Format the results in the way the front-end expects.
+
+(defn- format-col [col]
+  (merge {:description nil
+          :id          nil
+          :table_id    nil}
+         (-> col
+             (set/rename-keys  {:base-type    :base_type
+                                :field-id     :id
+                                :field-name   :name
+                                :special-type :special_type
+                                :table-id     :table_id})
+             (dissoc :position))))
 
 (defn post-annotate [qp]
   (fn [query]

--- a/src/metabase/driver/query_processor/annotate.clj
+++ b/src/metabase/driver/query_processor/annotate.clj
@@ -1,18 +1,109 @@
 (ns metabase.driver.query-processor.annotate
   (:refer-clojure :exclude [==])
   (:require [clojure.core.logic :refer :all]
+            [clojure.core.logic.arithmetic :as ar]
             (clojure [set :as set]
                      [string :as s])
-            [clojure.tools.logging :as log]
-            [medley.core :as m]
             [metabase.db :refer [sel]]
             [metabase.driver.query-processor.expand :as expand]
             (metabase.models [field :refer [Field], :as field]
                              [foreign-key :refer [ForeignKey]])
             [metabase.util :as u]))
 
-;; ## Ordering
-;;
+;;; # ------------------------------------------------------------ QUERY DICT ADDITIONAL INFO  ------------------------------------------------------------
+
+(defn- collapse-field [field]
+  (into {} (-> field
+               (assoc :field-name (->> (rest (expand/qualified-name-components field))
+                                       (interpose ".")
+                                       (apply str)
+                                       keyword))
+               (dissoc :parent :parent-id :table-name))))
+
+(defn- query-add-info [query results]
+  {:pre [(integer? (get-in query [:source-table :id]))]}
+  (let [fields (transient [])]
+    (clojure.walk/prewalk (fn [f]
+                            (if-not (= (type f) metabase.driver.query_processor.expand.Field) f
+                                    (conj! fields f)))
+                          query)
+    (assoc query
+           :result-keys  (vec (keys (first results)))
+           :query-fields (mapv collapse-field (persistent! fields))
+           :fields       (mapv collapse-field (:fields query))
+           :breakout     (mapv collapse-field (:breakout query)))))
+
+
+;;; # ------------------------------------------------------------ COLUMN RESOLUTION & ORDERING  ------------------------------------------------------------
+
+(defn- breakout-fieldo [{breakout-fields :breakout} field]
+  (membero field breakout-fields))
+
+(defn- explicit-fields-fieldo [{:keys [fields-is-implicit], fields-fields :fields} field]
+  (all (nilo fields-is-implicit)
+       (membero field fields-fields)))
+
+(defn- aggregate-fieldo [{{ag-type :aggregation-type, ag-field :field} :aggregation} field]
+  (all (membero ag-type [:count :avg :sum :stddev :distinct])
+       (== field (if (contains? #{:count :distinct} ag-type)
+                   {:base-type    :IntegerField
+                    :field-name   :count
+                    :special-type :number}
+                   (-> ag-field
+                       (select-keys [:base-type :special-type])
+                       (assoc :field-name (if (= ag-type :distinct) :count
+                                              ag-type)))))))
+
+(defn- valid-nameo [{:keys [result-keys]} field]
+  (fresh [field-name]
+    (featurec field {:field-name field-name})
+    (membero field-name result-keys)))
+
+(defn- fieldo [{:keys [query-fields], :as query} field]
+  (all (conde
+        ((aggregate-fieldo query field))
+        ((membero field query-fields)))
+       (valid-nameo query field)))
+
+
+;;; ## Ordering
+
+(defn- matches-sort-sequenceo [l [k & more-keys]]
+  (conda
+   ((emptyo l))
+   (s#        (if-not k
+                fail
+                (fresh [v1 v2 more-vals]
+                  (conso v1 more-vals l)
+                  (conde
+                   ((== k v1)             (matches-sort-sequenceo more-vals more-keys))
+                   ((firsto more-vals v2) (== k v2) fail)
+                   (s#                    (matches-sort-sequenceo l more-keys))))))))
+
+(defn- field-positiono [field v]
+  (featurec field {:position v}))
+
+(defn- fields-sorted-by-nameo [{:keys [result-keys]} f1 f2]
+  (fresh [n1 n2 n1+n2]
+    (featurec f1 {:field-name n1})
+    (featurec f2 {:field-name n2})
+    (matches-sort-sequenceo [n1 n2] (sort result-keys))))
+
+(defn- field-groupo [query field v]
+  (conda
+   ((breakout-fieldo query field)        (== v 0))
+   ((aggregate-fieldo query field)       (== v 1))
+   ((explicit-fields-fieldo query field) (== v 2))
+   (s#                                   (== v 3))))
+
+(defn special-type-groupo [field v]
+  (fresh [t]
+    (featurec field {:special-type t})
+    (conda
+     ((== t :id)   (== v 0))
+     ((== t :name) (== v 1))
+     (s#           (== v 2)))))
+
 ;; Fields should be returned in the following order:
 ;; 1.  Breakout Fields
 ;;
@@ -34,85 +125,59 @@
 ;;     C.  Field Name
 ;;         When two Fields have the same :position and :special_type "group", fall back to sorting Fields alphabetically by name.
 ;;         This is arbitrary, but it makes the QP deterministic by keeping the results in a consistent order, which makes it testable.
-;; (defn- order-cols
-;;   "Construct a sequence of column keywords that should be used for pulling ordered rows from RESULTS.
-;;    FIELDS should be a sequence of all `Fields` for the `Table` associated with QUERY."
-;;   [{{breakout-fields :breakout, {ag-type :aggregation-type} :aggregation, fields-fields :fields, fields-is-implicit :fields-is-implicit} :query} results fields]
-;;   (let [;; Get all the column name keywords returned by the results
-;;         result-kws       (set (keys (first results)))
-;;         valid-kw?        (partial contains? result-kws)
+(defn- fields-sortedo [query f1 f2]
+  (fresh [g1 g2]
+    (field-groupo query f1 g1)
+    (field-groupo query f2 g2)
+    (conda
+     ((ar/< g1 g2))
+     ((== g1 g2) (conda
+                  ((== g1 0) (matches-sort-sequenceo [f1 f2] (:breakout query)))
+                  ((== g1 2) (matches-sort-sequenceo [f1 f2] (:fields query)))
+                  ((== g2 3) (fresh [pos1 pos2]
+                               (field-positiono f1 pos1)
+                               (field-positiono f2 pos2)
+                               (conda
+                                ((ar/< pos1 pos2))
+                                ((== pos1 pos2) (fresh [t1 t2]
+                                                  (special-type-groupo f1 t1)
+                                                  (special-type-groupo f2 t2)
+                                                  (conda ((ar/< t1 t2))
+                                                         ((== t1 t2) (fields-sorted-by-nameo query f1 f2)))))))))))))
 
-;;         breakout-ids     (map :field-id breakout-fields)
 
-;;         breakout-kws     (->> (for [field breakout-fields]
-;;                                 (->> (rest (expand/qualified-name-components field)) ; TODO - this "qualified name for results" should be calculated in the Query expander
-;;                                      (interpose ".")
-;;                                      (apply str)
-;;                                      keyword))
-;;                               (filter valid-kw?))
+;;; ## Top-Level Resolution / Ordering
 
-;;         fields-ids       (map :field-id fields-fields)
+(defn- resolve+order-cols [query]
+  {:post [(or (sequential? %)
+              (println "FAILED!\n" (u/pprint-to-str query) "\nRESULTS:" %))
+          (every? map? %)]}
+  (let [num-cols (count (:result-keys query))
+        cols     (vec (lvars num-cols))]
+    (first (run 1 [q]
+             (== q cols)
+             (distincto q)
+             (everyg (partial fieldo query) q)
+             (everyg (fn [i]
+                       (fields-sortedo query (cols i) (cols (inc i))))
+                     (range 0 (dec num-cols)))))))
 
-;;         field-id->field  (zipmap (map :id fields) fields)
 
-;;         ;; Get IDs from Fields clause *if* it was added explicitly and other all other Field IDs for Table.
-;;         fields-ids       (when-not fields-is-implicit fields-ids)
-;;         all-field-ids    (->> fields    ; Sort the Fields.
-;;                               (sort-by (fn [{:keys [position special_type name]}] ; For each field generate a vector of
-;;                                          [position ; [position special-type-group name]
-;;                                           (cond ; and Clojure will take care of the rest.
-;;                                             (= special_type :id)   0
-;;                                             (= special_type :name) 1
-;;                                             :else                  2)
-;;                                           name]))
-;;                               (map :id)) ; Return the sorted IDs
+;;; # ------------------------------------------------------------ COLUMN DETAILS  ------------------------------------------------------------
 
-;;         ;; Get the aggregate column if any
-;;         ag-kws           (when (and ag-type
-;;                                     (not= ag-type :rows))
-;;                            (let [ag (if (= ag-type :distinct) :count
-;;                                         ag-type)]
-;;                              [ag]))
 
-;;         ;; Make a helper function that will take a sequence of Field IDs and convert them to corresponding column name keywords.
-;;         ;; Don't include names that aren't part of RESULT-KWS: we fetch *all* the Fields for a Table regardless of the Query, so
-;;         ;; there are likely some unused ones.
-;;         ids->kws         (fn [field-ids]
-;;                            (some->> (map field-id->field field-ids)
-;;                                     (map :name)
-;;                                     (map keyword)
-;;                                     (filter valid-kw?)))
-
-;;         ;; Concat the Fields clause IDs + the sequence of all Fields ID for the Table.
-;;         ;; Then filter out ones that appear in breakout clause and remove duplicates
-;;         ;; which effectively gives us parts #3 and #4 from above.
-;;         non-breakout-ids (->> (concat fields-ids all-field-ids)
-;;                               (filter (complement (partial contains? (set breakout-ids))))
-;;                               distinct)
-
-;;         ;; Use fn above to get the keyword column names of other non-aggregation fields [#3 and #4]
-;;         non-breakout-kws (->> (ids->kws non-breakout-ids)
-;;                               (filter (complement (partial contains? (set ag-kws)))))
-
-;;         ;; Collect all other Fields
-;;         other-kws        (->> result-kws
-;;                               (filter (complement (partial contains? (set (concat breakout-kws non-breakout-kws ag-kws)))))
-;;                               sort)] ; sort by name so results are deterministic
-
-;;     (when (seq other-kws)
-;;       (log/warn (u/format-color 'red "Warning: not 100%% sure how to order these columns: %s" (vec other-kws))))
-
-;;     ;; Now combine the breakout [#1] + aggregate [#2] + "non-breakout" [#3 &  #4] column name keywords into a single sequence
-;;     (when-not @(ns-resolve 'metabase.driver.query-processor '*disable-qp-logging*)
-;;       (log/debug (u/format-color 'magenta "Using this ordering: breakout: %s, ag: %s, non-breakout: %s, other: %s"
-;;                                  (vec breakout-kws) (vec ag-kws) (vec non-breakout-kws) (vec other-kws))))
-
-;;     (let [ordered-kws (concat breakout-kws ag-kws non-breakout-kws other-kws)]
-;;       (assert (and (= (set ordered-kws) result-kws)
-;;                    (= (count ordered-kws) (count result-kws)))
-;;         (format "Order-cols returned invalid results: expected %s, got %s\nbreakout: %s, ag: %s, non-breakout: %s, other: %s" result-kws (vec ordered-kws)
-;;                 (vec breakout-kws) (vec ag-kws) (vec non-breakout-kws) (vec other-kws)))
-;;       ordered-kws)))
+(defn- format-col [col]
+  (let [defaults {:description nil
+                  :id          nil
+                  :table_id    nil}]
+    (merge defaults
+           (-> col
+               (set/rename-keys  {:base-type    :base_type
+                                  :field-id     :id
+                                  :field-name   :name
+                                  :special-type :special_type
+                                  :table-id     :table_id})
+               (dissoc :parent :parent-id :position)))))
 
 (defn- add-fields-extra-info
   "Add `:extra_info` about `ForeignKeys` to `Fields` whose `special_type` is `:fk`."
@@ -143,228 +208,16 @@
                     :extra_info (if-not dest-field {}
                                         {:target_table_id (:table_id dest-field)})))))))
 
-;; (defn- get-cols-info
-;;   "Get column info for the `:cols` part of the QP results."
-;;   [{{{ag-type :aggregation-type, ag-field :field} :aggregation} :query} fields ordered-col-kws join-table-ids]
-;;   (let [field-kw->field (zipmap (map #(keyword (:name %)) fields)
-;;                                 fields)
-;;         field-id->field (delay (zipmap (map :id fields) ; a delay since we probably won't need it
-;;                                        fields))]
-;;     (->> (for [col-kw ordered-col-kws]
-;;            (or
-;;             ;; If col-kw is a known Field return that
-;;             (field-kw->field col-kw)
-
-;;             ;; Otherwise if this Query included any joins then attempt to lookup a matching Field from one of the join tables
-;;             (and (seq join-table-ids)
-;;                  (sel :one :fields [Field :id :table_id :name :description :base_type :special_type], :name (name col-kw), :table_id [in join-table-ids]))
-
-;;             ;; Otherwise if this is a nested Field recursively find the appropriate info
-;;             (let [name-components (s/split (name col-kw) #"\.")]
-;;               (when (> (count name-components) 1)
-;;                 ;; Find the nested Field by recursing through each Field's :children
-;;                 (loop [field-kw->field field-kw->field, [component & more] (map keyword name-components)]
-;;                   (when-let [f (field-kw->field component)]
-;;                     (if-not (seq more)
-;;                       ;; If the are no more components to recurse through give the resulting Field a qualified name like "source.service" and return it
-;;                       (assoc f :name (apply str (interpose "." name-components)))
-;;                       ;; Otherwise recurse with a map of child-name-kw -> child and the rest of the name components
-;;                       (recur (zipmap (map (comp keyword :name) (:children f))
-;;                                      (:children f))
-;;                              more))))))
-
-;;             ;; Otherwise it is an aggregation column like :sum, build a map of information to return
-;;             (merge (assert ag-type)
-;;                    {:name        (name col-kw)
-;;                     :id          nil
-;;                     :table_id    nil
-;;                     :description nil}
-;;                    (cond
-;;                      ;; avg, stddev, and sum should inherit the base_type and special_type from the Field they're aggregating
-;;                      (contains? #{:avg :stddev :sum} col-kw) {:base_type    (:base-type ag-field)
-;;                                                               :special_type (:special-type ag-field)}
-;;                      ;; count should always be IntegerField/number
-;;                      (= col-kw :count)                       {:base_type    :IntegerField
-;;                                                               :special_type :number}
-
-;;                      ;; Otherwise something went wrong !
-;;                      :else                                   (do (log/error (u/format-color 'red "Annotation failed: don't know what to do with Field '%s'.\nExpected these Fields:\n%s"
-;;                                                                                             col-kw
-;;                                                                                             (u/pprint-to-str field-kw->field)))
-;;                                                                  {:base_type    :UnknownField
-;;                                                                   :special_type nil})))))
-;;          ;; Add FK info the the resulting Fields
-;;          add-fields-extra-info
-
-;;          ;; Remove extra data from the resulting Fields
-;;          (map (u/rpartial dissoc :children :parent_id)))))
-
-;; (defn post-annotate
-;;   "Take a sequence of RESULTS of executing QUERY and return the \"annotated\" results we pass to postprocessing -- the map with `:cols`, `:columns`, and `:rows`.
-;;    RESULTS should be a sequence of *maps*, keyed by result column -> value."
-;;   [qp]
-;;   (fn [{{:keys [join-tables] {source-table-id :id} :source-table} :query, :as query}]
-;;     (let [{:keys [results uncastify-fn]} (qp query)
-;;           _                              (def -query query)
-;;           results                        (if-not uncastify-fn results
-;;                                                  (for [row results]
-;;                                                    (m/map-keys uncastify-fn row)))
-;;           _                              (def -results results)
-;;           _                              (when-not @(ns-resolve 'metabase.driver.query-processor '*disable-qp-logging*)
-;;                                            (log/debug (u/format-color 'magenta "Driver QP returned results with keys: %s." (vec (keys (first results))))))
-;;           join-table-ids                 (set (map :table-id join-tables))
-;;           fields                         (field/unflatten-nested-fields (sel :many :fields [Field :id :table_id :name :description :base_type :special_type :parent_id], :table_id source-table-id, :active true))
-;;           ordered-col-kws                (order-cols query results fields)]
-
-;;       {:rows    (for [row results]
-;;                   (mapv row ordered-col-kws))                                          ; might as well return each row and col info as vecs because we're not worried about making
-;;        :columns (mapv name ordered-col-kws)                                            ; making them lazy, and results are easier to play with in the REPL / paste into unit tests
-;;        :cols    (vec (get-cols-info query fields ordered-col-kws join-table-ids))})))  ; as vecs. Make sure :rows stays lazy!
-
-(defn- query-add-info [query results]
-  {:pre [(integer? (get-in query [:source-table :id]))]}
-  (let [fields (transient [])]
-    (clojure.walk/prewalk (fn [f]
-                            (if-not (= (type f) metabase.driver.query_processor.expand.Field) f
-                                    (conj! fields f)))
-                          query)
-    (assoc query
-           :query-fields (->> (persistent! fields)
-                              (mapv (partial into {}))
-                              (mapv #(update % :field-name keyword)))
-           :result-keys  (vec (keys (first results))))))
-
-(defn- breakout-fieldo [{breakout-fields :breakout} field]
-  (membero field breakout-fields))
-
-(defn- explicit-fields-fieldo [{:keys [fields-is-implicit], fields-fields :fields} field]
-  (if fields-is-implicit fail
-      (membero field fields-fields)))
-
-{:base_type :IntegerField, :special_type :category, :id nil, :table_id nil, :description nil, :extra_info {}, :target nil, :name "sum"}
-
-(defn- aggregate-fieldo [{{ag-type :aggregation-type, ag-field :field} :aggregation} field]
-  (or (when (contains? #{:count :avg :sum :stddev} ag-type)
-        (if-not ag-field
-          (do (assert (= ag-type :count))
-              (== field {:base-type    :IntegerField
-                         :field-name   :count
-                         :special-type :number}))
-          (fresh [field-name]
-            (== field (assoc (select-keys ag-field [:base-type :special-type])
-                             :field-name field-name))
-            (membero field-name [:count :avg :sum :stddev])
-            (conde
-             ((== ag-type field-name))
-             ((== ag-type :distinct) (== field-name :count))))))
-      fail))
-
-(defn- valid-nameo [{:keys [result-keys]} field]
-  (fresh [field-name]
-    (featurec field {:field-name field-name})
-    (membero field-name result-keys)))
-
-(defn- fieldo [{:keys [query-fields], :as query} field]
-  (all (conde
-        [(aggregate-fieldo query field)]
-        [(membero field query-fields)])
-       (valid-nameo query field)))
-
-(defn- special-typeo [field special-type]
-  (fresh [t]
-    (featurec field {:special-type t})
-    (== t special-type)))
-
-(defn- matches-sort-sequenceo [l [k & more-keys]]
-  #_(println k more-keys)
-  (conde
-   ((emptyo l) succeed)
-   (s#         (if-not k
-                 fail
-                 (fresh [v1 v2 more-vals]
-                   (conso v1 more-vals l)
-                   (conde
-                    ((== k v1)             (matches-sort-sequenceo more-vals more-keys))
-                    ((firsto more-vals v2)
-                     (== k v2)             fail)
-                    (s#                    (matches-sort-sequenceo l more-keys))))))))
-
-(defn- fields-sorted-by-positiono [f1 f2]
-  (fresh [p1 p2]
-    (featurec f1 {:position p1})
-    (featurec f2 {:position p2})
-    (ar/< p1 p2)))
-
-(defn- fields-sorted-by-nameo [{:keys [result-keys]} f1 f2]
-  (fresh [n1 n2 n1+n2]
-    (featurec f1 {:field-name n1})
-    (featurec f2 {:field-name n2})
-    (matches-sort-sequenceo [n1 n2] (sort result-keys))))
-
-(defn- fields-sortedo [query f1 f2]
-  (conde
-   ((breakout-fieldo query f1) (breakout-fieldo query f2) (matches-sort-sequenceo [f1 f2] (:breakout query)))
-   ((breakout-fieldo query f1))
-   ((aggregate-fieldo query f1))
-   ((explicit-fields-fieldo query f1) (explicit-fields-fieldo query f2) (matches-sort-sequenceo [f1 f2] (:fields query)))
-   ((explicit-fields-fieldo query f1))
-   ((fields-sorted-by-positiono f1 f2))
-   ((special-typeo f1 :id) (special-typeo f2 :id) (fields-sorted-by-nameo query f1 f2))
-   ((special-typeo f1 :id))
-   ((special-typeo f1 :name) (special-typeo f2 :name) (fields-sorted-by-nameo query f1 f2))
-   ((fields-sorted-by-nameo query f1 f2))))
-
-(defn- resolve+order-cols [query]
-  {:post [(or (sequential? %)
-              (println "FAILED!\n" (u/pprint-to-str query)))]}
-  (let [num-cols (count (:result-keys query))
-        cols     (vec (lvars num-cols))]
-    (first (run 1 [q]
-             (== q cols)
-             (distincto q)
-             (everyg (partial fieldo query) q)
-             (everyg (fn [i]
-                       (fields-sortedo query (cols i) (cols (inc i))))
-                     (range 0 (dec num-cols)))))))
-
-(defn- format-col [col]
-  (println (u/pprint-to-str 'cyan col))
-  (let [defaults {:description nil   ; TODO - actually fetch this
-                  :id          nil
-                  :table_id    nil}]
-    (merge defaults
-           (-> col
-               (set/rename-keys  {:base-type    :base_type
-                                  :field-id     :id
-                                  :field-name   :name
-                                  :special-type :special_type
-                                  :table-id     :table_id})
-               (dissoc :parent :parent-id :position)))))
-
 (defn post-annotate [qp]
   (fn [query]
     (let [{:keys [results uncastify-fn]} (qp query)
-          cols    (->> (query-add-info (:query query) results)
-                       resolve+order-cols
-                       (map format-col)
-                       add-fields-extra-info)
-          columns (mapv :name cols)]
-      {:cols    cols
-       :columns columns
+          cols    (time (->> (query-add-info (:query query) results)
+                             resolve+order-cols
+                             (map format-col)
+                             add-fields-extra-info))
+          columns (map :name cols)]
+      {:cols    (vec (for [col cols]
+                       (update col :name name)))
+       :columns (mapv name columns)
        :rows    (for [row results]
                   (mapv row columns))})))
-
-(require 'metabase.driver)
-
-(defn- x []
-  (let [id (fn id
-             ([table-name]
-              (sel :one :id 'Table :db_id 67, :name (name table-name)))
-             ([table-name field-name]
-              (sel :one :id 'Field :table_id (id table-name), :name (name field-name))))]
-    (metabase.driver/process-query {:database 67
-                                    :type     :query
-                                    :query    {:source_table (id :venues)
-                                               :aggregation  ["rows"]
-                                               :fields       [(id :venues :price)]
-                                               :limit        10}})))

--- a/src/metabase/driver/query_processor/annotate.clj
+++ b/src/metabase/driver/query_processor/annotate.clj
@@ -10,7 +10,7 @@
                              [foreign-key :refer [ForeignKey]])
             [metabase.util :as u]))
 
-;;; # ------------------------------------------------------------ QUERY DICT ADDITIONAL INFO  ------------------------------------------------------------
+;;; # ---------------------------------------- QUERY DICT ADDITIONAL INFO  ----------------------------------------
 
 (defn- collapse-field [field]
   (into {} (-> field
@@ -34,7 +34,7 @@
            :breakout     (mapv collapse-field (:breakout query)))))
 
 
-;;; # ------------------------------------------------------------ COLUMN RESOLUTION & ORDERING  ------------------------------------------------------------
+;;; # ---------------------------------------- COLUMN RESOLUTION & ORDERING  ----------------------------------------
 
 (defn- breakout-fieldo [{breakout-fields :breakout} field]
   (membero field breakout-fields))
@@ -163,7 +163,7 @@
                      (range 0 (dec num-cols)))))))
 
 
-;;; # ------------------------------------------------------------ COLUMN DETAILS  ------------------------------------------------------------
+;;; # ---------------------------------------- COLUMN DETAILS  ----------------------------------------
 
 
 (defn- format-col [col]

--- a/src/metabase/driver/query_processor/annotate.clj
+++ b/src/metabase/driver/query_processor/annotate.clj
@@ -1,8 +1,8 @@
 (ns metabase.driver.query-processor.annotate
   (:refer-clojure :exclude [==])
   (:require [clojure.core.logic :refer :all]
-            [clojure.core.logic.arithmetic :as ar]
-            [clojure.string :as s]
+            (clojure [set :as set]
+                     [string :as s])
             [clojure.tools.logging :as log]
             [medley.core :as m]
             [metabase.db :refer [sel]]
@@ -34,85 +34,85 @@
 ;;     C.  Field Name
 ;;         When two Fields have the same :position and :special_type "group", fall back to sorting Fields alphabetically by name.
 ;;         This is arbitrary, but it makes the QP deterministic by keeping the results in a consistent order, which makes it testable.
-(defn- order-cols
-  "Construct a sequence of column keywords that should be used for pulling ordered rows from RESULTS.
-   FIELDS should be a sequence of all `Fields` for the `Table` associated with QUERY."
-  [{{breakout-fields :breakout, {ag-type :aggregation-type} :aggregation, fields-fields :fields, fields-is-implicit :fields-is-implicit} :query} results fields]
-  (let [;; Get all the column name keywords returned by the results
-        result-kws       (set (keys (first results)))
-        valid-kw?        (partial contains? result-kws)
+;; (defn- order-cols
+;;   "Construct a sequence of column keywords that should be used for pulling ordered rows from RESULTS.
+;;    FIELDS should be a sequence of all `Fields` for the `Table` associated with QUERY."
+;;   [{{breakout-fields :breakout, {ag-type :aggregation-type} :aggregation, fields-fields :fields, fields-is-implicit :fields-is-implicit} :query} results fields]
+;;   (let [;; Get all the column name keywords returned by the results
+;;         result-kws       (set (keys (first results)))
+;;         valid-kw?        (partial contains? result-kws)
 
-        breakout-ids     (map :field-id breakout-fields)
+;;         breakout-ids     (map :field-id breakout-fields)
 
-        breakout-kws     (->> (for [field breakout-fields]
-                                (->> (rest (expand/qualified-name-components field)) ; TODO - this "qualified name for results" should be calculated in the Query expander
-                                     (interpose ".")
-                                     (apply str)
-                                     keyword))
-                              (filter valid-kw?))
+;;         breakout-kws     (->> (for [field breakout-fields]
+;;                                 (->> (rest (expand/qualified-name-components field)) ; TODO - this "qualified name for results" should be calculated in the Query expander
+;;                                      (interpose ".")
+;;                                      (apply str)
+;;                                      keyword))
+;;                               (filter valid-kw?))
 
-        fields-ids       (map :field-id fields-fields)
+;;         fields-ids       (map :field-id fields-fields)
 
-        field-id->field  (zipmap (map :id fields) fields)
+;;         field-id->field  (zipmap (map :id fields) fields)
 
-        ;; Get IDs from Fields clause *if* it was added explicitly and other all other Field IDs for Table.
-        fields-ids       (when-not fields-is-implicit fields-ids)
-        all-field-ids    (->> fields    ; Sort the Fields.
-                              (sort-by (fn [{:keys [position special_type name]}] ; For each field generate a vector of
-                                         [position ; [position special-type-group name]
-                                          (cond ; and Clojure will take care of the rest.
-                                            (= special_type :id)   0
-                                            (= special_type :name) 1
-                                            :else                  2)
-                                          name]))
-                              (map :id)) ; Return the sorted IDs
+;;         ;; Get IDs from Fields clause *if* it was added explicitly and other all other Field IDs for Table.
+;;         fields-ids       (when-not fields-is-implicit fields-ids)
+;;         all-field-ids    (->> fields    ; Sort the Fields.
+;;                               (sort-by (fn [{:keys [position special_type name]}] ; For each field generate a vector of
+;;                                          [position ; [position special-type-group name]
+;;                                           (cond ; and Clojure will take care of the rest.
+;;                                             (= special_type :id)   0
+;;                                             (= special_type :name) 1
+;;                                             :else                  2)
+;;                                           name]))
+;;                               (map :id)) ; Return the sorted IDs
 
-        ;; Get the aggregate column if any
-        ag-kws           (when (and ag-type
-                                    (not= ag-type :rows))
-                           (let [ag (if (= ag-type :distinct) :count
-                                        ag-type)]
-                             [ag]))
+;;         ;; Get the aggregate column if any
+;;         ag-kws           (when (and ag-type
+;;                                     (not= ag-type :rows))
+;;                            (let [ag (if (= ag-type :distinct) :count
+;;                                         ag-type)]
+;;                              [ag]))
 
-        ;; Make a helper function that will take a sequence of Field IDs and convert them to corresponding column name keywords.
-        ;; Don't include names that aren't part of RESULT-KWS: we fetch *all* the Fields for a Table regardless of the Query, so
-        ;; there are likely some unused ones.
-        ids->kws         (fn [field-ids]
-                           (some->> (map field-id->field field-ids)
-                                    (map :name)
-                                    (map keyword)
-                                    (filter valid-kw?)))
+;;         ;; Make a helper function that will take a sequence of Field IDs and convert them to corresponding column name keywords.
+;;         ;; Don't include names that aren't part of RESULT-KWS: we fetch *all* the Fields for a Table regardless of the Query, so
+;;         ;; there are likely some unused ones.
+;;         ids->kws         (fn [field-ids]
+;;                            (some->> (map field-id->field field-ids)
+;;                                     (map :name)
+;;                                     (map keyword)
+;;                                     (filter valid-kw?)))
 
-        ;; Concat the Fields clause IDs + the sequence of all Fields ID for the Table.
-        ;; Then filter out ones that appear in breakout clause and remove duplicates
-        ;; which effectively gives us parts #3 and #4 from above.
-        non-breakout-ids (->> (concat fields-ids all-field-ids)
-                              (filter (complement (partial contains? (set breakout-ids))))
-                              distinct)
+;;         ;; Concat the Fields clause IDs + the sequence of all Fields ID for the Table.
+;;         ;; Then filter out ones that appear in breakout clause and remove duplicates
+;;         ;; which effectively gives us parts #3 and #4 from above.
+;;         non-breakout-ids (->> (concat fields-ids all-field-ids)
+;;                               (filter (complement (partial contains? (set breakout-ids))))
+;;                               distinct)
 
-        ;; Use fn above to get the keyword column names of other non-aggregation fields [#3 and #4]
-        non-breakout-kws (->> (ids->kws non-breakout-ids)
-                              (filter (complement (partial contains? (set ag-kws)))))
+;;         ;; Use fn above to get the keyword column names of other non-aggregation fields [#3 and #4]
+;;         non-breakout-kws (->> (ids->kws non-breakout-ids)
+;;                               (filter (complement (partial contains? (set ag-kws)))))
 
-        ;; Collect all other Fields
-        other-kws        (->> result-kws
-                              (filter (complement (partial contains? (set (concat breakout-kws non-breakout-kws ag-kws)))))
-                              sort)] ; sort by name so results are deterministic
+;;         ;; Collect all other Fields
+;;         other-kws        (->> result-kws
+;;                               (filter (complement (partial contains? (set (concat breakout-kws non-breakout-kws ag-kws)))))
+;;                               sort)] ; sort by name so results are deterministic
 
-    (when (seq other-kws)
-      (log/warn (u/format-color 'red "Warning: not 100%% sure how to order these columns: %s" (vec other-kws))))
+;;     (when (seq other-kws)
+;;       (log/warn (u/format-color 'red "Warning: not 100%% sure how to order these columns: %s" (vec other-kws))))
 
-    ;; Now combine the breakout [#1] + aggregate [#2] + "non-breakout" [#3 &  #4] column name keywords into a single sequence
-    (when-not @(ns-resolve 'metabase.driver.query-processor '*disable-qp-logging*)
-      (log/debug (u/format-color 'magenta "Using this ordering: breakout: %s, ag: %s, non-breakout: %s, other: %s"
-                                 (vec breakout-kws) (vec ag-kws) (vec non-breakout-kws) (vec other-kws))))
+;;     ;; Now combine the breakout [#1] + aggregate [#2] + "non-breakout" [#3 &  #4] column name keywords into a single sequence
+;;     (when-not @(ns-resolve 'metabase.driver.query-processor '*disable-qp-logging*)
+;;       (log/debug (u/format-color 'magenta "Using this ordering: breakout: %s, ag: %s, non-breakout: %s, other: %s"
+;;                                  (vec breakout-kws) (vec ag-kws) (vec non-breakout-kws) (vec other-kws))))
 
-    (let [ordered-kws (concat breakout-kws ag-kws non-breakout-kws other-kws)]
-      (assert (and (= (set ordered-kws) result-kws)
-                   (= (count ordered-kws) (count result-kws)))
-        (format "Order-cols returned invalid results: expected %s, got %s\nbreakout: %s, ag: %s, non-breakout: %s, other: %s" result-kws (vec ordered-kws)
-                (vec breakout-kws) (vec ag-kws) (vec non-breakout-kws) (vec other-kws)))
-      ordered-kws)))
+;;     (let [ordered-kws (concat breakout-kws ag-kws non-breakout-kws other-kws)]
+;;       (assert (and (= (set ordered-kws) result-kws)
+;;                    (= (count ordered-kws) (count result-kws)))
+;;         (format "Order-cols returned invalid results: expected %s, got %s\nbreakout: %s, ag: %s, non-breakout: %s, other: %s" result-kws (vec ordered-kws)
+;;                 (vec breakout-kws) (vec ag-kws) (vec non-breakout-kws) (vec other-kws)))
+;;       ordered-kws)))
 
 (defn- add-fields-extra-info
   "Add `:extra_info` about `ForeignKeys` to `Fields` whose `special_type` is `:fk`."
@@ -133,146 +133,222 @@
                                   (sel :many :id->fields [Field :id :name :table_id :description :base_type :special_type], :id [in (vals field-id->dest-field-id)]))]
 
     ;; Add the :extra_info + :target to every Field. For non-FK Fields, these are just {} and nil, respectively.
-    (for [{field-id :id, :as field} fields]
-      (let [dest-field (when (seq fk-field-ids)
-                         (some->> field-id
-                                  field-id->dest-field-id
-                                  dest-field-id->field))]
-        (assoc field
-               :target     dest-field
-               :extra_info (if-not dest-field {}
-                                   {:target_table_id (:table_id dest-field)}))))))
+    (vec (for [{field-id :id, :as field} fields]
+           (let [dest-field (when (seq fk-field-ids)
+                              (some->> field-id
+                                       field-id->dest-field-id
+                                       dest-field-id->field))]
+             (assoc field
+                    :target     dest-field
+                    :extra_info (if-not dest-field {}
+                                        {:target_table_id (:table_id dest-field)})))))))
 
-(defn- get-cols-info
-  "Get column info for the `:cols` part of the QP results."
-  [{{{ag-type :aggregation-type, ag-field :field} :aggregation} :query} fields ordered-col-kws join-table-ids]
-  (let [field-kw->field (zipmap (map #(keyword (:name %)) fields)
-                                fields)
-        field-id->field (delay (zipmap (map :id fields) ; a delay since we probably won't need it
-                                       fields))]
-    (->> (for [col-kw ordered-col-kws]
-           (or
-            ;; If col-kw is a known Field return that
-            (field-kw->field col-kw)
+;; (defn- get-cols-info
+;;   "Get column info for the `:cols` part of the QP results."
+;;   [{{{ag-type :aggregation-type, ag-field :field} :aggregation} :query} fields ordered-col-kws join-table-ids]
+;;   (let [field-kw->field (zipmap (map #(keyword (:name %)) fields)
+;;                                 fields)
+;;         field-id->field (delay (zipmap (map :id fields) ; a delay since we probably won't need it
+;;                                        fields))]
+;;     (->> (for [col-kw ordered-col-kws]
+;;            (or
+;;             ;; If col-kw is a known Field return that
+;;             (field-kw->field col-kw)
 
-            ;; Otherwise if this Query included any joins then attempt to lookup a matching Field from one of the join tables
-            (and (seq join-table-ids)
-                 (sel :one :fields [Field :id :table_id :name :description :base_type :special_type], :name (name col-kw), :table_id [in join-table-ids]))
+;;             ;; Otherwise if this Query included any joins then attempt to lookup a matching Field from one of the join tables
+;;             (and (seq join-table-ids)
+;;                  (sel :one :fields [Field :id :table_id :name :description :base_type :special_type], :name (name col-kw), :table_id [in join-table-ids]))
 
-            ;; Otherwise if this is a nested Field recursively find the appropriate info
-            (let [name-components (s/split (name col-kw) #"\.")]
-              (when (> (count name-components) 1)
-                ;; Find the nested Field by recursing through each Field's :children
-                (loop [field-kw->field field-kw->field, [component & more] (map keyword name-components)]
-                  (when-let [f (field-kw->field component)]
-                    (if-not (seq more)
-                      ;; If the are no more components to recurse through give the resulting Field a qualified name like "source.service" and return it
-                      (assoc f :name (apply str (interpose "." name-components)))
-                      ;; Otherwise recurse with a map of child-name-kw -> child and the rest of the name components
-                      (recur (zipmap (map (comp keyword :name) (:children f))
-                                     (:children f))
-                             more))))))
+;;             ;; Otherwise if this is a nested Field recursively find the appropriate info
+;;             (let [name-components (s/split (name col-kw) #"\.")]
+;;               (when (> (count name-components) 1)
+;;                 ;; Find the nested Field by recursing through each Field's :children
+;;                 (loop [field-kw->field field-kw->field, [component & more] (map keyword name-components)]
+;;                   (when-let [f (field-kw->field component)]
+;;                     (if-not (seq more)
+;;                       ;; If the are no more components to recurse through give the resulting Field a qualified name like "source.service" and return it
+;;                       (assoc f :name (apply str (interpose "." name-components)))
+;;                       ;; Otherwise recurse with a map of child-name-kw -> child and the rest of the name components
+;;                       (recur (zipmap (map (comp keyword :name) (:children f))
+;;                                      (:children f))
+;;                              more))))))
 
-            ;; Otherwise it is an aggregation column like :sum, build a map of information to return
-            (merge (assert ag-type)
-                   {:name        (name col-kw)
-                    :id          nil
-                    :table_id    nil
-                    :description nil}
-                   (cond
-                     ;; avg, stddev, and sum should inherit the base_type and special_type from the Field they're aggregating
-                     (contains? #{:avg :stddev :sum} col-kw) {:base_type    (:base-type ag-field)
-                                                              :special_type (:special-type ag-field)}
-                     ;; count should always be IntegerField/number
-                     (= col-kw :count)                       {:base_type    :IntegerField
-                                                              :special_type :number}
+;;             ;; Otherwise it is an aggregation column like :sum, build a map of information to return
+;;             (merge (assert ag-type)
+;;                    {:name        (name col-kw)
+;;                     :id          nil
+;;                     :table_id    nil
+;;                     :description nil}
+;;                    (cond
+;;                      ;; avg, stddev, and sum should inherit the base_type and special_type from the Field they're aggregating
+;;                      (contains? #{:avg :stddev :sum} col-kw) {:base_type    (:base-type ag-field)
+;;                                                               :special_type (:special-type ag-field)}
+;;                      ;; count should always be IntegerField/number
+;;                      (= col-kw :count)                       {:base_type    :IntegerField
+;;                                                               :special_type :number}
 
-                     ;; Otherwise something went wrong !
-                     :else                                   (do (log/error (u/format-color 'red "Annotation failed: don't know what to do with Field '%s'.\nExpected these Fields:\n%s"
-                                                                                            col-kw
-                                                                                            (u/pprint-to-str field-kw->field)))
-                                                                 {:base_type    :UnknownField
-                                                                  :special_type nil})))))
-         ;; Add FK info the the resulting Fields
-         add-fields-extra-info
+;;                      ;; Otherwise something went wrong !
+;;                      :else                                   (do (log/error (u/format-color 'red "Annotation failed: don't know what to do with Field '%s'.\nExpected these Fields:\n%s"
+;;                                                                                             col-kw
+;;                                                                                             (u/pprint-to-str field-kw->field)))
+;;                                                                  {:base_type    :UnknownField
+;;                                                                   :special_type nil})))))
+;;          ;; Add FK info the the resulting Fields
+;;          add-fields-extra-info
 
-         ;; Remove extra data from the resulting Fields
-         (map (u/rpartial dissoc :children :parent_id)))))
+;;          ;; Remove extra data from the resulting Fields
+;;          (map (u/rpartial dissoc :children :parent_id)))))
 
-(defn post-annotate
-  "Take a sequence of RESULTS of executing QUERY and return the \"annotated\" results we pass to postprocessing -- the map with `:cols`, `:columns`, and `:rows`.
-   RESULTS should be a sequence of *maps*, keyed by result column -> value."
-  [qp]
-  (fn [{{:keys [join-tables] {source-table-id :id} :source-table} :query, :as query}]
+;; (defn post-annotate
+;;   "Take a sequence of RESULTS of executing QUERY and return the \"annotated\" results we pass to postprocessing -- the map with `:cols`, `:columns`, and `:rows`.
+;;    RESULTS should be a sequence of *maps*, keyed by result column -> value."
+;;   [qp]
+;;   (fn [{{:keys [join-tables] {source-table-id :id} :source-table} :query, :as query}]
+;;     (let [{:keys [results uncastify-fn]} (qp query)
+;;           _                              (def -query query)
+;;           results                        (if-not uncastify-fn results
+;;                                                  (for [row results]
+;;                                                    (m/map-keys uncastify-fn row)))
+;;           _                              (def -results results)
+;;           _                              (when-not @(ns-resolve 'metabase.driver.query-processor '*disable-qp-logging*)
+;;                                            (log/debug (u/format-color 'magenta "Driver QP returned results with keys: %s." (vec (keys (first results))))))
+;;           join-table-ids                 (set (map :table-id join-tables))
+;;           fields                         (field/unflatten-nested-fields (sel :many :fields [Field :id :table_id :name :description :base_type :special_type :parent_id], :table_id source-table-id, :active true))
+;;           ordered-col-kws                (order-cols query results fields)]
+
+;;       {:rows    (for [row results]
+;;                   (mapv row ordered-col-kws))                                          ; might as well return each row and col info as vecs because we're not worried about making
+;;        :columns (mapv name ordered-col-kws)                                            ; making them lazy, and results are easier to play with in the REPL / paste into unit tests
+;;        :cols    (vec (get-cols-info query fields ordered-col-kws join-table-ids))})))  ; as vecs. Make sure :rows stays lazy!
+
+(defn- query-add-info [query results]
+  {:pre [(integer? (get-in query [:source-table :id]))]}
+  (let [fields (transient [])]
+    (clojure.walk/prewalk (fn [f]
+                            (if-not (= (type f) metabase.driver.query_processor.expand.Field) f
+                                    (conj! fields f)))
+                          query)
+    (assoc query
+           :query-fields (->> (persistent! fields)
+                              (mapv (partial into {}))
+                              (mapv #(update % :field-name keyword)))
+           :result-keys  (vec (keys (first results))))))
+
+(defn- breakout-fieldo [{breakout-fields :breakout} field]
+  (membero field breakout-fields))
+
+(defn- explicit-fields-fieldo [{:keys [fields-is-implicit], fields-fields :fields} field]
+  (if fields-is-implicit fail
+      (membero field fields-fields)))
+
+(defn- aggregate-fieldo [{{ag-type :aggregation-type} :aggregation} field]
+  (all (membero ag-type [:count :avg :sum :stddev])
+    (fresh [field-name]
+      (== field {:field-name field-name})
+      (membero field-name [:count :avg :sum :stddev])
+      (conde [(== ag-type field-name)]
+             [(== ag-type :distinct) (== field-name :count)]))))
+
+(defn- valid-nameo [{:keys [result-keys]} field]
+  (fresh [field-name]
+    (featurec field {:field-name field-name})
+    (membero field-name result-keys)))
+
+(defn- fieldo [{:keys [query-fields], :as query} field]
+  (all (conde
+        [(aggregate-fieldo query field)]
+        [(membero field query-fields)])
+       (valid-nameo query field)))
+
+(defn- special-typeo [field special-type]
+  (fresh [t]
+    (featurec field {:special-type t})
+    (== t special-type)))
+
+(defn- matches-sort-sequenceo [l [k & more-keys]]
+  #_(println k more-keys)
+  (conde
+   ((emptyo l) succeed)
+   (s#         (if-not k
+                 fail
+                 (fresh [v1 v2 more-vals]
+                   (conso v1 more-vals l)
+                   (conde
+                    ((== k v1)             (matches-sort-sequenceo more-vals more-keys))
+                    ((firsto more-vals v2)
+                     (== k v2)             fail)
+                    (s#                    (matches-sort-sequenceo l more-keys))))))))
+
+(defn- fields-sorted-by-positiono [f1 f2]
+  (fresh [p1 p2]
+    (featurec f1 {:position p1})
+    (featurec f2 {:position p2})
+    (ar/< p1 p2)))
+
+(defn- fields-sorted-by-nameo [{:keys [result-keys]} f1 f2]
+  (fresh [n1 n2 n1+n2]
+    (featurec f1 {:field-name n1})
+    (featurec f2 {:field-name n2})
+    (matches-sort-sequenceo [n1 n2] (sort result-keys))))
+
+(defn- fields-sortedo [query f1 f2]
+  (conde
+   ((breakout-fieldo query f1) (breakout-fieldo query f2) (matches-sort-sequenceo [f1 f2] (:breakout query)))
+   ((breakout-fieldo query f1))
+   ((aggregate-fieldo query f1))
+   ((explicit-fields-fieldo query f1) (explicit-fields-fieldo query f2) (matches-sort-sequenceo [f1 f2] (:fields query)))
+   ((explicit-fields-fieldo query f1))
+   ((fields-sorted-by-positiono f1 f2))
+   ((special-typeo f1 :id) (special-typeo f2 :id) (fields-sorted-by-nameo query f1 f2))
+   ((special-typeo f1 :id))
+   ((special-typeo f1 :name) (special-typeo f2 :name) (fields-sorted-by-nameo query f1 f2))
+   ((fields-sorted-by-nameo query f1 f2))))
+
+(defn- resolve+order-cols [query]
+  (let [num-cols (count (:result-keys query))
+        cols     (vec (lvars num-cols))]
+    (first (run 1 [q]
+             (== q cols)
+             (distincto q)
+             (everyg (partial fieldo query) q)
+             (everyg (fn [i]
+                       (fields-sortedo query (cols i) (cols (inc i))))
+                     (range 0 (dec num-cols)))))))
+
+(defn- format-col [col]
+  (println (u/pprint-to-str 'cyan col))
+  (-> col
+      (set/rename-keys  {:base-type    :base_type
+                         :field-id     :id
+                         :field-name   :name
+                         :special-type :special_type
+                         :table-id     :table_id})
+      (dissoc :parent :parent-id :position)
+      ;; TODO - actually fetch this (!)
+      (assoc :description nil)))
+
+(defn post-annotate [qp]
+  (fn [query]
     (let [{:keys [results uncastify-fn]} (qp query)
-          _                              (def -query query)
-          results                        (if-not uncastify-fn results
-                                                 (for [row results]
-                                                   (m/map-keys uncastify-fn row)))
-          _                              (def -results results)
-          _                              (when-not @(ns-resolve 'metabase.driver.query-processor '*disable-qp-logging*)
-                                           (log/debug (u/format-color 'magenta "Driver QP returned results with keys: %s." (vec (keys (first results))))))
-          join-table-ids                 (set (map :table-id join-tables))
-          fields                         (field/unflatten-nested-fields (sel :many :fields [Field :id :table_id :name :description :base_type :special_type :parent_id], :table_id source-table-id, :active true))
-          ordered-col-kws                (order-cols query results fields)]
-
-      {:rows    (for [row results]
-                  (mapv row ordered-col-kws))                                          ; might as well return each row and col info as vecs because we're not worried about making
-       :columns (mapv name ordered-col-kws)                                            ; making them lazy, and results are easier to play with in the REPL / paste into unit tests
-       :cols    (vec (get-cols-info query fields ordered-col-kws join-table-ids))})))  ; as vecs. Make sure :rows stays lazy!
+          cols    (->> (query-add-info (:query query) results)
+                       resolve+order-cols
+                       (map format-col)
+                       add-fields-extra-info)
+          columns (mapv :name cols)]
+      {:rows    results
+       :cols    cols
+       :columns columns})))
 
 (require 'metabase.driver)
+
 (defn- x []
-  (metabase.driver/process-query {:database 484
-                                  :type     :query
-                                  :query    {:source_table 1102
-                                             :aggregation  ["rows"]
-                                             :limit        10}}))
-
-(defn- annotate-2 [{:keys [query]} [first-row :as results]]
-  (let [result-keys  (vec (keys first-row))
-        num-results  (count result-keys)
-        cols         (vec (lvars num-results))
-        columns      (vec (lvars num-results))
-        query-fields (let [fields (transient [])]
-                       (clojure.walk/prewalk (fn [f]
-                                               (if-not (= (type f) metabase.driver.query_processor.expand.Field) f
-                                                       (conj! fields f)))
-                                             query)
-                       (->> (persistent! fields)
-                            (mapv (partial into {}))
-                            (mapv #(update % :field-name keyword))))
-        _ (def -fields query-fields)]
-    (println result-keys)
-    (first (run 1 [q]
-             (== q {:cols    cols
-                    :columns columns})
-             (distincto cols)
-             (distincto columns)
-             (everyg #(membero % query-fields) cols)
-             (everyg #(membero % result-keys) columns)
-             (everyg (fn [i]
-                       (fresh [field-name]
-                         (== (columns i) field-name)
-                         (featurec (cols i) {:field-name field-name})))
-                     (range num-results))
-             (everyg (fn [i]
-                       (let [f1 (cols i)
-                             f2 (cols (inc i))
-                             special-types-orderedo (fn [st1 st2]
-                                                      )
-                             fields-orderedo (fn [f1 f2]
-                                               (fresh [st1 st2 id1 id2]
-                                                 (featurec f1 {:special-type st1, :field-id id1})
-                                                 (featurec f2 {:special-type st2, :field-id id2})
-                                                 (conde
-                                                  [(== st1 :id) (!= st2 :id)]
-                                                  [(== st1 :fk) (!= st2 :fk)]
-                                                  [(== st1 st2)
-                                                   (ar/< id1 id2)]
-                                                  [(!= st1 :id) (!= st1 :fk) (ar/< id1 id2)])))]
-                         (fields-orderedo f1 f2)))
-                     (range (dec num-results)))))))
-
-(defn- y []
-  (annotate-2 -query -results))
+  (let [id (fn id
+             ([table-name]
+              (sel :one :id 'Table :db_id 67, :name (name table-name)))
+             ([table-name field-name]
+              (sel :one :id 'Field :table_id (id table-name), :name (name field-name))))]
+    (metabase.driver/process-query {:database 67
+                                    :type     :query
+                                    :query    {:source_table (id :venues)
+                                               :aggregation  ["rows"]
+                                               :limit        10}})))

--- a/src/metabase/driver/query_processor/annotate.clj
+++ b/src/metabase/driver/query_processor/annotate.clj
@@ -82,7 +82,7 @@
 (defn- field-positiono [field v]
   (featurec field {:position v}))
 
-(defn- fields-sorted-by-nameo [{:keys [result-keys]} f1 f2]
+(defn- field-name< [{:keys [result-keys]} f1 f2]
   (fresh [n1 n2]
     (featurec f1 {:field-name n1})
     (featurec f2 {:field-name n2})
@@ -142,7 +142,7 @@
                                                   (special-type-groupo f1 t1)
                                                   (special-type-groupo f2 t2)
                                                   (conda ((ar/< t1 t2))
-                                                         ((== t1 t2) (fields-sorted-by-nameo query f1 f2)))))))))))))
+                                                         ((== t1 t2) (field-name< query f1 f2)))))))))))))
 
 
 ;;; ## Top-Level Resolution / Ordering

--- a/src/metabase/driver/query_processor/annotate.clj
+++ b/src/metabase/driver/query_processor/annotate.clj
@@ -105,9 +105,6 @@
 
 ;; Use core.logic to determine the appropriate
 
-(defn- fieldo [query field]
-  (member1o field (:query-fields query)))
-
 (defn- fields< [f1 f2]
   (fresh [g1 g2, gp1 gp2]
     (featurec f1 {:group g1, :group-position gp1})

--- a/src/metabase/driver/query_processor/expand.clj
+++ b/src/metabase/driver/query_processor/expand.clj
@@ -141,7 +141,7 @@
 
     ;; Re-bind *field-ids* in case we need to do recursive Field resolution
     (binding [*field-ids* (atom #{})]
-      (let [fields (->> (sel :many :id->fields [field/Field :name :base_type :special_type :table_id :parent_id :position], :id [in field-ids])
+      (let [fields (->> (sel :many :id->fields [field/Field :name :base_type :special_type :table_id :parent_id :position :description], :id [in field-ids])
                         (m/map-vals rename-mb-field-keys)
                         (m/map-vals #(assoc % :parent (when (:parent-id %)
                                                         (ph (:parent-id %))))))]
@@ -236,6 +236,7 @@
                   ^Integer table-id
                   ^String  table-name
                   ^Integer position
+                  ^String  description
                   ^Integer parent-id
                   parent] ; Field once its resolved; FieldPlaceholder before that
   IResolve

--- a/src/metabase/driver/query_processor/expand.clj
+++ b/src/metabase/driver/query_processor/expand.clj
@@ -134,7 +134,7 @@
 
 (defn- resolve-fields
   "Resolve the `Fields` in an EXPANDED-QUERY-DICT."
-  [expanded-query-dict field-ids & [count]]
+  [expanded-query-dict field-ids]
   (if-not (seq field-ids)
     ;; Base case: if there's no field-ids to expand we're done
     expanded-query-dict
@@ -149,9 +149,7 @@
 
         ;; Recurse in case any new [nested] Field placeholders were emitted and we need to do recursive Field resolution
         ;; We can't use recur here because binding wraps body in try/catch
-        (resolve-fields (walk/postwalk #(resolve-field % fields) expanded-query-dict)
-                        @*field-ids*
-                        (inc (or count 0)))))))
+        (resolve-fields (walk/postwalk #(resolve-field % fields) expanded-query-dict) @*field-ids*)))))
 
 (defn- resolve-database
   "Resolve the `Database` in question for an EXPANDED-QUERY-DICT."

--- a/src/metabase/driver/query_processor/expand.clj
+++ b/src/metabase/driver/query_processor/expand.clj
@@ -141,7 +141,7 @@
 
     ;; Re-bind *field-ids* in case we need to do recursive Field resolution
     (binding [*field-ids* (atom #{})]
-      (let [fields (->> (sel :many :id->fields [field/Field :name :base_type :special_type :table_id :parent_id], :id [in field-ids])
+      (let [fields (->> (sel :many :id->fields [field/Field :name :base_type :special_type :table_id :parent_id :position], :id [in field-ids])
                         (m/map-vals rename-mb-field-keys)
                         (m/map-vals #(assoc % :parent (when (:parent-id %)
                                                         (ph (:parent-id %))))))]
@@ -235,6 +235,7 @@
                   ^Keyword special-type
                   ^Integer table-id
                   ^String  table-name
+                  ^Integer position
                   ^Integer parent-id
                   parent] ; Field once its resolved; FieldPlaceholder before that
   IResolve

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -275,4 +275,12 @@
            ~(when (seq more)
               `(cond-let ~@more))))
 
+(defn filtered-stacktrace
+  "Get the stack trace associated with E and return it as a vector with non-metabase frames filtered out."
+  [^Throwable e]
+  (when e
+    (when-let [stacktrace (.getStackTrace e)]
+      (->> (map str (.getStackTrace e))
+           (filterv (partial re-find #"metabase"))))))
+
 (require-dox-in-this-namespace)

--- a/src/metabase/util/logic.clj
+++ b/src/metabase/util/logic.clj
@@ -3,15 +3,15 @@
   (:refer-clojure :exclude [==])
   (:require [clojure.core.logic :refer :all]))
 
-(defne butlasto
+(defne butlast°
   "A relation such that BUSTLAST is all items but the LAST of list L."
   [butlast last l]
   ([[]   ?x [?x]])
   ([_    _  [?x . ?more]] (fresh [more-butlast]
-                            (butlasto more-butlast last ?more)
+                            (butlast° more-butlast last ?more)
                             (conso ?x more-butlast butlast))))
 
-(defna splito
+(defna split°
   "A relation such that HALF1 and HALF2 are even divisions of list L.
    If L has an odd number of items, HALF1 will have one more item than HALF2."
   [half1 half2 l]
@@ -20,10 +20,10 @@
   ([[?x] [?y] [?x ?y]])
   ([[?x ?y . ?more-half1-butlast] [?more-half1-last . ?more-half2] [?x ?y . ?more]]
    (fresh [more-half1]
-     (splito more-half1 ?more-half2 ?more)
-     (butlasto ?more-half1-butlast ?more-half1-last more-half1))))
+     (split° more-half1 ?more-half2 ?more)
+     (butlast° ?more-half1-butlast ?more-half1-last more-half1))))
 
-(defn sorted-intoo
+(defn sorted-into°
   "A relation such that OUT is the list L with V sorted into it doing comparisons with PRED."
   [pred l v out]
   (matche [l]
@@ -31,20 +31,31 @@
     ([[?x . ?more]] (conda
                      ((pred v ?x) (conso v (lcons ?x ?more) out))
                      (s#          (fresh [more]
-                                    (sorted-intoo pred ?more v more)
+                                    (sorted-into° pred ?more v more)
                                     (conso ?x more out)))))))
 
-(defna sorted-permutationo
+(defna sorted-permutation°
   "A relation such that OUT is a permutation of L where all items are sorted by PRED."
   [pred l out]
   ([_ [] []])
   ([_ [?x . ?more] _] (fresh [more]
-                        (sorted-permutationo pred ?more more)
-                        (sorted-intoo pred more ?x out))))
+                        (sorted-permutation° pred ?more more)
+                        (sorted-into° pred more ?x out))))
 
-(defna matches-seq-ordero
+(defn matches-seq-order°
   "A relation such that V1 is present and comes before V2 in list L."
   [v1 v2 l]
-  ([_ _ [v1 . _]]    s#)
-  ([_ _ [v2 . _]]    fail)
-  ([_ _ [_ . ?more]] (matches-seq-ordero v1 v2 ?more)))
+  (conda
+    ;; This is just an optimization for cases where L isn't a logic var; it's much faster <3
+    ((nonlvaro l)  ((fn -ordered° [[item & more]]
+                      (conda
+                        ((== v1 item)         s#)
+                        ((== v2 item)         fail)
+                        ((when (seq more) s#) (-ordered° more))))
+                    l))
+    (s#            (conda
+                     ((firsto l v1))
+                     ((firsto l v2) fail)
+                     ((fresh [more]
+                        (resto l more)
+                        (matches-seq-order° v1 v2 more)))))))

--- a/src/metabase/util/logic.clj
+++ b/src/metabase/util/logic.clj
@@ -4,12 +4,12 @@
   (:require [clojure.core.logic :refer :all]))
 
 (defne butlast°
-  "A relation such that BUSTLAST is all items but the LAST of list L."
-  [butlast last l]
+  "A relation such that BUSTLASTV is all items but the last item LASTV of list L."
+  [butlastv lastv l]
   ([[]   ?x [?x]])
   ([_    _  [?x . ?more]] (fresh [more-butlast]
-                            (butlast° more-butlast last ?more)
-                            (conso ?x more-butlast butlast))))
+                            (butlast° more-butlast lastv ?more)
+                            (conso ?x more-butlast butlastv))))
 
 (defna split°
   "A relation such that HALF1 and HALF2 are even divisions of list L.

--- a/src/metabase/util/logic.clj
+++ b/src/metabase/util/logic.clj
@@ -42,20 +42,6 @@
                         (sorted-permutationo pred ?more more)
                         (sorted-intoo pred more ?x out))))
 
-(defn fpredo
-  "Succeds if PRED holds true for the fresh values obtained by `(f value fresh-value)`."
-  [pred f v1 v2]
-  (fresh [fresh-v1 fresh-v2]
-    (f v1 fresh-v1)
-    (f v2 fresh-v2)
-    (trace-lvars (str f) fresh-v1 fresh-v2)
-    (pred fresh-v1 fresh-v2)))
-
-(defmacro fpred-conda [[f & values] & clauses]
-  `(conda
-    ~@(for [[pred & body] clauses]
-        `((fpredo ~pred ~f ~@values) ~@body))))
-
 (defna matches-seq-ordero
   "A relation such that V1 is present and comes before V2 in list L."
   [v1 v2 l]

--- a/src/metabase/util/logic.clj
+++ b/src/metabase/util/logic.clj
@@ -1,0 +1,63 @@
+(ns metabase.util.logic
+  "Useful relations for `core.logic`."
+  (:refer-clojure :exclude [==])
+  (:require [clojure.core.logic :refer :all]))
+
+(defne butlasto
+  "A relation such that BUSTLAST is all items but the LAST of list L."
+  [butlast last l]
+  ([[]   ?x [?x]])
+  ([_    _  [?x . ?more]] (fresh [more-butlast]
+                            (butlasto more-butlast last ?more)
+                            (conso ?x more-butlast butlast))))
+
+(defna splito
+  "A relation such that HALF1 and HALF2 are even divisions of list L.
+   If L has an odd number of items, HALF1 will have one more item than HALF2."
+  [half1 half2 l]
+  ([[]   []   []])
+  ([[?x] []   [?x]])
+  ([[?x] [?y] [?x ?y]])
+  ([[?x ?y . ?more-half1-butlast] [?more-half1-last . ?more-half2] [?x ?y . ?more]]
+   (fresh [more-half1]
+     (splito more-half1 ?more-half2 ?more)
+     (butlasto ?more-half1-butlast ?more-half1-last more-half1))))
+
+(defn sorted-intoo
+  "A relation such that OUT is the list L with V sorted into it doing comparisons with PRED."
+  [pred l v out]
+  (matche [l]
+    ([[]]           (== out [v]))
+    ([[?x . ?more]] (conda
+                     ((pred v ?x) (conso v (lcons ?x ?more) out))
+                     (s#          (fresh [more]
+                                    (sorted-intoo pred ?more v more)
+                                    (conso ?x more out)))))))
+
+(defna sorted-permutationo
+  "A relation such that OUT is a permutation of L where all items are sorted by PRED."
+  [pred l out]
+  ([_ [] []])
+  ([_ [?x . ?more] _] (fresh [more]
+                        (sorted-permutationo pred ?more more)
+                        (sorted-intoo pred more ?x out))))
+
+(defn fpredo
+  "Succeds if PRED holds true for the fresh values obtained by  `(f value fresh-value)`."
+  [pred f v1 v2]
+  (fresh [fresh-v1 fresh-v2]
+    (f v1 fresh-v1)
+    (f v2 fresh-v2)
+    (pred fresh-v1 fresh-v2)))
+
+(defmacro fpred-conda [[f & values] & clauses]
+  `(conda
+    ~@(for [[pred & body] clauses]
+        `((fpredo ~pred ~f ~@values) ~@body))))
+
+(defna matches-seq-ordero
+  "A relation such that V1 is present and comes before V2 in list L."
+  [v1 v2 l]
+  ([_ _ [v1 . _]]    s#)
+  ([_ _ [v2 . _]]    fail)
+  ([_ _ [_ . ?more]] (matches-seq-ordero v1 v2 ?more)))

--- a/src/metabase/util/logic.clj
+++ b/src/metabase/util/logic.clj
@@ -24,23 +24,23 @@
      (butlast° ?more-half1-butlast ?more-half1-last more-half1))))
 
 (defn sorted-into°
-  "A relation such that OUT is the list L with V sorted into it doing comparisons with PRED."
-  [pred l v out]
+  "A relation such that OUT is the list L with V sorted into it doing comparisons with PRED-F."
+  [pred-f l v out]
   (matche [l]
     ([[]]           (== out [v]))
     ([[?x . ?more]] (conda
-                     ((pred v ?x) (conso v (lcons ?x ?more) out))
-                     (s#          (fresh [more]
-                                    (sorted-into° pred ?more v more)
-                                    (conso ?x more out)))))))
+                     ((pred-f v ?x) (conso v (lcons ?x ?more) out))
+                     (s#            (fresh [more]
+                                      (sorted-into° pred-f ?more v more)
+                                      (conso ?x more out)))))))
 
 (defna sorted-permutation°
-  "A relation such that OUT is a permutation of L where all items are sorted by PRED."
-  [pred l out]
+  "A relation such that OUT is a permutation of L where all items are sorted by PRED-F."
+  [pred-f l out]
   ([_ [] []])
   ([_ [?x . ?more] _] (fresh [more]
-                        (sorted-permutation° pred ?more more)
-                        (sorted-into° pred more ?x out))))
+                        (sorted-permutation° pred-f ?more more)
+                        (sorted-into° pred-f more ?x out))))
 
 (defn matches-seq-order°
   "A relation such that V1 is present and comes before V2 in list L."

--- a/src/metabase/util/logic.clj
+++ b/src/metabase/util/logic.clj
@@ -43,11 +43,12 @@
                         (sorted-intoo pred more ?x out))))
 
 (defn fpredo
-  "Succeds if PRED holds true for the fresh values obtained by  `(f value fresh-value)`."
+  "Succeds if PRED holds true for the fresh values obtained by `(f value fresh-value)`."
   [pred f v1 v2]
   (fresh [fresh-v1 fresh-v2]
     (f v1 fresh-v1)
     (f v2 fresh-v2)
+    (trace-lvars (str f) fresh-v1 fresh-v2)
     (pred fresh-v1 fresh-v2)))
 
 (defmacro fpred-conda [[f & values] & clauses]

--- a/test/metabase/driver/generic_sql/native_test.clj
+++ b/test/metabase/driver/generic_sql/native_test.clj
@@ -34,6 +34,9 @@
 (expect {:status :failed
          :error "Column \"ZID\" not found"}
   (do (log/info (color/green "NOTE: The following stacktrace is expected <3"))      ; this will print a stacktrace
-      (driver/process-query {:native   {:query "SELECT ZID FROM CHECKINS LIMIT 2;"} ; make sure people know it's to be expected
-                             :type     :native
-                             :database (db-id)})))
+      (dissoc (driver/process-query {:native   {:query "SELECT ZID FROM CHECKINS LIMIT 2;"} ; make sure people know it's to be expected
+                                     :type     :native
+                                     :database (db-id)})
+              :stacktrace
+              :query
+              :expanded-query)))

--- a/test/metabase/driver/query_processor_test.clj
+++ b/test/metabase/driver/query_processor_test.clj
@@ -1053,16 +1053,16 @@
 ;;; Nested Field in FIELDS
 ;; Return the first 10 tips with just tip.venue.name
 (datasets/expect-when-testing-dataset :mongo
-    [[1  {:name "Lucky's Gluten-Free Café"}]
-     [2  {:name "Joe's Homestyle Eatery"}]
-     [3  {:name "Lower Pac Heights Cage-Free Coffee House"}]
-     [4  {:name "Oakland European Liquor Store"}]
-     [5  {:name "Tenderloin Gormet Restaurant"}]
-     [6  {:name "Marina Modern Sushi"}]
-     [7  {:name "Sunset Homestyle Grill"}]
-     [8  {:name "Kyle's Low-Carb Grill"}]
-     [9  {:name "Mission Homestyle Churros"}]
-     [10 {:name "Sameer's Pizza Liquor Store"}]]
+    [[{:name "Lucky's Gluten-Free Café"} 1]
+     [{:name "Joe's Homestyle Eatery"} 2]
+     [{:name "Lower Pac Heights Cage-Free Coffee House"} 3]
+     [{:name "Oakland European Liquor Store"} 4]
+     [{:name "Tenderloin Gormet Restaurant"} 5]
+     [{:name "Marina Modern Sushi"} 6]
+     [{:name "Sunset Homestyle Grill"} 7]
+     [{:name "Kyle's Low-Carb Grill"} 8]
+     [{:name "Mission Homestyle Churros"} 9]
+     [{:name "Sameer's Pizza Liquor Store"} 10]]
   (Q run against geographical-tips using mongo
      return :data :rows
      aggregate rows of tips

--- a/test/metabase/driver/query_processor_test.clj
+++ b/test/metabase/driver/query_processor_test.clj
@@ -634,8 +634,9 @@
 (datasets/expect-with-dataset :mongo
   {:status :failed
    :error  "standard-deviation-aggregations is not supported by this driver."}
-  (Q run tbl venues
-     ag stddev latitude))
+  (select-keys (Q run tbl venues
+                  ag stddev latitude)
+               [:status :error]))
 
 
 ;;; ## order_by aggregate fields (SQL-only for the time being)
@@ -958,12 +959,13 @@
 (datasets/expect-with-dataset :mongo
   {:status :failed
    :error "foreign-keys is not supported by this driver."}
-  (query-with-temp-db defs/tupac-sightings
-    :source_table &sightings:id
-    :order_by     [[["fk->" &sightings.city_id:id &cities.name:id] "ascending"]
-                   [["fk->" &sightings.category_id:id &categories.name:id] "descending"]
-                   [&sightings.id:id "ascending"]]
-    :limit        10))
+  (select-keys (query-with-temp-db defs/tupac-sightings
+                 :source_table &sightings:id
+                 :order_by     [[["fk->" &sightings.city_id:id &cities.name:id] "ascending"]
+                                [["fk->" &sightings.category_id:id &categories.name:id] "descending"]
+                                [&sightings.id:id "ascending"]]
+                 :limit        10)
+               [:status :error]))
 
 
 ;; +------------------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
This was basically an experiment to see how feasible this was. The answer is:

core.logic is dope :sunglasses: 

Instead of 200 lines of hairy/fragile code we can just tell core.logic what the constraints are and it solves it for us. Code is much smaller and simpler and got to remove some DB calls and the "uncastify" nonsense (@agilliland I know this will make you happy)

I still need to do some tuning because this it takes a little longer than the old purely functional code but should be g2g soon :+1: 
