### PR TITLE
Fix joins on non-default-schemas :scream_cat:

### DIFF
--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -38,7 +38,7 @@
     "Return a korma form for truncating a date or timestamp field or value to a given resolution, or extracting a date component.")
 
   (excluded-schemas ^java.util.Set [this]
-                    "*OPTIONAL*. Set of string names of schemas to skip syncing tables from.")
+    "*OPTIONAL*. Set of string names of schemas to skip syncing tables from.")
 
   (set-timezone-sql ^String [this]
     "*OPTIONAL*. This should be a prepared JDBC SQL statement string to be used to set the timezone for the current transaction.

--- a/test/metabase/test/data/generic_sql.clj
+++ b/test/metabase/test/data/generic_sql.clj
@@ -104,8 +104,13 @@
             pk-field-name (pk-sql-type loader)
             pk-field-name)))
 
-(defn- default-drop-table-if-exists-sql [loader {:keys [databse-name]} {:keys [table-name]}]
-  (format "DROP TABLE IF EXISTS %s;" (qualify+quote-name loader databse-name table-name)))
+(defn- default-drop-table-if-exists-sql [loader {:keys [database-name]} {:keys [table-name]}]
+  (format "DROP TABLE IF EXISTS %s;" (qualify+quote-name loader database-name table-name)))
+
+(defn drop-table-if-exists-cascade-sql
+  "Alternate implementation of `drop-table-if-exists-sql` that adds `CASCADE` to the statement for DBs that support it."
+  [loader {:keys [database-name]} {:keys [table-name]}]
+  (format "DROP TABLE IF EXISTS %s CASCADE;" (qualify+quote-name loader database-name table-name)))
 
 (defn default-add-fk-sql [loader {:keys [database-name]} {:keys [table-name]} {dest-table-name :fk, field-name :field-name}]
   (let [quot            (partial quote-name loader)

--- a/test/metabase/test/data/postgres.clj
+++ b/test/metabase/test/data/postgres.clj
@@ -28,14 +28,10 @@
          (when (= context :db)
            {:db database-name})))
 
-(defn- drop-table-if-exists-sql [_ _ {:keys [table-name]}]
-  (format "DROP TABLE IF EXISTS \"%s\" CASCADE;" table-name))
-
-
 (extend PostgresDriver
   generic/IGenericSQLDatasetLoader
   (merge generic/DefaultsMixin
-         {:drop-table-if-exists-sql  drop-table-if-exists-sql
+         {:drop-table-if-exists-sql  generic/drop-table-if-exists-cascade-sql
           :pk-sql-type               (constantly "SERIAL")
           :field-base-type->sql-type (fn [_ base-type]
                                        (field-base-type->sql-type base-type))})


### PR DESCRIPTION
The SQL generated for a `JOIN` did not qualify table and field names with their schema (when applicable). This meant joins wouldn't work in some cases. Fix this.
