### PR TITLE
fix filter widget height issue

### DIFF
--- a/resources/frontend_client/app/query_builder/FilterWidget.react.js
+++ b/resources/frontend_client/app/query_builder/FilterWidget.react.js
@@ -338,7 +338,7 @@ export default React.createClass({
             } else if (this.state.fieldValues.type === "date") {
                 var date = value ? moment(value) : moment();
                 return (
-                    <div className="flex full-height layout-centered m2">
+                    <div className="flex layout-centered m2">
                         <Calendar
                             selected={date}
                             onChange={this.setDateValue.bind(null, valueIndex)}


### PR DESCRIPTION
fixes #981

when `.full-height` was refactored to use 100vh, it made the filter widget go all huge in some cases. we don't actually need that class here so removing it fixes the bug @mazameli found.
