### PR TITLE
Postgres UUID support

### DIFF
--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -126,9 +126,12 @@
   (formatted
     ([this]
      (formatted this false))
-    ([{:keys [value]} _]
-     (if-not (instance? java.util.Date value) value
-             `(raw ~(format "CAST('%s' AS DATE)" (.toString ^java.util.Date value)))))))
+    ([{:keys [value base-type]} _]
+     (cond
+       (instance? java.util.Date value) `(raw ~(format "CAST('%s' AS DATE)" (.toString ^java.util.Date value)))
+       (= base-type :UUIDField)         (do (assert (string? value))
+                                            (java.util.UUID/fromString value))
+       :else                            value))))
 
 
 (defmethod apply-form :aggregation [[_ {:keys [aggregation-type field]}]]

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -65,7 +65,7 @@
    :tsquery       :UnknownField
    :tsvector      :UnknownField
    :txid_snapshot :UnknownField
-   :uuid          :UnknownField
+   :uuid          :UUIDField
    :varbit        :UnknownField
    :varchar       :TextField
    :xml           :TextField

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -67,6 +67,7 @@
     :IntegerField
     :TextField
     :TimeField
+    :UUIDField      ; e.g. a Postgres 'UUID' column
     :UnknownField})
 
 (def ^:const field-types

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -51,7 +51,7 @@
                                                  :dbname "bird_sightings"
                                                  :user   "camsaul"}))
 ;;; # UUID Support
