### PR TITLE
Pulse fixes

### DIFF
--- a/frontend/src/pulse/actions.js
+++ b/frontend/src/pulse/actions.js
@@ -31,6 +31,10 @@ export const FETCH_PULSE_CARD_PREVIEW = 'FETCH_PULSE_CARD_PREVIEW';
 export const fetchPulses = createThunkAction(FETCH_PULSES, function() {
     return async function(dispatch, getState) {
         let pulses = await Pulse.list();
+        for (var p of pulses) {
+            p.updated_at = moment(p.updated_at);
+            p.created_at = moment(p.created_at);
+        }
         return normalize(pulses, arrayOf(pulse));
     };
 });

--- a/frontend/src/pulse/components/PulseList.jsx
+++ b/frontend/src/pulse/components/PulseList.jsx
@@ -52,7 +52,7 @@ export default class PulseList extends Component {
                 <LoadingAndErrorWrapper loading={!pulses}>
                 { () => pulses.length > 0 ?
                     <ul className="wrapper wrapper--trim">
-                        {pulses.slice().reverse().map(pulse =>
+                        {pulses.slice().sort((a,b) => b.created_at - a.created_at).map(pulse =>
                             <li key={pulse.id}>
                                 <PulseListItem
                                     pulse={pulse}

--- a/frontend/src/pulse/components/SchedulePicker.jsx
+++ b/frontend/src/pulse/components/SchedulePicker.jsx
@@ -77,7 +77,7 @@ export default class SchedulePicker extends Component {
                     onChange={(o) => this.props.onPropertyChange("schedule_hour", hour + o * 12) }
                 />
                 <div className="mt2 h4 text-bold text-grey-3">
-                    {CHANNEL_NOUN_PLURAL[cs && cs.type] || "Messages"} will be sent at {hour}:00 {amPm ? "PM" : "AM"} {timezone}, your Metabase timezone.
+                    {CHANNEL_NOUN_PLURAL[cs && cs.type] || "Messages"} will be sent at {hour === 0 ? 12 : hour}:00 {amPm ? "PM" : "AM"} {timezone}, your Metabase timezone.
                 </div>
             </div>
         );

--- a/frontend/src/query_builder/DataSelector.jsx
+++ b/frontend/src/query_builder/DataSelector.jsx
@@ -82,7 +82,7 @@ export default class DataSelector extends Component {
         var content;
         if (this.props.includeTables) {
             if (table) {
-                content = <span className="text-grey no-decoration">{table.display_name}</span>;
+                content = <span className="text-grey no-decoration">{table.display_name || table.name}</span>;
             } else {
                 content = <span className="text-grey-4 no-decoration">Select a table</span>;
             }
@@ -106,7 +106,7 @@ export default class DataSelector extends Component {
             sections = this.props.databases.map(database => ({
                 name: database.name,
                 items: database.tables.filter(isQueryable).map(table => ({
-                    name: table.display_name,
+                    name: table.display_name || table.name,
                     database: database,
                     table: table
                 })).sort(function(a, b) {

--- a/src/metabase/api/pulse.clj
+++ b/src/metabase/api/pulse.clj
@@ -11,7 +11,9 @@
                              [database :refer [Database]]
                              [pulse :refer [Pulse] :as pulse]
                              [pulse-channel :refer [channel-types]])
-            [metabase.pulse :as p]))
+            [metabase.pulse :as p]
+            [metabase.task.send-pulses :refer [send-pulse]]
+            [metabase.models.pulse :refer [retrieve-pulse]]))
 
 
 (defendpoint GET "/"
@@ -104,5 +106,13 @@
     (let [data (:data (driver/dataset-query (:dataset_query card) {:executed_by *current-user-id*}))
           ba (p/render-pulse-card-to-png card data true)]
       {:status 200 :headers {"Content-Type" "image/png"} :body (new java.io.ByteArrayInputStream ba) })))
+
+;; Using "GET" for now so it's easier to trigger from the browser. Switch to using POST if we add a button in the UI.
+(defendpoint GET "/:id/test"
+  "Test send a pulse"
+  [id]
+  (check-superuser)
+  (send-pulse (retrieve-pulse id))
+  {:status 200 :body {:ok true}})
 
 (define-routes)

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -144,20 +144,20 @@
     [:table {:style (str "padding-bottom: 8px; border-bottom: 4px solid " color-grey-1 ";")}
       [:thead
         [:tr
-          (map (fn [col-idx]
-                [:th {:style (str bar-td-style bar-th-style "min-width: 60px;")}
-                  (-> cols (nth col-idx) :display_name upper-case h)])
-                col-indexes)
-          (if bar-column [:th {:style (str bar-td-style bar-th-style "width: 99%;")}])]]
+          (for [col-idx col-indexes :let [col (-> cols (nth col-idx))]]
+            [:th {:style (str bar-td-style bar-th-style "min-width: 60px;")}
+              (h (upper-case (name (or (:display_name col) (:name col)))))])
+          (if bar-column
+            [:th {:style (str bar-td-style bar-th-style "width: 99%;")}])]]
       [:tbody
         (map-indexed (fn [row-idx row]
           [:tr {:style (str "color: " (if (odd? row-idx) color-grey-2 color-grey-3) ";")}
-            (map (fn [col-idx]
-                  [:td {:style (str bar-td-style (if (and bar-column (= col-idx 1)) "font-weight: 700;"))}
-                    (-> row (nth col-idx) (format-cell (nth cols col-idx )) h)])
-                  col-indexes)
-            (if bar-column [:td {:style (str bar-td-style "width: 99%;")}
-              [:div {:style (str "background-color: " color-purple "; height: 20px; width: " (float (* 100 (/ (bar-column row) max-value))) "%")} "&#160;"]])])
+            (for [col-idx col-indexes :let [col (-> cols (nth col-idx))]]
+              [:td {:style (str bar-td-style (if (and bar-column (= col-idx 1)) "font-weight: 700;"))}
+                (-> row (nth col-idx) (format-cell col) h)])
+            (if bar-column
+              [:td {:style (str bar-td-style "width: 99%;")}
+                [:div {:style (str "background-color: " color-purple "; height: 20px; width: " (float (* 100 (/ (bar-column row) max-value))) "%")} "&#160;"]])])
           rows)]]))
 
 (defn render-truncation-warning


### PR DESCRIPTION
- [x] Fix pulse rendering when display_name for column isn't set (e.x. raw SQL)
- [x] Sort pulses by decending `created_at`
- [x] Render 12:00 in pulse channel schedule picker as "12:00" not "0:00"
- [x] Test pulse endpoint
- [ ] Instrument pulses (#1487)
