### PR TITLE
Rename assoc* to assoc<> :scream_cat:

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -13,7 +13,6 @@
                             (define-clojure-indent
                               (api-let 2)
                               (assert 1)
-                              (assoc* 1)
                               (auto-parse 1)
                               (catch-api-exceptions 0)
                               (check 1)

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -421,7 +421,7 @@
   "Save QueryExecution state and construct a completed (successful) query response"
   [query-execution query-result]
   ;; record our query execution and format response
-  (-> (u/assoc* query-execution
+  (-> (u/assoc<> query-execution
         :status       :completed
         :finished_at  (u/new-sql-timestamp)
         :running_time (- (System/currentTimeMillis) (:start_time_millis <>))

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -31,7 +31,7 @@
 
   (post-select [_ {:keys [id] :as database}]
     (map->DatabaseInstance
-      (u/assoc* database
+      (assoc database
         :tables (delay (sel :many 'metabase.models.table/Table :db_id id :active true (order :display_name :ASC))))))
 
   (pre-cascade-delete [_ {:keys [id] :as database}]

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -93,16 +93,16 @@
 
   (post-select [this {:keys [id table_id parent_id] :as field}]
     (map->FieldInstance
-      (u/assoc* field
-        :table                     (delay (sel :one 'metabase.models.table/Table :id table_id))
-        :db                        (delay @(:db @(:table <>)))
-        :target                    (delay (field->fk-field field))
-        :parent                    (when parent_id
-                                     (delay (this parent_id)))
-        :children                  (delay (sel :many this :parent_id (:id field)))
-        :values                    (delay (sel :many [FieldValues :field_id :values] :field_id id))
-        :qualified-name-components (delay (qualified-name-components <>))
-        :qualified-name            (delay (apply str (interpose "." @(:qualified-name-components <>)))))))
+     (u/assoc<> field
+       :table                     (delay (sel :one 'metabase.models.table/Table :id table_id))
+       :db                        (delay @(:db @(:table <>)))
+       :target                    (delay (field->fk-field field))
+       :parent                    (when parent_id
+                                    (delay (this parent_id)))
+       :children                  (delay (sel :many this :parent_id (:id field)))
+       :values                    (delay (sel :many [FieldValues :field_id :values] :field_id id))
+       :qualified-name-components (delay (qualified-name-components <>))
+       :qualified-name            (delay (apply str (interpose "." @(:qualified-name-components <>)))))))
 
   (pre-cascade-delete [this {:keys [id]}]
     (cascade-delete this :parent_id id)

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -31,7 +31,7 @@
 
   (post-select [_ {:keys [id db db_id description] :as table}]
     (map->TableInstance
-     (u/assoc* table
+     (assoc table
        :db                  (or db (delay (sel :one db/Database :id db_id)))
        :fields              (delay (sel :many Field :table_id id :active true (order :position :ASC) (order :name :ASC)))
        :field_values        (delay

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -209,23 +209,20 @@
 
 ;;; ## Etc
 
-(defmacro -assoc*
-  "Internal. Don't use this directly; use `assoc*` instead."
-  [k v & more]
- `(let [~'<> (assoc ~'<> ~k ~v)]
-    ~(if (empty? more) `~'<>
-         `(-assoc* ~@more))))
-
-(defmacro assoc*
+(defmacro assoc<>
   "Like `assoc`, but associations happen sequentially; i.e. each successive binding can build
    upon the result of the previous one using `<>`.
 
-    (assoc* {}
-            :a 100
-            :b (+ 100 (:a <>)) ; -> {:a 100 :b 200}"
+    (assoc<> {}
+       :a 100
+       :b (+ 100 (:a <>)) ; -> {:a 100 :b 200}"
+  {:style/indent 1}
   [object & kvs]
-  `((fn [~'<>] ; wrap in a `fn` so this can be used in `->`/`->>` forms
-      (-assoc* ~@kvs))
+  ;; wrap in a `fn` so this can be used in `->`/`->>` forms
+  `((fn [~'<>]
+      (let [~@(apply concat (for [[k v] (partition 2 kvs)]
+                              ['<> `(assoc ~'<> ~k ~v)]))]
+        ~'<>))
     ~object))
 
 (defn format-num

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -34,15 +34,16 @@
 (expect #inst "2015-11-01"       (date-trunc :month   friday-the-13th))
 (expect #inst "2015-10-01"       (date-trunc :quarter friday-the-13th))
 
-;;; ## tests for ASSOC*
+;;; ## tests for ASSOC<>
 
-(expect {:a 100
-         :b 200
-         :c 300}
-  (assoc* {}
-          :a 100
-          :b (+ 100 (:a <>))
-          :c (+ 100 (:b <>))))
+(expect
+  {:a 100
+   :b 200
+   :c 300}
+  (assoc<> {}
+    :a 100
+    :b (+ 100 (:a <>))
+    :c (+ 100 (:b <>))))
 
 
 ;;; ## tests for HOST-UP?


### PR DESCRIPTION
Minor cleanup. Rename `metabase.utils/assoc*` to `assoc<>` since the name was misleading. Switch uses back to regular `assoc` where anaphor went unused. Slightly more concise implementation.

Resolves #1455 
