### PR TITLE
fix using 'false' as a filter value

### DIFF
--- a/src/metabase/driver/query_processor/expand.clj
+++ b/src/metabase/driver/query_processor/expand.clj
@@ -415,13 +415,13 @@
                                      :min   (ph lon-field lon-min)
                                      :max   (ph lon-field lon-max)}})
 
-  ["BETWEEN" (field-id :guard Field?) (min :guard identity) (max :guard identity)]
+  ["BETWEEN" (field-id :guard Field?) (min :guard (complement nil?)) (max :guard (complement nil?))]
   (map->Filter:Between {:filter-type :between
                         :field       (ph field-id)
                         :min-val     (ph field-id min)
                         :max-val     (ph field-id max)})
 
-  [(filter-type :guard (partial contains? #{"=" "!=" "<" ">" "<=" ">="})) (field-id :guard Field?) (val :guard identity)]
+  [(filter-type :guard (partial contains? #{"=" "!=" "<" ">" "<=" ">="})) (field-id :guard Field?) (val :guard (complement nil?))]
   (map->Filter:Field+Value {:filter-type (keyword filter-type)
                             :field       (ph field-id)
                             :value       (ph field-id val)})

--- a/test/metabase/driver/query_processor_test.clj
+++ b/test/metabase/driver/query_processor_test.clj
@@ -401,9 +401,9 @@
 ;; Check that we're checking for non-nil values, not just logically true ones.
 ;; There's only one place (out of 3) that I don't like
 (qp-expect-with-all-datasets
- [[1]]
+ 1
  (Q run against places-cam-likes
-    return :data :rows
+    return :data :rows first first
     aggregate count of places
     filter = liked false))
 

--- a/test/metabase/driver/query_processor_test.clj
+++ b/test/metabase/driver/query_processor_test.clj
@@ -397,6 +397,16 @@
   :breakout     [nil]
   :limit        nil})
 
+;; ### FILTER WITH A FALSE VALUE
+;; Check that we're checking for non-nil values, not just logically true ones.
+;; There's only one place (out of 3) that I don't like
+(qp-expect-with-all-datasets
+ [[1]]
+ (Q run against places-cam-likes
+    return :data :rows
+    aggregate count of places
+    filter = liked false))
+
 ;; ### FILTER -- "BETWEEN", single subclause (neither "AND" nor "OR")
 (qp-expect-with-all-datasets
  {:rows    [[21 "PizzaHacker" 58 37.7441 -122.421 2]

--- a/test/metabase/driver/query_processor_test.clj
+++ b/test/metabase/driver/query_processor_test.clj
@@ -400,7 +400,7 @@
 ;; ### FILTER WITH A FALSE VALUE
 ;; Check that we're checking for non-nil values, not just logically true ones.
 ;; There's only one place (out of 3) that I don't like
-(qp-expect-with-all-datasets
+(datasets/expect-with-all-datasets
  1
  (Q run against places-cam-likes
     return :data :rows first first

--- a/test/metabase/test/data/dataset_definitions.clj
+++ b/test/metabase/test/data/dataset_definitions.clj
@@ -39,3 +39,6 @@
 (def-database-definition-edn tupac-sightings)
 
 (def-database-definition-edn geographical-tips)
+
+;; A very tiny dataset with a list of places and a booleans
+(def-database-definition-edn places-cam-likes)

--- a/test/metabase/test/data/dataset_definitions/places-cam-likes.edn
+++ b/test/metabase/test/data/dataset_definitions/places-cam-likes.edn
@@ -1,0 +1,7 @@
+[["places" [{:field-name "name"
+             :base-type :CharField}
+            {:field-name "liked"
+             :base-type :BooleanField}]
+  [["Tempest" true]
+   ["Bullit" true]
+   ["The Dentist" false]]]]

--- a/test/metabase/test/util/mql.clj
+++ b/test/metabase/test/util/mql.clj
@@ -11,7 +11,7 @@
 (defn- partition-tokens [keywords tokens]
   (->> (loop [all [], current-split nil, [token & more] tokens]
          (cond
-           (and (not token)
+           (and (nil? token)
                 (not (seq more)))     (conj all current-split)
            (contains? keywords token) (recur (or (when (seq current-split)
                                                    (conj all current-split))
@@ -22,7 +22,7 @@
                                              (conj current-split token)
                                              more)))
        (map seq)
-       (filter identity)))
+       (filter (complement nil?))))
 
 (def ^:private ^:const outer-q-tokens '#{against with run return using})
 (def ^:private ^:const inner-q-tokens '#{ag aggregate breakout fields filter lim limit order page of tbl})


### PR DESCRIPTION
Fixes #727

Basically the new query validation stuff was checking for logically truthy values in filter clauses which meant it didn't recognize `false` as valid
