### PR TITLE
Stringify objects in object detail and table view, e.x. MongoDB nested objects

### DIFF
--- a/frontend/src/lib/formatting.js
+++ b/frontend/src/lib/formatting.js
@@ -35,6 +35,9 @@ export function formatCell(value, column) {
         } else {
             return formatNumber(value);
         }
+    } else if (typeof value === "object") {
+        // no extra whitespace for table cells
+        return JSON.stringify(value);
     } else {
         return String(value);
     }

--- a/frontend/src/query_builder/QueryVisualizationObjectDetailTable.jsx
+++ b/frontend/src/query_builder/QueryVisualizationObjectDetailTable.jsx
@@ -51,13 +51,14 @@ export default class QueryVisualizationObjectDetailTable extends Component {
         } else {
 
             var cellValue;
-            if (row[1] === null || (typeof row[1] === "string" && row[1].length === 0)) {
+            if (row[1] === null || row[1] === undefined || (typeof row[1] === "string" && row[1].length === 0)) {
                 cellValue = (<span className="text-grey-2">Empty</span>);
-
             } else if(row[0].special_type === "json") {
                 var formattedJson = JSON.stringify(JSON.parse(row[1]), null, 2);
                 cellValue = (<pre className="ObjectJSON">{formattedJson}</pre>);
-
+            } else if (typeof row[1] === "object") {
+                var formattedJson = JSON.stringify(row[1], null, 2);
+                cellValue = (<pre className="ObjectJSON">{formattedJson}</pre>);
             } else {
                 // TODO: should we be casting all values toString()?
                 cellValue = (<ExpandableString str={row[1].toString()} length={140}></ExpandableString>);


### PR DESCRIPTION
#1227

![screenshot 2015-10-12 18 48 08](https://cloud.githubusercontent.com/assets/18193/10443643/13136776-7112-11e5-803e-b1f69d0a4c50.png)

`[Object object]` etc is still shown in the table view. Should we do something special there as well?
