### PR TITLE
Add NSAppTransportSecurity exception to OS X app Info.plist

### DIFF
--- a/OSX/Metabase/Metabase-Info.plist
+++ b/OSX/Metabase/Metabase-Info.plist
@@ -38,5 +38,10 @@
 	<string>https://s3.amazonaws.com/downloads.metabase.com/appcast.xml</string>
 	<key>SUPublicDSAKeyFile</key>
 	<string>dsa_pub.pem</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
I'm suspecting OS X (El Capitan) is blocking connections to Heroku DBs because it doesn't like its SSL certificate. Tell OS X to knock that shit off.
