### PR TITLE
tweak the sorting logic in our QP annotations to use the `clause-position` for sorting on :breakout type fields.

### DIFF
--- a/src/metabase/driver/query_processor/annotate.clj
+++ b/src/metabase/driver/query_processor/annotate.clj
@@ -157,7 +157,7 @@
     (fn [{:keys [position clause-position field-name source], :as field}]
       [(source-importance field)
        (or position
-           (when (= source :fields)
+           (when (contains? #{:fields :breakout} source)
              clause-position)
            Integer/MAX_VALUE)
        (special-type-importance field)


### PR DESCRIPTION
use the position of the field within the `:breakout` clause to aid in result column sorting predictability on query results
