### PR TITLE
allow configuration of Jetty SSL vars through environment.

### DIFF
--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -23,7 +23,7 @@
    ;; check here for all available options:
    ;; https://github.com/ring-clojure/ring/blob/master/ring-jetty-adapter/src/ring/adapter/jetty.clj
    :mb-jetty-port "3000"
-   :mb-jetty-join "false"
+   :mb-jetty-join "true"
    ;; Other Application Settings
    :mb-password-complexity "normal"
    ;:mb-password-length "8"

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -166,16 +166,23 @@
   "Start the embedded Jetty web server."
   []
   (when-not @jetty-instance
-    (let [jetty-config (cond-> (m/filter-vals identity {:port (config/config-int :mb-jetty-port)
-                                                        :host (config/config-str :mb-jetty-host)
-                                                        :max-threads (config/config-int :mb-jetty-maxthreads)
-                                                        :min-threads (config/config-int :mb-jetty-minthreads)
-                                                        :max-queued (config/config-int :mb-jetty-maxqueued)
-                                                        :max-idle-time (config/config-int :mb-jetty-maxidletime)})
-                         (config/config-str :mb-jetty-join) (assoc :join? (config/config-bool :mb-jetty-join))
-                         (config/config-str :mb-jetty-daemon) (assoc :daemon? (config/config-bool :mb-jetty-daemon)))]
-      (log/info "Launching Embedded Jetty Webserver with config:\n" (with-out-str (clojure.pprint/pprint jetty-config)))
-      (->> (ring-jetty/run-jetty app jetty-config)
+    (let [jetty-ssl-config (m/filter-vals identity {:ssl-port       (config/config-int :mb-jetty-ssl-port)
+                                                    :keystore       (config/config-str :mb-jetty-ssl-keystore)
+                                                    :key-password   (config/config-str :mb-jetty-ssl-keystore-password)
+                                                    :truststore     (config/config-str :mb-jetty-ssl-truststore)
+                                                    :trust-password (config/config-str :mb-jetty-ssl-truststore-password)})
+          jetty-config     (cond-> (m/filter-vals identity {:port           (config/config-int :mb-jetty-port)
+                                                            :host           (config/config-str :mb-jetty-host)
+                                                            :max-threads    (config/config-int :mb-jetty-maxthreads)
+                                                            :min-threads    (config/config-int :mb-jetty-minthreads)
+                                                            :max-queued     (config/config-int :mb-jetty-maxqueued)
+                                                            :max-idle-time  (config/config-int :mb-jetty-maxidletime)})
+                             (config/config-str :mb-jetty-daemon) (assoc :daemon? (config/config-bool :mb-jetty-daemon))
+                             (config/config-str :mb-jetty-ssl)    (-> (assoc :ssl? true)
+                                                                      (merge jetty-ssl-config)))]
+      (log/info "Launching Embedded Jetty Webserver with config:\n" (with-out-str (clojure.pprint/pprint (m/filter-keys (fn [k] (not (re-matches #".*password.*" (str k)))) jetty-config))))
+      ;; NOTE: we always start jetty w/ join=false so we can start the server first then do init in the background
+      (->> (ring-jetty/run-jetty app (assoc jetty-config :join? false))
            (reset! jetty-instance)))))
 
 (defn stop-jetty
@@ -198,7 +205,8 @@
     ;; run our initialization process
     (init)
     ;; Ok, now block forever while Jetty does its thing
-    (.join ^org.eclipse.jetty.server.Server @jetty-instance)
+    (when (config/config-bool :mb-jetty-join)
+      (.join ^org.eclipse.jetty.server.Server @jetty-instance))
     (catch Exception e
       (.printStackTrace e)
       (log/error "Metabase Initialization FAILED: " (.getMessage e)))))


### PR DESCRIPTION
This resolves #1009 and makes it possible to specify a keystore and ssl config options at Metabase startup so that admins can run Metabase over https directly.
