### PR TITLE
Fix bad Last-Modified header (Fixes #1230)

### DIFF
--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -26,7 +26,7 @@
        :body (with-out-str
                (csv/write-csv *out* (into [columns] rows)))
        :headers {"Content-Type" "text/csv"
-                 "Content-Disposition" (str "attachment; filename=\"query_result_" (u/now-iso8601) ".csv\"")}}
+                 "Content-Disposition" (str "attachment; filename=\"query_result_" (u/date->iso-8601) ".csv\"")}}
       ;; failed query, send error message
       {:status 500
        :body response})))

--- a/src/metabase/routes.clj
+++ b/src/metabase/routes.clj
@@ -6,21 +6,17 @@
             [ring.util.response :as resp]
             [stencil.core :as stencil]
             [metabase.api.routes :as api]
-            [metabase.models.setting :as setting]))
+            [metabase.models.setting :as setting]
+            [metabase.util :as u]))
 
 (defn- index [_]
-  (if ((resolve 'metabase.core/initialized?))
-    (-> (io/resource "frontend_client/index.html")
-        slurp
-        (stencil/render-string {:bootstrap_json (json/generate-string (setting/public-settings))})
-        resp/response
-        (resp/content-type "text/html")
-        (resp/header "Last-Modified" "{now} GMT"))
-    (-> (io/resource "frontend_client/init.html")
-        slurp
-        resp/response
-        (resp/content-type "text/html")
-        (resp/header "Last-Modified" "{now} GMT"))))
+  (-> (if (@(resolve 'metabase.core/initialized?))
+        (stencil/render-string (slurp (io/resource "frontend_client/index.html"))
+                               {:bootstrap_json (json/generate-string (setting/public-settings))})
+        (slurp (io/resource "frontend_client/init.html")))
+      resp/response
+      (resp/content-type "text/html")
+      (resp/header "Last-Modified" (u/format-date :rfc822))))
 
 ;; Redirect naughty users who try to visit a page other than setup if setup is not yet complete
 (defroutes routes

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -7,13 +7,16 @@
             [clojure.tools.logging :as log]
             [colorize.core :as color]
             [medley.core :as m])
-  (:import (java.net Socket
+  (:import clojure.lang.Keyword
+           (java.net Socket
                      InetSocketAddress
                      InetAddress)
            java.sql.Timestamp
            (java.util Calendar TimeZone)
            javax.xml.bind.DatatypeConverter
            org.joda.time.format.DateTimeFormatter))
+
+(declare pprint-to-str)
 
 ;;; ### Protocols
 
@@ -46,8 +49,13 @@
     "Coerce object to a `DateTimeFormatter`."))
 
 (extend-protocol IDateTimeFormatterCoercible
+  ;; Specify a format string like "yyyy-MM-dd"
   String            (->DateTimeFormatter [this] (time/formatter this))
-  DateTimeFormatter (->DateTimeFormatter [this] this))
+  DateTimeFormatter (->DateTimeFormatter [this] this)
+  ;; Keyword will be used to get matching formatter from time/formatters
+  Keyword           (->DateTimeFormatter [this] (or (time/formatters this)
+                                                    (throw (Exception. (format "Invalid formatter name, must be one of:\n%s"
+                                                                               (pprint-to-str (sort (keys time/formatters)))))))))
 
 
 ;;; ## Date Stuff
@@ -59,24 +67,29 @@
   (->Timestamp (System/currentTimeMillis)))
 
 (defn format-date
-  "Format DATE using a given FORMATTER.
-   DATE is anything that can be passed `->Timestamp`, such as a `Long` or ISO-8601 `String`.
-   DATE-FORMAT is anything that can be passed to `->DateTimeFormatter`, including a `String` or `DateTimeFormatter`."
-  ^String [date-format date]
-  (time/unparse (->DateTimeFormatter date-format) (coerce/from-long (.getTime (->Timestamp date)))))
+  "Format DATE using a given DATE-FORMAT.
 
-(def ^{:arglists '([date])} date->yyyy-mm-dd
+   DATE is anything that can coerced to a `Timestamp` via `->Timestamp`, such as a `Date`, `Timestamp`,
+   `Long` (ms since the epoch), or an ISO-8601 `String`. DATE defaults to the current moment in time.
+
+   DATE-FORMAT is anything that can be passed to `->DateTimeFormatter`, such as `String`, `Keyword`, or `DateTimeFormatter`.
+
+
+     (format-date \"yyyy-MM-dd\")                        -> \"2015-11-18\"
+     (format-date :year (java.util.Date.))               -> \"2015\"
+     (format-date :date-time (System/currentTimeMillis)) -> \"2015-11-18T23:55:03.841Z\""
+  (^String [date-format]
+   (format-date date-format (System/currentTimeMillis)))
+  (^String [date-format date]
+   (time/unparse (->DateTimeFormatter date-format) (coerce/from-long (.getTime (->Timestamp date))))))
+
+(def ^{:arglists '([] [date])} date->yyyy-mm-dd
   "Format DATE as a `YYYY-MM-DD` string."
   (partial format-date "yyyy-MM-dd"))
 
-(def ^{:arglists '([date])} date->iso-8601
+(def ^{:arglists '([] [date])} date->iso-8601
   "Format DATE a an ISO-8601 string."
-  (partial format-date (time/formatters :date-time)))
-
-(defn now-iso8601
-  "Return the current date as an ISO-8601 formatted string."
-  ^String []
-  (date->iso-8601 (System/currentTimeMillis)))
+  (partial format-date :date-time))
 
 (defn date-string?
   "Is S a valid ISO 8601 date string?"


### PR DESCRIPTION
As discussed in #1230, the tards at Bishop Fox specifically recommended we include a `Last-Modifed: {now} GMT` header. @tlrobinson pointed out that such a header is in no way something that could be construed as "valid". It turns out the foxes just cut-and-pasted [a Stack Overflow answer](http://stackoverflow.com/questions/9884513/avoid-caching-of-the-http-responses). That itself is very worrying, but here's a PR that fixes the issue.
##### This also includes a few small improvments to `metabase.util`:
-  Make the second arg for `format-date` optional, and default to formatting the current date. Likewise, the arg for `date->yyyy-mm-dd` and `date->iso-8601` is now optional, and defaults to the current date.
-  Remove the `now-iso8601` fn since you can now do `(date->iso-8601)` instead.
-  `format-date` now accepts keywords as format specifiers. Valid keywords are any keys in `clj-time.format/formatters`
-  Extra dox and examples for `format-date`.

``` clojure
(format-date "yyyy-MM-dd")                          -> "2015-11-18"
(format-date :year (java.util.Date.))               -> "2015"
(format-date :date-time (System/currentTimeMillis)) -> "2015-11-18T23:55:03.841Z"
```

Fixes #1230
