### PR TITLE
object detail width fix #873

### DIFF
--- a/resources/frontend_client/app/css/query_builder.css
+++ b/resources/frontend_client/app/css/query_builder.css
@@ -517,6 +517,11 @@
     border: 1px solid #DEDEDE;
 }
 
+@media screen and (--breakpoint-min-xl) {
+  /* prevent the object detail from getting too wide on large screens */
+  .ObjectDetail { max-width: 1140px; }
+}
+
 .ObjectDetail-headingGroup {
     border-bottom: 1px solid #DEDEDE;
 }

--- a/resources/frontend_client/app/css/query_builder.css
+++ b/resources/frontend_client/app/css/query_builder.css
@@ -511,16 +511,10 @@
 
 /* object detail */
 .ObjectDetail {
-    border: 1px solid #DEDEDE;
-    min-width: 906px;
+    width: 100%;
     margin: 0 auto;
     margin-bottom: 2rem;
-}
-
-@media screen and (--breakpoint-min-lg) {
-   .ObjectDetail {
-       min-width: 1140px;
-   }
+    border: 1px solid #DEDEDE;
 }
 
 .ObjectDetail-headingGroup {


### PR DESCRIPTION
removes explicit width from object detail so that it is the width of the qb and does not overlap the data reference panel
