### PR TITLE
Fix DB details key name for SQL Server :yum: 

### DIFF
--- a/src/metabase/driver/sqlserver.clj
+++ b/src/metabase/driver/sqlserver.clj
@@ -119,9 +119,9 @@
                                                 :display-name "Port"
                                                 :type         :integer
                                                 :default      1433}
-                                               {:name         "dbname"
+                                               {:name         "db"
                                                 :display-name "Database name"
-                                                :placeholder  "birds_of_the_word"
+                                                :placeholder  "BirdsOfTheWorld"
                                                 :required     true}
                                                {:name         "user"
                                                 :display-name "Database username"


### PR DESCRIPTION
Fix wrong key name being exposed in the Edit DB UI for SQL Server.
Fixes #1481
