### PR TITLE
Toggle GA tracking on/off via settings

### DIFF
--- a/resources/frontend_client/app/admin/settings/settings.controllers.js
+++ b/resources/frontend_client/app/admin/settings/settings.controllers.js
@@ -3,8 +3,8 @@
 
 var SettingsAdminControllers = angular.module('corvusadmin.settings.controllers', ['corvusadmin.settings.services']);
 
-SettingsAdminControllers.controller('SettingsAdminController', ['$scope', '$q', 'SettingsAdminServices',
-    function($scope, $q, SettingsAdminServices) {
+SettingsAdminControllers.controller('SettingsAdminController', ['$scope', '$q', 'AppState', 'SettingsAdminServices',
+    function($scope, $q, AppState, SettingsAdminServices) {
         $scope.settings = [];
 
         SettingsAdminServices.list(function(results) {
@@ -36,6 +36,10 @@ SettingsAdminControllers.controller('SettingsAdminController', ['$scope', '$q', 
                 }
             })).then(function(results) {
                 $scope.$broadcast("form:api-success", "Successfully saved!");
+
+                // refresh the app-wide settings now as the user may have just changed some of them
+                AppState.refreshSiteSettings();
+
             }, function(error) {
                 $scope.$broadcast("form:api-error", error);
                 throw error;

--- a/resources/frontend_client/app/services.js
+++ b/resources/frontend_client/app/services.js
@@ -212,6 +212,18 @@ CorvusServices.factory('AppState', ['$rootScope', '$q', '$location', '$timeout',
             /* eslint-enable */
         });
 
+        // enable / disable GA based on opt-out of anonymous tracking
+        $rootScope.$on("appstate:site-settings", function(event, settings) {
+            var tracking = settings['anon-tracking-enabled']['value'];
+            if (tracking === "true" || tracking === null) {
+                // we are doing tracking
+                window['ga-disable-UA-60817802-1'] = null;
+            } else {
+                // tracking is disabled
+                window['ga-disable-UA-60817802-1'] = true;
+            }
+        });
+
         // NOTE: the below events are generated from the http-auth-interceptor which listens on our $http calls
         //       and intercepts calls that result in a 401 or 403 so that we can handle them here.  You must be
         //       careful to consider the implications of this because any endpoint that returns a 401/403 can

--- a/resources/frontend_client/app/services.js
+++ b/resources/frontend_client/app/services.js
@@ -7,8 +7,8 @@ import MetabaseAnalytics from './lib/metabase_analytics';
 
 var CorvusServices = angular.module('corvus.services', ['http-auth-interceptor', 'ipCookie', 'corvus.core.services']);
 
-CorvusServices.factory('AppState', ['$rootScope', '$q', '$location', '$timeout', 'ipCookie', 'Session', 'User', 'Settings',
-    function($rootScope, $q, $location, $timeout, ipCookie, Session, User, Settings) {
+CorvusServices.factory('AppState', ['$rootScope', '$q', '$location', '$interval', '$timeout', 'ipCookie', 'Session', 'User', 'Settings',
+    function($rootScope, $q, $location, $interval, $timeout, ipCookie, Session, User, Settings) {
         // this is meant to be a global service used for keeping track of our overall app state
         // we fire 2 events as things change in the app
         // 1. appstate:user
@@ -43,8 +43,8 @@ CorvusServices.factory('AppState', ['$rootScope', '$q', '$location', '$timeout',
 
                     // start Intercom updater
                     // this tells Intercom to update every 60s if we have a currently logged in user
-                    $timeout(function() {
-                        if (service.model.currentUser) {
+                    $interval(function() {
+                        if (service.model.currentUser && isTracking()) {
                             /* eslint-disable */
                             window.Intercom('update');
                             /* eslint-enable */
@@ -58,7 +58,6 @@ CorvusServices.factory('AppState', ['$rootScope', '$q', '$location', '$timeout',
             clearState: function() {
                 currentUserPromise = null;
                 service.model.currentUser = null;
-                service.model.siteSettings = null;
 
                 // clear any existing session cookies if they exist
                 ipCookie.remove('metabase.SESSION_ID');
@@ -171,6 +170,28 @@ CorvusServices.factory('AppState', ['$rootScope', '$q', '$location', '$timeout',
             }
         };
 
+        function isTracking() {
+            var settings = service.model.siteSettings;
+            if (!settings) return false;
+
+            var tracking = settings['anon-tracking-enabled']['value'];
+            return (tracking === "true" || tracking === null);
+        }
+
+        /* eslint-disable */
+        function startupIntercom(user) {
+            window.Intercom('boot', {
+                app_id: "gqfmsgf1",
+                name: user.common_name,
+                email: user.email
+            });
+        }
+
+        function teardownIntercom() {
+            window.Intercom('shutdown');
+        }
+        /* eslint-enable */
+
         // listen for location changes and use that as a trigger for page view tracking
         $rootScope.$on('$locationChangeSuccess', function() {
             // NOTE: we are only taking the path right now to avoid accidentally grabbing sensitive data like table/field ids
@@ -197,30 +218,31 @@ CorvusServices.factory('AppState', ['$rootScope', '$q', '$location', '$timeout',
             });
 
             // close down intercom
-            /* eslint-disable */
-            window.Intercom('shutdown');
-            /* eslint-enable */
+            teardownIntercom();
         });
 
         $rootScope.$on("appstate:user", function(event, user) {
-            /* eslint-disable */
-            window.Intercom('boot', {
-                app_id: "gqfmsgf1",
-                name: user.common_name,
-                email: user.email
-            });
-            /* eslint-enable */
+            if (isTracking()) {
+                startupIntercom(user);
+            }
         });
 
         // enable / disable GA based on opt-out of anonymous tracking
         $rootScope.$on("appstate:site-settings", function(event, settings) {
-            var tracking = settings['anon-tracking-enabled']['value'];
-            if (tracking === "true" || tracking === null) {
+            if (isTracking()) {
                 // we are doing tracking
                 window['ga-disable-UA-60817802-1'] = null;
+
+                if (currentUserPromise) {
+                    currentUserPromise.then(function(user) {
+                        startupIntercom(user);
+                    });
+                }
             } else {
                 // tracking is disabled
                 window['ga-disable-UA-60817802-1'] = true;
+
+                teardownIntercom();
             }
         });
 

--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -131,6 +131,9 @@
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+    // start off with tracking disabled (the angular app will re-enable this once we know the app runtime settings)
+    window['ga-disable-UA-60817802-1'] = true;
+
     ga('create', 'UA-60817802-1', 'auto');
     </script>
 </html>

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -105,7 +105,7 @@
 (defendpoint GET "/properties"
   "Get all global properties and their values. These are the specific `Settings` which are meant to be public."
   []
-  (filter #(= (:key %) :site-name) (setting/all-with-descriptions)))
+  (filter #(contains? #{:site-name :anon-tracking-enabled} (:key %)) (setting/all-with-descriptions)))
 
 
 (define-routes)

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -33,6 +33,8 @@
 
 (defsetting -site-url "The base URL of this Metabase instance, e.g. \"http://metabase.my-company.com\"")
 
+(defsetting anon-tracking-enabled "Enable the collection of anonymous usage data in order to help Metabase improve." "true")
+
 (defn site-url
   "Fetch the site base URL that should be used for password reset emails, etc.
    This strips off any trailing slashes that may have been added.

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -151,7 +151,11 @@
 ;; GET /session/properties
 ;; Check that a non-superuser can't read settings
 (expect
-  [{:value "Metabase Test"
+  [{:value nil
+    :key "anon-tracking-enabled"
+    :description "Enable the collection of anonymous usage data in order to help Metabase improve."
+    :default "true"}
+   {:value "Metabase Test"
     :key "site-name"
     :description "The name used for this instance of Metabase."
     :default "Metabase"}]


### PR DESCRIPTION
1. there is a new setting in the backend to capture the state of the user choice.  default is `true`.
2. frontend is wired up to listen for changes to the setting and disable/enable GA tracking as appropriate.  GA tracking starts disabled on page load.
