### PR TITLE
Cascade delete fixes

### DIFF
--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -58,6 +58,7 @@
                                                           :dashboards)))))
 
   (pre-cascade-delete [_ {:keys [id]}]
+    (cascade-delete 'Revision :model "Card" :model_id id)
     (cascade-delete 'DashboardCard :card_id id)
     (cascade-delete 'CardFavorite :card_id id)))
 

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -32,6 +32,7 @@
         map->DashboardInstance))
 
   (pre-cascade-delete [_ {:keys [id]}]
+    (cascade-delete 'Revision :model "Dashboard" :model_id id)
     (cascade-delete DashboardCard :dashboard_id id)))
 
 (extend-ICanReadWrite DashboardEntity :read :public-perms, :write :public-perms)

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -31,6 +31,7 @@
         :tables (delay (sel :many 'metabase.models.table/Table :db_id id :active true (order :display_name :ASC))))))
 
   (pre-cascade-delete [_ {:keys [id] :as database}]
+    (cascade-delete 'metabase.models.card/Card :database_id id)
     (cascade-delete 'metabase.models.table/Table :db_id id)))
 
 (extend-ICanReadWrite DatabaseEntity :read :always, :write :superuser)


### PR DESCRIPTION
- apply cascade-delete on Cards when a Database is deleted.
- apply cascade-delete on Revisions when either Cards or Dashboards are deleted.
