### PR TITLE
Various bits of refactoring & cleanup

### DIFF
--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -53,28 +53,18 @@
 
 ;; ## Driver Lookup
 
-
-(def ^{:arglists '([engine])} engine->driver
+(defn engine->driver
   "Return the driver instance that should be used for given ENGINE.
    This loads the corresponding driver if needed; it is expected that it resides in a var named
 
-     metabase.driver.<engine>/driver
+     metabase.driver.<engine>/driver"
+  [engine]
+  {:pre [(keyword? engine)
+         (contains? (set (keys available-drivers)) engine)]}
+  (let [nmspc (symbol (format "metabase.driver.%s" (name engine)))]
+    (require nmspc)
+    @(ns-resolve nmspc 'driver)))
 
-   i.e., the `:postgres` driver should be bound interned at `metabase.driver.postgres/driver`.
-
-     (require ['metabase.driver.interface :as i])
-     (i/active-table-names (engine->driver :postgres) some-pg-database)"
-  (memoize
-   (fn [engine]
-     {:pre [(keyword? engine)]}
-     (let [ns-symb (symbol (format "metabase.driver.%s" (name engine)))]
-       (log/debug (format "Loading metabase.driver.%s..." (name engine)))
-       (require ns-symb)
-       (let [driver (some-> (ns-resolve ns-symb 'driver)
-                            var-get)]
-         (assert driver)
-         (log/debug "Ok.")
-         driver)))))
 
 ;; Can the type of a DB change?
 (def ^{:arglists '([database-id])} database-id->driver
@@ -82,10 +72,11 @@
    (Databases aren't expected to change their types, and this optimization makes things a lot faster).
 
    This loads the corresponding driver if needed."
-  (memoize
-   (fn [database-id]
-     {:pre [(integer? database-id)]}
-     (engine->driver (sel :one :field [Database :engine] :id database-id)))))
+  (let [db-id->engine (memoize
+                       (fn [db-id]
+                         (sel :one :field [Database :engine] :id db-id)))]
+    (fn [db-id]
+      (engine->driver (db-id->engine db-id)))))
 
 
 ;; ## Implementation-Agnostic Driver API

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -2,6 +2,7 @@
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.tools.logging :as log]
             [korma.core :as k]
+            [korma.sql.utils :as utils]
             [metabase.driver :as driver]
             (metabase.driver [interface :refer [max-sync-lazy-seq-results IDriver ISyncDriverTableFKs ISyncDriverFieldAvgLength ISyncDriverFieldPercentUrls]]
                              [sync :as driver-sync])
@@ -109,7 +110,8 @@
   {:pre [(keyword? sql-string-length-fn)]}
   (or (some-> (korma-entity @(:table field))
               (k/select (k/aggregate (avg (k/sqlfn* sql-string-length-fn
-                                                    (k/raw (format "CAST(%s AS CHAR)" (i/quote-name driver (name (:name field)))))))
+                                                    (utils/func "CAST(%s AS CHAR)"
+                                                                [(keyword (:name field))])))
                                      :len))
               first
               :len

--- a/src/metabase/driver/generic_sql/interface.clj
+++ b/src/metabase/driver/generic_sql/interface.clj
@@ -1,4 +1,5 @@
-(ns metabase.driver.generic-sql.interface)
+(ns metabase.driver.generic-sql.interface
+  (:import clojure.lang.Keyword))
 
 (defprotocol ISqlDriverDatabaseSpecific
   "Methods a DB-specific concrete SQL driver should implement.
@@ -6,23 +7,17 @@
 
    *  `column->base-type`
    *  `sql-string-length-fn`"
+
   (connection-details->connection-spec [this connection-details])
   (database->connection-details        [this database])
-  (cast-timestamp-to-date              [this table-name field-name seconds-or-milliseconds]
-    "Return the raw SQL that should be used to cast a Unix-timestamped column with string
-     TABLE-NAME and string FIELD-NAME to a SQL `DATE`. SECONDS-OR-MILLISECONDS will be either
-     `:seconds` or `:milliseconds`.")
-  (timezone->set-timezone-sql          [this timezone]
+
+  (unix-timestamp->date [this ^Keyword seconds-or-milliseconds field-or-value]
+    "Return a korma form appropriate for converting a Unix timestamp integer field or value to an proper SQL `Timestamp`.
+     SECONDS-OR-MILLISECONDS refers to the resolution of the int in question and with be either `:seconds` or `:milliseconds`.")
+
+  (timezone->set-timezone-sql [this timezone]
     "Return a string that represents the SQL statement that should be used to set the timezone
-     for the current transaction."))
+     for the current transaction.")
 
-(defprotocol ISqlDriverQuoteName
-  "Optionally protocol to override how the Generic SQL driver quotes the names of databases, tables, and fields."
-  (quote-name [this ^String nm]
-    "Quote a name appropriately for this database."))
 
-;; Default implementation quotes using "
-(extend-protocol ISqlDriverQuoteName
-  Object
-  (quote-name [_ nm]
-    (str \" nm \")))
+  )

--- a/src/metabase/driver/generic_sql/interface.clj
+++ b/src/metabase/driver/generic_sql/interface.clj
@@ -11,7 +11,7 @@
   (connection-details->connection-spec [this connection-details])
   (database->connection-details        [this database])
 
-  (unix-timestamp->date [this ^Keyword seconds-or-milliseconds field-or-value]
+  (unix-timestamp->timestamp [this ^Keyword seconds-or-milliseconds field-or-value]
     "Return a korma form appropriate for converting a Unix timestamp integer field or value to an proper SQL `Timestamp`.
      SECONDS-OR-MILLISECONDS refers to the resolution of the int in question and with be either `:seconds` or `:milliseconds`.")
 

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -131,7 +131,7 @@
      (formatted this false))
     ([{:keys [value base-type]} _]
      (cond
-       (instance? Timestamp value) (cast-as-date (u/date->yyyy-mm-dd value))
+       (instance? Timestamp value) (cast-as-date `(Timestamp/valueOf ~(.toString value))) ; prevent Clojure from converting this to #inst literal, which is a util.date
        (= base-type :UUIDField)    (java.util.UUID/fromString value)
        :else                       value))))
 

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -14,7 +14,9 @@
                                          [native :as native]
                                          [util :refer :all])
             [metabase.util :as u])
-  (:import (metabase.driver.query_processor.expand Field
+  (:import java.sql.Timestamp
+           java.util.Date
+           (metabase.driver.query_processor.expand Field
                                                    OrderByAggregateField
                                                    Value)))
 
@@ -86,6 +88,10 @@
 
 (defmethod apply-form :default [form]) ;; nothing
 
+(defn- cast-as-date
+  "Generate a korma form to cast FIELD-OR-VALUE to a `DATE`."
+  [field-or-value]
+  (utils/func "CAST(%s AS DATE)" [field-or-value]))
 
 (defprotocol IGenericSQLFormattable
   (formatted [this] [this include-as?]))
@@ -95,8 +101,15 @@
   (formatted
     ([this]
      (formatted this false))
-    ([{:keys [table-name field-name]} _]
-     (keyword (format "%s.%s" table-name field-name))))
+    ([{:keys [table-name base-type special-type field-name], :as field} include-as?]
+     (let [kw-name (keyword (str table-name \. field-name))
+           field   (cond
+                     (contains? #{:DateField :DateTimeField} base-type) (cast-as-date kw-name)
+                     (= special-type :timestamp_seconds)                (cast-as-date (i/unix-timestamp->timestamp (:driver *query*) kw-name :seconds))
+                     (= special-type :timestamp_milliseconds)           (cast-as-date (i/unix-timestamp->timestamp (:driver *query*) kw-name :milliseconds))
+                     :else                                              kw-name)]
+       (if include-as? [field (keyword field-name)]
+           field))))
 
   ;; e.g. the ["aggregation" 0] fields we allow in order-by
   OrderByAggregateField
@@ -118,23 +131,9 @@
      (formatted this false))
     ([{:keys [value base-type]} _]
      (cond
-       (instance? java.util.Date value) `(raw ~(format "CAST('%s' AS DATE)" (.toString ^java.util.Date value)))
-       (= base-type :UUIDField)         (do (assert (string? value))
-                                            (java.util.UUID/fromString value))
-       :else                            value))))
-
-  DateTimeField
-  (formatted
-    ([this]
-     (formatted this false))
-    ([{:keys [unit], {:keys [special-type field-name], :as field} :field} include-as?]
-     (let [f     (partial i/date (:driver *query*) unit)
-           field (cond
-                   (= special-type :timestamp_seconds)      (i/unix-timestamp->date (:driver *query*) (formatted field) :seconds)
-                   (= special-type :timestamp_milliseconds) (i/unix-timestamp->date (:driver *query*) (formatted field) :milliseconds)
-                   :else                                    (formatted field))]
-       (cond-> (f field)
-         include-as? (vector (keyword field-name)))))))
+       (instance? Timestamp value) (cast-as-date (u/date->yyyy-mm-dd value))
+       (= base-type :UUIDField)    (java.util.UUID/fromString value)
+       :else                       value))))
 
 
 (defmethod apply-form :aggregation [[_ {:keys [aggregation-type field]}]]

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -111,10 +111,10 @@
 (defn- database->connection-details [_ {:keys [details]}]
   details)
 
-(defn- unix-timestamp->date [_ field-or-value seconds-or-milliseconds]
-  (utils/func (format "parseDateTime(%%s, '%s', 'en', 'GMT')" (case seconds-or-milliseconds
-                                                                :seconds      "s"
-                                                                :milliseconds "S"))
+(defn- unix-timestamp->timestamp [_ field-or-value seconds-or-milliseconds]
+  (utils/func (format "TIMESTAMPADD('%s', %%s, TIMESTAMP '1970-01-01T00:00:00Z')" (case seconds-or-milliseconds
+                                                                                    :seconds      "SECOND"
+                                                                                    :milliseconds "MILLISECOND"))
               [field-or-value]))
 
 (defn- wrap-process-query-middleware [_ qp]
@@ -137,7 +137,7 @@
 (extend H2Driver
   ISqlDriverDatabaseSpecific  {:connection-details->connection-spec connection-details->connection-spec
                                :database->connection-details        database->connection-details
-                               :unix-timestamp->date                unix-timestamp->date}
+                               :unix-timestamp->timestamp           unix-timestamp->timestamp}
   ;; Override the generic SQL implementation of wrap-process-query-middleware so we can block unsafe native queries (see above)
   IDriver                     (assoc GenericSQLIDriverMixin :wrap-process-query-middleware wrap-process-query-middleware)
   ISyncDriverTableFKs         GenericSQLISyncDriverTableFKsMixin

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -69,10 +69,10 @@
 (defn- database->connection-details [_ {:keys [details]}]
   details)
 
-(defn- unix-timestamp->date [_ field-or-value seconds-or-milliseconds]
+(defn- unix-timestamp->timestamp [_ field-or-value seconds-or-milliseconds]
   (utils/func (case seconds-or-milliseconds
                 :seconds      "FROM_UNIXTIME(%s)"
-                :milliseconds "FROM_UNIXTIME(%s * 1000)")
+                :milliseconds "FROM_UNIXTIME(%s / 1000)")
               [field-or-value]))
 
 (defn- timezone->set-timezone-sql [_ timezone]
@@ -86,7 +86,7 @@
 (extend MySQLDriver
   ISqlDriverDatabaseSpecific  {:connection-details->connection-spec connection-details->connection-spec
                                :database->connection-details        database->connection-details
-                               :unix-timestamp->date                unix-timestamp->date}
+                               :unix-timestamp->timestamp           unix-timestamp->timestamp}
   IDriver                     GenericSQLIDriverMixin
   ISyncDriverTableFKs         GenericSQLISyncDriverTableFKsMixin
   ISyncDriverFieldAvgLength   GenericSQLISyncDriverFieldAvgLengthMixin

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -86,7 +86,8 @@
 (extend MySQLDriver
   ISqlDriverDatabaseSpecific  {:connection-details->connection-spec connection-details->connection-spec
                                :database->connection-details        database->connection-details
-                               :unix-timestamp->timestamp           unix-timestamp->timestamp}
+                               :unix-timestamp->timestamp           unix-timestamp->timestamp
+                               :timezone->set-timezone-sql          timezone->set-timezone-sql}
   IDriver                     GenericSQLIDriverMixin
   ISyncDriverTableFKs         GenericSQLISyncDriverTableFKsMixin
   ISyncDriverFieldAvgLength   GenericSQLISyncDriverFieldAvgLengthMixin

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -102,10 +102,10 @@
                          port))
         (rename-keys {:dbname :db}))))
 
-(defn- unix-timestamp->date [_ field-or-value seconds-or-milliseconds]
+(defn- unix-timestamp->timestamp [_ field-or-value seconds-or-milliseconds]
   (utils/func (case seconds-or-milliseconds
                 :seconds      "TO_TIMESTAMP(%s)"
-                :milliseconds "TO_TIMESTAMP(%s * 1000)")
+                :milliseconds "TO_TIMESTAMP(%s / 1000)")
               [field-or-value]))
 
 (defn- timezone->set-timezone-sql [_ timezone]
@@ -124,7 +124,7 @@
 (extend PostgresDriver
   ISqlDriverDatabaseSpecific   {:connection-details->connection-spec connection-details->connection-spec
                                 :database->connection-details        database->connection-details
-                                :unix-timestamp->date                unix-timestamp->date
+                                :unix-timestamp->timestamp           unix-timestamp->timestamp
                                 :timezone->set-timezone-sql          timezone->set-timezone-sql}
   ISyncDriverSpecificSyncField {:driver-specific-sync-field!         driver-specific-sync-field!}
   IDriver                      GenericSQLIDriverMixin

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -34,26 +34,6 @@
     :url
     :zip_code})
 
-(def ^:const special-type->name
-  "User-facing names for the `Field` special types."
-  {:avatar            "Avatar Image URL"
-   :category          "Category"
-   :city              "City"
-   :country           "Country"
-   :desc              "Description"
-   :fk                "Foreign Key"
-   :id                "Entity Key"
-   :image             "Image URL"
-   :json              "Field containing JSON"
-   :latitude          "Latitude"
-   :longitude         "Longitude"
-   :name              "Entity Name"
-   :number            "Number"
-   :state             "State"
-   :timestamp_seconds "Timestamp - seconds since 1970"
-   :url               "URL"
-   :zip_code          "Zip Code"})
-
 (def ^:const base-types
   "Possible values for `Field.base_type`."
   #{:BigIntegerField

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -8,7 +8,11 @@
             [clj-time.coerce :as coerce])
   (:import (java.net Socket
                      InetSocketAddress
-                     InetAddress)))
+                     InetAddress)
+           java.sql.Timestamp
+           javax.xml.bind.DatatypeConverter))
+
+(set! *warn-on-reflection* true)
 
 (defmacro -assoc*
   "Internal. Don't use this directly; use `assoc*` instead."
@@ -33,45 +37,33 @@
   "`java.sql.Date` doesn't have an empty constructor so this is a convenience that lets you make one with the current date.
    (Some DBs like Postgres will get snippy if you don't use a `java.sql.Timestamp`)."
   []
-  (java.sql.Timestamp. (System/currentTimeMillis)))
+  (Timestamp. (System/currentTimeMillis)))
 
+;; Actually this only supports [RFC 3339](https://tools.ietf.org/html/rfc3339), which is basically a subset of ISO 8601
 (defn parse-iso8601
-  "Parse a string value expected in the iso8601 format into a `java.sql.Date`."
-  ^java.sql.Date
+  "Parse a string value expected in the iso8601 format into a `java.sql.Timestamp`.
+   NOTE: `YYYY-MM-DD` dates *are* valid iso8601 dates."
+  ^java.sql.Timestamp
   [^String datetime]
   (some->> datetime
-           (time/parse (time/formatters :date-time))
-           (coerce/to-long)
-           (java.sql.Date.)))
+           DatatypeConverter/parseDateTime
+           .getTime     ; Calendar -> Date
+           .getTime     ; Date -> ms
+           Timestamp.))
 
 (def ^:private ^java.text.SimpleDateFormat yyyy-mm-dd-simple-date-format
   (java.text.SimpleDateFormat. "yyyy-MM-dd"))
-
-(defn parse-date-yyyy-mm-dd
-  "Parse a date in the `yyyy-mm-dd` format and return a `java.sql.Date`."
-  ^java.sql.Date [^String date]
-  (-> (.parse yyyy-mm-dd-simple-date-format date)
-      .getTime
-      java.sql.Date.))
 
 (defn date->yyyy-mm-dd
   "Convert a date to a `YYYY-MM-DD` string."
   ^String [^java.util.Date date]
   (.format yyyy-mm-dd-simple-date-format date))
 
-(defn date-yyyy-mm-dd->unix-timestamp
-  "Convert a string DATE in the `YYYY-MM-DD` format to a Unix timestamp in seconds."
-  ^Float [^String date]
-  (-> date
-      parse-date-yyyy-mm-dd
-      .getTime
-      (/ 1000)))
-
 (defn date-string?
-  "Is S a valid [RFC 3339](https://tools.ietf.org/html/rfc3339) date string?"
+  "Is S a valid ISO 8601 date string?"
   [s]
   (boolean (when (string? s)
-             (try (parse-rfc-3339 s)
+             (try (parse-iso8601 s)
                   (catch Throwable e)))))
 
 (defn now-iso8601

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -33,9 +33,7 @@
   "`java.sql.Date` doesn't have an empty constructor so this is a convenience that lets you make one with the current date.
    (Some DBs like Postgres will get snippy if you don't use a `java.sql.Timestamp`)."
   []
-  (-> (java.util.Date.)
-      .getTime
-      (java.sql.Timestamp.)))
+  (java.sql.Timestamp. (System/currentTimeMillis)))
 
 (defn parse-iso8601
   "Parse a string value expected in the iso8601 format into a `java.sql.Date`."
@@ -68,6 +66,13 @@
       parse-date-yyyy-mm-dd
       .getTime
       (/ 1000)))
+
+(defn date-string?
+  "Is S a valid [RFC 3339](https://tools.ietf.org/html/rfc3339) date string?"
+  [s]
+  (boolean (when (string? s)
+             (try (parse-rfc-3339 s)
+                  (catch Throwable e)))))
 
 (defn now-iso8601
   "format the current time as iso8601 date/time string."

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -6,7 +6,8 @@
                              [common :as common])
             [metabase.test.data :refer :all]
             [metabase.test.data.users :refer :all]
-            [metabase.test.util :refer [match-$ expect-eval-actual-first random-name with-temp]]))
+            [metabase.test.util :refer [match-$ expect-eval-actual-first random-name with-temp]]
+            [metabase.test.util.q :refer [Q-expand]]))
 
 ;; # CARD LIFECYCLE
 
