### PR TITLE
Don't blow up when saving a question with a unicode characters 😁

### DIFF
--- a/frontend/src/card/card.util.js
+++ b/frontend/src/card/card.util.js
@@ -12,11 +12,20 @@ export function serializeCardForUrl(card) {
         display: card.display,
         visualization_settings: card.visualization_settings
     };
-    return btoa(JSON.stringify(cardCopy));
+    return utf8_to_b64(JSON.stringify(cardCopy));
 }
 
 export function deserializeCardFromUrl(serialized) {
-    return JSON.parse(atob(serialized));
+    return JSON.parse(b64_to_utf8(serialized));
+}
+
+// escaping before base64 encoding is necessary for non-ASCII characters
+// https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/btoa
+function utf8_to_b64(str) {
+    return window.btoa(unescape(encodeURIComponent(str)));
+}
+function b64_to_utf8(str) {
+    return decodeURIComponent(escape(window.atob(str)));
 }
 
 export function urlForCardState(state, dirty) {


### PR DESCRIPTION
Fixes #1386

Note that `btoa(unescape(encodeURIComponent(str))) == btoa(str)` for ASCII only strings, so this should be backwards compatible with existing URLs.
