### PR TITLE
Calculated fields

### DIFF
--- a/src/metabase/driver/query_processor/annotate.clj
+++ b/src/metabase/driver/query_processor/annotate.clj
@@ -13,27 +13,6 @@
             [metabase.util :as u]
             [metabase.util.logic :refer :all]))
 
-;; Fields should be returned in the following order:
-;; 1.  Breakout Fields
-;;
-;; 2.  Aggregation Fields (e.g. sum, count)
-;;
-;; 3.  Fields clause Fields, if they were added explicitly
-;;
-;; 4.  All other Fields, sorted by:
-;;     A.  :position (ascending)
-;;         Users can manually specify default Field ordering for a Table in the Metadata admin. In that case, return Fields in the specified
-;;         order; most of the time they'll have the default value of 0, in which case we'll compare...
-;;
-;;     B.  :special_type "group" -- :id Fields, then :name Fields, then everyting else
-;;         Attempt to put the most relevant Fields first. Order the Fields as follows:
-;;         1.  :id Fields
-;;         2.  :name Fields
-;;         3.  all other Fields
-;;
-;;     C.  Field Name
-;;         When two Fields have the same :position and :special_type "group", fall back to sorting Fields alphabetically by name.
-;;         This is arbitrary, but it makes the QP deterministic by keeping the results in a consistent order, which makes it testable.
 
 ;;; # ---------------------------------------- FIELD COLLECTION  ----------------------------------------
 
@@ -87,18 +66,25 @@
 (defn- breakout-field° [{:keys [breakout]}]
   (make-field-in° breakout))
 
