### PR TITLE
Only load temp DBs once :heart_eyes_cat: 

### DIFF
--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -24,32 +24,34 @@
 
 ;; ## GET /api/table?org
 ;; These should come back in alphabetical order and include relevant metadata
-(expect (set (reduce concat (for [engine datasets/test-engines]
-                              (datasets/with-engine-when-testing engine
-                                [{:name                (format-name "categories")
-                                  :display_name        "Categories"
-                                  :db_id               (id)
-                                  :active              true
-                                  :rows                75
-                                  :id                  (id :categories)}
-                                 {:name                (format-name "checkins")
-                                  :display_name        "Checkins"
-                                  :db_id               (id)
-                                  :active              true
-                                  :rows                1000
-                                  :id                  (id :checkins)}
-                                 {:name                (format-name "users")
-                                  :display_name        "Users"
-                                  :db_id               (id)
-                                  :active              true
-                                  :rows                15
-                                  :id                  (id :users)}
-                                 {:name                (format-name "venues")
-                                  :display_name        "Venues"
-                                  :db_id               (id)
-                                  :active              true
-                                  :rows                100
-                                  :id                  (id :venues)}]))))
+(expect
+  (do (destroy-loaded-temp-dbs!)
+      (set (reduce concat (for [engine datasets/test-engines]
+                            (datasets/with-engine-when-testing engine
+                              [{:name                (format-name "categories")
+                                :display_name        "Categories"
+                                :db_id               (id)
+                                :active              true
+                                :rows                75
+                                :id                  (id :categories)}
+                               {:name                (format-name "checkins")
+                                :display_name        "Checkins"
+                                :db_id               (id)
+                                :active              true
+                                :rows                1000
+                                :id                  (id :checkins)}
+                               {:name                (format-name "users")
+                                :display_name        "Users"
+                                :db_id               (id)
+                                :active              true
+                                :rows                15
+                                :id                  (id :users)}
+                               {:name                (format-name "venues")
+                                :display_name        "Venues"
+                                :db_id               (id)
+                                :active              true
+                                :rows                100
+                                :id                  (id :venues)}])))))
   (->> ((user->client :rasta) :get 200 "table")
        (map #(dissoc % :db :created_at :updated_at :schema :entity_name :description :entity_type :visibility_type))
        set))

--- a/test/metabase/driver/query_processor_test.clj
+++ b/test/metabase/driver/query_processor_test.clj
@@ -1383,7 +1383,7 @@
 
 ;; RELATIVE DATES
 (defn- database-def-with-timestamps [interval-seconds]
-  (create-database-definition "DB"
+  (create-database-definition (str "a-checkin-every-" interval-seconds "-seconds")
     ["checkins"
      [{:field-name "timestamp"
        :base-type  :DateTimeField}]


### PR DESCRIPTION
Lazily load various temp DBs once per driver and destroy them all at the end of the test suite. This makes the tests run significantly faster.

Finally had to implement this because the tests against Redshift take a redonk 18 minutes to run.

This was actually a fairly minor change.

Implements #1458.
