### PR TITLE
activity feed fix for error when database is deleted

### DIFF
--- a/resources/frontend_client/app/home/components/Activity.react.js
+++ b/resources/frontend_client/app/home/components/Activity.react.js
@@ -137,8 +137,12 @@ export default class Activity extends Component {
                 description.bodyLink = Urls.card(item.details.dashcards[0].card_id);
                 break;
             case "database-sync":
+                // NOTE: this is a relic from the very early days of the activity feed when we accidentally didn't
+                //       capture the name/description/engine of a Database properly in the details and so it was
+                //       possible for a database to be deleted and we'd lose any way of knowing what it's name was :(
+                const oldName = (item.database && 'name' in item.database) ? item.database.name : "Unknown";
                 description.subject = "received the latest data from";
-                description.subjectRefName = item.database.name;
+                description.subjectRefName = (item.details.name) ? item.details.name : oldName;
                 break;
             case "install":
                 description.userName = "Hello World!";

--- a/src/metabase/events/activity_feed.clj
+++ b/src/metabase/events/activity_feed.clj
@@ -81,6 +81,7 @@
 
 (defn- process-database-activity [topic object]
   (let [database            (db/sel :one Database :id (events/object->model-id topic object))
+        object              (merge object (select-keys database [:name :description :engine]))
         database-details-fn (fn [obj] (-> obj
                                           (assoc :status "started")
                                           (dissoc :database_id :custom_id)))

--- a/test/metabase/events/activity_feed_test.clj
+++ b/test/metabase/events/activity_feed_test.clj
@@ -192,14 +192,21 @@
     :model_id    (db-id)
     :database_id (db-id)
     :custom_id   "abc"
-    :details     {:status "started"}}
+    :details     {:status      "started"
+                  :name        (:name (db))
+                  :description (:description (db))
+                  :engine      (name (:engine (db)))}}
    {:topic       :database-sync
     :user_id     nil
     :model       "database"
     :model_id    (db-id)
     :database_id (db-id)
     :custom_id   "abc"
-    :details     {:status "completed" :running_time 0}}]
+    :details     {:status       "completed"
+                  :running_time 0
+                  :name         (:name (db))
+                  :description  (:description (db))
+                  :engine       (name (:engine (db)))}}]
   (do
     (k/delete Activity)
     (let [_            (process-activity-event {:topic :database-sync-begin


### PR DESCRIPTION
capture name/description/engine from databases at event time and use that for our activity feed rendering.