-(defn- calculated-field° [{:keys [calculate]}]
-  (if-not (seq calculate)
+(defn- calculated-field° [{:keys [calculated]}]
+  (if-not (seq calculated)
     (constantly fail)
-    (let [field-names (vec (keys calculate))]
-      (partial (fn calc-field° [[field-name & more] field]
-                 (conda
-                   ((field-name° field field-name) (== field {:field-name         field-name
-                                                              :field-display-name field-name
-                                                              :base-type          :UnknownField ; TODO - grab this info from Fields referenced by calculated field
-                                                              :special-type       nil}))
-                   ((!= more '()) (calc-field° more field))))
-               field-names))))
+    (fn calc-field°
+      ([[[f-name f] & more] field-name field]
+       (conda
+         ((== field-name f-name) (== field {:base-type          (:base-type f)
+                                            :special-type       (:special-type f)
+                                            :field-name         f-name
+                                            :field-display-name f-name}))
+         ((when (seq more) s#)   (calc-field° more field-name field))))
+
+      ([field-name field]
+       (calc-field° (seq calculated) field-name field))
+
+      ([field]
+       (fresh [field-name]
+         (field-name° field field-name)
+         (calc-field° field-name field))))))
 
 (defn- explicit-fields-field° [{:keys [fields-is-implicit fields], :as query}]
   (if fields-is-implicit (constantly fail)
@@ -136,28 +122,31 @@
                           (if-let [field (field-name->field field-name)]
                             (== out field)
                             fail)))
-        calced-field° (calculated-field° query)]
+        calc-field°     (calculated-field° query)]
     (fn [field-name field]
       (conda
         ((normal-field° field-name field))
         ((ag-field° field))
-        ((calced-field° field))))))
+        ((calc-field° field-name field))))))
 
 (def ^:const ^:private field-groups
   {:breakout        0
    :aggregation     1
    :explicit-fields 2
-   :other           3})
+   :calculated      3
+   :other           4})
 
 (defn- field-group° [query]
   (let [breakout° (breakout-field° query)
         agg°      (aggregate-field° query)
-        xfields°  (explicit-fields-field° query)]
+        xfields°  (explicit-fields-field° query)
+        calc°     (calculated-field° query)]
     (fn [field out]
       (conda
         ((breakout° field) (== out (field-groups :breakout)))
         ((agg° field)      (== out (field-groups :aggregation)))
         ((xfields° field)  (== out (field-groups :explicit-fields)))
+        ((calc° field)     (== out (field-groups :calculated)))
         (s#                (== out (field-groups :other)))))))
 
 (defn- field-position° [field out]
@@ -220,6 +209,7 @@
                            ((known-field°   result-key field))
                            ((unknown-field° result-key field))))
                        (zipmap result-keys fields))
+               (distincto fields)
                (sorted-permutation° (fields-sorted° query) fields q))))))
 
 

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -282,4 +282,17 @@
       (->> (map str (.getStackTrace e))
            (filterv (partial re-find #"metabase"))))))
 
+(defn most-frequent
+  "Return the item in VS with the highest frequency.
+
+    (most-frequent [:a :b :b :b :c :c]) -> :b"
+  [vs]
+  {:pre [(sequential? vs)]}
+  (when (seq vs)
+    (->> (for [[k vs] (group-by identity vs)]
+           [k (count vs)])
+         (sort-by second)
+         last
+         first)))
+
 (require-dox-in-this-namespace)

--- a/test/metabase/driver/query_processor_test.clj
+++ b/test/metabase/driver/query_processor_test.clj
@@ -1072,3 +1072,16 @@
  (Q return first-row
     aggregate count of venues
     filter != price 1 2))
+
+
+;;; # ---------------------------------------------------------------------------- CALCULATED COLUMNS ----------------------------------------------------------------------------
+
+(defn x []
+  (datasets/with-dataset :postgres
+    (driver/process-query {:database (db-id)
+                           :type     :query
+                           :query    {:calculate    {:total ["+" (id :venues :category_id) (id :venues :price) (id :venues :id)]}
+                                      :aggregation  ["rows"],
+                                      :source_table (id :venues)
+                                      :fields       [(id :venues :category_id) ["calculated" "total"]]
+                                      :limit        10}})))

--- a/test/metabase/driver/query_processor_test.clj
+++ b/test/metabase/driver/query_processor_test.clj
@@ -1080,8 +1080,10 @@
   (datasets/with-dataset :postgres
     (driver/process-query {:database (db-id)
                            :type     :query
-                           :query    {:calculate    {:total ["+" (id :venues :category_id) (id :venues :price) (id :venues :id)]}
+                           :query    {:calculated   {"total"  ["+" ["fk->" (id :venues :category_id) (id :categories :id)] (id :venues :price) (id :venues :id)]
+                                                     "total2" ["+" ["calculated" "total"] ["calculated" "total"]]
+                                                     "total3" ["+" ["calculated" "total"] ["calculated" "total2"]]}
                                       :aggregation  ["rows"],
                                       :source_table (id :venues)
-                                      :fields       [(id :venues :category_id) ["calculated" "total"]]
+                                      :fields       [(id :venues :category_id) ["calculated" "total"] ["calculated" "total2"] ["calculated" "total3"]]
                                       :limit        10}})))

--- a/test/metabase/driver/query_processor_test.clj
+++ b/test/metabase/driver/query_processor_test.clj
@@ -1081,8 +1081,8 @@
     (driver/process-query {:database (db-id)
                            :type     :query
                            :query    {:calculated   {"total"  ["+" ["fk->" (id :venues :category_id) (id :categories :id)] (id :venues :price) (id :venues :id)]
-                                                     "total2" ["+" ["calculated" "total"] ["calculated" "total"]]
-                                                     "total3" ["+" ["calculated" "total"] ["calculated" "total2"]]}
+                                                     "total2" ["*" ["calculated" "total"] ["calculated" "total"]]
+                                                     "total3" ["-" ["calculated" "total"] ["calculated" "total2"]]}
                                       :aggregation  ["rows"],
                                       :source_table (id :venues)
                                       :fields       [(id :venues :category_id) ["calculated" "total"] ["calculated" "total2"] ["calculated" "total3"]]


### PR DESCRIPTION
Implemented as we discussed earlier. Everything is G2G for the SQL drivers pending unit tests.

The Query Expander is so smart you guys. :trophy: It introspects on the columns you reference in a calculated column to determine what `base-type` / `special-type` the calculated column should have. Qué fancy :tada: 
#### Calculated Fields In Action

A query like this:

``` clojure
{:database 3,
 :type :query,
 :query
 {:calculated {"total" ["+" ["fk->" 65 53] 64 66]},
  :aggregation ["rows"],
  :source_table 12,
  :fields [65 ["calculated" "total"]],
  :limit 10}}
```

expands to one like this:

``` clojure
{:database
 {:name "Test Database", :details "😋 ", :id 3, :engine :postgres},
 :type :query,
 :query
 {:calculated
  {:total
   {:field-name "total",
    :calculation
    {:operator :+,
     :args
     [{:base-type :IntegerField,
       :table-id 10,
       :special-type :id,
       :field-name "id",
       :field-display-name "Id",
       :field-id 53,
       :table-name "categories"}
      {:base-type :IntegerField,
       :table-id 12,
       :special-type :category,
       :field-name "price",
       :field-display-name "Price",
       :field-id 64,
       :table-name "venues"}
      {:base-type :IntegerField,
       :table-id 12,
       :special-type :id,
       :field-name "id",
       :field-display-name "Id",
       :field-id 66,
       :table-name "venues"}]},
    :base-type :IntegerField,
    :special-type :id}},
  :aggregation {:aggregation-type :rows},
  :fields
  [{:base-type :IntegerField,
    :table-id 12,
    :special-type :fk,
    :field-name "category_id",
    :field-display-name "Category Id",
    :field-id 65,
    :table-name "venues"}
   {:field-name "total",
    :calculation
    {:operator :+,
     :args
     [{:base-type :IntegerField,
       :table-id 10,
       :special-type :id,
       :field-name "id",
       :field-display-name "Id",
       :field-id 53,
       :table-name "categories"}
      {:base-type :IntegerField,
       :table-id 12,
       :special-type :category,
       :field-name "price",
       :field-display-name "Price",
       :field-id 64,
       :table-name "venues"}
      {:base-type :IntegerField,
       :table-id 12,
       :special-type :id,
       :field-name "id",
       :field-display-name "Id",
       :field-id 66,
       :table-name "venues"}]},
    :base-type :IntegerField,
    :special-type :id}],
  :limit 10,
  :source-table {:name "venues", :id 12},
  :join-tables
  [{:source-field {:field-id 65, :field-name "category_id"},
    :pk-field {:field-id 53, :field-name "id"},
    :table-id 10,
    :table-name "categories"}]},
 :driver metabase.driver.postgres.PostgresDriver}
```

which we translate into this korma form:

``` clojure
(select
 entity
 (fields
  :venues.category_id
  [(infix :+ :categories.id :venues.price :venues.id) :total])
 (limit 10)
 (join "categories" (= :venues.category_id :categories.id)))
```

which gets translated into this SQL:

``` sql
SELECT "venues"."category_id", ("categories"."id" + "venues"."price" + "venues"."id") AS "total"
FROM "venues"
LEFT JOIN "categories" ON "venues"."category_id" = "categories"."id"
LIMIT 10
```

which gives us these results when ran:

``` clojure
{:row_count 10,
 :status :completed,
 :data
 {:cols
  [{:description nil,
    :id 65,
    :table_id 12,
    :base_type :IntegerField,
    :name "category_id",
    :display_name "Category Id",
    :special_type :fk,
    :target {:description nil, :table_id 10, :special_type :id, :name "id", :id 53, :display_name "Id", :base_type :IntegerField},
    :extra_info {:target_table_id 10}}
   {:description nil, :id nil, :table_id nil, :base_type :IntegerField, :name "total", :display_name :total, :special_type :id, :target nil, :extra_info {}}],
  :columns ["category_id" "total"],
  :rows ([4 8] [11 15] [11 16] [29 35] [20 27] [20 28] [44 53] [11 21] [71 81] [20 32])}}
```

WUTANG ! :+1: 
#### CRAY CRAY

You can even run redic queries like this:

``` clojure
{:database 3,
 :type :query,
 :query
 {:calculated
  {"total" ["+" ["fk->" 65 53] 64 66],
   "total2" ["*" ["calculated" "total"] ["calculated" "total"]],
   "total3" ["-" ["calculated" "total"] ["calculated" "total2"]]},
  :aggregation ["rows"],
  :source_table 12,
  :fields
  [65
   ["calculated" "total"]
   ["calculated" "total2"]
   ["calculated" "total3"]],
  :limit 10}}
```

I don't want to #breaktheinternet by including all the intermediate forms, so here's the results of the query:

``` clojure
{:row_count 10,
 :status :completed,
 :data
 {:cols
  [{:description nil,
    :id 65,
    :table_id 12,
    :base_type :IntegerField,
    :name "category_id",
    :display_name "Category Id",
    :special_type :fk,
    :target {:description nil, :table_id 10, :special_type :id, :name "id", :id 53, :display_name "Id", :base_type :IntegerField},
    :extra_info {:target_table_id 10}}
   {:description nil, :id nil, :table_id nil, :base_type nil, :name "total3", :display_name :total3, :special_type nil, :target nil, :extra_info {}}
   {:description nil, :id nil, :table_id nil, :base_type nil, :name "total2", :display_name :total2, :special_type nil, :target nil, :extra_info {}}
   {:description nil, :id nil, :table_id nil, :base_type :IntegerField, :name "total", :display_name :total, :special_type :id, :target nil, :extra_info {}}],
  :columns ["category_id" "total3" "total2" "total"],
  :rows
  ([4 -56 64 8] [11 -210 225 15] [11 -240 256 16] [29 -1190 1225 35] [20 -702 729 27] [20 -756 784 28] [44 -2756 2809 53] [11 -420 441 21] [71 -6480 6561 81] [20 -992 1024 32])}}
```

The end.
