### PR TITLE
Filter card listing by Database and Table

### DIFF
--- a/resources/migrations/012_add_card_query_fields.yaml
+++ b/resources/migrations/012_add_card_query_fields.yaml
@@ -1,0 +1,31 @@
+databaseChangeLog:
+  - changeSet:
+      id: 12
+      author: agilliland
+      changes:
+        - addColumn:
+            tableName: report_card
+            columns:
+              - column:
+                  name: database_id
+                  type: int
+                  constraints:
+                    nullable: true
+                    references: metabase_database(id)
+                    foreignKeyName: fk_report_card_ref_database_id
+                    deferrable: false
+                    initiallyDeferred: false
+              - column:
+                  name: table_id
+                  type: int
+                  constraints:
+                    nullable: true
+                    references: metabase_table(id)
+                    foreignKeyName: fk_report_card_ref_table_id
+                    deferrable: false
+                    initiallyDeferred: false
+              - column:
+                  name: query_type
+                  type: varchar(16)
+                  constraints:
+                    nullable: true

--- a/resources/migrations/liquibase.json
+++ b/resources/migrations/liquibase.json
@@ -9,6 +9,7 @@
       {"include": {"file": "migrations/008_add_display_name_columns.json"}},
       {"include": {"file": "migrations/009_add_table_visibility_type_column.json"}},
       {"include": {"file": "migrations/010_add_revision_table.yaml"}},
