### PR TITLE
extend password reset expiration

### DIFF
--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -94,8 +94,8 @@
             (when (try (creds/bcrypt-verify token reset_token)
                        (catch Throwable _))
 
-              ;; check that the reset was triggered within the last 1 HOUR, after that the token is considered expired
-              (checkp (> (* 60 60 1000) (- (System/currentTimeMillis) (or reset_triggered 0)))
+              ;; check that the reset was triggered within the last 48 HOURS, after that the token is considered expired
+              (checkp (> (* 48 60 60 1000) (- (System/currentTimeMillis) (or reset_triggered 0)))
                 'password "Reset token has expired")
 
               (set-user-password user-id password)


### PR DESCRIPTION
extend the password reset token expiration from 1 hour to 48 hours.  this is mostly driven by the fact that new user invites include a password reset and expiring those after 1 hour seems ludicrous.

fixes #1016
