### PR TITLE
Refactor MB Models a bit :yum:

### DIFF
--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -175,14 +175,14 @@
 ;; These are basically the same as the `api-` versions but with RESPONSE-PAIR already bound
 
 ;; #### GENERIC 400 RESPONSE HELPERS
-(def generic-400 [400 "Invalid Request."])
+(def ^:private ^:const generic-400 [400 "Invalid Request."])
 (defn     check-400 [tst]     (check tst generic-400))
 (defmacro let-400   [& args] `(api-let   ~generic-400 ~@args))
 (defmacro ->400     [& args] `(api->     ~generic-400 ~@args))
 (defmacro ->>400    [& args] `(api->>    ~generic-400 ~@args))
 
 ;; #### GENERIC 404 RESPONSE HELPERS
-(def generic-404 [404 "Not found."])
+(def ^:private ^:const generic-404 [404 "Not found."])
 (defn     check-404 [tst]     (check tst generic-404))
 (defmacro let-404   [& args] `(api-let   ~generic-404 ~@args))
 (defmacro ->404     [& args] `(api->     ~generic-404 ~@args))
@@ -190,7 +190,7 @@
 
 ;; #### GENERIC 403 RESPONSE HELPERS
 ;; If you can't be bothered to write a custom error message
-(def generic-403 [403 "You don't have permissions to do that."])
+(def ^:private ^:const generic-403 [403 "You don't have permissions to do that."])
 (defn     check-403 [tst]     (check tst generic-403))
 (defmacro let-403   [& args] `(api-let   ~generic-403 ~@args))
 (defmacro ->403     [& args] `(api->     ~generic-403 ~@args))
@@ -198,7 +198,7 @@
 
 ;; #### GENERIC 500 RESPONSE HELPERS
 ;; For when you don't feel like writing something useful
-(def generic-500 [500 "Internal server error."])
+(def ^:private ^:const generic-500 [500 "Internal server error."])
 (defn     check-500 [tst]     (check tst generic-500))
 (defmacro let-500   [& args] `(api-let   ~generic-500 ~@args))
 (defmacro ->500     [& args] `(api->     ~generic-500 ~@args))
@@ -423,7 +423,6 @@
                         (map first))]
     `(defroutes ~'routes ~@api-routes ~@additional-routes)))
 
-
 (defn read-check
   "Check whether we can read an existing OBJ, or ENTITY with ID."
   ([obj]
@@ -431,11 +430,7 @@
    (check-403 (models/can-read? obj))
    obj)
   ([entity id]
-   {:pre [(models/metabase-entity? entity)
-          (integer? id)]}
-   (if (satisfies? models/ICanReadWrite entity)
-     (models/can-read? entity id)
-     (read-check (entity id)))))
+   (check-403 (models/can-read? entity id))))
 
 (defn write-check
   "Check whether we can write an existing OBJ, or ENTITY with ID."
@@ -444,8 +439,4 @@
    (check-403 (models/can-write? obj))
    obj)
   ([entity id]
-   {:pre [(models/metabase-entity? entity)
-          (integer? id)]}
-   (if (satisfies? models/ICanReadWrite entity)
-     (models/can-write? entity id)
-     (write-check (entity id)))))
+   (check-403 (models/can-write? entity id))))

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -83,7 +83,8 @@
 
     (connection-string->file+options \"file:my-crazy-db;OPTION=100;OPTION_X=TRUE\")
       -> [\"file:my-crazy-db\" {\"OPTION\" \"100\", \"OPTION_X\" \"TRUE\"}]"
-  [connection-string]
+  [^String connection-string]
+  {:pre [connection-string]}
   (let [[file & options] (s/split connection-string #";+")
         options          (into {} (for [option options]
                                     (s/split option #"=")))]

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -26,21 +26,21 @@
     :bool          :BooleanField
     :boolean       :BooleanField
     :box           :UnknownField
-    :bpchar        :CharField ; "blank-padded char" is the internal name of "character"
-    :bytea         :UnknownField        ; byte array
-    :cidr          :TextField           ; IPv4/IPv6 network address
+    :bpchar        :CharField       ; "blank-padded char" is the internal name of "character"
+    :bytea         :UnknownField    ; byte array
+    :cidr          :TextField       ; IPv4/IPv6 network address
     :circle        :UnknownField
     :date          :DateField
     :decimal       :DecimalField
     :float4        :FloatField
     :float8        :FloatField
     :geometry      :UnknownField
-    :inet          :TextField ; This was `GenericIPAddressField` in some places in the Django code but not others ...
+    :inet          :TextField
     :int           :IntegerField
     :int2          :IntegerField
     :int4          :IntegerField
     :int8          :BigIntegerField
-    :interval      :UnknownField        ; time span
+    :interval      :UnknownField    ; time span
     :json          :TextField
     :jsonb         :TextField
     :line          :UnknownField
@@ -49,7 +49,7 @@
     :money         :DecimalField
     :numeric       :DecimalField
     :path          :UnknownField
-    :pg_lsn        :IntegerField        ; PG Log Sequence #
+    :pg_lsn        :IntegerField    ; PG Log Sequence #
     :point         :UnknownField
     :real          :FloatField
     :serial        :IntegerField

--- a/src/metabase/driver/query_processor/expand.clj
+++ b/src/metabase/driver/query_processor/expand.clj
@@ -157,7 +157,10 @@
 ;;; ## filter
 
 (s/defn ^:private ^:always-validate compound-filter :- i/Filter
-  ([_ subclause :- i/Filter] subclause)
+  ([compound-type subclause :- i/Filter]
+   (log/warn (u/format-color 'yellow "You shouldn't specify an %s filter with only one subclause." compound-type))
+   subclause)
+
   ([compound-type, subclause :- i/Filter, & more :- [i/Filter]]
    (i/map->CompoundFilter {:compound-type compound-type, :subclauses (cons subclause more)})))
 

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -1,10 +1,11 @@
 (ns metabase.models.card
-  (:require [korma.core :refer :all, :exclude [defentity update]]
+  (:require [korma.core :as k]
             [medley.core :as m]
-            [metabase.db :refer :all]
-            (metabase.models [interface :refer :all]
+            [metabase.db :refer [cascade-delete]]
+            (metabase.models [interface :as i]
                              [revision :as revision]
-                             [user :refer [User]])))
+                             [user :refer [User]])
+            [metabase.util :as u]))
 
 (def ^:const display-types
   "Valid values of `Card.display_type`."
@@ -19,13 +20,7 @@
     :table
     :timeseries})
 
-(defrecord CardInstance []
-  clojure.lang.IFn
-  (invoke [this k]
-    (get this k)))
-
-(extend-ICanReadWrite CardInstance :read :public-perms, :write :public-perms)
-
+(i/defentity Card :report_card)
 
 (defn- populate-query-fields [card]
   (let [{query :query, database-id :database, query-type :type} (:dataset_query card)
@@ -38,46 +33,43 @@
       (merge defaults card)
       card)))
 
-(defentity Card
-  [(table :report_card)
-   (hydration-keys card)
-   (types :display :keyword, :query_type :keyword, :dataset_query :json, :visualization_settings :json)
-   timestamped]
+(defn- post-select [{:keys [creator_id] :as card}]
+  (assoc card
+         :creator         (delay (User creator_id))
+         :dashboard_count (delay (-> (k/select @(ns-resolve 'metabase.models.dashboard-card 'DashboardCard)
+                                               (k/aggregate (count :*) :dashboards)
+                                               (k/where {:card_id (:id card)}))
+                                     first
+                                     :dashboards))))
 
-   (pre-insert [_ card]
-     (populate-query-fields card))
-
-   (pre-update [_ card]
-     (populate-query-fields card))
-
-  (post-select [_ {:keys [creator_id] :as card}]
-    (map->CardInstance (assoc card
-                              :creator         (delay (User creator_id))
-                              :dashboard_count (delay (-> (select @(ns-resolve 'metabase.models.dashboard-card 'DashboardCard)
-                                                                  (aggregate (count :*) :dashboards)
-                                                                  (where {:card_id (:id card)}))
-                                                          first
-                                                          :dashboards)))))
-
-  (pre-cascade-delete [_ {:keys [id]}]
-    (cascade-delete 'PulseCard :card_id id)
-    (cascade-delete 'Revision :model "Card" :model_id id)
-    (cascade-delete 'DashboardCard :card_id id)
-    (cascade-delete 'CardFavorite :card_id id)))
-
-(extend-ICanReadWrite CardEntity :read :public-perms, :write :public-perms)
-
-
-;;; ## ---------------------------------------- REVISIONS ----------------------------------------
-
+(defn- pre-cascade-delete [{:keys [id]}]
+  (cascade-delete 'PulseCard :card_id id)
+  (cascade-delete 'Revision :model "Card" :model_id id)
+  (cascade-delete 'DashboardCard :card_id id)
+  (cascade-delete 'CardFavorite :card_id id))
 
 (defn- serialize-instance [_ _ instance]
   (->> (dissoc instance :created_at :updated_at)
        (into {})                                 ; if it's a record type like CardInstance we need to convert it to a regular map or filter-vals won't work
        (m/filter-vals (complement delay?))))
 
-(extend CardEntity
+(extend (class Card)
+  i/IEntity
+  (merge i/IEntityDefaults
+         {:hydration-keys     (constantly [:card])
+          :types              (constantly {:display :keyword, :query_type :keyword, :dataset_query :json, :visualization_settings :json})
+          :timestamped?       (constantly true)
+          :can-read?          i/publicly-readable?
+          :can-write?         i/publicly-writeable?
+          :pre-update         populate-query-fields
+          :pre-insert         populate-query-fields
+          :post-select        post-select
+          :pre-cascade-delete pre-cascade-delete})
+
   revision/IRevisioned
   {:serialize-instance serialize-instance
    :revert-to-revision revision/default-revert-to-revision
    :describe-diff      revision/default-describe-diff})
+
+
+(u/require-dox-in-this-namespace)

--- a/src/metabase/models/card_favorite.clj
+++ b/src/metabase/models/card_favorite.clj
@@ -1,15 +1,17 @@
 (ns metabase.models.card-favorite
-  (:require [korma.core :refer :all, :exclude [defentity update]]
-            [metabase.db :refer :all]
-            (metabase.models [card :refer [Card]]
-                             [interface :refer :all]
+  (:require (metabase.models [card :refer [Card]]
+                             [interface :as i]
                              [user :refer [User]])))
 
-(defentity CardFavorite
-  [(table :report_cardfavorite)
-   timestamped]
+(i/defentity CardFavorite :report_cardfavorite)
 
-  (post-select [_ {:keys [card_id owner_id] :as card-favorite}]
-    (assoc card-favorite
-           :owner (delay (User owner_id))
-           :card  (delay (Card card_id)))))
+(defn- post-select [{:keys [card_id owner_id] :as card-favorite}]
+  (assoc card-favorite
+         :owner (delay (User owner_id))
+         :card  (delay (Card card_id))))
+
+(extend (class CardFavorite)
+  i/IEntity
+  (merge i/IEntityDefaults
+         {:timestamped? (constantly true)
+          :post-select  post-select}))

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -1,41 +1,27 @@
 (ns metabase.models.dashboard
-  (:require (clojure [data :refer [diff]]
-                     [string :as s])
-            [korma.core :refer :all, :exclude [defentity update]]
+  (:require [clojure.data :refer [diff]]
+            [korma.core :as k]
             [medley.core :as m]
             [metabase.db :refer :all]
             (metabase.models [common :refer :all]
                              [dashboard-card :refer [DashboardCard]]
-                             [interface :refer :all]
+                             [interface :as i]
                              [revision :refer [IRevisioned]]
                              [user :refer [User]])
             [metabase.models.revision.diff :refer [build-sentence]]
             [metabase.util :as u]))
 
-(defrecord DashboardInstance []
-  clojure.lang.IFn
-  (invoke [this k]
-    (get this k)))
+(i/defentity Dashboard :report_dashboard)
 
-(extend-ICanReadWrite DashboardInstance :read :public-perms, :write :public-perms)
+(defn- post-select [{:keys [id creator_id description] :as dash}]
+  (assoc dash
+         :creator       (delay (User creator_id))
+         :description   (u/jdbc-clob->str description)
+         :ordered_cards (delay (sel :many DashboardCard :dashboard_id id (k/order :created_at :asc)))))
 
-
-(defentity Dashboard
-  [(table :report_dashboard)
-   timestamped]
-
-  (post-select [_ {:keys [id creator_id description] :as dash}]
-    (-> dash
-        (assoc :creator       (delay (User creator_id))
-               :description   (u/jdbc-clob->str description)
-               :ordered_cards (delay (sel :many DashboardCard :dashboard_id id (order :created_at :asc))))
-        map->DashboardInstance))
-
-  (pre-cascade-delete [_ {:keys [id]}]
-    (cascade-delete 'Revision :model "Dashboard" :model_id id)
-    (cascade-delete DashboardCard :dashboard_id id)))
-
-(extend-ICanReadWrite DashboardEntity :read :public-perms, :write :public-perms)
+(defn- pre-cascade-delete [{:keys [id]}]
+  (cascade-delete 'Revision :model "Dashboard" :model_id id)
+  (cascade-delete DashboardCard :dashboard_id id))
 
 
 ;;; ## ---------------------------------------- REVISIONS ----------------------------------------
@@ -93,7 +79,16 @@
          (filter identity)
          build-sentence)))
 
-(extend DashboardEntity
+
+(extend (class Dashboard)
+  i/IEntity
+  (merge i/IEntityDefaults
+         {:timestamped?       (constantly true)
+          :can-read?          i/publicly-readable?
+          :can-write?         i/publicly-writeable?
+          :post-select        post-select
+          :pre-cascade-delete pre-cascade-delete})
+
   IRevisioned
   {:serialize-instance serialize-instance
    :revert-to-revision revert-to-revision

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -1,22 +1,26 @@
 (ns metabase.models.dashboard-card
   (:require [clojure.set :as set]
-            [korma.core :refer :all, :exclude [defentity update]]
-            [metabase.db :refer :all]
+            [metabase.db :refer [sel]]
             (metabase.models [card :refer [Card]]
-                             [interface :refer :all])))
+                             [interface :as i])))
 
-(defentity DashboardCard
-  [(table :report_dashboardcard)
-   timestamped]
+(i/defentity DashboardCard :report_dashboardcard)
 
-  (pre-insert [_ dashcard]
-    (let [defaults {:sizeX 2
-                    :sizeY 2}]
-      (merge defaults dashcard)))
+(defn- pre-insert [dashcard]
+  (let [defaults {:sizeX 2
+                  :sizeY 2}]
+    (merge defaults dashcard)))
 
-  (post-select [_ {:keys [card_id dashboard_id] :as dashcard}]
-    (-> dashcard
-        (set/rename-keys {:sizex :sizeX ; mildly retarded: H2 columns are all uppercase, we're converting them
-                          :sizey :sizeY}) ; to all downcase, and the Angular app expected mixed-case names here
-        (assoc :card      (delay (Card card_id))
-               :dashboard (delay (sel :one 'Dashboard :id dashboard_id))))))
+(defn- post-select [{:keys [card_id dashboard_id] :as dashcard}]
+  (-> dashcard
+      (set/rename-keys {:sizex :sizeX ; mildly retarded: H2 columns are all uppercase, we're converting them
+                        :sizey :sizeY}) ; to all downcase, and the Angular app expected mixed-case names here
+      (assoc :card      (delay (Card card_id))
+             :dashboard (delay (sel :one 'Dashboard :id dashboard_id)))))
+
+(extend (class DashboardCard)
+  i/IEntity
+  (merge i/IEntityDefaults
+         {:timestamped? (constantly true)
+          :pre-insert   pre-insert
+          :post-select  post-select}))

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -1,41 +1,38 @@
 (ns metabase.models.database
-  (:require [korma.core :refer :all, :exclude [defentity update]]
+  (:require [cheshire.generate :refer [add-encoder encode-map]]
+            [korma.core :as k]
             [metabase.api.common :refer [*current-user*]]
-            [metabase.db :refer :all]
-            [metabase.models.interface :refer :all]
+            [metabase.db :refer [cascade-delete sel]]
+            [metabase.models.interface :as i]
             [metabase.util :as u]))
 
 (def ^:const protected-password
+  "The string to replace passwords with when serializing Databases."
   "**MetabasePass**")
 
-(defrecord DatabaseInstance []
-  ;; preserve normal IFn behavior so things like ((sel :one Database) :id) work correctly
-  clojure.lang.IFn
-  (invoke [this k]
-    (get this k))
+(i/defentity Database :metabase_database)
 
-  IModelInstanceApiSerialize
-  (api-serialize [this]
-    ;; If current user isn't an admin strip out DB details which may include things like password
-    (cond-> this
-      (get-in this [:details :password])    (assoc-in [:details :password] protected-password)
-      (not (:is_superuser @*current-user*)) (dissoc :details))))
+(defn- post-select [{:keys [id] :as database}]
+  (assoc database :tables (delay (sel :many 'Table :db_id id :active true (k/order :display_name :ASC)))))
 
-(extend-ICanReadWrite DatabaseInstance :read :always, :write :superuser)
+(defn- pre-cascade-delete [{:keys [id] :as database}]
+  (cascade-delete 'Card  :database_id id)
+  (cascade-delete 'Table :db_id id))
 
-(defentity Database
-  [(table :metabase_database)
-   (hydration-keys database db)
-   (types :details :json, :engine :keyword)
-   timestamped]
+(extend (class Database)
+  i/IEntity
+  (merge i/IEntityDefaults
+         {:hydration-keys     (constantly [:database :db])
+          :types              (constantly {:details :json, :engine :keyword})
+          :timestamped?       (constantly true)
+          :post-select        post-select
+          :pre-cascade-delete pre-cascade-delete}))
 
-  (post-select [_ {:keys [id] :as database}]
-    (map->DatabaseInstance
-      (assoc database
-        :tables (delay (sel :many 'metabase.models.table/Table :db_id id :active true (order :display_name :ASC))))))
+(add-encoder DatabaseInstance (fn [db json-generator]
+                                (encode-map (cond
+                                              (not (:is_superuser @*current-user*)) (dissoc db :details)
+                                              (get-in db [:details :password])      (assoc-in db [:details :password] protected-password)
+                                              :else                                 db)
+                                            json-generator)))
 
-  (pre-cascade-delete [_ {:keys [id] :as database}]
-    (cascade-delete 'metabase.models.card/Card :database_id id)
-    (cascade-delete 'metabase.models.table/Table :db_id id)))
-
-(extend-ICanReadWrite DatabaseEntity :read :always, :write :superuser)
+(u/require-dox-in-this-namespace)

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -1,13 +1,11 @@
 (ns metabase.models.field
-  (:require [korma.core :refer :all, :exclude [defentity update]]
-            [metabase.api.common :refer [check]]
+  (:require [korma.core :as k]
             [metabase.db :refer :all]
             (metabase.models [common :as common]
                              [database :refer [Database]]
                              [field-values :refer [FieldValues field-should-have-field-values? create-field-values-if-needed]]
                              [foreign-key :refer [ForeignKey]]
-                             [hydrate :refer [hydrate]]
-                             [interface :refer :all])
+                             [interface :as i])
             [metabase.util :as u]))
 
 (declare field->fk-field
@@ -57,60 +55,59 @@
     :info        ; Non-numerical value that is not meant to be used
     :sensitive}) ; A Fields that should *never* be shown *anywhere*
 
-(defrecord FieldInstance []
-  clojure.lang.IFn
-  (invoke [this k]
-    (get this k)))
 
-(extend-ICanReadWrite FieldInstance :read :always, :write :superuser)
+(i/defentity Field :metabase_field)
 
+(defn- pre-insert [field]
+  (let [defaults {:active          true
+                  :preview_display true
+                  :field_type      :info
+                  :position        0
+                  :display_name    (common/name->human-readable-name (:name field))}]
+    (merge defaults field)))
 
-(defentity Field
-  [(table :metabase_field)
-   (hydration-keys destination field origin)
-   (types :base_type :keyword, :field_type :keyword, :special_type :keyword)
-   timestamped]
+(defn- post-insert [field]
+  (when (field-should-have-field-values? field)
+    (create-field-values-if-needed field))
+  field)
 
-  (pre-insert [_ field]
-    (let [defaults {:active          true
-                    :preview_display true
-                    :field_type      :info
-                    :position        0
-                    :display_name    (common/name->human-readable-name (:name field))}]
-      (merge defaults field)))
+(defn- post-update [{:keys [id] :as field}]
+  ;; if base_type or special_type were affected then we should asynchronously create corresponding FieldValues objects if need be
+  (when (or (contains? field :base_type)
+            (contains? field :field_type)
+            (contains? field :special_type))
+    (create-field-values-if-needed (sel :one [Field :id :table_id :base_type :special_type :field_type] :id id))))
 
-  (post-insert [_ field]
-    (when (field-should-have-field-values? field)
-      (create-field-values-if-needed field))
-    field)
+(defn- post-select [{:keys [id table_id parent_id] :as field}]
+  (u/assoc<> field
+    :table                     (delay (sel :one 'Table :id table_id))
+    :db                        (delay @(:db @(:table <>)))
+    :target                    (delay (field->fk-field field))
+    :parent                    (when parent_id
+                                 (delay (Field parent_id)))
+    :children                  (delay (sel :many Field :parent_id (:id field)))
+    :values                    (delay (sel :many [FieldValues :field_id :values] :field_id id))
+    :qualified-name-components (delay (qualified-name-components <>))
+    :qualified-name            (delay (apply str (interpose "." @(:qualified-name-components <>))))))
 
-  (post-update [this {:keys [id] :as field}]
-    ;; if base_type or special_type were affected then we should asynchronously create corresponding FieldValues objects if need be
-    (when (or (contains? field :base_type)
-              (contains? field :field_type)
-              (contains? field :special_type))
-      (create-field-values-if-needed (sel :one [this :id :table_id :base_type :special_type :field_type] :id id))))
-
-  (post-select [this {:keys [id table_id parent_id] :as field}]
-    (map->FieldInstance
-     (u/assoc<> field
-       :table                     (delay (sel :one 'metabase.models.table/Table :id table_id))
-       :db                        (delay @(:db @(:table <>)))
-       :target                    (delay (field->fk-field field))
-       :parent                    (when parent_id
-                                    (delay (this parent_id)))
-       :children                  (delay (sel :many this :parent_id (:id field)))
-       :values                    (delay (sel :many [FieldValues :field_id :values] :field_id id))
-       :qualified-name-components (delay (qualified-name-components <>))
-       :qualified-name            (delay (apply str (interpose "." @(:qualified-name-components <>)))))))
-
-  (pre-cascade-delete [this {:keys [id]}]
-    (cascade-delete this :parent_id id)
-    (cascade-delete ForeignKey (where (or (= :origin_id id)
+(defn- pre-cascade-delete [{:keys [id]}]
+  (cascade-delete Field :parent_id id)
+  (cascade-delete ForeignKey (k/where (or (= :origin_id id)
                                           (= :destination_id id))))
-    (cascade-delete 'metabase.models.field-values/FieldValues :field_id id)))
+  (cascade-delete 'FieldValues :field_id id))
 
-(extend-ICanReadWrite FieldEntity :read :always, :write :superuser)
+(extend (class Field)
+  i/IEntity (merge i/IEntityDefaults
+                   {:hydration-keys     (constantly [:destination :field :origin])
+                    :types              (constantly {:base_type :keyword, :field_type :keyword, :special_type :keyword})
+                    :timestamped?       (constantly true)
+                    :can-read?          (constantly true)
+                    :can-write?         i/superuser?
+                    :pre-insert         pre-insert
+                    :post-insert        post-insert
+                    :post-update        post-update
+                    :post-select        post-select
+                    :pre-cascade-delete pre-cascade-delete}))
 
 
 (defn field->fk-field

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -1,19 +1,21 @@
 (ns metabase.models.field-values
   (:require [clojure.tools.logging :as log]
-            [korma.core :refer :all, :exclude [defentity update]]
-            (metabase [db :refer :all]
-                      [util :as u])
-            [metabase.models.interface :refer :all]))
+            [metabase.db :refer [ins sel upd]]
+            [metabase.models.interface :as i]))
 
 ;; ## Entity + DB Multimethods
 
-(defentity FieldValues
-  [(table :metabase_fieldvalues)
-   timestamped
-   (types :human_readable_values :json, :values :json)]
+(i/defentity FieldValues :metabase_fieldvalues)
 
-  (post-select [_ field-values]
-    (update-in field-values [:human_readable_values] #(or % {}))))
+(defn- post-select [field-values]
+  (update-in field-values [:human_readable_values] #(or % {})))
+
+(extend (class FieldValues)
+  i/IEntity
+  (merge i/IEntityDefaults
+         {:timestamped? (constantly true)
+          :types        (constantly {:human_readable_values :json, :values :json})
+          :post-select  post-select}))
 
 ;; columns:
 ;; *  :id

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -1,63 +1,46 @@
 (ns metabase.models.interface
-  (:require (clojure.tools [logging :as log]
-                           [macro :refer [macrolet]])
-            [clojure.walk :refer [macroexpand-all], :as walk]
-            [cheshire.core :as cheshire]
+  (:require [clojure.tools.logging :as log]
+            [cheshire.core :as json]
             [korma.core :as k]
-            [medley.core :as m]
-            [metabase.config :as config]
-            [metabase.util :as u]))
+            (metabase [config :as config]
+                      [util :as u])
+            [metabase.models.common :as common]))
 
-;;; ## ---------------------------------------- PERMISSIONS CHECKING ----------------------------------------
+;;; permissions implementations
 
-(defprotocol ICanReadWrite
-  (can-read?  [obj] [entity ^Integer id])
-  (can-write? [obj] [entity ^Integer id]))
-
-(defn- superuser? [& _]
+(defn superuser?
+  "Is `*current-user*` is a superuser? Ignores args.
+   Intended for use as an implementation of `can-read?` and/or `can-write?`."
+  [& _]
   (:is_superuser @@(resolve 'metabase.api.common/*current-user*)))
 
-(defn- owner?
-  ([{:keys [creator_id], :as obj}]
-   (assert creator_id "Can't check user permissions: object doesn't have :creator_id.")
+(defn- creator?
+  "Did the current user create OBJ?"
+  [{:keys [creator_id], :as obj}]
+  {:pre [creator_id]}
+  (= creator_id @(resolve 'metabase.api.common/*current-user-id*)))
+
+(defn- publicly-?
+  ([perms {:keys [public_perms], :as obj}]
+   {:pre [public_perms]}
+   (or (>= public_perms perms)
+       (creator? obj)
+       (superuser?)))
+  ([perms entity id]
    (or (superuser?)
-       (= creator_id @(resolve 'metabase.api.common/*current-user-id*))))
-  ([entity id]
-   (or (superuser?)
-       (owner? (entity id)))))
+       (publicly-? perms (entity id)))))
 
-(defn- has-public-perms? [rw]
-  (let [perms (delay (require 'metabase.models.common)
-                     (case rw
-                       :r @(resolve 'metabase.models.common/perms-read)
-                       :w @(resolve 'metabase.models.common/perms-readwrite)))]
-    (fn -has-public-perms?
-      ([{:keys [public_perms], :as obj}]
-       (assert public_perms "Can't check user permissions: object doesn't have :public_perms.")
-       (or (owner? obj)
-           (>= public_perms @perms)))
-      ([entity id]
-       (or (owner? entity id)
-           (-has-public-perms? (entity id)))))))
+(def ^{:arglists '([obj] [entity id])} publicly-readable?
+  "Implementation of `can-read?` that returns `true` if `*current-user*` is a superuser, the person who created OBJ, or if OBJ has read `:public_perms`."
+  (partial publicly-? common/perms-read))
 
-(defn extend-ICanReadWrite
-  "Add standard implementations of `can-read?` and `can-write?` to KLASS."
-  [klass & {:keys [read write]}]
-  (let [key->method (fn [rw v]
-                      (case v
-                        :always       (constantly true)
-                        :public-perms (has-public-perms? rw)
-                        :owner        #'owner?
-                        :superuser    #'superuser?))]
-    (extend klass
-      ICanReadWrite {:can-read?  (key->method :r read)
-                     :can-write? (key->method :w write)})))
-
-
-;;; ## ---------------------------------------- ENTITIES ----------------------------------------
+(def ^{:arglists '([obj] [entity id])} publicly-writeable?
+  "Implementation of `can-write?` that returns `true` if `*current-user*` is a superuser, the person who created OBJ, or if OBJ has readwrite `:public_perms`."
+  (partial publicly-? common/perms-readwrite))
 
 (defprotocol IEntity
-  (pre-insert [this instance]
+  "Methods entity classes should implement; all have default implementations in `IEntityDefaults`."
+  (pre-insert [this]
     "Gets called by `ins` immediately before inserting a new object immediately before the korma `insert` call.
      This provides an opportunity to do things like encode JSON or provide default values for certain fields.
 
@@ -65,15 +48,15 @@
            (let [defaults {:version 1}]
              (merge defaults query))) ; set some default values")
 
-  (post-insert [this instance]
+  (post-insert [this]
     "Gets called by `ins` after an object is inserted into the DB. (This object is fetched via `sel`).
      A good place to do asynchronous tasks such as creating related objects.
      Implementations should return the newly created object.")
 
-  (pre-update [this instance]
+  (pre-update [this]
     "Called by `upd` before DB operations happen. A good place to set updated values for fields like `updated_at`, or serialize maps into JSON.")
 
-  (post-update [this instance]
+  (post-update [this]
     "Called by `upd` after a SQL `UPDATE` *succeeds*. (This gets called with whatever the output of `pre-update` was).
 
      A good place to schedule asynchronous tasks, such as creating a `FieldValues` object for a `Field`
@@ -81,11 +64,11 @@
 
      The output of this function is ignored.")
 
-  (post-select [this instance]
+  (post-select [this]
     "Called on the results from a call to `sel`. Default implementation doesn't do anything, but
      you can provide custom implementations to do things like add hydrateable keys or remove sensitive fields.")
 
-  (pre-cascade-delete [this instance]
+  (pre-cascade-delete [this]
     "Called by `cascade-delete` for each matching object that is about to be deleted.
      Implementations should delete any objects related to this object by recursively
      calling `cascade-delete`.
@@ -96,140 +79,207 @@
           (cascade-delete Card :database_id database-id)
           ...)")
 
-  (internal-pre-insert  [this instance])
-  (internal-pre-update  [this instance])
-  (internal-post-select [this instance]))
+  (can-read? ^Boolean [instance], ^Boolean [entity, ^Integer id]
+    "Return whether `*current-user*` has *read* permissions for an object. You should use one of these implmentations:
 
-(defn- identity-second [_ obj] obj)
-(def ^:private constantly-nil (constantly nil))
+     *  `(constantly true)` (default)
+     *  `superuser?`
+     *  `publicly-readable?`")
 
-(def ^:const ^:private default-entity-method-implementations
-  {:pre-insert         #'identity-second
-   :post-insert        #'identity-second
-   :pre-update         #'identity-second
-   :post-update        #'constantly-nil
-   :post-select        #'identity-second
-   :pre-cascade-delete #'constantly-nil})
+  (can-write? ^Boolean [instance], ^Boolean [entity, ^Integer id]
+    "Return whether `*current-user*` has *write* permissions for an object. You should use one of these implmentations:
 
-;; ## ---------------------------------------- READ-JSON ----------------------------------------
+     *  `(constantly true)`
+     *  `superuser?` (default)
+     *  `publicly-writeable?`")
 
-(defn- read-json-str-or-clob
-  "If JSON-STRING is a JDBC Clob, convert to a String. Then call `json/read-str`."
-  [json-str]
-  (some-> (u/jdbc-clob->str json-str)
-          cheshire/parse-string))
+  (default-fields ^clojure.lang.Sequential [this]
+    "Return a sequence of keyword field names that should be fetched by default when calling `sel` or invoking the entity (e.g., `(Database 1)`).")
 
-(defn- read-json
-  "Read JSON-STRING (or JDBC Clob) as JSON and keywordize keys."
-  [json-string]
-  (->> (read-json-str-or-clob json-string)
-       walk/keywordize-keys))
+  (timestamped? ^Boolean [this]
+    "Should `:created_at` and `:updated_at` be updated when calling `ins`, and `:updated_at` when calling `upd`? Default is `false`.")
 
-(defn- write-json
-  "If OBJ is not already a string, encode it as JSON."
-  [obj]
-  (if (string? obj) obj
-      (cheshire/generate-string obj)))
+  (hydration-keys ^clojure.lang.Sequential [this]
+    "Return a sequence of keyword field names that should be hydrated to this model. For example, `User` might inclide `:creator`, which means `hydrate`
+     will look for `:creator_id` in other objects and fetch the corresponding `Users`.")
 
-(def ^:const ^:private type-fns
-  {:json    {:in  #'write-json
-             :out #'read-json}
-   :keyword {:in  `name
-             :out `keyword}})
+  (types ^clojure.lang.IPersistentMap [this]
+    "Return a map of keyword field names to their types for fields that should be serialized/deserialized in a special way. Valid types are either `:json` or `:keyword`.
 
-(defmacro apply-type-fns [obj-binding direction entity-map]
-  {:pre [(symbol? obj-binding)
-         (keyword? direction)
-         (map? entity-map)]}
-  (let [fns (m/map-vals #(direction (type-fns %)) (::types entity-map))]
-    (if-not (seq fns) obj-binding
-            `(cond-> ~obj-binding
-               ~@(mapcat (fn [[k f]]
-                           [`(~k ~obj-binding) `(update-in [~k] ~f)])
-                         fns)))))
+     *  `:json` serializes objects as JSON strings before going into the DB, and parses JSON strings when coming out
+     *  `:keyword` calls `name` before going into the DB, and `keyword` when coming out
 
-(defn -invoke-entity
-  "Basically the same as `(sel :one Entity :id id)`." ; TODO - deduplicate with sel
-  [entity id]
-  (when id
-    (when (metabase.config/config-bool :mb-db-logging)
-      (when-not @(resolve 'metabase.db/*sel-disable-logging*)
-        (clojure.tools.logging/debug
-         "DB CALL: " (:name entity) id)))
-    (let [[obj] (k/select (assoc entity :fields (::default-fields entity))
-                          (k/where {:id id})
-                          (k/limit 1))]
-      (some->> obj
-               (internal-post-select entity)
-               (post-select entity)))))
+       (types [_] {:cards :json}) ; encode `:cards` as JSON when stored in the DB"))
 
-(defn- update-updated-at [obj]
-  (assoc obj :updated_at (u/new-sql-timestamp)))
 
-(defn- update-created-at-updated-at [obj]
-  (let [ts (u/new-sql-timestamp)]
-    (assoc obj :created_at ts, :updated_at ts)))
+(defprotocol ICreateFromMap
+  "Used by internal functions like `do-post-select`."
+  (^:private map-> [klass, ^clojure.lang.IPersistentMap m]
+   "Convert map M to instance of record type KLASS."))
 
-(defmacro macrolet-entity-map [entity & entity-forms]
-  `(macrolet [(~'default-fields [m# & fields#]       `(assoc ~m# ::default-fields [~@(map keyword fields#)]))
-              (~'timestamped    [m#]                 `(assoc ~m# ::timestamped true))
-              (~'types          [m# & {:as fields#}] `(assoc ~m# ::types ~fields#))
-              (~'hydration-keys [m# & fields#]       `(assoc ~m# ::hydration-keys #{~@(map keyword fields#)}))]
-     (-> (k/create-entity ~(name entity))
-         ~@entity-forms)))
+(def ^:private type-fns
+  "The functions that should be invoked for corresponding `types` when an object comes `:in` or `:out` of the DB."
+  {:json    {:in  (fn [obj]
+                    (if (string? obj)
+                      obj
+                      (json/generate-string obj)))
+             :out (fn [obj]
+                    (let [s (u/jdbc-clob->str obj)]
+                      (if (string? s)
+                        (json/parse-string s keyword)
+                        obj)))}
+   :keyword {:in  name
+             :out keyword}})
+
+(defn- apply-type-fns
+  "Apply the appropriate `type-fns` for OBJ."
+  [obj direction]
+  (into obj (for [[col type] (types obj)]
+              (when-let [v (get obj col)]
+                {col ((get-in type-fns [type direction]) v)}))))
+
+(defn- maybe-update-timestamps
+  "If OBJ is `timestamped?`, update each key in KS with a `new-sql-timestamp`."
+  [obj & ks]
+  (if-not (timestamped? obj)
+    obj
+    (let [ts (u/new-sql-timestamp)]
+      (into obj (for [k ks]
+                  {k ts})))))
+
+;; these functions call (map-> entity ...) twice to make sure functions like pre-insert/post-select didn't do something that accidentally removed the typing
+
+(defn do-pre-insert
+  "Don't call this directly! Apply functions like `pre-insert` before inserting an object into the DB."
+  [entity obj]
+  (as-> obj <>
+    (map-> entity <>)
+    (pre-insert <>)
+    (map-> entity <>)
+    (apply-type-fns <> :in)
+    (maybe-update-timestamps <> :created_at :updated_at)))
+
+(defn do-pre-update
+  "Don't call this directly! Apply internal functions like `pre-update` before updating an object in the DB."
+  [entity obj]
+  (as-> obj <>
+    (map-> entity <>)
+    (pre-update <>)
+    (map-> entity <>)
+    (apply-type-fns <> :in)
+    (maybe-update-timestamps <> :updated_at)))
+
+(defn do-post-select
+  "Don't call this directly! Apply internal functions like `post-select` when an object is retrieved from the DB."
+  [entity obj]
+  (as-> obj <>
+    (map-> entity <>)
+    (apply-type-fns <> :out)
+    (post-select <>)
+    (map-> entity <>)))
+
+
+(def IEntityDefaults
+  "Default implementations for `IEntity` methods."
+  {:default-fields       (constantly nil)
+   :timestamped?         (constantly false)
+   :hydration-keys       (constantly nil)
+   :types                (constantly nil)
+   :can-read?            (constantly true)
+   :can-write?           superuser?
+   :pre-insert           identity
+   :post-insert          identity
+   :pre-update           identity
+   :post-update          (constantly nil)
+   :post-select          identity
+   :pre-cascade-delete   (constantly nil)})
+
+(defn- invoke-entity
+  "Fetch an object with a specific ID or all objects of type ENTITY from the DB.
+
+     (invoke-entity Database)   -> seq of all databases
+     (invoke-entity Database 1) -> Database w/ ID 1"
+  ([entity]
+   (for [obj (k/select (assoc entity :fields (default-fields entity)))]
+     (do-post-select entity obj)))
+  ([entity id]
+   (when id
+     (when (and id
+                (config/config-bool :mb-db-logging)
+                (not @(resolve 'metabase.db/*sel-disable-logging*)))
+       (log/debug "DB CALL: " (:name entity) id))
+     (when-let [[obj] (seq (k/select (assoc entity :fields (default-fields entity))
+                                     (k/where {:id id})
+                                     (k/limit 1)))]
+       (do-post-select entity obj)))))
+
+(def ^:const ^{:arglists '([entity])} ^Boolean metabase-entity?
+  "Is ENTITY a valid metabase model entity?"
+  ::entity)
+
+;; We use the same record type (e.g., `DatabaseInstance`) for both the "entity" (e.g., `Database`) and objects fetched from the DB ("instances").
+;; entities have the key `::entity` assoced so we can differentiate.
+;; invoking an instance calls get so you can do things like `(db :name)` as if it were a regular map.
+(defn invoke-entity-or-instance
+  "Check whether OBJ is an entity (e.g. `Database`) or an object from the DB; if an entity, call `invoked-entity`; otherwise call `get`."
+  [obj & args]
+  (apply (if (metabase-entity? obj)
+           invoke-entity
+           get)
+         obj args))
+
 
 (defmacro defentity
-  "Similar to korma `defentity`, but creates a new record type where you can specify protocol implementations."
-  [entity entity-forms & methods+specs]
-  {:pre [(vector? entity-forms)]}
-  (let [entity-symb               (symbol (format "%sEntity" (name entity)))
-        internal-post-select-symb (symbol (format "internal-post-select-%s" (name entity)))
-        unevaled-entity-map       (macroexpand-all `(macrolet-entity-map ~entity ~@entity-forms))
-        entity-map                (eval unevaled-entity-map)
-        [methods specs]           (split-with list? methods+specs)]
+  "Define a new \"entity\". Entities encapsulate information and behaviors related to a specific table in the Metabase DB,
+   and have their own unique record type.
+
+   `defentity` defines a backing record type following the format `<entity>Instance`. For example, the class associated with
+   `User` is `metabase.models.user/UserInstance`. This class is used for both the titular korma entity (e.g. `User`) and
+   for objects that are fetched from the DB. This means they can share the `IEntity` protocol and simplifies the interface
+   somewhat; functions like `types` work on either the entity or instances fetched from the DB.
+
+     (defentity User :metabase_user)  ; creates class `UserInstance` and korma entity `User`
+
+     (metabase.db/sel :one User, ...) ; use with `metabase.db` functions. All results are instances of `UserInstance`
+     (korma.core/select User ...)     ; use with korma functions. Results will be regular maps
+
+   The record type automatically extends `IEntity` with `IEntityDefaults`, but you may call `extend` again if you need to
+   override default behaviors:
+
+     (extend (class User)             ; it's somewhat more readable to write `(class User)` instead `UserInstance`
+       IEntity (merge IEntityDefaults
+                      {...}))
+
+   Finally, the entity itself is invokable. Calling with no args returns *all* values of that object; calling with a single
+   arg can be used to fetch a specific instance by its integer ID.
+
+     (Database)                       ; return a seq of *all* Databases (as instances of `DatabaseInstance`)
+     (Database 1)                     ; return Database 1"
+  {:arglist      '([entity table-name] [entity docstr? table-name & korma-forms])
+   :style/indent 1}
+  [entity & args]
+  (let [[docstr [table-name & korma-forms]] (u/optional string? args)
+        instance                            (symbol (str entity "Instance"))
+        map->instance                       (symbol (str "map->" instance))]
     `(do
-       (defrecord ~entity-symb []
+       (defrecord ~instance []
          clojure.lang.IFn
-         (~'invoke [~'this ~'id]
-           (-invoke-entity ~'this ~'id))
+         (~'invoke [this#]     (invoke-entity-or-instance this#))
+         (~'invoke [this# id#] (invoke-entity-or-instance this# id#)))
 
-         ~@specs)
+       (extend ~instance
+         IEntity        IEntityDefaults
+         ICreateFromMap {:map-> (u/drop-first-arg ~map->instance)})
 
-       (extend ~entity-symb
-         IEntity ~(merge default-entity-method-implementations
-                         {:internal-pre-insert  `(fn [~'_ obj#]
-                                                   (-> obj#
-                                                       (apply-type-fns :in ~entity-map)
-                                                       ~@(when (::timestamped entity-map)
-                                                           [update-created-at-updated-at])))
-                          :internal-pre-update  `(fn [~'_ obj#]
-                                                   (-> obj#
-                                                       (apply-type-fns :in ~entity-map)
-                                                       ~@(when (::timestamped entity-map)
-                                                           [update-updated-at])))
-                          :internal-post-select `(fn [~'_ obj#]
-                                                   (apply-type-fns obj# :out ~entity-map))}
-                         (into {}
-                               (for [[method-name & impl] methods]
-                                 {(keyword method-name) `(fn ~@impl)}))))
-       (def ~entity
-         (~(symbol (format "map->%sEntity" (name entity))) (assoc ~unevaled-entity-map ::entity true))))))
+       (def ~(vary-meta entity assoc
+                        :tag      (symbol (str (namespace-munge *ns*) \. instance))
+                        :arglists ''([] [id])
+                        :doc      (or docstr
+                                      (format "Korma entity for '%s' table; instance of %s." (name table-name) instance)))
+         (-> (k/create-entity ~(name entity))
+             (k/table ~table-name)
+             ~@korma-forms
+             (assoc ::entity true)
+             ~map->instance)))))
 
-(defn metabase-entity?
-  "Is ENTITY a valid metabase model entity?"
-  [entity]
-  (::entity entity))
-
-
-;;; # ---------------------------------------- INSTANCE ----------------------------------------
-
-(defprotocol IModelInstanceApiSerialize
-  (api-serialize [this]
-    "Called on all objects being written out by the API. Default implementations return THIS as-is, but models can provide
-     custom methods to strip sensitive data, from non-admins, etc."))
-
-(extend Object
-  IModelInstanceApiSerialize {:api-serialize identity})
-
-(extend nil
-  IModelInstanceApiSerialize {:api-serialize identity})
+(u/require-dox-in-this-namespace)

--- a/src/metabase/models/pulse_card.clj
+++ b/src/metabase/models/pulse_card.clj
@@ -1,6 +1,4 @@
 (ns metabase.models.pulse-card
-  (:require [korma.core :as k]
-            [metabase.models.interface :refer :all]))
+  (:require [metabase.models.interface :as i]))
 
-(defentity PulseCard
-  [(k/table :pulse_card)])
+(i/defentity PulseCard :pulse_card)

--- a/src/metabase/models/pulse_channel_recipient.clj
+++ b/src/metabase/models/pulse_channel_recipient.clj
@@ -1,6 +1,4 @@
 (ns metabase.models.pulse-channel-recipient
-  (:require [korma.core :as k]
-            [metabase.models.interface :refer :all]))
+  (:require [metabase.models.interface :as i]))
 
-(defentity PulseChannelRecipient
-  [(k/table :pulse_channel_recipient)])
+(i/defentity PulseChannelRecipient :pulse_channel_recipient)

--- a/src/metabase/models/query_execution.clj
+++ b/src/metabase/models/query_execution.clj
@@ -1,18 +1,17 @@
 (ns metabase.models.query-execution
-  (:require [korma.core :refer :all, :exclude [defentity update]]
-            [metabase.api.common :refer [check]]
-            [metabase.db :refer :all]
-            (metabase.models [common :refer :all]
-                             [database :refer [Database]]
-                             [interface :refer :all])))
+  (:require [metabase.models.interface :as i]))
 
 
-(defentity QueryExecution
-  [(table :query_queryexecution)
-   (default-fields id uuid version json_query raw_query status started_at finished_at running_time error result_rows)
-   (types :json_query :json, :result_data :json, :status :keyword)]
+(i/defentity QueryExecution :query_queryexecution)
 
-  (post-select [_ {:keys [result_rows] :as query-execution}]
-    ;; sadly we have 2 ways to reference the row count :(
-    (assoc query-execution
-           :row_count (or result_rows 0))))
+(defn- post-select [{:keys [result_rows] :as query-execution}]
+  ;; sadly we have 2 ways to reference the row count :(
+  (assoc query-execution
+         :row_count (or result_rows 0)))
+
+(extend (class QueryExecution)
+  i/IEntity
+  (merge i/IEntityDefaults
+         {:default-fields (constantly [:id :uuid :version :json_query :raw_query :status :started_at :finished_at :running_time :error :result_rows])
+          :types          (constantly {:json_query :json, :result_data :json, :status :keyword})
+          :post-select    post-select}))

--- a/src/metabase/models/session.clj
+++ b/src/metabase/models/session.clj
@@ -1,18 +1,19 @@
 (ns metabase.models.session
   (:require [korma.core :as k]
-            (metabase.models [common :refer :all]
-                             [interface :refer :all]
+            (metabase.models [interface :as i]
                              [user :refer [User]])
             [metabase.util :as u]))
 
-(defentity Session
-  [(k/table :core_session)
-   (k/belongs-to User {:fk :user_id})]
+(i/defentity Session :core_session
+  (k/belongs-to User {:fk :user_id}))
 
-  (pre-insert [_ session]
-    (let [defaults {:created_at (u/new-sql-timestamp)}]
-      (merge defaults session))))
+(defn- pre-insert [session]
+  (assoc session :created_at (u/new-sql-timestamp)))
 
+(extend (class Session)
+  i/IEntity
+  (merge i/IEntityDefaults
+         {:pre-insert pre-insert}))
 
 ;; Persistence Functions
 
@@ -27,3 +28,6 @@
         (k/limit 1))
       first
       :id))
+
+
+(u/require-dox-in-this-namespace)

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -6,7 +6,7 @@
             [metabase.config :as config]
             [metabase.db :refer [sel del]]
             [metabase.models [common :as common]
-                             [interface :refer :all]]
+                             [interface :as i]]
             [metabase.setup :as setup]
             [metabase.util :as u]
             [metabase.util.password :as password])
@@ -232,9 +232,9 @@
   "Map of setting name (keyword) -> string value, as they exist in the DB."
   (atom nil))
 
-(defentity ^{:doc "The model that underlies `defsetting`."}
-  Setting
-  [(k/table :setting)])
+(i/defentity Setting
+  "The model that underlies `defsetting`."
+  :setting)
 
 (defn- settings-list
   "Return a list of all Settings (as created with `defsetting`).
@@ -254,5 +254,6 @@
                                                              (s/replace "-" "_")
                                                              s/upper-case)))
                                 default)}))))
+
 
 (u/require-dox-in-this-namespace)

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -1,11 +1,11 @@
 (ns metabase.models.table
-  (:require [korma.core :refer :all, :exclude [defentity update]]
-            [metabase.db :refer :all]
+  (:require [korma.core :as k]
+            [metabase.db :refer [cascade-delete sel]]
             (metabase.models [common :as common]
                              [database :as db]
                              [field :refer [Field]]
                              [field-values :refer [FieldValues]]
-                             [interface :refer :all])
+                             [interface :as i])
             [metabase.util :as u]))
 
 (def ^:const entity-types
@@ -13,43 +13,42 @@
   #{:person :event :photo :place})
 
 (def ^:const visibility-types
-"Valid values for `Table.visibility_type` (field may also be `nil`)."
-#{:hidden :technical :cruft})
+  "Valid values for `Table.visibility_type` (field may also be `nil`)."
+  #{:hidden :technical :cruft})
 
-(defrecord TableInstance []
-  clojure.lang.IFn
-  (invoke [this k]
-    (get this k)))
 
-(extend-ICanReadWrite TableInstance :read :always, :write :superuser)
+(i/defentity Table :metabase_table)
 
-(defentity Table
-  [(table :metabase_table)
-   (hydration-keys table)
-   (types :entity_type :keyword, :visibility_type :keyword)
-   timestamped]
+(defn- post-select [{:keys [id db db_id description] :as table}]
+  (u/assoc<> table
+    :db           (or db (delay (sel :one db/Database :id db_id)))
+    :fields       (delay (sel :many Field :table_id id :active true (k/order :position :ASC) (k/order :name :ASC)))
+    :field_values (delay
+                   (let [field-ids (sel :many :field [Field :id]
+                                        :table_id id
+                                        :active true
+                                        :field_type [not= "sensitive"]
+                                        (k/order :position :asc)
+                                        (k/order :name :asc))]
+                     (sel :many :field->field [FieldValues :field_id :values] :field_id [in field-ids])))
+    :description  (u/jdbc-clob->str description)
+    :pk_field     (delay (sel :one :id Field :table_id id (k/where {:special_type "id"})))))
 
-  (post-select [_ {:keys [id db db_id description] :as table}]
-    (map->TableInstance
-     (assoc table
-       :db                  (or db (delay (sel :one db/Database :id db_id)))
-       :fields              (delay (sel :many Field :table_id id :active true (order :position :ASC) (order :name :ASC)))
-       :field_values        (delay
-                             (let [field-ids (sel :many :field [Field :id]
-                                                  :table_id id
-                                                  :active true
-                                                  :field_type [not= "sensitive"]
-                                                  (order :position :asc)
-                                                  (order :name :asc))]
-                               (sel :many :field->field [FieldValues :field_id :values] :field_id [in field-ids])))
-       :description         (u/jdbc-clob->str description)
-       :pk_field            (delay (:id (sel :one :fields [Field :id] :table_id id (where {:special_type "id"})))))))
+(defn- pre-insert [table]
+  (let [defaults {:display_name (common/name->human-readable-name (:name table))}]
+    (merge defaults table)))
 
-  (pre-insert [_ table]
-    (let [defaults {:display_name (common/name->human-readable-name (:name table))}]
-      (merge defaults table)))
+(defn- pre-cascade-delete [{:keys [id] :as table}]
+  (cascade-delete Field :table_id id))
 
-  (pre-cascade-delete [_ {:keys [id] :as table}]
-    (cascade-delete Field :table_id id)))
+(extend (class Table)
+  i/IEntity (merge i/IEntityDefaults
+                   {:hydration-keys     (constantly [:table])
+                    :types              (constantly {:entity_type :keyword, :visibility_type :keyword})
+                    :timestamped?       (constantly true)
+                    :post-select        post-select
+                    :pre-insert         pre-insert
+                    :pre-cascade-delete pre-cascade-delete}))
 
-(extend-ICanReadWrite TableEntity :read :always, :write :superuser)
+
+(u/require-dox-in-this-namespace)

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -1,57 +1,64 @@
 (ns metabase.models.user
   (:require [clojure.string :as s]
             [cemerick.friend.credentials :as creds]
-            [korma.core :refer :all, :exclude [defentity update]]
-            [metabase.db :refer :all]
+            [korma.core :as k]
+            [metabase.db :refer [cascade-delete ins upd]]
             [metabase.email.messages :as email]
-            (metabase.models [interface :refer :all]
+            (metabase.models [interface :as i]
                              [setting :as setting])
             [metabase.util :as u]))
 
 ;; ## Enity + DB Multimethods
 
-(defentity User
-  [(table :core_user)
-   (default-fields id email date_joined first_name last_name last_login is_superuser)
-   (hydration-keys author creator user)]
+(i/defentity User :core_user)
 
-  (pre-insert [_ {:keys [email password reset_token] :as user}]
-    (assert (u/is-email? email))
-    (assert (and (string? password)
-                 (not (s/blank? password))))
-    (assert (not (:password_salt user))
-      "Don't try to pass an encrypted password to (ins User). Password encryption is handled by pre-insert.")
-    (let [salt     (.toString (java.util.UUID/randomUUID))
-          defaults {:date_joined  (u/new-sql-timestamp)
-                    :last_login   nil
-                    :is_staff     true
-                    :is_active    true
-                    :is_superuser false}]
-      ;; always salt + encrypt the password before putting new User in the DB
-      ;; TODO - we should do password encryption in pre-update too instead of in the session code
-      (merge defaults user
-             {:password_salt salt
-              :password      (creds/hash-bcrypt (str salt password))}
-             (when reset_token
-               {:reset_token (creds/hash-bcrypt reset_token)}))))
+(defn- pre-insert [{:keys [email password reset_token] :as user}]
+  (assert (u/is-email? email))
+  (assert (and (string? password)
+               (not (s/blank? password))))
+  (assert (not (:password_salt user))
+    "Don't try to pass an encrypted password to (ins User). Password encryption is handled by pre-insert.")
+  (let [salt     (.toString (java.util.UUID/randomUUID))
+        defaults {:date_joined  (u/new-sql-timestamp)
+                  :last_login   nil
+                  :is_staff     true
+                  :is_active    true
+                  :is_superuser false}]
+    ;; always salt + encrypt the password before putting new User in the DB
+    ;; TODO - we should do password encryption in pre-update too instead of in the session code
+    (merge defaults user
+           {:password_salt salt
+            :password      (creds/hash-bcrypt (str salt password))}
+           (when reset_token
+             {:reset_token (creds/hash-bcrypt reset_token)}))))
 
-  (pre-update [_ {:keys [email reset_token] :as user}]
-    (when email
-      (assert (u/is-email? email)))
-    (cond-> user
-      reset_token (assoc :reset_token (creds/hash-bcrypt reset_token))))
+(defn- pre-update [{:keys [email reset_token] :as user}]
+  (when email
+    (assert (u/is-email? email)))
+  (cond-> user
+    reset_token (assoc :reset_token (creds/hash-bcrypt reset_token))))
 
-  (post-select [_ {:keys [first_name last_name], :as user}]
-    (cond-> user
-      (or first_name last_name) (assoc :common_name (str first_name " " last_name))))
+(defn- post-select [{:keys [first_name last_name], :as user}]
+  (cond-> user
+    (or first_name last_name) (assoc :common_name (str first_name " " last_name))))
 
-  (pre-cascade-delete [_ {:keys [id]}]
-    (cascade-delete 'Session :user_id id)
-    (cascade-delete 'Dashboard :creator_id id)
-    (cascade-delete 'Card :creator_id id)
-    (cascade-delete 'Pulse :creator_id id)
-    (cascade-delete 'Activity :user_id id)
-    (cascade-delete 'ViewLog :user_id id)))
+(defn- pre-cascade-delete [{:keys [id]}]
+  (cascade-delete 'Session :user_id id)
+  (cascade-delete 'Dashboard :creator_id id)
+  (cascade-delete 'Card :creator_id id)
+  (cascade-delete 'Pulse :creator_id id)
+  (cascade-delete 'Activity :user_id id)
+  (cascade-delete 'ViewLog :user_id id))
+
+(extend (class User)
+  i/IEntity
+  (merge i/IEntityDefaults
+         {:default-fields     (constantly [:id :email :date_joined :first_name :last_name :last_login :is_superuser])
+          :hydration-keys     (constantly [:author :creator :user])
+          :pre-insert         pre-insert
+          :pre-update         pre-update
+          :post-select        post-select
+          :pre-cascade-delete pre-cascade-delete}))
 
 
 ;; ## Related Functions
@@ -109,3 +116,6 @@
   [reset-token]
   {:pre [(string? reset-token)]}
   (str (setting/get :-site-url) "/auth/reset_password/" reset-token))
+
+
+(u/require-dox-in-this-namespace)

--- a/src/metabase/models/view_log.clj
+++ b/src/metabase/models/view_log.clj
@@ -1,28 +1,19 @@
 (ns metabase.models.view-log
-  (:require [korma.core :refer :all, :exclude [defentity update]]
-            [metabase.api.common :refer [*current-user-id*]]
-            [metabase.db :refer :all]
-            [metabase.events :as events]
-            (metabase.models [card :refer [Card]]
-                             [dashboard :refer [Dashboard]]
-                             [interface :refer :all]
-                             [user :refer [User]])
+  (:require [metabase.models.interface :as i]
             [metabase.util :as u]))
 
 
-(defrecord ViewLogItemInstance []
-  clojure.lang.IFn
-  (invoke [this k]
-    (get this k)))
+(i/defentity ViewLog :view_log)
 
-(extend-ICanReadWrite ViewLogItemInstance :read :public-perms, :write :public-perms)
+(defn- pre-insert [log-entry]
+  (let [defaults {:timestamp (u/new-sql-timestamp)}]
+    (merge defaults log-entry)))
+
+(extend (class ViewLog)
+  i/IEntity (merge i/IEntityDefaults
+                   {:can-read?  i/publicly-readable?
+                    :can-write? i/publicly-writeable?
+                    :pre-insert pre-insert}))
 
 
-(defentity ViewLog
-           [(table :view_log)]
-
-           (pre-insert [_ log-entry]
-                       (let [defaults {:timestamp (u/new-sql-timestamp)}]
-                         (merge defaults log-entry))))
-
-(extend-ICanReadWrite ViewLogEntity :read :public-perms, :write :public-perms)
+(u/require-dox-in-this-namespace)

--- a/test/metabase/api/revision_test.clj
+++ b/test/metabase/api/revision_test.clj
@@ -29,8 +29,7 @@
       :display                "table"
       :dataset_query          {:database (id)
                                :type     "query"
-                               :query    {:aggregation ["rows"]
-                                          :source_table (id :categories)}}
+                               :query    {:source_table (id :categories)}}
       :visualization_settings {}
       :creator_id             (user->id :rasta))))
 

--- a/test/metabase/models/hydrate_test.clj
+++ b/test/metabase/models/hydrate_test.clj
@@ -434,6 +434,8 @@
 
 ;;; ## BATCHED HYDRATION TESTS
 
+(resolve-private-fns metabase.middleware remove-fns-and-delays)
+
 ;; Just double-check that batched hydration can hydrate fields with no delays
 (expect (match-$ (fetch-user :rasta)
           {:email "rasta@metabase.com"
@@ -446,7 +448,7 @@
            :common_name "Rasta Toucan"})
   (->> (hydrate {:user_id (user->id :rasta)} :user)
        :user
-       (m/filter-vals #(not (or (fn? %) (delay? %))))))
+       remove-fns-and-delays))
 
 ;; Check that batched hydration doesn't try to hydrate fields that already exist and are not delays
 (expect {:user_id (user->id :rasta)

--- a/test/metabase/models/revision_test.clj
+++ b/test/metabase/models/revision_test.clj
@@ -29,10 +29,9 @@
 (def ^:private reverted-to
   (atom nil))
 
-(defentity ^:private FakedCard
-  [(table :report_card)])
+(defentity ^:private FakedCard :report_card)
 
-(extend-type FakedCardEntity
+(extend-type (class FakedCard)
   IRevisioned
   (serialize-instance [_ _ obj]
     (assoc obj :serialized true))
@@ -53,27 +52,30 @@
     (revisions FakedCard card-id)))
 
 ;; Test that we can add a revision
-(expect [{:model        "FakedCard"
-          :user_id      (user->id :rasta)
-          :object       {:name "Tips Created by Day", :serialized true}
-          :is_reversion false
-          :is_creation  false}]
+(expect [(map->RevisionInstance
+          {:model        "FakedCard"
+           :user_id      (user->id :rasta)
+           :object       {:name "Tips Created by Day", :serialized true}
+           :is_reversion false
+           :is_creation  false})]
   (with-fake-card [{card-id :id}]
     (push-fake-revision card-id, :name "Tips Created by Day")
     (->> (revisions FakedCard card-id)
          (map (u/rpartial dissoc :timestamp :id :model_id)))))
 
 ;; Test that revisions are sorted in reverse chronological order
-(expect [{:model        "FakedCard"
-          :user_id      (user->id :rasta)
-          :object       {:name "Spots Created by Day", :serialized true}
-          :is_reversion false
-          :is_creation  false}
-         {:model        "FakedCard"
-          :user_id      (user->id :rasta)
-          :object       {:name "Tips Created by Day", :serialized true}
-          :is_reversion false
-          :is_creation  false}]
+(expect [(map->RevisionInstance
+          {:model        "FakedCard"
+           :user_id      (user->id :rasta)
+           :object       {:name "Spots Created by Day", :serialized true}
+           :is_reversion false
+           :is_creation  false})
+         (map->RevisionInstance
+          {:model        "FakedCard"
+           :user_id      (user->id :rasta)
+           :object       {:name "Tips Created by Day", :serialized true}
+           :is_reversion false
+           :is_creation  false})]
   (with-fake-card [{card-id :id}]
     (push-fake-revision card-id, :name "Tips Created by Day")
     (push-fake-revision card-id, :name "Spots Created by Day")
@@ -91,24 +93,27 @@
 ;;; # REVISIONS+DETAILS
 
 ;; Check that revisions+details pulls in user info and adds description
-(expect [{:is_reversion false,
-          :is_creation  false,
-          :user         {:id (user->id :rasta), :common_name "Rasta Toucan", :first_name "Rasta", :last_name "Toucan"},
-          :description  "First revision."}]
+(expect [(map->RevisionInstance
+          {:is_reversion false,
+           :is_creation  false,
+           :user         {:id (user->id :rasta), :common_name "Rasta Toucan", :first_name "Rasta", :last_name "Toucan"},
+           :description  "First revision."})]
   (with-fake-card [{card-id :id}]
     (push-fake-revision card-id, :name "Tips Created by Day")
     (->> (revisions+details FakedCard card-id)
          (map (u/rpartial dissoc :timestamp :id :model_id)))))
 
 ;; Check that revisions properly defer to describe-diff
-(expect [{:is_reversion false,
-          :is_creation  false,
-          :user         {:id (user->id :rasta), :common_name "Rasta Toucan", :first_name "Rasta", :last_name "Toucan"},
-          :description  "BEFORE={:name \"Tips Created by Day\", :serialized true},AFTER={:name \"Spots Created by Day\", :serialized true}"}
-         {:is_reversion false,
-          :is_creation  false,
-          :user         {:id (user->id :rasta), :common_name "Rasta Toucan", :first_name "Rasta", :last_name "Toucan"},
-          :description  "First revision."}]
+(expect [(map->RevisionInstance
+          {:is_reversion false,
+           :is_creation  false,
+           :user         {:id (user->id :rasta), :common_name "Rasta Toucan", :first_name "Rasta", :last_name "Toucan"},
+           :description  "BEFORE={:name \"Tips Created by Day\", :serialized true},AFTER={:name \"Spots Created by Day\", :serialized true}"})
+         (map->RevisionInstance
+          {:is_reversion false,
+           :is_creation  false,
+           :user         {:id (user->id :rasta), :common_name "Rasta Toucan", :first_name "Rasta", :last_name "Toucan"},
+           :description  "First revision."})]
   (with-fake-card [{card-id :id}]
     (push-fake-revision card-id, :name "Tips Created by Day")
     (push-fake-revision card-id, :name "Spots Created by Day")
@@ -137,21 +142,24 @@
        (:name (Card card-id)))]))
 
 ;; Check that reverting to a previous revision adds an appropriate revision
-(expect [{:model        "FakedCard"
-          :user_id      (user->id :rasta)
-          :object       {:name "Tips Created by Day", :serialized true}
-          :is_reversion true
-          :is_creation  false}
-         {:model        "FakedCard",
-          :user_id      (user->id :rasta)
-          :object       {:name "Spots Created by Day", :serialized true}
-          :is_reversion false
-          :is_creation  false}
-         {:model        "FakedCard",
-          :user_id      (user->id :rasta)
-          :object       {:name "Tips Created by Day", :serialized true}
-          :is_reversion false
-          :is_creation  false}]
+(expect [(map->RevisionInstance
+          {:model        "FakedCard"
+           :user_id      (user->id :rasta)
+           :object       {:name "Tips Created by Day", :serialized true}
+           :is_reversion true
+           :is_creation  false})
+         (map->RevisionInstance
+          {:model        "FakedCard",
+           :user_id      (user->id :rasta)
+           :object       {:name "Spots Created by Day", :serialized true}
+           :is_reversion false
+           :is_creation  false})
+         (map->RevisionInstance
+          {:model        "FakedCard",
+           :user_id      (user->id :rasta)
+           :object       {:name "Tips Created by Day", :serialized true}
+           :is_reversion false
+           :is_creation  false})]
   (with-fake-card [{card-id :id}]
     (push-fake-revision card-id, :name "Tips Created by Day")
     (push-fake-revision card-id, :name "Spots Created by Day")

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -14,32 +14,30 @@
 ;;
 ;; These users have permissions for the Test. They are lazily created as needed.
 ;; Three test users are defined:
-;; *  rasta     - an admin
-;; *  crowberto - an admin + superuser
+;; *  rasta
+;; *  crowberto - superuser
 ;; *  lucky
-;; *  trashbird
+;; *  trashbird - inactive
 
-(def ^:private user->info
-  {:rasta {:email "rasta@metabase.com"
-           :first "Rasta"
-           :last "Toucan"
-           :password "blueberries"
-           :admin true}
-   :crowberto {:email "crowberto@metabase.com"
-               :first "Crowberto"
-               :last "Corv"
-               :password "blackjet"
-               :admin true
+(def ^:private ^:const user->info
+  {:rasta     {:email    "rasta@metabase.com"
+               :first    "Rasta"
+               :last     "Toucan"
+               :password "blueberries"}
+   :crowberto {:email     "crowberto@metabase.com"
+               :first     "Crowberto"
+               :last      "Corv"
+               :password  "blackjet"
                :superuser true}
-   :lucky {:email "lucky@metabase.com"
-           :first "Lucky"
-           :last "Pigeon"
-           :password "almonds"}
-   :trashbird {:email "trashbird@metabase.com"
-               :first "Trash"
-               :last "Bird"
+   :lucky     {:email    "lucky@metabase.com"
+               :first    "Lucky"
+               :last     "Pigeon"
+               :password "almonds"}
+   :trashbird {:email    "trashbird@metabase.com"
+               :first    "Trash"
+               :last     "Bird"
                :password "birdseed"
-               :active false}})
+               :active   false}})
 
 (def ^:private usernames
   (set (keys user->info)))
@@ -123,22 +121,19 @@
 
 (defn- fetch-or-create-user
   "Create User if they don't already exist and return User."
-  [& {:keys [email first last password admin superuser active]
-      :or {admin false
-           superuser false
-           active true}}]
+  [& {:keys [email first last password superuser active]
+      :or {superuser false
+           active    true}}]
   {:pre [(string? email)
          (string? first)
          (string? last)
          (string? password)
-         (m/boolean? admin)
          (m/boolean? superuser)]}
   (or (sel :one User :email email)
-      (let [user (ins User
-                   :email email
-                   :first_name first
-                   :last_name last
-                   :password password
-                   :is_superuser superuser
-                   :is_active active)]
-        user)))
+      (ins User
+        :email        email
+        :first_name   first
+        :last_name    last
+        :password     password
+        :is_superuser superuser
+        :is_active    active)))

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -45,7 +45,6 @@
     :b (+ 100 (:a <>))
     :c (+ 100 (:b <>))))
 
-
 ;;; ## tests for HOST-UP?
 
 (expect true


### PR DESCRIPTION
The old `metabase.models/defentity` macro was too magical/opaque for my liking; it was difficult to understand or do anything useful with, and had 3 or 4 associated protocols, which is 2 or 3 more than it needed. It generated a separate record type for each model's korma entity (e.g. `Database`, a singleton instance of `DatabaseEntity`); in several cases, we had to define an additional record type for instances of that model (e.g., `DatabaseInstance`) and add additional boilerplate to coerce objects coming back from the DB in order to do useful type-based dispatch.

I replaced it with much simpler macro which defines a single record type used for both the entity and instances of that model, and a single protocol with a map of default implementations, much like our drivers.

This simplifies a lot of code in several places in the project and is a big win for readability and flexibility IMO. :+1: 

Resolves #834
