### PR TITLE
Sample Dataset sync improvements. Options for `defsetting` :yum:

### DIFF
--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -97,7 +97,7 @@
   []
   (log/info "Metabase Initializing ... ")
   ;; First of all, lets register a shutdown hook that will tidy things up for us on app exit
-  (.addShutdownHook (Runtime/getRuntime) (Thread. destroy))
+  (.addShutdownHook (Runtime/getRuntime) (Thread. ^Runnable destroy))
   (log/debug "Using Config:\n" (with-out-str (clojure.pprint/pprint config/config-all)))
 
   ;; Bootstrap the event system
@@ -152,8 +152,15 @@
 (def ^:private ^:const sample-dataset-name "Sample Dataset")
 (def ^:private ^:const sample-dataset-filename "sample-dataset.db.mv.db")
 
+(defsetting sample-dataset-id
+  "The string-serialized integer ID of the `Database` entry for the Sample Dataset. If this is `nil`, the Sample Dataset
+   hasn't been loaded yet, and we should do so; otherwise we've already loaded it, and should not do so again. Keep in
+   mind the user may delete the Sample Dataset's DB, so this ID is not guaranteed to correspond to an existent object."
+  nil
+  :internal true) ; don't expose in the UI
+
 (defn- add-sample-dataset! []
-  (when-not (db/exists? Database :name sample-dataset-name)
+  (when-not (sample-dataset-id)
     (try
       (log/info "Loading sample dataset...")
       (let [resource (-> (Thread/currentThread) ; hunt down the sample dataset DB file inside the current JAR
@@ -162,13 +169,15 @@
         (if-not resource
           (log/error (format "Can't load sample dataset: the DB file '%s' can't be found by the ClassLoader." sample-dataset-filename))
           (let [h2-file (-> (.getPath resource)
-                            (s/replace #"^file:" "zip:")         ; to connect to an H2 DB inside a JAR just replace file: with zip:
-                            (s/replace #"\.mv\.db$" "")          ; strip the .mv.db suffix from the path
-                            (str ";USER=GUEST;PASSWORD=guest"))] ; specify the GUEST user account created for the DB
-            (driver/sync-database! (db/ins Database
-                                     :name    sample-dataset-name
-                                     :details {:db h2-file}
-                                     :engine  :h2)))))
+                            (s/replace #"^file:" "zip:")        ; to connect to an H2 DB inside a JAR just replace file: with zip:
+                            (s/replace #"\.mv\.db$" "")         ; strip the .mv.db suffix from the path
+                            (str ";USER=GUEST;PASSWORD=guest")) ; specify the GUEST user account created for the DB
+                db      (db/ins Database
+                          :name    sample-dataset-name
+                          :details {:db h2-file}
+                          :engine  :h2)]
+            (driver/sync-database! db)
+            (sample-dataset-id (str (:id db))))))
       (catch Throwable e
         (log/error (format "Failed to load sample dataset: %s" (.getMessage e)))))))
 

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -106,7 +106,7 @@
    A setting can be set from the SuperAdmin page or via the corresponding env var,
    eg. `MB_MANDRILL_API_KEY` for the example above.
 
-   You may optionally pass any of the kvarg OPTIONS below, which are kept as part of the
+   You may optionally pass any of the kwarg OPTIONS below, which are kept as part of the
    metadata of the `Setting` under the key `::options`:
 
      *  `:internal` - This `Setting` is for internal use and shouldn't be exposed in the UI (i.e., not

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -5,7 +5,8 @@
             [environ.core :as env]
             [korma.core :as k]
             [metabase.db :refer [sel del]]
-            [metabase.models.interface :refer :all]))
+            [metabase.models.interface :refer :all]
+            [metabase.util :as u]))
 
 ;; Settings are a fast + simple way to create a setting that can be set
 ;; from the SuperAdmin page. They are saved to the Database, but intelligently
