### PR TITLE
Fix 0000-00-00 dates in MySQL :unamused: #1420

### DIFF
--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -36,8 +36,7 @@
   {:foreign-keys                       #{:table-fks}
    :nested-fields                      #{:active-nested-field-name->type}
    :set-timezone                       nil
-   :standard-deviation-aggregations    nil
-   :unix-timestamp-special-type-fields nil})
+   :standard-deviation-aggregations    nil})
 
 (def ^:private ^:const optional-features
   (set (keys feature->required-fns)))

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -208,8 +208,7 @@
   (verify-sql-driver driver)
   (merge
    {:features                  (set (cond-> [:foreign-keys
-                                             :standard-deviation-aggregations
-                                             :unix-timestamp-special-type-fields]
+                                             :standard-deviation-aggregations]
                                       (:set-timezone-sql driver) (conj :set-timezone)))
     :qp-clause->handler        qp/clause->handler
     :can-connect?              (partial can-connect? (:connection-details->spec driver))

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -8,7 +8,8 @@
                        [utils :as utils])
             [metabase.driver :as driver, :refer [defdriver]]
             [metabase.driver.generic-sql :refer [sql-driver]]
-            [metabase.driver.generic-sql.util :refer [funcs]]))
+            [metabase.driver.generic-sql.util :refer [funcs]]
+            [metabase.util :as u]))
 
 ;;; # Korma 0.4.2 Bug Workaround
 ;; (Buggy code @ https://github.com/korma/Korma/blob/684178c386df529558bbf82097635df6e75fb339/src/korma/mysql.clj)
@@ -61,7 +62,10 @@
 (defn- connection-details->spec [details]
   (-> details
       (set/rename-keys {:dbname :db})
-      kdb/mysql))
+      kdb/mysql
+      ;; 0000-00-00 dates are valid in MySQL, but JDBC barfs when queries return them because java.sql.Date doesn't allow it.
+      ;; Add a param to the end of the connection string that tells MySQL to convert 0000-00-00 dates to NULL when returning them.
+      (update :subname (u/rpartial str "?zeroDateTimeBehavior=convertToNull"))))
 
 (defn- unix-timestamp->timestamp [field-or-value seconds-or-milliseconds]
   (utils/func (case seconds-or-milliseconds

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -1,0 +1,17 @@
+(ns metabase.driver.mysql-test
+  (:require [expectations :refer :all]
+            [metabase.driver.mysql :refer [mysql]]
+            (metabase.test.data [datasets :refer [expect-with-engine]]
+                                [interface :refer [def-database-definition]])
+            [metabase.test.util.q :refer [Q]]))
+
+;; MySQL allows 0000-00-00 dates, but JDBC does not; make sure that MySQL is converting them to NULL when returning them like we asked
+(def-database-definition ^:private ^:const all-zero-dates
+  ["exciting-moments-in-history"
+   [{:field-name "moment", :base-type :DateTimeField}]
+   [["0000-00-00"]]])
+
+(expect-with-engine :mysql
+  [[1 nil]]
+  (Q dataset metabase.driver.mysql-test/all-zero-dates
+     return rows of exciting-moments-in-history))

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -35,7 +35,7 @@
                                            :dbname "bird_sightings"
                                            :user   "camsaul"}))
 ;;; # UUID Support
-(def-database-definition ^:private with-uuid
+(def-database-definition ^:const ^:private with-uuid
   ["users"
    [{:field-name "user_id", :base-type :UUIDField}]
    [[#uuid "4f01dcfd-13f7-430c-8e6f-e505c0851027"]


### PR DESCRIPTION
-  `0000-00-00` dates are valid in MySQL, but JDBC barfs when queries return them because `java.sql.Date` doesn't allow it. Add a param to the end of the connection string that tells MySQL to convert `0000-00-00` dates to `NULL` when returning them.
-  Add unit test to verify this behavior

Fixes #1420.
