### PR TITLE
Refactor schema_metadata's field type parsing, resolves zip/state/country showing INSIDE operator

### DIFF
--- a/frontend/src/query_builder/FieldList.jsx
+++ b/frontend/src/query_builder/FieldList.jsx
@@ -5,15 +5,16 @@ import Icon from "metabase/components/Icon.jsx";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger.jsx";
 import TimeGroupingPopover from "./TimeGroupingPopover.jsx";
 
-import { isDate, getUmbrellaType, TIME, NUMBER, STRING, LOCATION } from 'metabase/lib/schema_metadata';
+import { isDate, getFieldType, DATE_TIME, NUMBER, STRING, LOCATION, COORDINATE } from 'metabase/lib/schema_metadata';
 import { parseFieldBucketing, parseFieldTarget } from "metabase/lib/query_time";
 import { stripId, singularize } from "metabase/lib/formatting";
 
 import _ from "underscore";
 
 const ICON_MAPPING = {
-    [TIME]:  'calendar',
+    [DATE_TIME]:  'calendar',
     [LOCATION]: 'location',
+    [COORDINATE]: 'location',
     [STRING]: 'string',
     [NUMBER]: 'int'
 };
@@ -117,7 +118,7 @@ export default class FieldList extends Component {
     }
 
     renderTypeIcon(field) {
-        let type = getUmbrellaType(field);
+        let type = getFieldType(field);
         let name = ICON_MAPPING[type] || 'unknown';
         return <Icon name={name} width={18} height={18} />;
     }

--- a/frontend/test/unit/lib/schema_metadata.spec.js
+++ b/frontend/test/unit/lib/schema_metadata.spec.js
@@ -1,64 +1,47 @@
 /*eslint-env jasmine */
 
 import {
-    parseBaseType,
-    parseSpecialType,
-    getUmbrellaType,
-    TIME,
+    getFieldType,
+    DATE_TIME,
     STRING,
     NUMBER,
-    BOOL,
-    LOCATION
+    BOOLEAN,
+    LOCATION,
+    COORDINATE
 } from 'metabase/lib/schema_metadata';
 
-/* i'm a pretend latitude field */
-const specialField = {
-    base_type: 'FloatField',
-    special_type: 'latitude'
-}
-
 describe('schema_metadata', () => {
-
-    describe('parseBaseType', () => {
+    describe('getFieldType', () => {
         it('should know a date', () => {
-            expect(parseBaseType('DateField')).toEqual(TIME)
-            expect(parseBaseType('DateTimeField')).toEqual(TIME)
-            expect(parseBaseType('TimeField')).toEqual(TIME)
+            expect(getFieldType({ base_type: 'DateField' })).toEqual(DATE_TIME)
+            expect(getFieldType({ base_type: 'DateTimeField' })).toEqual(DATE_TIME)
+            expect(getFieldType({ base_type: 'TimeField' })).toEqual(DATE_TIME)
+            expect(getFieldType({ special_type: 'timestamp_seconds' })).toEqual(DATE_TIME)
+            expect(getFieldType({ special_type: 'timestamp_milliseconds' })).toEqual(DATE_TIME)
         });
         it('should know a number', () => {
-            expect(parseBaseType('BigIntegerField')).toEqual(NUMBER)
-            expect(parseBaseType('IntegerField')).toEqual(NUMBER)
-            expect(parseBaseType('FloatField')).toEqual(NUMBER)
-            expect(parseBaseType('DecimalField')).toEqual(NUMBER)
+            expect(getFieldType({ base_type: 'BigIntegerField' })).toEqual(NUMBER)
+            expect(getFieldType({ base_type: 'IntegerField' })).toEqual(NUMBER)
+            expect(getFieldType({ base_type: 'FloatField' })).toEqual(NUMBER)
+            expect(getFieldType({ base_type: 'DecimalField' })).toEqual(NUMBER)
         });
         it('should know a string', () => {
-            expect(parseBaseType('CharField')).toEqual(STRING)
-            expect(parseBaseType('TextField')).toEqual(STRING)
+            expect(getFieldType({ base_type: 'CharField' })).toEqual(STRING)
+            expect(getFieldType({ base_type: 'TextField' })).toEqual(STRING)
         });
         it('should know a bool', () => {
-            expect(parseBaseType('BooleanField')).toEqual(BOOL)
-        });
-        it('should know what it doesn\'t know', () => {
-            expect(parseBaseType('DERP DERP DERP')).toEqual(undefined)
-        });
-    });
-
-    describe('parseSpecialType', () => {
-        it('should know a date', () => {
-            expect(parseSpecialType('timestamp_seconds')).toEqual(TIME)
-            expect(parseSpecialType('timestamp_milliseconds')).toEqual(TIME)
+            expect(getFieldType({ base_type: 'BooleanField' })).toEqual(BOOLEAN)
         });
         it('should know a location', () => {
-            expect(parseSpecialType('city')).toEqual(LOCATION)
-            expect(parseSpecialType('country')).toEqual(LOCATION)
-            expect(parseSpecialType('latitude')).toEqual(LOCATION)
-            expect(parseSpecialType('longitude')).toEqual(LOCATION)
+            expect(getFieldType({ special_type: 'city' })).toEqual(LOCATION)
+            expect(getFieldType({ special_type: 'country' })).toEqual(LOCATION)
         });
-    });
-
-    describe('getUmbrellaType', () => {
-        it('should parse a special type if both types are present', () => {
-            expect(getUmbrellaType(specialField)).toEqual(LOCATION)
+        it('should know a coordinate', () => {
+            expect(getFieldType({ special_type: 'latitude' })).toEqual(COORDINATE)
+            expect(getFieldType({ special_type: 'longitude' })).toEqual(COORDINATE)
+        });
+        it('should know what it doesn\'t know', () => {
+            expect(getFieldType({ base_type: 'DERP DERP DERP' })).toEqual(undefined)
         });
     });
 });


### PR DESCRIPTION
#1188

I ran some tests to compare the results of the old and new implementations with every `field_type`, `base_type`, and `special_type` (and updated the unit tests), so I think this is pretty safe.