@@ -17,13 +18,7 @@
                                            :can_read               true
                                            :can_write              true
                                            :display                "scalar"
-                                           :dataset_query          {:type     "query"
-                                                                    :query    {:source_table (id :categories)
-                                                                               :filter       [nil nil]
-                                                                               :aggregation  ["count"]
-                                                                               :breakout     [nil]
-                                                                               :limit        nil}
-                                                                    :database (db-id)}
+                                           :dataset_query          (Q-expand aggregate count of categories)
                                            :visualization_settings {:global {:title nil}}}))
 
 ;; ## GET /api/card
@@ -54,13 +49,7 @@
                                :name card-name
                                :creator_id (user->id :rasta)
                                :updated_at $
-                               :dataset_query {:type "query"
-                                               :query {:source_table (id :categories)
-                                                       :filter [nil nil]
-                                                       :aggregation ["count"]
-                                                       :breakout [nil]
-                                                       :limit nil}
-                                               :database (db-id)}
+                               :dataset_query (Q-expand aggregate count of categories)
                                :id $
                                :display "scalar"
                                :visualization_settings {:global {:title nil}}
@@ -89,13 +78,7 @@
                      :email "rasta@metabase.com",
                      :id $})
          :updated_at $
-         :dataset_query {:type "query"
-                         :query {:source_table (id :categories)
-                                 :filter [nil nil]
-                                 :aggregation ["count"]
-                                 :breakout [nil]
-                                 :limit nil}
-                         :database (db-id)}
+         :dataset_query (Q-expand aggregate count of categories)
          :id $
          :display "scalar"
          :visualization_settings {:global {:title nil}}

