### PR TITLE
Allow setting instance for SQL Server DBs :yum: 

### DIFF
--- a/src/metabase/driver/sqlserver.clj
+++ b/src/metabase/driver/sqlserver.clj
@@ -47,13 +47,15 @@
    :xml              :UnknownField
    (keyword "int identity") :IntegerField}) ; auto-incrementing integer (ie pk) field
 
-(defn- connection-details->spec [details]
+(defn- connection-details->spec [{:keys [instance], :as details}]
   (-> (kdb/mssql details)
       ;; swap out Microsoft Driver details for jTDS ones
       (assoc :classname   "net.sourceforge.jtds.jdbc.Driver"
              :subprotocol "jtds:sqlserver")
       ;; adjust the connection URL to match up with the jTDS format (see http://jtds.sourceforge.net/faq.html#urlFormat)
-      (update :subname #(s/replace % #";database=" "/"))))
+      ;; and add the ;instance= option if applicable
+      (update :subname #(cond-> (s/replace % #";database=" "/")
+                          (seq instance) (str ";instance=" instance)))))
 
 ;; See also the [jTDS SQL <-> Java types table](http://jtds.sourceforge.net/typemap.html)
 (defn- date [unit field-or-value]
@@ -114,7 +116,7 @@
   (-> (sql-driver {:driver-name               "SQL Server"
                    :details-fields            [{:name         "host"
                                                 :display-name "Host"
-                                                :default "localhost"}
+                                                :default      "localhost"}
                                                {:name         "port"
                                                 :display-name "Port"
                                                 :type         :integer
@@ -123,6 +125,9 @@
                                                 :display-name "Database name"
                                                 :placeholder  "BirdsOfTheWorld"
                                                 :required     true}
+                                               {:name         "instance"
+                                                :display-name "Database instance name"
+                                                :placeholder  "N/A"}
                                                {:name         "user"
                                                 :display-name "Database username"
                                                 :placeholder  "What username do you use to login to the database?"


### PR DESCRIPTION
SQL Server allows [multiple instances of the DB engine on the same computer](https://technet.microsoft.com/en-us/library/aa174516%28v=sql.80%29.aspx). Add optional `instance` param for SQL Server for cases where someone is using a non-default instance.

Fixes #1481 
