### PR TITLE
flex squish fixes [WIP + CODE SMELL ADVISORY]

### DIFF
--- a/resources/frontend_client/app/admin/settings/components/SettingsEditor.react.js
+++ b/resources/frontend_client/app/admin/settings/components/SettingsEditor.react.js
@@ -74,7 +74,7 @@ export default React.createClass({
 
     render: function() {
         return (
-            <div className="MetadataEditor flex flex-column flex-full p4">
+            <div className="MetadataEditor force-content flex flex-column flex-full p4">
                 <SettingsHeader ref="header" />
                 <div className="MetadataEditor-main flex flex-row flex-full mt2">
                     {this.renderSettingsSections()}

--- a/resources/frontend_client/app/admin/settings/settings.module.js
+++ b/resources/frontend_client/app/admin/settings/settings.module.js
@@ -7,7 +7,7 @@ var SettingsAdmin = angular.module('metabaseadmin.settings', [
 
 SettingsAdmin.config(['$routeProvider', function($routeProvider) {
     $routeProvider.when('/admin/settings/', {
-        template: '<div class="flex flex-column flex-full" mb-react-component="SettingsEditor"></div>',
+        template: '<div class="flex flex-column flex-full scroll-x" mb-react-component="SettingsEditor"></div>',
         controller: 'SettingsEditor',
         resolve: {
             settings: ['SettingsAdminServices', async function(SettingsAdminServices) {

--- a/resources/frontend_client/app/css/core/grid.css
+++ b/resources/frontend_client/app/css/core/grid.css
@@ -2,6 +2,10 @@
 
 }
 
+.force-content > * {
+  min-width: -webkit-min-content;
+}
+
 .Grid {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
so i found a solution that fixes the problem. if you pull the branch, you can check it out by going to 
http://localhost:3000/admin/settings/ and then making your window #HellaSmall. If you compare that page to staging you can see that it keeps its usable width and just scrolls. when the window is too small.

_thar be dragons_
the problem is any time you find yourself writing a `.force-*` class you've found a code smell. in this case i think the smell is we're overusing flex and flex-full and our other furry flex friends in places we don't really need them. (QB is an example of the usage making more sense, but basic content layout like settings etc is less of a candidate i think) as a result. content is squashing other content necessarily while they fight for space under the flexbox spec. 

normal unstyled html does basically everything this branch implements by default, which is kinda neat, so this "solution" freaks me out a little. however, i'm not sure i see another solution that  without refactoring a quite a bit of our code to slim down on our flex box usage.
