### PR TITLE
MySQL Driver

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -22,6 +22,7 @@
                               (context 2)
                               (create-database-definition 1)
                               (execute-query 1)
+                              (execute-sql! 2)
                               (expect 1)
                               (expect-eval-actual-first 1)
                               (expect-expansion 0)

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -51,6 +51,7 @@
                               (pre-insert 1)
                               (pre-update 1)
                               (project 1)
+                              (qp-expect-with-all-datasets 1)
                               (qp-expect-with-datasets 1)
                               (query-with-temp-db 1)
                               (resolve-private-fns 1)

--- a/circle.yml
+++ b/circle.yml
@@ -11,13 +11,13 @@ dependencies:
     - pip install awscli==1.7.3
 test:
   override:
-    # 0) runs unit tests w/ H2 local DB. Runs against both Mongo + H2 test datasets
+    # 0) runs unit tests w/ H2 local DB. Runs against Mongo, H2, Postgres, MySQL test datasets
     # 1) runs unit tests w/ Postgres local DB. Only runs against H2 test dataset so we can be sure tests work in either scenario
     # 2) runs Eastwood linter
     # 3) Bikeshed linter
     # 4) runs JS linter + JS test
     # 5) runs lein uberjar
-    - case $CIRCLE_NODE_INDEX in 0) MB_TEST_DATASETS=h2,mongo,postgres lein test ;; 1) MB_DB_TYPE=postgres MB_DB_DBNAME=circle_test MB_DB_PORT=5432 MB_DB_USER=ubuntu MB_DB_HOST=localhost lein test ;; 2) lein eastwood ;; 3) lein bikeshed --max-line-length 240 ;; 4) npm run lint && npm run build && npm run test ;; 5) CI_DISABLE_WEBPACK_MINIFICATION=1 lein uberjar ;; esac:
+    - case $CIRCLE_NODE_INDEX in 0) MB_TEST_DATASETS=h2,mongo,postgres,mysql lein test ;; 1) MB_DB_TYPE=postgres MB_DB_DBNAME=circle_test MB_DB_PORT=5432 MB_DB_USER=ubuntu MB_DB_HOST=localhost lein test ;; 2) lein eastwood ;; 3) lein bikeshed --max-line-length 240 ;; 4) npm run lint && npm run build && npm run test ;; 5) CI_DISABLE_WEBPACK_MINIFICATION=1 lein uberjar ;; esac:
         parallel: true
 deployment:
   master:

--- a/circle.yml
+++ b/circle.yml
@@ -9,6 +9,9 @@ machine:
 dependencies:
   pre:
     - pip install awscli==1.7.3
+database:
+  post:
+    - mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u ubuntu mysql
 test:
   override:
     # 0) runs unit tests w/ H2 local DB. Runs against Mongo, H2, Postgres, MySQL test datasets

--- a/circle.yml
+++ b/circle.yml
@@ -11,6 +11,7 @@ dependencies:
     - pip install awscli==1.7.3
 database:
   post:
+    # MySQL doesn't load named timezone information automatically, you have to run this command to load it
     - mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u ubuntu mysql
 test:
   override:

--- a/project.clj
+++ b/project.clj
@@ -38,6 +38,7 @@
                                com.sun.jdmk/jmxtools
                                com.sun.jmx/jmxri]]
                  [medley "0.7.0"]                                     ; lightweight lib of useful functions
+                 [mysql/mysql-connector-java "5.1.36"]                ; MySQL JDBC driver
                  [org.liquibase/liquibase-core "3.4.0"]               ; migration management (Java lib)
                  [org.slf4j/slf4j-log4j12 "1.7.12"]
                  [org.yaml/snakeyaml "1.15"]                          ; YAML parser (required by liquibase)

--- a/resources/frontend_client/app/services.js
+++ b/resources/frontend_client/app/services.js
@@ -502,6 +502,40 @@ CorvusServices.service('CorvusCore', ['$resource', 'User', function($resource, U
                 }]
             }]
         },