-      {"include": {"file": "migrations/011_cleanup_dashboard_perms.yaml"}}
+      {"include": {"file": "migrations/011_cleanup_dashboard_perms.yaml"}},
+      {"include": {"file": "migrations/012_add_card_query_fields.yaml"}}
   ]
 }

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -40,7 +40,7 @@
     (checkp (integer? id) "id" (format "id is required parameter when filter mode is '%s'" (name f)))
     (case f
       :database (read-check Database id)
-      :table    (read-check Database (:db_id (sel :one :fields [Table :database_id])))))
+      :table    (read-check Database (:db_id (sel :one :fields [Table :db_id])))))
   (-> (case (or f :all) ; default value for `f` is `:all`
         :all      (sel :many Card (k/order :name :ASC) (k/where (or {:creator_id *current-user-id*}
                                                                     {:public_perms [> common/perms-none]})))

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -40,7 +40,7 @@
     (checkp (integer? id) "id" (format "id is required parameter when filter mode is '%s'" (name f)))
     (case f
       :database (read-check Database id)
-      :table    (read-check Database (:db_id (sel :one :fields [Table :db_id])))))
+      :table    (read-check Database (:db_id (sel :one :fields [Table :db_id] :id id)))))
   (-> (case (or f :all) ; default value for `f` is `:all`
         :all      (sel :many Card (k/order :name :ASC) (k/where (or {:creator_id *current-user-id*}
                                                                     {:public_perms [> common/perms-none]})))

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -8,7 +8,9 @@
                              [card :refer [Card] :as card]
                              [card-favorite :refer [CardFavorite]]
                              [common :as common]
+                             [database :refer [Database]]
                              [revision :refer [push-revision]]
+                             [table :refer [Table]]
                              [user :refer [User]])))
 
 (defannotation CardFilterOption
@@ -35,7 +37,10 @@
   {f CardFilterOption
    id Integer}
   (when (contains? #{:database :table} f)
-    (checkp (integer? id) "id" (format "id is required parameter when filter mode is '%s'" (name f))))
+    (checkp (integer? id) "id" (format "id is required parameter when filter mode is '%s'" (name f)))
+    (case f
+      :database (read-check Database id)
+      :table    (read-check Database (:db_id (sel :one :fields [Table :database_id])))))
   (-> (case (or f :all) ; default value for `f` is `:all`
         :all      (sel :many Card (k/order :name :ASC) (k/where (or {:creator_id *current-user-id*}
                                                                     {:public_perms [> common/perms-none]})))

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -34,6 +34,8 @@
   [f id]
   {f CardFilterOption
    id Integer}
+  (when (contains? #{:database :table} f)
+    (checkp (integer? id) "id" (format "id is required parameter when filter mode is '%s'" (name f))))
   (-> (case (or f :all) ; default value for `f` is `:all`
         :all      (sel :many Card (k/order :name :ASC) (k/where (or {:creator_id *current-user-id*}
                                                                     {:public_perms [> common/perms-none]})))

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -14,7 +14,7 @@
 (defannotation CardFilterOption
   "Option must be one of `all`, `mine`, or `fav`."
   [symb value :nillable]
-  (checkp-contains? #{:all :mine :fav} symb (keyword value)))
+  (checkp-contains? #{:all :mine :fav :database :table} symb (keyword value)))
 
 (defannotation CardDisplayType
   "Option must be a valid `display_type`."
@@ -24,19 +24,30 @@
 (defendpoint GET "/"
   "Get all the `Cards`. With param `f` (default is `all`), restrict cards as follows:
 
-   *  `all`  Return all `Cards` which were created by current user or are publicly visible
-   *  `mine` Return all `Cards` created by current user
-   *  `fav`  Return all `Cards` favorited by the current user"
-  [f]
-  {f CardFilterOption}
+   *  `all`         Return all `Cards`
+   *  `mine`        Return all `Cards` created by current user
+   *  `fav`         Return all `Cards` favorited by the current user
+   *  `database`    Return all `Cards` with `:database_id` equal to `id`
+   *  `table`       Return all `Cards` with `:table_id` equal to `id`
+
+   All returned cards must be either created by current user or are publicly visible."
+  [f id]
+  {f CardFilterOption
+   id Integer}
   (-> (case (or f :all) ; default value for `f` is `:all`
-        :all  (sel :many Card (k/order :name :ASC) (k/where (or {:creator_id *current-user-id*}
-                                                              {:public_perms [> common/perms-none]})))
-        :mine (sel :many Card :creator_id *current-user-id* (k/order :name :ASC))
-        :fav  (->> (-> (sel :many [CardFavorite :card_id] :owner_id *current-user-id*)
-                       (hydrate :card))
-                   (map :card)
-                   (sort-by :name)))
+        :all      (sel :many Card (k/order :name :ASC) (k/where (or {:creator_id *current-user-id*}
+                                                                    {:public_perms [> common/perms-none]})))
+        :mine     (sel :many Card :creator_id *current-user-id* (k/order :name :ASC))
+        :fav      (->> (-> (sel :many [CardFavorite :card_id] :owner_id *current-user-id*)
+                           (hydrate :card))
+                       (map :card)
+                       (sort-by :name))
+        :database (sel :many Card (k/order :name :ASC) (k/where (and {:database_id id}
+                                                                  (or {:creator_id *current-user-id*}
+                                                                      {:public_perms [> common/perms-none]}))))
+        :table    (sel :many Card (k/order :name :ASC) (k/where (and {:table_id id}
+                                                                     (or {:creator_id *current-user-id*}
+                                                                         {:public_perms [> common/perms-none]})))))
       (hydrate :creator)))
 
 (defendpoint POST "/"

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -119,7 +119,11 @@
   (log/info "Database Migrations Current ... CHECK")
 
   ;; Establish our 'default' Korma DB Connection
-  (kdb/default-connection (kdb/create-db @jdbc-connection-details)))
+  (kdb/default-connection (kdb/create-db @jdbc-connection-details))
+
+  ;; Do any custom code-based migrations now that the db structure is up to date
+  ;; NOTE: we use dynamic resolution to prevent circular dependencies
+  ((u/runtime-resolved-fn 'metabase.db.migrations 'run-all)))
 
 (defn setup-db-if-needed [& args]
   (when-not @setup-db-has-been-called?

--- a/src/metabase/db/migrations.clj
+++ b/src/metabase/db/migrations.clj
@@ -1,0 +1,27 @@
+(ns metabase.db.migrations
+  (:require [clojure.tools.logging :as log]
+            [korma.core :as k]
+            [metabase.db :as db]
+            [metabase.models.card :refer [Card]]))
+
+(defn- set-card-database-and-table-ids
+  "Upgrade for the `Card` model when `:database_id` and `:table_id` were added and needed populating.
+
+   This reads through all saved cards, extracts the JSON from the `:dataset_query`, and tries to populate
+   the values for `:database_id` and `:table_id` if possible."
+  []
+  ;; only execute when `:database_id` column on all cards is `nil`
+  (when (= 0 (:cnt (first (k/select Card (k/aggregate (count :*) :cnt) (k/where (not= :database_id nil))))))
+    (log/info "Data migration: Setting database/table/type fields on all Cards.")
+    (doseq [{id :id {{table :source_table} :query :keys [database type]} :dataset_query} (db/sel :many [Card :id :dataset_query])]
+      (when type
+        (db/upd Card id
+          :query_type  type
+          :database_id database
+          :table_id    table)))))
+
+(defn run-all
+  "Run all coded data migrations."
+  []
+  ;; Append to the bottom of this list so that these run in chronological order
+  (set-card-database-and-table-ids))

--- a/src/metabase/db/migrations.clj
+++ b/src/metabase/db/migrations.clj
@@ -5,20 +5,18 @@
             [metabase.models.card :refer [Card]]))
 
 (defn- set-card-database-and-table-ids
-  "Upgrade for the `Card` model when `:database_id` and `:table_id` were added and needed populating.
+  "Upgrade for the `Card` model when `:database_id`, `:table_id`, and `:query_type` were added and needed populating.
 
    This reads through all saved cards, extracts the JSON from the `:dataset_query`, and tries to populate
-   the values for `:database_id` and `:table_id` if possible."
+   the values for `:database_id`, `:table_id`, and `:query_type` if possible."
   []
   ;; only execute when `:database_id` column on all cards is `nil`
   (when (= 0 (:cnt (first (k/select Card (k/aggregate (count :*) :cnt) (k/where (not= :database_id nil))))))
     (log/info "Data migration: Setting database/table/type fields on all Cards.")
-    (doseq [{id :id {{table :source_table} :query :keys [database type]} :dataset_query} (db/sel :many [Card :id :dataset_query])]
+    (doseq [{id :id {:keys [type] :as dataset-query} :dataset_query} (db/sel :many [Card :id :dataset_query])]
       (when type
-        (db/upd Card id
-          :query_type  type
-          :database_id database
-          :table_id    table)))))
+        ;; simply resave the card with the dataset query which will automatically set the database, table, and type
+        (db/upd Card id :dataset_query dataset-query)))))
 
 (defn run-all
   "Run all coded data migrations."

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -25,11 +25,26 @@
 (extend-ICanReadWrite CardInstance :read :public-perms, :write :public-perms)
 
 
+(defn- populate-query-fields [card]
+  (let [{{table-id :source_table} :query database-id :database query-type :type} (:dataset_query card)
+        defaults {:database_id database-id
+                  :table_id    table-id
+                  :query_type  (keyword query-type)}]
+    (if query-type
+      (merge defaults card)
+      card)))
+
 (defentity Card
   [(table :report_card)
    (hydration-keys card)
-   (types :dataset_query :json, :display :keyword, :visualization_settings :json)
+   (types :display :keyword, :query_type :keyword, :dataset_query :json, :visualization_settings :json)
    timestamped]
+
+   (pre-insert [_ card]
+     (populate-query-fields card))
+
+   (pre-update [_ card]
+     (populate-query-fields card))
 
   (post-select [_ {:keys [creator_id] :as card}]
     (map->CardInstance (assoc card

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -1,6 +1,5 @@
 (ns metabase.models.card
   (:require [korma.core :refer :all, :exclude [defentity update]]
-            [metabase.api.common :refer [*current-user-id*]]
             [metabase.db :refer :all]
             (metabase.models [interface :refer :all]
                              [user :refer [User]])))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -50,9 +50,9 @@
                                                (map :id)
                                                set)
                                           card-id))]
-          [(card-returned? 1 id1)
-           (card-returned? 2 id1)
-           (card-returned? 2 id2)])))))
+          [(card-returned? (db-id) id1)
+           (card-returned? dbid id1)
+           (card-returned? dbid id2)])))))
 
 ;; Make sure `id` is required when `f` is :database
 (expect {:errors {:id "id is required parameter when filter mode is 'database'"}}

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2,6 +2,7 @@
   "Tests for /api/card endpoints."
   (:require [expectations :refer :all]
             [metabase.db :refer :all]
+            [metabase.http-client :refer :all]
             (metabase.models [card :refer [Card]]
                              [common :as common]
                              [database :refer [Database]])
@@ -53,6 +54,10 @@
            (card-returned? 2 id1)
            (card-returned? 2 id2)])))))
 
