### PR TITLE
use inflection on table and relationships for object details

### DIFF
--- a/resources/frontend_client/app/query_builder/QueryVisualizationObjectDetailTable.react.js
+++ b/resources/frontend_client/app/query_builder/QueryVisualizationObjectDetailTable.react.js
@@ -1,10 +1,10 @@
 'use strict';
 
 import ExpandableString from './ExpandableString.react';
-import Humanize from 'humanize';
 import Icon from 'metabase/components/Icon.react';
 import IconBorder from 'metabase/components/IconBorder.react';
 import LoadingSpinner from 'metabase/components/LoadingSpinner.react';
+import { singularize, inflect } from 'inflection';
 
 import cx from "classnames";
 
@@ -121,7 +121,7 @@ export default React.createClass({
                 </IconBorder>
             );
 
-            var relationName = Humanize.pluralize(fkCountValue, fk.origin.table.display_name);
+            var relationName = inflect(fk.origin.table.display_name, fkCountValue);
 
             var info = (
                 <div>
@@ -176,7 +176,7 @@ export default React.createClass({
             return false;
         }
 
-        var tableName = (this.props.tableMetadata) ? this.props.tableMetadata.display_name : "Unknown",
+        var tableName = (this.props.tableMetadata) ? singularize(this.props.tableMetadata.display_name) : "Unknown",
             // TODO: once we nail down the "title" column of each table this should be something other than the id
             idValue = this.getIdValue();
 


### PR DESCRIPTION
fixes #859 

This gives relationships and table names the proper inflection on object detail views. We also get the added benefit of it knowing that a single row on the "People" table is a "Person" which is pretty nice.

Previously:
![image](https://cloud.githubusercontent.com/assets/5248953/9833199/7b063200-5943-11e5-8ba0-9ca2c27f12c9.png)
![image](https://cloud.githubusercontent.com/assets/5248953/9833200/7e775ec8-5943-11e5-9e03-c5af441c2c85.png)

Now:
<img width="1398" alt="screen shot 2015-09-12 at 11 37 15 am" src="https://cloud.githubusercontent.com/assets/5248953/9833193/4b1fa63e-5943-11e5-9d3c-33d6f11f5188.png">
<img width="1398" alt="screen shot 2015-09-12 at 11 36 30 am" src="https://cloud.githubusercontent.com/assets/5248953/9833192/4b19352e-5943-11e5-9635-e250e9072629.png">
