### PR TITLE
Escape dots in SQL identifiers :unamused: #1408

### DIFF
--- a/src/metabase/driver/query_processor/interface.clj
+++ b/src/metabase/driver/query_processor/interface.clj
@@ -67,7 +67,8 @@
                     description        :- (s/maybe s/Str)
                     parent-id          :- (s/maybe IntGreaterThanZero)
                     ;; Field once its resolved; FieldPlaceholder before that
-                    parent             :- s/Any]
+                    parent             :- s/Any
+                    preview-display    :- (s/maybe s/Bool)]
   IField
   (qualified-name-components [this]
     (conj (if parent

--- a/src/metabase/util/korma_extensions.clj
+++ b/src/metabase/util/korma_extensions.clj
@@ -2,7 +2,9 @@
   "Extensions and utility functions for [SQL Korma](http://www.sqlkorma.com/docs)."
   (:refer-clojure :exclude [+ - / * mod inc dec cast concat format])
   (:require [clojure.core.match :refer [match]]
-            [korma.core :as k]
+            [clojure.string :as s]
+            (korma [core :as k]
+                   [db :as kdb])
             (korma.sql [engine :as kengine]
                        [utils :as kutils])
             [metabase.util :as u]))
@@ -21,6 +23,35 @@
 
 (intern 'korma.sql.fns 'pred-not= pred-not=)
 
+;;; DB util fns
+
+;; Korma assumes dots are used to separate schemas/tables/fields, and stores names as a single string.
+;; e.g. a Table name might be "public.bits", which becomes SQL like "public"."bits".
+;; This works fine 99.9% of the time, but there are crazies who put dots in their Table names, e.g. "objects.stuff".
+;; Since korma doesn't know how to handle this situation, we'll replace the dots *within* names with unicode
+;; WHITE MEDIUM LOZENGE (⬨) and tell korma to switch the triangles back to dots when generating SQL.
+;; Hopefully no one uses WHITE MEDIUM LOZENGE in their table/field names.
+(def ^{:arglists '([s])} ^String escape-name   "Replace dots in a string with WHITE MEDIUM LOZENGES (⬨)." (u/rpartial s/replace #"\." "⬨"))
+(def ^{:arglists '([s])} ^String unescape-name "Replace WHITE MEDIUM LOZENGES (⬨) in a string with dots." (u/rpartial s/replace #"⬨"  "."))
+
+(defn create-db
+  "Like `korma.db/create-db`, but adds a fn to unescape escaped dots when generating SQL."
+  [spec]
+  (update-in (kdb/create-db spec) [:options :naming :fields] comp unescape-name))
+
+(defn combine+escape-name-components
+  "Combine a sequence of keyword or string NAME-COMPONENTS into a single dot-separated korma string.
+   Since korma doesn't know how to handle dots inside names, they're replaced with unicode
+   WHITE MEDIUM LOZENGE (⬨), which are switched back to dots when the SQL is generated.
+   Blank strings in NAME-COMPONENTS are automatically skipped."
+  ^String [name-components]
+  (apply str (interpose "." (for [s     name-components
+                                  :when (seq s)]
+                              (escape-name (name s))))))
+
+(def ^{:arglists '([name-components])} create-entity
+  "Like `korma.db/create-entity`, but takes a sequence of name components instead; escapes dots in names as well."
+  (comp k/create-entity combine+escape-name-components))
 
 ;;; util fns
 

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -66,3 +66,21 @@
         (data/run-query users
           (ql/filter (ql/= $user_id "4652b2e7-d940-4d55-a971-7e484566663e"))))
       :data :rows))
+
+
+;;; # Make sure that Tables / Fields with dots in their names get escaped properly
+(def-database-definition ^:const ^:private dots-in-names
+  ["objects.stuff"
+   [{:field-name "dotted.name", :base-type :TextField}]
+   [["toucan_cage"]
+    ["four_loko"]
+    ["ouija_board"]]])
+
+(expect-with-engine :postgres
+  {:columns ["id" "dotted.name"]
+   :rows    [[1 "toucan_cage"]
+             [2 "four_loko"]
+             [3 "ouija_board"]]}
+  (-> (data/dataset metabase.driver.postgres-test/dots-in-names
+        (data/run-query objects.stuff))
+      :data (dissoc :cols)))


### PR DESCRIPTION
This required a bit of hackery since korma uses dots to separate parts of an identifer.

Replace dots within names with `WHITE MEDIUM LOZENGE` (`⬨`) so korma doesn't try to treat them as actual SQL separators, then convert back to dots when the SQL gets generated. Having dots in table names is silly enough; hopefully no one puts lozenges in their table names.

Fixes #1408