--- a/test/metabase/api/dash_test.clj
+++ b/test/metabase/api/dash_test.clj
@@ -11,7 +11,8 @@
                              [user :refer [User]])
             [metabase.test.data :refer :all]
             [metabase.test.data.users :refer :all]
-            [metabase.test.util :refer [match-$ expect-eval-actual-first random-name with-temp]]))
+            [metabase.test.util :refer [match-$ expect-eval-actual-first random-name with-temp]]
+            [metabase.test.util.q :refer [Q-expand]]))
 
 ;; # DASHBOARD LIFECYCLE
 
@@ -120,13 +121,7 @@
                      :name $
                      :creator_id (user->id :rasta)
                      :updated_at $
-                     :dataset_query {:database (db-id)
-                                     :query {:limit nil
-                                             :breakout [nil]
-                                             :aggregation ["count"]
-                                             :filter [nil nil]
-                                             :source_table (id :categories)}
-                                     :type "query"}
+                     :dataset_query (Q-expand aggregate count of categories)
                      :id card-id
                      :display "scalar"
                      :visualization_settings {:global {:title nil}}

--- a/test/metabase/api/meta/dataset_test.clj
+++ b/test/metabase/api/meta/dataset_test.clj
@@ -6,7 +6,8 @@
             [metabase.models.query-execution :refer [QueryExecution]]
             [metabase.test.data :refer :all]
             [metabase.test.data.users :refer :all]
