### PR TITLE
combine some sync logging statements to reduce clutter

### DIFF
--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -102,11 +102,9 @@
                       :details (database->connection-details dataset-loader database-definition))]
 
              ;; Sync the database
-             (log/info (color/blue "Syncing DB..."))
              (driver/sync-database! db)
 
              ;; Add extra metadata like Field field-type, base-type, etc.
-             (log/info (color/blue "Adding schema metadata..."))
              (doseq [^TableDefinition table-definition (:table-definitions database-definition)]
                (let [table-name (:table-name table-definition)
                      table      (delay (let [table (metabase-instance table-definition db)]


### PR DESCRIPTION
Log newly found Tables & Fields in a single statement instead of on a separate line for each.
###### BEFORE

```
Found new field: "VENUES.CATEGORY_ID"
Found new field: "VENUES.LATITUDE"
Found new field: "VENUES.ID"
Found new field: "VENUES.LONGITUDE"
Found new field: "VENUES.PRICE"
```
###### AFTER

```
Found new fields for table 'VENUES': #{"CATEGORY_ID" "NAME" "LATITUDE" "ID" "LONGITUDE" "PRICE"}
```
