### PR TITLE
Run scripts like `java -jar metabase.jar --script <script>`

### DIFF
--- a/resources/scripts/hello
+++ b/resources/scripts/hello
@@ -1,0 +1,15 @@
+#! /bin/bash
+FILENAME=$1
+
+if [ ! "$FILENAME" ]; then
+    echo "Usage: $0 <file>"
+    exit 1
+fi
+
+echo "File is: $FILENAME"
+
+if [ -f "$FILENAME" ]; then
+    echo 'FILE EXISTS.'
+else
+    echo 'FILE DOES NOT EXIST.'
+fi


### PR DESCRIPTION
Scripts that live inside `resources/scripts` are bundled inside, and can be ran from, the uberjar.

e.g.

``` bash
java -jar path/to/metabase.jar --script [script-name] [args...]
# or
lein run --script [script-name] [args...]
```

Unfortunately this does not work with interactive scripts like the migration fixer I wrote for #1070, and does not bring the ruckus. You'll have to pass things as args to these scripts instead.

The script `hello` is provided for your enjoyment / as a proof-of-concept; try it out using the Shaolin script invocation techniques listed above.
