### PR TITLE
Fussing with unit test encapsulation [Experimental]

### DIFF
--- a/test/metabase/driver/sync_test.clj
+++ b/test/metabase/driver/sync_test.clj
@@ -14,13 +14,14 @@
                            [util :refer [resolve-private-fns]])
             (metabase.test.data [datasets :as datasets]
                                 [interface :refer [create-database-definition]])
+            [metabase.test.data.data :refer [test-data]]
             [metabase.util :as u]))
 
 (def users-table
-  (delay (sel :one Table :name "USERS")))
+  (delay (Table (id :users))))
 
 (def venues-table
-  (delay (sel :one Table :name "VENUES")))
+  (delay (Table (id :venues))))
 
 (def korma-users-table
   (delay (korma-entity @users-table)))
@@ -30,11 +31,12 @@
 
 
 ;; ## TEST PK SYNCING
-(expect [:id
-         nil
-         :id
-         :latitude
-         :id]
+(expect-with-test-db [_ test-data]
+  [:id
+   nil
+   :id
+   :latitude
+   :id]
   (let [get-special-type (fn [] (sel :one :field [Field :special_type] :id (id :venues :id)))]
     [;; Special type should be :id to begin with
      (get-special-type)
@@ -56,19 +58,23 @@
 
 ;; Check that Foreign Key relationships were created on sync as we expect
 
-(expect (id :venues :id)
+(expect-with-test-db [_ test-data]
+  (id :venues :id)
   (sel :one :field [ForeignKey :destination_id] :origin_id (id :checkins :venue_id)))
 
-(expect (id :users :id)
+(expect-with-test-db [_ test-data]
+  (id :users :id)
   (sel :one :field [ForeignKey :destination_id] :origin_id (id :checkins :user_id)))
 
-(expect (id :categories :id)
+(expect-with-test-db [_ test-data]
+  (id :categories :id)
   (sel :one :field [ForeignKey :destination_id] :origin_id (id :venues :category_id)))
 
 ;; Check that sync-table! causes FKs to be set like we'd expect
-(expect [[:fk true]
-         [nil false]
-         [:fk true]]
+(expect-with-test-db [_ test-data]
+  [[:fk true]
+   [nil false]
+   [:fk true]]
   (let [field-id (id :checkins :user_id)
         get-special-type-and-fk-exists? (fn []
                                           [(sel :one :field [Field :special_type] :id field-id)
@@ -87,45 +93,49 @@
 ;; ## Tests for DETERMINE-FK-TYPE
 ;; Since COUNT(category_id) > COUNT(DISTINCT(category_id)) the FK relationship should be Mt1
 (def determine-fk-type (u/runtime-resolved-fn 'metabase.driver.sync 'determine-fk-type))
-(expect :Mt1
+(expect-with-test-db [_ test-data]
+  :Mt1
   (determine-fk-type (Field (id :venues :category_id))))
 
 ;; Since COUNT(id) == COUNT(DISTINCT(id)) the FK relationship should be 1t1
 ;; (yes, ID isn't really a FK field, but determine-fk-type doesn't need to know that)
-(expect :1t1
+(expect-with-test-db [_ test-data]
+  :1t1
   (determine-fk-type (Field (id :venues :id))))
 
 
 ;;; ## FieldValues Syncing
 
-(let [get-field-values    (fn [] (sel :one :field [FieldValues :values] :field_id (id :venues :price)))
-      get-field-values-id (fn [] (sel :one :id FieldValues :field_id (id :venues :price)))]
-  ;; Test that when we delete FieldValues syncing the Table again will cause them to be re-created
-  (expect
-      [[1 2 3 4]  ; 1
-       nil        ; 2
-       [1 2 3 4]] ; 3
+;; Test that when we delete FieldValues syncing the Table again will cause them to be re-created
+(expect-with-test-db [_ test-data]
+  [[1 2 3 4]  ; 1
+   nil        ; 2
+   [1 2 3 4]] ; 3
+  (let [get-field-values    (fn [] (sel :one :field [FieldValues :values] :field_id (id :venues :price)))
+        get-field-values-id (fn [] (sel :one :id FieldValues :field_id (id :venues :price)))]
     [ ;; 1. Check that we have expected field values to start with
      (get-field-values)
      ;; 2. Delete the Field values, make sure they're gone
      (do (cascade-delete FieldValues :id (get-field-values-id))
          (get-field-values))
      ;; 3. Now re-sync the table and make sure they're back
-     (do (driver/sync-table! @venues-table)
-         (get-field-values))])
+     (do (driver/sync-table! (Table (id :venues)))
+         (get-field-values))]))
 
-  ;; Test that syncing will cause FieldValues to be updated
-  (expect
-      [[1 2 3 4]  ; 1
-       [1 2 3]    ; 2
-       [1 2 3 4]] ; 3
+;; Test that syncing will cause FieldValues to be updated
+(expect-with-test-db [_ test-data]
+  [[1 2 3 4]  ; 1
+   [1 2 3]    ; 2
+   [1 2 3 4]] ; 3
+  (let [get-field-values    (fn [] (sel :one :field [FieldValues :values] :field_id (id :venues :price)))
+        get-field-values-id (fn [] (sel :one :id FieldValues :field_id (id :venues :price)))]
     [ ;; 1. Check that we have expected field values to start with
      (get-field-values)
      ;; 2. Update the FieldValues, remove one of the values that should be there
      (do (upd FieldValues (get-field-values-id) :values [1 2 3])
          (get-field-values))
      ;; 3. Now re-sync the table and make sure the value is back
-     (do (driver/sync-table! @venues-table)
+     (do (driver/sync-table! (Table (id :venues)))
          (get-field-values))]))
 
 

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -4,6 +4,7 @@
                      [walk :as walk])
             [clojure.tools.logging :as log]
             [colorize.core :as color]
+            [expectations :as expectations]
             [medley.core :as m]
             (metabase [db :refer :all]
                       [driver :as driver])
@@ -212,3 +213,53 @@
   `(-with-temp-db ~database-definition
      (fn [~db-binding]
        ~@body)))
+
+
+(defmacro expect-with-test-db
+  "Identical to `expect` but wraps the entire evaluation in `with-temp-db` so that both expected and actual statements
+   have access to the test data required for the test.
+
+     (expect-with-test-db [_ test-data]
+       (id :venues :id)
+       (sel :one :field [ForeignKey :destination_id] :origin_id (id :checkins :venue_id)))"
+  [test-db-binding expected actual]
+  (let [fn-name (gensym)]
+    `(def ~(vary-meta fn-name assoc :expectation true)
+       (fn []
+         (with-temp-db ~test-db-binding
+           (expectations/doexpect ~expected ~actual))))))
+
+
+;;; ## ---------------------------------------- Test-Data Interface ----------------------------------------
+
+
+(def base-test-data
+  {:init! (fn [_])
+   :restart! (fn [_])
+   :destroy! (fn [_])})
+
+(defn with-test-data [i-test-data f]
+  (try
+    (binding [*sel-disable-logging* true]
+      (when (:init! i-test-data)
+        ((:init! i-test-data) i-test-data))
+      (binding [*sel-disable-logging* false]
+        (f)))
+    (finally
+      (binding [*sel-disable-logging* true]
+        (when (:destroy! i-test-data)
+          ((:destroy! i-test-data) i-test-data))))))
+
+(defmacro expect-with-test-data
+  "Identical to `expect` but wraps the entire evaluation in `with-temp-db` so that both expected and actual statements
+   have access to the test data required for the test.
+
+     (expect-with-test-db [_ test-data]
+       (id :venues :id)
+       (sel :one :field [ForeignKey :destination_id] :origin_id (id :checkins :venue_id)))"
+  [i-test-data expected actual]
+  (let [fn-name (gensym)]
+    `(def ~(vary-meta fn-name assoc :expectation true)
+       (fn []
+         (with-test-data ~i-test-data
+           (fn [] (expectations/doexpect ~expected ~actual)))))))

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -233,22 +233,17 @@
 ;;; ## ---------------------------------------- Test-Data Interface ----------------------------------------
 
 
-(def base-test-data
-  {:init! (fn [_])
-   :restart! (fn [_])
-   :destroy! (fn [_])})
-
 (defn with-test-data [i-test-data f]
   (try
     (binding [*sel-disable-logging* true]
-      (when (:init! i-test-data)
-        ((:init! i-test-data) i-test-data))
+      (when (fn? (:before i-test-data))
+        ((:before i-test-data)))
       (binding [*sel-disable-logging* false]
         (f)))
     (finally
       (binding [*sel-disable-logging* true]
-        (when (:destroy! i-test-data)
-          ((:destroy! i-test-data) i-test-data))))))
+        (when (fn? (:after i-test-data))
+          ((:after i-test-data)))))))
 
 (defmacro expect-with-test-data
   "Identical to `expect` but wraps the entire evaluation in `with-temp-db` so that both expected and actual statements

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -66,13 +66,12 @@
   (m/mapply fetch-or-create-user (user->info username)))
 
 (def user->id
-  "Memoized fn that returns the ID of User associated with USERNAME.
+  "fn that returns the ID of User associated with USERNAME, creating the user if needed.
 
     (user->id :rasta) -> 4"
-  (memoize
-   (fn [username]
-     {:pre [(contains? usernames username)]}
-     (:id (fetch-user username)))))
+  (fn [username]
+    {:pre [(contains? usernames username)]}
+    (:id (fetch-user username))))
 
 (defn user->credentials
   "Return a map with `:email` and `:password` for User with USERNAME.


### PR DESCRIPTION
Primary goal here is 2 things:
1. completely purge all app data between each unit test execution to ensure that tests are fully encapsulated and don't affect each other.
2. provide a simple and lightweight way to define a test which specifies it's own arbitrary set of data to use with the test execution.

The inspiration for this is from a variety of places such as:

```
(do
    ;; Delete all the other random Users we've created so far
    (let [user-ids (set (map user->id [:crowberto :rasta :lucky :trashbird]))]
      (cascade-delete User :id [not-in user-ids]))
    ;; Now do the request
    (set ((user->client :crowberto) :get 200 "user")))
```

:cry: we have a lot of code in unit tests which is there purely to cleanup existing data and attempt to create a concrete dataset for its own test.  this is both ugly and error prone.

```
(when-let [user (create-user-api rand-name)]
      ;; create a random user then set them to :inactive
      (upd User (:id user)
        :is_active false
        :is_superuser true)
      ;; then try creating the same user again
      ((user->client :crowberto) :post 200 "user" {:first_name (:first_name user)
                                                   :last_name "whatever"
                                                   :email (:email user)}))
```

:disappointed: we repeat ourselves quite a bit from test to test specifically to create simple things like test objects and that muddies the reading of the unit tests and duplicates code unnecessarily.

:smile: instead of both of these scenarios we can add in a little code the resets the app db for each unit test and then we can provide a simple macro which allows us to create our desired test data with the test execution.  for example:

```
(def single-example-user 
    {:before (fn []
                    (ins User :first_name "Rasta" :last_name "Toucan" :email "rasta@metabase.com"))})

(expect-with-test-data single-example-user
    "Rasta"
    (sel :one :field [User :first_name] :email "rasta@metabase.com"))

(expect-with-test-data single-example-user
    "Toucan"
    (sel :one :field [User :last_name] :email "rasta@metabase.com"))
```
