### PR TITLE
Remove more special casing in QP unit tests :heart_eyes_cat:

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -36,7 +36,6 @@
                               (expect-with-engine 1)
                               (expect-with-engines 1)
                               (format-color 2)
-                              (if-questionable-timezone-support 0)
                               (ins 1)
                               (let-400 1)
                               (let-404 1)

--- a/test/metabase/test/data/h2.clj
+++ b/test/metabase/test/data/h2.clj
@@ -90,9 +90,10 @@
 
   i/IDatasetLoader
   (merge generic/IDatasetLoaderMixin
-         {:database->connection-details database->connection-details
-          :default-schema               (constantly "PUBLIC")
-          :engine                       (constantly :h2)
-          :format-name                  (fn [_ table-or-field-name]
-                                          (s/upper-case table-or-field-name))
-          :id-field-type                (constantly :BigIntegerField)}))
+         {:database->connection-details       database->connection-details
+          :default-schema                     (constantly "PUBLIC")
+          :engine                             (constantly :h2)
+          :format-name                        (fn [_ table-or-field-name]
+                                                (s/upper-case table-or-field-name))
+          :has-questionable-timezone-support? (constantly false)
+          :id-field-type                      (constantly :BigIntegerField)}))

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -5,6 +5,7 @@
    actual physical RDMS database. This functionality allows us to easily test with multiple datasets."
   (:require [clojure.string :as s]
             [metabase.db :refer :all]
+            [metabase.driver :as driver]
             (metabase.models [database :refer [Database]]
                              [field :refer [Field] :as field]
                              [table :refer [Table]]))
@@ -95,15 +96,21 @@
     "*OPTIONAL* Transform a lowercase string `Table` or `Field` name in a way appropriate for this dataset
      (e.g., `h2` would want to upcase these names; `mongo` would want to use `\"_id\"` in place of `\"id\"`.")
 
+  (has-questionable-timezone-support? [this]
+    "*OPTIONAL*. Does this driver have \"questionable\" timezone support? (i.e., does it group things by UTC instead of the `US/Pacific` when we're testing?)
+     Defaults to `(not (contains? (metabase.driver/features this) :set-timezone)`")
+
   (id-field-type [this]
     "*OPTIONAL* Return the `base_type` of the `id` `Field` (e.g. `:IntegerField` or `:BigIntegerField`). Defaults to `:IntegerField`."))
 
 (def IDatasetLoaderDefaultsMixin
-  {:expected-base-type->actual (fn [_ base-type] base-type)
-   :default-schema             (constantly nil)
-   :format-name                (fn [_ table-or-field-name]
-                                 table-or-field-name)
-   :id-field-type              (constantly :IntegerField)})
+  {:expected-base-type->actual         (fn [_ base-type] base-type)
+   :default-schema                     (constantly nil)
+   :format-name                        (fn [_ table-or-field-name]
+                                         table-or-field-name)
+   :has-questionable-timezone-support? (fn [driver]
+                                         (not (contains? (driver/features driver) :set-timezone)))
+   :id-field-type                      (constantly :IntegerField)})
 
 
 ;; ## Helper Functions for Creating New Definitions


### PR DESCRIPTION
Another improvement backported from the Oracle driver branch.

Make `has-questionable-timezone-support?` a formal method instead of hardcoding a list of drivers with "questionable timezone support" in `metabase.driver.query-processor-test`
