### PR TITLE
Use functions for hydration instead of delays :disappointed_relieved:

### DIFF
--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -74,7 +74,7 @@
   {cardId [Required Integer]}
   (write-check Dashboard id)
   (check-400 (exists? Card :id cardId))
-  (let [result (ins DashboardCard :card_id cardId :dashboard_id id)]
+  (let [result (ins DashboardCard :card_id cardId, :dashboard_id id)]
     (events/publish-event :dashboard-add-cards {:id id :actor_id *current-user-id* :dashcards [result]})
     result))
 

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -1,7 +1,6 @@
 (ns metabase.api.user
   (:require [cemerick.friend.credentials :as creds]
             [compojure.core :refer [defroutes GET DELETE POST PUT]]
-            [medley.core :refer [mapply]]
             [metabase.api.common :refer :all]
             [metabase.db :refer [sel upd upd-non-nil-keys exists?]]
             [metabase.email.messages :as email]

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -57,7 +57,6 @@
   (-> routes/routes
       (mb-middleware/log-api-call :request :response)
       mb-middleware/add-security-headers              ; [METABASE] Add HTTP headers to API responses to prevent them from being cached
-      mb-middleware/format-response                   ; [METABASE] Do formatting before converting to JSON so serializer doesn't barf
       (wrap-json-body                                 ; extracts json POST body and makes it avaliable on request
         {:keywords? true})
       wrap-json-response                              ; middleware to automatically serialize suitable objects as JSON in responses

--- a/src/metabase/db/metadata_queries.clj
+++ b/src/metabase/db/metadata_queries.clj
@@ -2,7 +2,7 @@
   "Predefined QP queries for getting metadata about an external database."
   (:require [metabase.driver :as driver]
             [metabase.driver.query-processor.expand :as ql]
-            [metabase.models.interface :as models]
+            [metabase.models.field :as field]
             [metabase.util :as u]))
 
 (defn- qp-query [db-id query]
@@ -14,7 +14,7 @@
       :rows))
 
 (defn- field-query [field query]
-  (let [table (models/table field)]
+  (let [table (field/table field)]
     (qp-query (:db_id table)
               (ql/query (merge query)
                         (ql/source-table (:id table))))))

--- a/src/metabase/db/metadata_queries.clj
+++ b/src/metabase/db/metadata_queries.clj
@@ -2,6 +2,7 @@
   "Predefined QP queries for getting metadata about an external database."
   (:require [metabase.driver :as driver]
             [metabase.driver.query-processor.expand :as ql]
+            [metabase.models.interface :as models]
             [metabase.util :as u]))
 
 (defn- qp-query [db-id query]
@@ -13,9 +14,10 @@
       :rows))
 
 (defn- field-query [field query]
-  (qp-query ((u/deref-> field :table :db) :id)
-            (ql/query (merge query)
-                      (ql/source-table ((u/deref-> field :table) :id)))))
+  (let [table (models/table field)]
+    (qp-query (:db_id table)
+              (ql/query (merge query)
+                        (ql/source-table (:id table))))))
 
 (defn table-row-count
   "Fetch the row count of TABLE via the query processor."

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -7,7 +7,8 @@
                    [db :as kdb])
             [metabase.driver :as driver]
             metabase.driver.query-processor.interface
