### PR TITLE
Don't try to check if engine is valid before drivers are loaded

### DIFF
--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -306,7 +306,6 @@
      (can-connect-with-details? :postgres {:host \"localhost\", :port 5432, ...})"
   [engine details-map & [rethrow-exceptions]]
   {:pre [(keyword? engine)
-         (is-engine? engine)
          (map? details-map)]}
   (let [driver (engine->driver engine)]
     (try


### PR DESCRIPTION
Check isn't needed anyway since `engine->driver` with fail if it can't find a matching driver
