### PR TITLE
Dont sync sample dataset

### DIFF
--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -149,7 +149,7 @@
     (.stop ^org.eclipse.jetty.server.Server @jetty-instance)
     (reset! jetty-instance nil)))
 
-(def ^:private ^:const sample-dataset-name "Sample Dataset")
+(def ^:const sample-dataset-name "Sample Dataset")
 (def ^:private ^:const sample-dataset-filename "sample-dataset.db.mv.db")
 
 (defn- add-sample-dataset! []

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -149,7 +149,7 @@
     (.stop ^org.eclipse.jetty.server.Server @jetty-instance)
     (reset! jetty-instance nil)))
 
-(def ^:const sample-dataset-name "Sample Dataset")
+(def ^:private ^:const sample-dataset-name "Sample Dataset")
 (def ^:private ^:const sample-dataset-filename "sample-dataset.db.mv.db")
 
 (defn- add-sample-dataset! []


### PR DESCRIPTION
skip sample dataset when running `SyncDatabases`.

@agilliland : you can use `doseq` instead of `dorun + for`, see diff for example
