### PR TITLE
`map` returns a lazy seq! Fix bad code

### DIFF
--- a/test/metabase/test_setup.clj
+++ b/test/metabase/test_setup.clj
@@ -112,11 +112,12 @@
 (defn- clear-test-db
   "Delete the test db file if it's still lying around."
   []
-  (let [filename (-> (re-find #"file:(\w+\.db).*" (db/db-file)) second)] ; db-file is prefixed with "file:", so we strip that off
-    (map (fn [file-extension]                                         ; delete the database files, e.g. `metabase.db.h2.db`, `metabase.db.trace.db`, etc.
-           (let [file (str filename file-extension)]
-             (when (.exists (io/file file))
-               (io/delete-file file))))
-         [".h2.db"
-          ".trace.db"
-          ".lock.db"])))
+  ;; db-file is prefixed with "file:", so we strip that off
+  ;; delete the database files, e.g. `metabase.db.h2.db`, `metabase.db.trace.db`, etc.
+  (let [filename (-> (re-find #"file:(\w+\.db).*" (db/db-file)) second)]
+    (doseq [file-extension [".h2.db"
+                            ".trace.db"
+                            ".lock.db"]]
+      (let [file (str filename file-extension)]
+        (when (.exists (io/file file))
+          (io/delete-file file))))))


### PR DESCRIPTION
@agilliland I think I figured out why your unit tests were failing. The code you added to delete all the test databases when tests started wasn't actually doing that, so your test databases got in some weird state which made tests fail on subsequent runs even when they shouldn't have.

Remember that `map` returns a lazy seq, so don't use it purely for side effects unless you're consuming the sequence somehow (e.g. with [`dorun`](http://clojuredocs.org/clojure.core/dorun)). [`doseq`](http://clojuredocs.org/clojure.core/doseq) is better suited to this use case; it's like a `for` loop wrapped in a `dorun`.
