### PR TITLE
Make MB driver spec a formal protocol :yum:

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -38,12 +38,13 @@
         (catch Throwable e
           (response-invalid :dbname (.getMessage e)))))))
 
+;; TODO - Just make `:ssl` a `feature`
 (defn supports-ssl?
   "Predicate function which determines if a given `engine` supports the `:ssl` setting."
   [engine]
   {:pre [(driver/is-engine? engine)]}
   (let [driver-props (->> (driver/engine->driver engine)
-                          :details-fields
+                          driver/details-fields
                           (map :name)
                           set)]
     (contains? driver-props "ssl")))

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -75,7 +75,7 @@
                           :user     (config/config-str :mb-db-user)
                           :password (config/config-str :mb-db-pass)}))))
 
-(defn jdbc-details
+(defn- jdbc-details
   "Takes our own MB details map and formats them properly for connection details for Korma / JDBC."
   [db-details]
   {:pre [(map? db-details)]}
@@ -127,8 +127,8 @@
 
 (def ^:dynamic *allow-potentailly-unsafe-connections*
   "We want to make *every* database connection made by the drivers safe -- read-only, only connect if DB file exists, etc.
-   At the same time, we'd like to be able to use driver functionality like `can-connect?` to check whether we can connect
-   to the Metabase database, in which case we'd like to allow connections to databases that don't exist.
+   At the same time, we'd like to be able to use driver functionality like `can-connect-with-details?` to check whether we can
+   connect to the Metabase database, in which case we'd like to allow connections to databases that don't exist.
 
    So we need some way to distinguish the Metabase database from other databases. We could add a key to the details map
    specifying that it's the Metabase DB, but what if some shady user added that key to another database?
@@ -141,9 +141,15 @@
    forever after, making all other connnections \"safe\"."
   false)
 
-(defn- db-can-connect? [details]
-  (binding [*allow-potentailly-unsafe-connections* true]
-    (@(resolve 'metabase.driver/can-connect?) details)))
+(defn- verify-db-connection
+  "Test connection to database with DETAILS and throw an exception if we have any troubles connecting."
+  [engine details]
+  {:pre [(keyword? engine) (map? details)]}
+  (log/info "Verifying Database Connection ...")
+  (assert (binding [*allow-potentailly-unsafe-connections* true]
+            (@(resolve 'metabase.driver/can-connect-with-details?) engine details))
+    "Unable to connect to Metabase DB.")
+  (log/info "Verify Database Connection ... CHECK"))
 
 (defn setup-db
   "Do general perparation of database by validating that we can connect.
@@ -153,12 +159,7 @@
              auto-migrate true}}]
   (reset! setup-db-has-been-called? true)
 
-  ;; Test DB connection and throw exception if we have any troubles connecting
-  (log/info "Verifying Database Connection ...")
-  (assert (db-can-connect? {:engine  (:type db-details)
-                            :details db-details})
-    "Unable to connect to Metabase DB.")
-  (log/info "Verify Database Connection ... CHECK")
+  (verify-db-connection (:type db-details) db-details)
 
   ;; Run through our DB migration process and make sure DB is fully prepared
   (if auto-migrate

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -1,9 +1,10 @@
 (ns metabase.driver
-  (:require [clojure.string :as s]
+  (:require [clojure.math.numeric-tower :as math]
+            [clojure.string :as s]
             [clojure.tools.logging :as log]
+            [korma.core :as k]
             [medley.core :as m]
             [metabase.db :refer [ins sel upd]]
-            [metabase.driver.query-processor :as qp]
             (metabase.models [database :refer [Database]]
                              [query-execution :refer [QueryExecution]])
             [metabase.models.setting :refer [defsetting]]
@@ -30,229 +31,186 @@
    :username-incorrect                 "Looks like your username is incorrect."
    :username-or-password-incorrect     "Looks like the username or password is incorrect."})
 
-(def ^:private ^:const feature->required-fns
-  "Map of optional driver features (as keywords) to a set of functions drivers that support that feature must define."
-  {:foreign-keys                       #{:table-fks}
-   :nested-fields                      #{:active-nested-field-name->type}
-   :set-timezone                       nil
-   :standard-deviation-aggregations    nil})
-
-(def ^:private ^:const optional-features
-  (set (keys feature->required-fns)))
-
-(def ^:private ^:const required-fns
-  #{:can-connect?
-    :active-tables
-    :active-column-names->type
-    :table-pks
-    :field-values-lazy-seq
-    :process-query})
-
-(def ^:private ^:const optional-fns
-  #{:humanize-connection-error-message
-    :sync-in-context
-    :process-query-in-context
-    :table-rows-seq
-    :field-avg-length
-    :field-percent-urls
-    :driver-specific-sync-field!})
-
-(defn verify-driver
-  "Verify that a Metabase DB driver contains the expected properties and that they are the correct type."
-  [{:keys [details-fields features], :as driver}]
-  ;; Check the :details-fields
-  (assert details-fields
-    "Driver is missing property :details-fields.")
-  (assert (vector? details-fields)
-    ":details-fields should be a vector.")
-  (doseq [f details-fields]
-    (assert (map? f)
-      (format "Details fields must be maps: %s" f))
-    (assert (:name f)
-      (format "Details field %s is missing a :name property." f))
-    (assert (:display-name f)
-      (format "Details field %s is missing a :display-name property." f))
-    (when (:type f)
-      (assert (contains? #{:string :integer :password :boolean} (:type f))
-        (format "Invalid type %s in details field %s." (:type f) f)))
-    (when (:default f)
-      (assert (not (:placeholder f))
-        (format "Fields should not define both :default and :placeholder: %s" f))
-      (assert (not (:required f))
-        (format "Fields that define a :default cannot be :required: %s" f))))
-
-  ;; Check that all required functions are defined
-  (doseq [f required-fns]
-    (assert (f driver)
-      (format "Missing fn: %s" f))
-    (assert (fn? (f driver))
-      (format "Not a fn: %s" (f driver))))
-
-  ;; Check that all features declared are valid
-  (when features
-    (assert (and (set? features)
-                 (every? keyword? features))
-      ":features must be a set of keywords.")
-    (doseq [feature features]
-      (assert (contains? optional-features feature)
-        (format "Not a valid feature: %s" feature))
-      (doseq [f (feature->required-fns feature)]
-        (assert (f driver)
-          (format "Drivers that support feature %s must have fn %s." feature f))
-        (assert (fn? (f driver))
-          (format "Not a fn: %s" f)))))
-
-  ;; Check that the optional fns, if included, are actually fns
-  (doseq [f optional-fns]
-    (when (f driver)
-      (assert (fn? (f driver))
-        (format "Not a fn: %s" f)))))
-
-(def ^:const driver-defaults
-  "Default implementations of methods for drivers."
-  {:date-interval u/relative-date})
-
-(defn driver
-  "Define and validate a new Metabase DB driver.
-
-   Drivers should implement `getName` from `clojure.lang.Named`, so we can call `name` on them:
+(defprotocol IDriver
+  "Methods that Metabase drivers must implement. Methods marked *OPTIONAL* have default implementations in `IDriverDefaultsMixin`.
+   Drivers should also implement `getName` form `clojure.lang.Named`, so we can call `name` on them:
 
      (name (PostgresDriver.)) -> \"PostgreSQL\"
 
-   This name should be a \"nice-name\" that we'll display to the user.
+   This name should be a \"nice-name\" that we'll display to the user."
+  (active-column-names->type ^java.util.Map [this, ^TableInstance table]
+    "Return a map of string names of active columns (or equivalent) -> `Field` `base_type` for TABLE (or equivalent).")
 
-   Drivers must include the following keys:
+  (active-nested-field-name->type ^java.util.Map [this, ^FieldInstance field]
+    "*OPTIONAL, BUT REQUIRED FOR DRIVERS THAT SUPPORT `:nested-fields`*
 
-#### PROPERTIES
+     Return a map of string names of active child `Fields` of FIELD -> `Field.base_type`.")
 
-*  `:details-fields`
+  (active-tables ^java.util.Set [this, ^DatabaseInstance database]
+    "Return a set of maps containing information about the active tables/views, collections, or equivalent that currently exist in DATABASE.
+     Each map should contain the key `:name`, which is the string name of the table. For databases that have a concept of schemas,
+     this map should also include the string name of the table's `:schema`.")
 
-    A vector of maps that contain information about connection properties that should
-    be exposed to the user for databases that will use this driver. This information is used to build the UI for editing
-    a `Database` `details` map, and for validating it on the Backend. It should include things like `host`,
-    `port`, and other driver-specific parameters. Each field information map should have the following properties:
+  (can-connect? ^Boolean [this, ^Map details-map]
+    "Check whether we can connect to a `Database` with DETAILS-MAP and perform a simple query. For example, a SQL database might
+     try running a query like `SELECT 1;`. This function should return `true` or `false`.")
 
-    *  `:name`
+  (date-interval [this, ^Keyword unit, ^Number amount]
+    "*OPTIONAL* Return an driver-appropriate representation of a moment relative to the current moment in time. By default, this returns an `Timestamp` by calling
+     `metabase.util/relative-date`; but when possible drivers should return a native form so we can be sure the correct timezone is applied. For example, SQL drivers should
+     return a Korma form to call the appropriate SQL fns:
 
-        The key that should be used to store this property in the `details` map.
+       (date-interval (PostgresDriver.) :month 1) -> (k/raw* \"(NOW() + INTERVAL '1 month')\")")
 
-    *  `:display-name`
+  (details-fields ^clojure.lang.Sequential [this]
+    "A vector of maps that contain information about connection properties that should
+     be exposed to the user for databases that will use this driver. This information is used to build the UI for editing
+     a `Database` `details` map, and for validating it on the Backend. It should include things like `host`,
+     `port`, and other driver-specific parameters. Each field information map should have the following properties:
 
-        Human-readable name that should be displayed to the User in UI for editing this field.
+       *  `:name`
 
-    *  `:type` *(OPTIONAL)*
+           The key that should be used to store this property in the `details` map.
 
-       `:string`, `:integer`, `:boolean`, or `:password`. Defaults to `:string`.
+       *  `:display-name`
 
-    *  `:default` *(OPTIONAL)*
+           Human-readable name that should be displayed to the User in UI for editing this field.
 
-        A default value for this field if the user hasn't set an explicit value. This is shown in the UI as a placeholder.
+       *  `:type` *(OPTIONAL)*
 
-    *  `:placeholder` *(OPTIONAL)*
+          `:string`, `:integer`, `:boolean`, or `:password`. Defaults to `:string`.
 
-       Placeholder value to show in the UI if user hasn't set an explicit value. Similar to `:default`, but this value is
-       *not* saved to `:details` if no explicit value is set. Since `:default` values are also shown as placeholders, you
-       cannot specify both `:default` and `:placeholder`.
+       *  `:default` *(OPTIONAL)*
 
-    *  `:required` *(OPTIONAL)*
+           A default value for this field if the user hasn't set an explicit value. This is shown in the UI as a placeholder.
 
-       Is this property required? Defaults to `false`.
+       *  `:placeholder` *(OPTIONAL)*
 
-*  `:features` *(OPTIONAL)*
+          Placeholder value to show in the UI if user hasn't set an explicit value. Similar to `:default`, but this value is
+          *not* saved to `:details` if no explicit value is set. Since `:default` values are also shown as placeholders, you
+          cannot specify both `:default` and `:placeholder`.
 
-    A set of keyword names of optional features supported by this driver, such as `:foreign-keys`.
+       *  `:required` *(OPTIONAL)*
 
-#### FUNCTIONS
+          Is this property required? Defaults to `false`.")
 
-*  `(can-connect? [details-map])`
+  (driver-specific-sync-field! ^metabase.models.field.FieldInstance [this, ^FieldInstance field]
+    "*OPTIONAL*. This is a chance for drivers to do custom `Field` syncing specific to their database.
+     For example, the Postgres driver can mark Postgres JSON fields as `special_type = json`.
+     As with the other Field syncing functions in `metabase.driver.sync`, this method should return the modified FIELD, if any, or `nil`.")
 
-   Check whether we can connect to a `Database` with DETAILS-MAP and perform a simple query. For example, a SQL database might
-   try running a query like `SELECT 1;`. This function should return `true` or `false`.
+  (features ^java.util.Set [this]
+    "*OPTIONAL*. A set of keyword names of optional features supported by this driver, such as `:foreign-keys`.
+     Valid features are: `:foreign-keys :nested-fields :set-timezone :standard-deviation-aggregations`")
 
-*  `(active-tables [database])`
+  (field-avg-length ^Float [this, ^FieldInstance field]
+    "*OPTIONAL*. If possible, provide an efficent DB-level function to calculate the average length of non-nil values of textual FIELD, which is used to determine whether a `Field`
+     should be marked as a `:category`. If this function is not provided, a fallback implementation that iterates over results in Clojure-land is used instead.")
 
-   Return a set of maps containing information about the active tables/views, collections, or equivalent that currently exist in DATABASE.
-   Each map should contain the key `:name`, which is the string name of the table. For databases that have a concept of schemas,
-   this map should also include the string name of the table's `:schema`.
+  (field-percent-urls ^Float [this, ^FieldInstance field]
+    "*OPTIONAL*. If possible, provide an efficent DB-level function to calculate what percentage of non-nil values of textual FIELD are valid URLs, which is used to determine
+     whether a `Field` should be marked as a `:url`. If this function is not provided, a fallback implementation that iterates over results in Clojure-land is used instead.")
 
-*  `(active-column-names->type [table])`
+  (field-values-lazy-seq ^clojure.lang.Sequential [this, ^FieldInstance field]
+    "Return a lazy sequence of all values of FIELD.
+     This is used to implement `mark-json-field!`, and fallback implentations of `mark-no-preview-display-field!` and `mark-url-field!`
+     if drivers *don't* implement `field-avg-length` and `field-percent-urls`, respectively.")
 
-   Return a map of string names of active columns (or equivalent) -> `Field` `base_type` for TABLE (or equivalent).
+  (humanize-connection-error-message ^String [this, ^String message]
+    "*OPTIONAL*. Return a humanized (user-facing) version of an connection error message string.
+     Generic error messages are provided in the constant `connection-error-messages`; return one of these whenever possible.")
 
-*  `(table-pks [table])`
+  (process-native [this, ^Map query]
+    "Process a native QUERY. This function is called by `metabase.driver/process-query`.")
 
-   Return a set of string names of active Fields that are primary keys for TABLE (or equivalent).
+  (process-structured [this, ^Map query]
+    "Process a native or structured QUERY. This function is called by `metabase.driver/process-query` after performing various driver-unspecific
+     steps like Query Expansion and other preprocessing.")
 
-*  `(field-values-lazy-seq [field])`
+  (process-query-in-context [this, ^IFn qp]
+    "*OPTIONAL*. Similar to `sync-in-context`, but for running queries rather than syncing. This should be used to do things like open DB connections
+     that need to remain open for the duration of post-processing. This function follows a middleware pattern and is injected into the QP
+     middleware stack immediately after the Query Expander; in other words, it will receive the expanded query.
+     See the Mongo and H2 drivers for examples of how this is intended to be used.
 
-   Return a lazy sequence of all values of FIELD.
-   This is used to implement `mark-json-field!`, and fallback implentations of `mark-no-preview-display-field!` and `mark-url-field!`
-   if drivers *don't* implement `field-avg-length` and `field-percent-urls`, respectively.
+       (defn process-query-in-context [driver qp]
+         (fn [query]
+           (qp query)))")
 
-*  `(process-query [query])`
+  (sync-in-context [this, ^DatabaseInstance database, ^IFn f]
+    "*OPTIONAL*. Drivers may provide this function if they need to do special setup before a sync operation such as `sync-database!`. The sync
+     operation itself is encapsulated as the lambda F, which must be called with no arguments.
 
-   Process a native or structured QUERY. This function is called by `metabase.driver/process-query` after performing various driver-unspecific
-   steps like Query Expansion and other preprocessing.
-
-*  `(table-fks [table])` *(REQUIRED FOR DRIVERS THAT SUPPORT `:foreign-keys`)*
-
-   Return a set of maps containing info about FK columns for TABLE.
-   Each map should contain the following keys:
-
-     *  `fk-column-name`
-     *  `dest-table-name`
-     *  `dest-column-name`
-
-*  `(active-nested-field-name->type [field])` *(REQUIRED FOR DRIVERS THAT SUPPORT `:nested-fields`)*
-
-   Return a map of string names of active child `Fields` of FIELD -> `Field.base_type`.
-
-*  `(humanize-connection-error-message [message])` *(OPTIONAL)*
-
-   Return a humanized (user-facing) version of an connection error message string.
-   Generic error messages are provided in the constant `connection-error-messages`; return one of these whenever possible.
-
-*  `(sync-in-context [database f])` *(OPTIONAL)*
-
-   Drivers may provide this function if they need to do special setup before a sync operation such as `sync-database!`. The sync
-   operation itself is encapsulated as the lambda F, which must be called with no arguments.
-
-       (defn sync-in-context [database f]
+       (defn sync-in-context [driver database f]
          (with-jdbc-metadata [_ database]
-           (f)))
+           (f)))")
 
-*  `(process-query-in-context [f])` *(OPTIONAL)*
+  (table-fks ^java.util.Set [this, ^TableInstance table]
+    "*OPTIONAL*, BUT REQUIRED FOR DRIVERS THAT SUPPORT `:foreign-keys`*
 
-   Similar to `sync-in-context`, but for running queries rather than syncing. This should be used to do things like open DB connections
-   that need to remain open for the duration of post-processing. This function follows a middleware pattern and is injected into the QP
-   middleware stack immediately after the Query Expander; in other words, it will receive the expanded query.
-   See the Mongo and H2 drivers for examples of how this is intended to be used.
+     Return a set of maps containing info about FK columns for TABLE.
+     Each map should contain the following keys:
 
-*  `(table-rows-seq [database table-name])` *(OPTIONAL)*
+       *  `fk-column-name`
+       *  `dest-table-name`
+       *  `dest-column-name`")
 
-   Return a sequence of all the rows in a table with a given TABLE-NAME.
-   Currently, this is only used for iterating over the values in a `_metabase_metadata` table. As such, the results are not expected to be returned lazily.
+  (table-pks ^java.util.Set [this, ^TableInstance table]
+    "Return a set of string names of active Fields that are primary keys for TABLE (or equivalent).")
 
-*  `(field-avg-length [field])` *(OPTIONAL)*
+  (table-rows-seq ^clojure.lang.Sequential [this, ^DatabaseInstance database, ^String table-name]
+    "*OPTIONAL*. Return a sequence of all the rows in a table with a given TABLE-NAME.
+     Currently, this is only used for iterating over the values in a `_metabase_metadata` table. As such, the results are not expected to be returned lazily."))
 
-   If possible, provide an efficent DB-level function to calculate the average length of non-nil values of textual FIELD, which is used to determine whether a `Field`
-   should be marked as a `:category`. If this function is not provided, a fallback implementation that iterates over results in Clojure-land is used instead.
+(defn- percent-valid-urls
+  "Recursively count the values of non-nil values in VS that are valid URLs, and return it as a percentage."
+  [vs]
+  (loop [valid-count 0, non-nil-count 0, [v & more :as vs] vs]
+    (cond (not (seq vs)) (if (zero? non-nil-count) 0.0
+                             (float (/ valid-count non-nil-count)))
+          (nil? v)       (recur valid-count non-nil-count more)
+          :else          (let [valid? (and (string? v)
+                                           (u/is-url? v))]
+                           (recur (if valid? (inc valid-count) valid-count)
+                                  (inc non-nil-count)
+                                  more)))))
 
-*  `(field-percent-urls [field])` *(OPTIONAL)*
 
-   If possible, provide an efficent DB-level function to calculate what percentage of non-nil values of textual FIELD are valid URLs, which is used to determine
-   whether a `Field` should be marked as a `:url`. If this function is not provided, a fallback implementation that iterates over results in Clojure-land is used instead.
+(defn- default-field-percent-urls
+  "Default implementation for optional driver fn `:field-percent-urls` that calculates percentage in Clojure-land."
+  [driver field]
+  (->> (field-values-lazy-seq driver field)
+       (filter identity)
+       (take max-sync-lazy-seq-results)
+       percent-valid-urls))
 
-*  `(driver-specific-sync-field! [field])` *(OPTIONAL)*
+(defn- default-field-avg-length [driver field]
+  (let [field-values        (->> (field-values-lazy-seq driver field)
+                                 (filter identity)
+                                 (take max-sync-lazy-seq-results))
+        field-values-count (count field-values)]
+    (if (= field-values-count 0) 0
+        (int (math/round (/ (->> field-values
+                                 (map str)
+                                 (map count)
+                                 (reduce +))
+                            field-values-count))))))
 
-   This is a chance for drivers to do custom `Field` syncing specific to their database.
-   For example, the Postgres driver can mark Postgres JSON fields as `special_type = json`.
-   As with the other Field syncing functions in `metabase.driver.sync`, this method should return the modified FIELD, if any, or `nil`."
-  [driver-map]
-  (let [m (merge driver-defaults
-                 driver-map)]
-    (verify-driver m)
-    m))
+
+(def IDriverDefaultsMixin
+  "Default implementations of `IDriver` methods marked *OPTIONAL*."
+  {:active-nested-field-name->type    (constantly nil)
+   :date-interval                     (fn [_ unit amount] (u/relative-date unit amount))
+   :driver-specific-sync-field!       (constantly nil)
+   :features                          (constantly nil)
+   :field-avg-length                  default-field-avg-length
+   :field-percent-urls                default-field-percent-urls
+   :humanize-connection-error-message (fn [_ message] message)
+   :process-query-in-context          (fn [_ qp]      qp)
+   :sync-in-context                   (fn [_ _ f] (f))
+   :table-fks                         (constantly nil)
+   :table-rows-seq                    (constantly nil)})
+
 
 
 ;;; ## CONFIG
@@ -275,9 +233,9 @@
   "Info about available drivers."
   []
   (m/map-vals (fn [driver]
-                {:details-fields (:details-fields driver)
+                {:details-fields (details-fields driver)
                  :driver-name    (name driver)
-                 :features       (:features driver)})
+                 :features       (features driver)})
               @registered-drivers))
 
 (defn is-engine?
@@ -340,39 +298,24 @@
   "Consider `can-connect?`/`can-connect-with-details?` to have failed after this many milliseconds."
   5000)
 
-(defn can-connect?
-  "Check whether we can connect to DATABASE and perform a basic query (such as `SELECT 1`)."
-  [database]
-  {:pre [(map? database)]}
-  (let [driver (engine->driver (:engine database))]
-    (try
-      (u/with-timeout can-connect-timeout-ms
-        ((:can-connect? driver) (:details database)))
-      (catch Throwable e
-        (log/error "Failed to connect to database:" (.getMessage e))
-        false))))
-
 (defn can-connect-with-details?
-  "Check whether we can connect to a database with ENGINE and DETAILS-MAP and perform a basic query.
-   Specify optional param RETHROW-EXCEPTIONS if you want to handle any exceptions thrown yourself
-   (e.g., so you can pass the exception message along to the user).
+  "Check whether we can connect to a database with ENGINE and DETAILS-MAP and perform a basic query
+   such as `SELECT 1`. Specify optional param RETHROW-EXCEPTIONS if you want to handle any exceptions
+   thrown yourself (e.g., so you can pass the exception message along to the user).
 
      (can-connect-with-details? :postgres {:host \"localhost\", :port 5432, ...})"
   [engine details-map & [rethrow-exceptions]]
   {:pre [(keyword? engine)
          (is-engine? engine)
          (map? details-map)]}
-  (let [{:keys [humanize-connection-error-message], :as driver} (engine->driver engine)]
+  (let [driver (engine->driver engine)]
     (try
       (u/with-timeout can-connect-timeout-ms
-        ((:can-connect? driver) details-map))
+        (can-connect? driver details-map))
       (catch Throwable e
         (log/error "Failed to connect to database:" (.getMessage e))
         (when rethrow-exceptions
-          (let [^String message ((or humanize-connection-error-message
-                                     identity)
-                                 (.getMessage e))]
-            (throw (Exception. message))))
+          (throw (Exception. (humanize-connection-error-message driver (.getMessage e)))))
         false))))
 
 (defn sync-database!
@@ -390,7 +333,7 @@
 (defn process-query
   "Process a structured or native query, and return the result."
   [query]
-  (qp/process (database-id->driver (:database query)) query))
+  (@(resolve 'metabase.driver.query-processor/process) (database-id->driver (:database query)) query))
 
 
 ;; ## Query Execution Stuff

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -10,8 +10,7 @@
                        [utils :as utils])
             [metabase.config :as config]
             [metabase.driver :as driver]
-            (metabase.driver.generic-sql [native :as native]
-                                         [util :refer :all])
+            [metabase.driver.generic-sql.util :refer :all]
             [metabase.driver.query-processor :as qp]
             [metabase.util :as u])
   (:import java.sql.Timestamp
@@ -259,10 +258,3 @@
                                        second)                               ; (?s) = Pattern.DOTALL - tell regex `.` to match newline characters as well
                                   (.getMessage e))]
           (throw (Exception. message)))))))
-
-(defn process-and-run
-  "Process and run a query and return results."
-  [{:keys [type] :as query}]
-  (case (keyword type)
-    :native (native/process-and-run query)
-    :query  (process-structured query)))

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -7,7 +7,7 @@
             (korma.sql [engine :refer [sql-func]]
                        [utils :as utils])
             [metabase.driver :as driver]
-            [metabase.driver.generic-sql :refer [sql-driver]]
+            [metabase.driver.generic-sql :as sql]
             [metabase.driver.generic-sql.util :refer [funcs]]
             [metabase.util :as u]))
 
@@ -116,7 +116,7 @@
 (defn- date-interval [unit amount]
   (utils/generated (format "DATE_ADD(NOW(), INTERVAL %d %s)" amount (s/upper-case (name unit)))))
 
-(defn- humanize-connection-error-message [message]
+(defn- humanize-connection-error-message [_ message]
   (condp re-matches message
         #"^Communications link failure\s+The last packet sent successfully to the server was 0 milliseconds ago. The driver has not received any packets from the server.$"
         (driver/connection-error-messages :cannot-connect-check-host-and-port)
@@ -137,39 +137,43 @@
   clojure.lang.Named
   (getName [_] "MySQL"))
 
+(extend MySQLDriver
+  driver/IDriver
+  (merge sql/IDriverSQLDefaultsMixin
+         {:details-fields                    (constantly [{:name         "host"
+                                                           :display-name "Host"
+                                                           :default      "localhost"}
+                                                          {:name         "port"
+                                                           :display-name "Port"
+                                                           :type         :integer
+                                                           :default      3306}
+                                                          {:name         "dbname"
+                                                           :display-name "Database name"
+                                                           :placeholder  "birds_of_the_word"
+                                                           :required     true}
+                                                          {:name         "user"
+                                                           :display-name "Database username"
+                                                           :placeholder  "What username do you use to login to the database?"
+                                                           :required     true}
+                                                          {:name         "password"
+                                                           :display-name "Database password"
+                                                           :type         :password
+                                                           :placeholder  "*******"}])
+          :humanize-connection-error-message humanize-connection-error-message}))
+
 (def mysql
   (map->MySQLDriver
-   (sql-driver
-    {:details-fields                    [{:name         "host"
-                                          :display-name "Host"
-                                          :default      "localhost"}
-                                         {:name         "port"
-                                          :display-name "Port"
-                                          :type         :integer
-                                          :default      3306}
-                                         {:name         "dbname"
-                                          :display-name "Database name"
-                                          :placeholder  "birds_of_the_word"
-                                          :required     true}
-                                         {:name         "user"
-                                          :display-name "Database username"
-                                          :placeholder  "What username do you use to login to the database?"
-                                          :required     true}
-                                         {:name         "password"
-                                          :display-name "Database password"
-                                          :type         :password
-                                          :placeholder  "*******"}]
-     :column->base-type                 column->base-type
-     :string-length-fn                  :CHAR_LENGTH
-     :excluded-schemas                  #{"INFORMATION_SCHEMA"}
-     :connection-details->spec          connection-details->spec
-     :unix-timestamp->timestamp         unix-timestamp->timestamp
-     :date                              date
-     :date-interval                     date-interval
+   (sql/sql-driver
+    {:column->base-type         column->base-type
+     :connection-details->spec  connection-details->spec
+     :date                      date
+     :date-interval             date-interval
+     :excluded-schemas          #{"INFORMATION_SCHEMA"}
+     :string-length-fn          :CHAR_LENGTH
      ;; If this fails you need to load the timezone definitions from your system into MySQL;
      ;; run the command `mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root mysql`
      ;; See https://dev.mysql.com/doc/refman/5.7/en/time-zone-support.html for details
-     :set-timezone-sql                  "SET @@session.time_zone = ?;"
-     :humanize-connection-error-message humanize-connection-error-message})))
+     :set-timezone-sql          "SET @@session.time_zone = ?;"
+     :unix-timestamp->timestamp unix-timestamp->timestamp})))
 
 (driver/register-driver! :mysql mysql)

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -10,7 +10,7 @@
             [metabase.db :refer [upd]]
             [metabase.models.field :refer [Field]]
             [metabase.driver :as driver]
-            [metabase.driver.generic-sql :refer [sql-driver]]
+            [metabase.driver.generic-sql :as sql]
             [metabase.driver.generic-sql.util :refer [with-jdbc-metadata]])
   ;; This is necessary for when NonValidatingFactory is passed in the sslfactory connection string argument,
   ;; e.x. when connecting to a Heroku Postgres database from outside of Heroku.
@@ -100,7 +100,7 @@
                 :milliseconds "TO_TIMESTAMP(%s / 1000)")
               [field-or-value]))
 
-(defn- driver-specific-sync-field! [{:keys [table], :as field}]
+(defn- driver-specific-sync-field! [_ {:keys [table], :as field}]
   (with-jdbc-metadata [^java.sql.DatabaseMetaData md @(:db @table)]
     (let [[{:keys [type_name]}] (->> (.getColumns md nil nil (:name @table) (:name field))
                                      jdbc/result-set-seq)]
@@ -133,7 +133,7 @@
 (defn- date-interval [unit amount]
   (utils/generated (format "(NOW() + INTERVAL '%d %s')" amount (name unit))))
 
-(defn- humanize-connection-error-message [message]
+(defn- humanize-connection-error-message [_ message]
   (condp re-matches message
     #"^FATAL: database \".*\" does not exist$"
     (driver/connection-error-messages :database-name-incorrect)
@@ -161,41 +161,44 @@
   clojure.lang.Named
   (getName [_] "PostgreSQL"))
 
+(extend PostgresDriver
+  driver/IDriver
+  (merge sql/IDriverSQLDefaultsMixin
+         {:details-fields                    (constantly [{:name         "host"
+                                                           :display-name "Host"
+                                                           :default "localhost"}
+                                                          {:name         "port"
+                                                           :display-name "Port"
+                                                           :type         :integer
+                                                           :default      5432}
+                                                          {:name         "dbname"
+                                                           :display-name "Database name"
+                                                           :placeholder  "birds_of_the_word"
+                                                           :required     true}
+                                                          {:name         "user"
+                                                           :display-name "Database username"
+                                                           :placeholder  "What username do you use to login to the database?"
+                                                           :required     true}
+                                                          {:name         "password"
+                                                           :display-name "Database password"
+                                                           :type         :password
+                                                           :placeholder  "*******"}
+                                                          {:name         "ssl"
+                                                           :display-name "Use a secure connection (SSL)?"
+                                                           :type         :boolean
+                                                           :default      false}])
+          :driver-specific-sync-field!       driver-specific-sync-field!
+          :humanize-connection-error-message humanize-connection-error-message}))
+
 (def postgres
   (map->PostgresDriver
-   (sql-driver
-    {:details-fields                    [{:name         "host"
-                                          :display-name "Host"
-                                          :default "localhost"}
-                                         {:name         "port"
-                                          :display-name "Port"
-                                          :type         :integer
-                                          :default      5432}
-                                         {:name         "dbname"
-                                          :display-name "Database name"
-                                          :placeholder  "birds_of_the_word"
-                                          :required     true}
-                                         {:name         "user"
-                                          :display-name "Database username"
-                                          :placeholder  "What username do you use to login to the database?"
-                                          :required     true}
-                                         {:name         "password"
-                                          :display-name "Database password"
-                                          :type         :password
-                                          :placeholder  "*******"}
-                                         {:name         "ssl"
-                                          :display-name "Use a secure connection (SSL)?"
-                                          :type         :boolean
-                                          :default      false}]
-     :string-length-fn                  :CHAR_LENGTH
-     :column->base-type                 column->base-type
-     :connection-details->spec          connection-details->spec
-     :unix-timestamp->timestamp         unix-timestamp->timestamp
-     :date                              date
-     :date-interval                     date-interval
-     :set-timezone-sql                  "UPDATE pg_settings SET setting = ? WHERE name ILIKE 'timezone';"
-     :driver-specific-sync-field!       driver-specific-sync-field!
-     :humanize-connection-error-message humanize-connection-error-message})))
-
+   (sql/sql-driver
+    {:column->base-type         column->base-type
+     :connection-details->spec  connection-details->spec
+     :date                      date
+     :date-interval             date-interval
+     :set-timezone-sql          "UPDATE pg_settings SET setting = ? WHERE name ILIKE 'timezone';"
+     :string-length-fn          :CHAR_LENGTH
+     :unix-timestamp->timestamp unix-timestamp->timestamp})))
 
 (driver/register-driver! :postgres postgres)

--- a/src/metabase/driver/query_processor.clj
+++ b/src/metabase/driver/query_processor.clj
@@ -8,6 +8,7 @@
             [medley.core :as m]
             [swiss.arrows :refer [<<-]]
             [metabase.db :refer :all]
+            [metabase.driver :as driver]
             (metabase.driver.query-processor [annotate :as annotate]
                                              [expand :as expand]
                                              [interface :refer :all]
@@ -156,8 +157,7 @@
                                                                                   :fields      [ag-field])))]
 
       ;; Otherwise if we're breaking out on different fields, rewrite the query as a "sum" aggregation
-      cum-sum-with-breakout? [ag-field (-> query
-                                           (assoc-in [:query :aggregation] (map->Aggregation {:aggregation-type :sum, :field ag-field})))]
+      cum-sum-with-breakout? [ag-field (assoc-in query [:query :aggregation] (map->Aggregation {:aggregation-type :sum, :field ag-field}))]
 
       ;; Cumulative sum without any breakout fields should just be treated the same way as "sum". Rewrite query as such
       cum-sum? [false (assoc-in query [:query :aggregation] (map->Aggregation {:aggregation-type :sum, :field ag-field}))]
@@ -255,7 +255,7 @@
 ;;
 ;; Many functions do both pre and post-processing; this middleware pattern allows them to return closures that maintain some sort of
 ;; internal state. For example, cumulative-sum can determine if it needs to perform cumulative summing, and, if so, modify the query
-;; before passing it to QP, and modify the results of that call.
+;; before passing it to QP; once the query is processed, it can use modify the results as needed.
 ;;
 ;; For the sake of clarity, functions are named with the following convention:
 ;; *  Ones that only do pre-processing are prefixed with pre-
@@ -263,23 +263,22 @@
 ;; *  Ones that do both aren't prefixed
 ;;
 ;; The <<- (reverse-threading macro) is used below for clarity.
-;; Pre-processing happens from top-to-bottom, i.e. the QUERY passed to the function returned by POST-ADD-ROW-COUNT-AND-STATUS is the
-;; query as modified by PRE-EXPAND.
+;; Pre-processing happens from top-to-bottom, i.e. the QUERY passed to the function returned by PRE-ADD-IMPLICIT-BREAKOUT-ORDER-BY is the
+;; query as modified by PRE-ADD-IMPLICIT-FIELDS.
 ;;
 ;; Post-processing then happens in order from bottom-to-top; i.e. POST-ANNOTATE gets to modify the results, then LIMIT, then CUMULATIVE-SUM, etc.
-
 
 (defn process
   "Process a QUERY and return the results."
   [driver query]
   (when-not *disable-qp-logging*
     (log/debug (u/format-color 'blue "\nQUERY: 😎\n%s" (u/pprint-to-str query))))
-  (let [driver-process-query      (:process-query driver)
-        driver-wrap-process-query (or (:process-query-in-context driver)
-                                      (fn [qp] qp))]
+  (let [driver-process-query (partial (if (structured-query? query)
+                                        driver/process-structured
+                                        driver/process-native) driver)]
     ((<<- wrap-catch-exceptions
           pre-expand
-          driver-wrap-process-query
+          (driver/process-query-in-context driver)
           post-add-row-count-and-status
           pre-add-implicit-fields
           pre-add-implicit-breakout-order-by
@@ -288,5 +287,4 @@
           annotate/post-annotate
           pre-log-query
           wrap-guard-multiple-calls
-          driver-process-query) (assoc query
-                                       :driver driver))))
+          driver-process-query) (assoc query :driver driver))))

--- a/src/metabase/driver/query_processor/expand.clj
+++ b/src/metabase/driver/query_processor/expand.clj
@@ -9,6 +9,7 @@
             [korma.core :as k]
             [swiss.arrows :refer [-<>]]
             [metabase.db :refer [sel]]
+            [metabase.driver :as driver]
             [metabase.driver.query-processor.interface :refer :all]
             [metabase.util :as u])
   (:import (clojure.lang Keyword)))
@@ -29,7 +30,7 @@
 
 (defn- assert-driver-supports [^Keyword feature]
   {:pre [(:driver *original-query-dict*)]}
-  (when-not (contains? (:features (:driver *original-query-dict*)) feature)
+  (when-not (contains? (driver/features (:driver *original-query-dict*)) feature)
     (throw (Exception. (format "%s is not supported by this driver." (name feature))))))
 
 (defn- non-empty-clause? [clause]

--- a/src/metabase/driver/sqlserver.clj
+++ b/src/metabase/driver/sqlserver.clj
@@ -4,7 +4,7 @@
                    [db :as kdb])
             [korma.sql.utils :as utils]
             [metabase.driver :as driver]
-            [metabase.driver.generic-sql :refer [sql-driver]]
+            [metabase.driver.generic-sql :as sql]
             [metabase.driver.generic-sql.util :refer [funcs]])
   (:import net.sourceforge.jtds.jdbc.Driver)) ; need to import this in order to load JDBC driver
 
@@ -116,39 +116,44 @@
   clojure.lang.Named
   (getName [_] "SQL Server"))
 
+(extend SQLServerDriver
+  driver/IDriver
+  (merge sql/IDriverSQLDefaultsMixin
+         {:details-fields (constantly [{:name         "host"
+                                        :display-name "Host"
+                                        :default      "localhost"}
+                                       {:name         "port"
+                                        :display-name "Port"
+                                        :type         :integer
+                                        :default      1433}
+                                       {:name         "db"
+                                        :display-name "Database name"
+                                        :placeholder  "BirdsOfTheWorld"
+                                        :required     true}
+                                       {:name         "instance"
+                                        :display-name "Database instance name"
+                                        :placeholder  "N/A"}
+                                       {:name         "user"
+                                        :display-name "Database username"
+                                        :placeholder  "What username do you use to login to the database?"
+                                        :required     true}
+                                       {:name         "password"
+                                        :display-name "Database password"
+                                        :type         :password
+                                        :placeholder  "*******"}])}))
+
 (def sqlserver
   (map->SQLServerDriver
-   (-> (sql-driver {:details-fields            [{:name         "host"
-                                                 :display-name "Host"
-                                                 :default      "localhost"}
-                                                {:name         "port"
-                                                 :display-name "Port"
-                                                 :type         :integer
-                                                 :default      1433}
-                                                {:name         "db"
-                                                 :display-name "Database name"
-                                                 :placeholder  "BirdsOfTheWorld"
-                                                 :required     true}
-                                                {:name         "instance"
-                                                 :display-name "Database instance name"
-                                                 :placeholder  "N/A"}
-                                                {:name         "user"
-                                                 :display-name "Database username"
-                                                 :placeholder  "What username do you use to login to the database?"
-                                                 :required     true}
-                                                {:name         "password"
-                                                 :display-name "Database password"
-                                                 :type         :password
-                                                 :placeholder  "*******"}]
-                    :string-length-fn          :LEN
-                    :stddev-fn                 :STDEV
-                    :current-datetime-fn       (k/sqlfn* :GETUTCDATE)
-                    :excluded-schemas          #{"sys" "INFORMATION_SCHEMA"}
-                    :column->base-type         column->base-type
-                    :connection-details->spec  connection-details->spec
-                    :date                      date
-                    :date-interval             date-interval
-                    :unix-timestamp->timestamp unix-timestamp->timestamp})
+   (-> (sql/sql-driver
+        {:column->base-type         column->base-type
+         :connection-details->spec  connection-details->spec
+         :current-datetime-fn       (k/sqlfn* :GETUTCDATE)
+         :date                      date
+         :date-interval             date-interval
+         :excluded-schemas          #{"sys" "INFORMATION_SCHEMA"}
+         :stddev-fn                 :STDEV
+         :string-length-fn          :LEN
+         :unix-timestamp->timestamp unix-timestamp->timestamp})
        (update :qp-clause->handler merge {:limit apply-limit
                                           :page  apply-page}))))
 

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -13,13 +13,13 @@
 ;; HELPER FNS
 
 (defn create-db [db-name]
-  ((user->client :crowberto) :post 200 "database" {:engine  :postgres
-                                                  :name    db-name
-                                                  :details {:host   "localhost"
-                                                            :port   5432
-                                                            :dbname "fakedb"
-                                                            :user   "cam"
-                                                            :ssl    false}}))
+  ((user->client :crowberto) :post 200 "database" {:engine :postgres
+                                                   :name    db-name
+                                                   :details {:host   "localhost"
+                                                             :port   5432
+                                                             :dbname "fakedb"
+                                                             :user   "cam"
+                                                             :ssl    false}}))
 
 ;; # DB LIFECYCLE ENDPOINTS
 

--- a/test/metabase/driver/generic_sql/connection_test.clj
+++ b/test/metabase/driver/generic_sql/connection_test.clj
@@ -8,19 +8,21 @@
 ;; ## TESTS FOR CAN-CONNECT?
 
 ;; Check that we can connect to the Test DB
-(expect true
-  (driver/can-connect? (db)))
+(expect
+  true
+  (driver/can-connect-with-details? :h2 (:details (db))))
 
 ;; Lie and say Test DB is Postgres. CAN-CONNECT? should fail
-(expect false
-  (driver/can-connect? (assoc (db) :engine :postgres)))
+(expect
+  false
+  (driver/can-connect-with-details? :postgres (:details (db))))
 
 ;; Random made-up DBs should fail
-(expect false
-  (driver/can-connect? {:engine  :postgres
-                        :details {:host "localhost", :port 5432, :dbname "ABCDEFGHIJKLMNOP", :user "rasta"}}))
+(expect
+  false
+  (driver/can-connect-with-details? :postgres {:host "localhost", :port 5432, :dbname "ABCDEFGHIJKLMNOP", :user "rasta"}))
 
 ;; Things that you can connect to, but are not DBs, should fail
-(expect false
-  (driver/can-connect? {:engine  :postgres
-                        :details {:host "google.com", :port 80}}))
+(expect
+  false
+  (driver/can-connect-with-details? :postgres {:host "google.com", :port 80}))

--- a/test/metabase/driver/generic_sql_test.clj
+++ b/test/metabase/driver/generic_sql_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.driver.generic-sql-test
   (:require [expectations :refer :all]
             [metabase.db :refer :all]
+            [metabase.driver :as driver]
             [metabase.driver.h2 :refer [h2]]
             [metabase.driver.generic-sql.util :refer [korma-entity]]
             (metabase.models [field :refer [Field]]
@@ -27,7 +28,7 @@
       {:name "VENUES",     :schema "PUBLIC"}
       {:name "CHECKINS",   :schema "PUBLIC"}
       {:name "USERS",      :schema "PUBLIC"}}
-    ((:active-tables h2) (db)))
+    (driver/active-tables h2 (db)))
 
 ;; ACTIVE-COLUMN-NAMES->TYPE
 (expect
@@ -37,15 +38,15 @@
      "PRICE"       :IntegerField
      "CATEGORY_ID" :IntegerField
      "ID"          :BigIntegerField}
-  ((:active-column-names->type h2) @venues-table))
+  (driver/active-column-names->type h2 @venues-table))
 
 
 ;; ## TEST TABLE-PK-NAMES
 ;; Pretty straightforward
 (expect #{"ID"}
-  ((:table-pks h2) @venues-table))
+  (driver/table-pks h2 @venues-table))
 
 
 ;; ## TEST FIELD-AVG-LENGTH
 (expect 13
-  ((:field-avg-length h2) @users-name-field))
+  (driver/field-avg-length h2 @users-name-field))

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.driver.h2-test
   (:require [expectations :refer :all]
             [metabase.db :as db]
+            [metabase.driver :as driver]
             [metabase.driver.h2 :refer :all]
             [metabase.test.util :refer [resolve-private-fns]]))
 
@@ -26,7 +27,7 @@
 
 ;; Make sure we *cannot* connect to a non-existent database
 (expect :exception-thrown
-  (try ((:can-connect? h2) {:db (str (System/getProperty "user.dir") "/toucan_sightings")})
+  (try (driver/can-connect? h2 {:db (str (System/getProperty "user.dir") "/toucan_sightings")})
        (catch org.h2.jdbc.JdbcSQLException e
          (and (re-matches #"Database .+ not found .+" (.getMessage e))
               :exception-thrown))))
@@ -34,4 +35,4 @@
 ;; Check that we can connect to a non-existent Database when we enable potentailly unsafe connections (e.g. to the Metabase database)
 (expect true
   (binding [db/*allow-potentailly-unsafe-connections* true]
-    ((:can-connect? h2) {:db (str (System/getProperty "user.dir") "/pigeon_sightings")})))
+    (driver/can-connect? h2 {:db (str (System/getProperty "user.dir") "/pigeon_sightings")})))

--- a/test/metabase/driver/mongo_test.clj
+++ b/test/metabase/driver/mongo_test.clj
@@ -66,22 +66,10 @@
 
 ;; ## Tests for connection functions
 
-(expect-when-testing-mongo true
-  (driver/can-connect? {:engine  :mongo
-                        :details {:host   "localhost"
-                                  :dbname "metabase-test"
-                                  :port   27017}}))
-
 (expect-when-testing-mongo false
-  (driver/can-connect? {:engine :mongo
-                        :details {:host   "123.4.5.6"
-                                  :dbname "bad-db-name"}}))
-
-(expect-when-testing-mongo false
-  (driver/can-connect? {:engine :mongo
-                        :details {:host   "localhost"
-                                  :port   3000
-                                  :dbname "bad-db-name"}}))
+  (driver/can-connect-with-details? :mongo {:host   "localhost"
+                                            :port   3000
+                                            :dbname "bad-db-name"}))
 
 (expect-when-testing-mongo false
   (driver/can-connect-with-details? :mongo {}))
@@ -116,7 +104,7 @@
       {:name "categories"}
       {:name "users"}
       {:name "venues"}}
-    ((:active-tables mongo) (mongo-db)))
+    (driver/active-tables mongo (mongo-db)))
 
 ;; ### table->column-names
 (expect-when-testing-mongo
@@ -157,14 +145,14 @@
      {"_id" :IntegerField, "name" :TextField, "longitude" :FloatField, "latitude" :FloatField, "price" :IntegerField, "category_id" :IntegerField}] ; venues
   (->> table-names
        (map table-name->fake-table)
-       (mapv (:active-column-names->type mongo))))
+       (mapv (partial driver/active-column-names->type mongo))))
 
 ;; ### table-pks
 (expect-when-testing-mongo
     [#{"_id"} #{"_id"} #{"_id"} #{"_id"}] ; _id for every table
   (->> table-names
        (map table-name->fake-table)
-       (mapv (:table-pks mongo))))
+       (mapv (partial driver/table-pks mongo))))
 
 
 ;; ## Big-picture tests for the way data should look post-sync

--- a/test/metabase/driver/query_processor_test.clj
+++ b/test/metabase/driver/query_processor_test.clj
@@ -23,7 +23,7 @@
 
 (defn- engines-that-support [feature]
   (set (filter (fn [engine]
-                 (contains? (:features (driver/engine->driver engine)) feature))
+                 (contains? (driver/features (driver/engine->driver engine)) feature))
                datasets/all-valid-engines)))
 
 (defn- engines-that-dont-support [feature]
@@ -1360,15 +1360,14 @@
 
 ;; RELATIVE DATES
 (defn- database-def-with-timestamps [interval-seconds]
-  (let [{:keys [date-interval]} *data-loader*]
-    (create-database-definition "DB"
-      ["checkins"
-       [{:field-name "timestamp"
-         :base-type  :DateTimeField}]
-       (vec (for [i (range -15 15)]
-              ;; Create timestamps using relative dates (e.g. `DATEADD(second, -195, GETUTCDATE())` instead of generating `java.sql.Timestamps` here so
-              ;; they'll be in the DB's native timezone. Some DBs refuse to use the same timezone we're running the tests from *cough* SQL Server *cough*
-              [(date-interval :second (* i interval-seconds))]))])))
+  (create-database-definition "DB"
+    ["checkins"
+     [{:field-name "timestamp"
+       :base-type  :DateTimeField}]
+     (vec (for [i (range -15 15)]
+            ;; Create timestamps using relative dates (e.g. `DATEADD(second, -195, GETUTCDATE())` instead of generating `java.sql.Timestamps` here so
+            ;; they'll be in the DB's native timezone. Some DBs refuse to use the same timezone we're running the tests from *cough* SQL Server *cough*
+            [(driver/date-interval *data-loader* :second (* i interval-seconds))]))]))
 
 (def ^:private checkins:4-per-minute (partial database-def-with-timestamps 15))
 (def ^:private checkins:4-per-hour   (partial database-def-with-timestamps (* 60 15)))

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -73,7 +73,7 @@
 (defn fks-supported?
   "Does the current engine support foreign keys?"
   []
-  (contains? (:features *data-loader*) :foreign-keys))
+  (contains? (driver/features *data-loader*) :foreign-keys))
 
 (defn default-schema []       (datasets/default-schema *data-loader*))
 (defn id-field-type []        (datasets/id-field-type *data-loader*))


### PR DESCRIPTION
In the last month (especially while working on the SQL Server driver and Test Dataset refactoring) I developed a 3.5x better understanding of how to use Clojure protocols effectively for fun and profit. And I have this illness where if I know there's a better way some code could be written I get really itchy. So to resolve my symptoms here is a PR to formally define the methods a Metabase driver must implement.

No real difference here except instead of having functions stored as values in a plain-old map, they're formally defined methods:

``` clojure
;; before
((:process-query my-driver) query)

;; after
(process-query driver)
```

Which gives you better compile-time method signature checking as well as auto-complete/dox in decent editors / REPLs. This should also make it clearer when people offer to start working on DB2 or Firebird drivers -- We can just say, "Write a class that implements `IDriver`." Nice!

I know we have a poorly-implemented version of this in the past, but this time it's different! Things actually work the way I wished they did in the first place! I pinky swear we're not going to change the driver interface again (at least for a long time). Now I can die happy! :ghost: 