-            [metabase.test.util :refer [match-$ expect-eval-actual-first]]))
+            [metabase.test.util :refer [match-$ expect-eval-actual-first]]
+            [metabase.test.util.q :refer [Q-expand]]))
 
 ;;; ## POST /api/meta/dataset
 ;; Just a basic sanity check to make sure Query Processor endpoint is still working correctly.
@@ -20,13 +21,7 @@
        :status    "completed"
        :id        $
        :uuid      $})
-  ((user->client :rasta) :post 200 "meta/dataset" {:database (db-id)
-                                                   :type     "query"
-                                                   :query    {:aggregation  ["count"]
-                                                              :breakout     [nil]
-                                                              :filter       [nil nil]
-                                                              :limit        nil
-                                                              :source_table (id :checkins)}}))
+  ((user->client :rasta) :post 200 "meta/dataset" (Q-expand aggregate count of checkins)))
 
 ;; Even if a query fails we still expect a 200 response from the api
 (expect-eval-actual-first

--- a/test/metabase/driver/query_processor_test.clj
+++ b/test/metabase/driver/query_processor_test.clj
@@ -770,41 +770,24 @@
 
 
 ;;; Unix timestamp breakouts -- SQL only
-(let [do-query (fn [] (->> (Q dataset sad-toucan-incidents
-                              aggregate count of incidents
-                              breakout timestamp
-                              limit 10
-                              return rows)
-                           (map (fn [[^java.util.Date date count]]
-                                  [(.toString date) (int count)]))))]
-
-  (datasets/expect-with-dataset :h2
-    [["2015-06-01" 6]
-     ["2015-06-02" 9]
-     ["2015-06-03" 5]
-     ["2015-06-04" 9]
-     ["2015-06-05" 8]
-     ["2015-06-06" 9]
-     ["2015-06-07" 8]
-     ["2015-06-08" 9]
-     ["2015-06-09" 7]
-     ["2015-06-10" 8]]
-    (do-query))
-
-  ;; postgres gives us *slightly* different answers because I think it's actually handling UNIX timezones properly (with timezone = UTC)
-  ;; as opposed to H2 which is giving us the wrong timezome. TODO - verify this
-  (datasets/expect-with-dataset :postgres
-    [["2015-06-01" 8]
-     ["2015-06-02" 9]
-     ["2015-06-03" 9]
-     ["2015-06-04" 4]
-     ["2015-06-05" 11]
-     ["2015-06-06" 8]
-     ["2015-06-07" 6]
-     ["2015-06-08" 10]
-     ["2015-06-09" 6]
-     ["2015-06-10" 10]]
-    (do-query)))
+(datasets/expect-with-datasets #{:h2 :postgres :mysql}
+  [["2015-06-01" 8]
+   ["2015-06-02" 9]
+   ["2015-06-03" 9]
+   ["2015-06-04" 4]
+   ["2015-06-05" 11]
+   ["2015-06-06" 8]
+   ["2015-06-07" 6]
+   ["2015-06-08" 10]
+   ["2015-06-09" 6]
+   ["2015-06-10" 10]]
+  (->> (Q dataset sad-toucan-incidents
+          aggregate count of incidents
+          breakout timestamp
+          limit 10
+          return rows)
+       (map (fn [[^java.util.Date date count]]
+              [(.toString date) (int count)]))))
 
 
 ;; +------------------------------------------------------------------------------------------------------------------------+

--- a/test/metabase/driver/query_processor_test.clj
+++ b/test/metabase/driver/query_processor_test.clj
@@ -757,10 +757,7 @@
 
 ;; There were 9 "sad toucan incidents" on 2015-06-02
 (datasets/expect-with-datasets #{:h2 :postgres :mysql}
-  (datasets/dataset-case
-    :h2       9
-    :postgres 9
-    :mysql    10) ; not sure exactly these disagree
+  9
   (Q dataset sad-toucan-incidents
      of incidents
      filter and > timestamp "2015-06-01"

--- a/test/metabase/driver/sync_test.clj
+++ b/test/metabase/driver/sync_test.clj
@@ -176,9 +176,8 @@
   :json
   (with-temp-db
     [_
-     (dataset-loader)
      (create-database-definition "Postgres with a JSON Field"
        ["venues"
         [{:field-name "address", :base-type {:native "json"}}]
         [[(k/raw "to_json('{\"street\": \"431 Natoma\", \"city\": \"San Francisco\", \"state\": \"CA\", \"zip\": 94103}'::text)")]]])]
-    (sel :one :field [Field :special_type] :id &venues.address:id)))
+    (sel :one :field [Field :special_type] :id (id :venues :address))))

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -20,62 +20,47 @@
                                          FieldDefinition
                                          TableDefinition)))
 
