### PR TITLE
Command for manually releasing migration locks

### DIFF
--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -64,21 +64,31 @@
   "migrations/liquibase.json")
 
 (defn migrate
-  "Migrate the database `:up`, `:down`, or `:print`."
-  [jdbc-connection-details direction]
-  (try
-    (jdbc/with-db-transaction [conn jdbc-connection-details]
-      (let [^Database  database  (-> (DatabaseFactory/getInstance)
-                                     (.findCorrectDatabaseImplementation (JdbcConnection. (jdbc/get-connection conn))))
-            ^Liquibase liquibase (Liquibase. changelog-file (ClassLoaderResourceAccessor.) database)]
-        (case direction
-          :up    (.update liquibase "")
-          :down  (.rollback liquibase 10000 "")
-          :print (let [writer (StringWriter.)]
-                   (.update liquibase "" writer)
-                   (.toString writer)))))
-    (catch Throwable e
-      (throw (DatabaseException. e)))))
+  "Migrate the database:
+
+   *  `:up`            - Migrate up
+   *  `:down`          - Rollback *all* migrations
+   *  `:print`         - Just print the SQL for running the migrations, don't actually run them.
+   *  `:release-locks` - Manually release migration locks left by an earlier failed migration.
+                         (This shouldn't be necessary now that we run migrations inside a transaction,
+                         but is available just in case)."
+  ([direction]
+   (migrate @jdbc-connection-details direction))
+  ([jdbc-connection-details direction]
+   (try
+     (jdbc/with-db-transaction [conn jdbc-connection-details]
+       (let [^Database  database  (-> (DatabaseFactory/getInstance)
+                                      (.findCorrectDatabaseImplementation (JdbcConnection. (jdbc/get-connection conn))))
+             ^Liquibase liquibase (Liquibase. changelog-file (ClassLoaderResourceAccessor.) database)]
+         (case direction
+           :up            (.update liquibase "")
+           :down          (.rollback liquibase 10000 "")
+           :print         (let [writer (StringWriter.)]
+                            (.update liquibase "" writer)
+                            (.toString writer))
+           :release-locks (.forceReleaseLocks liquibase))))
+     (catch Throwable e
+       (throw (DatabaseException. e))))))
 
 
 ;; ## SETUP-DB
@@ -122,10 +132,10 @@
 
   ;; Run through our DB migration process and make sure DB is fully prepared
   (if auto-migrate
-    (migrate @jdbc-connection-details :up)
+    (migrate :up)
     ;; if we are not doing auto migrations then print out migration sql for user to run manually
     ;; then throw an exception to short circuit the setup process and make it clear we can't proceed
-    (let [sql (migrate @jdbc-connection-details :print)]
+    (let [sql (migrate :print)]
       (log/info (str "Database Upgrade Required\n\n"
                      "NOTICE: Your database requires updates to work with this version of Metabase.  "
                      "Please execute the following sql commands on your database before proceeding.\n\n"


### PR DESCRIPTION
Implements #988 and #1069. Obsoletes #1070 & #1072 .

The command can be run as follows:

``` bash
java -jar metabase.jar migrate release-locks
```

or

``` bash
lein run migrate release-locks
```

Other arguments to `migrate` (`up`, `down`, and `print`) work as well.