-            [metabase.models.field :as field]
+            (metabase.models [field :as field]
+                             [interface :as models])
             [metabase.util :as u]
             [metabase.util.korma-extensions :as kx])
   (:import java.util.Map
@@ -160,7 +161,7 @@
 
 
 (defn- active-column-names->type [driver table]
-  (with-metadata [md driver @(:db table)]
+  (with-metadata [md driver (models/database table)]
     (into {} (for [{:keys [column_name type_name]} (jdbc/result-set-seq (.getColumns md nil (:schema table) (:name table) nil))]
                {column_name (or (column->base-type driver (keyword type_name))
                                 (do (log/warn (format "Don't know how to map column type '%s' to a Field base_type, falling back to :UnknownField." type_name))
@@ -177,7 +178,7 @@
           (seq more)                    (recur more))))))
 
 (defn- table-pks [driver table]
-  (with-metadata [md driver @(:db table)]
+  (with-metadata [md driver (models/database table)]
     (->> (.getPrimaryKeys md nil nil (:name table))
          jdbc/result-set-seq
          (map :column_name)
@@ -191,13 +192,9 @@
   ;; 3. Not fetching too many results for things like mark-json-field! which will fail after the first result that isn't valid JSON
   500)
 
-(defn- field-values-lazy-seq [driver {:keys [qualified-name-components table], :as field}]
-  (assert (and (map? field)
-               (delay? qualified-name-components)
-               (delay? table))
-    (format "Field is missing required information:\n%s" (u/pprint-to-str 'red field)))
-  (let [table           @table
-        name-components (rest @qualified-name-components)
+(defn- field-values-lazy-seq [driver field]
+  (let [table           (models/table field)
+        name-components (field/qualified-name-components field)
         transform-fn    (if (contains? #{:TextField :CharField} (:base_type field))
                           u/jdbc-clob->str
                           identity)
@@ -226,7 +223,7 @@
 
 
 (defn- table-fks [driver table]
-  (with-metadata [md driver @(:db table)]
+  (with-metadata [md driver (models/database table)]
     (->> (.getImportedKeys md nil nil (:name table))
          jdbc/result-set-seq
          (map (fn [result]
@@ -236,7 +233,7 @@
          set)))
 
 (defn- field-avg-length [driver field]
-  (or (some-> (korma-entity @(:table field))
+  (or (some-> (korma-entity (models/table field))
               (k/select (k/aggregate (avg (k/sqlfn* (string-length-fn driver)
                                                     (kx/cast :CHAR (escape-field-name (:name field)))))
                                      :len))
@@ -246,7 +243,7 @@
       0))
 
 (defn- field-percent-urls [_ field]
-  (or (let [korma-table (korma-entity @(:table field))]
+  (or (let [korma-table (korma-entity (models/table field))]
         (when-let [total-non-null-count (:count (first (k/select korma-table
                                                                  (k/aggregate (count (k/raw "*")) :count)
                                                                  (k/where {(escape-field-name (:name field)) [not= nil]}))))]
@@ -303,8 +300,7 @@
         korma-entity
         (select (aggregate (count :*) :count)))"
   ([table]
-   {:pre [(delay? (:db table))]}
-   (korma-entity @(:db table) table))
+   (korma-entity (models/database table) table))
 
   ([db table]             (table+db->entity table (db->korma-db db)))
   ([driver details table] (table+db->entity table (db->korma-db driver details))))

--- a/src/metabase/driver/query_processor/expand.clj
+++ b/src/metabase/driver/query_processor/expand.clj
@@ -59,7 +59,9 @@
 
 (s/defn ^:ql ^:always-validate datetime-field :- FieldPlaceholder
   "Reference to a `DateTimeField`. This is just a `Field` reference with an associated datetime UNIT."
-  ([f _ unit] (datetime-field f unit))
+  ([f _ unit] (log/warn (u/format-color 'yellow (str "The syntax for datetime-field has changed in MBQL '98. [:datetime-field <field> :as <unit>] is deprecated. "
+                                                     "Prefer [:datetime-field <field> <unit>] instead.")))
+              (datetime-field f unit))
   ([f unit]   (assoc (field f) :datetime-unit (normalize-token unit))))
 
 (s/defn ^:ql ^:always-validate fk-> :- FieldPlaceholder

--- a/src/metabase/driver/sync.clj
+++ b/src/metabase/driver/sync.clj
@@ -17,8 +17,7 @@
                              [field :refer [Field] :as field]
                              [field-values :as field-values]
                              [foreign-key :refer [ForeignKey]]
-                             [interface :as models]
-                             [table :refer [Table]])
+                             [table :refer [Table], :as table])
             [metabase.util :as u]))
 
 (declare auto-assign-field-special-type-by-name!
@@ -151,9 +150,9 @@
    This is used *instead* of `sync-database!` when syncing just one Table is desirable."
   [driver table]
   (binding [qp/*disable-qp-logging* true]
-    (driver/sync-in-context driver (models/database table) (fn []
-                                                             (sync-database-active-tables! driver [table])
-                                                             (events/publish-event :table-sync {:table_id (:id table)})))))
+    (driver/sync-in-context driver (table/database table) (fn []
+                                                            (sync-database-active-tables! driver [table])
+                                                            (events/publish-event :table-sync {:table_id (:id table)})))))
 
 
 ;; ### sync-database-active-tables! -- runs the sync-table steps over sequence of Tables

--- a/src/metabase/events/activity_feed.clj
+++ b/src/metabase/events/activity_feed.clj
@@ -7,6 +7,7 @@
             (metabase.models [activity :refer [Activity] :as activity]
                              [dashboard :refer [Dashboard]]
                              [database :refer [Database]]
+                             [interface :as models]
                              [session :refer [Session first-session-for-user]]
                              [table :as table])))
 
@@ -57,8 +58,8 @@
                                   ;; plus a `:dashcards` attribute which is a vector of the cards added/removed
                                   (-> (db/sel :one Dashboard :id (events/object->model-id topic obj))
                                       (select-keys [:description :name :public_perms])
-                                      (assoc :dashcards (for [{:keys [id card_id card]} dashcards]
-                                                          (-> @card
+                                      (assoc :dashcards (for [{:keys [id card_id], :as dashcard} dashcards]
+                                                          (-> (models/card dashcard)
                                                               (select-keys [:name :description :public_perms])
                                                               (assoc :id id)
                                                               (assoc :card_id card_id))))))]

--- a/src/metabase/events/activity_feed.clj
+++ b/src/metabase/events/activity_feed.clj
@@ -4,7 +4,8 @@
             [metabase.db :as db]
             [metabase.config :as config]
             [metabase.events :as events]
-            (metabase.models [activity :refer [Activity] :as activity]
+            (metabase.models [activity :refer [Activity], :as activity]
+                             [card :refer [Card]]
                              [dashboard :refer [Dashboard]]
                              [database :refer [Database]]
                              [interface :as models]
@@ -56,11 +57,9 @@
         add-remove-card-details (fn [{:keys [dashcards] :as obj}]
                                   ;; we expect that the object has just a dashboard :id at the top level
                                   ;; plus a `:dashcards` attribute which is a vector of the cards added/removed
-                                  (-> (db/sel :one Dashboard :id (events/object->model-id topic obj))
-                                      (select-keys [:description :name :public_perms])
+                                  (-> (db/sel :one [Dashboard :description :name :public_perms], :id (events/object->model-id topic obj))
                                       (assoc :dashcards (for [{:keys [id card_id], :as dashcard} dashcards]
-                                                          (-> (models/card dashcard)
-                                                              (select-keys [:name :description :public_perms])
+                                                          (-> (db/sel :one [Card :name :description :public_perms], :id card_id)
                                                               (assoc :id id)
                                                               (assoc :card_id card_id))))))]
     (activity/record-activity

--- a/src/metabase/middleware.clj
+++ b/src/metabase/middleware.clj
@@ -228,32 +228,6 @@
                                     (.writeString json-generator ^String (apply str "0x" (for [b (take 4 byte-ar)]
                                                                                            (format "%02X" b))))))
 
-(defprotocol ^:private IRemoveFnsAndDelays
-  (^:private remove-fns-and-delays [this]))
-
-(extend-protocol IRemoveFnsAndDelays
-  nil                         (remove-fns-and-delays [_]    nil)
-  Object                      (remove-fns-and-delays [this] this)
-  clojure.lang.IPersistentMap (remove-fns-and-delays [m]
-                                (loop [m m, [k & more] (keys m)]
-                                  (if-not k
-                                    m
-                                    (let [v (get m k)]
-                                      (recur (if (or (delay? v) (fn? v))
-                                               (dissoc m k)
-                                               (assoc m k (remove-fns-and-delays v)))
-                                             more)))))
-  clojure.lang.Sequential    (remove-fns-and-delays [this]
-                               (map remove-fns-and-delays this)))
-
-(defn format-response
-  "Middleware that recurses over Clojure object before it gets converted to JSON and makes adjustments neccessary so the formatter doesn't barf.
-   e.g. functions and delays are stripped and H2 Clobs are converted to strings."
-  [handler]
-  (comp remove-fns-and-delays handler))
-
-
-
 ;;; # ------------------------------------------------------------ LOGGING ------------------------------------------------------------
 
 (def ^:private ^:const sensitive-fields

--- a/src/metabase/models/activity.clj
+++ b/src/metabase/models/activity.clj
@@ -20,13 +20,10 @@
                   :details {}}]
     (merge defaults activity)))
 
-(defn- database [{:keys [database_id]}]
-  (db/sel :one [Database :id :name :description], :id database_id))
-
-(defn- table [{:keys [table_id]}]
-  (db/sel :one [Table :id :name :display_name :description], :id table_id))
-
-(defn- ^{:hydrate :model_exists} model-exists? [{:keys [model model_id]}]
+(defn model-exists?
+  "Does the object associated with this `Activity` exist in the DB?"
+  {:hydrate :model_exists, :arglists '([activity])}
+  [{:keys [model model_id]}]
   (case model
     "card"      (db/exists? Card,      :id model_id)
     "dashboard" (db/exists? Dashboard, :id model_id)
@@ -35,18 +32,13 @@
     "segment"   (db/exists? Segment,   :id model_id, :is_active true)
                  nil))
 
-(defn- ^:hydrate user [{:keys [user_id]}]
-  (User user_id))
-
 (extend (class Activity)
   i/IEntity
   (merge i/IEntityDefaults
          {:types       (constantly {:details :json, :topic :keyword})
           :can-read?   i/publicly-readable?
           :can-write?  i/publicly-writeable?
-          :pre-insert  pre-insert
-          :database    database
-          :table       table}))
+          :pre-insert  pre-insert}))
 
 
 ;; ## Persistence Functions

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -36,8 +36,9 @@
       (merge defaults card)
       card)))
 
-(defn ^{:hydrate :dashboard_count} dashboard-count
+(defn dashboard-count
   "Return the number of Dashboards this Card is in."
+  {:hydrate :dashboard_count}
   [{:keys [id]}]
   (-> (k/select @(ns-resolve 'metabase.models.dashboard-card 'DashboardCard)
                 (k/aggregate (count :*) :dashboards)
@@ -84,8 +85,7 @@
           :can-write?         i/publicly-writeable?
           :pre-update         populate-query-fields
           :pre-insert         populate-query-fields
-          :pre-cascade-delete pre-cascade-delete
-          :creator            (comp User :creator_id)})
+          :pre-cascade-delete pre-cascade-delete})
 
   revision/IRevisioned
   {:serialize-instance serialize-instance
@@ -94,7 +94,7 @@
    :diff-str           revision/default-diff-str}
 
   dependency/IDependent
-  {:dependencies       card-dependencies})
+  {:dependencies card-dependencies})
 
 
 (u/require-dox-in-this-namespace)

--- a/src/metabase/models/card_favorite.clj
+++ b/src/metabase/models/card_favorite.clj
@@ -5,13 +5,11 @@
 
 (i/defentity CardFavorite :report_cardfavorite)
 
-(defn- post-select [{:keys [card_id owner_id] :as card-favorite}]
-  (assoc card-favorite
-         :owner (delay (User owner_id))
-         :card  (delay (Card card_id))))
+(defn- ^:hydrate owner [{:keys [card_id]}]
+  (Card card_id))
 
 (extend (class CardFavorite)
   i/IEntity
   (merge i/IEntityDefaults
          {:timestamped? (constantly true)
-          :post-select  post-select}))
+          :card         (comp Card :card_id)}))

--- a/src/metabase/models/card_favorite.clj
+++ b/src/metabase/models/card_favorite.clj
@@ -1,15 +1,14 @@
 (ns metabase.models.card-favorite
   (:require (metabase.models [card :refer [Card]]
                              [interface :as i]
-                             [user :refer [User]])))
+                             [user :refer [User]])
+            [metabase.util :as u]))
 
 (i/defentity CardFavorite :report_cardfavorite)
-
-(defn- ^:hydrate owner [{:keys [card_id]}]
-  (Card card_id))
 
 (extend (class CardFavorite)
   i/IEntity
   (merge i/IEntityDefaults
-         {:timestamped? (constantly true)
-          :card         (comp Card :card_id)}))
+         {:timestamped? (constantly true)}))
+
+(u/require-dox-in-this-namespace)

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -13,8 +13,9 @@
 
 (i/defentity Dashboard :report_dashboard)
 
-(defn- ordered-cards
-  {:hydrate :ordered_cards}
+(defn ordered-cards
+  "Return the `DashboardCards` associated with DASHBOARD, in the order they were created."
+  {:hydrate :ordered_cards, :arglists '([dashboard])}
   [{:keys [id]}]
   (sel :many DashboardCard, :dashboard_id id, (k/order :created_at :asc)))
 
@@ -29,7 +30,6 @@
          {:timestamped?       (constantly true)
           :can-read?          i/publicly-readable?
           :can-write?         i/publicly-writeable?
-          :post-select        post-select
           :pre-cascade-delete pre-cascade-delete}))
 
 
@@ -97,11 +97,14 @@
           :types              (constantly {:description :clob})
           :can-read?          i/publicly-readable?
           :can-write?         i/publicly-writeable?
-          :pre-cascade-delete pre-cascade-delete
-          :creator            (comp User :creator_id)})
+          :pre-cascade-delete pre-cascade-delete})
 
   revision/IRevisioned
   {:serialize-instance serialize-instance
    :revert-to-revision revert-to-revision
    :diff-map           revision/default-diff-map
-   :diff-str           describe-diff})
+   :diff-str           describe-diff
+   :describe-diff      describe-diff})
+
+
+(u/require-dox-in-this-namespace)

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -17,5 +17,7 @@
   (merge i/IEntityDefaults
          {:timestamped? (constantly true)
           :pre-insert   pre-insert
-          :post-select  (u/rpartial set/rename-keys {:sizex :sizeX, :sizey :sizeY}) ;; TODO - frontend expects mixed-case names here, should change that
-          :card         (comp Card :card_id)}))
+          :post-select  (u/rpartial set/rename-keys {:sizex :sizeX, :sizey :sizeY})})) ; TODO - frontend expects mixed-case names here, should change that
+
+
+(u/require-dox-in-this-namespace)

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -2,7 +2,8 @@
   (:require [clojure.set :as set]
             [metabase.db :refer [sel]]
             (metabase.models [card :refer [Card]]
-                             [interface :as i])))
+                             [interface :as i])
+            [metabase.util :as u]))
 
 (i/defentity DashboardCard :report_dashboardcard)
 
@@ -11,16 +12,10 @@
                   :sizeY 2}]
     (merge defaults dashcard)))
 
-(defn- post-select [{:keys [card_id dashboard_id] :as dashcard}]
-  (-> dashcard
-      (set/rename-keys {:sizex :sizeX ; mildly retarded: H2 columns are all uppercase, we're converting them
-                        :sizey :sizeY}) ; to all downcase, and the Angular app expected mixed-case names here
-      (assoc :card      (delay (Card card_id))
-             :dashboard (delay (sel :one 'Dashboard :id dashboard_id)))))
-
 (extend (class DashboardCard)
   i/IEntity
   (merge i/IEntityDefaults
          {:timestamped? (constantly true)
           :pre-insert   pre-insert
-          :post-select  post-select}))
+          :post-select  (u/rpartial set/rename-keys {:sizex :sizeX, :sizey :sizeY}) ;; TODO - frontend expects mixed-case names here, should change that
+          :card         (comp Card :card_id)}))

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -16,7 +16,8 @@
   (cascade-delete 'Card  :database_id id)
   (cascade-delete 'Table :db_id id))
 
-(defn- ^:hydrate tables
+(defn ^:hydrate tables
+  "Return the `Tables` associated with this `Database`."
   [{:keys [id]}]
   (sel :many 'Table :db_id id, :active true, (k/order :display_name :ASC)))
 
@@ -26,6 +27,8 @@
          {:hydration-keys     (constantly [:database :db])
           :types              (constantly {:details :json, :engine :keyword})
           :timestamped?       (constantly true)
+          :can-read?          (constantly true)
+          :can-write?         i/superuser?
           :pre-cascade-delete pre-cascade-delete}))
 
 

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -8,9 +8,6 @@
                              [interface :as i])
             [metabase.util :as u]))
 
-(declare field->fk-field
-         qualified-name-components)
-
 (def ^:const special-types
   "Possible values for `Field.special_type`."
   #{:avatar
@@ -55,7 +52,6 @@
     :info        ; Non-numerical value that is not meant to be used
     :sensitive}) ; A Fields that should *never* be shown *anywhere*
 
-
 (i/defentity Field :metabase_field)
 
 (defn- pre-insert [field]
@@ -78,69 +74,51 @@
             (contains? field :special_type))
     (create-field-values-if-needed (sel :one [Field :id :table_id :base_type :special_type :field_type] :id id))))
 
-(defn- post-select [{:keys [id table_id parent_id] :as field}]
-  (u/assoc<> field
-    :table                     (delay (sel :one 'Table :id table_id))
-    :db                        (delay @(:db @(:table <>)))
-    :target                    (delay (field->fk-field field))
-    :parent                    (when parent_id
-                                 (delay (Field parent_id)))
-    :children                  (delay (sel :many Field :parent_id (:id field)))
-    :values                    (delay (sel :many [FieldValues :field_id :values] :field_id id))
-    :qualified-name-components (delay (qualified-name-components <>))
-    :qualified-name            (delay (apply str (interpose "." @(:qualified-name-components <>))))))
-
 (defn- pre-cascade-delete [{:keys [id]}]
   (cascade-delete Field :parent_id id)
   (cascade-delete ForeignKey (k/where (or (= :origin_id id)
                                           (= :destination_id id))))
   (cascade-delete 'FieldValues :field_id id))
 
+(defn- ^:hydrate values [{:keys [id]}]
+  (sel :many [FieldValues :field_id :values], :field_id id))
+
+(defn qualified-name-components
+  "Return the pieces that represent a path to FIELD, of the form `[table-name parent-fields-name* field-name]`."
+  [{field-name :name, table-id :table_id, parent-id :parent_id, :as field}]
+  (conj (if-let [parent (Field parent-id)]
+          (qualified-name-components parent)
+          [(sel :one :field ['Table :name], :id table-id)])
+        field-name))
+
+(defn qualified-name
+  "Return a combined qualified name for FIELD, e.g. `table_name.parent_field_name.field_name`."
+  [field]
+  (apply str (interpose \. (qualified-name-components field))))
+
+(defn- table [{:keys [table_id]}]
+  (sel :one 'Table, :id table_id))
+
 (extend (class Field)
   i/IEntity (merge i/IEntityDefaults
-                   {:hydration-keys     (constantly [:destination :field :origin])
-                    :types              (constantly {:base_type :keyword, :field_type :keyword, :special_type :keyword})
-                    :timestamped?       (constantly true)
-                    :can-read?          (constantly true)
-                    :can-write?         i/superuser?
-                    :pre-insert         pre-insert
-                    :post-insert        post-insert
-                    :post-update        post-update
-                    :post-select        post-select
-                    :pre-cascade-delete pre-cascade-delete}))
+                   {:hydration-keys            (constantly [:destination :field :origin])
+                    :types                     (constantly {:base_type :keyword, :field_type :keyword, :special_type :keyword})
+                    :timestamped?              (constantly true)
+                    :pre-insert                pre-insert
+                    :post-insert               post-insert
+                    :post-update               post-update
+                    :pre-cascade-delete        pre-cascade-delete
+                    :qualified-name-components qualified-name-components
+                    :table                     table
+                    :database                  (comp i/database table)}))
 
 
-(defn field->fk-field
+(defn- field->fk-field
   "Attempts to follow a `ForeignKey` from the the given `Field` to a destination `Field`.
 
    Only evaluates if the given field has :special_type `fk`, otherwise does nothing."
+  {:hydrate :target}
   [{:keys [id special_type] :as field}]
   (when (= :fk special_type)
     (let [dest-id (sel :one :field [ForeignKey :destination_id] :origin_id id)]
       (Field dest-id))))
-
-(defn unflatten-nested-fields
-  "Take a sequence of both top-level and nested FIELDS, and return a sequence of top-level `Fields`
-   with nested `Fields` moved into sequences keyed by `:children` in their parents.
-
-     (unflatten-nested-fields [{:id 1, :parent_id nil}, {:id 2, :parent_id 1}])
-       -> [{:id 1, :parent_id nil, :children [{:id 2, :parent_id 1, :children nil}]}]
-
-   You may optionally specify a different PARENT-ID-KEY; the default is `:parent_id`."
-  ([fields]
-   (unflatten-nested-fields fields :parent_id))
-  ([fields parent-id-key]
-   (let [parent-id->fields (group-by parent-id-key fields)
-         resolve-children  (fn resolve-children [field]
-                             (assoc field :children (map resolve-children
-                                                         (parent-id->fields (:id field)))))]
-     (map resolve-children (parent-id->fields nil)))))
-
-(defn- qualified-name-components
-  "Return the pieces that represent a path to FIELD, of the form `[table-name parent-fields-name* field-name]`."
-  [{:keys [table parent], :as field}]
-  {:pre [(delay? table)]}
-  (conj (if parent
-          (qualified-name-components @parent)
-          [(:name @table)])
-        (:name field)))

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -68,3 +68,6 @@
   (when (field-should-have-field-values? field)
     (or (sel :one FieldValues :field_id field-id)
         (create-field-values field human-readable-values))))
+
+
+(u/require-dox-in-this-namespace)

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -1,21 +1,19 @@
 (ns metabase.models.field-values
   (:require [clojure.tools.logging :as log]
             [metabase.db :refer [ins sel upd]]
-            [metabase.models.interface :as i]))
+            [metabase.models.interface :as i]
+            [metabase.util :as u]))
 
 ;; ## Entity + DB Multimethods
 
 (i/defentity FieldValues :metabase_fieldvalues)
-
-(defn- post-select [field-values]
-  (update-in field-values [:human_readable_values] #(or % {})))
 
 (extend (class FieldValues)
   i/IEntity
   (merge i/IEntityDefaults
          {:timestamped? (constantly true)
           :types        (constantly {:human_readable_values :json, :values :json})
-          :post-select  post-select}))
+          :post-select  (u/rpartial update :human_readable_values #(or % {}))}))
 
 ;; columns:
 ;; *  :id
@@ -43,8 +41,7 @@
   "Create `FieldValues` for a `Field`."
   {:arglists '([field] [field human-readable-values])}
   [{field-id :id, field-name :name, :as field} & [human-readable-values]]
-  {:pre [(integer? field-id)
-         (:table field)]} ; need to pass a full `Field` object with delays beause the `metadata/` functions need those
+  {:pre [(integer? field-id)]}
   (log/debug (format "Creating FieldValues for Field %s..." (or field-name field-id))) ; use field name if available
   (ins FieldValues
     :field_id              field-id
@@ -67,8 +64,7 @@
   {:arglists '([field]
                [field human-readable-values])}
   [{field-id :id :as field} & [human-readable-values]]
-  {:pre [(integer? field-id)
-         (:table field)]}
+  {:pre [(integer? field-id)]}
   (when (field-should-have-field-values? field)
     (or (sel :one FieldValues :field_id field-id)
         (create-field-values field human-readable-values))))

--- a/src/metabase/models/foreign_key.clj
+++ b/src/metabase/models/foreign_key.clj
@@ -1,5 +1,6 @@
 (ns metabase.models.foreign-key
-  (:require [metabase.models.interface :as i]))
+  (:require [metabase.models.interface :as i]
+            [metabase.util :as u]))
 
 (def ^:const relationships
   "Valid values for `ForeginKey.relationship`."
@@ -14,3 +15,6 @@
   (merge i/IEntityDefaults
          {:types        (constantly {:relationship :keyword})
           :timestamped? (constantly true)}))
+
+
+(u/require-dox-in-this-namespace)

--- a/src/metabase/models/foreign_key.clj
+++ b/src/metabase/models/foreign_key.clj
@@ -1,6 +1,5 @@
 (ns metabase.models.foreign-key
-  (:require [metabase.db :refer [sel]]
-            [metabase.models.interface :as i]))
+  (:require [metabase.models.interface :as i]))
 
 (def ^:const relationships
   "Valid values for `ForeginKey.relationship`."
@@ -10,14 +9,8 @@
 
 (i/defentity ForeignKey :metabase_foreignkey)
 
-(defn- post-select [{:keys [origin_id destination_id] :as fk}]
-  (assoc fk
-         :origin      (delay (sel :one 'Field :id origin_id))
-         :destination (delay (sel :one 'Field :id destination_id))))
-
 (extend (class ForeignKey)
   i/IEntity
   (merge i/IEntityDefaults
          {:types        (constantly {:relationship :keyword})
-          :timestamped? (constantly true)
-          :post-select  post-select}))
+          :timestamped? (constantly true)}))

--- a/src/metabase/models/hydrate.clj
+++ b/src/metabase/models/hydrate.clj
@@ -1,7 +1,9 @@
 (ns metabase.models.hydrate
   "Functions for deserializing and hydrating fields in objects fetched from the DB."
   (:require [clojure.java.classpath :as classpath]
+            [clojure.set :as set]
             [clojure.tools.namespace.find :as ns-find]
+            [medley.core :as m]
             [metabase.db :refer [sel]]
             [metabase.models.interface :as i]
             [metabase.util :as u]))
@@ -27,7 +29,7 @@
 
   **Batched Hydration**
 
-  Hydration attempts to do a *batched hydration* where possible.
+  `hydrate` attempts to do a *batched hydration* where possible.
   If the key being hydrated is defined as one of some entity's `hydration-keys`,
   `hydrate` will do a batched `sel` if a corresponding key ending with `_id`
   is found in the objects being hydrated.
@@ -43,12 +45,23 @@
 
   **Simple Hydration**
 
-  If the key is *not* eligible for batched hydration, `hydrate` will look for delays
-  in objects being hydrated whose keys match the hydration key. These will be
-  evaluated and their values will replace the delays.
+  If the key is *not* eligible for batched hydration, `hydrate` will look for a method or
+  function tagged with `:hydrate` in its metadata, and use that instead; if a matching function
+  is found, it is called on the object being hydrated and the result is `assoc`ed:
 
-    (hydrate [{:fish (delay 1)} {:fish (delay 2)}] :fish)
-      -> [{:fish 1} {:fish 2}]
+    (defn ^:hydrate dashboard [{:keys [dashboard_id]}]
+      (Dashboard dashboard_id))
+
+    (let [dc (DashboardCard ...)]
+      (hydrate dc :dashboard))    ; roughly equivalent to (assoc dc :dashboard (dashboard dc))
+
+  By default, the function will be used to hydrate keys that match its name; you
+  can specify a different key to hydrate instead as the metadata value of `:hydrate`:
+
+    (defn ^{:hydrate :pk_field} pk-field-id [obj] ...) ; hydrate :pk_field with pk-field-id
+
+  Keep in mind that you can only define a single function/method to hydrate each key; move functions into the
+  `IEntity` interface as needed.
 
   **Hydrating Multiple Keys**
 
@@ -128,29 +141,44 @@
   (if (can-batched-hydrate? results k) (batched-hydrate results k)
       (simple-hydrate results k)))
 
-(def ^:private hydration-k->method
-  "Methods that can be used to hydrate corresponding keys."
-  {:can_read  #'i/can-read?    ; Not sure why but these don't work if they're not vars
-   :can_write #'i/can-write?})
+(def ^:private used-fn-keys (atom #{}))
+
+(def ^:private k->f
+  (delay (into {} (for [ns          (all-ns)
+                        [symb varr] (ns-interns ns)
+                        :let        [hydration-key (:hydrate (meta varr))]
+                        :when       hydration-key]
+                    {(if (m/boolean? hydration-key)
+                       (keyword (name symb))
+                       hydration-key) varr}))))
+
+(defn- hydration-key->f
+  "Get the function marked `^:hydrate` for K."
+  [k]
+  (swap! used-fn-keys conj k)
+  (@k->f k))
+
+(defn- check-all-hydration-keys-used
+  "Warn about hydration functions that go unused."
+  {:expectations-options :after-run}
+  []
+  (let [available-keys (set (keys @k->f))
+        used-keys      @used-fn-keys
+        unused-keys    (set/difference available-keys used-keys)]
+    (doseq [k unused-keys]
+      (println (u/format-color 'red "%s is marked `^:hydrate` but is never used for hydration." k)))))
 
 (defn- simple-hydrate
   "Hydrate keyword K in results by dereferencing corresponding delays when applicable."
   [results k]
   {:pre [(keyword? k)]}
-  (map (fn [result]
-         (let [v (k result)]
-           (cond
-             (delay? v)                    (assoc result k @v)                               ; hydrate delay if possible
-             (and (not v)
-                  (hydration-k->method k)) (assoc result k ((hydration-k->method k) result)) ; otherwise if no value exists look for a method we can use for hydration
-             :else                         result)))                                         ; otherwise don't barf, v may already be hydrated
-       results))
-
-(defn- already-hydrated?
-  "Is `(obj k)` a non-nil value that is not a delay?"
-  [obj k]
-  (let [{v k} obj]
-    (and v (not (delay? v)))))
+  (for [result results]
+    ;; don't try to hydrate if they key is already present. If we find a matching fn, hydrate with it
+    (when result
+      (or (when-not (k result)
+            (when-let [f (hydration-key->f k)]
+              (assoc result k (f result))))
+          result))))
 
 (defn- batched-hydrate
   "Hydrate keyword DEST-KEY across all RESULTS by aggregating corresponding source keys (`DEST-KEY_id`),
@@ -159,25 +187,15 @@
    {:pre [(keyword? dest-key)]}
    (let [entity     (@hydration-key->entity dest-key)
          source-key (k->k_id dest-key)
-         results    (map (fn [{dest-obj dest-key :as result}]   ; if there are realized delays for `dest-key`
-                           (if (and (delay? dest-obj)          ; in any of the objects replace delay with its value
-                                    (realized? dest-obj))
-                             (assoc result dest-key @dest-obj)
-                             result))
-                         results)
-         ids        (->> results
-                         (filter (u/rpartial (complement already-hydrated?) dest-key)) ; filter out results that are already hydrated
-                         (map source-key)
-                         set)
-         objs       (->> (sel :many entity :id [in ids])
-                         (map (fn [obj]
-                                {(:id obj) obj}))
-                         (into {}))]
-     (map (fn [{source-id source-key :as result}]
-            (if (already-hydrated? result dest-key) result
-                (let [obj (objs source-id)]
-                  (assoc result dest-key obj))))
-          results))))
+         ids        (set (for [result results
+                               :when  (not (get result dest-key))]
+                           (source-key result)))
+         objs       (into {} (for [obj (sel :many entity :id [in ids])]
+                               {(:id obj) obj}))]
+     (for [{source-id source-key :as result} results]
+       (if (get result dest-key)
+         result
+         (assoc result dest-key (objs source-id)))))))
 
 
 ;; ### Helper Fns

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -79,15 +79,15 @@
           (cascade-delete Card :database_id database-id)
           ...)")
 
-  (can-read? ^Boolean [instance], ^Boolean [entity, ^Integer id]
-    "Return whether `*current-user*` has *read* permissions for an object. You should use one of these implmentations:
+  (^{:hydrate :can_read} can-read? ^Boolean [instance], ^Boolean [entity, ^Integer id]
+   "Return whether `*current-user*` has *read* permissions for an object. You should use one of these implmentations:
 
      *  `(constantly true)` (default)
      *  `superuser?`
      *  `publicly-readable?`")
 
-  (can-write? ^Boolean [instance], ^Boolean [entity, ^Integer id]
-    "Return whether `*current-user*` has *write* permissions for an object. You should use one of these implmentations:
+  (^{:hydrate :can_write} can-write? ^Boolean [instance], ^Boolean [entity, ^Integer id]
+   "Return whether `*current-user*` has *write* permissions for an object. You should use one of these implmentations:
 
      *  `(constantly true)`
      *  `superuser?` (default)
@@ -104,18 +104,32 @@
      will look for `:creator_id` in other objects and fetch the corresponding `Users`.")
 
   (types ^clojure.lang.IPersistentMap [this]
-    "Return a map of keyword field names to their types for fields that should be serialized/deserialized in a special way. Valid types are either `:json` or `:keyword`.
+    "Return a map of keyword field names to their types for fields that should be serialized/deserialized in a special way. Valid types are `:json`, `:keyword`, or `:clob`.
 
      *  `:json` serializes objects as JSON strings before going into the DB, and parses JSON strings when coming out
      *  `:keyword` calls `name` before going into the DB, and `keyword` when coming out
+     *  `:clob` converts clobs to Strings (via `metabase.util/jdbc-clob->str`) when coming out
 
-       (types [_] {:cards :json}) ; encode `:cards` as JSON when stored in the DB"))
+       (types [_] {:cards :json}) ; encode `:cards` as JSON when stored in the DB")
 
+;;; Fetching Related Models (Hydration Methods)
 
-(defprotocol ICreateFromMap
-  "Used by internal functions like `do-post-select`."
-  (^:private map-> [klass, ^clojure.lang.IPersistentMap m]
-   "Convert map M to instance of record type KLASS."))
+  ;; The following hydration methods are defined here because they are used by multiple models. Ones only used by a single model live in that model's namespace.
+  ;; Since you can't define multiple methods to hydrate the same key, move those functions into this protocol as needed. Be sure to update docstrs and add a default
+  ;; implementation that throws an `UnsupportedOperationException` as well.
+
+  (^{:hydrate :db} database [table-field-or-activity]
+    "Fetch the `Database` for this `Table`, `Field`, or `Activitiy.`")
+
+  (^:hydrate table [field-or-activity]
+    "Fetch the `Table` for this `Field` or `Activity`.")
+
+  (^:hydrate creator [card-pulse-or-dashboard]
+    "Fetch the `User` who created this `Card`, `Pulse`, or `Dashboard`.")
+
+  (^:hydrate card [card-favorite-or-dashboard-card]
+     "Fetch the `Card` for this `CardFavorite` or `DashboardCard`."))
+
 
 (def ^:private type-fns
   "The functions that should be invoked for corresponding `types` when an object comes `:in` or `:out` of the DB."
@@ -129,7 +143,9 @@
                         (json/parse-string s keyword)
                         obj)))}
    :keyword {:in  name
-             :out keyword}})
+             :out keyword}
+   :clob    {:in  identity
+             :out u/jdbc-clob->str}})
 
 (defn- apply-type-fns
   "Apply the appropriate `type-fns` for OBJ."
@@ -146,6 +162,12 @@
     (let [ts (u/new-sql-timestamp)]
       (into obj (for [k ks]
                   {k ts})))))
+
+
+(defprotocol ICreateFromMap
+  "Used by internal functions like `do-post-select`."
+  (^:private map-> [klass, ^clojure.lang.IPersistentMap m]
+   "Convert map M to instance of record type KLASS."))
 
 ;; these functions call (map-> entity ...) twice to make sure functions like pre-insert/post-select didn't do something that accidentally removed the typing
 
@@ -178,21 +200,24 @@
     (post-select <>)
     (map-> entity <>)))
 
-
 (def IEntityDefaults
   "Default implementations for `IEntity` methods."
-  {:default-fields       (constantly nil)
-   :timestamped?         (constantly false)
-   :hydration-keys       (constantly nil)
-   :types                (constantly nil)
-   :can-read?            (constantly true)
-   :can-write?           superuser?
-   :pre-insert           identity
-   :post-insert          identity
-   :pre-update           identity
-   :post-update          (constantly nil)
-   :post-select          identity
-   :pre-cascade-delete   (constantly nil)})
+  {:default-fields            (constantly nil)
+   :timestamped?              (constantly false)
+   :hydration-keys            (constantly nil)
+   :types                     (constantly nil)
+   :can-read?                 (constantly true)
+   :can-write?                superuser?
+   :pre-insert                identity
+   :post-insert               identity
+   :pre-update                identity
+   :post-update               (constantly nil)
+   :post-select               identity
+   :pre-cascade-delete        (constantly nil)
+   :database                  (fn [this] (throw (UnsupportedOperationException. (str "No implementation of metabase.models.interface/database for " (class this)))))
+   :table                     (fn [this] (throw (UnsupportedOperationException. (str "No implementation of metabase.models.interface/table for "    (class this)))))
+   :creator                   (fn [this] (throw (UnsupportedOperationException. (str "No implementation of metabase.models.interface/creator for "  (class this)))))
+   :card                      (fn [this] (throw (UnsupportedOperationException. (str "No implementation of metabase.models.interface/card for "     (class this)))))})
 
 (defn- invoke-entity
   "Fetch an object with a specific ID or all objects of type ENTITY from the DB.

--- a/src/metabase/models/pulse_channel.clj
+++ b/src/metabase/models/pulse_channel.clj
@@ -1,10 +1,12 @@
 (ns metabase.models.pulse-channel
   (:require [clojure.set :as set]
+            [cheshire.generate :refer [add-encoder encode-map]]
             [korma.core :as k]
             [metabase.db :as db]
             (metabase.models [pulse-channel-recipient :refer [PulseChannelRecipient]]
                              [interface :as i]
-                             [user :refer [User]])))
+                             [user :refer [User]])
+            [medley.core :as m]))
 
 
 ;; ## Static Definitions
@@ -14,13 +16,13 @@
 
    NOTE: order is important here!!
          these indexes match the values from clj-time `day-of-week` function (0 = Sunday, 6 = Saturday)"
-  [{:id "sun" :name "Sun"},
-   {:id "mon" :name "Mon"},
-   {:id "tue" :name "Tue"},
-   {:id "wed" :name "Wed"},
-   {:id "thu" :name "Thu"},
-   {:id "fri" :name "Fri"},
-   {:id "sat" :name "Sat"}])
+  [{:id "sun", :name "Sun"},
+   {:id "mon", :name "Mon"},
+   {:id "tue", :name "Tue"},
+   {:id "wed", :name "Wed"},
+   {:id "thu", :name "Thu"},
+   {:id "fri", :name "Fri"},
+   {:id "sat", :name "Sat"}])
 
 (defn day-of-week?
   "Predicate function which returns `true` if the given day is a valid day-of-week choice, `false` otherwise."
@@ -30,7 +32,7 @@
 (defn hour-of-day?
   "Predicate function which returns `true` if the given hour is a valid hour of the day (24 hour), `false` otherwise."
   [hour]
-  (and (integer? hour) (<= 0 hour) (>= 23 hour)))
+  (and (integer? hour) (<= 0 hour 23)))
 
 (def ^:const schedule-type-hourly :hourly)
 (def ^:const schedule-type-daily :daily)
@@ -101,14 +103,10 @@
 
 (i/defentity PulseChannel :pulse_channel)
 
-(defn- post-select [{:keys [id creator_id details] :as pulse-channel}]
-  (assoc pulse-channel
-         ;; don't include `:emails`, we use that purely internally
-         :details (dissoc details :emails)
-         ;; here we recombine user details w/ freeform emails
-         :recipients (delay (into (mapv (partial array-map :email) (:emails details))
-                                  (db/sel :many [User :id :email :first_name :last_name]
-                                          (k/where {:id [in (k/subselect PulseChannelRecipient (k/fields :user_id) (k/where {:pulse_channel_id id}))]}))))))
+(defn- ^:hydrate recipients [{:keys [id creator_id details] :as pulse-channel}]
+  (into (mapv (partial array-map :email) (:emails details))
+        (db/sel :many [User :id :email :first_name :last_name]
+                (k/where {:id [in (k/subselect PulseChannelRecipient (k/fields :user_id) (k/where {:pulse_channel_id id}))]}))))
 
 (defn- pre-cascade-delete [{:keys [id]}]
   (db/cascade-delete PulseChannelRecipient :pulse_channel_id id))
@@ -120,7 +118,6 @@
                     :timestamped?       (constantly true)
                     :can-read?          (constantly true)
                     :can-write          i/superuser?
-                    :post-select        post-select
                     :pre-cascade-delete pre-cascade-delete}))
 
 
@@ -181,14 +178,14 @@
          (every? map? recipients)]}
   (let [recipients-by-type (group-by integer? (filter identity (map #(or (:id %) (:email %)) recipients)))]
     (db/upd PulseChannel id
-      :details          (cond-> details
-                          (supports-recipients? channel_type) (assoc :emails (get recipients-by-type false)))
-      :schedule_type    schedule_type
-      :schedule_hour    (when (not= schedule_type schedule-type-hourly)
-                          schedule_hour)
-      :schedule_day     (when (= schedule_type schedule-type-weekly)
-                          schedule_day))
-    (when (and (supports-recipients? channel_type))
+      :details       (cond-> details
+                       (supports-recipients? channel_type) (assoc :emails (get recipients-by-type false)))
+      :schedule_type schedule_type
+      :schedule_hour (when (not= schedule_type schedule-type-hourly)
+                       schedule_hour)
+      :schedule_day  (when (= schedule_type schedule-type-weekly)
+                       schedule_day))
+    (when (supports-recipients? channel_type)
       (update-recipients! id (or (get recipients-by-type true) [])))))
 
 (defn create-pulse-channel
@@ -217,3 +214,9 @@
       (update-recipients! id (get recipients-by-type true)))
     ;; return the id of our newly created channel
     id))
+
+
+;; don't include `:emails`, we use that purely internally
+(add-encoder PulseChannelInstance (fn [pulse-channel json-generator]
+                                    (encode-map (m/dissoc-in pulse-channel [:details :emails])
+                                                json-generator)))

--- a/src/metabase/models/pulse_channel.clj
+++ b/src/metabase/models/pulse_channel.clj
@@ -103,7 +103,9 @@
 
 (i/defentity PulseChannel :pulse_channel)
 
-(defn- ^:hydrate recipients [{:keys [id creator_id details] :as pulse-channel}]
+(defn ^:hydrate recipients
+  "Return the `PulseChannelRecipients` associated with this PULSE-CHANNEL."
+  [{:keys [id creator_id details] :as pulse-channel}]
   (into (mapv (partial array-map :email) (:emails details))
         (db/sel :many [User :id :email :first_name :last_name]
                 (k/where {:id [in (k/subselect PulseChannelRecipient (k/fields :user_id) (k/where {:pulse_channel_id id}))]}))))

--- a/src/metabase/models/query_execution.clj
+++ b/src/metabase/models/query_execution.clj
@@ -6,8 +6,7 @@
 
 (defn- post-select [{:keys [result_rows] :as query-execution}]
   ;; sadly we have 2 ways to reference the row count :(
-  (assoc query-execution
-         :row_count (or result_rows 0)))
+  (assoc query-execution :row_count (or result_rows 0)))
 
 (extend (class QueryExecution)
   i/IEntity

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -171,7 +171,6 @@
                                         :created_at      $
                                         :base_type       "BigIntegerField"
                                         :parent_id       nil
-                                        :parent          nil
                                         :values          []})
                                      (match-$ (Field (id :categories :name))
                                        {:description     nil
@@ -189,7 +188,6 @@
                                         :created_at      $
                                         :base_type       "TextField"
                                         :parent_id       nil
-                                        :parent          nil
                                         :values          []})]
                    :segments        []
                    :metrics         []

--- a/test/metabase/api/field_test.clj
+++ b/test/metabase/api/field_test.clj
@@ -49,8 +49,7 @@
        :preview_display true
        :created_at      $
        :base_type       "TextField"
-       :parent_id       nil
-       :parent          nil})
+       :parent_id       nil})
     ((user->client :rasta) :get 200 (format "field/%d" (id :users :name))))
 
 
@@ -82,8 +81,7 @@
               :preview_display true
               :created_at      $
               :base_type       "FloatField"
-              :parent_id       nil
-              :parent          nil})
+              :parent_id       nil})
   ((user->client :crowberto) :put 200 (format "field/%d" (id :venues :latitude)) {:special_type :fk}))
 
 (defn- field->field-values

--- a/test/metabase/api/metric_test.clj
+++ b/test/metabase/api/metric_test.clj
@@ -140,17 +140,17 @@
                                          :db_id  database-id
                                          :active true}]
       (tu/with-temp Metric [{:keys [id]} {:creator_id  (user->id :rasta)
-                                           :table_id    table-id
-                                           :name        "Droids in the desert"
-                                           :description "Lookin' for a jedi"
-                                           :definition  {}}]
+                                          :table_id    table-id
+                                          :name        "Droids in the desert"
+                                          :description "Lookin' for a jedi"
+                                          :definition  {}}]
         (metric-response ((user->client :crowberto) :put 200 (format "metric/%d" id) {:id               id
-                                                                                        :name             "Tatooine"
-                                                                                        :description      nil
-                                                                                        :table_id         456
-                                                                                        :revision_message "I got me some revisions"
-                                                                                        :definition       {:database 2
-                                                                                                           :query    {:filter ["not" "the droids you're looking for"]}}}))))))
+                                                                                      :name             "Tatooine"
+                                                                                      :description      nil
+                                                                                      :table_id         456
+                                                                                      :revision_message "I got me some revisions"
+                                                                                      :definition       {:database 2
+                                                                                                         :query    {:filter ["not" "the droids you're looking for"]}}}))))))
 
 
 ;; ## DELETE /api/metric/:id

--- a/test/metabase/api/pulse_test.clj
+++ b/test/metabase/api/pulse_test.clj
@@ -134,7 +134,6 @@
                    :schedule_type "daily"
                    :schedule_hour 12
                    :schedule_day  nil
-                   :details       {}
                    :recipients    []}]}
   (-> (pulse-response ((user->client :rasta) :post 200 "pulse" {:name     "A Pulse"
                                                                 :cards    [{:id (:id card1)} {:id (:id card2)}]

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -11,7 +11,9 @@
             (metabase.test.data [dataset-definitions :as defs]
                                 [datasets :as datasets]
                                 [users :refer :all])
-            [metabase.test.util :refer [match-$ expect-eval-actual-first]]))
+            [metabase.test.util :refer [match-$ expect-eval-actual-first resolve-private-fns]]))
+
+(resolve-private-fns metabase.models.table pk-field-id)
 
 
 ;; ## /api/org/* AUTHENTICATION Tests
@@ -76,7 +78,7 @@
        :updated_at      $
        :entity_name     nil
        :active          true
-       :pk_field        (deref $pk_field)
+       :pk_field        (pk-field-id $$)
        :id              (id :venues)
        :db_id           (id)
        :created_at      $})
@@ -97,8 +99,7 @@
             :preview_display     true
             :created_at          $
             :base_type           "BigIntegerField"
-            :parent_id           nil
-            :parent              nil})
+            :parent_id           nil})
          (match-$ (Field (id :categories :name))
            {:description         nil
             :table_id            (id :categories)
@@ -113,8 +114,7 @@
             :preview_display     true
             :created_at          $
             :base_type           "TextField"
-            :parent_id           nil
-            :parent              nil})]
+            :parent_id           nil})]
   ((user->client :rasta) :get 200 (format "table/%d/fields" (id :categories))))
 
 ;; ## GET /api/table/:id/query_metadata
@@ -150,8 +150,7 @@
                             :preview_display true
                             :created_at      $
                             :base_type       "BigIntegerField"
-                            :parent_id       nil
-                            :parent          nil})
+                            :parent_id       nil})
                          (match-$ (Field (id :categories :name))
                            {:description     nil
                             :table_id        (id :categories)
@@ -167,8 +166,7 @@
                             :preview_display true
                             :created_at      $
                             :base_type       "TextField"
-                            :parent_id       nil
-                            :parent          nil})]
+                            :parent_id       nil})]
        :field_values    {}
        :rows            75
        :updated_at      $
@@ -234,8 +232,7 @@
                             :preview_display true
                             :created_at      $
                             :base_type       "BigIntegerField"
-                            :parent_id       nil
-                            :parent          nil})
+                            :parent_id       nil})
                          (match-$ (sel :one Field :id (id :users :last_login))
                            {:description     nil
                             :table_id        (id :users)
@@ -251,8 +248,7 @@
                             :preview_display true
                             :created_at      $
                             :base_type       "DateTimeField"
-                            :parent_id       nil
-                            :parent          nil})
+                            :parent_id       nil})
                          (match-$ (sel :one Field :id (id :users :name))
                            {:description     nil
                             :table_id        (id :users)
@@ -268,8 +264,7 @@
                             :preview_display true
                             :created_at      $
                             :base_type       "TextField"
-                            :parent_id       nil
-                            :parent          nil})
+                            :parent_id       nil})
                          (match-$ (sel :one Field :table_id (id :users) :name "PASSWORD")
                            {:description     nil
                             :table_id        (id :users)
@@ -285,8 +280,7 @@
                             :preview_display true
                             :created_at      $
                             :base_type       "TextField"
-                            :parent_id       nil
-                            :parent          nil})]
+                            :parent_id       nil})]
        :rows            15
        :updated_at      $
        :entity_name     nil
@@ -348,8 +342,7 @@
                             :preview_display true
                             :created_at      $
                             :base_type       "BigIntegerField"
-                            :parent_id       nil
-                            :parent          nil})
+                            :parent_id       nil})
                          (match-$ (Field (id :users :last_login))
                            {:description     nil
                             :table_id        (id :users)
@@ -365,8 +358,7 @@
                             :preview_display true
                             :created_at      $
                             :base_type       "DateTimeField"
-                            :parent_id       nil
-                            :parent          nil})
+                            :parent_id       nil})
                          (match-$ (Field (id :users :name))
                            {:description     nil
                             :table_id        (id :users)
@@ -382,8 +374,7 @@
                             :preview_display true
                             :created_at      $
                             :base_type       "TextField"
-                            :parent_id       nil
-                            :parent          nil})]
+                            :parent_id       nil})]
        :rows            15
        :updated_at      $
        :entity_name     nil
@@ -438,7 +429,7 @@
        :entity_name     nil
        :display_name    "Userz"
        :active          true
-       :pk_field        (deref $pk_field)
+       :pk_field        (pk-field-id $$)
        :id              $
        :db_id           (id)
        :created_at      $})
@@ -464,7 +455,6 @@
                         {:id              $
                          :table_id        $
                          :parent_id       nil
-                         :parent          nil
                          :name            "USER_ID"
                          :display_name    "User Id"
                          :description     nil
@@ -503,7 +493,6 @@
                         {:id              $
                          :table_id        $
                          :parent_id       nil
-                         :parent          nil
                          :name            "ID"
                          :display_name    "Id"
                          :description     nil

--- a/test/metabase/http_client.clj
+++ b/test/metabase/http_client.clj
@@ -18,7 +18,6 @@
   (str "http://localhost:" (config/config-str :mb-jetty-port) "/api/"))
 
 (defn
-  ^{:arglists ([credentials? method expected-status-code? url http-body-map? & url-kwargs])}
   client
   "Perform an API call and return the response (for test purposes).
    The first arg after URL will be passed as a JSON-encoded body if it is a map.
@@ -38,6 +37,7 @@
    *  URL                   Base URL of the request, which will be appended to `*url-prefix*`. e.g. `card/1/favorite`
    *  HTTP-BODY-MAP         Optional map to send a the JSON-serialized HTTP body of the request
    *  URL-KWARGS            key-value pairs that will be encoded and added to the URL as GET params"
+  {:arglists '([credentials? method expected-status-code? url http-body-map? & url-kwargs])}
   [& args]
   (let [[credentials [method & args]] (u/optional #(or (map? %)
                                                        (string? %)) args)

--- a/test/metabase/middleware_test.clj
+++ b/test/metabase/middleware_test.clj
@@ -173,36 +173,6 @@
   (api-key-enforced-handler (request-with-api-key "foobar")))
 
 
-
-;;; # ------------------------------------------------------------ FORMATTING TESTS ------------------------------------------------------------
-
-;; `format`, being a middleware function, expects a `handler`
-;; and returns a function that actually affects the response.
-;; Since we're just interested in testing the returned function pass it `identity` as a handler
-;; so whatever we pass it is unaffected
-(def fmt (format-response identity))
-
-;; check basic stripping
-(expect {:a 1}
-        (fmt {:a 1
-              :b (fn [] 2)}))
-
-;; check recursive stripping w/ map
-(expect {:response {:a 1}}
-        (fmt {:response {:a 1
-                         :b (fn [] 2)}}))
-
-;; check recursive stripping w/ array
-(expect [{:a 1}]
-        (fmt [{:a 1
-               :b (fn [] 2)}]))
-
-;; check combined recursive stripping
-(expect [{:a [{:b 1}]}]
-        (fmt [{:a [{:b 1
-                    :c (fn [] 2)} ]}]))
-
-
 ;;; JSON encoding tests
 
 ;; Check that we encode byte arrays as the hex values of their first four bytes

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -10,7 +10,7 @@
 ;; Check that the :dashboard_count delay returns the correct count of Dashboards a Card is in
 (expect [0 1 2]
   (let [{card-id :id}       (post-card (random-name))
-        get-dashboard-count (fn [] @(:dashboard_count (Card card-id)))]
+        get-dashboard-count (fn [] (dashboard-count (Card card-id)))]
 
     [(get-dashboard-count)
      (do (ins DashboardCard :card_id card-id, :dashboard_id (:id (create-dash (random-name))))

--- a/test/metabase/models/hydrate_test.clj
+++ b/test/metabase/models/hydrate_test.clj
@@ -6,12 +6,15 @@
                            [util :refer :all])
             [metabase.test.data.users :refer :all]))
 
-(def d1 (delay 1))
-(def d2 (delay 2))
-(def d3 (delay 3))
-(def d4 (delay 4))
-(def d5 (delay 5))
-(def d6 (delay 6))
+(defn- ^:hydrate x [{:keys [id]}]
+  id)
+
+(defn- ^:hydrate y [{:keys [id2]}]
+  id2)
+
+(defn- ^:hydrate z [{:keys [n]}]
+  (vec (for [i (range n)]
+         {:id i})))
 
 ;; ## TESTS FOR HYDRATION HELPER FNS
 
@@ -60,21 +63,21 @@
 (def counts-of (ns-resolve 'metabase.models.hydrate 'counts-of))
 
 (expect [:atom :atom]
-  (counts-of [{:f d1}
-              {:f d2}]
+  (counts-of [{:f {:id 1}}
+              {:f {:id 2}}]
              :f))
 
 (expect [2 2]
-  (counts-of [{:f [d1 d2]}
-              {:f [d3 d4]}]
+  (counts-of [{:f [{:id 1} {:id 2}]}
+              {:f [{:id 3} {:id 4}]}]
              :f))
 
 (expect [3 2]
-  (counts-of [{:f [{:g {:i d1}}
-                   {:g {:i d2}}
-                   {:g {:i d3}}]}
-              {:f [{:g {:i d4}}
-                   {:g {:i d5}}]}]
+  (counts-of [{:f [{:g {:i {:id 1}}}
+                   {:g {:i {:id 2}}}
+                   {:g {:i {:id 3}}}]}
+              {:f [{:g {:i {:id 4}}}
+                   {:g {:i {:id 5}}}]}]
              :f))
 
 (expect [2 :atom :nil]
@@ -87,32 +90,32 @@
          :atom
          :nil
          :atom]
-    (counts-of [{:f {:g d1}}
-                {:f {:g d2}}
+    (counts-of [{:f {:id 1}}
+                {:f {:id 2}}
                 {:f nil}
-                {:f {:g d4}}]
+                {:f {:id 4}}]
                :f))
 
 (expect [:atom nil :nil :atom]
-  (counts-of [{:h {:i d1}}
+  (counts-of [{:h {:i {:id 1}}}
               {}
               {:h nil}
-              {:h {:i d3}}]
+              {:h {:i {:id 3}}}]
              :h))
 
 ;; ### counts-flatten
 (def counts-flatten (ns-resolve 'metabase.models.hydrate 'counts-flatten))
 
-(expect [{:g {:i d1}}
-         {:g {:i d2}}
-         {:g {:i d3}}
-         {:g {:i d4}}
-         {:g {:i d5}}]
-  (counts-flatten [{:f [{:g {:i d1}}
-                        {:g {:i d2}}
-                        {:g {:i d3}}]}
-                   {:f [{:g {:i d4}}
-                        {:g {:i d5}}]}]
+(expect [{:g {:i {:id 1}}}
+         {:g {:i {:id 2}}}
+         {:g {:i {:id 3}}}
+         {:g {:i {:id 4}}}
+         {:g {:i {:id 5}}}]
+  (counts-flatten [{:f [{:g {:i {:id 1}}}
+                        {:g {:i {:id 2}}}
+                        {:g {:i {:id 3}}}]}
+                   {:f [{:g {:i {:id 4}}}
+                        {:g {:i {:id 5}}}]}]
                   :f))
 
 (expect [1 2 nil]
@@ -131,16 +134,16 @@
 ;; ### counts-unflatten
 (def counts-unflatten (ns-resolve 'metabase.models.hydrate 'counts-unflatten))
 
-(expect [{:f [{:g {:i d1}}
-              {:g {:i d2}}
-              {:g {:i d3}}]}
-         {:f [{:g {:i d4}}
-              {:g {:i d5}}]}]
-  (counts-unflatten [{:g {:i d1}}
-                     {:g {:i d2}}
-                     {:g {:i d3}}
-                     {:g {:i d4}}
-                     {:g {:i d5}}] :f [3 2]))
+(expect [{:f [{:g {:i {:id 1}}}
+              {:g {:i {:id 2}}}
+              {:g {:i {:id 3}}}]}
+         {:f [{:g {:i {:id 4}}}
+              {:g {:i {:id 5}}}]}]
+  (counts-unflatten [{:g {:i {:id 1}}}
+                     {:g {:i {:id 2}}}
+                     {:g {:i {:id 3}}}
+                     {:g {:i {:id 4}}}
+                     {:g {:i {:id 5}}}] :f [3 2]))
 
 (expect [{:f {:g 1}}
                    {:f {:g 2}}
@@ -153,30 +156,30 @@
 ;; ### counts-apply
 (def counts-apply (ns-resolve 'metabase.models.hydrate 'counts-apply))
 
-(expect [{:f d1}
-         {:f d2}]
-  (counts-apply [{:f d1}
-                 {:f d2}]
+(expect [{:f {:id 1}}
+         {:f {:id 2}}]
+  (counts-apply [{:f {:id 1}}
+                 {:f {:id 2}}]
                 :f
                 identity))
 
-(expect [{:f [d1 d2]}
-         {:f [d3 d4]}]
-  (counts-apply [{:f [d1 d2]}
-                 {:f [d3 d4]}]
+(expect [{:f [{:id 1} {:id 2}]}
+         {:f [{:id 3} {:id 4}]}]
+  (counts-apply [{:f [{:id 1} {:id 2}]}
+                 {:f [{:id 3} {:id 4}]}]
                 :f
                 identity))
 
-(expect [{:f [{:g {:i d1}}
-              {:g {:i d2}}
-              {:g {:i d3}}]}
-         {:f [{:g {:i d4}}
-              {:g {:i d5}}]}]
-  (counts-apply [{:f [{:g {:i d1}}
-                      {:g {:i d2}}
-                      {:g {:i d3}}]}
-                 {:f [{:g {:i d4}}
-                      {:g {:i d5}}]}]
+(expect [{:f [{:g {:i {:id 1}}}
+              {:g {:i {:id 2}}}
+              {:g {:i {:id 3}}}]}
+         {:f [{:g {:i {:id 4}}}
+              {:g {:i {:id 5}}}]}]
+  (counts-apply [{:f [{:g {:i {:id 1}}}
+                      {:g {:i {:id 2}}}
+                      {:g {:i {:id 3}}}]}
+                 {:f [{:g {:i {:id 4}}}
+                      {:g {:i {:id 5}}}]}]
                 :f
                 identity))
 
@@ -196,259 +199,257 @@
 ;; ## TESTS FOR HYDRATE INTERNAL FNS
 
 ;; ### hydrate-vector (nested hydration)
-(def hydrate-vector (ns-resolve 'metabase.models.hydrate 'hydrate-vector))
+(def hydrate-vector (resolve 'metabase.models.hydrate/hydrate-vector))
 
 ;; check with a nested hydration that returns one result
-(expect [{:f {:g 1}}]
-    (hydrate-vector [{:f (delay {:g d1})}]
-                    [:f :g]))
+(expect
+  [{:f {:id 1, :x 1}}]
+  (hydrate-vector [{:f {:id 1}}]
+                  [:f :x]))
 
-(expect [{:f {:g 1}}
-         {:f {:g 2}}]
-  (hydrate-vector [{:f (delay {:g d1})}
-                   {:f (delay {:g d2})}]
-                  [:f :g]))
+(expect
+  [{:f {:id 1, :x 1}}
+   {:f {:id 2, :x 2}}]
+  (hydrate-vector [{:f {:id 1}}
+                   {:f {:id 2}}]
+                  [:f :x]))
 
 ;; check with a nested hydration that returns multiple results
-(expect [{:f [{:g 1}
-              {:g 2}
-              {:g 3}]}]
-  (hydrate-vector [{:f (delay [{:g d1}
-                               {:g d2}
-                               {:g d3}])}]
-                  [:f :g]))
+(expect
+  [{:f [{:id 1, :x 1}
+        {:id 2, :x 2}
+        {:id 3, :x 3}]}]
+  (hydrate-vector [{:f [{:id 1}
+                        {:id 2}
+                        {:id 3}]}]
+                  [:f :x]))
 
 ;; ### hydrate-kw
 (def hydrate-kw (ns-resolve 'metabase.models.hydrate 'hydrate-kw))
-(expect [{:g 1}
-         {:g 2}
-         {:g 3}]
-    (hydrate-kw [{:g d1}
-                 {:g d2}
-                 {:g d3}] :g))
+(expect
+  [{:id 1, :x 1}
+   {:id 2, :x 2}
+   {:id 3, :x 3}]
+  (hydrate-kw [{:id 1}
+               {:id 2}
+               {:id 3}] :x))
 
 ;; ### batched-hydrate
 
 ;; ### hydrate - tests for overall functionality
 
 ;; make sure we can do basic hydration
-(expect {:a 1 :b 2}
-        (hydrate {:a 1
-                  :b d2}
-                 :b))
+(expect
+  {:a 1, :id 2, :x 2}
+  (hydrate {:a 1, :id 2}
+           :x))
 
 ;; specifying "nested" hydration with no "nested" keys should throw an exception and tell you not to do it
 (expect "Assert failed: Replace '[:b]' with ':b'. Vectors are for nested hydration. There's no need to use one when you only have a single key.\n(> (count vect) 1)"
-  (try (hydrate {:a 1
-                 :b d2}
+  (try (hydrate {:a 1, :id 2}
                 [:b])
        (catch Throwable e
          (.getMessage e))))
 
 ;; check that returning an array works correctly
-(expect {:c [1 2 3]}
-        (hydrate {:c (delay [1 2 3])} :c))
+(expect {:n 3
+         :z [{:id 0}
+             {:id 1}
+             {:id 2}]}
+        (hydrate {:n 3} :z))
 
 ;; check that nested keys aren't hydrated if we don't ask for it
-(expect {:d {:e d1}}
-  (hydrate {:d (delay {:e d1})}
+(expect {:d {:id 1}}
+  (hydrate {:d {:id 1}}
            :d))
 
 ;; check that nested keys can be hydrated if we DO ask for it
-(expect {:d {:e 1}}
-  (hydrate {:d (delay {:e d1})}
-           [:d :e]))
+(expect {:d {:id 1, :x 1}}
+  (hydrate {:d {:id 1}}
+           [:d :x]))
 
 ;; check that nested hydration also works if one step returns multiple results
-(expect {:f [{:g 1}
-             {:g 2}
-             {:g 3}]}
-  (hydrate {:f (delay [{:g d1}
-                       {:g d2}
-                       {:g d3}])}
-           [:f :g]))
+(expect {:n 3
+         :z [{:id 0, :x 0}
+             {:id 1, :x 1}
+             {:id 2, :x 2}]}
+  (hydrate {:n 3} [:z :x]))
 
 ;; check nested hydration with nested maps
-(expect [{:f {:g 1}}
-         {:f {:g 2}}
-         {:f {:g 3}}
-         {:f {:g 4}}]
-  (hydrate [{:f {:g d1}}
-            {:f {:g d2}}
-            {:f {:g d3}}
-            {:f {:g d4}}] [:f :g]))
+(expect [{:f {:id 1, :x 1}}
+         {:f {:id 2, :x 2}}
+         {:f {:id 3, :x 3}}
+         {:f {:id 4, :x 4}}]
+  (hydrate [{:f {:id 1}}
+            {:f {:id 2}}
+            {:f {:id 3}}
+            {:f {:id 4}}] [:f :x]))
 
 ;; check with a nasty mix of maps and seqs
-(expect [{:f [{:g 1} {:g 2} {:g 3}]}
-         {:f {:g 1}}
-         {:f [{:g 4} {:g 5} {:g 6}]}]
-  (hydrate [{:f [{:g d1}
-                 {:g d2}
-                 {:g d3}]}
-            {:f {:g d1}}
-            {:f [{:g d4}
-                 {:g d5}
-                 {:g d6}]}] [:f :g]))
+(expect [{:f [{:id 1, :x 1} {:id 2, :x 2} {:id 3, :x 3}]}
+         {:f {:id 1, :x 1}}
+         {:f [{:id 4, :x 4} {:id 5, :x 5} {:id 6, :x 6}]}]
+  (hydrate [{:f [{:id 1}
+                 {:id 2}
+                 {:id 3}]}
+            {:f {:id 1}}
+            {:f [{:id 4}
+                 {:id 5}
+                 {:id 6}]}] [:f :x]))
 
 ;; check that hydration works with top-level nil values
-(expect [{:f 1}
-         {:f 2}
+(expect [{:id 1, :x 1}
+         {:id 2, :x 2}
          nil
-         {:f 4}]
-    (hydrate [{:f d1}
-              {:f d2}
+         {:id 4, :x 4}]
+    (hydrate [{:id 1}
+              {:id 2}
               nil
-              {:f d4}] :f))
+              {:id 4}] :x))
 
 ;; check nested hydration with top-level nil values
-(expect [{:f {:g 1}}
-         {:f {:g 2}}
+(expect [{:f {:id 1, :x 1}}
+         {:f {:id 2, :x 2}}
          nil
-         {:f {:g 4}}]
-  (hydrate [{:f {:g d1}}
-            {:f {:g d2}}
+         {:f {:id 4, :x 4}}]
+  (hydrate [{:f {:id 1}}
+            {:f {:id 2}}
             nil
-            {:f {:g d4}}] [:f :g]))
+            {:f {:id 4}}] [:f :x]))
 
 ;; check that nested hydration w/ nested nil values
-(expect [{:f {:g 1}}
-         {:f {:g 2}}
+(expect [{:f {:id 1, :x 1}}
+         {:f {:id 2, :x 2}}
          {:f nil}
-         {:f {:g 4}}]
-  (hydrate [{:f {:g d1}}
-            {:f {:g d2}}
+         {:f {:id 4, :x 4}}]
+  (hydrate [{:f {:id 1}}
+            {:f {:id 2}}
             {:f nil}
-            {:f {:g d4}}] [:f :g]))
+            {:f {:id 4}}] [:f :x]))
 
-(expect [{:f {:g 1}}
-         {:f {:g 2}}
-         {:f {:g nil}}
-         {:f {:g 4}}]
-  (hydrate [{:f {:g d1}}
-            {:f {:g d2}}
-            {:f {:g nil}}
-            {:f {:g d4}}] [:f :g]))
+(expect [{:f {:id 1, :x 1}}
+         {:f {:id 2, :x 2}}
+         {:f {:id nil, :x nil}}
+         {:f {:id 4, :x 4}}]
+  (hydrate [{:f {:id 1}}
+            {:f {:id 2}}
+            {:f {:id nil}}
+            {:f {:id 4}}] [:f :x]))
 
 ;; check that it works with some objects missing the key
-(expect [{:f [{:g 1} {:g 2} {:h d3}]}
-         {:f {:g 1}}
-         {:f [{:g 4} {:h d5} {:g 6}]}]
-    (hydrate [{:f [{:g d1}
-                   {:g d2}
-                   {:h d3}]}
-              {:f  {:g d1}}
-              {:f [{:g d4}
-                   {:h d5}
-                   {:g d6}]}] [:f :g]))
+(expect
+  [{:f [{:id 1, :x 1}
+        {:id 2, :x 2}
+        {:g 3, :x nil}]}
+   {:f {:id 1, :x 1}}
+   {:f [{:id 4, :x 4}
+        {:g 5, :x nil}
+        {:id 6, :x 6}]}]
+  (hydrate [{:f [{:id 1}
+                 {:id 2}
+                 {:g 3}]}
+            {:f  {:id 1}}
+            {:f [{:id 4}
+                 {:g 5}
+                 {:id 6}]}] [:f :x]))
 
 ;; check that we can handle wonky results: :f is [sequence, map sequence] respectively
-(expect [{:f [{:g 1, :h 1} {:g 2} {:g 3, :h 3}]}
-         {:f {:g 1, :h 1}}
-         {:f [{:g 4} {:g 5, :h 5} {:g 6}]}]
-  (hydrate [{:f [{:g d1 :h d1}
-                 {:g d2}
-                 {:g d3 :h d3}]}
-            {:f  {:g d1 :h d1}}
-            {:f [{:g d4}
-                 {:g d5 :h d5}
-                 {:g d6}]}] [:f :g :h]))
+(expect
+  [{:f [{:id 1, :id2 10, :x 1, :y 10}
+        {:id 2, :x 2, :y nil}
+        {:id 3, :id2 30, :x 3, :y 30}]}
+   {:f {:id 1, :id2 10, :x 1, :y 10}}
+   {:f [{:id 4, :x 4, :y nil}
+        {:id 5, :id2 50, :x 5, :y 50}
+        {:id 6, :x 6, :y nil}]}]
+  (hydrate [{:f [{:id 1, :id2 10}
+                 {:id 2}
+                 {:id 3, :id2 30}]}
+            {:f  {:id 1, :id2 10}}
+            {:f [{:id 4}
+                 {:id 5, :id2 50}
+                 {:id 6}]}] [:f :x :y]))
 
 ;; nested-nested hydration
-(expect [{:f [{:g {:i 1}}
-              {:g {:i 2}}
-              {:g {:i 3}}]}
-         {:f [{:g {:i 4}}
-              {:g {:i 5}}]}]
-  (hydrate [{:f [{:g {:i d1}}
-                 {:g {:i d2}}
-                 {:g {:i d3}}]}
-            {:f [{:g {:i d4}}
-                 {:g {:i d5}}]}]
-           [:f [:g :i]]))
+(expect
+  [{:f [{:g {:id 1, :x 1}}
+        {:g {:id 2, :x 2}}
+        {:g {:id 3, :x 3}}]}
+   {:f [{:g {:id 4, :x 4}}
+        {:g {:id 5, :x 5}}]}]
+  (hydrate [{:f [{:g {:id 1}}
+                 {:g {:id 2}}
+                 {:g {:id 3}}]}
+            {:f [{:g {:id 4}}
+                 {:g {:id 5}}]}]
+           [:f [:g :x]]))
 
 ;; nested + nested-nested hydration
-(expect [{:f [{:g 1 :h {:i 1}}]}
-         {:f [{:g 2 :h {:i 4}}
-              {:g 3 :h {:i 5}}]}]
-  (hydrate [{:f [{:g d1 :h {:i d1}}]}
-            {:f [{:g d2 :h {:i d4}}
-                 {:g d3 :h {:i d5}}]}]
-           [:f :g [:h :i]]))
+(expect
+  [{:f [{:id 1, :g {:id 1, :x 1}, :x 1}]}
+   {:f [{:id 2, :g {:id 4, :x 4}, :x 2}
+        {:id 3, :g {:id 5, :x 5}, :x 3}]}]
+  (hydrate [{:f [{:id 1, :g {:id 1}}]}
+            {:f [{:id 2, :g {:id 4}}
+                 {:id 3, :g {:id 5}}]}]
+           [:f :x [:g :x]]))
 
 ;; make sure nested-nested hydration doesn't accidentally return maps where there were none
-(expect {:f [{:h {:i 1}}
-             {}
-             {:h {:i 3}}]}
-  (hydrate {:f [{:h {:i d1}}
+(expect
+  {:f [{:h {:id 1, :x 1}}
+       {}
+       {:h {:id 3, :x 3}}]}
+  (hydrate {:f [{:h {:id 1}}
                 {}
-                {:h {:i d3}}]}
-           [:f [:h :i]]))
+                {:h {:id 3}}]}
+           [:f [:h :x]]))
 
 ;; check nested hydration with several keys
-(expect [{:f [{:g 1
-               :h {:i 1, :j 1}}]}
-         {:f [{:g 2
-               :h {:i 4, :j 2}}
-              {:g 3
-               :h {:i 5, :j 3}}]}]
-  (hydrate [{:f [{:g d1 :h {:i d1 :j d1}}]}
-            {:f [{:g d2 :h {:i d4 :j d2}}
-                 {:g d3 :h {:i d5 :j d3}}]}]
-           [:f :g [:h :i :j]]))
+(expect
+  [{:f [{:id 1, :h {:id 1, :id2 1, :x 1, :y 1}, :x 1}]}
+   {:f [{:id 2, :h {:id 4, :id2 2, :x 4, :y 2}, :x 2}
+        {:id 3, :h {:id 5, :id2 3, :x 5, :y 3}, :x 3}]}]
+  (hydrate [{:f [{:id 1, :h {:id 1, :id2 1}}]}
+            {:f [{:id 2, :h {:id 4, :id2 2}}
+                 {:id 3, :h {:id 5, :id2 3}}]}]
+           [:f :x [:h :x :y]]))
 
 ;; multiple nested-nested hydrations
-(expect [{:f [{:g {:k 1}
-               :h {:i {:j 1}}}]}
-         {:f [{:g {:k 2}
-               :h {:i {:j 2}}}
-              {:g {:k 3}
-               :h {:i {:j 3}}}]}]
-  (hydrate [{:f [{:g {:k d1}
-                  :h (delay {:i {:j d1}})}]}
-            {:f [{:g {:k d2}
-                  :h (delay {:i {:j d2}})}
-                 {:g {:k d3}
-                  :h (delay {:i {:j d3}})}]}]
-           [:f [:g :k] [:h [:i :j]]]))
+(expect
+  [{:f [{:g {:id 1, :x 1}, :h {:i {:id2 1, :y 1}}}]}
+   {:f [{:g {:id 2, :x 2}, :h {:i {:id2 2, :y 2}}}
+        {:g {:id 3, :x 3}, :h {:i {:id2 3, :y 3}}}]}]
+  (hydrate [{:f [{:g {:id 1}
+                  :h {:i {:id2 1}}}]}
+            {:f [{:g {:id 2}
+                  :h {:i {:id2 2}}}
+                 {:g {:id 3}
+                  :h {:i {:id2 3}}}]}]
+           [:f [:g :x] [:h [:i :y]]]))
 
 ;; *nasty* nested-nested hydration
-(expect [{:f [{:g 1 :h {:i 1}}
-              {:g 2}
-              {:g 3 :h {:i 3}}]}
-         {:f  {:g 1 :h {:i 1}}}
-         {:f [{:g 4}
-              {:g 5 :h {:i 5}}
-              {:g 6}]}]
-  (hydrate [{:f [{:g d1 :h {:i d1}}
-                 {:g d2}
-                 {:g d3 :h {:i d3}}]}
-            {:f  {:g d1 :h {:i d1}}}
-            {:f [{:g d4}
-                 {:g d5 :h {:i d5}}
-                 {:g d6}]}]
-           [:f :g [:h :i]]))
+(expect
+  [{:f [{:id 1, :h {:id2 1, :y 1}, :x 1}
+        {:id 2, :x 2}
+        {:id 3, :h {:id2 3, :y 3}, :x 3}]}
+   {:f {:id 1, :h {:id2 1, :y 1}, :x 1}}
+   {:f [{:id 4, :x 4}
+        {:id 5, :h {:id2 5, :y 5}, :x 5}
+        {:id 6, :x 6}]}]
+  (hydrate [{:f [{:id 1, :h {:id2 1}}
+                 {:id 2}
+                 {:id 3, :h {:id2 3}}]}
+            {:f  {:id 1, :h {:id2 1}}}
+            {:f [{:id 4}
+                 {:id 5, :h {:id2 5}}
+                 {:id 6}]}]
+           [:f :x [:h :y]]))
 
 ;; check that hydration doesn't barf if we ask it to hydrate an object that's not there
 (expect {:f [:a 100]}
-  (hydrate {:f [:a 100]} :x))
+  (hydrate {:f [:a 100]} :p))
 
 ;;; ## BATCHED HYDRATION TESTS
-
-(resolve-private-fns metabase.middleware remove-fns-and-delays)
-
-;; Just double-check that batched hydration can hydrate fields with no delays
-(expect (match-$ (fetch-user :rasta)
-          {:email "rasta@metabase.com"
-           :first_name "Rasta"
-           :last_login $
-           :is_superuser false
-           :id $
-           :last_name "Toucan"
-           :date_joined $
-           :common_name "Rasta Toucan"})
-  (->> (hydrate {:user_id (user->id :rasta)} :user)
-       :user
-       remove-fns-and-delays))
 
 ;; Check that batched hydration doesn't try to hydrate fields that already exist and are not delays
 (expect {:user_id (user->id :rasta)
@@ -456,12 +457,3 @@
   (hydrate {:user_id (user->id :rasta)
             :user "OK <3"}
            :user))
-
-;; Check that batched hydration just re-uses values of delays that have been realized
-(expect {:user_id (user->id :rasta)
-         :user "OK <3"}
-  (let [user-delay (delay "OK <3")]
-    @user-delay
-    (hydrate {:user_id (user->id :rasta)
-              :user user-delay}
-             :user)))


### PR DESCRIPTION
After poking around the models a lot I noticed that 99.9% of the delays we associate with instances in `post-select` go unused. So now instead of:

``` clojure
@(:db (Table 1))
```

I've replaced them with functions:

``` clojure
(database (Table 1))
```

You can mark a function as eligible for use for hydration via metadata:

``` clojure
(defn ^:hydrate database [{:keys [db_id]}]
  (Database db_id))
```

Voila! :tada: 

This makes the models code even more readable (IMO) and lets us remove the API middleware that walked our entire response, removing delays where it saw them; combined with the performance bump we get from avoiding the creation of (way too many) delays the Metabase API is now faster than ever.
