### PR TITLE
Stream JSON responses [Proof Of Concept]

### DIFF
--- a/src/metabase/routes.clj
+++ b/src/metabase/routes.clj
@@ -3,7 +3,8 @@
             [cheshire.core :as json]
             (compojure [core :refer [context defroutes GET]]
                        [route :as route])
-            [ring.util.response :as resp]
+            (ring.util [io :as ring-io]
+                       [response :as resp])
             [stencil.core :as stencil]
             [metabase.api.routes :as api]
             [metabase.models.setting :as setting]))
@@ -16,6 +17,26 @@
       (resp/content-type "text/html")
       (resp/header "Last-Modified" "{now} GMT")))
 
+(defn- some-very-long-handler [_]
+  (Thread/sleep 3000)
+  {:success true})
+
+(defn- streaming-response [handler]
+  (fn [request]
+    ;; TODO - handle exceptions  & have some sort of maximum timeout for these requests
+    (let [response (future (handler request))
+          f        (fn [^java.io.PipedOutputStream ostream]
+                     (if (realized? response)
+                       (json/generate-stream @response (io/writer ostream))
+                       (do
+                         (println "Response not ready, writing one byte & sleeping 500ms...")
+                         (.write ostream (byte \ ))
+                         (.flush ostream)
+                         (Thread/sleep 500)
+                         (recur ostream))))]
+      (-> (resp/response (ring-io/piped-input-stream f))
+          (resp/content-type "application/json")))))
+
 ;; Redirect naughty users who try to visit a page other than setup if setup is not yet complete
 (defroutes routes
   (GET "/" [] index)                                     ; ^/$           -> index.html
@@ -25,4 +46,6 @@
     (route/resources "/" {:root "frontend_client/app"})  ; ^/app/        -> static files under frontend_client/app
     (route/not-found {:status 404                        ; return 404 for anything else starting with ^/app/ that doesn't exist
                       :body "Not found."}))
+  (context "/stream-test" []
+    (streaming-response some-very-long-handler))
   (GET "*" [] index))                                    ; Anything else (e.g. /user/edit_current) should serve up index.html; Angular app will handle the rest


### PR DESCRIPTION
Basically the idea here is:
-  create a future to run the code that actually generates the API response
-  run a loop that checks to see if the future has finished and:
  -  writes the API response to the stream if it has, and exists
  -  writes a space to the output buffer, sleeps for some interval, then recurses

This is written in the normal ring middleware pattern which means we can just selectively wrap it around the API handling functions or routes that we think need it, that way we don't have to deal with the added overhead for simple endpoints

This still needs some tweaking and better error handling. WIP
