### PR TITLE
Fix activity user joined logic

### DIFF
--- a/src/metabase/events/activity_feed.clj
+++ b/src/metabase/events/activity_feed.clj
@@ -7,7 +7,7 @@
             (metabase.models [activity :refer [Activity]]
                              [dashboard :refer [Dashboard]]
                              [database :refer [Database]]
-                             [session :refer [Session]])))
+                             [session :refer [Session first-session-for-user]])))
 
 
 (def activity-feed-topics
@@ -99,7 +99,7 @@
 (defn- process-user-activity [topic object]
   ;; we only care about login activity when its the users first session (a.k.a. new user!)
   (when (and (= :user-login topic)
-             (= (:session_id object) (db/sel :one :field [Session :id] :user_id (:user_id object))))
+             (= (:session_id object) (first-session-for-user (:user_id object))))
     (db/ins Activity
       :topic    :user-joined
       :user_id  (:user_id object)

--- a/src/metabase/models/session.clj
+++ b/src/metabase/models/session.clj
@@ -20,8 +20,10 @@
   "Retrieves the first Session `:id` for a given user (if available), or nil otherwise."
   [user-id]
   {:pre [(integer? user-id)]}
-  (k/select Session
-    (k/fields :id)
-    (k/where {:user_id user-id})
-    (k/order :created_at :ASC)
-    (k/limit 1)))
+  (-> (k/select Session
+        (k/fields :id)
+        (k/where {:user_id user-id})
+        (k/order :created_at :ASC)
+        (k/limit 1))
+      first
+      :id))

--- a/src/metabase/models/session.clj
+++ b/src/metabase/models/session.clj
@@ -1,15 +1,27 @@
 (ns metabase.models.session
-  (:require [korma.core :refer :all, :exclude [defentity update]]
-            [metabase.db :refer :all]
+  (:require [korma.core :as k]
             (metabase.models [common :refer :all]
                              [interface :refer :all]
                              [user :refer [User]])
             [metabase.util :as u]))
 
 (defentity Session
-  [(table :core_session)
-   (belongs-to User {:fk :user_id})]
+  [(k/table :core_session)
+   (k/belongs-to User {:fk :user_id})]
 
   (pre-insert [_ session]
     (let [defaults {:created_at (u/new-sql-timestamp)}]
       (merge defaults session))))
+
+
+;; Persistence Functions
+
+(defn first-session-for-user
+  "Retrieves the first Session `:id` for a given user (if available), or nil otherwise."
+  [user-id]
+  {:pre [(integer? user-id)]}
+  (k/select Session
+    (k/fields :id)
+    (k/where {:user_id user-id})
+    (k/order :created_at :ASC)
+    (k/limit 1)))

--- a/test/metabase/models/session_test.clj
+++ b/test/metabase/models/session_test.clj
@@ -2,23 +2,28 @@
   (:require [expectations :refer :all]
             [korma.core :as k]
             [metabase.models.session :refer :all]
+            [metabase.models.user :refer [User]]
+            [metabase.test.util :refer :all]
             [metabase.test.data.users :refer :all]))
 
 ;; first-session-for-user
 (expect
   "the-greatest-day-ever"
-  (do
+  (with-temp User [{:keys [id]} {:first_name (random-name)
+                                 :last_name  (random-name)
+                                 :email      (str (random-name) "@metabase.com")
+                                 :password   "nada"}]
     (k/insert Session
               (k/values [{:id         "the-greatest-day-ever"
-                          :user_id    (user->id :rasta)
+                          :user_id    id
                           :created_at (metabase.util/->Timestamp "1980-10-19")}
                          {:id         "the-world-of-bi-changes-forever"
-                          :user_id    (user->id :rasta)
+                          :user_id    id
                           :created_at (metabase.util/->Timestamp "2015-10-21")}
                          {:id         "something-could-have-happened"
-                          :user_id    (user->id :rasta)
+                          :user_id    id
                           :created_at (metabase.util/->Timestamp "1999-12-31")}
                          {:id         "now"
-                          :user_id    (user->id :rasta)
+                          :user_id    id
                           :created_at (metabase.util/new-sql-timestamp)}]))
-    (first-session-for-user (user->id :rasta))))
+    (first-session-for-user id)))

--- a/test/metabase/models/session_test.clj
+++ b/test/metabase/models/session_test.clj
@@ -1,0 +1,24 @@
+(ns metabase.models.session-test
+  (:require [expectations :refer :all]
+            [korma.core :as k]
+            [metabase.models.session :refer :all]
+            [metabase.test.data.users :refer :all]))
+
+;; first-session-for-user
+(expect
+  "the-greatest-day-ever"
+  (do
+    (k/insert Session
+              (k/values [{:id         "the-greatest-day-ever"
+                          :user_id    (user->id :rasta)
+                          :created_at (metabase.util/->Timestamp "1980-10-19")}
+                         {:id         "the-world-of-bi-changes-forever"
+                          :user_id    (user->id :rasta)
+                          :created_at (metabase.util/->Timestamp "2015-10-21")}
+                         {:id         "something-could-have-happened"
+                          :user_id    (user->id :rasta)
+                          :created_at (metabase.util/->Timestamp "1999-12-31")}
+                         {:id         "now"
+                          :user_id    (user->id :rasta)
+                          :created_at (metabase.util/new-sql-timestamp)}]))
+    (first-session-for-user (user->id :rasta))))


### PR DESCRIPTION
tighten up the logic around how we calculate first session for a user so that we avoid intermittent issues accidentally creating multiple join feed items for the same user.