+        mysql: {
+            name: 'MySQL',
+            fields: [{
+                displayName: "Host",
+                fieldName: "host",
+                type: "text",
+                placeholder: "localhost",
+                placeholderIsDefault: true
+            }, {
+                displayName: "Port",
+                fieldName: "port",
+                type: "text",
+                transform: parseInt,
+                placeholder: "3306",
+                placeholderIsDefault: true
+            }, {
+                displayName: "Database name",
+                fieldName: "dbname",
+                type: "text",
+                placeholder: "birds_of_the_world",
+                required: true
+            }, {
+                displayName: "Database username",
+                fieldName: "user",
+                type: "text",
+                placeholder: "What username do you use to login to the database?",
+                required: true
+            }, {
+                displayName: "Database password",
+                fieldName: "password",
+                type: "password",
+                placeholder: "*******"
+            }]
+        },
         h2: {
             name: 'H2',
             fields: [{

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -30,7 +30,10 @@
               :example "host=[ip address] port=5432 dbname=examples user=corvus password=******"}
    :mongo    {:id      "mongo"
               :name    "MongoDB"
-              :example "mongodb://password:username@127.0.0.1:27017/db-name"}})
+              :example "mongodb://password:username@127.0.0.1:27017/db-name"}
+   :mysql    {:id      "mysql"
+              :name    "MySQL"
+              :example "N/A"}}) ; TODO - we don't use connection strings any more so we shouldn't define example ones (!)
 
 (defn class->base-type
   "Return the `Field.base_type` that corresponds to a given class returned by the DB."

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -21,14 +21,14 @@
 
 (def ^:const available-drivers
   "Available DB drivers."
-  {:h2       {:id      "h2"
-              :name    "H2"}
-   :postgres {:id      "postgres"
-              :name    "Postgres"}
-   :mongo    {:id      "mongo"
-              :name    "MongoDB"}
-   :mysql    {:id      "mysql"
-              :name    "MySQL"}})
+  {:h2       {:id   "h2"
+              :name "H2"}
+   :postgres {:id   "postgres"
+              :name "Postgres"}
+   :mongo    {:id   "mongo"
+              :name "MongoDB"}
+   :mysql    {:id   "mysql"
+              :name "MySQL"}})
 
 (defn class->base-type
   "Return the `Field.base_type` that corresponds to a given class returned by the DB."

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -20,20 +20,15 @@
 ;; ## Constants
 
 (def ^:const available-drivers
-  "DB drivers that are available as a dictionary.  Each key is a driver with dictionary of attributes.
-  ex: `:h2 {:id \"h2\" :name \"H2\"}`"
+  "Available DB drivers."
   {:h2       {:id      "h2"
-              :name    "H2"
-              :example "file:[filename]"}
+              :name    "H2"}
    :postgres {:id      "postgres"
-              :name    "Postgres"
-              :example "host=[ip address] port=5432 dbname=examples user=corvus password=******"}
+              :name    "Postgres"}
    :mongo    {:id      "mongo"
-              :name    "MongoDB"
-              :example "mongodb://password:username@127.0.0.1:27017/db-name"}
+              :name    "MongoDB"}
    :mysql    {:id      "mysql"
-              :name    "MySQL"
-              :example "N/A"}}) ; TODO - we don't use connection strings any more so we shouldn't define example ones (!)
+              :name    "MySQL"}})
 
 (defn class->base-type
   "Return the `Field.base_type` that corresponds to a given class returned by the DB."

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -111,9 +111,7 @@
   {:pre [(keyword? sql-string-length-fn)]}
   (or (some-> (korma-entity @(:table field))
               (k/select (k/aggregate (avg (k/sqlfn* sql-string-length-fn
-                                                    (k/raw (let [s (format "CAST(%s AS CHAR)" (i/quote-name driver (name (:name field))))]
-                                                             (println (u/format-color 'cyan "------------------------------> %s" s))
-                                                             s))))
+                                                    (k/raw (format "CAST(%s AS CHAR)" (i/quote-name driver (name (:name field)))))))
                                      :len))
               first
               :len

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -60,8 +60,6 @@
          (filter #(not= (:table_schem %) "INFORMATION_SCHEMA")) ; filter out internal tables
          (map (fn [{:keys [column_name type_name]}]
                 {column_name (or (column->base-type (keyword type_name))
-                                 (println (u/format-color 'red "\n\n--------------------------------------------------------------------------------\nTYPE NAME: %s\n--------------------------------------------------------------------------------\n\n"
-                                                          type_name))
                                  :UnknownField)}))
          (into {}))))
 

--- a/src/metabase/driver/generic_sql/interface.clj
+++ b/src/metabase/driver/generic_sql/interface.clj
@@ -15,3 +15,14 @@
   (timezone->set-timezone-sql          [this timezone]
     "Return a string that represents the SQL statement that should be used to set the timezone
      for the current transaction."))
+
+(defprotocol ISqlDriverQuoteName
+  "Optionally protocol to override how the Generic SQL driver quotes the names of databases, tables, and fields."
+  (quote-name [this ^String nm]
+    "Quote a name appropriately for this database."))
+
+;; Default implementation quotes using "
+(extend-protocol ISqlDriverQuoteName
+  Object
+  (quote-name [_ nm]
+    (str \" nm \")))

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -104,7 +104,7 @@
          (= special-type :timestamp_milliseconds)           `(raw ~(str (i/cast-timestamp-to-date (:driver *query*) table-name field-name :milliseconds)
                                                                         (when include-as?
                                                                           (format " AS %s" (quot field-name)))))
-         :else                                              (keyword (format "%s.%s" (quot table-name) (quot field-name)))))))
+         :else                                              (keyword (format "%s.%s" table-name field-name))))))
 
 
   ;; e.g. the ["aggregation" 0] fields we allow in order-by
@@ -230,16 +230,16 @@
   (when-not qp/*disable-qp-logging*
     (log/debug
      (u/format-color 'green "\n\nKORMA FORM: 😏\n%s" (->> (nth korma-form 2)                                    ; korma form is wrapped in a let clause. Discard it
-                                                       (walk/prewalk (fn [form]                              ; strip korma.core/ qualifications from symbols in the form
-                                                                       (if-not (symbol? form) form           ; to remove some of the clutter
-                                                                               (symbol (name form)))))
-                                                       (u/pprint-to-str)))
+                                                         (walk/prewalk (fn [form]                               ; strip korma.core/ qualifications from symbols in the form
+                                                                         (if-not (symbol? form) form            ; to remove some of the clutter
+                                                                                 (symbol (name form)))))
+                                                         (u/pprint-to-str)))
      (u/format-color 'blue  "\nSQL: 😈\n%s\n"        (-> (eval (let [[let-form binding-form & body] korma-form] ; wrap the (select ...) form in a sql-only clause
-                                                               `(~let-form ~binding-form                     ; has to go there to work correctly
-                                                                           (sql-only ~@body))))
-                                                      (s/replace #"\sFROM" "\nFROM")                         ; add newlines to the SQL to make it more readable
-                                                      (s/replace #"\sLEFT JOIN" "\nLEFT JOIN")
-                                                      (s/replace #"\sWHERE" "\nWHERE")
-                                                      (s/replace #"\sGROUP BY" "\nGROUP BY")
-                                                      (s/replace #"\sORDER BY" "\nORDER BY")
-                                                      (s/replace #"\sLIMIT" "\nLIMIT"))))))
+                                                                `(~let-form ~binding-form                       ; has to go there to work correctly
+                                                                            (sql-only ~@body))))
+                                                        (s/replace #"\sFROM" "\nFROM")                          ; add newlines to the SQL to make it more readable
+                                                        (s/replace #"\sLEFT JOIN" "\nLEFT JOIN")
+                                                        (s/replace #"\sWHERE" "\nWHERE")
+                                                        (s/replace #"\sGROUP BY" "\nGROUP BY")
+                                                        (s/replace #"\sORDER BY" "\nORDER BY")
+                                                        (s/replace #"\sLIMIT" "\nLIMIT"))))))

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -93,17 +93,17 @@
     ([this]
      (formatted this false))
     ([{:keys [table-name field-name base-type special-type]} include-as?]
-     (let [quot (partial i/quote-name (:driver *query*))]
+     (let [quote-name (partial i/quote-name (:driver *query*))]
        (cond
-         (contains? #{:DateField :DateTimeField} base-type) `(raw ~(str (format "CAST(%s.%s AS DATE)" (quot table-name) (quot field-name))
+         (contains? #{:DateField :DateTimeField} base-type) `(raw ~(str (format "CAST(%s.%s AS DATE)" (quote-name table-name) (quote-name field-name))
                                                                         (when include-as?
-                                                                          (format " AS %s" (quot field-name)))))
+                                                                          (format " AS %s" (quote-name field-name)))))
          (= special-type :timestamp_seconds)                `(raw ~(str (i/cast-timestamp-to-date (:driver *query*) table-name field-name :seconds)
                                                                         (when include-as?
-                                                                          (format " AS %s" (quot field-name)))))
+                                                                          (format " AS %s" (quote-name field-name)))))
          (= special-type :timestamp_milliseconds)           `(raw ~(str (i/cast-timestamp-to-date (:driver *query*) table-name field-name :milliseconds)
                                                                         (when include-as?
-                                                                          (format " AS %s" (quot field-name)))))
+                                                                          (format " AS %s" (quote-name field-name)))))
          :else                                              (keyword (format "%s.%s" table-name field-name))))))
 
 

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -93,18 +93,18 @@
     ([this]
      (formatted this false))
     ([{:keys [table-name field-name base-type special-type]} include-as?]
-     ;; TODO - add Table names
-     (cond
-       (contains? #{:DateField :DateTimeField} base-type) `(raw ~(str (format "CAST(\"%s\".\"%s\" AS DATE)" table-name field-name)
-                                                                      (when include-as?
-                                                                        (format " AS \"%s\"" field-name))))
-       (= special-type :timestamp_seconds)                `(raw ~(str (i/cast-timestamp-to-date (:driver *query*) table-name field-name :seconds)
-                                                                      (when include-as?
-                                                                        (format " AS \"%s\"" field-name))))
-       (= special-type :timestamp_milliseconds)           `(raw ~(str (i/cast-timestamp-to-date (:driver *query*) table-name field-name :milliseconds)
-                                                                      (when include-as?
-                                                                        (format " AS \"%s\"" field-name))))
-       :else                                              (keyword (format "%s.%s" table-name field-name)))))
+     (let [quot (partial i/quote-name (:driver *query*))]
+       (cond
+         (contains? #{:DateField :DateTimeField} base-type) `(raw ~(str (format "CAST(%s.%s AS DATE)" (quot table-name) (quot field-name))
+                                                                        (when include-as?
+                                                                          (format " AS %s" (quot field-name)))))
+         (= special-type :timestamp_seconds)                `(raw ~(str (i/cast-timestamp-to-date (:driver *query*) table-name field-name :seconds)
+                                                                        (when include-as?
+                                                                          (format " AS %s" (quot field-name)))))
+         (= special-type :timestamp_milliseconds)           `(raw ~(str (i/cast-timestamp-to-date (:driver *query*) table-name field-name :milliseconds)
+                                                                        (when include-as?
+                                                                          (format " AS %s" (quot field-name)))))
+         :else                                              (keyword (format "%s.%s" (quot table-name) (quot field-name)))))))
 
 
   ;; e.g. the ["aggregation" 0] fields we allow in order-by

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -1,5 +1,6 @@
 (ns metabase.driver.mysql
-  (:require (korma [db :as kdb]
+  (:require [clojure.set :as set]
+            (korma [db :as kdb]
                    mysql)
             (korma.sql [engine :refer [sql-func]]
                        [utils :as korma-utils])
@@ -57,14 +58,12 @@
    :VARCHAR    :TextField
    :YEAR       :IntegerField})
 
-#_(defn- column->base-type [t]
-  (println "t ================================================================================>" t)
-  (column->base-type* t))
-
 (defrecord MySQLDriver []
   ISqlDriverDatabaseSpecific
   (connection-details->connection-spec [_ details]
-    (kdb/mysql details))
+    (-> details
+        (set/rename-keys {:dbname :db})
+        kdb/mysql))
 
   (database->connection-details [_ {:keys [details]}]
     details)

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -1,0 +1,37 @@
+(ns metabase.driver.mysql
+  (:require [korma.db :as kdb]
+            (metabase.driver [generic-sql :as generic-sql, :refer [GenericSQLIDriverMixin GenericSQLISyncDriverTableFKsMixin
+                                                                   GenericSQLISyncDriverFieldAvgLengthMixin GenericSQLISyncDriverFieldPercentUrlsMixin]]
+                             [interface :refer [IDriver ISyncDriverTableFKs ISyncDriverFieldAvgLength ISyncDriverFieldPercentUrls
+                                                ISyncDriverSpecificSyncField driver-specific-sync-field!]])
+            (metabase.driver.generic-sql [interface :refer :all])))
+
+(def ^:private ^:const column->base-type
+  {})
+
+(defrecord MySQLDriver []
+  ISqlDriverDatabaseSpecific
+  (connection-details->connection-spec [_ details]
+    (kdb/mysql details))
+
+  (database->connection-details [_ {:keys [details]}]
+    details)
+
+  (cast-timestamp-to-date [_ table-name field-name seconds-or-milliseconds]
+    ;; TODO
+    )
+
+  (timezone->set-timezone-sql [_ timezone]
+    ;; see http://stackoverflow.com/questions/930900/how-to-set-time-zone-of-mysql
+    (format "SET @@session.time_zone = '%s';" timezone)))
+
+(extend MySQLDriver
+  IDriver                     GenericSQLIDriverMixin
+  ISyncDriverTableFKs         GenericSQLISyncDriverTableFKsMixin
+  ISyncDriverFieldAvgLength   GenericSQLISyncDriverFieldAvgLengthMixin
+  ISyncDriverFieldPercentUrls GenericSQLISyncDriverFieldPercentUrlsMixin)
+
+(def ^:const driver
+  (map->MySQLDriver {:column->base-type    column->base-type
+                     :features             (conj generic-sql/features :set-timezone)
+                     :sql-string-length-fn :CHAR_LENGTH}))

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -7,7 +7,36 @@
             (metabase.driver.generic-sql [interface :refer :all])))
 
 (def ^:private ^:const column->base-type
-  {})
+  {:bigint     :BigIntegerField
+   :binary     :UnknownField
+   :bit        :UnknownField
+   :blob       :UnknownField
+   :char       :CharField
+   :date       :DateField
+   :datetime   :DateTimeField
+   :decimal    :DecimalField
+   :double     :FloatField
+   :enum       :UnknownField
+   :float      :FloatField
+   :int        :IntegerField
+   :integer    :IntegerField
+   :longblob   :UnknownField
+   :longtext   :TextField
+   :mediumblob :UnknownField
+   :mediumint  :IntegerField
+   :mediumtext :TextField
+   :numeric    :DecimalField
+   :real       :FloatField
+   :set        :UnknownField
+   :text       :TextField
+   :time       :TimeField
+   :timestamp  :DateTimeField
+   :tinyblob   :UnknownField
+   :tinyint    :IntegerField
+   :tinytext   :TextField
+   :varbinary  :UnknownField
+   :varchar    :CharField
+   :year       :IntegerField})
 
 (defrecord MySQLDriver []
   ISqlDriverDatabaseSpecific

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -54,7 +54,7 @@
    :TINYINT    :IntegerField
    :TINYTEXT   :TextField
    :VARBINARY  :UnknownField
-   :VARCHAR    :CharField
+   :VARCHAR    :TextField
    :YEAR       :IntegerField})
 
 #_(defn- column->base-type [t]

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -1,44 +1,63 @@
 (ns metabase.driver.mysql
-  (:require [korma.db :as kdb]
+  (:require (korma [db :as kdb]
+                   mysql)
+            (korma.sql [engine :refer [sql-func]]
+                       [utils :as korma-utils])
             (metabase.driver [generic-sql :as generic-sql, :refer [GenericSQLIDriverMixin GenericSQLISyncDriverTableFKsMixin
                                                                    GenericSQLISyncDriverFieldAvgLengthMixin GenericSQLISyncDriverFieldPercentUrlsMixin]]
                              [interface :refer [IDriver ISyncDriverTableFKs ISyncDriverFieldAvgLength ISyncDriverFieldPercentUrls
                                                 ISyncDriverSpecificSyncField driver-specific-sync-field!]])
             (metabase.driver.generic-sql [interface :refer :all])))
 
-(def ^:private ^:const column->base-type*
-  {:bigint     :BigIntegerField
-   :binary     :UnknownField
-   :bit        :UnknownField
-   :blob       :UnknownField
-   :char       :CharField
-   :date       :DateField
-   :datetime   :DateTimeField
-   :decimal    :DecimalField
-   :double     :FloatField
-   :enum       :UnknownField
-   :float      :FloatField
-   :int        :IntegerField
-   :integer    :IntegerField
-   :longblob   :UnknownField
-   :longtext   :TextField
-   :mediumblob :UnknownField
-   :mediumint  :IntegerField
-   :mediumtext :TextField
-   :numeric    :DecimalField
-   :real       :FloatField
-   :set        :UnknownField
-   :text       :TextField
-   :time       :TimeField
-   :timestamp  :DateTimeField
-   :tinyblob   :UnknownField
-   :tinyint    :IntegerField
-   :tinytext   :TextField
-   :varbinary  :UnknownField
-   :varchar    :CharField
-   :year       :IntegerField})
+;;; # Korma 0.4.2 Bug Workaround
+;; (Buggy code @ https://github.com/korma/Korma/blob/684178c386df529558bbf82097635df6e75fb339/src/korma/mysql.clj)
+;; This looks like it's been fixed upstream but until a new release is available we'll have to hack the function here
 
-(defn- column->base-type [t]
+(defn- mysql-count [query v]
+  (sql-func "COUNT" (if (and (or (instance? clojure.lang.Named v) ; the issue was that name was being called on things that like maps when we tried to get COUNT(DISTINCT(...))
+                                 (string? v))                     ; which would barf since maps don't implement clojure.lang.Named
+                             (= (name v) "*"))
+                      (korma-utils/generated "*")
+                      v)))
+
+(intern 'korma.mysql 'count mysql-count)
+
+
+;;; # IMPLEMENTATION
+
+(def ^:private ^:const column->base-type
+  {:BIGINT     :BigIntegerField
+   :BINARY     :UnknownField
+   :BIT        :UnknownField
+   :BLOB       :UnknownField
+   :CHAR       :CharField
+   :DATE       :DateField
+   :DATETIME   :DateTimeField
+   :DECIMAL    :DecimalField
+   :DOUBLE     :FloatField
+   :ENUM       :UnknownField
+   :FLOAT      :FloatField
+   :INT        :IntegerField
+   :INTEGER    :IntegerField
+   :LONGBLOB   :UnknownField
+   :LONGTEXT   :TextField
+   :MEDIUMBLOB :UnknownField
+   :MEDIUMINT  :IntegerField
+   :MEDIUMTEXT :TextField
+   :NUMERIC    :DecimalField
+   :REAL       :FloatField
+   :SET        :UnknownField
+   :TEXT       :TextField
+   :TIME       :TimeField
+   :TIMESTAMP  :DateTimeField
+   :TINYBLOB   :UnknownField
+   :TINYINT    :IntegerField
+   :TINYTEXT   :TextField
+   :VARBINARY  :UnknownField
+   :VARCHAR    :CharField
+   :YEAR       :IntegerField})
+
+#_(defn- column->base-type [t]
   (println "t ================================================================================>" t)
   (column->base-type* t))
 

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -68,6 +68,9 @@
 (defn id-field-type []
   (datasets/id-field-type *dataset*))
 
+(defn sum-field-type []
+  (datasets/sum-field-type *dataset*))
+
 (defn timestamp-field-type []
   (datasets/timestamp-field-type *dataset*))
 

--- a/test/metabase/test/data/generic_sql.clj
+++ b/test/metabase/test/data/generic_sql.clj
@@ -47,7 +47,7 @@
 
 (defn drop-physical-table! [dataset-loader database-definition {:keys [table-name]}]
   (execute-sql! dataset-loader database-definition
-    (format "DROP TABLE IF EXISTS %s;" (quote-name dataset-loader table-name)))) ; don't quote table name because MySQL doesn't like it
+    (format "DROP TABLE IF EXISTS %s;" (quote-name dataset-loader table-name))))
 
 
 (defn create-physical-db! [dataset-loader {:keys [table-definitions], :as database-definition}]

--- a/test/metabase/test/data/generic_sql.clj
+++ b/test/metabase/test/data/generic_sql.clj
@@ -2,6 +2,7 @@
   "Common functionality for various Generic SQL dataset loaders."
   (:require [clojure.tools.logging :as log]
             [korma.core :as k]
+            [metabase.driver.generic-sql.interface :refer [quote-name]]
             [metabase.test.data.interface :as i])
   (:import (metabase.test.data.interface DatabaseDefinition
                                          TableDefinition)))
