### PR TITLE
Minor SQL driver refactor

### DIFF
--- a/src/metabase/db/internal.clj
+++ b/src/metabase/db/internal.clj
@@ -68,13 +68,12 @@
 ;;; Low-level sel implementation
 
 (defmacro sel-fn [& forms]
-  (let [forms               (sel-apply-kwargs forms)
-        entity-placeholder  (gensym "ENTITY--")]
-    (loop [query `(k/select* ~entity-placeholder), [[f & args] & more] forms]
+  (let [forms               (sel-apply-kwargs forms)]
+    (loop [query `(k/select* ~'entity), [[f & args] & more] forms]
       (cond
         f          (recur `(~f ~query ~@args) more)
         (seq more) (recur query more)
-        :else      `[(fn [~entity-placeholder]
+        :else      `[(fn [~'entity]
                        ~query) ~(str query)]))))
 
 (defn sel-exec [entity [select-fn log-str]]

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -3,112 +3,111 @@
             [clojure.tools.logging :as log]
             [korma.core :as k]
             [metabase.driver :as driver]
-            (metabase.driver [interface :refer :all]
+            (metabase.driver [interface :refer [IDriver ISyncDriverTableFKs ISyncDriverFieldAvgLength ISyncDriverFieldPercentUrls]]
                              [sync :as driver-sync])
-            (metabase.driver.generic-sql [query-processor :as qp]
+            (metabase.driver.generic-sql [interface :as i]
+                                         [query-processor :as qp]
                                          [util :refer :all])))
 
-(def ^:private ^:const sql-driver-features
+(def ^:const features
   "Features supported by *all* Generic SQL drivers."
   #{:foreign-keys
     :standard-deviation-aggregations
     :unix-timestamp-special-type-fields})
 
-(defrecord SqlDriver [ ;; A set of additional features supported by a specific driver implmentation, e.g. :set-timezone for :postgres
-                      additional-supported-features
-                      column->base-type
-                      connection-details->connection-spec
-                      database->connection-details
-                      sql-string-length-fn
-                      timezone->set-timezone-sql
-                      ;; These functions take a string name of a Table and a string name of a Field and return the raw SQL to select it as a DATE
-                      cast-timestamp-seconds-field-to-date-fn
-                      cast-timestamp-milliseconds-field-to-date-fn]
-  IDriver
-  ;; Features
-  (supports? [_ feature]
-    (or (contains? sql-driver-features feature)
-        (contains? additional-supported-features feature)))
+(defn- can-connect-with-details? [driver details]
+  (let [connection (i/connection-details->connection-spec driver details)]
+    (= 1 (-> (k/exec-raw connection "SELECT 1" :results)
+             first
+             vals
+             first))))
 
-  ;; Connection
-  (can-connect? [this database]
-    (can-connect-with-details? this (database->connection-details database)))
+(defn- can-connect? [driver database]
+  (can-connect-with-details? driver (i/database->connection-details driver database)))
 
-  (can-connect-with-details? [_ details]
-    (let [connection (connection-details->connection-spec details)]
-      (= 1 (-> (k/exec-raw connection "SELECT 1" :results)
-               first
-               vals
-               first))))
+(defn- wrap-process-query-middleware [_ qp]
+  (fn [query]
+    (qp query)))
 
-  ;; Query Processing
-  (wrap-process-query-middleware [_ qp]
-    (fn [query]
-      (qp query)))                      ; Nothing to do here
+(defn- process-query [_ query]
+  (qp/process-and-run query))
 
-  (process-query [_ query]
-    (qp/process-and-run query))
+(defn- sync-in-context [_ database do-sync-fn]
+  (with-jdbc-metadata [_ database]
+    (do-sync-fn)))
 
-  ;; Syncing
-  (sync-in-context [_ database do-sync-fn]
-      (with-jdbc-metadata [_ database]
-        (do-sync-fn)))
+(defn- active-table-names [_ database]
+  (with-jdbc-metadata [^java.sql.DatabaseMetaData md database]
+    (->> (.getTables md nil nil nil (into-array String ["TABLE"]))
+         jdbc/result-set-seq
+         (map :table_name)
+         set)))
 
-  (active-table-names [_ database]
-    (with-jdbc-metadata [^java.sql.DatabaseMetaData md database]
-      (->> (.getTables md nil nil nil (into-array String ["TABLE"]))
-           jdbc/result-set-seq
-           (map :table_name)
-           set)))
+(defn- active-column-names->type [{:keys [column->base-type]} table]
+  {:pre [(map? column->base-type)]}
+  (with-jdbc-metadata [^java.sql.DatabaseMetaData md @(:db table)]
+    (->> (.getColumns md nil nil (:name table) nil)
+         jdbc/result-set-seq
+         (filter #(not= (:table_schem %) "INFORMATION_SCHEMA")) ; filter out internal tables
+         (map (fn [{:keys [column_name type_name]}]
+                {column_name (or (column->base-type (keyword type_name))
+                                 :UnknownField)}))
+         (into {}))))
 
-  (active-column-names->type [_ table]
-    (with-jdbc-metadata [^java.sql.DatabaseMetaData md @(:db table)]
-      (->> (.getColumns md nil nil (:name table) nil)
-           jdbc/result-set-seq
-           (filter #(not= (:table_schem %) "INFORMATION_SCHEMA")) ; filter out internal tables
-           (map (fn [{:keys [column_name type_name]}]
-                  {column_name (or (column->base-type (keyword type_name))
-                                   :UnknownField)}))
-           (into {}))))
+(defn- table-pks [_ table]
+  (with-jdbc-metadata [^java.sql.DatabaseMetaData md @(:db table)]
+    (->> (.getPrimaryKeys md nil nil (:name table))
+         jdbc/result-set-seq
+         (map :column_name)
+         set)))
 
-  (table-pks [_ table]
-    (with-jdbc-metadata [^java.sql.DatabaseMetaData md @(:db table)]
-      (->> (.getPrimaryKeys md nil nil (:name table))
-           jdbc/result-set-seq
-           (map :column_name)
-           set)))
+(defn- table-fks [_ table]
+  (with-jdbc-metadata [^java.sql.DatabaseMetaData md @(:db table)]
+    (->> (.getImportedKeys md nil nil (:name table))
+         jdbc/result-set-seq
+         (map (fn [result]
+                {:fk-column-name   (:fkcolumn_name result)
+                 :dest-table-name  (:pktable_name result)
+                 :dest-column-name (:pkcolumn_name result)}))
+         set)))
 
-  ISyncDriverTableFKs
-  (table-fks [_ table]
-    (with-jdbc-metadata [^java.sql.DatabaseMetaData md @(:db table)]
-      (->> (.getImportedKeys md nil nil (:name table))
-           jdbc/result-set-seq
-           (map (fn [result]
-                  {:fk-column-name   (:fkcolumn_name result)
-                   :dest-table-name  (:pktable_name result)
-                   :dest-column-name (:pkcolumn_name result)}))
-           set)))
+(defn- field-avg-length [{:keys [sql-string-length-fn]} field]
+  {:pre [(keyword? sql-string-length-fn)]}
+  (or (some-> (korma-entity @(:table field))
+              (k/select (k/aggregate (avg (k/sqlfn* sql-string-length-fn
+                                                    (k/raw (format "CAST(\"%s\" AS TEXT)" (name (:name field))))))
+                                     :len))
+              first
+              :len
+              int)
+      0))
 
-  ISyncDriverFieldAvgLength
-  (field-avg-length [_ field]
-    (or (some-> (korma-entity @(:table field))
-                (k/select (k/aggregate (avg (k/sqlfn* sql-string-length-fn
-                                                      (k/raw (format "CAST(\"%s\" AS TEXT)" (name (:name field))))))
-                                       :len))
-                first
-                :len
-                int)
-        0))
+(defn- field-percent-urls [_ field]
+  (let [korma-table          (korma-entity @(:table field))
+        total-non-null-count (-> (k/select korma-table
+                                           (k/aggregate (count :*) :count)
+                                           (k/where {(keyword (:name field)) [not= nil]})) first :count)]
+    (if (= total-non-null-count 0) 0.0
+        (let [url-count (or (-> (k/select korma-table
+                                          (k/aggregate (count :*) :count)
+                                          (k/where {(keyword (:name field)) [like "http%://_%.__%"]})) first :count)
+                            0)]
+          (float (/ url-count total-non-null-count))))))
 
-  ISyncDriverFieldPercentUrls
-  (field-percent-urls [_ field]
-    (let [korma-table (korma-entity @(:table field))
-          total-non-null-count (-> (k/select korma-table
-                                             (k/aggregate (count :*) :count)
-                                             (k/where {(keyword (:name field)) [not= nil]})) first :count)]
-      (if (= total-non-null-count 0) 0.0
-          (let [url-count (or (-> (k/select korma-table
-                                            (k/aggregate (count :*) :count)
-                                            (k/where {(keyword (:name field)) [like "http%://_%.__%"]})) first :count)
-                              0)]
-            (float (/ url-count total-non-null-count)))))))
+(defn extend-add-generic-sql-mixins [driver-type]
+  (extend driver-type
+    IDriver
+    {:can-connect?                  can-connect?
+     :can-connect-with-details?     can-connect-with-details?
+     :wrap-process-query-middleware wrap-process-query-middleware
+     :process-query                 process-query
+     :sync-in-context               sync-in-context
+     :active-table-names            active-table-names
+     :active-column-names->type     active-column-names->type
+     :table-pks table-pks}
+    ISyncDriverTableFKs
+    {:table-fks table-fks}
+    ISyncDriverFieldAvgLength
+    {:field-avg-length field-avg-length}
+    ISyncDriverFieldPercentUrls
+    {:field-percent-urls field-percent-urls}))

--- a/src/metabase/driver/generic_sql/interface.clj
+++ b/src/metabase/driver/generic_sql/interface.clj
@@ -1,0 +1,17 @@
+(ns metabase.driver.generic-sql.interface)
+
+(defprotocol ISqlDriverDatabaseSpecific
+  "Methods a DB-specific concrete SQL driver should implement.
+   They should also have the following properties:
+
+   *  `column->base-type`
+   *  `sql-string-length-fn`"
+  (connection-details->connection-spec [this connection-details])
+  (database->connection-details        [this database])
+  (cast-timestamp-to-date              [this table-name field-name seconds-or-milliseconds]
+    "Return the raw SQL that should be used to cast a Unix-timestamped column with string
+     TABLE-NAME and string FIELD-NAME to a SQL `DATE`. SECONDS-OR-MILLISECONDS will be either
+     `:seconds` or `:milliseconds`.")
+  (timezone->set-timezone-sql          [this timezone]
+    "Return a string that represents the SQL statement that should be used to set the timezone
+     for the current transaction."))

--- a/src/metabase/driver/generic_sql/native.clj
+++ b/src/metabase/driver/generic_sql/native.clj
@@ -6,7 +6,9 @@
                    db)
             [metabase.db :refer [sel]]
             [metabase.driver :as driver]
-            [metabase.driver.generic-sql.util :refer :all]
+            [metabase.driver.interface :refer [supports?]]
+            (metabase.driver.generic-sql [interface :as i]
+                                         [util :refer :all])
             [metabase.models.database :refer [Database]]))
 
 (defn- value->base-type
@@ -27,12 +29,14 @@
                     db->korma-db
                     korma.db/get-connection)
              [columns & [first-row :as rows]] (jdbc/with-db-transaction [conn db :read-only? true]
-                                                ;; If timezone is specified in the Query and the driver supports setting the timezone then execute SQL to set it
+                                                ;; If timezone is specified in the Query and the driver supports setting the timezone
+                                                ;; then execute SQL to set it
                                                 (when-let [timezone (or (-> query :native :timezone)
                                                                         (driver/report-timezone))]
-                                                  (when-let [timezone->set-timezone-sql (:timezone->set-timezone-sql (driver/engine->driver (:engine database)))]
-                                                    (log/debug "Setting timezone to:" timezone)
-                                                    (jdbc/db-do-prepared conn (timezone->set-timezone-sql timezone))))
+                                                  (let [driver (driver/engine->driver (:engine database))]
+                                                    (when (supports? driver :set-timezone)
+                                                      (log/debug "Setting timezone to:" timezone)
+                                                      (jdbc/db-do-prepared conn (i/timezone->set-timezone-sql driver timezone)))))
                                                 (jdbc/query conn sql :as-arrays? true))]
          ;; TODO - Why don't we just use annotate?
          {:rows    rows

--- a/src/metabase/driver/generic_sql/util.clj
+++ b/src/metabase/driver/generic_sql/util.clj
@@ -16,8 +16,7 @@
     (merge (-> database database->connection-details connection-details->connection-spec)
            ;; unless this is a temp DB, we need to make a pool or the connection will be closed before we get a chance to unCLOB-er the results during JSON serialization
            ;; TODO - what will we do once we have CLOBS in temp DBs?
-           (when-not short-lived?
-             {:make-pool? true}))))
+           {:make-pool? (not short-lived?)})))
 
 (def ^{:arglists '([database])}
   db->korma-db

--- a/src/metabase/driver/generic_sql/util.clj
+++ b/src/metabase/driver/generic_sql/util.clj
@@ -6,12 +6,13 @@
             [korma.core :as korma]
             [korma.db :as kdb]
             [metabase.driver :as driver]
-            [metabase.driver.query-processor :as qp]))
+            [metabase.driver.query-processor :as qp]
+            [metabase.driver.generic-sql.interface :as i]))
 
 (defn- db->connection-spec [{{:keys [short-lived?]} :details, :as database}]
   (let [driver                              (driver/engine->driver (:engine database))
-        database->connection-details        (:database->connection-details driver)
-        connection-details->connection-spec (:connection-details->connection-spec driver)]
+        database->connection-details        (partial i/database->connection-details driver)
+        connection-details->connection-spec (partial i/connection-details->connection-spec driver)]
     (merge (-> database database->connection-details connection-details->connection-spec)
            ;; unless this is a temp DB, we need to make a pool or the connection will be closed before we get a chance to unCLOB-er the results during JSON serialization
            ;; TODO - what will we do once we have CLOBS in temp DBs?

--- a/src/metabase/driver/interface.clj
+++ b/src/metabase/driver/interface.clj
@@ -14,12 +14,11 @@
 ;; ## IDriver Protocol
 
 (defprotocol IDriver
-  "Methods all drivers must implement."
-  ;; Features
-  (supports? [this ^Keyword feature]
-    "Does this driver support optional FEATURE?
+  "Methods all drivers must implement.
+   They should also include the following properties:
 
-       (supports? metabase.driver.h2/driver :timestamps) -> false")
+   *  `features` (optional)
+      A set containing one or more `driver-optional-features`"
 
   ;; Connection
   (can-connect? [this database]
@@ -112,6 +111,16 @@
 
 
 ;; ## Helper Functions
+
+(def ^:private valid-feature? (partial contains? driver-optional-features))
+
+(defn supports?
+  "Does DRIVER support FEATURE?"
+  [{:keys [features]} ^Keyword feature]
+  {:pre [(set? features)
+         (every? valid-feature? features)
+         (valid-feature? feature)]}
+  (contains? features feature))
 
 (defn assert-driver-supports
   "Helper fn. Assert that DRIVER supports FEATURE."

--- a/src/metabase/driver/mongo.clj
+++ b/src/metabase/driver/mongo.clj
@@ -49,16 +49,8 @@
 
 ;;; ## MongoDriver
 
-(def ^:const ^:private mongo-driver-features
-  "Optional features supported by the Mongo driver."
-  #{:nested-fields})
-
-(deftype MongoDriver []
+(defrecord MongoDriver []
   IDriver
-;;; ### Features
-  (supports? [_ feature]
-    (contains? mongo-driver-features feature))
-
 ;;; ### Connection
   (can-connect? [_ database]
     (with-mongo-connection [^com.mongodb.DBApiLayer conn database]
@@ -136,4 +128,4 @@
 
 (def driver
   "Concrete instance of the MongoDB driver."
-  (MongoDriver.))
+  (map->MongoDriver {:features #{:nested-fields}}))

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -5,14 +5,10 @@
             [korma.db :as kdb]
             [swiss.arrows :refer :all]
             [metabase.driver :as driver]
-            (metabase.driver [generic-sql :as generic-sql]
-                             [interface :as i])))
+            [metabase.driver.generic-sql :as generic-sql]
+            [metabase.driver.generic-sql.interface :refer :all]))
 
-(declare driver)
-
-;; ## SYNCING
-
-(def ^:const column->base-type
+(def ^:private ^:const column->base-type
   "Map of Postgres column types -> Field base types.
    Add more mappings here as you come across them."
   {:bigint        :BigIntegerField
@@ -73,60 +69,43 @@
    (keyword "timestamp with timezone")    :DateTimeField
    (keyword "timestamp without timezone") :DateTimeField})
 
-
-;; ## CONNECTION
-
 (def ^:private ^:const ssl-params
   "Params to include in the JDBC connection spec for an SSL connection."
   {:ssl        true
    :sslmode    "require"
    :sslfactory "org.postgresql.ssl.NonValidatingFactory"})  ; HACK Why enable SSL if we disable certificate validation?
 
-(defn- connection-details->connection-spec [{:keys [ssl] :as details-map}]
-  (-> details-map
-      (dissoc :ssl)                                           ; remove :ssl in case it's false; DB will still try (& fail) to connect if the key is there
-      (merge (when ssl                                        ; merging ssl-params will add :ssl back in if desirable
-               ssl-params))
-      (rename-keys {:dbname :db})
-      kdb/postgres))
+(defrecord ^:private PostgresDriver []
+  ISqlDriverDatabaseSpecific
+  (connection-details->connection-spec [_ {:keys [ssl] :as details-map}]
+    (-> details-map
+        (dissoc :ssl)              ; remove :ssl in case it's false; DB will still try (& fail) to connect if the key is there
+        (merge (when ssl           ; merging ssl-params will add :ssl back in if desirable
+                 ssl-params))
+        (rename-keys {:dbname :db})
+        kdb/postgres))
 
+  (database->connection-details [_ {:keys [details]}]
+    (let [{:keys [host port]} details]
+      (-> details
+          (assoc :host host
+                 :ssl  (:ssl details)
+                 :port (if (string? port) (Integer/parseInt port)
+                           port))
+          (rename-keys {:dbname :db}))))
 
-(defn- database->connection-details [{:keys [details]}]
-  (let [{:keys [host port]} details]
-    (-> details
-        (assoc :host       host
-               :make-pool? false
-               :db-type    :postgres                          ; What purpose is this serving?
-               :ssl        (:ssl details)
-               :port       (if (string? port) (Integer/parseInt port)
-                               port))
-        (rename-keys {:dbname :db}))))
+  (cast-timestamp-to-date [_ table-name field-name seconds-or-milliseconds]
+    (format "(TIMESTAMP WITH TIME ZONE 'epoch' + (\"%s\".\"%s\" * INTERVAL '1 %s'))::date" table-name field-name
+            (case           seconds-or-milliseconds
+              :seconds      "second"
+              :milliseconds "millisecond")))
 
+  (timezone->set-timezone-sql [_ timezone]
+    (format "SET LOCAL timezone TO '%s';" timezone)))
 
-;; ## QP
-
-(defn- timezone->set-timezone-sql [timezone]
-  (format "SET LOCAL timezone TO '%s';" timezone))
-
-(defn- cast-timestamp-seconds-field-to-date-fn [table-name field-name]
-  {:pre [(string? table-name)
-         (string? field-name)]}
-  (format "(TIMESTAMP WITH TIME ZONE 'epoch' + (\"%s\".\"%s\" * INTERVAL '1 second'))::date" table-name field-name))
-
-(defn- cast-timestamp-milliseconds-field-to-date-fn [table-name field-name]
-  {:pre [(string? table-name)
-         (string? field-name)]}
-  (format "(TIMESTAMP WITH TIME ZONE 'epoch' + (\"%s\".\"%s\" * INTERVAL '1 millisecond'))::date" table-name field-name))
-
-;; ## DRIVER
+(generic-sql/extend-add-generic-sql-mixins PostgresDriver)
 
 (def ^:const driver
-  (generic-sql/map->SqlDriver
-   {:additional-supported-features                #{:set-timezone}
-    :column->base-type                            column->base-type
-    :connection-details->connection-spec          connection-details->connection-spec
-    :database->connection-details                 database->connection-details
-    :sql-string-length-fn                         :CHAR_LENGTH
-    :timezone->set-timezone-sql                   timezone->set-timezone-sql
-    :cast-timestamp-seconds-field-to-date-fn      cast-timestamp-seconds-field-to-date-fn
-    :cast-timestamp-milliseconds-field-to-date-fn cast-timestamp-milliseconds-field-to-date-fn}))
+  (map->PostgresDriver {:column->base-type    column->base-type
+                        :features             (conj generic-sql/features :set-timezone)
+                        :sql-string-length-fn :CHAR_LENGTH}))

--- a/src/metabase/driver/query_processor.clj
+++ b/src/metabase/driver/query_processor.clj
@@ -6,14 +6,14 @@
             [clojure.walk :as walk]
             [korma.core :as k]
             [medley.core :as m]
+            [swiss.arrows :refer [<<-]]
             [metabase.db :refer :all]
             [metabase.driver.interface :as i]
             (metabase.driver.query-processor [annotate :as annotate]
                                              [expand :as expand])
             (metabase.models [field :refer [Field], :as field]
                              [foreign-key :refer [ForeignKey]])
-            [metabase.util :as u]
-            [swiss.arrows :refer [<<-]]))
+            [metabase.util :as u]))
 
 ;; # CONSTANTS
 

--- a/src/metabase/driver/query_processor.clj
+++ b/src/metabase/driver/query_processor.clj
@@ -3,16 +3,17 @@
   (:require [clojure.core.match :refer [match]]
             [clojure.string :as s]
             [clojure.tools.logging :as log]
+            [clojure.walk :as walk]
             [korma.core :as k]
             [medley.core :as m]
-            [swiss.arrows :refer [<<-]]
             [metabase.db :refer :all]
             [metabase.driver.interface :as i]
             (metabase.driver.query-processor [annotate :as annotate]
                                              [expand :as expand])
             (metabase.models [field :refer [Field], :as field]
                              [foreign-key :refer [ForeignKey]])
-            [metabase.util :as u]))
+            [metabase.util :as u]
+            [swiss.arrows :refer [<<-]]))
 
 ;; # CONSTANTS
 
@@ -202,11 +203,17 @@
 (defn- pre-log-query [qp]
   (fn [query]
     (when-not *disable-qp-logging*
-      (log/debug (u/format-color 'magenta "\n\nPREPROCESSED/EXPANDED:\n%s"
-                                 ;; obscure DB details when logging
-                                 (u/pprint-to-str (-> query
-                                                      (assoc-in [:database :details] "**********")
-                                                      (update :driver class))))))
+      (log/debug (u/format-color 'magenta "\n\nPREPROCESSED/EXPANDED: 😻\n%s"
+                                 (u/pprint-to-str
+                                  ;; Remove empty kv pairs because otherwise expanded query is HUGE
+                                  (walk/prewalk
+                                   (fn [f]
+                                     (if-not (map? f) f
+                                             (m/filter-vals identity (into {} f))))
+                                   ;; obscure DB details when logging. Just log the class of driver because we don't care about its properties
+                                   (-> query
+                                       (assoc-in [:database :details] "😋 ") ; :yum:
+                                       (update :driver class)))))))
     (qp query)))
 
 
@@ -282,7 +289,7 @@
   "Process a QUERY and return the results."
   [driver query]
   (when-not *disable-qp-logging*
-    (log/debug (u/format-color 'blue "\nQUERY:\n%s" (u/pprint-to-str query))))
+    (log/debug (u/format-color 'blue "\nQUERY: 😎\n%s" (u/pprint-to-str query))))
   ((case (keyword (:type query))
      :native process-native
      :query  process-structured)

--- a/test/metabase/api/meta/db_test.clj
+++ b/test/metabase/api/meta/db_test.clj
@@ -133,15 +133,14 @@
                                 :name            "Test Database"
                                 :organization_id nil
                                 :description     nil})))
-                         (datasets/when-testing-dataset :h2
-                           (match-$ (sel :one Database :name db-name)
-                             {:created_at      $
-                              :engine          "postgres"
-                              :id              $
-                              :updated_at      $
-                              :name            $
-                              :organization_id nil
-                              :description     nil})))))
+                         (match-$ (sel :one Database :name db-name)
+                           {:created_at      $
+                            :engine          "postgres"
+                            :id              $
+                            :updated_at      $
+                            :name            $
+                            :organization_id nil
+                            :description     nil}))))
     (do
       ;; Delete all the randomly created Databases we've made so far
       (cascade-delete Database :id [not-in (set (filter identity

--- a/test/metabase/api/meta/table_test.clj
+++ b/test/metabase/api/meta/table_test.clj
@@ -25,7 +25,7 @@
 
 ;; ## GET /api/meta/table?org
 ;; These should come back in alphabetical order and include relevant metadata
-(expect (set (reduce concat (for [dataset-name @datasets/test-dataset-names]
+(expect (set (reduce concat (for [dataset-name datasets/test-dataset-names]
                               (datasets/with-dataset-when-testing dataset-name
                                 [{:name                (format-name "categories")
                                   :human_readable_name "Categories"

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -1,12 +1,10 @@
 (ns metabase.driver.h2-test
   (:require [expectations :refer :all]
-            [metabase.driver.h2 :refer :all]
-            [metabase.test.util :refer [resolve-private-fns]]))
-
-(resolve-private-fns metabase.driver.h2 database->connection-details)
+            [metabase.driver.generic-sql.interface :as i]
+            [metabase.driver.h2 :refer :all]))
 
 ;; # Check that database->connection-details works
 ;; ## new-style
 (expect {:db
          "file:/Users/cam/birdly/bird_sightings.db;AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1"}
-  (database->connection-details {:details {:db "file:/Users/cam/birdly/bird_sightings.db;AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1"}}))
+  (i/database->connection-details driver {:details {:db "file:/Users/cam/birdly/bird_sightings.db;AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1"}}))

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -1,54 +1,48 @@
 (ns metabase.driver.postgres-test
   (:require [expectations :refer :all]
-            [metabase.driver.postgres :refer :all]
-            [metabase.test.util :refer [resolve-private-fns]]))
-
-(resolve-private-fns metabase.driver.postgres
-  connection-details->connection-spec
-  database->connection-details)
+            [metabase.driver.generic-sql.interface :as i]
+            [metabase.driver.postgres :refer :all]))
 
 ;; # Check that database->connection details still works whether we're dealing with new-style or legacy details
 ;; ## new-style
-(expect {:db "bird_sightings"
-         :db-type :postgres
-         :make-pool? false
-         :ssl false
+(expect {:db   "bird_sightings"
+         :ssl  false
          :port 5432
          :host "localhost"
          :user "camsaul"}
-  (database->connection-details {:details {:ssl    false
-                                           :host   "localhost"
-                                           :port   5432
-                                           :dbname "bird_sightings"
-                                           :user   "camsaul"}}))
+  (i/database->connection-details driver {:details {:ssl    false
+                                                    :host   "localhost"
+                                                    :port   5432
+                                                    :dbname "bird_sightings"
+                                                    :user   "camsaul"}}))
 
 
 ;; # Check that SSL params get added the connection details in the way we'd like
 ;; ## no SSL -- this should *not* include the key :ssl (regardless of its value) since that will cause the PG driver to use SSL anyway
 (expect
-    {:user "camsaul"
-     :classname "org.postgresql.Driver"
+    {:user        "camsaul"
+     :classname   "org.postgresql.Driver"
      :subprotocol "postgresql"
-     :subname "//localhost:5432/bird_sightings"
-     :make-pool? true}
-  (connection-details->connection-spec {:ssl    false
-                                        :host   "localhost"
-                                        :port   5432
-                                        :dbname "bird_sightings"
-                                        :user   "camsaul"}))
+     :subname     "//localhost:5432/bird_sightings"
+     :make-pool?  true}
+  (i/connection-details->connection-spec driver {:ssl    false
+                                                 :host   "localhost"
+                                                 :port   5432
+                                                 :dbname "bird_sightings"
+                                                 :user   "camsaul"}))
 
 ;; ## ssl - check that expected params get added
 (expect
-    {:ssl true
-     :make-pool? true
-     :sslmode "require"
-     :classname "org.postgresql.Driver"
+    {:ssl         true
+     :make-pool?  true
+     :sslmode     "require"
+     :classname   "org.postgresql.Driver"
      :subprotocol "postgresql"
-     :user "camsaul"
-     :sslfactory "org.postgresql.ssl.NonValidatingFactory"
-     :subname "//localhost:5432/bird_sightings"}
-  (connection-details->connection-spec {:ssl    true
-                                        :host   "localhost"
-                                        :port   5432
-                                        :dbname "bird_sightings"
-                                        :user   "camsaul"}))
+     :user        "camsaul"
+     :sslfactory  "org.postgresql.ssl.NonValidatingFactory"
+     :subname     "//localhost:5432/bird_sightings"}
+  (i/connection-details->connection-spec driver {:ssl    true
+                                                 :host   "localhost"
+                                                 :port   5432
+                                                 :dbname "bird_sightings"
+                                                 :user   "camsaul"}))

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -88,18 +88,16 @@
      (or (metabase-instance database-definition engine)
          (do
            ;; Create the database
-           (log/info (u/format-color 'blue "Creating %s database %s..." (name engine) database-name))
+           (log/info (format "Creating %s database %s..." (name engine) database-name))
            (create-physical-db! dataset-loader database-definition)
 
            ;; Load data
            (log/debug (color/blue "Loading data..."))
            (doseq [^TableDefinition table-definition (:table-definitions database-definition)]
-             (log/info (u/format-color 'blue "Loading data for table '%s'..." (:table-name table-definition)))
              (load-table-data! dataset-loader database-definition table-definition)
-             (log/info (u/format-color 'blue "Inserted %d rows." (count (:rows table-definition)))))
+             (log/info (u/format-color 'blue "Loaded table '%s' (%d rows)." (:table-name table-definition) (count (:rows table-definition)))))
 
            ;; Add DB object to Metabase DB
-           (log/info (color/blue "Adding DB to Metabase..."))
            (let [db (ins Database
                       :name    database-name
                       :engine  (name engine)

--- a/test/metabase/test/data/generic_sql.clj
+++ b/test/metabase/test/data/generic_sql.clj
@@ -51,7 +51,6 @@
 (defn create-physical-db! [dataset-loader {:keys [table-definitions], :as database-definition}]
   ;; Create all the Tables
   (doseq [^TableDefinition table-definition table-definitions]
-    (log/info (format "Creating table '%s'..." (:table-name table-definition)))
     (i/create-physical-table! dataset-loader database-definition table-definition))
 
   ;; Now add the foreign key constraints

--- a/test/metabase/test_setup.clj
+++ b/test/metabase/test_setup.clj
@@ -69,7 +69,7 @@
 (defn load-test-datasets
   "Call `load-data!` on all the datasets we're testing against."
   []
-  (doseq [dataset-name @datasets/test-dataset-names]
+  (doseq [dataset-name datasets/test-dataset-names]
     (log/info (format "Loading test data: %s..." (name dataset-name)))
     (let [dataset (datasets/dataset-name->dataset dataset-name)]
       (datasets/load-data! dataset)


### PR DESCRIPTION
Made `GenericSqlDriver` a mixin and DB-specific drivers like `H2Driver` concrete record types instead of vice-versa. 

And also cut down on QP logging a bit.
