### PR TITLE
Support SQL Server Clobs (`VARCHAR(MAX)`) :sweat:

### DIFF
--- a/src/metabase/middleware.clj
+++ b/src/metabase/middleware.clj
@@ -203,24 +203,24 @@
 
 ;; ## Custom JSON encoders
 
+;; Always fall back to `.toString` instead of barfing.
+;; In some cases we should be able to improve upon this behavior; `.toString` may just return the Class and address, e.g. `net.sourceforge.jtds.jdbc.ClobImpl@72a8b25e`
+;; The following are known few classes where `.toString` is the optimal behavior:
+;; *  `org.postgresql.jdbc4.Jdbc4Array` (Postgres arrays)
+;; *  `org.bson.types.ObjectId`         (Mongo BSON IDs)
+;; *  `java.sql.Date`                   (SQL Dates -- .toString returns YYYY-MM-DD)
+(add-encoder Object encode-str)
+
+(defn- encode-jdbc-clob [clob, ^JsonGenerator json-generator]
+  (.writeString json-generator (u/jdbc-clob->str clob)))
+
 ;; stringify JDBC clobs
-(add-encoder org.h2.jdbc.JdbcClob (fn [clob, ^JsonGenerator json-generator]
-                                    (.writeString json-generator (u/jdbc-clob->str clob))))
+(add-encoder org.h2.jdbc.JdbcClob               encode-jdbc-clob) ; H2
+(add-encoder net.sourceforge.jtds.jdbc.ClobImpl encode-jdbc-clob) ; SQLServer
+(add-encoder org.postgresql.util.PGobject       encode-jdbc-clob) ; Postgres
 
-;; stringify Postgres binary objects (e.g. PostGIS geometries)
-(add-encoder org.postgresql.util.PGobject encode-str)
-
-;; Do the same for PG arrays
-(add-encoder org.postgresql.jdbc4.Jdbc4Array encode-str)
-
-;; Encode BSON IDs like strings
-(add-encoder org.bson.types.ObjectId encode-str)
-
-;; Encode BSON undefined like nil
+;; Encode BSON undefined like `nil`
 (add-encoder org.bson.BsonUndefined encode-nil)
-
-;; serialize sql dates (i.e., QueryProcessor results) like YYYY-MM-DD instead of as a full-blown timestamp
-(add-encoder java.sql.Date encode-str)
 
 ;; Binary arrays ("[B") -- hex-encode their first four bytes, e.g. "0xC42360D7"
 (add-encoder (Class/forName "[B") (fn [byte-ar, ^JsonGenerator json-generator]

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.driver.mysql-test
   (:require [expectations :refer :all]
-            [metabase.driver.query-processor.expand :as ql]
             [metabase.test.data :as data]
             (metabase.test.data [datasets :refer [expect-with-engine]]
                                 [interface :refer [def-database-definition]])))

--- a/test/metabase/driver/sql_server_test.clj
+++ b/test/metabase/driver/sql_server_test.clj
@@ -1,0 +1,24 @@
+(ns metabase.driver.sql-server-test
+  (:require  [cheshire.core :as json]
+             [expectations :refer :all]
+             [metabase.test.data :as data]
+             (metabase.test.data [datasets :refer [expect-with-engine]]
+                                 [interface :refer [def-database-definition]])
+             [metabase.test.util :refer [obj->json->obj]]))
+
+;;; ------------------------------------------------------------ VARCHAR(MAX) ------------------------------------------------------------
+;; VARCHAR(MAX) comes back from jTDS as a "ClobImpl" so make sure it gets encoded like a normal string by Cheshire
+(def ^:private ^:const a-gene
+  "Really long string representing a gene like \"GGAGCACCTCCACAAGTGCAGGCTATCCTGTCGAGTAAGGCCT...\""
+  (apply str (repeatedly 1000 (partial rand-nth [\A \G \C \T]))))
+
+(def-database-definition ^:private ^:const genetic-data
+  ["genetic-data"
+   [{:field-name "gene", :base-type {:native "VARCHAR(MAX)"}}]
+   [[a-gene]]])
+
+(expect-with-engine :sqlserver
+  [[1 a-gene]]
+  (-> (data/dataset metabase.driver.sql-server-test/genetic-data
+        (data/run-query genetic-data))
+      :data :rows obj->json->obj)) ; convert to JSON + back so the Clob gets stringified


### PR DESCRIPTION
Also add a default JSON encoder impl for `Object` that calls `.toString` instead of barfing for other unknown types. 

Fixes #1651