@@ -31,39 +32,42 @@
 
   ;; Now create the new table
   (execute-sql! dataset-loader database-definition
-    (format "CREATE TABLE \"%s\" (%s, \"%s\" %s, PRIMARY KEY (\"%s\"));"
-            table-name
-            (->> field-definitions
-                 (map (fn [{:keys [field-name base-type]}]
-                        (format "\"%s\" %s" field-name (field-base-type->sql-type dataset-loader base-type))))
-                 (interpose ", ")
-                 (apply str))
-            (pk-field-name dataset-loader)
-            (pk-sql-type dataset-loader)
-            (pk-field-name dataset-loader))))
+    (let [quot (partial quote-name dataset-loader)
+          pk-field-name (quot (pk-field-name dataset-loader))]
+      (format "CREATE TABLE %s (%s, %s %s, PRIMARY KEY (%s));"
+              (quot table-name)
+              (->> field-definitions
+                   (map (fn [{:keys [field-name base-type]}]
+                          (format "%s %s" (quot field-name) (field-base-type->sql-type dataset-loader base-type))))
+                   (interpose ", ")
+                   (apply str))
+              pk-field-name (pk-sql-type dataset-loader)
+              pk-field-name))))
 
 
-(defn drop-physical-table! [dataset-loader database-definition table-definition]
+(defn drop-physical-table! [dataset-loader database-definition {:keys [table-name]}]
   (execute-sql! dataset-loader database-definition
-    (format "DROP TABLE IF EXISTS \"%s\";" (:table-name table-definition))))
+    (format "DROP TABLE IF EXISTS %s;" (quote-name dataset-loader table-name)))) ; don't quote table name because MySQL doesn't like it
 
 
 (defn create-physical-db! [dataset-loader {:keys [table-definitions], :as database-definition}]
-  ;; Create all the Tables
-  (doseq [^TableDefinition table-definition table-definitions]
-    (i/create-physical-table! dataset-loader database-definition table-definition))
+  (let [quot (partial quote-name dataset-loader)]
+    ;; Create all the Tables
+    (doseq [^TableDefinition table-definition table-definitions]
+      (i/create-physical-table! dataset-loader database-definition table-definition))
 
-  ;; Now add the foreign key constraints
-  (doseq [{:keys [table-name field-definitions]} table-definitions]
-    (doseq [{dest-table-name :fk, field-name :field-name} field-definitions]
-      (when dest-table-name
-        (execute-sql! dataset-loader database-definition
-          (format "ALTER TABLE \"%s\" ADD CONSTRAINT \"FK_%s_%s\" FOREIGN KEY (\"%s\") REFERENCES \"%s\" (\"%s\");"
-                  table-name
-                  field-name (name dest-table-name)
-                  field-name
-                  (name dest-table-name)
-                  (pk-field-name dataset-loader)))))))
+    ;; Now add the foreign key constraints
+    (doseq [{:keys [table-name field-definitions]} table-definitions]
+      (doseq [{dest-table-name :fk, field-name :field-name} field-definitions]
+        (when dest-table-name
+          (let [dest-table-name (name dest-table-name)]
+            (execute-sql! dataset-loader database-definition
+              (format "ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s (%s);"
+                      (quot table-name)
+                      (quot (format "FK_%s_%s_%s" table-name field-name dest-table-name))
+                      (quot field-name)
+                      (quot dest-table-name)
+                      (quot (pk-field-name dataset-loader))))))))))
 
 
 (defn load-table-data! [dataset-loader database-definition table-definition]

--- a/test/metabase/test/data/mysql.clj
+++ b/test/metabase/test/data/mysql.clj
@@ -13,7 +13,7 @@
 
 (def ^:private ^:const field-base-type->sql-type
   {:BigIntegerField "BIGINT"
-   :BooleanField    "BOOL" ;; TODO
+   :BooleanField    "BIT" ; There's no boolean type in MySQL (!)
    :CharField       "VARCHAR(254)"
    :DateField       "DATE"
    :DateTimeField   "TIMESTAMP"

--- a/test/metabase/test/data/mysql.clj
+++ b/test/metabase/test/data/mysql.clj
@@ -1,0 +1,101 @@
+(ns metabase.test.data.mysql
+  "Code for creating / destroying a MySQL database from a `DatabaseDefinition`."
+  (:require [clojure.java.jdbc :as jdbc]
+            [clojure.tools.logging :as log]
+            [environ.core :refer [env]]
+            (korma [core :as k]
+                   [db :as kdb])
+            (metabase.test.data [generic-sql :as generic]
+                                [interface :refer :all]))
+  (:import (metabase.test.data.interface DatabaseDefinition
+                                         FieldDefinition
+                                         TableDefinition)))
+
+(def ^:private ^:const field-base-type->sql-type ;; TODO
+  {:BigIntegerField "BIGINT"
+   :BooleanField    "BOOL"
+   :CharField       "VARCHAR(254)"
+   :DateField       "DATE"
+   :DateTimeField   "TIMESTAMP"
+   :DecimalField    "DECIMAL"
+   :FloatField      "FLOAT"
+   :IntegerField    "INTEGER"
+   :TextField       "TEXT"
+   :TimeField       "TIME"})
+
+(defn- mysql-connection-details [^DatabaseDefinition {:keys [short-lived?]}]
+  (merge {:host         "localhost"
+          :port         3306
+          :short-lived? short-lived?}
+         ;; HACK
+         (when (env :circleci)
+           {:user "ubuntu"})))
+
+(defn- db-connection-details [^DatabaseDefinition database-definition]
+  (assoc (mysql-connection-details database-definition)
+         :db (:database-name database-definition)))
+
+(defn- execute! [scope ^DatabaseDefinition database-definition & format-strings]
+  (jdbc/execute! (-> ((case scope
+                        :mysql mysql-connection-details
+                        :db    db-connection-details) database-definition)
+                     kdb/mysql
+                     (assoc :make-pool? false))
+                 [(apply format format-strings)]
+                 :transaction? false))
+
+
+(defrecord MySQLDatasetLoader []
+  generic/IGenericSQLDatasetLoader
+  (generic/execute-sql! [_ database-definition raw-sql]
+    (log/debug raw-sql)
+    (execute! :db database-definition raw-sql))
+
+  (generic/korma-entity [_ database-definition table-definition]
+    (-> (k/create-entity (:table-name table-definition))
+        (k/database (-> (db-connection-details database-definition)
+                        kdb/mysql
+                        (assoc :make-pool? false)
+                        kdb/create-db))))
+
+  (generic/pk-sql-type   [_] "MEDIUMINT NOT NULL AUTO_INCREMENT")
+  (generic/pk-field-name [_] "id")
+
+  (generic/field-base-type->sql-type [_ field-type]
+    (if (map? field-type) (:native field-type)
+        (field-base-type->sql-type field-type))))
+
+(extend-protocol IDatasetLoader
+  MySQLDatasetLoader
+  (engine [_]
+    :mysql)
+
+  (database->connection-details [_ database-definition]
+    (assoc (db-connection-details database-definition)
+           :timezone :America/Los_Angeles))
+
+  (drop-physical-db! [_ database-definition]
+    (execute! :mysql database-definition "DROP DATABASE IF EXISTS \"%s\";" (:database-name database-definition)))
+
+  (drop-physical-table! [this database-definition table-definition]
+    (generic/drop-physical-table! this database-definition table-definition))
+
+  (create-physical-table! [this database-definition table-definition]
+    (generic/create-physical-table! this database-definition table-definition))
+
+  (create-physical-db! [this {:keys [database-name], :as database-definition}]
+    (execute! :mysql database-definition "DROP DATABASE IF EXISTS \"%s\";" database-name)
+    (execute! :mysql database-definition "CREATE DATABASE \"%s\";" database-name)
+
+    ;; double check that we can connect to the newly created DB
+    (metabase.driver/can-connect-with-details? :mysql (db-connection-details database-definition) :rethrow-exceptions)
+
+    ;; call the generic implementation to create Tables + FKs
+    (generic/create-physical-db! this database-definition))
+
+  (load-table-data! [this database-definition table-definition]
+    (generic/load-table-data! this database-definition table-definition)))
+
+
+(defn dataset-loader []
+  (MySQLDatasetLoader.))

--- a/test/metabase/test/data/mysql.clj
+++ b/test/metabase/test/data/mysql.clj
@@ -11,9 +11,9 @@
                                          FieldDefinition
                                          TableDefinition)))
 
