### PR TITLE
Add legends to bar chart 

### DIFF
--- a/frontend/src/card/card.charting.js
+++ b/frontend/src/card/card.charting.js
@@ -164,7 +164,7 @@ function applyChartLegend(dcjsChart, card) {
         legendEnabled = false;
     
     if (card.display && settings[card.display]) {
-        legendEnabled = settings[card.display].legend_enabled
+        legendEnabled = settings[card.display].legend_enabled;
     } else if (settings.chart) {
         legendEnabled = settings.chart.legend_enabled;
     }

--- a/frontend/src/card/card.charting.js
+++ b/frontend/src/card/card.charting.js
@@ -162,15 +162,9 @@ function applyChartLegend(dcjsChart, card) {
     // I'm sure it made sense to somebody at some point to make this setting live in two different places depending on the type of chart.
     var settings = card.visualization_settings,
         legendEnabled = false;
-
-    if (card.display === "pie" && settings.pie) {
-        legendEnabled = settings.pie.legend_enabled;
-    } else if (card.display === "bar" && settings.bar) {
-        legendEnabled = settings.bar.legend_enabled;
-    } else if (card.display === "line" && settings.line) {
-        legendEnabled = settings.line.legend_enabled;
-    } else if (card.display === "area" && settings.area) {
-        legendEnabled = settings.area.legend_enabled;
+    
+    if (card.display && settings[card.display]) {
+        legendEnabled = settings[card.display].legend_enabled
     } else if (settings.chart) {
         legendEnabled = settings.chart.legend_enabled;
     }

--- a/frontend/src/card/card.charting.js
+++ b/frontend/src/card/card.charting.js
@@ -182,6 +182,12 @@ function applyChartLegend(dcjsChart, card) {
     }
 }
 
+function addLegendMarginsForCharts(dcjsChart, card, legendCount) {
+    if (card.display === "bar" || card.display === "line" || card.display === "area") {
+        dcjsChart.margins().top = dcjsChart.margins().top + legendCount*(dcjsChart.legend().itemHeight() + dcjsChart.legend().gap())
+    } 
+}
+
 function setCardTitle(card, elementId) {
     // SET THE CARD TITLE if applicable (probably not, since there's no UI to set this AFAIK)
     var settings = card.visualization_settings,
@@ -899,11 +905,14 @@ export var CardRenderer = {
                             return d.value;
                         });
 
+        var legendCount = 1;
+
         // apply any stacked series if applicable
         if (isMultiSeries) {
             chart.stack(dimension.group().reduceSum(function(d) {
                 return d[2];
             }), result.cols[2].name);
+            legendCount++;
 
             // to keep things sane, draw the line at 2 stacked series
             // putting more than 3 series total on the same chart is a lot
@@ -911,6 +920,7 @@ export var CardRenderer = {
                 chart.stack(dimension.group().reduceSum(function(d) {
                     return d[3];
                 }), result.cols[3].name);
+                legendCount++;
             }
         }
 
@@ -928,6 +938,7 @@ export var CardRenderer = {
 
         applyChartTooltips(chart, id, card, result.cols);
         applyChartColors(chart, card);
+        addLegendMarginsForCharts(chart, card, legendCount);
 
         // if the chart supports 'brushing' (brush-based range filter), disable this since it intercepts mouse hovers which means we can't see tooltips
         if (chart.brushOn) chart.brushOn(false);
@@ -976,11 +987,13 @@ export var CardRenderer = {
                         })
                         .renderArea(isAreaChart);
 
+        var legendCount = 1;
         // apply any stacked series if applicable
         if (isMultiSeries) {
             chart.stack(dimension.group().reduceSum(function(d) {
                 return d[2];
             }), result.cols[2].name);
+            legendCount++;
 
             // to keep things sane, draw the line at 2 stacked series
             // putting more than 3 series total on the same chart is a lot
@@ -988,6 +1001,7 @@ export var CardRenderer = {
                 chart.stack(dimension.group().reduceSum(function(d) {
                     return d[3];
                 }), result.cols[3].name);
+                legendCount++;
             }
         }
 
@@ -1005,6 +1019,7 @@ export var CardRenderer = {
 
         applyChartTooltips(chart, id, card, result.cols);
         applyChartColors(chart, card);
+        addLegendMarginsForCharts(chart, card, legendCount);
 
         // if the chart supports 'brushing' (brush-based range filter), disable this since it intercepts mouse hovers which means we can't see tooltips
         if (chart.brushOn) chart.brushOn(false);

--- a/frontend/src/card/card.charting.js
+++ b/frontend/src/card/card.charting.js
@@ -165,6 +165,8 @@ function applyChartLegend(dcjsChart, card) {
 
     if (card.display === "pie" && settings.pie) {
         legendEnabled = settings.pie.legend_enabled;
+    } else if (card.display === "bar" && settings.bar) {
+        legendEnabled = settings.bar.legend_enabled;
     } else if (settings.chart) {
         legendEnabled = settings.chart.legend_enabled;
     }
@@ -888,7 +890,7 @@ export var CardRenderer = {
                         }),
             chart = initializeChart(card, id, DEFAULT_CARD_WIDTH, DEFAULT_CARD_HEIGHT)
                         .dimension(dimension)
-                        .group(group)
+                        .group(group, result.cols[1]["name"])
                         .valueAccessor(function(d) {
                             return d.value;
                         });
@@ -897,14 +899,14 @@ export var CardRenderer = {
         if (isMultiSeries) {
             chart.stack(dimension.group().reduceSum(function(d) {
                 return d[2];
-            }));
+            }), result.cols[2]["name"]);
 
             // to keep things sane, draw the line at 2 stacked series
             // putting more than 3 series total on the same chart is a lot
             if (result.cols.length > 3) {
                 chart.stack(dimension.group().reduceSum(function(d) {
                     return d[3];
-                }));
+                }), result.cols[3]["name"]);
             }
         }
 

