### PR TITLE
Disable JRE stripping in bin/osx-setup since it breaks SSL

### DIFF
--- a/OSX/Metabase/Metabase-Info.plist
+++ b/OSX/Metabase/Metabase-Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.12.0.1</string>
+	<string>0.12.0.7</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>0.12.0.1</string>
+	<string>0.12.0.7</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/bin/osx-release
+++ b/bin/osx-release
@@ -187,7 +187,7 @@ sub create_dmg_from_source_dir {
            '-fs', 'HFS+',
            '-fsargs', '-c c=64,a=16,e=16',
            '-format', 'UDRW',
-           '-size', '144MB',          # it looks like this can be whatever size we want; compression slims it down
+           '-size', '256MB',          # it looks like this can be whatever size we want; compression slims it down
            $dmg_filename) == 0 or die $!;
 }
 

--- a/bin/osx-setup
+++ b/bin/osx-setup
@@ -19,6 +19,7 @@ use constant UBERJAR_SRC => getcwd() . '/target/uberjar/metabase.jar';
 use constant UBERJAR_DEST => getcwd() . '/OSX/Resources/metabase.jar';
 
 use constant ENABLE_JAR_PACKING => 0;
+use constant ENABLE_JAR_OPTIONAL_FILE_STRIPPING => 0;
 
 sub remove_jre_optional_files {
     my @optional_files = ('bin/keytool',
@@ -70,7 +71,7 @@ sub pack_jre_jars {
 (rcopy(JRE_HOME, JRE_DEST) or die $!) unless -d JRE_DEST;
 
 # Remove optional files from JRE dest
-remove_jre_optional_files();
+remove_jre_optional_files() if ENABLE_JAR_OPTIONAL_FILE_STRIPPING;
 
 # Pack JARs in JRE if applicable
 pack_jar() if ENABLE_JAR_PACKING;


### PR DESCRIPTION
feature flagged this with a `use constant`.

There's a big list of files that we strip from the JRE which saves almost 30MB from the built DMG, but at least one of them is necessary for SSL DB connections. So until we figure out exactly what it is just go with the heavy JRE for right now.