@@ -71,7 +72,7 @@
                         (k/set-fields {:value v})
                         (k/where {:key (name k)}))
       (k/insert Setting
-                (k/values {:key (name k)
+                (k/values {:key   (name k)
                            :value v})))
   (restore-cache-if-needed)
   (swap! cached-setting->value assoc k v)
@@ -103,16 +104,21 @@
      (mandrill-api-key nil)       ; delete the value
 
    A setting can be set from the SuperAdmin page or via the corresponding env var,
-   eg. `MB_MANDRILL_API_KEY` for the example above."
-  {:arglists '([setting-name description]
-               [setting-name description default-value])}
-  [nm description & [default-value]]
+   eg. `MB_MANDRILL_API_KEY` for the example above.
+
+   You may optionally pass any of the kvarg OPTIONS below, which are kept as part of the
+   metadata of the `Setting` under the key `::options`:
+
+     *  `:internal` - This `Setting` is for internal use and shouldn't be exposed in the UI (i.e., not
+        returned by the corresponding endpoints). Default: `false`"
+  [nm description & [default-value & {:as options}]]
   {:pre [(symbol? nm)
          (string? description)]}
   (let [setting-key (keyword nm)]
     `(defn ~nm ~description
-       {::is-setting? true
-        ::default-value ~default-value}
+       {::is-setting?   true
+        ::default-value ~default-value
+        ::options       ~options}
        ([]
         (or (get ~setting-key)
             (get-from-env-var ~setting-key)
@@ -161,13 +167,15 @@
   [(k/table :setting)])
 
 (defn- settings-list
-  "Return a list of all Settings (as created with `defsetting`)."
+  "Return a list of all Settings (as created with `defsetting`).
+   This excludes Settings created with the option `:internal`."
   []
   (->> (all-ns)
        (mapcat ns-interns)
        vals
        (map meta)
        (filter ::is-setting?)
+       (filter (complement (u/rpartial get-in [::options :internal]))) ; filter out :internal Settings
        (map (fn [{k :name desc :doc default ::default-value}]
               {:key         (keyword k)
                :description desc

--- a/src/metabase/task/sync_databases.clj
+++ b/src/metabase/task/sync_databases.clj
@@ -3,11 +3,12 @@
             [clojurewerkz.quartzite.jobs :as jobs]
             [clojurewerkz.quartzite.triggers :as triggers]
             [clojurewerkz.quartzite.schedule.cron :as cron]
-            [metabase.config :as config]
-            [metabase.db :as db]
-            [metabase.driver :as driver]
-            [metabase.models.database :refer [Database]]
-            [metabase.task :as task]))
+            (metabase [config :as config]
+                      [core :refer [sample-dataset-id]]
+                      [db :as db]
+                      [driver :as driver]
+                      [task :as task])
+            [metabase.models.database :refer [Database]]))
 
 (def sync-databases-job-key "metabase.task.sync-databases.job")
 (def sync-databases-trigger-key "metabase.task.sync-databases.trigger")
@@ -16,11 +17,10 @@
 (defonce ^:private sync-databases-trigger (atom nil))
 
 ;; simple job which looks up all databases and runs a sync on them
-;; TODO - skip the sample dataset?
 (jobs/defjob SyncDatabases
   [ctx]
   (dorun
-    (for [database (db/sel :many Database)]
+   (for [database (db/sel :many Database, :id [not= (some-> (sample-dataset-id) Integer/parseInt)])] ; skip Sample Dataset DB
       (try
         ;; NOTE: this happens synchronously for now to avoid excessive load if there are lots of databases
         (driver/sync-database! database)

--- a/src/metabase/task/sync_databases.clj
+++ b/src/metabase/task/sync_databases.clj
@@ -1,7 +1,7 @@
 (ns metabase.task.sync-databases
   (:require [clojure.tools.logging :as log]
-            [clojurewerkz.quartzite.jobs :as jobs]
-            [clojurewerkz.quartzite.triggers :as triggers]
+            (clojurewerkz.quartzite [jobs :as jobs]
+                                    [triggers :as triggers])
             [clojurewerkz.quartzite.schedule.cron :as cron]
             (metabase [config :as config]
                       [core :refer [sample-dataset-id]]


### PR DESCRIPTION
-  `defsetting` macro now takes optional kwargs that are stored under `::options` key in the metadata
-  `:internal` option can be set to prevent settings from being exposed in UI
-  Sample Dataset DB ID now tracked with `sample-dataset-id` `Setting`
-  Sample Dataset will not be recreated if deleted and server is restarted
-  Sync DB task skips Sample Dataset 

This supersedes #1042 .
