### PR TITLE
Small driver loading tweaks :yum:

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -17,7 +17,7 @@
 (defannotation DBEngine
   "Param must be a valid database engine type, e.g. `h2` or `postgres`."
   [symb value :nillable]
-  (checkp-contains? (set (map name (keys @driver/available-drivers))) symb value))
+  (checkp-with driver/is-engine? symb value))
 
 (defn test-database-connection
   "Try out the connection details for a database and useful error message if connection fails, returns `nil` if connection succeeds."

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -190,7 +190,7 @@
 
 (defrecord H2Driver [])
 
-(def ^:metabase.driver/driver h2
+(def h2
   (map->H2Driver
    (sql-driver
     {:driver-name                       "H2"
@@ -206,3 +206,5 @@
      :unix-timestamp->timestamp         unix-timestamp->timestamp
      :humanize-connection-error-message humanize-connection-error-message
      :process-query-in-context          process-query-in-context})))
+
+(driver/register-driver! :h2 h2)

--- a/src/metabase/driver/mongo.clj
+++ b/src/metabase/driver/mongo.clj
@@ -123,7 +123,7 @@
 
 (defrecord MongoDriver [])
 
-(def ^:metabase.driver/driver mongo
+(def mongo
   (map->MongoDriver
    (driver/driver
     {:driver-name                       "MongoDB"
@@ -161,3 +161,5 @@
      :date-interval                     u/relative-date
      :humanize-connection-error-message humanize-connection-error-message
      :active-nested-field-name->type    active-nested-field-name->type})))
+
+(driver/register-driver! :mongo mongo)

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -135,7 +135,7 @@
 
 (defrecord MySQLDriver [])
 
-(def ^:metabase.driver/driver mysql
+(def mysql
   (map->MySQLDriver
    (sql-driver
     {:driver-name                       "MySQL"
@@ -170,3 +170,5 @@
      ;; See https://dev.mysql.com/doc/refman/5.7/en/time-zone-support.html for details
      :set-timezone-sql                  "SET @@session.time_zone = ?;"
      :humanize-connection-error-message humanize-connection-error-message})))
+
+(driver/register-driver! :mysql mysql)

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -159,7 +159,7 @@
 
 (defrecord PostgresDriver [])
 
-(def ^:metabase.driver/driver postgres
+(def postgres
   (map->PostgresDriver
    (sql-driver
     {:driver-name                       "PostgreSQL"
@@ -195,3 +195,6 @@
      :set-timezone-sql                  "UPDATE pg_settings SET setting = ? WHERE name ILIKE 'timezone';"
      :driver-specific-sync-field!       driver-specific-sync-field!
      :humanize-connection-error-message humanize-connection-error-message})))
+
+
+(driver/register-driver! :postgres postgres)

--- a/src/metabase/driver/sqlite.clj
+++ b/src/metabase/driver/sqlite.clj
@@ -5,6 +5,7 @@
                    [db :as kdb])
             [korma.sql.utils :as kutils]
             [metabase.config :as config]
+            [metabase.driver :as driver]
             [metabase.driver.generic-sql :refer [sql-driver]]
             [metabase.util :as u]))
 
@@ -108,7 +109,7 @@
 
 (defrecord SQLiteDriver [])
 
-(def ^:metabase.driver/driver sqlite
+(def sqlite
   (map->SQLiteDriver
    (cond-> (-> (sql-driver {:driver-name               "SQLite"
                             :details-fields            [{:name         "db"
@@ -127,3 +128,5 @@
      ;; HACK SQLite doesn't support ALTER TABLE ADD CONSTRAINT FOREIGN KEY and I don't have all day to work around this
      ;; so for now we'll just skip the foreign key stuff in the tests.
      (config/is-test?) (update :features set/difference #{:foreign-keys}))))
+
+(driver/register-driver! :sqlite sqlite)

--- a/src/metabase/driver/sqlserver.clj
+++ b/src/metabase/driver/sqlserver.clj
@@ -3,6 +3,7 @@
             (korma [core :as k]
                    [db :as kdb])
             [korma.sql.utils :as utils]
+            [metabase.driver :as driver]
             [metabase.driver.generic-sql :refer [sql-driver]]
             [metabase.driver.generic-sql.util :refer [funcs]])
   (:import net.sourceforge.jtds.jdbc.Driver)) ; need to import this in order to load JDBC driver
@@ -113,7 +114,7 @@
 
 (defrecord SQLServerDriver [])
 
-(def ^:metabase.driver/driver sqlserver
+(def sqlserver
   (map->SQLServerDriver
    (-> (sql-driver {:driver-name               "SQL Server"
                     :details-fields            [{:name         "host"
@@ -149,3 +150,5 @@
                     :unix-timestamp->timestamp unix-timestamp->timestamp})
        (update :qp-clause->handler merge {:limit apply-limit
                                           :page  apply-page}))))
+
+(driver/register-driver! :sqlserver sqlserver)

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -171,7 +171,7 @@
 (defn public-settings
   "Return a simple map of key/value pairs which represent the public settings for the front-end application."
   []
-  {:engines               (deref @(ns-resolve 'metabase.driver 'available-drivers))
+  {:engines               (@(resolve 'metabase.driver/available-drivers))
    :ga_code               "UA-60817802-1"
    :password_complexity   (password/active-password-complexity)
    :setup_token           (setup/token-value)


### PR DESCRIPTION
-  Instead of having `metabase.driver` iterate over all the namespaces on the classpath looking for drivers, have the drivers register themselves with a function `register-driver!`
-  This lets us eliminate some hairy driver lookup logic and dynamic runtime resolution of drivers
-  `available-drivers` can be a simple function instead of a delay :tada: 
-  Slight startup time improvement since drivers are lazily loaded
-  Slight performance boost since dynamic lookup is eliminated
