### PR TITLE
fix ssl connection logic for new databases added in setup

### DIFF
--- a/frontend/src/setup/components/DatabaseStep.jsx
+++ b/frontend/src/setup/components/DatabaseStep.jsx
@@ -46,18 +46,16 @@ export default class DatabaseStep extends Component {
 
         } catch (error) {
             let formError = error;
-            if (details.details.ssl === true) {
-                details.details.ssl = false;
+            details.details.ssl = false;
 
-                try {
-                    // validate the details before we move forward
-                    await this.props.dispatch(validateDatabase(details));
+            try {
+                // ssl connection failed, lets try non-ssl
+                await this.props.dispatch(validateDatabase(details));
 
-                    formError = null;
+                formError = null;
 
-                } catch (error2) {
-                    formError = error2;
-                }
+            } catch (error2) {
+                formError = error2;
             }
 
             if (formError) {

--- a/frontend/src/setup/components/DatabaseStep.jsx
+++ b/frontend/src/setup/components/DatabaseStep.jsx
@@ -37,25 +37,47 @@ export default class DatabaseStep extends Component {
             'formError': null
         });
 
+        // make sure that we are trying ssl db connections to start with
+        details.details.ssl = true;
+
         try {
-            // validate them first
+            // validate the details before we move forward
             await this.props.dispatch(validateDatabase(details));
 
-            // now that they are good, store them
-            this.props.dispatch(setDatabaseDetails({
-                'nextStep': ++this.props.stepNumber,
-                'details': details
-            }));
-
-            MetabaseAnalytics.trackEvent('Setup', 'Database Step', this.state.engine);
-
         } catch (error) {
-            MetabaseAnalytics.trackEvent('Setup', 'Error', 'database validation: '+this.state.engine);
+            let formError = error;
+            if (details.details.ssl === true) {
+                details.details.ssl = false;
 
-            this.setState({
-                'formError': error
-            });
+                try {
+                    // validate the details before we move forward
+                    await this.props.dispatch(validateDatabase(details));
+
+                    formError = null;
+
+                } catch (error2) {
+                    formError = error2;
+                }
+            }
+
+            if (formError) {
+                MetabaseAnalytics.trackEvent('Setup', 'Error', 'database validation: '+this.state.engine);
+
+                this.setState({
+                    'formError': formError
+                });
+
+                return;
+            }
         }
+
+        // now that they are good, store them
+        this.props.dispatch(setDatabaseDetails({
+            'nextStep': ++this.props.stepNumber,
+            'details': details
+        }));
+
+        MetabaseAnalytics.trackEvent('Setup', 'Database Step', this.state.engine);
     }
 
     skipDatabase() {


### PR DESCRIPTION
add back the ssl and non-ssl database connection try logic which went missing when we moved setup over to react/redux.  fixes #1304
