### PR TITLE
Basic typing for drivers

### DIFF
--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -119,7 +119,7 @@
   "Default implementations of methods for drivers."
   {:date-interval u/relative-date})
 
-(defmacro defdriver
+(defn driver
   "Define and validate a new Metabase DB driver.
 
    All drivers must include the following keys:
@@ -253,12 +253,11 @@
    This is a chance for drivers to do custom `Field` syncing specific to their database.
    For example, the Postgres driver can mark Postgres JSON fields as `special_type = json`.
    As with the other Field syncing functions in `metabase.driver.sync`, this method should return the modified FIELD, if any, or `nil`."
-  [driver-name driver-map]
-  `(def ~(vary-meta driver-name assoc :metabase.driver/driver (keyword driver-name))
-     (let [m# (merge driver-defaults
-                     ~driver-map)]
-       (verify-driver m#)
-       m#)))
+  [driver-map]
+  (let [m (merge driver-defaults
+                 driver-map)]
+    (verify-driver m)
+    m))
 
 
 ;;; ## CONFIG

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -3,7 +3,7 @@
             [korma.db :as kdb]
             [korma.sql.utils :as utils]
             [metabase.db :as db]
-            [metabase.driver :as driver, :refer [defdriver]]
+            [metabase.driver :as driver]
             [metabase.driver.generic-sql :refer [sql-driver]]
             [metabase.driver.generic-sql.util :refer [funcs]]
             [metabase.models.database :refer [Database]]))
@@ -188,17 +188,21 @@
     #".*" ; default
     message))
 
-(defdriver h2
-  (sql-driver {:driver-name                       "H2"
-               :details-fields                    [{:name         "db"
-                                                    :display-name "Connection String"
-                                                    :placeholder  "file:/Users/camsaul/bird_sightings/toucans;AUTO_SERVER=TRUE"
-                                                    :required     true}]
-               :column->base-type                 column->base-type
-               :string-length-fn                  :LENGTH
-               :connection-details->spec          connection-details->spec
-               :date                              date
-               :date-interval                     date-interval
-               :unix-timestamp->timestamp         unix-timestamp->timestamp
-               :humanize-connection-error-message humanize-connection-error-message
-               :process-query-in-context          process-query-in-context}))
+(defrecord H2Driver [])
+
+(def ^:metabase.driver/driver h2
+  (map->H2Driver
+   (sql-driver
+    {:driver-name                       "H2"
+     :details-fields                    [{:name         "db"
+                                          :display-name "Connection String"
+                                          :placeholder  "file:/Users/camsaul/bird_sightings/toucans;AUTO_SERVER=TRUE"
+                                          :required     true}]
+     :column->base-type                 column->base-type
+     :string-length-fn                  :LENGTH
+     :connection-details->spec          connection-details->spec
+     :date                              date
+     :date-interval                     date-interval
+     :unix-timestamp->timestamp         unix-timestamp->timestamp
+     :humanize-connection-error-message humanize-connection-error-message
+     :process-query-in-context          process-query-in-context})))

--- a/src/metabase/driver/mongo.clj
+++ b/src/metabase/driver/mongo.clj
@@ -11,7 +11,7 @@
                     [core :as mg]
                     [db :as mdb]
                     [query :as mq])
-            [metabase.driver :as driver, :refer [defdriver]]
+            [metabase.driver :as driver]
             (metabase.driver.mongo [query-processor :as qp]
                                    [util :refer [*mongo-connection* with-mongo-connection values->base-type]])
             [metabase.util :as u]))
@@ -121,39 +121,43 @@
                             first                         ; keep just the type
                             driver/class->base-type))))))
 
-(defdriver mongo
-  {:driver-name                       "MongoDB"
-   :details-fields                    [{:name         "host"
-                                        :display-name "Host"
-                                        :default      "localhost"}
-                                       {:name         "port"
-                                        :display-name "Port"
-                                        :type         :integer
-                                        :default      27017}
-                                       {:name         "dbname"
-                                        :display-name "Database name"
-                                        :placeholder  "carrierPigeonDeliveries"
-                                        :required     true}
-                                       {:name         "user"
-                                        :display-name "Database username"
-                                        :placeholder  "What username do you use to login to the database?"}
-                                       {:name         "pass"
-                                        :display-name "Database password"
-                                        :type         :password
-                                        :placeholder  "******"}
-                                       {:name         "ssl"
-                                        :display-name "Use a secure connection (SSL)?"
-                                        :type         :boolean
-                                        :default      false}]
-   :features                          #{:nested-fields}
-   :can-connect?                      can-connect?
-   :active-tables                     active-tables
-   :field-values-lazy-seq             field-values-lazy-seq
-   :active-column-names->type         active-column-names->type
-   :table-pks                         (constantly #{"_id"})
-   :process-query                     process-query
-   :process-query-in-context          process-query-in-context
-   :sync-in-context                   sync-in-context
-   :date-interval                     u/relative-date
-   :humanize-connection-error-message humanize-connection-error-message
-   :active-nested-field-name->type    active-nested-field-name->type})
+(defrecord MongoDriver [])
+
+(def ^:metabase.driver/driver mongo
+  (map->MongoDriver
+   (driver/driver
+    {:driver-name                       "MongoDB"
+     :details-fields                    [{:name         "host"
+                                          :display-name "Host"
+                                          :default      "localhost"}
+                                         {:name         "port"
+                                          :display-name "Port"
+                                          :type         :integer
+                                          :default      27017}
+                                         {:name         "dbname"
+                                          :display-name "Database name"
+                                          :placeholder  "carrierPigeonDeliveries"
+                                          :required     true}
+                                         {:name         "user"
+                                          :display-name "Database username"
+                                          :placeholder  "What username do you use to login to the database?"}
+                                         {:name         "pass"
+                                          :display-name "Database password"
+                                          :type         :password
+                                          :placeholder  "******"}
+                                         {:name         "ssl"
+                                          :display-name "Use a secure connection (SSL)?"
+                                          :type         :boolean
+                                          :default      false}]
+     :features                          #{:nested-fields}
+     :can-connect?                      can-connect?
+     :active-tables                     active-tables
+     :field-values-lazy-seq             field-values-lazy-seq
+     :active-column-names->type         active-column-names->type
+     :table-pks                         (constantly #{"_id"})
+     :process-query                     process-query
+     :process-query-in-context          process-query-in-context
+     :sync-in-context                   sync-in-context
+     :date-interval                     u/relative-date
+     :humanize-connection-error-message humanize-connection-error-message
+     :active-nested-field-name->type    active-nested-field-name->type})))

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -6,7 +6,7 @@
                    mysql)
             (korma.sql [engine :refer [sql-func]]
                        [utils :as utils])
-            [metabase.driver :as driver, :refer [defdriver]]
+            [metabase.driver :as driver]
             [metabase.driver.generic-sql :refer [sql-driver]]
             [metabase.driver.generic-sql.util :refer [funcs]]
             [metabase.util :as u]))
@@ -133,37 +133,40 @@
         #".*" ; default
         message))
 
-(defdriver mysql
-  (sql-driver
-   {:driver-name                       "MySQL"
-    :details-fields                    [{:name         "host"
-                                         :display-name "Host"
-                                         :default      "localhost"}
-                                        {:name         "port"
-                                         :display-name "Port"
-                                         :type         :integer
-                                         :default      3306}
-                                        {:name         "dbname"
-                                         :display-name "Database name"
-                                         :placeholder  "birds_of_the_word"
-                                         :required     true}
-                                        {:name         "user"
-                                         :display-name "Database username"
-                                         :placeholder  "What username do you use to login to the database?"
-                                         :required     true}
-                                        {:name         "password"
-                                         :display-name "Database password"
-                                         :type         :password
-                                         :placeholder  "*******"}]
-    :column->base-type                 column->base-type
-    :string-length-fn                  :CHAR_LENGTH
-    :excluded-schemas                  #{"INFORMATION_SCHEMA"}
-    :connection-details->spec          connection-details->spec
-    :unix-timestamp->timestamp         unix-timestamp->timestamp
-    :date                              date
-    :date-interval                     date-interval
-    ;; If this fails you need to load the timezone definitions from your system into MySQL;
-    ;; run the command `mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root mysql`
-    ;; See https://dev.mysql.com/doc/refman/5.7/en/time-zone-support.html for details
-    :set-timezone-sql                  "SET @@session.time_zone = ?;"
-    :humanize-connection-error-message humanize-connection-error-message}))
+(defrecord MySQLDriver [])
+
+(def ^:metabase.driver/driver mysql
+  (map->MySQLDriver
+   (sql-driver
+    {:driver-name                       "MySQL"
+     :details-fields                    [{:name         "host"
+                                          :display-name "Host"
+                                          :default      "localhost"}
+                                         {:name         "port"
+                                          :display-name "Port"
+                                          :type         :integer
+                                          :default      3306}
+                                         {:name         "dbname"
+                                          :display-name "Database name"
+                                          :placeholder  "birds_of_the_word"
+                                          :required     true}
+                                         {:name         "user"
+                                          :display-name "Database username"
+                                          :placeholder  "What username do you use to login to the database?"
+                                          :required     true}
+                                         {:name         "password"
+                                          :display-name "Database password"
+                                          :type         :password
+                                          :placeholder  "*******"}]
+     :column->base-type                 column->base-type
+     :string-length-fn                  :CHAR_LENGTH
+     :excluded-schemas                  #{"INFORMATION_SCHEMA"}
+     :connection-details->spec          connection-details->spec
+     :unix-timestamp->timestamp         unix-timestamp->timestamp
+     :date                              date
+     :date-interval                     date-interval
+     ;; If this fails you need to load the timezone definitions from your system into MySQL;
+     ;; run the command `mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root mysql`
+     ;; See https://dev.mysql.com/doc/refman/5.7/en/time-zone-support.html for details
+     :set-timezone-sql                  "SET @@session.time_zone = ?;"
+     :humanize-connection-error-message humanize-connection-error-message})))

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -9,7 +9,7 @@
             [swiss.arrows :refer :all]
             [metabase.db :refer [upd]]
             [metabase.models.field :refer [Field]]
-            [metabase.driver :as driver, :refer [defdriver]]
+            [metabase.driver :as driver]
             [metabase.driver.generic-sql :refer [sql-driver]]
             [metabase.driver.generic-sql.util :refer [with-jdbc-metadata]])
   ;; This is necessary for when NonValidatingFactory is passed in the sslfactory connection string argument,
@@ -157,38 +157,41 @@
     #".*" ; default
     message))
 
-(defdriver postgres
-  (sql-driver
-   {:driver-name                       "PostgreSQL"
-    :details-fields                    [{:name         "host"
-                                         :display-name "Host"
-                                         :default "localhost"}
-                                        {:name         "port"
-                                         :display-name "Port"
-                                         :type         :integer
-                                         :default      5432}
-                                        {:name         "dbname"
-                                         :display-name "Database name"
-                                         :placeholder  "birds_of_the_word"
-                                         :required     true}
-                                        {:name         "user"
-                                         :display-name "Database username"
-                                         :placeholder  "What username do you use to login to the database?"
-                                         :required     true}
-                                        {:name         "password"
-                                         :display-name "Database password"
-                                         :type         :password
-                                         :placeholder  "*******"}
-                                        {:name         "ssl"
-                                         :display-name "Use a secure connection (SSL)?"
-                                         :type         :boolean
-                                         :default      false}]
-    :string-length-fn                  :CHAR_LENGTH
-    :column->base-type                 column->base-type
-    :connection-details->spec          connection-details->spec
-    :unix-timestamp->timestamp         unix-timestamp->timestamp
-    :date                              date
-    :date-interval                     date-interval
-    :set-timezone-sql                  "UPDATE pg_settings SET setting = ? WHERE name ILIKE 'timezone';"
-    :driver-specific-sync-field!       driver-specific-sync-field!
-    :humanize-connection-error-message humanize-connection-error-message}))
+(defrecord PostgresDriver [])
+
+(def ^:metabase.driver/driver postgres
+  (map->PostgresDriver
+   (sql-driver
+    {:driver-name                       "PostgreSQL"
+     :details-fields                    [{:name         "host"
+                                          :display-name "Host"
+                                          :default "localhost"}
+                                         {:name         "port"
+                                          :display-name "Port"
+                                          :type         :integer
+                                          :default      5432}
+                                         {:name         "dbname"
+                                          :display-name "Database name"
+                                          :placeholder  "birds_of_the_word"
+                                          :required     true}
+                                         {:name         "user"
+                                          :display-name "Database username"
+                                          :placeholder  "What username do you use to login to the database?"
+                                          :required     true}
+                                         {:name         "password"
+                                          :display-name "Database password"
+                                          :type         :password
+                                          :placeholder  "*******"}
+                                         {:name         "ssl"
+                                          :display-name "Use a secure connection (SSL)?"
+                                          :type         :boolean
+                                          :default      false}]
+     :string-length-fn                  :CHAR_LENGTH
+     :column->base-type                 column->base-type
+     :connection-details->spec          connection-details->spec
+     :unix-timestamp->timestamp         unix-timestamp->timestamp
+     :date                              date
+     :date-interval                     date-interval
+     :set-timezone-sql                  "UPDATE pg_settings SET setting = ? WHERE name ILIKE 'timezone';"
+     :driver-specific-sync-field!       driver-specific-sync-field!
+     :humanize-connection-error-message humanize-connection-error-message})))

--- a/src/metabase/driver/sqlserver.clj
+++ b/src/metabase/driver/sqlserver.clj
@@ -3,7 +3,6 @@
             (korma [core :as k]
                    [db :as kdb])
             [korma.sql.utils :as utils]
-            [metabase.driver :refer [defdriver]]
             [metabase.driver.generic-sql :refer [sql-driver]]
             [metabase.driver.generic-sql.util :refer [funcs]])
   (:import net.sourceforge.jtds.jdbc.Driver)) ; need to import this in order to load JDBC driver
@@ -112,38 +111,41 @@
                                 (* items (dec page))
                                 items)))
 
-(defdriver sqlserver
-  (-> (sql-driver {:driver-name               "SQL Server"
-                   :details-fields            [{:name         "host"
-                                                :display-name "Host"
-                                                :default      "localhost"}
-                                               {:name         "port"
-                                                :display-name "Port"
-                                                :type         :integer
-                                                :default      1433}
-                                               {:name         "db"
-                                                :display-name "Database name"
-                                                :placeholder  "BirdsOfTheWorld"
-                                                :required     true}
-                                               {:name         "instance"
-                                                :display-name "Database instance name"
-                                                :placeholder  "N/A"}
-                                               {:name         "user"
-                                                :display-name "Database username"
-                                                :placeholder  "What username do you use to login to the database?"
-                                                :required     true}
-                                               {:name         "password"
-                                                :display-name "Database password"
-                                                :type         :password
-                                                :placeholder  "*******"}]
-                   :string-length-fn          :LEN
-                   :stddev-fn                 :STDEV
-                   :current-datetime-fn       (k/sqlfn* :GETUTCDATE)
-                   :excluded-schemas          #{"sys" "INFORMATION_SCHEMA"}
-                   :column->base-type         column->base-type
-                   :connection-details->spec  connection-details->spec
-                   :date                      date
-                   :date-interval             date-interval
-                   :unix-timestamp->timestamp unix-timestamp->timestamp})
-      (update :qp-clause->handler merge {:limit apply-limit
-                                         :page  apply-page})))
+(defrecord SQLServerDriver [])
+
+(def ^:metabase.driver/driver sqlserver
+  (map->SQLServerDriver
+   (-> (sql-driver {:driver-name               "SQL Server"
+                    :details-fields            [{:name         "host"
+                                                 :display-name "Host"
+                                                 :default      "localhost"}
+                                                {:name         "port"
+                                                 :display-name "Port"
+                                                 :type         :integer
+                                                 :default      1433}
+                                                {:name         "db"
+                                                 :display-name "Database name"
+                                                 :placeholder  "BirdsOfTheWorld"
+                                                 :required     true}
+                                                {:name         "instance"
+                                                 :display-name "Database instance name"
+                                                 :placeholder  "N/A"}
+                                                {:name         "user"
+                                                 :display-name "Database username"
+                                                 :placeholder  "What username do you use to login to the database?"
+                                                 :required     true}
+                                                {:name         "password"
+                                                 :display-name "Database password"
+                                                 :type         :password
+                                                 :placeholder  "*******"}]
+                    :string-length-fn          :LEN
+                    :stddev-fn                 :STDEV
+                    :current-datetime-fn       (k/sqlfn* :GETUTCDATE)
+                    :excluded-schemas          #{"sys" "INFORMATION_SCHEMA"}
+                    :column->base-type         column->base-type
+                    :connection-details->spec  connection-details->spec
+                    :date                      date
+                    :date-interval             date-interval
+                    :unix-timestamp->timestamp unix-timestamp->timestamp})
+       (update :qp-clause->handler merge {:limit apply-limit
+                                          :page  apply-page}))))

--- a/test/metabase/driver/query_processor_test.clj
+++ b/test/metabase/driver/query_processor_test.clj
@@ -1360,7 +1360,7 @@
 
 ;; RELATIVE DATES
 (defn- database-def-with-timestamps [interval-seconds]
-  (let [{:keys [date-interval]} (driver)]
+  (let [{:keys [date-interval]} *data-loader*]
     (create-database-definition "DB"
       ["checkins"
        [{:field-name "timestamp"

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -70,16 +70,10 @@
          parent-id
          (recur (get-field-id-or-explode table-id nested-field-name, :parent-id parent-id) more))))))
 
-(defn driver
-  "Get the driver used by the current enigne."
-  []
-  {:post [(map? %)]}
-  (driver/engine->driver datasets/*engine*))
-
 (defn fks-supported?
   "Does the current engine support foreign keys?"
   []
-  (contains? (:features (driver)) :foreign-keys))
+  (contains? (:features *data-loader*) :foreign-keys))
 
 (defn default-schema []       (datasets/default-schema *data-loader*))
 (defn id-field-type []        (datasets/id-field-type *data-loader*))

--- a/test/metabase/test/data/datasets.clj
+++ b/test/metabase/test/data/datasets.clj
@@ -7,6 +7,12 @@
             [expectations :refer :all]
             [metabase.db :refer :all]
             [metabase.driver :as driver]
+            (metabase.driver [h2 :refer [h2]]
+                             [mongo :refer [mongo]]
+                             [mysql :refer [mysql]]
+                             [postgres :refer [postgres]]
+                             [sqlite :refer [sqlite]]
+                             [sqlserver :refer [sqlserver]])
             (metabase.models [field :refer [Field]]
                              [table :refer [Table]])
             (metabase.test.data [dataset-definitions :as defs]
@@ -17,12 +23,12 @@
                                 [sqlite :as sqlite]
                                 [sqlserver :as sqlserver])
             [metabase.util :as u])
-  (:import metabase.test.data.h2.H2DatasetLoader
-           metabase.test.data.mongo.MongoDatasetLoader
-           metabase.test.data.mysql.MySQLDatasetLoader
-           metabase.test.data.postgres.PostgresDatasetLoader
-           metabase.test.data.sqlite.SQLiteDatasetLoader
-           metabase.test.data.sqlserver.SQLServerDatasetLoader))
+  (:import metabase.driver.h2.H2Driver
+           metabase.driver.mongo.MongoDriver
+           metabase.driver.mysql.MySQLDriver
+           metabase.driver.postgres.PostgresDriver
+           metabase.driver.sqlite.SQLiteDriver
+           metabase.driver.sqlserver.SQLServerDriver))
 
 ;; # IDataset
 
@@ -61,7 +67,7 @@
 
 ;; ## Mongo
 
-(extend MongoDatasetLoader
+(extend MongoDriver
   IDataset
   (merge IDatasetDefaultsMixin
          {:format-name          (fn [_ table-or-field-name]
@@ -81,7 +87,7 @@
 
 ;;; ### H2
 
-(extend H2DatasetLoader
+(extend H2Driver
   IDataset
   (merge GenericSQLIDatasetMixin
          {:default-schema (constantly "PUBLIC")
@@ -93,7 +99,7 @@
 
 ;;; ### Postgres
 
-(extend PostgresDatasetLoader
+(extend PostgresDriver
   IDataset
   (merge GenericSQLIDatasetMixin
          {:default-schema (constantly "public")}))
@@ -101,7 +107,7 @@
 
 ;;; ### MySQL
 
-(extend MySQLDatasetLoader
+(extend MySQLDriver
   IDataset
   (merge GenericSQLIDatasetMixin
          {:sum-field-type (constantly :BigIntegerField)}))
@@ -109,14 +115,14 @@
 
 ;;; ### SQLite
 
-(extend SQLiteDatasetLoader
+(extend SQLiteDriver
   IDataset
   GenericSQLIDatasetMixin)
 
 
 ;;; ### SQLServer
 
-(extend SQLServerDatasetLoader
+(extend SQLServerDriver
   IDataset
   (merge GenericSQLIDatasetMixin
          {:default-schema (constantly "dbo")
@@ -127,12 +133,12 @@
 
 (def ^:private engine->loader*
   "Map of dataset keyword name -> dataset instance (i.e., an object that implements `IDataset`)."
-  {:mongo     (MongoDatasetLoader.     (promise))
-   :h2        (H2DatasetLoader.        (promise))
-   :postgres  (PostgresDatasetLoader.  (promise))
-   :mysql     (MySQLDatasetLoader.     (promise))
-   :sqlite    (SQLiteDatasetLoader.    (promise))
-   :sqlserver (SQLServerDatasetLoader. (promise))})
+  {:mongo     (assoc mongo     :dbpromise (promise))
+   :h2        (assoc h2        :dbpromise (promise))
+   :postgres  (assoc postgres  :dbpromise (promise))
+   :mysql     (assoc mysql     :dbpromise (promise))
+   :sqlite    (assoc sqlite    :dbpromise (promise))
+   :sqlserver (assoc sqlserver :dbpromise (promise))})
 
 (def ^:const all-valid-engines
   "Set of names of all valid datasets."

--- a/test/metabase/test/data/h2.clj
+++ b/test/metabase/test/data/h2.clj
@@ -5,7 +5,8 @@
             (korma [core :as k]
                    [db :as kdb])
             (metabase.test.data [generic-sql :as generic]
-                                [interface :as i])))
+                                [interface :as i]))
+  (:import metabase.driver.h2.H2Driver))
 
 (def ^:private ^:const field-base-type->sql-type
   {:BigIntegerField "BIGINT"
@@ -64,9 +65,7 @@
    (format "GRANT ALL ON %s TO GUEST;" (quote-name this table-name))))
 
 
-(defrecord H2DatasetLoader [dbpromise])
-
-(extend H2DatasetLoader
+(extend H2Driver
   generic/IGenericSQLDatasetLoader
   (let [{:keys [execute-sql!], :as mixin} generic/DefaultsMixin]
     (merge mixin

--- a/test/metabase/test/data/mongo.clj
+++ b/test/metabase/test/data/mongo.clj
@@ -1,9 +1,9 @@
 (ns metabase.test.data.mongo
-  "MongoDB Dataset Loader."
   (:require (monger [collection :as mc]
                     [core :as mg])
             [metabase.driver.mongo.util :refer [with-mongo-connection]]
-            [metabase.test.data.interface :as i]))
+            [metabase.test.data.interface :as i])
+  (:import metabase.driver.mongo.MongoDriver))
 
 (defn- database->connection-details
   ([dbdef]
@@ -39,9 +39,7 @@
               (catch com.mongodb.MongoException _))))))))
 
 
-(defrecord MongoDatasetLoader [dbpromise])
-
-(extend MongoDatasetLoader
+(extend MongoDriver
   i/IDatasetLoader
   {:create-db!                   create-db!
    :destroy-db!                  destroy-db!

--- a/test/metabase/test/data/mysql.clj
+++ b/test/metabase/test/data/mysql.clj
@@ -3,7 +3,8 @@
   (:require [clojure.string :as s]
             [environ.core :refer [env]]
             (metabase.test.data [generic-sql :as generic]
-                                [interface :as i])))
+                                [interface :as i]))
+  (:import metabase.driver.mysql.MySQLDriver))
 
 (def ^:private ^:const field-base-type->sql-type
   {:BigIntegerField "BIGINT"
@@ -30,9 +31,7 @@
 (defn- quote-name [_ nm]
   (str \` nm \`))
 
-(defrecord MySQLDatasetLoader [dbpromise])
-
-(extend MySQLDatasetLoader
+(extend MySQLDriver
   generic/IGenericSQLDatasetLoader
   (merge generic/DefaultsMixin
          {:execute-sql!              generic/sequentially-execute-sql!

--- a/test/metabase/test/data/postgres.clj
+++ b/test/metabase/test/data/postgres.clj
@@ -2,7 +2,8 @@
   "Code for creating / destroying a Postgres database from a `DatabaseDefinition`."
   (:require [environ.core :refer [env]]
             (metabase.test.data [generic-sql :as generic]
-                                [interface :as i])))
+                                [interface :as i]))
+  (:import metabase.driver.postgres.PostgresDriver))
 
 (def ^:private ^:const field-base-type->sql-type
   {:BigIntegerField "BIGINT"
@@ -31,9 +32,7 @@
   (format "DROP TABLE IF EXISTS \"%s\" CASCADE;" table-name))
 
 
-(defrecord PostgresDatasetLoader [dbpromise])
-
-(extend PostgresDatasetLoader
+(extend PostgresDriver
   generic/IGenericSQLDatasetLoader
   (merge generic/DefaultsMixin
          {:drop-table-if-exists-sql  drop-table-if-exists-sql

--- a/test/metabase/test/data/sqlite.clj
+++ b/test/metabase/test/data/sqlite.clj
@@ -3,7 +3,8 @@
             [korma.core :as k]
             (metabase.test.data [generic-sql :as generic]
                                 [interface :as i])
-            [metabase.util :as u]))
+            [metabase.util :as u])
+  (:import metabase.driver.sqlite.SQLiteDriver))
 
 (defn- database->connection-details
   [_ context {:keys [short-lived?], :as dbdef}]
@@ -31,9 +32,7 @@
                                                                                 (k/raw (format "DATETIME('%s')" (u/date->iso-8601 v)))
                                                                                 v)))))))
 
-(defrecord SQLiteDatasetLoader [dbpromise])
-
-(extend SQLiteDatasetLoader
+(extend SQLiteDriver
   generic/IGenericSQLDatasetLoader
   (merge generic/DefaultsMixin
          {:add-fk-sql                (constantly nil) ; TODO - fix me

--- a/test/metabase/test/data/sqlserver.clj
+++ b/test/metabase/test/data/sqlserver.clj
@@ -5,7 +5,8 @@
             [environ.core :refer [env]]
             [metabase.driver.sqlserver :refer [sqlserver]]
             (metabase.test.data [generic-sql :as generic]
-                                [interface :as i])))
+                                [interface :as i]))
+  (:import metabase.driver.sqlserver.SQLServerDriver))
 
 (def ^:private ^:const field-base-type->sql-type
   {:BigIntegerField "BIGINT"
@@ -78,9 +79,7 @@
    [(+suffix db-name) "dbo" table-name field-name]))
 
 
-(defrecord SQLServerDatasetLoader [dbpromise])
-
-(extend SQLServerDatasetLoader
+(extend SQLServerDriver
   generic/IGenericSQLDatasetLoader
   (merge generic/DefaultsMixin
          {:drop-db-if-exists-sql     drop-db-if-exists-sql
@@ -104,7 +103,7 @@
   {:expectations-options :before-run}
   []
   (when (contains? @(resolve 'metabase.test.data.datasets/test-engines) :sqlserver)
-    (let [connection-spec ((sqlserver :connection-details->spec) (database->connection-details nil :server nil))
+    (let [connection-spec ((:connection-details->spec sqlserver) (database->connection-details nil :server nil))
           leftover-dbs    (mapv :name (jdbc/query connection-spec "SELECT name
                                                                    FROM   master.dbo.sysdatabases
                                                                    WHERE  name NOT IN ('tempdb', 'master', 'model', 'msdb', 'rdsadmin');"))]


### PR DESCRIPTION
Tiny refactor. Make the various drivers instances of their own record types so we can eliminate the need to have redundant "DatasetLoader" classes in tests
