### PR TITLE
Only log API calls once :ghost:

### DIFF
--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -55,7 +55,7 @@
 (def app
   "The primary entry point to the HTTP server"
   (-> routes/routes
-      (mb-middleware/log-api-call :request :response)
+      (mb-middleware/log-api-call)
       mb-middleware/add-security-headers              ; [METABASE] Add HTTP headers to API responses to prevent them from being cached
       (wrap-json-body                                 ; extracts json POST body and makes it avaliable on request
         {:keywords? true})

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -207,6 +207,16 @@
      (contains? date-trunc-units unit)
      (date-trunc unit date))))
 
+(defn format-nanoseconds
+  "Format a time interval in nanoseconds to something more readable (µs/ms/etc.)
+   Useful for logging elapsed time when using `(System/nanotime)`"
+  [nanoseconds]
+  (loop [n nanoseconds, [[unit divisor] & more] [[:ns 1000] [:µs 1000] [:ms 1000] [:s 1000] [:mins 60] [:hours 60]]]
+    (if (and (> n divisor)
+             (seq more))
+      (recur (/ n divisor) more)
+      (format "%.0f %s" (double n) (name unit)))))
+
 
 ;;; ## Etc
 


### PR DESCRIPTION
-  Only log API calls once instead of when both they come in & when they complete. This was way too much clutter in the logs, especially when some pages make ~100 API calls as mentioned in #1726
-  Tweak API call logging to use most appropriate unit (ns/µs/ms/s) for elapsed time
