### PR TITLE
Error message for when reset token expires

### DIFF
--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -70,7 +70,7 @@
 
 ;;; #### checkp- functions: as in "check param". These functions expect that you pass a symbol so they can throw exceptions w/ relevant error messages.
 
-(defn- invalid-param-exception
+(defn invalid-param-exception
   "Create an `ExceptionInfo` that contains information about an invalid API params in the expected format."
   [field-name message]
   (ex-info (format "Invalid field: %s" field-name)

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -87,17 +87,18 @@
   [:as {{:keys [token password] :as body} :body}]
   {token    Required
    password [Required ComplexPassword]}
-  (api-let [400 "Invalid reset token"] [[_ user-id]                           (re-matches #"(^\d+)_.+$" token)
+  (api-let [400 "Invalid reset token"] [[_ user-id] (re-matches #"(^\d+)_.+$" token)
                                         user-id                               (Integer/parseInt user-id)
                                         {:keys [reset_token reset_triggered]} (sel :one :fields [User :reset_triggered :reset_token] :id user-id)]
     ;; Make sure the plaintext token matches up with the hashed one for this user
-    (check (try (creds/bcrypt-verify token reset_token)
-                (catch Throwable _))
-      [400 "Invalid reset token"]
+    (checkp (try (creds/bcrypt-verify token reset_token)
+                 (catch Throwable _))
+      'password "Invalid reset token")
 
-      ;; check that the reset was triggered within the last 1 HOUR, after that the token is considered expired
-      (> (* 60 60 1000) (- (System/currentTimeMillis) (or reset_triggered 0)))
-      [400 "Reset token has expired"])
+    ;; check that the reset was triggered within the last 1 HOUR, after that the token is considered expired
+    (checkp (> (* 60 60 1000) (- (System/currentTimeMillis) (or reset_triggered 0)))
+      'password "Reset token has expired")
+
     (set-user-password user-id password)
     ;; after a successful password update go ahead and offer the client a new session that they can use
     (let [session-id (create-session user-id)]

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -87,7 +87,7 @@
   [:as {{:keys [token password] :as body} :body}]
   {token    Required
    password [Required ComplexPassword]}
-  (api-let [400 "Invalid reset token"] [[_ user-id] (re-matches #"(^\d+)_.+$" token)
+  (api-let [400 "Invalid reset token"] [[_ user-id]                           (re-matches #"(^\d+)_.+$" token)
                                         user-id                               (Integer/parseInt user-id)
                                         {:keys [reset_token reset_triggered]} (sel :one :fields [User :reset_triggered :reset_token] :id user-id)]
     ;; Make sure the plaintext token matches up with the hashed one for this user

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -87,24 +87,24 @@
   [:as {{:keys [token password] :as body} :body}]
   {token    Required
    password [Required ComplexPassword]}
-  (api-let [400 "Invalid reset token"] [[_ user-id]                           (re-matches #"(^\d+)_.+$" token)
-                                        user-id                               (Integer/parseInt user-id)
-                                        {:keys [reset_token reset_triggered]} (sel :one :fields [User :reset_triggered :reset_token] :id user-id)]
-    ;; Make sure the plaintext token matches up with the hashed one for this user
-    (checkp (try (creds/bcrypt-verify token reset_token)
-                 (catch Throwable _))
-      'password "Invalid reset token")
+  (or (when-let [[_ user-id] (re-matches #"(^\d+)_.+$" token)]
+        (let [user-id (Integer/parseInt user-id)]
+          (when-let [{:keys [reset_token reset_triggered]} (sel :one :fields [User :reset_triggered :reset_token] :id user-id)]
+            ;; Make sure the plaintext token matches up with the hashed one for this user
+            (when (try (creds/bcrypt-verify token reset_token)
+                       (catch Throwable _))
 
-    ;; check that the reset was triggered within the last 1 HOUR, after that the token is considered expired
-    (checkp (> (* 60 60 1000) (- (System/currentTimeMillis) (or reset_triggered 0)))
-      'password "Reset token has expired")
+              ;; check that the reset was triggered within the last 1 HOUR, after that the token is considered expired
+              (checkp (> (* 60 60 1000) (- (System/currentTimeMillis) (or reset_triggered 0)))
+                'password "Reset token has expired")
 
-    (set-user-password user-id password)
-    ;; after a successful password update go ahead and offer the client a new session that they can use
-    (let [session-id (create-session user-id)]
-      (events/publish-event :user-login {:user_id user-id :session_id session-id})
-      {:success    true
-       :session_id session-id})))
+              (set-user-password user-id password)
+              ;; after a successful password update go ahead and offer the client a new session that they can use
+              (let [session-id (create-session user-id)]
+                (events/publish-event :user-login {:user_id user-id :session_id session-id})
+                {:success    true
+                 :session_id session-id})))))
+      (throw (invalid-param-exception :password "Invalid reset token"))))
 
 
 (defendpoint GET "/properties"

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -131,7 +131,7 @@
   (client :post 400 "session/reset_password" {:token "anything"}))
 
 ;; Test that malformed token returns 400
-(expect "Invalid reset token"
+(expect {:errors {:password "Invalid reset token"}}
   (client :post 400 "session/reset_password" {:token "not-found"
                                               :password "whateverUP12!!"}))
 

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -136,12 +136,12 @@
                                               :password "whateverUP12!!"}))
 
 ;; Test that invalid token returns 400
-(expect "Invalid reset token"
+(expect {:errors {:password "Invalid reset token"}}
   (client :post 400 "session/reset_password" {:token "1_not-found"
                                               :password "whateverUP12!!"}))
 
 ;; Test that old token can expire
-(expect "Reset token has expired"
+(expect {:errors {:password "Reset token has expired"}}
   (let [token (str (user->id :rasta) "_" (java.util.UUID/randomUUID))]
     (upd User (user->id :rasta) :reset_token token, :reset_triggered 0)
     (client :post 400 "session/reset_password" {:token token


### PR DESCRIPTION
Fixes #594. Make suer error messages are returned in format expected by frontend so they are displayed properly.
