### PR TITLE
Make drivers implement clojure.lang.Named :yum:

### DIFF
--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -59,13 +59,7 @@
 
 (defn verify-driver
   "Verify that a Metabase DB driver contains the expected properties and that they are the correct type."
-  [{:keys [driver-name details-fields features], :as driver}]
-  ;; Check :driver-name is a string
-  (assert driver-name
-    "Missing property :driver-name.")
-  (assert (string? driver-name)
-    ":driver-name must be a string.")
-
+  [{:keys [details-fields features], :as driver}]
   ;; Check the :details-fields
   (assert details-fields
     "Driver is missing property :details-fields.")
@@ -121,13 +115,15 @@
 (defn driver
   "Define and validate a new Metabase DB driver.
 
-   All drivers must include the following keys:
+   Drivers should implement `getName` from `clojure.lang.Named`, so we can call `name` on them:
+
+     (name (PostgresDriver.)) -> \"PostgreSQL\"
+
+   This name should be a \"nice-name\" that we'll display to the user.
+
+   Drivers must include the following keys:
 
 #### PROPERTIES
-
-*  `:driver-name`
-
-    A human-readable string naming the DB this driver works with, e.g. `\"PostgreSQL\"`.
 
 *  `:details-fields`
 
@@ -280,7 +276,7 @@
   []
   (m/map-vals (fn [driver]
                 {:details-fields (:details-fields driver)
-                 :driver-name    (:driver-name driver)
+                 :driver-name    (name driver)
                  :features       (:features driver)})
               @registered-drivers))
 

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -188,13 +188,14 @@
     #".*" ; default
     message))
 
-(defrecord H2Driver [])
+(defrecord H2Driver []
+  clojure.lang.Named
+  (getName [_] "H2"))
 
 (def h2
   (map->H2Driver
    (sql-driver
-    {:driver-name                       "H2"
-     :details-fields                    [{:name         "db"
+    {:details-fields                    [{:name         "db"
                                           :display-name "Connection String"
                                           :placeholder  "file:/Users/camsaul/bird_sightings/toucans;AUTO_SERVER=TRUE"
                                           :required     true}]

--- a/src/metabase/driver/mongo.clj
+++ b/src/metabase/driver/mongo.clj
@@ -121,13 +121,14 @@
                             first                         ; keep just the type
                             driver/class->base-type))))))
 
-(defrecord MongoDriver [])
+(defrecord MongoDriver []
+  clojure.lang.Named
+  (getName [_] "MongoDB"))
 
 (def mongo
   (map->MongoDriver
    (driver/driver
-    {:driver-name                       "MongoDB"
-     :details-fields                    [{:name         "host"
+    {:details-fields                    [{:name         "host"
                                           :display-name "Host"
                                           :default      "localhost"}
                                          {:name         "port"

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -133,13 +133,14 @@
         #".*" ; default
         message))
 
-(defrecord MySQLDriver [])
+(defrecord MySQLDriver []
+  clojure.lang.Named
+  (getName [_] "MySQL"))
 
 (def mysql
   (map->MySQLDriver
    (sql-driver
-    {:driver-name                       "MySQL"
-     :details-fields                    [{:name         "host"
+    {:details-fields                    [{:name         "host"
                                           :display-name "Host"
                                           :default      "localhost"}
                                          {:name         "port"

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -157,13 +157,14 @@
     #".*" ; default
     message))
 
-(defrecord PostgresDriver [])
+(defrecord PostgresDriver []
+  clojure.lang.Named
+  (getName [_] "PostgreSQL"))
 
 (def postgres
   (map->PostgresDriver
    (sql-driver
-    {:driver-name                       "PostgreSQL"
-     :details-fields                    [{:name         "host"
+    {:details-fields                    [{:name         "host"
                                           :display-name "Host"
                                           :default "localhost"}
                                          {:name         "port"

--- a/src/metabase/driver/query_processor.clj
+++ b/src/metabase/driver/query_processor.clj
@@ -223,7 +223,7 @@
                                    ;; obscure DB details when logging. Just log the name of driver because we don't care about its properties
                                    (-> query
                                        (assoc-in [:database :details] "😋 ") ; :yum:
-                                       (update :driver :driver-name)))))))
+                                       (update :driver name)))))))
     (qp query)))
 
 

--- a/src/metabase/driver/sqlite.clj
+++ b/src/metabase/driver/sqlite.clj
@@ -107,12 +107,13 @@
                  :milliseconds "DATETIME(%s / 1000, 'unixepoch')")
                [field-or-value]))
 
-(defrecord SQLiteDriver [])
+(defrecord SQLiteDriver []
+  clojure.lang.Named
+  (getName [_] "SQLite"))
 
 (def sqlite
   (map->SQLiteDriver
-   (cond-> (-> (sql-driver {:driver-name               "SQLite"
-                            :details-fields            [{:name         "db"
+   (cond-> (-> (sql-driver {:details-fields            [{:name         "db"
                                                          :display-name "Filename"
                                                          :placeholder  "/home/camsaul/toucan_sightings.sqlite 😋"
                                                          :required     true}]

--- a/src/metabase/driver/sqlserver.clj
+++ b/src/metabase/driver/sqlserver.clj
@@ -112,12 +112,13 @@
                                 (* items (dec page))
                                 items)))
 
-(defrecord SQLServerDriver [])
+(defrecord SQLServerDriver []
+  clojure.lang.Named
+  (getName [_] "SQL Server"))
 
 (def sqlserver
   (map->SQLServerDriver
-   (-> (sql-driver {:driver-name               "SQL Server"
-                    :details-fields            [{:name         "host"
+   (-> (sql-driver {:details-fields            [{:name         "host"
                                                  :display-name "Host"
                                                  :default      "localhost"}
                                                 {:name         "port"

--- a/src/metabase/driver/sync.clj
+++ b/src/metabase/driver/sync.clj
@@ -94,13 +94,13 @@
 (defn- -sync-database-with-tracking! [driver database]
   (let [start-time    (System/currentTimeMillis)
         tracking-hash (str (java.util.UUID/randomUUID))]
-    (log/info (u/format-color 'magenta "Syncing %s database '%s'..." (name (:engine database)) (:name database)))
+    (log/info (u/format-color 'magenta "Syncing %s database '%s'..." (name driver) (:name database)))
     (events/publish-event :database-sync-begin {:database_id (:id database) :custom_id tracking-hash})
 
     (-sync-database! driver database)
 
     (events/publish-event :database-sync-end {:database_id (:id database) :custom_id tracking-hash :running_time (- (System/currentTimeMillis) start-time)})
-    (log/info (u/format-color 'magenta "Finished syncing %s database %s. (%d ms)" (name (:engine database)) (:name database)
+    (log/info (u/format-color 'magenta "Finished syncing %s database %s. (%d ms)" (name driver) (:name database)
                               (- (System/currentTimeMillis) start-time)))))
 
 (defn sync-database!


### PR DESCRIPTION
Another small tweak. Make drivers implement the `clojure.lang.Named` interface instead of defining a "driver-name" property. This lets us call `name` on drivers:

``` clojure
(name metabase.driver.postgres/postgres) -> "PostgreSQL"

(defn some-sync-fn [driver database]
  (log/debug (format "Syncing tables for %s database '%s'..." (name driver) (:name database)))
  ...)
;; -> Syncing tables for PostgreSQL database 'sad-toucan-incidents'...
```