+;; Make sure `id` is required when `f` is :database
+(expect {:errors {:id "id is required parameter when filter mode is 'database'"}}
+  ((user->client :crowberto) :get 400 "card" :f :database))
+
 ;; Filter cards by table
 (expect [true
          false
@@ -79,6 +84,10 @@
       [(card-returned? 1 id1)
        (card-returned? 2 id1)
        (card-returned? 2 id2)]))))
+
+;; Make sure `id` is required when `f` is :table
+(expect {:errors {:id "id is required parameter when filter mode is 'table'"}}
+  ((user->client :crowberto) :get 400 "card" :f :table))
 
 ;; Check that only the creator of a private Card can see it
 (expect [true

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -54,7 +54,10 @@
                                :display "scalar"
                                :visualization_settings {:global {:title nil}}
                                :public_perms 0
-                               :created_at $})
+                               :created_at $
+                               :database_id (db-id)
+                               :table_id (id :categories)
+                               :query_type "query"})
     (post-card card-name)))
 
 ;; ## GET /api/card/:id
@@ -84,7 +87,10 @@
          :display "scalar"
          :visualization_settings {:global {:title nil}}
          :public_perms 0
-         :created_at $})
+         :created_at $
+         :database_id (db-id)
+         :table_id (id :categories)
+         :query_type "query"})
     (let [{:keys [id]} (post-card card-name)]
       ((user->client :rasta) :get 200 (format "card/%d" id)))))
 

--- a/test/metabase/api/dash_test.clj
+++ b/test/metabase/api/dash_test.clj
@@ -126,7 +126,10 @@
                      :display "scalar"
                      :visualization_settings {:global {:title nil}}
                      :public_perms 0
-                     :created_at $})
+                     :created_at $
+                     :database_id (db-id)
+                     :table_id (id :categories)
+                     :query_type "query"})
             :updated_at $
             :col nil
             :id $


### PR DESCRIPTION
This is a pre-requisite for some of the new Homepage designs where we want to be able to filter things by the data they are using.  

This adds new fields to the `Card` model for :database_id, :table_id, and :query_type which are all in the :dataset_query but are not easily usable because they are inside a JSON blob.  So we are pulling them out into their own db columns now.

We also update the GET /api/card endpoint so that you can pass a filter mode `f` of :table or :database and when those options are chosen the caller must also supply an `id` value for the id of the database or table they want to filter on.
