### PR TITLE
Remove old is_creator checks for editing cards

### DIFF
--- a/resources/frontend_client/app/card/card.controllers.js
+++ b/resources/frontend_client/app/card/card.controllers.js
@@ -782,13 +782,6 @@ CardControllers.controller('CardDetail', [
         }
 
         function setCard(result, options = {}) {
-            // when loading an existing card for viewing, mark when the card creator is our current user
-            // TODO: there may be a better way to maintain this, but it seemed worse to inject currentUser
-            //       into a bunch of our react models and then bury this conditional in react component code
-            if (result.creator_id === $scope.user.id) {
-                result.is_creator = true;
-            }
-
             // update our react models as needed
             card = result;
 

--- a/resources/frontend_client/app/query_builder/query_header.react.js
+++ b/resources/frontend_client/app/query_builder/query_header.react.js
@@ -228,8 +228,8 @@ export default React.createClass({
             <Header
                 objectType="question"
                 item={this.props.card}
-                isEditing={!this.props.cardIsNewFn() && this.props.card.is_creator}
-                isEditingInfo={!this.props.cardIsNewFn() && this.props.card.is_creator}
+                isEditing={!this.props.cardIsNewFn()}
+                isEditingInfo={!this.props.cardIsNewFn()}
                 headerButtons={this.getHeaderButtons()}
                 editingTitle="You are editing a saved question"
                 editingSubtitle={subtitleText}


### PR DESCRIPTION
Fixes not being able to see the edit header if you didn't create a card.
