### PR TITLE
State that only H2 and Postgres are available

### DIFF
--- a/docs/operations-guide/running-the-metabase-jar-file.md
+++ b/docs/operations-guide/running-the-metabase-jar-file.md
@@ -51,7 +51,7 @@ Now that you’ve installed Metabase, it’s time to [set it up and connect it t
 
 ### The Metabase Application Database
 
-The application database is where Metabase stores information about users, saved questions, dashboards, and any other data needed to run the application.  The default settings use an H2 database, but other options are available.
+The application database is where Metabase stores information about users, saved questions, dashboards, and any other data needed to run the application.  The default settings use an H2 database, but other also Postgres is available.
 
 #### [H2](http://www.h2database.com/) (default)
 To use the H2 database for your Metabase instance you don't need to do anything at all.  When the application is first launched it will attempt to create a new H2 database in the same filesystem location the application is launched from.


### PR DESCRIPTION
State that there is currently only H2 and Postgres as Application Database. This helps #1332.