-(def ^:private ^:const field-base-type->sql-type ;; TODO
+(def ^:private ^:const field-base-type->sql-type
   {:BigIntegerField "BIGINT"
-   :BooleanField    "BOOL"
+   :BooleanField    "BOOL" ;; TODO
    :CharField       "VARCHAR(254)"
    :DateField       "DATE"
    :DateTimeField   "TIMESTAMP"

--- a/test/metabase/test/data/mysql.clj
+++ b/test/metabase/test/data/mysql.clj
@@ -13,7 +13,7 @@
 
 (def ^:private ^:const field-base-type->sql-type
   {:BigIntegerField "BIGINT"
-   :BooleanField    "BIT" ; There's no boolean type in MySQL (!)
+   :BooleanField    "BOOLEAN" ; Synonym of TINYINT(1)
    :CharField       "VARCHAR(254)"
    :DateField       "DATE"
    :DateTimeField   "TIMESTAMP"

--- a/test/metabase/test/data/mysql.clj
+++ b/test/metabase/test/data/mysql.clj
@@ -19,7 +19,7 @@
    :DateField       "DATE"
    :DateTimeField   "TIMESTAMP"
    :DecimalField    "DECIMAL"
-   :FloatField      "FLOAT"
+   :FloatField      "DOUBLE"
    :IntegerField    "INTEGER"
    :TextField       "TEXT"
    :TimeField       "TIME"})
@@ -36,7 +36,6 @@
          :db (:database-name database-definition)))
 
 (defn- execute! [scope ^DatabaseDefinition database-definition & format-strings]
-  (println "SQL -> " (apply format format-strings))
   (jdbc/execute! (-> ((case scope
                         :mysql mysql-connection-details
                         :db    db-connection-details) database-definition)

--- a/test/metabase/test/data/mysql.clj
+++ b/test/metabase/test/data/mysql.clj
@@ -33,8 +33,7 @@
 
 (defn- db-connection-details [^DatabaseDefinition database-definition]
   (assoc (mysql-connection-details database-definition)
-         :db (:database-name database-definition)
-         :timezone :America/Los_Angeles))
+         :db (:database-name database-definition)))
 
 (defn- execute! [scope ^DatabaseDefinition database-definition & format-strings]
   (println "SQL -> " (apply format format-strings))

--- a/test/metabase/test/data/postgres.clj
+++ b/test/metabase/test/data/postgres.clj
@@ -84,7 +84,7 @@
     (generic/create-physical-table! this database-definition table-definition))
 
   (create-physical-db! [this {:keys [database-name], :as database-definition}]
-    (execute! :pg database-definition "DROP DATABASE IF EXISTS \"%s\";" database-name)
+    (drop-physical-db! this database-definition)
     (execute! :pg database-definition "CREATE DATABASE \"%s\";" database-name)
 
     ;; double check that we can connect to the newly created DB

--- a/test_resources/log4j.properties
+++ b/test_resources/log4j.properties
@@ -18,4 +18,5 @@ log4j.appender.file.layout.ConversionPattern=%d [%t] %-5p%c - %m%n
 log4j.logger.com.mchange=WARN
 log4j.logger.liquibase=WARN
 log4j.logger.metabase=INFO
+log4j.logger.org.eclipse.jetty=WARN
 log4j.logger.org.mongodb=WARN


### PR DESCRIPTION
MySQL doesn't load timezone info by default upon installation so make sure you've done this on your local box.

On OS X or Linux run this command:

``` shell
mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root mysql
```

You might see an error or two but it will still work correctly.
