### PR TITLE
Remove deprecated use of React.addons.classSet in favor of 'classnames' package

### DIFF
--- a/resources/frontend_client/app/components/ActionButton.react.js
+++ b/resources/frontend_client/app/components/ActionButton.react.js
@@ -3,7 +3,7 @@
 
 import Icon from "metabase/components/Icon.react";
 
-var cx = React.addons.classSet;
+import cx from "classnames";
 
 export default React.createClass({
     displayName: 'ActionButton',

--- a/resources/frontend_client/app/components/ColumnarSelector.react.js
+++ b/resources/frontend_client/app/components/ColumnarSelector.react.js
@@ -2,7 +2,7 @@
 
 import Icon from "metabase/components/Icon.react";
 
-var cx = React.addons.classSet;
+import cx from "classnames";
 
 export default React.createClass({
     displayName: "ColumnarSelector",

--- a/resources/frontend_client/app/components/CreateDashboardModal.react.js
+++ b/resources/frontend_client/app/components/CreateDashboardModal.react.js
@@ -3,7 +3,7 @@
 import FormField from "metabase/components/FormField.react";
 import ModalContent from "metabase/components/ModalContent.react";
 
-var cx = React.addons.classSet;
+import cx from "classnames";
 
 export default React.createClass({
     displayName: "CreateDashboardModal",

--- a/resources/frontend_client/app/components/FormField.react.js
+++ b/resources/frontend_client/app/components/FormField.react.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var cx = React.addons.classSet;
+import cx from "classnames";
 
 export default React.createClass({
     displayName: 'FormField',

--- a/resources/frontend_client/app/components/SaveQuestionModal.react.js
+++ b/resources/frontend_client/app/components/SaveQuestionModal.react.js
@@ -5,7 +5,7 @@ import ModalContent from "metabase/components/ModalContent.react";
 
 import Query from "metabase/lib/query";
 
-var cx = React.addons.classSet;
+import cx from "classnames";
 
 export default React.createClass({
     displayName: "SaveQuestionModal",

--- a/resources/frontend_client/app/query_builder/AddToDashboardPopover.react.js
+++ b/resources/frontend_client/app/query_builder/AddToDashboardPopover.react.js
@@ -6,7 +6,7 @@ import OnClickOutside from 'react-onclickoutside';
 import FormField from "metabase/components/FormField.react";
 import Icon from "metabase/components/Icon.react";
 
-var cx = React.addons.classSet;
+import cx from "classnames";
 
 export default React.createClass({
     displayName: 'AddToDashboardPopover',

--- a/resources/frontend_client/app/query_builder/Calendar.react.js
+++ b/resources/frontend_client/app/query_builder/Calendar.react.js
@@ -2,7 +2,7 @@
 
 import Icon from "metabase/components/Icon.react";
 
-var cx = React.addons.classSet;
+import cx from "classnames";
 
 export default React.createClass({
     displayName: "Calendar",

--- a/resources/frontend_client/app/query_builder/CardFavoriteButton.react.js
+++ b/resources/frontend_client/app/query_builder/CardFavoriteButton.react.js
@@ -2,7 +2,7 @@
 
 import Icon from "metabase/components/Icon.react";
 
-var cx = React.addons.classSet;
+import cx from "classnames";
 
 export default React.createClass({
     displayName: 'CardFavoriteButton',

--- a/resources/frontend_client/app/query_builder/DataReferenceField.react.js
+++ b/resources/frontend_client/app/query_builder/DataReferenceField.react.js
@@ -5,7 +5,7 @@ import Icon from "metabase/components/Icon.react";
 import Query from "metabase/lib/query";
 import inflection from 'inflection';
 
-var cx = React.addons.classSet;
+import cx from "classnames";
 
 export default React.createClass({
     displayName: 'DataReferenceField',

--- a/resources/frontend_client/app/query_builder/DataReferenceMain.react.js
+++ b/resources/frontend_client/app/query_builder/DataReferenceMain.react.js
@@ -2,7 +2,7 @@
 
 import inflection from 'inflection';
 
-var cx = React.addons.classSet;
+import cx from "classnames";
 
 export default React.createClass({
     displayName: 'DataReferenceMain',

--- a/resources/frontend_client/app/query_builder/DataReferenceTable.react.js
+++ b/resources/frontend_client/app/query_builder/DataReferenceTable.react.js
@@ -3,7 +3,7 @@
 import DataReferenceQueryButton from './DataReferenceQueryButton.react';
 
 import inflection from 'inflection';
-var cx = React.addons.classSet;
+import cx from "classnames";
 
 export default React.createClass({
     displayName: 'DataReferenceTable',

--- a/resources/frontend_client/app/query_builder/FieldName.react.js
+++ b/resources/frontend_client/app/query_builder/FieldName.react.js
@@ -5,7 +5,7 @@ import Icon from "metabase/components/Icon.react";
 
 import Query from "metabase/lib/query";
 
-var cx = React.addons.classSet;
+import cx from "classnames";
 
 export default React.createClass({
     displayName: "FieldName",

--- a/resources/frontend_client/app/query_builder/FilterWidget.react.js
+++ b/resources/frontend_client/app/query_builder/FilterWidget.react.js
@@ -11,7 +11,7 @@ import ColumnarSelector from "metabase/components/ColumnarSelector.react";
 import Query from "metabase/lib/query";
 import moment from 'moment';
 
-var cx = React.addons.classSet;
+import cx from "classnames";
 
 export default React.createClass({
     displayName: 'FilterWidget',

--- a/resources/frontend_client/app/query_builder/GuiQueryEditor.react.js
+++ b/resources/frontend_client/app/query_builder/GuiQueryEditor.react.js
@@ -12,7 +12,7 @@ import PopoverWithTrigger from "metabase/components/PopoverWithTrigger.react";
 import MetabaseAnalytics from 'metabase/lib/analytics';
 import Query from "metabase/lib/query";
 
-var cx = React.addons.classSet;
+import cx from "classnames";
 
 export default React.createClass({
     displayName: 'GuiQueryEditor',

--- a/resources/frontend_client/app/query_builder/IconBorder.react.js
+++ b/resources/frontend_client/app/query_builder/IconBorder.react.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var cx = React.addons.classSet;
+import cx from "classnames";
 
 var IconBorder = React.createClass({
     displayName: 'IconBorder',

--- a/resources/frontend_client/app/query_builder/QueryModeToggle.react.js
+++ b/resources/frontend_client/app/query_builder/QueryModeToggle.react.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var cx = React.addons.classSet;
+import cx from "classnames";
 
 export default React.createClass({
     displayName: 'QueryModeToggle',

--- a/resources/frontend_client/app/query_builder/QueryVisualization.react.js
+++ b/resources/frontend_client/app/query_builder/QueryVisualization.react.js
@@ -10,7 +10,7 @@ import VisualizationSettings from './VisualizationSettings.react';
 
 import Query from "metabase/lib/query";
 
-var cx = React.addons.classSet;
+import cx from "classnames";
 
 export default React.createClass({
     displayName: 'QueryVisualization',

--- a/resources/frontend_client/app/query_builder/QueryVisualizationObjectDetailTable.react.js
+++ b/resources/frontend_client/app/query_builder/QueryVisualizationObjectDetailTable.react.js
@@ -6,7 +6,7 @@ import Icon from "metabase/components/Icon.react";
 import IconBorder from './IconBorder.react';
 import LoadingSpinner from 'metabase/components/LoadingSpinner.react';
 
-var cx = React.addons.classSet;
+import cx from "classnames";
 
 export default React.createClass({
     displayName: 'QueryVisualizationObjectDetailTable',

--- a/resources/frontend_client/app/query_builder/QueryVisualizationTable.react.js
+++ b/resources/frontend_client/app/query_builder/QueryVisualizationTable.react.js
@@ -8,7 +8,7 @@ import FixedDataTable from 'fixed-data-table';
 import Icon from "metabase/components/Icon.react";
 import Popover from "metabase/components/Popover.react";
 
-var cx = React.addons.classSet;
+import cx from "classnames";
 var Table = FixedDataTable.Table;
 var Column = FixedDataTable.Column;
 

--- a/resources/frontend_client/app/query_builder/RunButton.react.js
+++ b/resources/frontend_client/app/query_builder/RunButton.react.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var cx = React.addons.classSet;
+import cx from "classnames";
 
 export default React.createClass({
     displayName: 'RunButton',

--- a/resources/frontend_client/app/query_builder/SelectionModule.react.js
+++ b/resources/frontend_client/app/query_builder/SelectionModule.react.js
@@ -6,7 +6,7 @@ import Popover from "metabase/components/Popover.react";
 import Icon from "metabase/components/Icon.react";
 import SearchBar from './SearchBar.react';
 
-var cx = React.addons.classSet;
+import cx from "classnames";
 
 export default React.createClass({
     displayName:'SelectionModule',

--- a/resources/frontend_client/app/query_builder/VisualizationSettings.react.js
+++ b/resources/frontend_client/app/query_builder/VisualizationSettings.react.js
@@ -3,7 +3,7 @@
 import Icon from "metabase/components/Icon.react";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger.react";
 
-var cx = React.addons.classSet;
+import cx from "classnames";
 
 export default React.createClass({
     displayName: 'VisualizationSettings',


### PR DESCRIPTION
Deprecated in React v0.13: https://facebook.github.io/react/blog/2015/03/10/react-v0.13.html

Using `classnames` instead: https://github.com/JedWatson/classnames
