### PR TITLE
Smart aggregation options

### DIFF
--- a/frontend/src/lib/schema_metadata.js
+++ b/frontend/src/lib/schema_metadata.js
@@ -364,7 +364,8 @@ var Aggregators = [{
     "name": "Standard deviation of ...",
     "short": "stddev",
     "description": "Number which expresses how much the values of a column vary among all rows in the answer.",
-    "validFieldsFilters": [summableFields]
+    "validFieldsFilters": [summableFields],
+    "requiredDriverFeature": "standard-deviation-aggregations"
 }];
 
 var BreakoutAggregator = {
@@ -386,9 +387,16 @@ function populateFields(aggregator, fields) {
     };
 }
 
-function getAggregators(fields) {
-    return _.map(Aggregators, function(aggregator) {
-        return populateFields(aggregator, fields);
+function getAggregators(table) {
+    const supportedAggregations = Aggregators.filter(function (agg) {
+        if (agg.requiredDriverFeature && !_.contains(table.db.features, agg.requiredDriverFeature)) {
+            return false;
+        } else {
+            return true;
+        }
+    });
+    return _.map(supportedAggregations, function(aggregator) {
+        return populateFields(aggregator, table.fields);
     });
 }
 
@@ -403,7 +411,7 @@ export function addValidOperatorsToFields(table) {
     for (let field of table.fields) {
         field.valid_operators = getOperators(field, table);
     }
-    table.aggregation_options = getAggregators(table.fields);
+    table.aggregation_options = getAggregators(table);
     table.breakout_options = getBreakouts(table.fields);
     return table;
 }

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -296,12 +296,11 @@
      metabase.driver.<engine>/<engine>"
   [engine]
   {:pre [engine]}
-  (when (is-engine? engine)
-    (or ((keyword engine) @registered-drivers)
-        (let [namespce (symbol (format "metabase.driver.%s" (name engine)))]
-          (log/debug (format "Loading driver '%s'..." engine))
-          (require namespce)
-          ((keyword engine) @registered-drivers)))))
+  (or ((keyword engine) @registered-drivers)
+      (let [namespce (symbol (format "metabase.driver.%s" (name engine)))]
+        (log/debug (format "Loading driver '%s'..." engine))
+        (u/try-ignore-exceptions (require namespce))
+        ((keyword engine) @registered-drivers))))
 
 
 ;; Can the type of a DB change?

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -296,11 +296,12 @@
      metabase.driver.<engine>/<engine>"
   [engine]
   {:pre [engine]}
-  (or ((keyword engine) @registered-drivers)
-      (let [namespce (symbol (format "metabase.driver.%s" (name engine)))]
-        (log/debug (format "Loading driver '%s'..." engine))
-        (require namespce)
-        ((keyword engine) @registered-drivers))))
+  (when (is-engine? engine)
+    (or ((keyword engine) @registered-drivers)
+        (let [namespce (symbol (format "metabase.driver.%s" (name engine)))]
+          (log/debug (format "Loading driver '%s'..." engine))
+          (require namespce)
+          ((keyword engine) @registered-drivers)))))
 
 
 ;; Can the type of a DB change?

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -12,7 +12,7 @@
 
 (i/defentity Database :metabase_database)
 
