### PR TITLE
Type weight cleanup

### DIFF
--- a/frontend/app/components/DashboardsDropdown.react.js
+++ b/frontend/app/components/DashboardsDropdown.react.js
@@ -106,7 +106,7 @@ export default class DashboardsDropdown extends Component {
                                                         {dash.name}
                                                     </div>
                                                     { dash.description ?
-                                                        <div className="mt1 text-light text-brand-light">
+                                                        <div className="mt1 text-brand-light">
                                                             {dash.description}
                                                         </div>
                                                     : null }

--- a/frontend/app/components/DashboardsDropdown.react.js
+++ b/frontend/app/components/DashboardsDropdown.react.js
@@ -92,7 +92,7 @@ export default class DashboardsDropdown extends Component {
                                     <div className="NavDropdown-content-layer text-white text-centered">
                                         <div className="p2"><div style={this.styles.dashIcon} className="ml-auto mr-auto"></div></div>
                                         <div className="px2 py1 text-bold">You don’t have any dashboards yet.</div>
-                                        <div className="px2 pb2 text-light">Dashboards group visualizations for frequent questions in a single handy place.</div>
+                                        <div className="px2 pb2">Dashboards group visualizations for frequent questions in a single handy place.</div>
                                         <div className="border-top border-light">
                                             <a className="Dropdown-item block text-white no-decoration" href="#" onClick={this.toggleModal}>Create your first dashboard</a>
                                         </div>

--- a/frontend/app/css/core/base.css
+++ b/frontend/app/css/core/base.css
@@ -17,7 +17,8 @@ body {
     display: flex;
     flex-direction: column;
     text-rendering: optimizeLegibility;
-    -webkit-font-smoothing: antialiased;
+    -webkit-font-smoothing: subpixel-antialiased;
+            font-smoothing: subpixel-antialiased;
 }
 
 /*

--- a/frontend/app/css/core/base.css
+++ b/frontend/app/css/core/base.css
@@ -17,8 +17,7 @@ body {
     display: flex;
     flex-direction: column;
     text-rendering: optimizeLegibility;
-    -webkit-font-smoothing: subpixel-antialiased;
-            font-smoothing: subpixel-antialiased;
+    -webkit-font-smoothing: antialiased;
 }
 
 /*

--- a/frontend/app/css/core/text.css
+++ b/frontend/app/css/core/text.css
@@ -70,17 +70,9 @@
 }
 
 /* text weight */
-.text-light {
-    font-weight: 100;
-}
-
-.text-normal {
-  font-weight: 400;
-}
-
-.text-bold {
-  font-weight: 700;
-}
+.text-light  { font-weight: 300; }
+.text-normal { font-weight: 400; }
+.text-bold   { font-weight: 700; }
 
 /* text style */
 

--- a/resources/frontend_client/app/user/partials/edit_current_user.html
+++ b/resources/frontend_client/app/user/partials/edit_current_user.html
@@ -1,6 +1,6 @@
 <div class="py4 border-bottom">
     <div class="wrapper wrapper--trim">
-        <h2 class="text-light text-grey-4">Account settings</h2>
+        <h2 class="text-grey-4">Account settings</h2>
     </div>
 </div>
 <div class="mt2 md-mt4 wrapper wrapper--trim">

--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -25,9 +25,7 @@
     <script src="//ajax.googleapis.com/ajax/libs/webfont/1.4.7/webfont.js"></script>
     <script>
         WebFont.load({
-          google: {
-            families: ['Lato:n1,n2,n4,n7']
-          }
+          google: { families: ['Lato:n3,n4,n7'] }
         });
       </script>
 


### PR DESCRIPTION
Initially this PR changed the type smoothing setting but after a bit more investigation the real reason we've been seeing font differences was due to Safari doing a better job of rendering hairline Lato than Chrome. 

So now:
- Switches to Lato 300 for light type
- Removes a nonexistent reference to Lato 200
- Uses regular in cases where light was still a bit light.

fixes #627 
