### PR TITLE
Fix for infinite re-render loop when editing SQL card w/ chart viz ಠ_ಠ

### DIFF
--- a/frontend/src/card/card.charting.js
+++ b/frontend/src/card/card.charting.js
@@ -753,7 +753,8 @@ export var CardRenderer = {
                 parentPaddingTop = getComputedSizeProperty('padding-top', parent),
                 parentPaddingBottom = getComputedSizeProperty('padding-bottom', parent);
 
-            return parentHeight - parentPaddingTop - parentPaddingBottom - 5; // why the magic number :/
+            // NOTE: if this magic number is not 3 we can get into infinite re-render loops
+            return parentHeight - parentPaddingTop - parentPaddingBottom - 3; // why the magic number :/
         }
 
         return null;


### PR DESCRIPTION
Resolves #1452

Previously with the magic number set to 5 we would get into a situation where `getAvailableCanvasHeight` would return 2 less pixels each time it was rendered, causing an infinite loop of re-rendering. I'm not sure why the calculation is off by 3 pixels, but this works for both query builder and SQL cards.
