### PR TITLE
Provide full QB error details

### DIFF
--- a/frontend/src/css/core/colors.css
+++ b/frontend/src/css/core/colors.css
@@ -141,6 +141,7 @@
 .text-grey-4,
 .text-grey-4-hover:hover { color: color(var(--base-grey) shade(40%)) }
 
+.bg-grey-0 { background-color: var(--base-grey) }
 .bg-grey-1 { background-color: color(var(--base-grey) shade(10%)) }
 .bg-grey-2 { background-color: color(var(--base-grey) shade(20%)) }
 .bg-grey-3 { background-color: color(var(--base-grey) shade(30%)) }

--- a/frontend/src/css/query_builder.css
+++ b/frontend/src/css/query_builder.css
@@ -323,11 +323,13 @@
 }
 
 .QueryError2-details {
-    max-width: 50%;
+    max-width: 500px;
 }
 
 .QueryError2-detailBody {
-  background-color: #f8f8f8;
+    background-color: #f8f8f8;
+    max-height: 15rem;
+    overflow: auto;
 }
 
 

--- a/frontend/src/css/query_builder.css
+++ b/frontend/src/css/query_builder.css
@@ -316,6 +316,21 @@
   margin-left: -41px; /* ugh */
 }
 
+.QueryError2 {
+    padding-top: 4rem;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.QueryError2-details {
+    max-width: 50%;
+}
+
+.QueryError2-detailBody {
+  background-color: #f8f8f8;
+}
+
+
 /* GUI BUILDER */
 
 .GuiBuilder {

--- a/frontend/src/query_builder/QueryVisualization.jsx
+++ b/frontend/src/query_builder/QueryVisualization.jsx
@@ -189,8 +189,10 @@ export default class QueryVisualization extends Component {
     }
 
     showDetailError() {
-        this.refs.detailErrorLink.getDOMNode().style.display = "none";
-        this.refs.detailErrorBody.getDOMNode().style.display = "inherit";
+        if (this._detailErrorLink && this._detailErrorBody ) {
+            this._detailErrorLink.getDOMNode().style.display = "none";
+            this._detailErrorBody.getDOMNode().style.display = "inherit";
+        }
     }
 
     render() {
@@ -263,10 +265,10 @@ export default class QueryVisualization extends Component {
                             <div className="QueryError2-details">
                                 <h1 className="text-bold">There was a problem with your question</h1>
                                 <p className="QueryError-messageText">Most of the time this is caused by an invalid selection or bad input value.  Double check your inputs and retry your query.</p>
-                                <div ref="detailErrorLink" className="pt2">
+                                <div ref={(c) => this._detailErrorLink = c} className="pt2">
                                     <a onClick={this.showDetailError.bind(this)} className="link cursor-pointer">Show error details</a>
                                 </div>
-                                <div ref="detailErrorBody" style={{display: "none"}} className="pt3 text-left">
+                                <div ref={(c) => this._detailErrorBody = c} style={{display: "none"}} className="pt3 text-left">
                                     <h2>Here's the full error message</h2>
                                     <div style={{fontFamily: "monospace"}} className="QueryError2-detailBody bordered rounded bg-grey-0 text-bold p2 mt1">{error}</div>
                                 </div>

--- a/frontend/src/query_builder/QueryVisualization.jsx
+++ b/frontend/src/query_builder/QueryVisualization.jsx
@@ -188,6 +188,11 @@ export default class QueryVisualization extends Component {
         }
     }
 
+    showDetailError() {
+        this.refs.detailErrorLink.getDOMNode().style.display = "none";
+        this.refs.detailErrorBody.getDOMNode().style.display = "inherit";
+    }
+
     render() {
         var loading,
             viz;
@@ -211,9 +216,9 @@ export default class QueryVisualization extends Component {
         } else {
             let { result } = this.props;
             let error = result.error;
+            let adminEmail = MetabaseSettings.adminEmail();
             if (error) {
                 if (typeof error.status === "number") {
-                    let adminEmail = MetabaseSettings.adminEmail();
                     // Assume if the request took more than 15 seconds it was due to a timeout
                     // Some platforms like Heroku return a 503 for numerous types of errors so we can't use the status code to distinguish between timeouts and other failures.
                     if (result.duration > 15*1000) {
@@ -253,14 +258,19 @@ export default class QueryVisualization extends Component {
                     );
                 } else {
                     viz = (
-                        <div className="QueryError flex full align-center">
-                            <div className="QueryError-image QueryError-image--queryError"></div>
-                            <div className="QueryError-message text-centered">
-                                <h1 className="text-bold">We couldn't understand your question.</h1>
-                                <p className="QueryError-messageText">Your question might contain an invalid parameter or some other error.</p>
-                                <button className="Button" onClick={() => window.history.back() }>
-                                    Back to last run
-                                </button>
+                        <div className="QueryError2 flex full justify-center">
+                            <div className="QueryError-image QueryError-image--queryError mr4"></div>
+                            <div className="QueryError2-details">
+                                <h1 className="text-bold">There was a problem with your question</h1>
+                                <p className="QueryError-messageText">Most of the time this is caused by an invalid selection or bad input value.  Double check your inputs and retry your query, if the problem persists then contact an admin.</p>
+                                {adminEmail && <span className="QueryError-adminEmail"><a className="no-decoration" href={"mailto:"+adminEmail}>{adminEmail}</a></span>}
+                                <div ref="detailErrorLink" className="pt2">
+                                    <a onClick={this.showDetailError.bind(this)} className="link cursor-pointer">Show error details</a>
+                                </div>
+                                <div ref="detailErrorBody" style={{display: "none"}} className="pt3 text-left">
+                                    <h2>Here's the full error message</h2>
+                                    <div style={{fontFamily: "monospace"}} className="bordered rounded bg-grey-0 text-bold p3 mt1">{error}</div>
+                                </div>
                             </div>
                         </div>
                     );

--- a/frontend/src/query_builder/QueryVisualization.jsx
+++ b/frontend/src/query_builder/QueryVisualization.jsx
@@ -262,14 +262,13 @@ export default class QueryVisualization extends Component {
                             <div className="QueryError-image QueryError-image--queryError mr4"></div>
                             <div className="QueryError2-details">
                                 <h1 className="text-bold">There was a problem with your question</h1>
-                                <p className="QueryError-messageText">Most of the time this is caused by an invalid selection or bad input value.  Double check your inputs and retry your query, if the problem persists then contact an admin.</p>
-                                {adminEmail && <span className="QueryError-adminEmail"><a className="no-decoration" href={"mailto:"+adminEmail}>{adminEmail}</a></span>}
+                                <p className="QueryError-messageText">Most of the time this is caused by an invalid selection or bad input value.  Double check your inputs and retry your query.</p>
                                 <div ref="detailErrorLink" className="pt2">
                                     <a onClick={this.showDetailError.bind(this)} className="link cursor-pointer">Show error details</a>
                                 </div>
                                 <div ref="detailErrorBody" style={{display: "none"}} className="pt3 text-left">
                                     <h2>Here's the full error message</h2>
-                                    <div style={{fontFamily: "monospace"}} className="bordered rounded bg-grey-0 text-bold p3 mt1">{error}</div>
+                                    <div style={{fontFamily: "monospace"}} className="QueryError2-detailBody bordered rounded bg-grey-0 text-bold p2 mt1">{error}</div>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
implements #1672 

<img width="1547" alt="screen shot 2016-01-21 at 9 24 48 pm" src="https://cloud.githubusercontent.com/assets/1987787/12503128/15ab75aa-c086-11e5-9e0d-190b08cf11d8.png">

@mazameli @kdoh let me know if we need to tweak the content on this at all.  also, if we want to switch over to the image from the mocks then i'll need that as well.
