### PR TITLE
Rework how tests get selectively enabled for certain drivers :yum:

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -37,7 +37,6 @@
                               (expect-with-engines 1)
                               (format-color 2)
                               (if-questionable-timezone-support 0)
-                              (if-sqlserver 0)
                               (ins 1)
                               (let-400 1)
                               (let-404 1)


### PR DESCRIPTION
I noticed that the tests for ordering by an aggregate field weren't being ran for Mongo even though the driver supports it as of last week's rewrite. To prevent this from happening in the future, rework tests to run against all drivers that declare a given `feature` instead of hardcoding sets of engines.
##### BEFORE

``` clojure
(datasets/expect-with-engines #{:h2 :postgres :mysql :sqlserver}
  ...)
```
##### AFTER

``` clojure
(datasets/expect-with-engines (engines-that-support :foreign-keys)
  ...)
```