-(def-database-definition ^:private postgres-with-uuid
+(def-database-definition ^:private with-uuid
   ["users"
    [{:field-name "user_id", :base-type :UUIDField}]
    [[#uuid "4f01dcfd-13f7-430c-8e6f-e505c0851027"]
@@ -69,14 +69,14 @@
                    [3 #uuid "da1d6ecc-e775-4008-b366-c38e7a2e8433"]
                    [4 #uuid "7a5ce4a2-0958-46e7-9685-1a4eaa3bd08a"]
                    [5 #uuid "84ed434e-80b4-41cf-9c88-e334427104ae"]]}
-  (-> (Q run against metabase.driver.postgres-test/postgres-with-uuid using postgres
+  (-> (Q run against metabase.driver.postgres-test/with-uuid using postgres
          return :data
          aggregate rows of users)
       (update :cols (partial mapv #(dissoc % :id :table_id)))))
 
 ;; Check that we can filter by a UUID Field
 (expect [[2 #uuid "4652b2e7-d940-4d55-a971-7e484566663e"]]
-  (Q run against metabase.driver.postgres-test/postgres-with-uuid using postgres
+  (Q run against metabase.driver.postgres-test/with-uuid using postgres
      return :data :rows
      aggregate rows of users
      filter = user_id "4652b2e7-d940-4d55-a971-7e484566663e"))

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -1,7 +1,11 @@
 (ns metabase.driver.postgres-test
   (:require [expectations :refer :all]
             [metabase.driver.generic-sql.interface :as i]
-            [metabase.driver.postgres :refer :all]))
+            [metabase.driver.postgres :refer :all]
+            [metabase.test.data :as data]
+            (metabase.test.data [datasets :as datasets]
+                                [interface :refer [def-database-definition]])
+            [metabase.test.util.mql :refer [Q]]))
 
 ;; # Check that database->connection details still works whether we're dealing with new-style or legacy details
 ;; ## new-style
@@ -46,3 +50,33 @@
                                                  :port   5432
                                                  :dbname "bird_sightings"
                                                  :user   "camsaul"}))
+;;; # UUID Support
+(def-database-definition ^:private postgres-with-uuid
+  ["users"
+   [{:field-name "user_id", :base-type :UUIDField}]
+   [[#uuid "4f01dcfd-13f7-430c-8e6f-e505c0851027"]
+    [#uuid "4652b2e7-d940-4d55-a971-7e484566663e"]
+    [#uuid "da1d6ecc-e775-4008-b366-c38e7a2e8433"]
+    [#uuid "7a5ce4a2-0958-46e7-9685-1a4eaa3bd08a"]
+    [#uuid "84ed434e-80b4-41cf-9c88-e334427104ae"]]])
+
+;; Check that we can load a Postgres Database with a :UUIDField
+(expect {:cols    [{:description nil, :base_type :IntegerField, :name "id", :display_name "Id", :special_type :id, :target nil, :extra_info {}}
+                   {:description nil, :base_type :UUIDField, :name "user_id", :display_name "User Id", :special_type :category, :target nil, :extra_info {}}],
+         :columns ["id" "user_id"],
+         :rows    [[1 #uuid "4f01dcfd-13f7-430c-8e6f-e505c0851027"]
+                   [2 #uuid "4652b2e7-d940-4d55-a971-7e484566663e"]
+                   [3 #uuid "da1d6ecc-e775-4008-b366-c38e7a2e8433"]
+                   [4 #uuid "7a5ce4a2-0958-46e7-9685-1a4eaa3bd08a"]
+                   [5 #uuid "84ed434e-80b4-41cf-9c88-e334427104ae"]]}
+  (-> (Q run against postgres-with-uuid using postgres
+         return :data
+         aggregate rows of users)
+      (update :cols (partial mapv #(dissoc % :id :table_id)))))
+
+;; Check that we can filter by a UUID Field
+(expect [[2 #uuid "4652b2e7-d940-4d55-a971-7e484566663e"]]
+  (Q run against postgres-with-uuid using postgres
+     return :data :rows
+     aggregate rows of users
+     filter = user_id "4652b2e7-d940-4d55-a971-7e484566663e"))

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -69,14 +69,14 @@
                    [3 #uuid "da1d6ecc-e775-4008-b366-c38e7a2e8433"]
                    [4 #uuid "7a5ce4a2-0958-46e7-9685-1a4eaa3bd08a"]
                    [5 #uuid "84ed434e-80b4-41cf-9c88-e334427104ae"]]}
-  (-> (Q run against postgres-with-uuid using postgres
+  (-> (Q run against metabase.driver.postgres-test/postgres-with-uuid using postgres
          return :data
          aggregate rows of users)
       (update :cols (partial mapv #(dissoc % :id :table_id)))))
 
 ;; Check that we can filter by a UUID Field
 (expect [[2 #uuid "4652b2e7-d940-4d55-a971-7e484566663e"]]
-  (Q run against postgres-with-uuid using postgres
+  (Q run against metabase.driver.postgres-test/postgres-with-uuid using postgres
      return :data :rows
      aggregate rows of users
      filter = user_id "4652b2e7-d940-4d55-a971-7e484566663e"))

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -2,9 +2,7 @@
   (:require [expectations :refer :all]
             [metabase.driver.generic-sql.interface :as i]
             [metabase.driver.postgres :refer :all]
-            [metabase.test.data :as data]
-            (metabase.test.data [datasets :as datasets]
-                                [interface :refer [def-database-definition]])
+            [metabase.test.data.interface :refer [def-database-definition]]
             [metabase.test.util.mql :refer [Q]]))
 
 ;; # Check that database->connection details still works whether we're dealing with new-style or legacy details

--- a/test/metabase/test/data/postgres.clj
+++ b/test/metabase/test/data/postgres.clj
@@ -21,7 +21,8 @@
    :FloatField      "FLOAT"
    :IntegerField    "INTEGER"
    :TextField       "TEXT"
-   :TimeField       "TIME"})
+   :TimeField       "TIME"
+   :UUIDField       "UUID"})
 
 (defn- pg-connection-details [^DatabaseDefinition {:keys [short-lived?]}]
   (merge {:host         "localhost"

--- a/test/metabase/test/util/mql.clj
+++ b/test/metabase/test/util/mql.clj
@@ -31,8 +31,11 @@
   `(:id (data/-temp-get ~'db ~@(map name args))))
 
 (defn Q:resolve-dataset [^clojure.lang.Symbol dataset]
-  (require 'metabase.test.data.dataset-definitions)
-  (var-get (ns-resolve 'metabase.test.data.dataset-definitions dataset)))
+  ;; Try to resolve symbol as-is, otherwise try to resolve in the metabase.test.data.dataset-definitions namespace
+  (var-get (or (resolve dataset)
+               (do (require 'metabase.test.data.dataset-definitions)
+                   (ns-resolve 'metabase.test.data.dataset-definitions dataset))
+               (throw (Exception. (format "Don't know how to find dataset '%s'." dataset))))))
 
 (defmacro Q:with-temp-db [dataset body]
   `(data/with-temp-db [~'db (data/dataset-loader) (Q:resolve-dataset '~dataset)]


### PR DESCRIPTION
This is all g2g & tested. These l33t macros really make writing tests really fast :sunglasses: 

``` clojure
;;; # UUID Support
(def-database-definition ^:private with-uuid
  ["users"
   [{:field-name "user_id", :base-type :UUIDField}]
   [[#uuid "4f01dcfd-13f7-430c-8e6f-e505c0851027"]
    [#uuid "4652b2e7-d940-4d55-a971-7e484566663e"]
    [#uuid "da1d6ecc-e775-4008-b366-c38e7a2e8433"]
    [#uuid "7a5ce4a2-0958-46e7-9685-1a4eaa3bd08a"]
    [#uuid "84ed434e-80b4-41cf-9c88-e334427104ae"]]])

;; Check that we can filter by a UUID Field
(expect [[2 #uuid "4652b2e7-d940-4d55-a971-7e484566663e"]]
  (Q run against metabase.driver.postgres-test/with-uuid using postgres
     return :data :rows
     aggregate rows of users
     filter = user_id "4652b2e7-d940-4d55-a971-7e484566663e"))
```
