### PR TITLE
Command for migrating MB DB from H2 to Postgres/MySQL

### DIFF
--- a/src/metabase/cmd/load_from_h2.clj
+++ b/src/metabase/cmd/load_from_h2.clj
@@ -1,0 +1,83 @@
+(ns metabase.cmd.load-from-h2
+  "Commands for loading data from an H2 file into another database."
+  (:require [colorize.core :as color]
+            (korma [core :as k]
+                   [db :as kdb])
+            [metabase.db :as db]
+            (metabase.models [activity :refer [Activity]]
+                             [card :refer [Card]]
+                             [card-favorite :refer [CardFavorite]]
+                             [dashboard :refer [Dashboard]]
+                             [dashboard-card :refer [DashboardCard]]
+                             [database :refer [Database]]
+                             [dependency :refer [Dependency]]
+                             [field :refer [Field]]
+                             [field-values :refer [FieldValues]]
+                             [foreign-key :refer [ForeignKey]]
+                             [metric :refer [Metric]]
+                             [pulse :refer [Pulse]]
+                             [pulse-card :refer [PulseCard]]
+                             [pulse-channel :refer [PulseChannel]]
+                             [pulse-channel-recipient :refer [PulseChannelRecipient]]
+                             [query-execution :refer [QueryExecution]]
+                             [revision :refer [Revision]]
+                             [segment :refer [Segment]]
+                             [session :refer [Session]]
+                             [setting :refer [Setting]]
+                             [table :refer [Table]]
+                             [user :refer [User]]
+                             [view-log :refer [ViewLog]])
+            [metabase.util :as u]))
+
+(def ^:private entities
+  "Entities in the order they should be serialized/deserialized.
+   This is done so we make sure that we load load instances of entities before others
+   that might depend on them, e.g. `Databases` before `Tables` before `Fields`."
+  [Database
+   User
+   Setting
+   Dependency
+   Table
+   Field
+   FieldValues
+   ForeignKey
+   Segment
+   Metric
+   Revision
+   ViewLog
+   Session
+   Dashboard
+   Card
+   CardFavorite
+   DashboardCard
+   Activity
+   QueryExecution
+   Pulse
+   PulseCard
+   PulseChannel
+   PulseChannelRecipient])
+
+(defn load-from-h2
+  "Transfer data from existing H2 database to the newly created (presumably MySQL or Postgres) DB specified by env vars.
+   Intended as a tool for upgrading from H2 to a 'real' Database.
+
+   Defaults to using `@metabase.db/db-file` as the connection string."
+  [h2-connection-string-or-nil]
+  (let [filename (or h2-connection-string-or-nil
+                     @metabase.db/db-file)
+        h2-db    (kdb/create-db (db/jdbc-details {:type :h2, :db (str filename ";IFEXISTS=TRUE")}))] ; TODO - would be nice to add `ACCESS_MODE_DATA=r` but it doesn't work with `AUTO_SERVER=TRUE`
+    (db/setup-db)
+    (kdb/transaction
+     (doseq [e     entities
+             :let  [objs (kdb/with-db h2-db
+                           (k/select (k/database e h2-db)))]
+             :when (seq objs)]
+       (print (u/format-color 'blue "Transfering %d instances of %s..." (count objs) (:name e)))
+       (flush)
+
+       ;; The connection closes prematurely on occasion when we're inserting thousands of rows at once. Break into smaller chunks so connection stays alive
+       (doseq [chunk (partition-all 300 objs)]
+         (print (color/blue \.))
+         (flush)
+         (k/insert e (k/values chunk)))
+       (println (color/green "[OK]"))))))

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -24,7 +24,7 @@
 
 ;; ## DB FILE, JDBC/KORMA DEFINITONS
 
-(def ^:private db-file
+(def db-file
   "Path to our H2 DB file from env var or app config."
   ;; see http://h2database.com/html/features.html for explanation of options
   (delay (if (config/config-bool :mb-db-in-memory)
@@ -75,7 +75,7 @@
                           :user     (config/config-str :mb-db-user)
                           :password (config/config-str :mb-db-pass)}))))
 
-(defn- jdbc-details
+(defn jdbc-details
   "Takes our own MB details map and formats them properly for connection details for Korma / JDBC."
   [db-details]
   {:pre [(map? db-details)]}

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -79,7 +79,7 @@
   i/IEntity
   (merge i/IEntityDefaults
          {:hydration-keys     (constantly [:card])
-          :types              (constantly {:display :keyword, :query_type :keyword, :dataset_query :json, :visualization_settings :json})
+          :types              (constantly {:display :keyword, :query_type :keyword, :dataset_query :json, :visualization_settings :json, :description :clob})
           :timestamped?       (constantly true)
           :can-read?          i/publicly-readable?
           :can-write?         i/publicly-writeable?

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -1,11 +1,16 @@
 (ns metabase.models.dashboard-card
   (:require [clojure.set :as set]
+            [korma.core :as k]
             [metabase.db :refer [sel]]
             (metabase.models [card :refer [Card]]
                              [interface :as i])
             [metabase.util :as u]))
 
-(i/defentity DashboardCard :report_dashboardcard)
+(i/defentity DashboardCard :report_dashboardcard
+             ;; This is implemented as a `transform` function instead of `post-select` because we want it to apply even
+             ;; when we use low-level korma primitives like `select`. Otherwise you can't `insert` what you `select`.
+             ;; TODO - The fact that we have to work around these names means we should probably just rename them
+             (k/transform (u/rpartial set/rename-keys {:sizex :sizeX, :sizey :sizeY})))
 
 (defn- pre-insert [dashcard]
   (let [defaults {:sizeX 2
@@ -16,8 +21,7 @@
   i/IEntity
   (merge i/IEntityDefaults
          {:timestamped? (constantly true)
-          :pre-insert   pre-insert
-          :post-select  (u/rpartial set/rename-keys {:sizex :sizeX, :sizey :sizeY})})) ; TODO - frontend expects mixed-case names here, should change that
+          :pre-insert   pre-insert}))
 
 
 (u/require-dox-in-this-namespace)

--- a/src/metabase/models/query_execution.clj
+++ b/src/metabase/models/query_execution.clj
@@ -12,5 +12,5 @@
   i/IEntity
   (merge i/IEntityDefaults
          {:default-fields (constantly [:id :uuid :version :json_query :raw_query :status :started_at :finished_at :running_time :error :result_rows])
-          :types          (constantly {:json_query :json, :result_data :json, :status :keyword})
+          :types          (constantly {:json_query :json, :result_data :json, :status :keyword, :raw_query :clob, :error :clob, :additional_info :clob})
           :post-select    post-select}))


### PR DESCRIPTION
After considering the options I believe this is the least hacky / sketchy way to get what we want in #1456. We can do a SQL dump of an H2 database, but there are significant dialectal differences between H2 and Postgres/MySQL (not to mention H2's uppercasing of all table and column names). So that route would mean we'd have to translate H2 SQL to PostgreSQL and/or MySQL. 

Instead, we'll just dump the objects into an EDN file and rely on our existing code to insert rows back into the DB. We'll expose 2 new command-line commands, `dump` and `load-dump`:
###### `dump`

`dump` serializes the contents of the Metabase database to a file.

``` bash
# from leiningen
lein run dump mb-dump.edn

# from uberjar
java -jar metabase.jar dump mb-dump.edn
```
###### `load-dump`

`load-dump` loads the contents of a Metabase DB dump into the DB.

``` bash
MB_DB_TYPE=postgres MB_DB_HOST=localhost MB_DB_PORT=5432 \
  MB_DB_DBNAME=metabase MB_DB_USER=camsaul lein run load-dump mb-dump.edn
```

Supplying different DB details for `dump` and `load-dump` can be used to migrate from one underlying DB to another, which would also make this suitable for upgrading from a "single-player" instance to a cloud-based one.
