### PR TITLE
ISQLDriver protocol :yum:

### DIFF
--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -321,17 +321,20 @@
   "Sync a `Database`, its `Tables`, and `Fields`."
   [database]
   {:pre [(map? database)]}
+  (require 'metabase.driver.sync)
   (@(resolve 'metabase.driver.sync/sync-database!) (engine->driver (:engine database)) database))
 
 (defn sync-table!
   "Sync a `Table` and its `Fields`."
   [table]
   {:pre [(map? table)]}
+  (require 'metabase.driver.sync)
   (@(resolve 'metabase.driver.sync/sync-table!) (database-id->driver (:db_id table)) table))
 
 (defn process-query
   "Process a structured or native query, and return the result."
   [query]
+  (require 'metabase.driver.query-processor)
   (@(resolve 'metabase.driver.query-processor/process) (database-id->driver (:database query)) query))
 
 

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -4,22 +4,77 @@
             [korma.core :as k]
             [korma.sql.utils :as utils]
             [metabase.driver :as driver]
-            (metabase.driver.generic-sql [native :as native]
-                                         [query-processor :as qp]
-                                         [util :refer :all])
+            [metabase.driver.generic-sql.util :refer :all]
             [metabase.models.field :as field]
-            [metabase.util :as u]))
+            [metabase.util :as u])
+  (:import java.util.Map
+           clojure.lang.Keyword))
 
-(def ^:private ^:const field-values-lazy-seq-chunk-size
-  "How many Field values should we fetch at a time for `field-values-lazy-seq`?"
-  ;; Hopefully this is a good balance between
-  ;; 1. Not doing too many DB calls
-  ;; 2. Not running out of mem
-  ;; 3. Not fetching too many results for things like mark-json-field! which will fail after the first result that isn't valid JSON
-  500)
+(defprotocol ISQLDriver
+  "Methods SQL-based drivers should implement in order to use `IDriverSQLDefaultsMixin`.
+   Methods marked *OPTIONAL* have default implementations in `ISQLDriverDefaultsMixin`."
+  ;; The following apply-* methods define how the SQL Query Processor handles given query clauses. Each method is called when a matching clause is present
+  ;; in QUERY, and should return an appropriately modified version of KORMA-QUERY. Most drivers can use the default implementations for all of these methods,
+  ;; but some may need to override one or more (e.g. SQL Server needs to override the behavior of `apply-limit`, since T-SQL uses `TOP` instead of `LIMIT`).
+  (apply-aggregation [this korma-query, ^Map query] "*OPTIONAL*.")
+  (apply-breakout    [this korma-query, ^Map query] "*OPTIONAL*.")
+  (apply-fields      [this korma-query, ^Map query] "*OPTIONAL*.")
+  (apply-filter      [this korma-query, ^Map query] "*OPTIONAL*.")
+  (apply-join-tables [this korma-query, ^Map query] "*OPTIONAL*.")
+  (apply-limit       [this korma-query, ^Map query] "*OPTIONAL*.")
+  (apply-order-by    [this korma-query, ^Map query] "*OPTIONAL*.")
+  (apply-page        [this korma-query, ^Map query] "*OPTIONAL*.")
 
-(defn- can-connect? [{:keys [connection-details->spec]} details]
-  (let [connection (connection-details->spec details)]
+  (column->base-type ^clojure.lang.Keyword [this, ^Keyword column-type]
+    "Given a native DB column type, return the corresponding `Field` `base-type`.")
+
+  (connection-details->spec [this, ^Map details-map]
+    "Given a `Database` DETAILS-MAP, return a JDBC connection spec.")
+
+  (current-datetime-fn [this]
+    "*OPTIONAL*. Korma form that should be used to get the current `DATETIME` (or equivalent). Defaults to `(k/sqlfn* :NOW)`.")
+
+  (date [this, ^Keyword unit, field-or-value]
+    "Return a korma form for truncating a date or timestamp field or value to a given resolution, or extracting a date component.")
+
+  (excluded-schemas ^java.util.Set [this]
+                    "*OPTIONAL*. Set of string names of schemas to skip syncing tables from.")
+
+  (set-timezone-sql ^String [this]
+    "*OPTIONAL*. This should be a prepared JDBC SQL statement string to be used to set the timezone for the current transaction.
+
+       \"SET @@session.timezone = ?;\"")
+
+  (stddev-fn ^clojure.lang.Keyword [this]
+    "*OPTIONAL*. Keyword name of the SQL function that should be used to get the length of a string. Defaults to `:STDDEV`.")
+
+  (string-length-fn ^clojure.lang.Keyword [this]
+    "Keyword name of the SQL function that should be used to get the length of a string, e.g. `:LENGTH`.")
+
+  (unix-timestamp->timestamp [this, ^Keyword seconds-or-milliseconds, field-or-value]
+    "Return a korma form appropriate for converting a Unix timestamp integer field or value to an proper SQL `Timestamp`.
+     SECONDS-OR-MILLISECONDS refers to the resolution of the int in question and with be either `:seconds` or `:milliseconds`."))
+
+
+(defn ISQLDriverDefaultsMixin
+  "Default implementations for methods in `ISQLDriver`."
+  []
+  (require 'metabase.driver.generic-sql.query-processor)
+  {:apply-aggregation   (resolve 'metabase.driver.generic-sql.query-processor/apply-aggregation) ; don't resolve the vars yet so during interactive dev if the
+   :apply-breakout      (resolve 'metabase.driver.generic-sql.query-processor/apply-breakout)    ; underlying impl changes we won't have to reload all the drivers
+   :apply-fields        (resolve 'metabase.driver.generic-sql.query-processor/apply-fields)
+   :apply-filter        (resolve 'metabase.driver.generic-sql.query-processor/apply-filter)
+   :apply-join-tables   (resolve 'metabase.driver.generic-sql.query-processor/apply-join-tables)
+   :apply-limit         (resolve 'metabase.driver.generic-sql.query-processor/apply-limit)
+   :apply-order-by      (resolve 'metabase.driver.generic-sql.query-processor/apply-order-by)
+   :apply-page          (resolve 'metabase.driver.generic-sql.query-processor/apply-page)
+   :current-datetime-fn (constantly (k/sqlfn* :NOW))
+   :excluded-schemas    (constantly nil)
+   :stddev-fn           (constantly :STDDEV)})
+
+
+(defn- can-connect? [driver details]
+  (let [connection (connection-details->spec driver details)]
     (= 1 (-> (k/exec-raw connection "SELECT 1" :results)
              first
              vals
@@ -29,17 +84,17 @@
   (with-jdbc-metadata [_ database]
     (do-sync-fn)))
 
-(defn- active-tables [{:keys [excluded-schemas]} database]
+(defn- active-tables [driver database]
   (with-jdbc-metadata [^java.sql.DatabaseMetaData md database]
-    (set (for [table (filter #(not (contains? excluded-schemas (:table_schem %)))
+    (set (for [table (filter #(not (contains? (excluded-schemas driver) (:table_schem %)))
                              (jdbc/result-set-seq (.getTables md nil nil nil (into-array String ["TABLE", "VIEW"]))))]
            {:name   (:table_name table)
             :schema (:table_schem table)}))))
 
-(defn- active-column-names->type [{:keys [column->base-type]} table]
+(defn- active-column-names->type [driver table]
   (with-jdbc-metadata [^java.sql.DatabaseMetaData md @(:db table)]
     (into {} (for [{:keys [column_name type_name]} (jdbc/result-set-seq (.getColumns md nil (:schema table) (:name table) nil))]
-               {column_name (or (column->base-type (keyword type_name))
+               {column_name (or (column->base-type driver (keyword type_name))
                                 (do (log/warn (format "Don't know how to map column type '%s' to a Field base_type, falling back to :UnknownField." type_name))
                                     :UnknownField))}))))
 
@@ -50,30 +105,44 @@
          (map :column_name)
          set)))
 
-(defn- field-values-lazy-seq [_ {:keys [qualified-name-components table], :as field}]
+(def ^:private ^:const field-values-lazy-seq-chunk-size
+  "How many Field values should we fetch at a time for `field-values-lazy-seq`?"
+  ;; Hopefully this is a good balance between
+  ;; 1. Not doing too many DB calls
+  ;; 2. Not running out of mem
+  ;; 3. Not fetching too many results for things like mark-json-field! which will fail after the first result that isn't valid JSON
+  500)
+
+(defn- field-values-lazy-seq [driver {:keys [qualified-name-components table], :as field}]
   (assert (and (map? field)
                (delay? qualified-name-components)
                (delay? table))
     (format "Field is missing required information:\n%s" (u/pprint-to-str 'red field)))
   (let [table           @table
         name-components (rest @qualified-name-components)
+        transform-fn    (if (contains? #{:TextField :CharField} (:base_type field))
+                          u/jdbc-clob->str
+                          identity)
+
+        fetch-one-page  (fn [page-num]
+                          (let [query (as-> (k/select* (korma-entity table)) <>
+                                        (k/fields <> (:name field))
+                                        (apply-page driver <> {:page {:items field-values-lazy-seq-chunk-size, :page page-num}}))]
+                            (->> (k/exec query)
+                                 (map (keyword (:name field)))
+                                 (map transform-fn))))
+
         ;; This function returns a chunked lazy seq that will fetch some range of results, e.g. 0 - 500, then concat that chunk of results
         ;; with a recursive call to (lazily) fetch the next chunk of results, until we run out of results or hit the limit.
-        fetch-chunk     (fn -fetch-chunk [start step limit]
+        fetch-page      (fn -fetch-page [page-num]
                           (lazy-seq
-                           (let [results (->> (k/select (korma-entity table)
-                                                        (k/fields (:name field))
-                                                        (k/offset start)
-                                                        (k/limit (+ start step)))
-                                              (map (keyword (:name field)))
-                                              (map (if (contains? #{:TextField :CharField} (:base_type field)) u/jdbc-clob->str
-                                                       identity)))]
+                           (let [results             (fetch-one-page page-num)
+                                 total-items-fetched (* (inc page-num) field-values-lazy-seq-chunk-size)]
                              (concat results (when (and (seq results)
-                                                        (< (+ start step) limit)
-                                                        (= (count results) step))
-                                               (-fetch-chunk (+ start step) step limit))))))]
-    (fetch-chunk 0 field-values-lazy-seq-chunk-size
-                 driver/max-sync-lazy-seq-results)))
+                                                        (< total-items-fetched driver/max-sync-lazy-seq-results)
+                                                        (= (count results) field-values-lazy-seq-chunk-size))
+                                               (-fetch-page (inc page-num)))))))]
+    (fetch-page 0)))
 
 (defn- table-rows-seq [_ database table-name]
   (k/select (-> (k/create-entity table-name)
@@ -90,9 +159,9 @@
                  :dest-column-name (:pkcolumn_name result)}))
          set)))
 
-(defn- field-avg-length [{:keys [string-length-fn]} field]
+(defn- field-avg-length [driver field]
   (or (some-> (korma-entity @(:table field))
-              (k/select (k/aggregate (avg (k/sqlfn* string-length-fn
+              (k/select (k/aggregate (avg (k/sqlfn* (string-length-fn driver)
                                                     (utils/func "CAST(%s AS CHAR)"
                                                                 [(keyword (:name field))])))
                                      :len))
@@ -113,118 +182,27 @@
               (float (/ url-count total-non-null-count))))))
       0.0))
 
-(def ^:private ^:const required-fns
-  "Functions that concrete SQL drivers must define."
-  #{:connection-details->spec
-    :unix-timestamp->timestamp
-    :date
-    :date-interval})
-
-(defn- verify-sql-driver [{:keys [column->base-type string-length-fn], :as driver}]
-  ;; Check the :column->base-type map
-  (assert column->base-type
-    "SQL drivers must define :column->base-type.")
-
-  ;; Check :string-length-fn
-  (assert string-length-fn
-    "SQL drivers must define :string-length-fn.")
-  (assert (keyword? string-length-fn)
-    ":string-length-fn must be a keyword.")
-
-  ;; Check required fns
-  (doseq [f required-fns]
-    (assert (f driver)
-      (format "SQL drivers must define %s." f))
-    (assert (fn? (f driver))
-      (format "%s must be a fn." f))))
-
 (defn features [driver]
   (set (cond-> [:foreign-keys
                 :standard-deviation-aggregations]
          (:set-timezone-sql driver) (conj :set-timezone))))
 
-;; TODO - just define this method directly
-(defn- date-interval [driver unit amount]
-  ((:date-interval driver) unit amount))
-
-(def IDriverSQLDefaultsMixin
+(defn IDriverSQLDefaultsMixin
   "Default implementations of methods in `IDriver` for SQL drivers."
+  []
+  (require 'metabase.driver.generic-sql.native
+           'metabase.driver.generic-sql.query-processor)
   (merge driver/IDriverDefaultsMixin
          {:active-column-names->type active-column-names->type
           :active-tables             active-tables
           :can-connect?              can-connect?
-          :date-interval             date-interval
           :features                  features
           :field-avg-length          field-avg-length
           :field-percent-urls        field-percent-urls
           :field-values-lazy-seq     field-values-lazy-seq
-          :process-native            (fn [_ query]
-                                       (native/process-and-run query))
-          :process-structured        (fn [_ query]
-                                       (qp/process-structured query))
+          :process-native            (resolve 'metabase.driver.generic-sql.native/process-and-run)
+          :process-structured        (resolve 'metabase.driver.generic-sql.query-processor/process-structured)
           :sync-in-context           sync-in-context
           :table-fks                 table-fks
           :table-pks                 table-pks
           :table-rows-seq            table-rows-seq}))
-
-(def ^:private sql-driver-defaults
-  "Default implementations of SQL driver internal methods."
-  {:qp-clause->handler  qp/clause->handler
-   :stddev-fn           :STDDEV
-   :current-datetime-fn (k/sqlfn* :NOW)})
-
-(defn sql-driver
-  "Create a Metabase DB driver using the Generic SQL functions.
-
-   A SQL driver must define the following properties / functions:
-
-   *  `column->base-type`
-
-      A map of native DB column types (as keywords) to the `Field` `base-types` they map to.
-
-   *  `string-length-fn`
-
-      Keyword name of the SQL function that should be used to get the length of a string, e.g. `:LENGTH`.
-
-   *  `stddev-fn` *(OPTIONAL)*
-
-      Keyword name of the SQL function that should be used to get the length of a string. Defaults to `:STDDEV`.
-
-   *  `current-datetime-fn` *(OPTIONAL)*
-
-      Korma form that should be used to get the current `DATETIME` (or equivalent).  Defaults to `(k/sqlfn* :NOW)`.
-
-   *  `(connection-details->spec [details-map])`
-
-      Given a `Database` DETAILS-MAP, return a JDBC connection spec.
-
-   *  `(unix-timestamp->timestamp [seconds-or-milliseconds field-or-value])`
-
-      Return a korma form appropriate for converting a Unix timestamp integer field or value to an proper SQL `Timestamp`.
-      SECONDS-OR-MILLISECONDS refers to the resolution of the int in question and with be either `:seconds` or `:milliseconds`.
-
-   *  `set-timezone-sql` *(OPTIONAL)*
-
-      This should be a prepared JDBC SQL statement string to be used to set the timezone for the current transaction.
-
-          \"SET @@session.timezone = ?;\"
-
-   *  `(date [this ^Keyword unit field-or-value])`
-
-      Return a korma form for truncating a date or timestamp field or value to a given resolution, or extracting a
-      date component.
-
-   *  `excluded-schemas` *(OPTIONAL)*
-
-      Set of string names of schemas to skip syncing tables from.
-
-   * `qp-clause->handler` *(OPTIONAL)*
-
-     A map of query processor clause keywords to functions of the form `(fn [korma-query query-map])` that are used apply them.
-     By default, its value is `metabase.driver.generic-sql.query-processor/clause->handler`. These functions are exposed in this way so drivers
-     can override default clause application behavior where appropriate -- for example, SQL Server needs to override the function used to apply the
-     `:limit` clause, since T-SQL uses `TOP` rather than `LIMIT`."
-  [driver]
-  ;; Verify the driver
-  (verify-sql-driver driver)
-  (merge sql-driver-defaults driver))

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -10,6 +10,7 @@
                        [utils :as utils])
             [metabase.config :as config]
             [metabase.driver :as driver]
+            [metabase.driver.generic-sql :as sql]
             [metabase.driver.generic-sql.util :refer :all]
             [metabase.driver.query-processor :as qp]
             [metabase.util :as u])
@@ -35,7 +36,7 @@
     ([this]
      (formatted this false))
     ([{:keys [schema-name table-name special-type field-name], :as field} include-as?]
-     (let [->timestamp (:unix-timestamp->timestamp (:driver *query*))
+     (let [->timestamp (partial sql/unix-timestamp->timestamp (:driver *query*))
            field       (cond-> (keyword (str (when schema-name (str schema-name \.)) table-name \. field-name))
                          (= special-type :timestamp_seconds)      (->timestamp :seconds)
                          (= special-type :timestamp_milliseconds) (->timestamp :milliseconds))]
@@ -47,7 +48,7 @@
     ([this]
      (formatted this false))
     ([{unit :unit, {:keys [field-name base-type special-type], :as field} :field} include-as?]
-     (let [field ((:date (:driver *query*)) unit (formatted field))]
+     (let [field (sql/date (:driver *query*) unit (formatted field))]
        (if include-as? [field (keyword field-name)]
            field))))
 
@@ -80,22 +81,22 @@
      (formatted this false))
     ([{value :value, {unit :unit} :field} _]
      ;; prevent Clojure from converting this to #inst literal, which is a util.date
-     ((:date (:driver *query*)) unit value)))
+     (sql/date (:driver *query*) unit value)))
 
   RelativeDateTimeValue
   (formatted
     ([this]
      (formatted this false))
     ([{:keys [amount unit], {field-unit :unit} :field} _]
-     (let [{:keys [date date-interval]} (:driver *query*)]
-       (date field-unit (if (zero? amount)
-                          (-> *query* :driver :current-datetime-fn)
-                          (date-interval unit amount)))))))
+     (let [driver (:driver *query*)]
+       (sql/date driver field-unit (if (zero? amount)
+                                     (sql/current-datetime-fn driver)
+                                     (driver/date-interval driver unit amount)))))))
 
 
 ;;; ## Clause Handlers
 
-(defn- apply-aggregation [korma-query {{:keys [aggregation-type field]} :aggregation}]
+(defn apply-aggregation [driver korma-query {{:keys [aggregation-type field]} :aggregation}]
   (if-not field
     ;; aggregation clauses w/o a Field
     (case aggregation-type
@@ -107,19 +108,19 @@
         :avg      (k/aggregate korma-query (avg field) :avg)
         :count    (k/aggregate korma-query (count field) :count)
         :distinct (k/aggregate korma-query (count (k/sqlfn :DISTINCT field)) :count)
-        :stddev   (k/fields    korma-query [(k/sqlfn* (-> *query* :driver :stddev-fn) field) :stddev])
+        :stddev   (k/fields    korma-query [(k/sqlfn* (sql/stddev-fn driver) field) :stddev])
         :sum      (k/aggregate korma-query (sum field) :sum)))))
 
-(defn- apply-breakout [korma-query {fields :breakout}]
+(defn apply-breakout [_ korma-query {breakout-fields :breakout, fields-fields :fields}]
   (-> korma-query
       ;; Group by all the breakout fields
-      ((partial apply k/group) (map formatted fields))
+      ((partial apply k/group) (map formatted breakout-fields))
       ;; Add fields form only for fields that weren't specified in :fields clause -- we don't want to include it twice, or korma will barf
-      ((partial apply k/fields) (->> fields
-                                     (filter (partial (complement contains?) (set (:fields (:query *query*)))))
+      ((partial apply k/fields) (->> breakout-fields
+                                     (filter (partial (complement contains?) (set fields-fields)))
                                      (map (u/rpartial formatted :include-as))))))
 
-(defn- apply-fields [korma-query {fields :fields}]
+(defn apply-fields [_ korma-query {fields :fields}]
   (apply k/fields korma-query (for [field fields]
                                 (formatted field :include-as))))
 
@@ -155,10 +156,10 @@
     :or  (apply kfns/pred-or  (map filter-clause->predicate subclauses))
     nil  (filter-subclause->predicate clause)))
 
-(defn- apply-filter [korma-query {clause :filter}]
+(defn apply-filter [_ korma-query {clause :filter}]
   (k/where korma-query (filter-clause->predicate clause)))
 
-(defn- apply-join-tables [korma-query {join-tables :join-tables, {source-table-name :name} :source-table}]
+(defn apply-join-tables [_ korma-query {join-tables :join-tables, {source-table-name :name} :source-table}]
   (loop [korma-query korma-query, [{:keys [table-name pk-field source-field]} & more] join-tables]
     (let [korma-query (k/join korma-query table-name
                               (= (keyword (format "%s.%s" source-table-name (:field-name source-field)))
@@ -167,10 +168,10 @@
         (recur korma-query more)
         korma-query))))
 
-(defn- apply-limit [korma-query {value :limit}]
+(defn apply-limit [_ korma-query {value :limit}]
   (k/limit korma-query value))
 
-(defn- apply-order-by [korma-query {subclauses :order-by}]
+(defn apply-order-by [_ korma-query {subclauses :order-by}]
   (loop [korma-query korma-query, [{:keys [field direction]} & more] subclauses]
     (let [korma-query (k/order korma-query (formatted field) (case direction
                                                                :ascending  :ASC
@@ -179,7 +180,7 @@
         (recur korma-query more)
         korma-query))))
 
-(defn- apply-page [korma-query {{:keys [items page]} :page}]
+(defn apply-page [_ korma-query {{:keys [items page]} :page}]
   (-> korma-query
       (k/limit items)
       (k/offset (* items (dec page)))))
@@ -205,56 +206,60 @@
         (catch Throwable e
           (log/error (u/format-color 'red "Invalid korma form: %s" (.getMessage e))))))))
 
-(def ^:const clause->handler
-  "A map of QL clauses to fns that handle them. Each function is called like
+(def ^:private clause-handlers
+  {:aggregation #'sql/apply-aggregation ; use the vars rather than the functions themselves because them implementation
+   :breakout    #'sql/apply-breakout    ; will get swapped around and  we'll be left with old version of the function that nobody implements
+   :fields      #'sql/apply-fields
+   :filter      #'sql/apply-filter
+   :join-tables #'sql/apply-join-tables
+   :limit       #'sql/apply-limit
+   :order-by    #'sql/apply-order-by
+   :page        #'sql/apply-page})
 
-       (fn [korma-query query])
+(defn- apply-clauses
+  "Loop through all the `clause->handler` entries; if the query contains a given clause, apply the handler fn."
+  [driver korma-query query]
+  (loop [korma-query korma-query, [[clause f] & more] (seq clause-handlers)]
+    (let [korma-query (if (clause query)
+                        (f driver korma-query query)
+                        korma-query)]
+      (if (seq more)
+        (recur korma-query more)
+        korma-query))))
 
-   and should return an appropriately modified KORMA-QUERY. SQL drivers contain a copy of this map keyed by `:qp-clause->handler`.
-   Most drivers can use the default implementations for all clauses, but some may need to override one or more (e.g. SQL Server needs to
-   override the behavior of `apply-limit`, since T-SQL uses `TOP` instead of `LIMIT`)."
-  {:aggregation apply-aggregation
-   :breakout    apply-breakout
-   :fields      apply-fields
-   :filter      apply-filter
-   :join-tables apply-join-tables
-   :limit       apply-limit
-   :order-by    apply-order-by
-   :page        apply-page})
+(defn- do-with-timezone [driver f]
+  (try (kdb/transaction (k/exec-raw [(sql/set-timezone-sql driver) [(driver/report-timezone)]])
+                        (f))
+       (catch Throwable e
+         (log/error (u/format-color 'red "Failed to set timezone:\n%s"
+                      (with-out-str (jdbc/print-sql-exception-chain e))))
+         (f))))
+
+(defn- do-with-try-catch [f]
+  (try
+    (f)
+    (catch java.sql.SQLException e
+      (jdbc/print-sql-exception-chain e)
+      (let [^String message (or (->> (.getMessage e)                       ; error message comes back like "Error message ... [status-code]" sometimes
+                                     (re-find  #"(?s)(^.*)\s+\[[\d-]+\]$") ; status code isn't useful and makes unit tests hard to write so strip it off
+                                     second)                               ; (?s) = Pattern.DOTALL - tell regex `.` to match newline characters as well
+                                (.getMessage e))]
+        (throw (Exception. message))))))
 
 (defn process-structured
   "Convert QUERY into a korma `select` form, execute it, and annotate the results."
-  [{{:keys [source-table] :as query} :query, driver :driver, database :database, :as outer-query}]
-  (binding [*query* outer-query]
-    (try
-      (let [entity      (korma-entity database source-table)
-            timezone    (driver/report-timezone)
-            ;; Loop through all the :qp-clause->handler entries in the current driver. If the query contains a given clause, apply its handler fn.
-            korma-query (loop [korma-query (k/select* entity), [[clause f] & more] (seq (:qp-clause->handler driver))]
-                          (let [korma-query (if (clause query)
-                                              (f korma-query query)
-                                              korma-query)]
-                            (if (seq more)
-                              (recur korma-query more)
-                              korma-query)))]
-
-        (log-korma-form korma-query)
-
-        (kdb/with-db (:db entity)
-          (if (and (seq timezone)
-                   (contains? (:features driver) :set-timezone))
-            (try (kdb/transaction (k/exec-raw [(:set-timezone-sql driver) [timezone]])
-                                  (k/exec korma-query))
-                 (catch Throwable e
-                   (log/error (u/format-color 'red "Failed to set timezone:\n%s"
-                                (with-out-str (jdbc/print-sql-exception-chain e))))
-                   (k/exec korma-query)))
-            (k/exec korma-query))))
-
-      (catch java.sql.SQLException e
-        (jdbc/print-sql-exception-chain e)
-        (let [^String message (or (->> (.getMessage e)                       ; error message comes back like "Error message ... [status-code]" sometimes
-                                       (re-find  #"(?s)(^.*)\s+\[[\d-]+\]$") ; status code isn't useful and makes unit tests hard to write so strip it off
-                                       second)                               ; (?s) = Pattern.DOTALL - tell regex `.` to match newline characters as well
-                                  (.getMessage e))]
-          (throw (Exception. message)))))))
+  [driver {{:keys [source-table] :as query} :query, database :database, :as outer-query}]
+  (let [set-timezone? (and (seq (driver/report-timezone))
+                           (contains? (driver/features driver) :set-timezone))
+        entity        (korma-entity database source-table)
+        korma-query   (binding [*query* outer-query]
+                        (apply-clauses driver (k/select* entity) query))
+        f             (fn []
+                        (k/exec korma-query))
+        f             (fn []
+                        (kdb/with-db (:db entity)
+                          (if set-timezone?
+                            (do-with-timezone driver f)
+                            (f))))]
+    (log-korma-form korma-query)
+    (do-with-try-catch f)))

--- a/src/metabase/driver/generic_sql/util.clj
+++ b/src/metabase/driver/generic_sql/util.clj
@@ -12,8 +12,8 @@
 (defn- db->connection-spec
   "Return a JDBC connection spec for a Metabase `Database`."
   [{{:keys [short-lived?]} :details, :as database}]
-  (let [{:keys [connection-details->spec]} (driver/engine->driver (:engine database))]
-    (assoc (connection-details->spec (:details database))
+  (let [driver (driver/engine->driver (:engine database))]
+    (assoc (@(resolve 'metabase.driver.generic-sql/connection-details->spec) driver (:details database))
            ;; unless this is a temp DB, we need to make a pool or the connection will be closed before we get a chance to unCLOB-er the results during JSON serialization
            ;; TODO - what will we do once we have CLOBS in temp DBs?
            :make-pool? (not short-lived?))))

--- a/src/metabase/driver/mongo.clj
+++ b/src/metabase/driver/mongo.clj
@@ -161,7 +161,4 @@
           :sync-in-context                   sync-in-context
           :table-pks                         (constantly #{"_id"})}))
 
-(def mongo
-  (MongoDriver.))
-
-(driver/register-driver! :mongo mongo)
+(driver/register-driver! :mongo (MongoDriver.))

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -16,66 +16,67 @@
   ;; e.x. when connecting to a Heroku Postgres database from outside of Heroku.
   (:import org.postgresql.ssl.NonValidatingFactory))
 
-(def ^:private ^:const column->base-type
+(defn- column->base-type
   "Map of Postgres column types -> Field base types.
    Add more mappings here as you come across them."
-  {:bigint        :BigIntegerField
-   :bigserial     :BigIntegerField
-   :bit           :UnknownField
-   :bool          :BooleanField
-   :boolean       :BooleanField
-   :box           :UnknownField
-   :bpchar        :CharField        ; "blank-padded char" is the internal name of "character"
-   :bytea         :UnknownField     ; byte array
-   :cidr          :TextField        ; IPv4/IPv6 network address
-   :circle        :UnknownField
-   :date          :DateField
-   :decimal       :DecimalField
-   :float4        :FloatField
-   :float8        :FloatField
-   :geometry      :UnknownField
-   :inet          :TextField        ; This was `GenericIPAddressField` in some places in the Django code but not others ...
-   :int           :IntegerField
-   :int2          :IntegerField
-   :int4          :IntegerField
-   :int8          :BigIntegerField
-   :interval      :UnknownField     ; time span
-   :json          :TextField
-   :jsonb         :TextField
-   :line          :UnknownField
-   :lseg          :UnknownField
-   :macaddr       :TextField
-   :money         :DecimalField
-   :numeric       :DecimalField
-   :path          :UnknownField
-   :pg_lsn        :IntegerField     ; PG Log Sequence #
-   :point         :UnknownField
-   :real          :FloatField
-   :serial        :IntegerField
-   :serial2       :IntegerField
-   :serial4       :IntegerField
-   :serial8       :BigIntegerField
-   :smallint      :IntegerField
-   :smallserial   :IntegerField
-   :text          :TextField
-   :time          :TimeField
-   :timetz        :TimeField
-   :timestamp     :DateTimeField
-   :timestamptz   :DateTimeField
-   :tsquery       :UnknownField
-   :tsvector      :UnknownField
-   :txid_snapshot :UnknownField
-   :uuid          :UUIDField
-   :varbit        :UnknownField
-   :varchar       :TextField
-   :xml           :TextField
-   (keyword "bit varying")                :UnknownField
-   (keyword "character varying")          :TextField
-   (keyword "double precision")           :FloatField
-   (keyword "time with time zone")        :TimeField
-   (keyword "time without time zone")     :TimeField
-   (keyword "timestamp with timezone")    :DateTimeField
-   (keyword "timestamp without timezone") :DateTimeField})
+  [_ column-type]
+  ({:bigint        :BigIntegerField
+    :bigserial     :BigIntegerField
+    :bit           :UnknownField
+    :bool          :BooleanField
+    :boolean       :BooleanField
+    :box           :UnknownField
+    :bpchar        :CharField ; "blank-padded char" is the internal name of "character"
+    :bytea         :UnknownField        ; byte array
+    :cidr          :TextField           ; IPv4/IPv6 network address
+    :circle        :UnknownField
+    :date          :DateField
+    :decimal       :DecimalField
+    :float4        :FloatField
+    :float8        :FloatField
+    :geometry      :UnknownField
+    :inet          :TextField ; This was `GenericIPAddressField` in some places in the Django code but not others ...
+    :int           :IntegerField
+    :int2          :IntegerField
+    :int4          :IntegerField
+    :int8          :BigIntegerField
+    :interval      :UnknownField        ; time span
+    :json          :TextField
+    :jsonb         :TextField
+    :line          :UnknownField
+    :lseg          :UnknownField
+    :macaddr       :TextField
+    :money         :DecimalField
+    :numeric       :DecimalField
+    :path          :UnknownField
+    :pg_lsn        :IntegerField        ; PG Log Sequence #
+    :point         :UnknownField
+    :real          :FloatField
+    :serial        :IntegerField
+    :serial2       :IntegerField
+    :serial4       :IntegerField
+    :serial8       :BigIntegerField
+    :smallint      :IntegerField
+    :smallserial   :IntegerField
+    :text          :TextField
+    :time          :TimeField
+    :timetz        :TimeField
+    :timestamp     :DateTimeField
+    :timestamptz   :DateTimeField
+    :tsquery       :UnknownField
+    :tsvector      :UnknownField
+    :txid_snapshot :UnknownField
+    :uuid          :UUIDField
+    :varbit        :UnknownField
+    :varchar       :TextField
+    :xml           :TextField
+    (keyword "bit varying")                :UnknownField
+    (keyword "character varying")          :TextField
+    (keyword "double precision")           :FloatField
+    (keyword "time with time zone")        :TimeField
+    (keyword "time without time zone")     :TimeField
+    (keyword "timestamp with timezone")    :DateTimeField
+    (keyword "timestamp without timezone") :DateTimeField} column-type))
 
 (def ^:private ^:const ssl-params
   "Params to include in the JDBC connection spec for an SSL connection."
@@ -83,7 +84,7 @@
    :sslmode    "require"
    :sslfactory "org.postgresql.ssl.NonValidatingFactory"})  ; HACK Why enable SSL if we disable certificate validation?
 
-(defn- connection-details->spec [{:keys [ssl] :as details-map}]
+(defn- connection-details->spec [_ {:keys [ssl] :as details-map}]
   (-> details-map
       (update :port (fn [port]
                       (if (string? port) (Integer/parseInt port)
@@ -94,7 +95,7 @@
       (rename-keys {:dbname :db})
       kdb/postgres))
 
-(defn- unix-timestamp->timestamp [field-or-value seconds-or-milliseconds]
+(defn- unix-timestamp->timestamp [_ field-or-value seconds-or-milliseconds]
   (utils/func (case seconds-or-milliseconds
                 :seconds      "TO_TIMESTAMP(%s)"
                 :milliseconds "TO_TIMESTAMP(%s / 1000)")
@@ -108,7 +109,7 @@
         (upd Field (:id field) :special_type :json)
         (assoc field :special_type :json)))))
 
-(defn- date [unit field-or-value]
+(defn- date [_ unit field-or-value]
   (utils/func (case unit
                 :default         "CAST(%s AS TIMESTAMP)"
                 :minute          "DATE_TRUNC('minute', %s)"
@@ -130,7 +131,7 @@
                 :year            "CAST(EXTRACT(YEAR FROM %s) AS INTEGER)")
               [field-or-value]))
 
-(defn- date-interval [unit amount]
+(defn- date-interval [_ unit amount]
   (utils/generated (format "(NOW() + INTERVAL '%d %s')" amount (name unit))))
 
 (defn- humanize-connection-error-message [_ message]
@@ -163,8 +164,9 @@
 
 (extend PostgresDriver
   driver/IDriver
-  (merge sql/IDriverSQLDefaultsMixin
-         {:details-fields                    (constantly [{:name         "host"
+  (merge (sql/IDriverSQLDefaultsMixin)
+         {:date-interval                     date-interval
+          :details-fields                    (constantly [{:name         "host"
                                                            :display-name "Host"
                                                            :default "localhost"}
                                                           {:name         "port"
@@ -188,17 +190,15 @@
                                                            :type         :boolean
                                                            :default      false}])
           :driver-specific-sync-field!       driver-specific-sync-field!
-          :humanize-connection-error-message humanize-connection-error-message}))
+          :humanize-connection-error-message humanize-connection-error-message})
 
-(def postgres
-  (map->PostgresDriver
-   (sql/sql-driver
-    {:column->base-type         column->base-type
-     :connection-details->spec  connection-details->spec
-     :date                      date
-     :date-interval             date-interval
-     :set-timezone-sql          "UPDATE pg_settings SET setting = ? WHERE name ILIKE 'timezone';"
-     :string-length-fn          :CHAR_LENGTH
-     :unix-timestamp->timestamp unix-timestamp->timestamp})))
+  sql/ISQLDriver
+  (merge (sql/ISQLDriverDefaultsMixin)
+         {:column->base-type         column->base-type
+          :connection-details->spec  connection-details->spec
+          :date                      date
+          :set-timezone-sql          (constantly "UPDATE pg_settings SET setting = ? WHERE name ILIKE 'timezone';")
+          :string-length-fn          (constantly :CHAR_LENGTH)
+          :unix-timestamp->timestamp unix-timestamp->timestamp}))
 
-(driver/register-driver! :postgres postgres)
+(driver/register-driver! :postgres (PostgresDriver.))

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -513,4 +513,5 @@
                                   ~nm)]))]
      ~nm))
 
+
 (require-dox-in-this-namespace)

--- a/test/metabase/driver/generic_sql_test.clj
+++ b/test/metabase/driver/generic_sql_test.clj
@@ -2,13 +2,13 @@
   (:require [expectations :refer :all]
             [metabase.db :refer :all]
             [metabase.driver :as driver]
-            [metabase.driver.h2 :refer [h2]]
             [metabase.driver.generic-sql.util :refer [korma-entity]]
             (metabase.models [field :refer [Field]]
                              [foreign-key :refer [ForeignKey]]
                              [table :refer [Table]])
             [metabase.test.data :refer :all]
-            [metabase.test.util :refer [resolve-private-fns]]))
+            [metabase.test.util :refer [resolve-private-fns]])
+  (:import metabase.driver.h2.H2Driver))
 
 (def users-table
   (delay (sel :one Table :name "USERS")))
@@ -28,7 +28,7 @@
       {:name "VENUES",     :schema "PUBLIC"}
       {:name "CHECKINS",   :schema "PUBLIC"}
       {:name "USERS",      :schema "PUBLIC"}}
-    (driver/active-tables h2 (db)))
+    (driver/active-tables (H2Driver.) (db)))
 
 ;; ACTIVE-COLUMN-NAMES->TYPE
 (expect
@@ -38,15 +38,15 @@
      "PRICE"       :IntegerField
      "CATEGORY_ID" :IntegerField
      "ID"          :BigIntegerField}
-  (driver/active-column-names->type h2 @venues-table))
+  (driver/active-column-names->type (H2Driver.) @venues-table))
 
 
 ;; ## TEST TABLE-PK-NAMES
 ;; Pretty straightforward
 (expect #{"ID"}
-  (driver/table-pks h2 @venues-table))
+  (driver/table-pks (H2Driver.) @venues-table))
 
 
 ;; ## TEST FIELD-AVG-LENGTH
 (expect 13
-  (driver/field-avg-length h2 @users-name-field))
+  (driver/field-avg-length (H2Driver.) @users-name-field))

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -3,7 +3,8 @@
             [metabase.db :as db]
             [metabase.driver :as driver]
             [metabase.driver.h2 :refer :all]
-            [metabase.test.util :refer [resolve-private-fns]]))
+            [metabase.test.util :refer [resolve-private-fns]])
+  (:import metabase.driver.h2.H2Driver))
 
 (resolve-private-fns metabase.driver.h2 connection-string->file+options file+options->connection-string connection-string-set-safe-options)
 
@@ -27,7 +28,7 @@
 
 ;; Make sure we *cannot* connect to a non-existent database
 (expect :exception-thrown
-  (try (driver/can-connect? h2 {:db (str (System/getProperty "user.dir") "/toucan_sightings")})
+  (try (driver/can-connect? (H2Driver.) {:db (str (System/getProperty "user.dir") "/toucan_sightings")})
        (catch org.h2.jdbc.JdbcSQLException e
          (and (re-matches #"Database .+ not found .+" (.getMessage e))
               :exception-thrown))))
@@ -35,4 +36,4 @@
 ;; Check that we can connect to a non-existent Database when we enable potentailly unsafe connections (e.g. to the Metabase database)
 (expect true
   (binding [db/*allow-potentailly-unsafe-connections* true]
-    (driver/can-connect? h2 {:db (str (System/getProperty "user.dir") "/pigeon_sightings")})))
+    (driver/can-connect? (H2Driver.) {:db (str (System/getProperty "user.dir") "/pigeon_sightings")})))

--- a/test/metabase/driver/mongo_test.clj
+++ b/test/metabase/driver/mongo_test.clj
@@ -4,11 +4,11 @@
             [korma.core :as k]
             [metabase.db :refer :all]
             [metabase.driver :as driver]
-            [metabase.driver.mongo :refer [mongo]]
             (metabase.models [field :refer [Field]]
                              [table :refer [Table]])
             [metabase.test.data.datasets :as datasets]
-            [metabase.test.util :refer [expect-eval-actual-first resolve-private-fns]]))
+            [metabase.test.util :refer [expect-eval-actual-first resolve-private-fns]])
+  (:import metabase.driver.mongo.MongoDriver))
 
 ;; ## Logic for selectively running mongo
 
@@ -104,7 +104,7 @@
       {:name "categories"}
       {:name "users"}
       {:name "venues"}}
-    (driver/active-tables mongo (mongo-db)))
+    (driver/active-tables (MongoDriver.) (mongo-db)))
 
 ;; ### table->column-names
 (expect-when-testing-mongo
@@ -145,14 +145,14 @@
      {"_id" :IntegerField, "name" :TextField, "longitude" :FloatField, "latitude" :FloatField, "price" :IntegerField, "category_id" :IntegerField}] ; venues
   (->> table-names
        (map table-name->fake-table)
-       (mapv (partial driver/active-column-names->type mongo))))
+       (mapv (partial driver/active-column-names->type (MongoDriver.)))))
 
 ;; ### table-pks
 (expect-when-testing-mongo
     [#{"_id"} #{"_id"} #{"_id"} #{"_id"}] ; _id for every table
   (->> table-names
        (map table-name->fake-table)
-       (mapv (partial driver/table-pks mongo))))
+       (mapv (partial driver/table-pks (MongoDriver.)))))
 
 
 ;; ## Big-picture tests for the way data should look post-sync

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.driver.mysql-test
   (:require [expectations :refer :all]
-            [metabase.driver.mysql :refer [mysql]]
             (metabase.test.data [datasets :refer [expect-with-engine]]
                                 [interface :refer [def-database-definition]])
             [metabase.test.util.q :refer [Q]]))

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -1,39 +1,40 @@
 (ns metabase.driver.postgres-test
   (:require [expectations :refer :all]
-            [metabase.driver.postgres :refer [postgres]]
+            [metabase.driver.generic-sql :as sql]
             (metabase.test.data [datasets :refer [expect-with-engine]]
                                 [interface :refer [def-database-definition]])
-            [metabase.test.util.q :refer [Q]]))
+            [metabase.test.util.q :refer [Q]])
+  (:import metabase.driver.postgres.PostgresDriver))
 
 ;; # Check that SSL params get added the connection details in the way we'd like
 ;; ## no SSL -- this should *not* include the key :ssl (regardless of its value) since that will cause the PG driver to use SSL anyway
 (expect
-    {:user        "camsaul"
-     :classname   "org.postgresql.Driver"
-     :subprotocol "postgresql"
-     :subname     "//localhost:5432/bird_sightings"
-     :make-pool?  true}
-    ((:connection-details->spec postgres) {:ssl    false
-                                           :host   "localhost"
-                                           :port   5432
-                                           :dbname "bird_sightings"
-                                           :user   "camsaul"}))
+  {:user        "camsaul"
+   :classname   "org.postgresql.Driver"
+   :subprotocol "postgresql"
+   :subname     "//localhost:5432/bird_sightings"
+   :make-pool?  true}
+  (sql/connection-details->spec (PostgresDriver.) {:ssl    false
+                                                   :host   "localhost"
+                                                   :port   5432
+                                                   :dbname "bird_sightings"
+                                                   :user   "camsaul"}))
 
 ;; ## ssl - check that expected params get added
 (expect
-    {:ssl         true
-     :make-pool?  true
-     :sslmode     "require"
-     :classname   "org.postgresql.Driver"
-     :subprotocol "postgresql"
-     :user        "camsaul"
-     :sslfactory  "org.postgresql.ssl.NonValidatingFactory"
-     :subname     "//localhost:5432/bird_sightings"}
-    ((:connection-details->spec postgres) {:ssl    true
-                                           :host   "localhost"
-                                           :port   5432
-                                           :dbname "bird_sightings"
-                                           :user   "camsaul"}))
+  {:ssl         true
+   :make-pool?  true
+   :sslmode     "require"
+   :classname   "org.postgresql.Driver"
+   :subprotocol "postgresql"
+   :user        "camsaul"
+   :sslfactory  "org.postgresql.ssl.NonValidatingFactory"
+   :subname     "//localhost:5432/bird_sightings"}
+  (sql/connection-details->spec (PostgresDriver.) {:ssl    true
+                                                   :host   "localhost"
+                                                   :port   5432
+                                                   :dbname "bird_sightings"
+                                                   :user   "camsaul"}))
 ;;; # UUID Support
 (def-database-definition ^:const ^:private with-uuid
   ["users"

--- a/test/metabase/test/data/datasets.clj
+++ b/test/metabase/test/data/datasets.clj
@@ -7,12 +7,12 @@
             [expectations :refer :all]
             [metabase.db :refer :all]
             [metabase.driver :as driver]
-            (metabase.driver [h2 :refer [h2]]
-                             [mongo :refer [mongo]]
-                             [mysql :refer [mysql]]
-                             [postgres :refer [postgres]]
-                             [sqlite :refer [sqlite]]
-                             [sqlserver :refer [sqlserver]])
+            (metabase.driver [h2 :refer [map->H2Driver]]
+                             [mongo :refer [map->MongoDriver]]
+                             [mysql :refer [map->MySQLDriver]]
+                             [postgres :refer [map->PostgresDriver]]
+                             [sqlite :refer [map->SQLiteDriver]]
+                             [sqlserver :refer [map->SQLServerDriver]])
             (metabase.models [field :refer [Field]]
                              [table :refer [Table]])
             (metabase.test.data [dataset-definitions :as defs]
@@ -133,12 +133,12 @@
 
 (def ^:private engine->loader*
   "Map of dataset keyword name -> dataset instance (i.e., an object that implements `IDataset`)."
-  {:mongo     (assoc mongo     :dbpromise (promise))
-   :h2        (assoc h2        :dbpromise (promise))
-   :postgres  (assoc postgres  :dbpromise (promise))
-   :mysql     (assoc mysql     :dbpromise (promise))
-   :sqlite    (assoc sqlite    :dbpromise (promise))
-   :sqlserver (assoc sqlserver :dbpromise (promise))})
+  {:h2        (map->H2Driver        {:dbpromise (promise)})
+   :mongo     (map->MongoDriver     {:dbpromise (promise)})
+   :mysql     (map->MySQLDriver     {:dbpromise (promise)})
+   :postgres  (map->PostgresDriver  {:dbpromise (promise)})
+   :sqlite    (map->SQLiteDriver    {:dbpromise (promise)})
+   :sqlserver (map->SQLServerDriver {:dbpromise (promise)})})
 
 (def ^:const all-valid-engines
   "Set of names of all valid datasets."
@@ -194,7 +194,8 @@
 
 (def ^:dynamic *data-loader*
   "The dataset we're currently testing against, bound by `with-engine`.
-   Defaults to `(engine->loader :h2)`."
+   This is just a regular driver, e.g. `MySQLDriver`, with an extra promise keyed by `:dbpromise`
+   that is used to store the `test-data` dataset when you call `load-data!`."
   (engine->loader default-engine))
 
 

--- a/test/metabase/test/data/sqlserver.clj
+++ b/test/metabase/test/data/sqlserver.clj
@@ -3,7 +3,7 @@
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.string :as s]
             [environ.core :refer [env]]
-            [metabase.driver.sqlserver :refer [sqlserver]]
+            [metabase.driver.generic-sql :as sql]
             (metabase.test.data [generic-sql :as generic]
                                 [interface :as i]))
   (:import metabase.driver.sqlserver.SQLServerDriver))
@@ -103,7 +103,7 @@
   {:expectations-options :before-run}
   []
   (when (contains? @(resolve 'metabase.test.data.datasets/test-engines) :sqlserver)
-    (let [connection-spec ((:connection-details->spec sqlserver) (database->connection-details nil :server nil))
+    (let [connection-spec (sql/connection-details->spec (SQLServerDriver.) (database->connection-details nil :server nil))
           leftover-dbs    (mapv :name (jdbc/query connection-spec "SELECT name
                                                                    FROM   master.dbo.sysdatabases
                                                                    WHERE  name NOT IN ('tempdb', 'master', 'model', 'msdb', 'rdsadmin');"))]

--- a/test/metabase/test_setup.clj
+++ b/test/metabase/test_setup.clj
@@ -94,7 +94,7 @@
       (core/initialization-complete!)
       ;; If test setup fails exit right away
       (catch Throwable e
-        (log/error (u/format-color 'red "Test setup failed: %s\n%s" (.getMessage e) (u/pprint-to-str (.getStackTrace e))))
+        (log/error (u/format-color 'red "Test setup failed: %s\n%s" e (u/pprint-to-str (.getStackTrace e))))
         (System/exit -1)))
 
     @start-jetty!))


### PR DESCRIPTION
@agilliland take a look at this. I moved the methods SQL drivers were required to define into a formal protocol as well. Again, this isn't really a big change, since we were already doing an ad-hoc version of the same thing. It seems like a big PR tho because lots of lines have changed, but most of those are indentation shifts. 

This will give us better compile-time checking (try it -- it will yell at you have a method call with the wrong number of args). It's a bit more actionable too for people who want to write their own drivers (the instructions are now "write a class that implements `ISQLDriver`" vs "read the documentation in `metabase.driver.generic-sql` and create a map with the keys and functions we tell you to"). 

This is a bit more flexible too. Since the driver is now getting passed around throughout the SQL QP it will make it super easy to make internal functions a part of the `ISQLDriver` protocol itself if some driver (_cough_ Redshift _cough_) needs to override any of them in the future :scream_cat: 
