### PR TITLE
Fix object detail view so that columns with `:preview_display false` still show up

### DIFF
--- a/resources/frontend_client/app/card/card.controllers.js
+++ b/resources/frontend_client/app/card/card.controllers.js
@@ -2,6 +2,7 @@
 /*global _, document, confirm*/
 
 import MetabaseAnalytics from '../lib/analytics';
+import DataGrid from "metabase/lib/data_grid";
 
 import DataReference from '../query_builder/data_reference.react';
 import GuiQueryEditor from '../query_builder/gui_query_editor.react';
@@ -496,6 +497,12 @@ CardControllers.controller('CardDetail', [
                         dataset_query.query.aggregation[0] === "rows") {
                     // if our query aggregation is "rows" then ALWAYS set the display to "table"
                     card.display = "table";
+                }
+
+                // if we are display bare rows, filter out columns with preview_display = false
+                if (Query.isStructured(dataset_query) &&
+                        Query.isBareRowsAggregation(dataset_query.query)) {
+                    queryResult.data = DataGrid.filterOnPreviewDisplay(queryResult.data);
                 }
 
                 renderAll();

--- a/resources/frontend_client/app/lib/data_grid.js
+++ b/resources/frontend_client/app/lib/data_grid.js
@@ -9,6 +9,29 @@ function compareNumbers(a, b) {
 
 
 var DataGrid = {
+    filterOnPreviewDisplay: function(data) {
+        // find any columns where preview_display = false
+        var hiddenColumnIdxs = _.map(data.cols, function(col, idx) { if(!col.preview_display) return idx; });
+        hiddenColumnIdxs = _.filter(hiddenColumnIdxs, function(val) { return val !== undefined; });
+
+        // filter out our data grid using the indexes of the hidden columns
+        var filteredRows = data.rows.map(function(row, rowIdx) {
+            return row.filter(function(cell, cellIdx) {
+                if (_.contains(hiddenColumnIdxs, cellIdx)) {
+                    return false;
+                } else {
+                    return true;
+                }
+            });
+        });
+
+        return {
+            cols: _.filter(data.cols, function(col) { return col.preview_display; }),
+            columns: _.map(data.cols, function(col) { return col.display_name; }),
+            rows: filteredRows
+        };
+    },
+
     pivot: function(data) {
         // find the lowest cardinality dimension and make it our "pivoted" column
         // TODO: we assume dimensions are in the first 2 columns, which is less than ideal

--- a/src/metabase/driver/query_processor.clj
+++ b/src/metabase/driver/query_processor.clj
@@ -78,8 +78,8 @@
   (fn [{{:keys [source-table], {source-table-id :id} :source-table} :query, :as query}]
     (qp (if-not (should-add-implicit-fields? query)
           query
-          (let [fields (->> (sel :many :fields [Field :name :display_name :base_type :special_type :table_id :id :position :description], :table_id source-table-id, :active true,
-                                 :preview_display true, :field_type [not= "sensitive"], :parent_id nil, (k/order :position :asc), (k/order :id :desc))
+          (let [fields (->> (sel :many :fields [Field :name :display_name :base_type :special_type :preview_display :display_name :table_id :id :position :description], :table_id source-table-id,
+                                 :active true, :field_type [not= "sensitive"], :parent_id nil, (k/order :position :asc), (k/order :id :desc))
                             (map expand/rename-mb-field-keys)
                             (map expand/map->Field)
                             (map #(expand/resolve-table % {source-table-id source-table})))]

--- a/src/metabase/driver/query_processor/annotate.clj
+++ b/src/metabase/driver/query_processor/annotate.clj
@@ -224,6 +224,7 @@
                                 :field-name         :name
                                 :field-display-name :display_name
                                 :special-type       :special_type
+                                :preview-display    :preview_display
                                 :table-id           :table_id})
              (dissoc :position))))
 
@@ -243,7 +244,7 @@
         ;; Build a map of Destination Field IDs -> Destination Fields
         dest-field-id->field    (when (and (seq fk-field-ids)
                                            (seq (vals field-id->dest-field-id)))
-                                  (sel :many :id->fields [Field :id :name :display_name :table_id :description :base_type :special_type], :id [in (vals field-id->dest-field-id)]))]
+                                  (sel :many :id->fields [Field :id :name :display_name :table_id :description :base_type :special_type :preview_display], :id [in (vals field-id->dest-field-id)]))]
 
     ;; Add the :extra_info + :target to every Field. For non-FK Fields, these are just {} and nil, respectively.
     (vec (for [{field-id :id, :as field} fields]

--- a/src/metabase/driver/query_processor/expand.clj
+++ b/src/metabase/driver/query_processor/expand.clj
@@ -125,13 +125,14 @@
 (defn rename-mb-field-keys
   "Rename the keys in a Metabase `Field` to match the format of those in Query Expander `Fields`."
   [field]
-  (set/rename-keys field {:id           :field-id
-                          :name         :field-name
-                          :display_name :field-display-name
-                          :special_type :special-type
-                          :base_type    :base-type
-                          :table_id     :table-id
-                          :parent_id    :parent-id}))
+  (set/rename-keys field {:id              :field-id
+                          :name            :field-name
+                          :display_name    :field-display-name
+                          :special_type    :special-type
+                          :base_type       :base-type
+                          :preview_display :preview-display
+                          :table_id        :table-id
+                          :parent_id       :parent-id}))
 
 (defn- resolve-fields
   "Resolve the `Fields` in an EXPANDED-QUERY-DICT."
@@ -142,7 +143,7 @@
 
     ;; Re-bind *field-ids* in case we need to do recursive Field resolution
     (binding [*field-ids* (atom #{})]
-      (let [fields (->> (sel :many :id->fields [field/Field :name :display_name :base_type :special_type :table_id :parent_id :description], :id [in field-ids])
+      (let [fields (->> (sel :many :id->fields [field/Field :name :display_name :base_type :special_type :preview_display :table_id :parent_id :description], :id [in field-ids])
                         (m/map-vals rename-mb-field-keys)
                         (m/map-vals #(assoc % :parent (when (:parent-id %)
                                                         (ph (:parent-id %))))))]

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -59,8 +59,8 @@
     [#uuid "84ed434e-80b4-41cf-9c88-e334427104ae"]]])
 
 ;; Check that we can load a Postgres Database with a :UUIDField
-(expect {:cols    [{:description nil, :base_type :IntegerField, :name "id", :display_name "Id", :special_type :id, :target nil, :extra_info {}}
-                   {:description nil, :base_type :UUIDField, :name "user_id", :display_name "User Id", :special_type :category, :target nil, :extra_info {}}],
+(expect {:cols    [{:description nil, :base_type :IntegerField, :name "id", :display_name "Id", :preview_display true, :special_type :id, :target nil, :extra_info {}}
+                   {:description nil, :base_type :UUIDField, :name "user_id", :display_name "User Id", :preview_display true, :special_type :category, :target nil, :extra_info {}}],
          :columns ["id" "user_id"],
          :rows    [[1 #uuid "4f01dcfd-13f7-430c-8e6f-e505c0851027"]
                    [2 #uuid "4652b2e7-d940-4d55-a971-7e484566663e"]

--- a/test/metabase/driver/query_processor_test.clj
+++ b/test/metabase/driver/query_processor_test.clj
@@ -918,7 +918,7 @@
      [426 "Kyle's Low-Carb Grill"]
      [470 "Kyle's Low-Carb Grill"]]
   (Q dataset geographical-tips use mongo
-     return rows (map (fn [[id _ _  {venue-name :name}]] [id venue-name]))
+     return rows (map (fn [[id _ _ _ {venue-name :name}]] [id venue-name]))
      aggregate rows of tips
      filter = venue...name "Kyle's Low-Carb Grill"
      order id
@@ -929,24 +929,28 @@
 (datasets/expect-when-testing-dataset :mongo
   [[446
     {:mentions ["@cams_mexican_gastro_pub"], :tags ["#mexican" "#gastro" "#pub"], :service "twitter", :username "kyle"}
+    "Cam's Mexican Gastro Pub is a historical and underappreciated place to conduct a business meeting with friends."
     {:large  "http://cloudfront.net/6e3a5256-275f-4056-b61a-25990b4bb484/large.jpg",
      :medium "http://cloudfront.net/6e3a5256-275f-4056-b61a-25990b4bb484/med.jpg",
      :small  "http://cloudfront.net/6e3a5256-275f-4056-b61a-25990b4bb484/small.jpg"}
     {:phone "415-320-9123", :name "Cam's Mexican Gastro Pub", :categories ["Mexican" "Gastro Pub"], :id "bb958ac5-758e-4f42-b984-6b0e13f25194"}]
    [230
     {:mentions ["@haight_european_grill"], :tags ["#european" "#grill"], :service "twitter", :username "kyle"}
+    "Haight European Grill is a horrible and amazing place to have a birthday party during winter."
     {:large  "http://cloudfront.net/1dcef7de-a1c4-405b-a9e1-69c92d686ef1/large.jpg",
      :medium "http://cloudfront.net/1dcef7de-a1c4-405b-a9e1-69c92d686ef1/med.jpg",
      :small  "http://cloudfront.net/1dcef7de-a1c4-405b-a9e1-69c92d686ef1/small.jpg"}
     {:phone "415-191-2778", :name "Haight European Grill", :categories ["European" "Grill"], :id "7e6281f7-5b17-4056-ada0-85453247bc8f"}]
    [319
     {:mentions ["@haight_soul_food_pop_up_food_stand"], :tags ["#soul" "#food" "#pop-up" "#food" "#stand"], :service "twitter", :username "kyle"}
+    "Haight Soul Food Pop-Up Food Stand is a underground and modern place to have breakfast on a Tuesday afternoon."
     {:large  "http://cloudfront.net/8f613909-550f-4d79-96f6-dc498ff65d1b/large.jpg",
      :medium "http://cloudfront.net/8f613909-550f-4d79-96f6-dc498ff65d1b/med.jpg",
      :small  "http://cloudfront.net/8f613909-550f-4d79-96f6-dc498ff65d1b/small.jpg"}
     {:phone "415-741-8726", :name "Haight Soul Food Pop-Up Food Stand", :categories ["Soul Food" "Pop-Up Food Stand"], :id "9735184b-1299-410f-a98e-10d9c548af42"}]
    [224
     {:mentions ["@pacific_heights_free_range_eatery"], :tags ["#free-range" "#eatery"], :service "twitter", :username "kyle"}
+    "Pacific Heights Free-Range Eatery is a wonderful and modern place to take visiting friends and relatives Friday nights."
     {:large  "http://cloudfront.net/cedd4221-dbdb-46c3-95a9-935cce6b3fe5/large.jpg",
      :medium "http://cloudfront.net/cedd4221-dbdb-46c3-95a9-935cce6b3fe5/med.jpg",
      :small  "http://cloudfront.net/cedd4221-dbdb-46c3-95a9-935cce6b3fe5/small.jpg"}

--- a/test/metabase/driver/query_processor_test.clj
+++ b/test/metabase/driver/query_processor_test.clj
@@ -50,9 +50,9 @@
   [col]
   (case col
     :id   {:extra_info {} :target nil :special_type :id, :base_type (id-field-type), :description nil,
-           :name (format-name "id") :display_name "Id" :table_id (id :categories), :id (id :categories :id)}
+           :name (format-name "id") :display_name "Id" :preview_display true :table_id (id :categories), :id (id :categories :id)}
     :name {:extra_info {} :target nil :special_type :name, :base_type :TextField, :description nil,
-           :name (format-name "name") :display_name "Name" :table_id (id :categories), :id (id :categories :name)}))
+           :name (format-name "name") :display_name "Name" :preview_display true :table_id (id :categories), :id (id :categories :name)}))
 
 ;; #### users
 (defn- users-col
@@ -66,6 +66,7 @@
                  :description  nil
                  :name         (format-name "id")
                  :display_name "Id"
+                 :preview_display true
                  :table_id     (id :users)
                  :id           (id :users :id)}
     :name       {:extra_info   {}
@@ -75,6 +76,7 @@
                  :description  nil
                  :name         (format-name "name")
                  :display_name "Name"
+                 :preview_display true
                  :table_id     (id :users)
                  :id           (id :users :name)}
     :last_login {:extra_info   {}
@@ -84,6 +86,7 @@
                  :description  nil
                  :name         (format-name "last_login")
                  :display_name "Last Login"
+                 :preview_display true
                  :table_id     (id :users)
                  :id           (id :users :last_login)}))
 
@@ -104,6 +107,7 @@
                   :description  nil
                   :name         (format-name "id")
                   :display_name "Id"
+                  :preview_display true
                   :table_id     (id :venues)
                   :id           (id :venues :id)}
     :category_id {:extra_info   (if (fks-supported?) {:target_table_id (id :categories)}
@@ -117,6 +121,7 @@
                   :description  nil
                   :name         (format-name "category_id")
                   :display_name "Category Id"
+                  :preview_display true
                   :table_id     (id :venues)
                   :id           (id :venues :category_id)}
     :price       {:extra_info   {}
@@ -126,6 +131,7 @@
                   :description  nil
                   :name         (format-name "price")
                   :display_name "Price"
+                  :preview_display true
                   :table_id     (id :venues)
                   :id           (id :venues :price)}
     :longitude   {:extra_info   {}
@@ -135,6 +141,7 @@
                   :description  nil
                   :name         (format-name "longitude")
                   :display_name "Longitude"
+                  :preview_display true
                   :table_id     (id :venues)
                   :id           (id :venues :longitude)}
     :latitude    {:extra_info   {}
@@ -144,6 +151,7 @@
                   :description  nil
                   :name         (format-name "latitude")
                   :display_name "Latitude"
+                  :preview_display true
                   :table_id     (id :venues)
                   :id           (id :venues :latitude)}
     :name        {:extra_info   {}
@@ -153,6 +161,7 @@
                   :description  nil
                   :name         (format-name "name")
                   :display_name "Name"
+                  :preview_display true
                   :table_id     (id :venues)
                   :id           (id :venues :name)}))
 
@@ -173,6 +182,7 @@
                :description  nil
                :name         (format-name "id")
                :display_name "Id"
+               :preview_display true
                :table_id     (id :checkins)
                :id           (id :checkins :id)}
     :venue_id {:extra_info   (if (fks-supported?) {:target_table_id (id :venues)}
@@ -186,6 +196,7 @@
                :description  nil
                :name         (format-name "venue_id")
                :display_name "Venue Id"
+               :preview_display true
                :table_id     (id :checkins)
                :id           (id :checkins :venue_id)}
     :user_id  {:extra_info   (if (fks-supported?) {:target_table_id (id :users)}
@@ -199,6 +210,7 @@
                :description  nil
                :name         (format-name "user_id")
                :display_name "User Id"
+               :preview_display true
                :table_id     (id :checkins)
                :id           (id :checkins :user_id)}))
 
@@ -689,15 +701,21 @@
      order ag.0-))
 
 
-;;; ### make sure that rows where preview_display = false don't get displayed
+;;; ### make sure that rows where preview_display = false are included and properly marked up
 (datasets/expect-with-all-datasets
- [(set (->columns "category_id" "name" "latitude" "id" "longitude" "price"))
-  (set (->columns "category_id" "name" "latitude" "id" "longitude"))
-  (set (->columns "category_id" "name" "latitude" "id" "longitude" "price"))]
+ [(set (venues-cols))
+  #{(venues-col :category_id)
+    (venues-col :name)
+    (venues-col :latitude)
+    (venues-col :id)
+    (venues-col :longitude)
+    (-> (venues-col :price)
+        (assoc :preview_display false))}
+  (set (venues-cols))]
  (let [get-col-names (fn [] (Q aggregate rows of venues
                                order id+
                                limit 1
-                               return :data :columns set))]
+                               return :data :cols set))]
    [(get-col-names)
     (do (upd Field (id :venues :price) :preview_display false)
         (get-col-names))


### PR DESCRIPTION
I'm not all that happy with this solution, so I'm open to thoughts from others.

The core problem is that currently the QP on the backend filters all queries on `:rows` type aggregations so that they don't return any fields where `:preview_display = false`.  This is what we want in rows listings, but unfortunately we use that same aggregation type to pull the data for the Object Detail page and on that page we actually want to show these fields.

So, we either need to 
1. return the fields and their data when the query is run and then rely on the frontend to filter out columns & data when it doesn't want to show them, or
2. tweak the QP so that we have a way to query for a specific object detail (single row via PK = <value>) and return the relevant fields.

I've implemented #1 and it feels icky to me.  Starting to think that #2 makes more sense really.
