### PR TITLE
more consistent highlighting

### DIFF
--- a/docs/operations-guide/running-the-metabase-mac-app.md
+++ b/docs/operations-guide/running-the-metabase-mac-app.md
@@ -8,12 +8,12 @@ Start off by downloading the [Metabase Mac Application](http://www.metabase.com/
 
 ![macinstaller](images/MacInstaller.png)
 
-Next simply click and drag the Metabase.app icon over to the `Applications` Folder icon on the left.  That will install Metabase into your main Applications folder.
+Next simply click and drag the Metabase.app icon over to the `Applications` folder icon on the left.  That will install Metabase into your main `Applications` folder.
 
 
 ### Launching Metabase
 
-To launch Metabase open the Mac Finder application and click on Applications on the left.  Then scroll down your applications list until you see Metabase.app and double click it.
+To launch Metabase open the Mac Finder application and click on `Applications` on the left.  Then scroll down your applications list until you see Metabase.app and double click it.
 
 The Metabase application should now have opened and you should see the loading screen in the application window with a spinner going.
 


### PR DESCRIPTION
I propose some small changes in the documentation to keep the file more consistent by highlighting all references to the Applications folder the same way.