-;; ## Dataset-Independent Data Fns
-;; These functions offer a generic way to get bits of info like Table + Field IDs from any of our
-;; many driver/dataset combos. Internally, these call the implementations of the current dataset, which
-;; is bound to *dataset*. By default, this is bound to the Generic SQL Default Dataset; you can swap it
-;; put with the macro `with-dataset`.
-;;
-;; A suite of macros exist in `metabase.test.data.datasets` that let you write a unit test once and have
-;; it run against many drivers. The take care of establishing the correct bindings; you can use these
-;; functions seamlessly when writing such tests.
-(defn id
-  "Return the ID of a `Table` or `Field` for the current driver data set."
+(declare temp-get)
+
+(def ^:private ^:dynamic *temp-db* nil)
+
+;;; ## ---------------------------------------- Dataset-Independent Data Fns ----------------------------------------
+;; These functions offer a generic way to get bits of info like Table + Field IDs from any of our many driver/dataset combos.
+
+(defn- default-dataset-get
   ([table-name]
-   {:pre [*dataset*
-          (keyword? table-name)]
-    :post [(integer? %)]}
    (datasets/table-name->id *dataset* table-name))
   ([table-name field-name]
-   {:pre [*dataset*
-          (keyword? table-name)
-          (keyword? field-name)]
-    :post [(integer? %)]}
    (datasets/field-name->id *dataset* table-name field-name)))
 
+(defn id
+  "Return the ID of a `Table` or `Field` for the current driver / dataset."
+  {:arglists '([table-name]
+               [table-name field-name]
+               [table-name parent-field-name & nested-field-names])}
+  [& args]
+  {:pre [(every? keyword? args)]
+   :post [(integer? %)]}
+  (apply (if *temp-db* (comp :id temp-get)
+             default-dataset-get)
+         args))
+
 (defn db []
-  {:pre [*dataset*]
-   :post [(map? %)]}
-  (datasets/db *dataset*))
+  {:post [(map? %)]}
+  (if *temp-db*
+    *temp-db*
+    (datasets/db *dataset*)))
 
 (defn db-id []
-  {:pre  [*dataset*]
-   :post [(integer? %)]}
-  (:id (datasets/db *dataset*)))
+  {:post [(integer? %)]}
+  (:id (db)))
 