-(defn- pre-cascade-delete [{:keys [id] :as database}]
+(defn- pre-cascade-delete [{:keys [id]}]
   (cascade-delete 'Card  :database_id id)
   (cascade-delete 'Table :db_id id))
 
@@ -29,6 +29,7 @@
           :timestamped?       (constantly true)
           :can-read?          (constantly true)
           :can-write?         i/superuser?
+          :post-select        #(assoc % :features ((resolve 'metabase.driver/features) ((resolve 'metabase.driver/engine->driver) (:engine %))))
           :pre-cascade-delete pre-cascade-delete}))
 
 

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -12,6 +12,12 @@
 
 (i/defentity Database :metabase_database)
 
+(defn- post-select [{:keys [engine] :as database}]
+  (if-not engine database
+                 (assoc database :features (if-let [driver ((resolve 'metabase.driver/engine->driver) engine)]
+                                             ((resolve 'metabase.driver/features) driver)
+                                             []))))
+
 (defn- pre-cascade-delete [{:keys [id]}]
   (cascade-delete 'Card  :database_id id)
   (cascade-delete 'Table :db_id id))
@@ -29,7 +35,7 @@
           :timestamped?       (constantly true)
           :can-read?          (constantly true)
           :can-write?         i/superuser?
-          :post-select        #(assoc % :features ((resolve 'metabase.driver/features) ((resolve 'metabase.driver/engine->driver) (:engine %))))
+          :post-select        post-select
           :pre-cascade-delete pre-cascade-delete}))
 
 

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -496,6 +496,12 @@
                                                      (last args)
                                                      [(last args)]))))
 
+(defmacro try-ignore-exceptions
+  "Simple macro which wraps the given expression in a try/catch block and ignores the exception if caught."
+  [& body]
+  `(try ~@body (catch Throwable e#)))
+
+
 (defn wrap-try-catch!
   "Re-intern FN-SYMB as a new fn that wraps the original with a `try-catch`. Intended for debugging.
 

--- a/test/metabase/api/field_test.clj
+++ b/test/metabase/api/field_test.clj
@@ -8,6 +8,20 @@
             [metabase.test.data.users :refer :all]
             [metabase.test.util :refer [match-$ expect-eval-actual-first]]))
 
+;; Helper Fns
+
+(defn- db-details []
+  (match-$ (db)
+    {:created_at      $
+     :engine          "h2"
+     :id              $
+     :updated_at      $
+     :name            "test-data"
+     :is_sample       false
+     :is_full_sync    true
+     :organization_id nil
+     :description     nil
+     :features        (mapv name (metabase.driver/features (metabase.driver/engine->driver :h2)))}))
 
 
 ;; ## GET /api/field/:id
@@ -19,16 +33,7 @@
                           {:description     nil
                            :entity_type     nil
                            :visibility_type nil
-                           :db              (match-$ (db)
-                                              {:created_at      $
-                                               :engine          "h2"
-                                               :id              $
-                                               :updated_at      $
-                                               :name            "test-data"
-                                               :is_sample       false
-                                               :is_full_sync    true
-                                               :organization_id nil
-                                               :description     nil})
+                           :db              (db-details)
                            :schema          "PUBLIC"
                            :name            "USERS"
                            :display_name    "Users"

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -24,6 +24,22 @@
 (expect (get middleware/response-unauthentic :body) (http/client :get 401 (format "table/%d" (id :users))))
 
 
+;; Helper Fns
+
+(defn- db-details []
+  (match-$ (db)
+    {:created_at      $
+     :engine          "h2"
+     :id              $
+     :updated_at      $
+     :name            "test-data"
+     :is_sample       false
+     :is_full_sync    true
+     :organization_id nil
+     :description     nil
+     :features        (mapv name (metabase.driver/features (metabase.driver/engine->driver :h2)))}))
+
+
 ;; ## GET /api/table?org
 ;; These should come back in alphabetical order and include relevant metadata
 (expect
@@ -62,16 +78,7 @@
       {:description     nil
        :entity_type     nil
        :visibility_type nil
-       :db              (match-$ (db)
-                          {:created_at      $
-                           :engine          "h2"
-                           :id              $
-                           :updated_at      $
-                           :name            "test-data"
-                           :is_sample       false
-                           :is_full_sync    true
-                           :organization_id nil
-                           :description     nil})
+       :db              (db-details)
        :schema          "PUBLIC"
        :name            "VENUES"
        :display_name    "Venues"
@@ -124,16 +131,7 @@
       {:description     nil
        :entity_type     nil
        :visibility_type nil
-       :db              (match-$ (db)
-                          {:created_at      $
-                           :engine          "h2"
-                           :id              $
-                           :updated_at      $
-                           :name            "test-data"
-                           :is_sample       false
-                           :is_full_sync    true
-                           :organization_id nil
-                           :description     nil})
+       :db              (db-details)
        :schema          "PUBLIC"
        :name            "CATEGORIES"
        :display_name    "Categories"
@@ -207,16 +205,7 @@
       {:description     nil
        :entity_type     nil
        :visibility_type nil
-       :db              (match-$ (db)
-                          {:created_at      $
-                           :engine          "h2"
-                           :id              $
-                           :updated_at      $
-                           :name            "test-data"
-                           :is_sample       false
-                           :is_full_sync    true
-                           :organization_id nil
-                           :description     nil})
+       :db              (db-details)
        :schema          "PUBLIC"
        :name            "USERS"
        :display_name    "Users"
@@ -318,16 +307,7 @@
       {:description     nil
        :entity_type     nil
        :visibility_type nil
-       :db              (match-$ (db)
-                          {:created_at      $
-                           :engine          "h2"
-                           :id              $
-                           :updated_at      $
-                           :name            "test-data"
-                           :is_sample       false
-                           :is_full_sync    true
-                           :organization_id nil
-                           :description     nil})
+       :db              (db-details)
        :schema          "PUBLIC"
        :name            "USERS"
        :display_name    "Users"
@@ -426,7 +406,8 @@
                            :details         $
                            :id              $
                            :engine          "h2"
-                           :created_at      $})
+                           :created_at      $
+                           :features        (mapv name (metabase.driver/features (metabase.driver/engine->driver :h2)))})
        :schema          "PUBLIC"
        :name            "USERS"
        :rows            15
@@ -485,16 +466,7 @@
                                              :id              $
                                              :db_id           $
                                              :created_at      $
-                                             :db              (match-$ (db)
-                                                                {:description     nil,
-                                                                 :organization_id nil,
-                                                                 :name            "test-data",
-                                                                 :is_sample       false,
-                                                                 :is_full_sync    true,
-                                                                 :updated_at      $,
-                                                                 :id              $,
-                                                                 :engine          "h2",
-                                                                 :created_at      $})})})
+                                             :db              (db-details)})})
       :destination    (match-$ users-id-field
                         {:id              $
                          :table_id        $


### PR DESCRIPTION
fixes #1683 
- We now pass the database driver `:features` back to the frontend via the api
- Updated the building of aggregation options on the frontend to only include `stddev` if the database supports it as a feature
