### PR TITLE
change the way the password reset unit test is done to avoid issues with the way mysql handles datetimes.

### DIFF
--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -214,27 +214,20 @@
 
 ;; ## PUT /api/user/:id/password
 ;; Test that a User can change their password
-(let [user-last-name (random-name)]
-  (expect-eval-actual-first
-      (let [{user-id :id} (sel :one User :last_name user-last-name)]
-        (sel :one :fields [Session :id] :user_id user-id (k/order :created_at :desc))) ; get the latest Session for this User
-    (let [password {:old "password"
-                    :new "whateverUP12!!"}
-          {:keys [email id] :as user} (create-user :password (:old password) :last_name user-last-name)
-          creds {:old {:password (:old password)
-                       :email email}
-                 :new {:password (:new password)
-                       :email email}}]
-      ;; Check that creds work
-      (metabase.http-client/client :post 200 "session" (:old creds))
-      ;; Change the PW
-      (metabase.http-client/client (:old creds) :put 200 (format "user/%d/password" id) {:password (:new password)
-                                                                                         :old_password (:old password)})
-      ;; Old creds should no longer work
-      (assert (= (metabase.http-client/client :post 400 "session" (:old creds))
-                {:errors {:password "did not match stored password"}}))
-      ;; New creds *should* work
-      (metabase.http-client/client :post 200 "session" (:new creds)))))
+(expect-let [creds                 {:email    "abc@metabase.com"
+                                    :password "def"}
+             {:keys [id password]} (ins User
+                                     :first_name "test"
+                                     :last_name  "user"
+                                     :email      "abc@metabase.com"
+                                     :password   "def")]
+  true
+  (do
+    ;; use API to reset the users password
+    (metabase.http-client/client creds :put 200 (format "user/%d/password" id) {:password     "abc123!!DEF"
+                                                                                :old_password (:password creds)})
+    ;; now simply grab the lastest pass from the db and compare to the one we have from before reset
+    (not= password (sel :one :field [User :password] :email (:email creds)))))
 
 ;; Check that a non-superuser CANNOT update someone else's password
 (expect "You don't have permissions to do that."


### PR DESCRIPTION
fixes #1466 
