### PR TITLE
Lint JSX files and error-on-warnings

### DIFF
--- a/frontend/src/admin/databases/components/DatabaseEdit.jsx
+++ b/frontend/src/admin/databases/components/DatabaseEdit.jsx
@@ -5,7 +5,6 @@ import DatabaseEditForms from "./DatabaseEditForms.jsx";
 
 import ActionButton from "metabase/components/ActionButton.jsx";
 import Breadcrumbs from "metabase/components/Breadcrumbs.jsx"
-import Icon from "metabase/components/Icon.jsx";
 import ModalWithTrigger from "metabase/components/ModalWithTrigger.jsx";
 
 export default class DatabaseEdit extends Component {

--- a/frontend/src/home/components/Activity.jsx
+++ b/frontend/src/home/components/Activity.jsx
@@ -87,20 +87,6 @@ export default class Activity extends Component {
             timeSince: item.timestamp.fromNow()
         };
 
-        function handleSubject(item) {
-            if(item.table) {
-                return {
-                    subject: "saved a question about",
-                    subjectRefName: item.table.display_name,
-                }
-            } else {
-                return {
-                    subject: "saved a question",
-                    subjectRefName: null
-                }
-            }
-        }
-
         switch (item.topic) {
             case "card-create":
             case "card-update":

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "webpack-postcss-tools": "^1.1.1"
   },
   "scripts": {
-    "lint": "./node_modules/eslint/bin/eslint.js frontend/src",
+    "lint": "./node_modules/eslint/bin/eslint.js --ext .js --ext .jsx --max-warnings 0 frontend/src",
     "test": "./node_modules/karma/bin/karma start frontend/test/karma.conf.js --single-run --reporters nyan",
     "test-watch": "./node_modules/karma/bin/karma start frontend/test/karma.conf.js --auto-watch --reporters nyan",
     "test-e2e": "./node_modules/protractor/bin/webdriver-manager update && ./node_modules/protractor/bin/protractor frontend/test/protractor-conf.js",


### PR DESCRIPTION
We weren't actually linting most of our frontend code in CI because it ignored `.jsx` extensions (which wasn't a big deal since it's linted by webpack anyway), however we should so that we can treat warnings (unused variables, etc) as errors in CI.
