### PR TITLE
Mongo driver: handle empty string connection params

### DIFF
--- a/frontend/app/lib/core.js
+++ b/frontend/app/lib/core.js
@@ -392,7 +392,8 @@ import _ from "underscore";
                 fieldName: "port",
                 type: "text",
                 transform: parseInt,
-                placeholder: "27017"
+                placeholder: "27017",
+                placeholderIsDefault: true
             }, {
                 displayName: "Database name",
                 fieldName: "dbname",

--- a/src/metabase/driver/mongo/util.clj
+++ b/src/metabase/driver/mongo/util.clj
@@ -46,6 +46,10 @@
                                         (:dbname (:details database)) (:details database) ; entire Database obj
                                         (:dbname database)            database            ; connection details map only
                                         :else                         (throw (Exception. (str "with-mongo-connection failed: bad connection details:" (:details database)))))
+        user             (when (seq user) ; ignore empty :user and :pass strings
+                           user)
+        pass             (when (seq pass)
+                           pass)
         server-address   (mg/server-address host port)
         credentials      (when user
                            (mcred/create user dbname pass))


### PR DESCRIPTION
Front end has a bug where it passes empty fields in DB connection details (e.g., `user` or `pass`) as blank strings, which broke the Mongo driver for local DBs that didn't need those settings.

Make Mongo driver a little better about handling cases like that
