### PR TITLE
Fast implementation of `active-tables` for SQL DBs :scream_cat:

### DIFF
--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -198,7 +198,8 @@
 (extend H2Driver
   driver/IDriver
   (merge (sql/IDriverSQLDefaultsMixin)
-         {:date-interval                     date-interval
+         {:active-tables                     sql/post-filtered-active-tables
+          :date-interval                     date-interval
           :details-fields                    (constantly [{:name         "db"
                                                            :display-name "Connection String"
                                                            :placeholder  "file:/Users/camsaul/bird_sightings/toucans;AUTO_SERVER=TRUE"

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -141,7 +141,8 @@
 (extend MySQLDriver
   driver/IDriver
   (merge (sql/IDriverSQLDefaultsMixin)
-         {:date-interval                     date-interval
+         {:active-tables                     sql/post-filtered-active-tables
+          :date-interval                     date-interval
           :details-fields                    (constantly [{:name         "host"
                                                            :display-name "Host"
                                                            :default      "localhost"}

--- a/src/metabase/driver/sqlite.clj
+++ b/src/metabase/driver/sqlite.clj
@@ -108,7 +108,8 @@
 (extend SQLiteDriver
   driver/IDriver
   (merge (sql/IDriverSQLDefaultsMixin)
-         {:date-interval  date-interval
+         {:active-tables  sql/post-filtered-active-tables
+          :date-interval  date-interval
           :details-fields (constantly [{:name         "db"
                                         :display-name "Filename"
                                         :placeholder  "/home/camsaul/toucan_sightings.sqlite 😋"

--- a/src/metabase/driver/sync.clj
+++ b/src/metabase/driver/sync.clj
@@ -84,12 +84,12 @@
     (validate-active-tables active-tables)
 
     (mark-inactive-tables! database active-tables existing-table->id)
-    (create-new-tables!    database active-tables existing-table->id))
+    (create-new-tables!    database active-tables existing-table->id)
 
-  (fetch-and-sync-database-active-tables! driver database)
+    (fetch-and-sync-database-active-tables! driver database)
 
-  ;; Ok, now if we had a _metabase_metadata table from earlier we can go ahead and sync from it
-  (sync-metabase-metadata-table! driver database active-tables))
+    ;; Ok, now if we had a _metabase_metadata table from earlier we can go ahead and sync from it
+    (sync-metabase-metadata-table! driver database active-tables)))
 
 (defn- -sync-database-with-tracking! [driver database]
   (let [start-time    (System/currentTimeMillis)

--- a/src/metabase/driver/sync.clj
+++ b/src/metabase/driver/sync.clj
@@ -89,7 +89,7 @@
   (fetch-and-sync-database-active-tables! driver database)
 
   ;; Ok, now if we had a _metabase_metadata table from earlier we can go ahead and sync from it
-  (sync-metabase-metadata-table! driver database))
+  (sync-metabase-metadata-table! driver database active-tables))
 
 (defn- -sync-database-with-tracking! [driver database]
   (let [start-time    (System/currentTimeMillis)
@@ -125,8 +125,8 @@
    `keypath` is of the form `table-name.key` or `table-name.field-name.key`, where `key` is the name of some property of `Table` or `Field`.
 
    This functionality is currently only used by the Sample Dataset. In order to use this functionality, drivers must implement optional fn `:table-rows-seq`."
-  [driver database]
-  (doseq [{table-name :name} (driver/active-tables driver database)]
+  [driver database active-tables]
+  (doseq [{table-name :name} active-tables]
     (when (= (s/lower-case table-name) "_metabase_metadata")
       (doseq [{:keys [keypath value]} (driver/table-rows-seq driver database table-name)]
         (let [[_ table-name field-name k] (re-matches #"^([^.]+)\.(?:([^.]+)\.)?([^.]+)$" keypath)]


### PR DESCRIPTION
Some more optimizations backported from the Oracle branch. 
##### fast `active-tables`

DBs like Oracle have hundreds of system Tables. Our old implementation of `active-tables` for SQL drivers fetched this entire list of Tables, and then filtered out ones from system schemas. 

New implementation that fetches list of schemas, and then fetches Tables only for non-system schemas. With the `test-data` DB on a remote (`us-east-1`) Oracle instance, the new implementation takes ~4 seconds, vs ~60 seconds for the old implementation.
##### Remove duplicate call to `active-tables`

This was called twice in sync, instead of re-using the results from the first call.
##### TL;DR

Syncing the `test-data` database on a `us-east-1` Oracle DB takes around ~10 seconds on my machine, as opposed to ~2.5 minutes previously. Other databases will see sync performance improvements as well, although probably not as dramatic.
