### PR TITLE
Need cond-as-> macro :flushed:

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -18,6 +18,7 @@
                               (catch-api-exceptions 0)
                               (check 1)
                               (checkp 1)
+                              (cond-as-> 2)
                               (cond-let 0)
                               (conda 0)
                               (context 2)

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -293,4 +293,24 @@
        (throw (Exception. (format "Timed out after %d milliseconds." ~timeout-ms))))
      result#))
 
+(defmacro cond-as->
+  "Anaphoric version of `cond->`. Binds EXPR to NAME through a series
+   of pairs of TEST and FORM. NAME is successively bound to the value
+   of each FORM whose TEST succeeds.
+
+     (defn maybe-wrap-fn [before after f]
+       (as-> f <>
+         (fn? before) (fn [] (before) (<>))
+         (fn? after)  (fn [] (try (<>)
+                                  (finally (after))))))"
+  {:arglists '([expr nm tst form & more])}
+  [expr nm & clauses]
+  {:pre [(even? (count clauses))]}
+  `(let [~nm ~expr
+         ~@(apply concat (for [[tst form] (partition 2 clauses)]
+                           [nm `(if ~tst
+                                  ~form
+                                  ~nm)]))]
+     ~nm))
+
 (require-dox-in-this-namespace)

--- a/test/metabase/test_util.clj
+++ b/test/metabase/test_util.clj
@@ -81,3 +81,24 @@
 
 (expect -7
   ((rpartial - 5 10) 8))
+
+
+;;; ## cond-as->
+(expect 100
+  (cond-as-> 100 <>))
+
+(expect 106
+  (cond-as-> 100 <>
+    true  (+  1 <>)
+    false (+ 10 <>)
+    :ok   (+  5 <>)))
+
+(expect 101
+  (cond-as-> 100 <>
+    (odd? <>)  (inc <>)
+    (even? <>) (inc <>)))
+
+(expect 102
+  (cond-as-> 100 <>
+    (even? <>) (inc <>)
+    (odd? <>)  (inc <>)))


### PR DESCRIPTION
Anaphoric version of `cond->` macro. Can't believe this isn't in `clojure.core`. :scream_cat: 

There's been several times in the past where this macro would have made my life easier, but I ended up just settling for using regular old `cond->` or `as->` because of time constraints :crying_cat_face: I'm not generally a fan of putting things in the codebase to save for a rainy day :umbrella: but I I think this macro is so useful that we should make an exception in this case. :briefcase: It will be nice to have it available in the REPL too.
#### Use Cases

@agilliland I think this macro could be super handy for some of the unit test stuff you're working on. Here's `with-test-data` rewritten to use`cond-as->`:
###### No `cond-as->` :sob:

``` clojure
(defn with-test-data [i-test-data f]
  (try
    (binding [*sel-disable-logging* true]
      (when (fn? (:before i-test-data))
        ((:before i-test-data)))
      (binding [*sel-disable-logging* false]
        (f)))
    (finally
      (binding [*sel-disable-logging* true]
        (when (fn? (:after i-test-data))
          ((:after i-test-data)))))))
```
###### With `cond-as->` :heart_eyes_cat:

``` clojure
(defn with-test-data [{:keys [before after]} f]
  (let [no-log (fn [x] (binding [*sel-disable-logging* true]
                         (x)))]
    ((cond-as-> f <>
       (fn? before) (fn [] (no-log before) (<>))
       (fn? after)  (fn [] (try (<>)
                                (finally (no-log after))))))))
```

I think  in certain cases  it really facilitates writing clean code  :pencil2: :shower:
###### Expansion :boom:

This actually has a super simple expansion too:

``` clojure
(let [<> f
      <> (if (fn? before)
           (fn [] (no-log before) (<>))
           <>)
      <> (if (fn? after)
           (fn [] (try (<>) 
                       (finally (no-log after))))
           <>)]
  <>)
```

Now I need to go write one of these for [dash.el](https://github.com/magnars/dash.el) too :gift: 
