### PR TITLE
Disallow connections to non-existent H2 databases

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -82,7 +82,7 @@
              :expectations {:injections [(require 'metabase.test-setup)]
                             :resource-paths ["test_resources"]
                             :env {:mb-test-setting-1 "ABCDEFG"}
-                            :jvm-opts ["-Dmb.db.file=target/metabase-test"
+                            :jvm-opts ["-Dmb.db.in.memory=true"
                                        "-Dmb.jetty.join=false"
                                        "-Dmb.jetty.port=3010"
                                        "-Dmb.api.key=test-api-key"

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -21,7 +21,7 @@
   ;; see http://h2database.com/html/features.html for explanation of options
   (if (config/config-bool :mb-db-in-memory)
     ;; In-memory (i.e. test) DB
-    "mem:metabase;DB_CLOSE_DELAY=-1;MULTI_THREADED=TRUE"
+    "mem:metabase;DB_CLOSE_DELAY=-1"
     ;; File-based DB
     (let [db-file-name (config/config-str :mb-db-file)
           db-file      (clojure.java.io/file db-file-name)

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -1,10 +1,47 @@
 (ns metabase.driver.h2-test
   (:require [expectations :refer :all]
+            [metabase.db :as db]
+            (metabase.driver [h2 :refer :all]
+                             [interface :refer [can-connect?]])
             [metabase.driver.generic-sql.interface :as i]
-            [metabase.driver.h2 :refer :all]))
+            [metabase.test.util :refer [resolve-private-fns]]))
+
+(resolve-private-fns metabase.driver.h2 connection-string->file+options file+options->connection-string connection-string-set-safe-options)
 
 ;; # Check that database->connection-details works
-;; ## new-style
 (expect {:db
          "file:/Users/cam/birdly/bird_sightings.db;AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1"}
   (i/database->connection-details driver {:details {:db "file:/Users/cam/birdly/bird_sightings.db;AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1"}}))
+
+
+;; Check that the functions for exploding a connection string's options work as expected
+(expect
+    ["file:my-file" {"OPTION_1" "TRUE", "OPTION_2" "100", "LOOK_I_INCLUDED_AN_EXTRA_SEMICOLON" "NICE_TRY"}]
+  (connection-string->file+options "file:my-file;OPTION_1=TRUE;OPTION_2=100;;LOOK_I_INCLUDED_AN_EXTRA_SEMICOLON=NICE_TRY"))
+
+(expect "file:my-file;OPTION_1=TRUE;OPTION_2=100;LOOK_I_INCLUDED_AN_EXTRA_SEMICOLON=NICE_TRY"
+  (file+options->connection-string "file:my-file" {"OPTION_1" "TRUE", "OPTION_2" "100", "LOOK_I_INCLUDED_AN_EXTRA_SEMICOLON" "NICE_TRY"}))
+
+
+;; Check that we add safe connection options to connection strings
+(expect "file:my-file;LOOK_I_INCLUDED_AN_EXTRA_SEMICOLON=NICE_TRY;IFEXISTS=TRUE;ACCESS_MODE_DATA=r"
+  (connection-string-set-safe-options "file:my-file;;LOOK_I_INCLUDED_AN_EXTRA_SEMICOLON=NICE_TRY"))
+
+;; Check that we override shady connection string options set by shady admins with safe ones
+(expect "file:my-file;LOOK_I_INCLUDED_AN_EXTRA_SEMICOLON=NICE_TRY;IFEXISTS=TRUE;ACCESS_MODE_DATA=r"
+  (connection-string-set-safe-options "file:my-file;;LOOK_I_INCLUDED_AN_EXTRA_SEMICOLON=NICE_TRY;IFEXISTS=FALSE;ACCESS_MODE_DATA=rws"))
+
+
+;; Make sure we *cannot* connect to a non-existent database
+(expect :exception-thrown
+  (try (can-connect? driver {:engine :h2
+                             :details {:db (str (System/getProperty "user.dir") "/toucan_sightings")}})
+       (catch org.h2.jdbc.JdbcSQLException e
+         (and (re-matches #"Database .+ not found .+" (.getMessage e))
+              :exception-thrown))))
+
+;; Check that we can connect to a non-existent Database when we enable potentailly unsafe connections (e.g. to the Metabase database)
+(expect true
+  (binding [db/*allow-potentailly-unsafe-connections* true]
+    (can-connect? driver {:engine :h2
+                          :details {:db (str (System/getProperty "user.dir") "/pigeon_sightings")}})))

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -92,10 +92,8 @@
            (create-physical-db! dataset-loader database-definition)
 
            ;; Load data
-           (log/debug (color/blue "Loading data..."))
            (doseq [^TableDefinition table-definition (:table-definitions database-definition)]
-             (load-table-data! dataset-loader database-definition table-definition)
-             (log/info (u/format-color 'blue "Loaded table '%s' (%d rows)." (:table-name table-definition) (count (:rows table-definition)))))
+             (load-table-data! dataset-loader database-definition table-definition))
 
            ;; Add DB object to Metabase DB
            (let [db (ins Database

--- a/test/metabase/test/data/h2.clj
+++ b/test/metabase/test/data/h2.clj
@@ -25,20 +25,13 @@
 
 ;; ## DatabaseDefinition helper functions
 
-(defn- filename
-  "Return filename that should be used for connecting to H2 database defined by DATABASE-DEFINITION.
-   This does not include the `.mv.db` extension."
-  [^DatabaseDefinition database-definition]
-  (format "%s/target/%s" (System/getProperty "user.dir") (escaped-name database-definition)))
-
 (defn- connection-details
   "Return a Metabase `Database.details` for H2 database defined by DATABASE-DEFINITION."
   [^DatabaseDefinition {:keys [short-lived?], :as database-definition}]
-  {:db (format (if short-lived?
-                 ;; for so-called 'short-lived' (temp) DBs create them in-memory
-                 "mem:%s"
-                 "file:%s;AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1")
-        (filename database-definition))
+  {:db (str (format "mem:%s" (escaped-name database-definition))
+            ;; For non "short-lived" (temp) databases keep the connection open for the duration of unit tests
+            (when-not short-lived?
+              ";DB_CLOSE_DELAY=-1"))
    :short-lived? short-lived?})
 
 (defn- korma-connection-pool
@@ -88,9 +81,8 @@
     (connection-details database-definition))
 
   (drop-physical-db! [_ database-definition]
-    (let [file (io/file (format "%s.mv.db" (filename database-definition)))]
-      (when (.exists file)
-        (.delete file))))
+    ;; Nothing to do here - there are no physical dbs <3
+    )
 
   (create-physical-table! [this database-definition table-definition]
     (generic/create-physical-table! this database-definition (format-for-h2 table-definition)))

--- a/test/metabase/test/data/h2.clj
+++ b/test/metabase/test/data/h2.clj
@@ -34,9 +34,11 @@
 (defn- connection-details
   "Return a Metabase `Database.details` for H2 database defined by DATABASE-DEFINITION."
   [^DatabaseDefinition {:keys [short-lived?], :as database-definition}]
-  {:db (format (if short-lived? "file:%s" ; for short-lived connections don't create a server thread and don't use a keep-alive connection
-                   "file:%s;AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1")
-               (filename database-definition))
+  {:db (format (if short-lived?
+                 ;; for so-called 'short-lived' (temp) DBs create them in-memory
+                 "mem:%s"
+                 "file:%s;AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1")
+        (filename database-definition))
    :short-lived? short-lived?})
 
 (defn- korma-connection-pool

--- a/test/metabase/test_setup.clj
+++ b/test/metabase/test_setup.clj
@@ -11,8 +11,6 @@
             (metabase.models [table :refer [Table]])
             [metabase.test.data.datasets :as datasets]))
 
-(declare clear-test-db)
-
 ;; # ---------------------------------------- EXPECTAIONS FRAMEWORK SETTINGS ------------------------------
 
 ;; ## GENERAL SETTINGS
@@ -83,9 +81,6 @@
   []
   (log/info "Starting up Metabase unit test runner")
 
-  ;; clear out any previous test data that's lying around
-  (log/info "Clearing out test DB...")
-  (clear-test-db)
   (log/info "Setting up test DB and running migrations...")
   (db/setup-db :auto-migrate true)
 
@@ -105,18 +100,3 @@
   (log/info "Shutting down Metabase unit test runner")
   (task/stop-task-runner!)
   (core/stop-jetty))
-
-
-;; ## DB Setup
-
-(defn- clear-test-db
-  "Delete the test db file if it's still lying around."
-  []
-  (let [filename (-> (re-find #"file:(\w+\.db).*" (db/db-file)) second)] ; db-file is prefixed with "file:", so we strip that off
-    (map (fn [file-extension]                                         ; delete the database files, e.g. `metabase.db.h2.db`, `metabase.db.trace.db`, etc.
-           (let [file (str filename file-extension)]
-             (when (.exists (io/file file))
-               (io/delete-file file))))
-         [".h2.db"
-          ".trace.db"
-          ".lock.db"])))


### PR DESCRIPTION
So I couldn't help myself and did some refactoring here too. I made the test databases all in-memory since that makes more sense than deleting them on every run anyway. I also made the DB settings stuff in `metabase.db` constants instead of functions because environment variables aren't going to change during runtime, and did a bit of de-duplication there too (a korma connection spec _is_ a JDBC connection spec are the same thing)