--- a/frontend/src/card/card.charting.js
+++ b/frontend/src/card/card.charting.js
@@ -183,7 +183,10 @@ function applyChartLegend(dcjsChart, card) {
 }
 
 function addLegendMarginsForCharts(dcjsChart, card, legendCount) {
-    if (card.display === "bar" || card.display === "line" || card.display === "area") {
+    //Chart types which support legends
+    var chartTypes = ["bar", "line", "area"];
+
+    if (chartTypes.indexOf(card.display) > -1) {
         dcjsChart.margins().top = dcjsChart.margins().top + legendCount*(dcjsChart.legend().itemHeight() + dcjsChart.legend().gap())
     } 
 }

--- a/frontend/src/card/card.charting.js
+++ b/frontend/src/card/card.charting.js
@@ -167,6 +167,10 @@ function applyChartLegend(dcjsChart, card) {
         legendEnabled = settings.pie.legend_enabled;
     } else if (card.display === "bar" && settings.bar) {
         legendEnabled = settings.bar.legend_enabled;
+    } else if (card.display === "line" && settings.line) {
+        legendEnabled = settings.line.legend_enabled;
+    } else if (card.display === "area" && settings.area) {
+        legendEnabled = settings.area.legend_enabled;
     } else if (settings.chart) {
         legendEnabled = settings.chart.legend_enabled;
     }
@@ -890,7 +894,7 @@ export var CardRenderer = {
                         }),
             chart = initializeChart(card, id, DEFAULT_CARD_WIDTH, DEFAULT_CARD_HEIGHT)
                         .dimension(dimension)
-                        .group(group, result.cols[1]["name"])
+                        .group(group, result.cols[1].name)
                         .valueAccessor(function(d) {
                             return d.value;
                         });
@@ -899,14 +903,14 @@ export var CardRenderer = {
         if (isMultiSeries) {
             chart.stack(dimension.group().reduceSum(function(d) {
                 return d[2];
-            }), result.cols[2]["name"]);
+            }), result.cols[2].name);
 
             // to keep things sane, draw the line at 2 stacked series
             // putting more than 3 series total on the same chart is a lot
             if (result.cols.length > 3) {
                 chart.stack(dimension.group().reduceSum(function(d) {
                     return d[3];
-                }), result.cols[3]["name"]);
+                }), result.cols[3].name);
             }
         }
 
@@ -966,7 +970,7 @@ export var CardRenderer = {
                         }),
             chart = initializeChart(card, id, DEFAULT_CARD_WIDTH, DEFAULT_CARD_HEIGHT)
                         .dimension(dimension)
-                        .group(group)
+                        .group(group, result.cols[1].name)
                         .valueAccessor(function(d) {
                             return d.value;
                         })
@@ -976,14 +980,14 @@ export var CardRenderer = {
         if (isMultiSeries) {
             chart.stack(dimension.group().reduceSum(function(d) {
                 return d[2];
-            }));
+            }), result.cols[2].name);
 
             // to keep things sane, draw the line at 2 stacked series
             // putting more than 3 series total on the same chart is a lot
             if (result.cols.length > 3) {
                 chart.stack(dimension.group().reduceSum(function(d) {
                     return d[3];
-                }));
+                }), result.cols[3].name);
             }
         }
 

--- a/frontend/src/card/card.services.js
+++ b/frontend/src/card/card.services.js
@@ -323,6 +323,7 @@ CardServices.service('VisualizationSettings', [function() {
             'colors': EXPANDED_COLOR_HARMONY
         },
         'bar': {
+            'legend_enabled': true,
             'colors': DEFAULT_COLOR_HARMONY,
             'color': DEFAULT_COLOR
         },

--- a/frontend/src/card/card.services.js
+++ b/frontend/src/card/card.services.js
@@ -300,6 +300,7 @@ CardServices.service('VisualizationSettings', [function() {
             'labels_step': null
         },
         'line': {
+            'legend_enabled': true,
             'lineColor': DEFAULT_COLOR,
             'colors': DEFAULT_COLOR_HARMONY,
             'lineWidth': 2,
@@ -312,6 +313,7 @@ CardServices.service('VisualizationSettings', [function() {
             'yAxis_columns': []
         },
         'area': {
+            'legend_enabled': true,
             'fillColor': DEFAULT_COLOR,
             'fillOpacity': 0.75
         },


### PR DESCRIPTION
We are using metabase at @signeasy. We think it's amazing.

We thought of adding legends to the bar and line charts as stated it #1454

After this, we can also use it add it in the annotation using this commit https://github.com/signeasy/metabase/commit/6c7e18a3a4ba9dbeb6f39a2980ed0809a615caa5

It will now look like 

![screen shot 2015-11-19 at 3 13 40 pm](https://cloud.githubusercontent.com/assets/1110844/11269302/30224840-8edc-11e5-94c4-665fae9f3bda.png)

I'm not sure about the design goals you have. I thought I'd drop it here.
