### PR TITLE
Fix column title ordering in Raw SQL queries with lots of columns

### DIFF
--- a/src/metabase/driver/generic_sql/native.clj
+++ b/src/metabase/driver/generic_sql/native.clj
@@ -43,7 +43,7 @@
                (let [[columns & [first-row :as rows]] (jdbc/query t-conn sql, :as-arrays? true)]
                  {:rows    rows
                   :columns columns
-                  :cols    (for [[column first-value] (zipmap columns first-row)]
+                  :cols    (for [[column first-value] (partition 2 (interleave columns first-row))]
                              {:name      column
                               :base_type (value->base-type first-value)})})
 


### PR DESCRIPTION
Fix bug where raw SQL queries that returned more than 10 or more columns would have column names in the wrong order in the results table. 

We were using `zipmap` to create a map out of two sequences. For maps with less than 10 keys, this creates `clojure.lang.PersistentArrayMap`, which retains the ordering of original sequences when iterating over key-value pairs; for 10 or more keys, it returns `PersistentHashMap`, which has a different ordering.
