### PR TITLE
fix dashboard card repositioning bug

### DIFF
--- a/src/metabase/api/dash.clj
+++ b/src/metabase/api/dash.clj
@@ -88,8 +88,9 @@
               :col} ...]}"
   [id :as {{:keys [cards]} :body}]
   (write-check Dashboard id)
-  (doseq [{:keys [card_id sizeX sizeY row col]} cards]
-    (let [{dashcard-id :id} (sel :one [DashboardCard :id] :card_id card_id :dashboard_id id)]
+  (doseq [{dashcard-id :id :keys [sizeX sizeY row col]} cards]
+    ;; we lookup the dashcard purely to ensure the card is part of the given dashboard
+    (let [_ (sel :one [DashboardCard :id] :id dashcard-id :dashboard_id id)]
       (upd DashboardCard dashcard-id :sizeX sizeX :sizeY sizeY :row row :col col)))
   (push-revision :entity Dashboard, :object (Dashboard id))
   {:status :ok})


### PR DESCRIPTION
look cards for repositioning using their dashcard id instead of combination of card id and dashboard id.  this was causing a problem because its possible for the same card to exist multiple times on a dashboard.  fixes #899
