### PR TITLE
Don't show links in table cells for aggregations

### DIFF
--- a/frontend/src/card/card.controllers.js
+++ b/frontend/src/card/card.controllers.js
@@ -254,7 +254,7 @@ CardControllers.controller('CardDetail', [
 
                 if (!coldef || !coldef.special_type) return false;
 
-                if (coldef.special_type === 'id' || (coldef.special_type === 'fk' && coldef.target)) {
+                if (coldef.table_id != null && coldef.special_type === 'id' || (coldef.special_type === 'fk' && coldef.target)) {
                     return true;
                 } else {
                     return false;

--- a/frontend/src/lib/schema_metadata.js
+++ b/frontend/src/lib/schema_metadata.js
@@ -46,7 +46,8 @@ const TYPES = {
     },
 
     [SUMMABLE]: {
-        include: [NUMBER]
+        include: [NUMBER],
+        exclude: [ENTITY, LOCATION, DATE_TIME]
     },
     [CATEGORY]: {
         base: ["BooleanField"],
@@ -67,7 +68,15 @@ export function isFieldType(type, field) {
             return true;
         }
     }
-    // recursively check to see if it's another field th:
+    // recursively check to see if it's NOT another field type:
+    if (def.exclude) {
+        for (let excludeType of def.exclude) {
+            if (isFieldType(excludeType, field)) {
+                return false;
+            }
+        }
+    }
+    // recursively check to see if it's another field type:
     if (def.include) {
         for (let includeType of def.include) {
             if (isFieldType(includeType, field)) {


### PR DESCRIPTION
#803

This only prevents the linkification, not selecting senseless aggregations. Perhaps changing the `SUMMABLE` type to exclude `fk` and `id` `special_type`s would be sufficient? https://github.com/metabase/metabase/blob/master/frontend/src/lib/schema_metadata.js#L48