-;; (defn fetch-table [table-name]
-;;   {:pre [*dataset*
-;;          (keyword? table-name)]
-;;    :post [(map? %)]}
-;;   (datasets/table-name->table *dataset* table-name))
-
-(defn fks-supported? []
-  (datasets/fks-supported? *dataset*))
-
-(defn format-name [name]
-  (datasets/format-name *dataset* name))
-
-(defn id-field-type []
-  (datasets/id-field-type *dataset*))
-
-(defn sum-field-type []
-  (datasets/sum-field-type *dataset*))
-
-(defn timestamp-field-type []
-  (datasets/timestamp-field-type *dataset*))
-
-(defn dataset-loader []
-  (datasets/dataset-loader *dataset*))
+(defn fks-supported? []       (datasets/fks-supported? *dataset*))
+(defn format-name [name]      (datasets/format-name *dataset* name))
+(defn id-field-type []        (datasets/id-field-type *dataset*))
+(defn sum-field-type []       (datasets/sum-field-type *dataset*))
+(defn timestamp-field-type [] (datasets/timestamp-field-type *dataset*))
+(defn dataset-loader []       (datasets/dataset-loader *dataset*))
 
 
 ;; ## Loading / Deleting Test Datasets
@@ -139,9 +124,7 @@
 
 
 ;; ## Temporary Dataset Macros
-
 ;; The following functions are used internally by with-temp-db to implement easy Table/Field lookup
