### PR TITLE
Remove `runtime-resolved-fn` :imp:

### DIFF
--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -143,7 +143,7 @@
 
 (defn- db-can-connect? [details]
   (binding [*allow-potentailly-unsafe-connections* true]
-    ((u/runtime-resolved-fn 'metabase.driver 'can-connect?) details)))
+    (@(resolve 'metabase.driver/can-connect?) details)))
 
 (defn setup-db
   "Do general perparation of database by validating that we can connect.
@@ -180,7 +180,8 @@
 
   ;; Do any custom code-based migrations now that the db structure is up to date
   ;; NOTE: we use dynamic resolution to prevent circular dependencies
-  ((u/runtime-resolved-fn 'metabase.db.migrations 'run-all)))
+  (require 'metabase.db.migrations)
+  (@(resolve 'metabase.db.migrations/run-all)))
 
 (defn setup-db-if-needed [& args]
   (when-not @setup-db-has-been-called?

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -378,19 +378,17 @@
             (throw (Exception. message))))
         false))))
 
-(def ^{:arglists '([database])} sync-database!
+(defn sync-database!
   "Sync a `Database`, its `Tables`, and `Fields`."
-  (let [-sync-database! (u/runtime-resolved-fn 'metabase.driver.sync 'sync-database!)] ; these need to be resolved at runtime to avoid circular deps
-    (fn [database]
-      {:pre [(map? database)]}
-      (-sync-database! (engine->driver (:engine database)) database))))
+  [database]
+  {:pre [(map? database)]}
+  (@(resolve 'metabase.driver.sync/sync-database!) (engine->driver (:engine database)) database))
 
-(def ^{:arglists '([table])} sync-table!
+(defn sync-table!
   "Sync a `Table` and its `Fields`."
-  (let [-sync-table! (u/runtime-resolved-fn 'metabase.driver.sync 'sync-table!)]
-    (fn [table]
-      {:pre [(map? table)]}
-      (-sync-table! (database-id->driver (:db_id table)) table))))
+  [table]
+  {:pre [(map? table)]}
+  (@(resolve 'metabase.driver.sync/sync-table!) (database-id->driver (:db_id table)) table))
 
 (defn process-query
   "Process a structured or native query, and return the result."

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -37,9 +37,6 @@
        (or (contains? #{:category :city :state :country} (keyword special_type))
            (= (keyword base_type) :BooleanField))))
 
-(def ^:private field-distinct-values
-  (u/runtime-resolved-fn 'metabase.db.metadata-queries 'field-distinct-values))
-
 (defn- create-field-values
   "Create `FieldValues` for a `Field`."
   {:arglists '([field] [field human-readable-values])}
@@ -49,7 +46,7 @@
   (log/debug (format "Creating FieldValues for Field %s..." (or field-name field-id))) ; use field name if available
   (ins FieldValues
     :field_id              field-id
-    :values                (field-distinct-values field)
+    :values                (@(resolve 'metabase.db.metadata-queries/field-distinct-values) field)
     :human_readable_values human-readable-values))
 
 (defn update-field-values!
@@ -59,7 +56,7 @@
          (field-should-have-field-values? field)]}
   (if-let [field-values (sel :one FieldValues :field_id field-id)]
     (upd FieldValues (:id field-values)
-      :values (field-distinct-values field))
+      :values (@(resolve 'metabase.db.metadata-queries/field-distinct-values) field))
     (create-field-values field)))
 
 (defn create-field-values-if-needed

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -328,21 +328,6 @@
   (fn [& args]
     (apply f (concat args bound-args))))
 
-(defn runtime-resolved-fn
-  "Return a function that calls a function in another namespace.
-   Function is resolved (and its namespace required, if need be) at runtime.
-   Useful for avoiding circular dependencies.
-
-    (def ^:private table->id (runtime-resolved-fn 'metabase.test.data 'table->id))
-    (id :users) -> 4"
-  [orig-namespace orig-fn-name]
-  {:pre [(symbol? orig-namespace)
-         (symbol? orig-fn-name)]}
-  (let [resolved-fn (delay (require orig-namespace)
-                           (ns-resolve orig-namespace orig-fn-name))]
-    (fn [& args]
-      (apply @resolved-fn args))))
-
 (defmacro deref->
   "Threads OBJ through FORMS, calling `deref` after each.
    Now you can write:

--- a/test/metabase/driver/query_processor_test.clj
+++ b/test/metabase/driver/query_processor_test.clj
@@ -494,7 +494,7 @@
 ;; ## LIMIT-MAX-RESULT-ROWS
 ;; Apply limit-max-result-rows to an infinite sequence and make sure it gets capped at `max-result-rows`
 (expect max-result-rows
-  (->> (((u/runtime-resolved-fn 'metabase.driver.query-processor 'limit) identity) {:rows (repeat [:ok])})
+  (->> ((@(resolve 'metabase.driver.query-processor/limit) identity) {:rows (repeat [:ok])})
        :rows
        count))
 

--- a/test/metabase/driver/sync_test.clj
+++ b/test/metabase/driver/sync_test.clj
@@ -86,7 +86,8 @@
 
 ;; ## Tests for DETERMINE-FK-TYPE
 ;; Since COUNT(category_id) > COUNT(DISTINCT(category_id)) the FK relationship should be Mt1
-(def determine-fk-type (u/runtime-resolved-fn 'metabase.driver.sync 'determine-fk-type))
+(def determine-fk-type @(resolve 'metabase.driver.sync/determine-fk-type))
+
 (expect :Mt1
   (determine-fk-type (Field (id :venues :category_id))))
 


### PR DESCRIPTION
##### THE CHARGES

This function had such a cool name is mislead everybody into thinking it was the only way to resolve a function at runtime. In reality this would have more appropriately been titled `cached-runtimed-resolved-fn`. But even then it saved only fractions of a millisecond. And when used where a simple `resolve` would have been appropriate it actually hurt performance. 
##### THE VERDICT

Not worth keeping around. We only used it in a half-dozen places, and only a fraction of those were used in situations it was intended for.
