### PR TITLE
fix for dashboard update state bug

### DIFF
--- a/resources/frontend_client/app/dashboard/actions.js
+++ b/resources/frontend_client/app/dashboard/actions.js
@@ -176,6 +176,9 @@ export const saveDashboard = createThunkAction(SAVE_DASHBOARD, function(dashId) 
             }
         }
 
+        // make sure that we've fully cleared out any dirty state from editing (this is overkill, but simple)
+        dispatch(fetchDashboard(dashId));
+
         return dashboard;
     };
 });


### PR DESCRIPTION
fixes #970 by refetching the dashboard after a save in order to ensure all previous editing state is cleared.