-;; with `$table` and `$table.field` forms.
 
 (defn- table-id->field-name->field
   "Return a map of lowercased `Field` names -> fields for `Table` with TABLE-ID."
@@ -162,91 +145,69 @@
        (m/map-keys s/lower-case)
        (m/map-vals #(assoc % :field-name->field (delay (table-id->field-name->field (:id %)))))))
 
-(defn -temp-db-add-getter-delay
+(defn- temp-db-add-getter-delay
   "Add a delay `:table-name->table` to DB that calls `db-id->table-name->table`."
   [db]
   (assoc db :table-name->table (delay (db-id->table-name->table (:id db)))))
 
-(defn -temp-get
+
+(defn temp-get
   "Internal - don't call this directly.
    With two args, fetch `Table` with TABLE-NAME using `:table-name->table` delay on TEMP-DB.
    With three args, fetch `Field` with FIELD-NAME by recursively fetching `Table` and using its `:field-name->field` delay."
-  ([temp-db table-name]
-   {:pre [(map? temp-db)
-          (string? table-name)]
-    :post [(or (map? %) (assert nil (format "Couldn't find table '%s'.\nValid choices are: %s" table-name
-                                            (vec (keys @(:table-name->table temp-db))))))]}
-   (@(:table-name->table temp-db) table-name))
+  ([table-name]
+   {:pre [*temp-db*]
+    :post [(or (map? %) (assert nil (format "Couldn't find table '%s'.\nValid choices are: %s" (name table-name)
+                                            (vec (keys @(:table-name->table *temp-db*))))))]}
+   (@(:table-name->table *temp-db*) (name table-name)))
 
-  ([temp-db table-name field-name]
-   {:pre [(string? field-name)]
-    :post [(or (map? %) (assert nil (format "Couldn't find field '%s.%s'.\nValid choices are: %s" table-name field-name
-                                            (vec (keys @(:field-name->field (-temp-get temp-db table-name)))))))]}
-   (@(:field-name->field (-temp-get temp-db table-name)) field-name))
+  ([table-name field-name]
+   {:post [(or (map? %) (assert nil (format "Couldn't find field '%s.%s'.\nValid choices are: %s" (name table-name) (name field-name)
+                                            (vec (keys @(:field-name->field (temp-get table-name)))))))]}
+   (@(:field-name->field (temp-get table-name)) (name field-name)))
 
-  ([temp-db table-name parent-field-name & nested-field-names]
-   {:pre [(every? string? nested-field-names)]
-    :post [(or (map? %) (assert nil (format "Couldn't find nested field '%s.%s.%s'.\nValid choices are: %s" table-name parent-field-name
-                                            (apply str (interpose "." nested-field-names))
-                                            (vec (map :name @(:children (apply -temp-get temp-db table-name parent-field-name (butlast nested-field-names))))))))]}
+  ([table-name parent-field-name & nested-field-names]
+   {:post [(or (map? %) (assert nil (format "Couldn't find nested field '%s.%s.%s'.\nValid choices are: %s" (name table-name) (name parent-field-name)
+                                            (apply str (interpose "." (map name nested-field-names)))
+                                            (vec (map :name @(:children (apply temp-get table-name parent-field-name (butlast nested-field-names))))))))]}
    (binding [*sel-disable-logging* true]
-     (let [parent            (apply -temp-get temp-db table-name parent-field-name (butlast nested-field-names))
+     (let [parent            (apply temp-get table-name parent-field-name (some-> (butlast nested-field-names)
+                                                                                  name))
            children          @(:children parent)
            child-name->child (zipmap (map :name children) children)]
-       (child-name->child (last nested-field-names))))))
+       (child-name->child (name (last nested-field-names)))))))
 
-(defn- walk-expand-&
-  "Walk BODY looking for symbols like `&table` or `&table.field` and expand them to appropriate `-temp-get` forms.
-   If symbol ends in a `:field` form, wrap the call to `-temp-get` in call in a keyword getter for that field.
 
-    &sightings      -> (-temp-get db \"sightings\")
-    &cities.name    -> (-temp-get db \"cities\" \"name\")
-    &cities.name:id -> (:id (-temp-get db \"cities\" \"name\"))"
-  [db-binding body]
-  (walk/prewalk
-   (fn [form]
-     (or (when (symbol? form)
-           (when-let [[_ table-name field-name prop-name] (re-matches #"^&([^.:]+)(?:\.([^.:]+))?(?::([^.:]+))?$" (name form))]
-             (let [temp-get `(-temp-get ~db-binding ~table-name ~@(when field-name [field-name]))]
-               (if prop-name `(~(keyword prop-name) ~temp-get)
-                   temp-get))))
-         form))
-   body))
-
-(defn -with-temp-db [loader ^DatabaseDefinition dbdef f]
-  (let [dbdef (map->DatabaseDefinition (assoc dbdef :short-lived? true))]
+(defn -with-temp-db [^DatabaseDefinition dbdef f]
+  (let [loader (dataset-loader)
+        dbdef  (map->DatabaseDefinition (assoc dbdef :short-lived? true))]
     (try
       (binding [*sel-disable-logging* true]
         (remove-database! loader dbdef)
         (let [db (-> (get-or-create-database! loader dbdef)
-                     -temp-db-add-getter-delay)]
+                     temp-db-add-getter-delay)]
           (assert db)
           (assert (exists? Database :id (:id db)))
-          (binding [*sel-disable-logging* false]
+          (binding [*temp-db*             db
+                    *sel-disable-logging* false]
             (f db))))
       (finally
         (binding [*sel-disable-logging* true]
           (remove-database! loader dbdef))))))
+
 
 (defmacro with-temp-db
   "Load and sync DATABASE-DEFINITION with DATASET-LOADER and execute BODY with
    the newly created `Database` bound to DB-BINDING.
    Remove `Database` and destroy data afterward.
 
-   Within BODY, symbols like `&table` and `&table.field` will be expanded into function calls to
-   fetch corresponding `Tables` and `Fields`. Symbols like `&table:id` wrap a getter around the resulting
-   forms (see `walk-expand-&` for details).
-
-   These are accessed via lazily-created maps of Table/Field names to the objects themselves.
-   To facilitate mutli-driver tests, these names are lowercased.
-
-     (with-temp-db [db (h2/dataset-loader) us-history-1607-to-1774]
+     (with-temp-db [db tupac-sightings]
        (driver/process-quiery {:database (:id db)
                                :type     :query
                                :query    {:source_table (:id &events)
                                           :aggregation  [\"count\"]
                                           :filter       [\"<\" (:id &events.timestamp) \"1765-01-01\"]}}))"
-  [[db-binding dataset-loader ^DatabaseDefinition database-definition] & body]
-  `(-with-temp-db ~dataset-loader ~database-definition
+  [[db-binding ^DatabaseDefinition database-definition] & body]
+  `(-with-temp-db ~database-definition
      (fn [~db-binding]
-       ~@(walk-expand-& db-binding body))))
+       ~@body)))

--- a/test/metabase/test/data/generic_sql.clj
+++ b/test/metabase/test/data/generic_sql.clj
@@ -2,13 +2,19 @@
   "Common functionality for various Generic SQL dataset loaders."
   (:require [clojure.tools.logging :as log]
             [korma.core :as k]
-            [metabase.driver.generic-sql.interface :refer [quote-name]]
             [metabase.test.data.interface :as i])
   (:import (metabase.test.data.interface DatabaseDefinition
                                          TableDefinition)))
 
+(defn- quote-name [{:keys [quote-character], :or {quote-character \"}} nm]
+  (str quote-character nm quote-character))
+
 (defprotocol IGenericSQLDatasetLoader
-  "Methods that generic SQL dataset loaders should implement so they can use the shared functions in `metabase.test.data.generic-sql`."
+  "Methods that generic SQL dataset loaders should implement so they can use the shared functions in `metabase.test.data.generic-sql`.
+
+   (Optional) Properies:
+
+   *  `quote-character`: Character to use to quote table & field names in raw SQL. Defaults to double-quote."
   (execute-sql! [this ^DatabaseDefinition database-definition ^String raw-sql]
     "Execute RAW-SQL against  database defined by DATABASE-DEFINITION.")
 

--- a/test/metabase/test/data/mysql.clj
+++ b/test/metabase/test/data/mysql.clj
@@ -5,7 +5,6 @@
             [environ.core :refer [env]]
             (korma [core :as k]
                    [db :as kdb])
-            [metabase.driver.generic-sql.interface :refer [ISqlDriverQuoteName quote-name]]
             (metabase.test.data [generic-sql :as generic]
                                 [interface :refer :all]))
   (:import (metabase.test.data.interface DatabaseDefinition
@@ -63,11 +62,7 @@
 
   (generic/field-base-type->sql-type [_ field-type]
     (if (map? field-type) (:native field-type)
-        (field-base-type->sql-type field-type)))
-
-  ISqlDriverQuoteName
-  (quote-name [_ nm]
-    (str \` nm \`)))
+        (field-base-type->sql-type field-type))))
 
 (extend-protocol IDatasetLoader
   MySQLDatasetLoader
@@ -102,4 +97,4 @@
 
 
 (defn dataset-loader []
-  (MySQLDatasetLoader.))
+  (map->MySQLDatasetLoader {:quote-character \`}))

--- a/test/metabase/test/util/q.clj
+++ b/test/metabase/test/util/q.clj
@@ -1,4 +1,5 @@
 (ns metabase.test.util.q
+  "See https://github.com/metabase/metabase-init/wiki/Q-Cheatsheet"
   (:refer-clojure :exclude [or and filter use = != < > <= >=])
   (:require [clojure.core :as core]
             [clojure.core.match :refer [match]]
@@ -34,21 +35,7 @@
 
 ;;; ## ID LOOKUP
 
-(def ^:dynamic *db* nil)
 (def ^:dynamic *table-name* nil)
-
-(defn db-id []
-  {:post [(integer? %)]}
-  (core/or (:id *db*)
-              (data/db-id)))
-
-(defn id [& args]
-  {:pre [(every? keyword? args)]
-   :post [(core/or (integer? %)
-                      (println (str "Couldn't find ID of: " args)))]}
-  (if *db*
-    (:id (apply data/-temp-get *db* (map name args)))
-    (apply data/id args)))
 
 (defmacro field [f]
   {:pre [(symbol? f)]}
@@ -69,10 +56,10 @@
 
       ;; table.field <-> (id table field)
       [[_ table field] (re-matches #"^([^\.]+)\.([^\.]+)$" f)]
-      `(id ~(keyword table) ~(keyword field))))
+      `(data/id ~(keyword table) ~(keyword field))))
 
    ;; fallback : (id *table-name* field)
-   `(id *table-name* ~(keyword f))))
+   `(data/id *table-name* ~(keyword f))))
 
 (defn resolve-dataset [dataset]
   (var-get (core/or (resolve dataset)
@@ -92,7 +79,7 @@
 
 (defmacro of [query table-name]
   (-> query
-      (assoc-in [:query :source_table] `(id ~(keyword table-name)))
+      (assoc-in [:query :source_table] `(data/id ~(keyword table-name)))
       (assoc-in [:context :table-name] (keyword table-name))))
 
 
@@ -206,7 +193,8 @@
        (core/filter seq)))
 
 (defmacro filter* [& args]
-  (first (filter-split args)))
+  (let [[filter-clause & more] (filter-split args)]
+    `(~@filter-clause ~@more)))
 
 (defmacro filter [query & args]
   (assoc-in query [:query :filter] `(filter* ~@args)))
@@ -249,9 +237,8 @@
 (defmacro with-temp-db [dataset query]
   (if-not dataset
     query
-    `(data/with-temp-db [db# (data/dataset-loader) (resolve-dataset ~dataset)]
-       (binding [*db* db#]
-         ~query))))
+    `(data/with-temp-db [~'_ (resolve-dataset ~dataset)]
+       ~query)))
 
 (defmacro with-driver [driver query]
   (if-not driver
@@ -259,25 +246,36 @@
     `(datasets/with-dataset ~driver
        ~query)))
 
-(defmacro Q** [{:keys [driver dataset return table-name]} query]
+(defmacro Q*** [f {:keys [driver dataset return table-name]} query]
   (assert table-name
     "Table name not specified in query, did you include an 'of' clause?")
   `(do (db/setup-db-if-needed)
        (->> (with-driver ~driver
               (binding [*table-name* ~table-name]
                 (with-temp-db ~dataset
-                  (driver/process-query ~query))))
+                  (~f ~query))))
             ~@return)))
 
-(defmacro Q* [q & [form & more]]
+(defmacro Q** [f q & [form & more]]
   (if-not form
-    `(Q** ~(:context q) ~(dissoc q :context))
-    `(Q* ~(macroexpand `(-> ~q ~form)) ~@more)))
+    `(Q*** ~f ~(:context q) ~(dissoc q :context))
+    `(Q** ~f ~(macroexpand `(-> ~q ~form)) ~@more)))
 
-(defmacro Q [& args]
-  `(Q* {:database (db-id)
-         :type     :query
+(defmacro Q* [f & args]
+  `(Q** ~f
+        {:database (data/db-id)
+         :type     "query"
          :query    {}
          :context  {:driver  nil
                     :dataset nil}}
         ~@(split-with-tokens top-level-tokens args)))
+
+(defmacro Q
+  "Expand and run a query written with the `Q` shorthand DSL."
+  [& args]
+  `(Q* driver/process-query ~@args))
+
+(defmacro Q-expand
+  "Expand (without running) a query written with the `Q` shorthand DSL."
+  [& args]
+  `(Q* identity ~@args))


### PR DESCRIPTION
I've been working on the date stuff off and on for 3 weeks or so and I ended up fixing and refactoring a lot of little things along the way. I broke those changes out into this PR some I can merge this in and have a more focused PR for adding the date stuff.

Highlights:
-  Un-memoize the driver lookup functions in `metabase.driver`. They didn't really save more than a millisecond or two and they broke automatic dependecy reloading in dev. Changing `metabase.driver.postgres` for example would sometimes require you to reload `metabase.driver` as well
- I figured out how to write custom korma operators (i.e. prepared function calls), which means we don't need to inject bits of raw SQL into queries we generate any more. We can let korma do more of the heavy lifting, like handling quoting table & field names; I was able to remove the `ISQLDriverQuoteName` protocol as a result. 
-  Learned about the existence of MySQL's `FROM_UNIXTIME()` and Postgres' `TO_TIMESTAP()` functions, simplifying unix timestamp support a lot

etc
