### PR TITLE
fix data reference scroll issue

### DIFF
--- a/resources/frontend_client/app/query_builder/DataReference.react.js
+++ b/resources/frontend_client/app/query_builder/DataReference.react.js
@@ -78,7 +78,7 @@ export default React.createClass({
         );
 
         return (
-            <div className="DataReference-container p3 scroll-y full-height">
+            <div className="DataReference-container p3 scroll-y">
                 <div className="DataReference-header flex mb1">
                     {backButton}
                     {closeButton}


### PR DESCRIPTION
since we changed `.full-height` to use vh instead of height 100% the data reference wasn't getting a proper height and was cutting off content.
