### PR TITLE
Reflection linter

### DIFF
--- a/bin/reflection-linter
+++ b/bin/reflection-linter
@@ -3,9 +3,9 @@
 warnings=`lein check 2>&1 | grep Reflection | grep metabase`
 
 if [ ! -z "$warnings" ]; then
-    echo -e "\e[4;31mYour code has cased introduced some reflection warnings.\e[0m 😞"
+    echo -e "\e[1;31mYour code has cased introduced some reflection warnings.\e[0m 😞"
     echo "$warnings";
     exit -1;
 fi
 
-echo "\e[1;32mNo reflection warnings! Success.\e[0m"
+echo -e "\e[1;32mNo reflection warnings! Success.\e[0m"

--- a/bin/reflection-linter
+++ b/bin/reflection-linter
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+warnings=`lein check 2>&1 | grep Reflection | grep metabase`
+
+if [ ! -z "$warnings" ]; then
+    echo -e "\e[4;31mYour code has cased introduced some reflection warnings.\e[0m 😞"
+    echo "$warnings";
+    exit -1;
+fi
+
+echo "\e[1;32mNo reflection warnings! Success.\e[0m"

--- a/circle.yml
+++ b/circle.yml
@@ -26,10 +26,10 @@ test:
     # 1) runs unit tests w/ Postgres local DB. Runs against H2, SQL Server
     # 2) runs unit tests w/ MySQL local DB. Runs against H2, Postgres, SQLite
     # 3) runs unit tests w/ H2 local DB. Runs against H2, Redshift
-    # 4) runs Eastwood linter & Bikeshed linter
+    # 4) runs Eastwood linter & Bikeshed linter && ./bin/reflection-linter
     # 5) runs JS linter + JS test
     # 6) runs lein uberjar. (We don't run bin/build because we're not really concerned about `npm install` (etc) in this test, which runs elsewhere)
-    - case $CIRCLE_NODE_INDEX in 0) ENGINES=h2,mongo,mysql lein test ;; 1) ENGINES=h2,sqlserver MB_DB_TYPE=postgres MB_DB_DBNAME=circle_test MB_DB_PORT=5432 MB_DB_USER=ubuntu MB_DB_HOST=localhost lein test ;; 2) ENGINES=h2,postgres,sqlite MB_DB_TYPE=mysql MB_DB_DBNAME=circle_test MB_DB_PORT=3306 MB_DB_USER=ubuntu MB_DB_HOST=localhost lein test ;; 3) ENGINES=h2,redshift lein test ;; 4) lein eastwood && lein bikeshed --max-line-length 240 ;; 5) npm install && npm run lint && npm run build && npm run test ;; 6) lein uberjar ;; esac:
+    - case $CIRCLE_NODE_INDEX in 0) ENGINES=h2,mongo,mysql lein test ;; 1) ENGINES=h2,sqlserver MB_DB_TYPE=postgres MB_DB_DBNAME=circle_test MB_DB_PORT=5432 MB_DB_USER=ubuntu MB_DB_HOST=localhost lein test ;; 2) ENGINES=h2,postgres,sqlite MB_DB_TYPE=mysql MB_DB_DBNAME=circle_test MB_DB_PORT=3306 MB_DB_USER=ubuntu MB_DB_HOST=localhost lein test ;; 3) ENGINES=h2,redshift lein test ;; 4) lein eastwood 2>&1 | grep -v Reflection && lein bikeshed 2>&1 | grep -v Reflection && ./bin/reflection-linter ;; 5) npm install && npm run lint && npm run build && npm run test ;; 6) lein uberjar ;; esac:
         parallel: true
 deployment:
   master:

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,8 @@
   :description "Metabase Community Edition"
   :url "http://metabase.com/"
   :min-lein-version "2.5.0"
-  :aliases {"test" ["with-profile" "+expectations" "expectations"]
+  :aliases {"bikeshed" ["with-profile" "+bikeshed" "bikeshed" "--max-line-length" "240"]
+            "test" ["with-profile" "+expectations" "expectations"]
             "generate-sample-dataset" ["with-profile" "+generate-sample-dataset" "run"]}
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/core.async "0.2.374"]

--- a/src/metabase/driver/mongo.clj
+++ b/src/metabase/driver/mongo.clj
@@ -86,7 +86,7 @@
     (-> field-def
         (update :count safe-inc)
         (update :len #(if (string? field-value)
-                       (+ (or % 0) (.length field-value))
+                       (+ (or % 0) (count field-value))
                        %))
         (update :types (fn [types]
                          (update types (type field-value) safe-inc)))


### PR DESCRIPTION
-  Fix another reflection warning in `metabase.driver.mongo`
-  Add a new linter script that fails if any new reflection warnings are introduced.
