### PR TITLE
Make Query Builder Tutorial more robust

### DIFF
--- a/frontend/src/card/card.controllers.js
+++ b/frontend/src/card/card.controllers.js
@@ -88,8 +88,7 @@ CardControllers.controller('CardDetail', [
                 visualization_settings: {},
                 dataset_query: {},
             },
-            savedCardSerialized = null,
-            isShowingTutorial = !!$routeParams.tutorial;
+            savedCardSerialized = null;
 
         resetDirty();
 
@@ -333,7 +332,7 @@ CardControllers.controller('CardDetail', [
             // ensure rendering model is up to date
             editorModel.isRunning = isRunning;
             editorModel.isShowingDataReference = $scope.isShowingDataReference;
-            editorModel.isShowingTutorial = isShowingTutorial;
+            editorModel.isShowingTutorial = !!$routeParams.tutorial;
             editorModel.databases = databases;
             editorModel.tableMetadata = tableMetadata;
             editorModel.tableForeignKeys = tableForeignKeys;
@@ -374,15 +373,16 @@ CardControllers.controller('CardDetail', [
 
         let tutorialModel = {
             onClose: () => {
-                isShowingTutorial = false;
+                $routeParams.tutorial = false;
+                updateUrl();
                 renderAll();
             }
         }
 
         function renderTutorial() {
-            tutorialModel.isShowingTutorial = isShowingTutorial;
+            tutorialModel.isShowingTutorial = !!$routeParams.tutorial;
             React.render(
-                <span>{isShowingTutorial && <QueryBuilderTutorial {...tutorialModel} /> }</span>
+                <span>{tutorialModel.isShowingTutorial && <QueryBuilderTutorial {...tutorialModel} /> }</span>
             , document.getElementById('react_qb_tutorial'));
         }
 
@@ -812,6 +812,11 @@ CardControllers.controller('CardDetail', [
 
         // needs to be performed asynchronously otherwise we get weird infinite recursion
         var updateUrl = (replaceState) => setTimeout(function() {
+            // don't update the URL if we're currently showing the tutorial
+            if (!!$routeParams.tutorial) {
+                return;
+            }
+
             var copy = cleanCopyCard(card);
             var newState = {
                 card: copy,
@@ -908,7 +913,7 @@ CardControllers.controller('CardDetail', [
                 // finish initializing our page and render
                 await loadAndSetCard();
 
-                if (isShowingTutorial) {
+                if (!!$routeParams.tutorial) {
                     setSampleDataset();
                 }
             } catch (error) {

--- a/frontend/src/tutorial/QueryBuilderTutorial.jsx
+++ b/frontend/src/tutorial/QueryBuilderTutorial.jsx
@@ -34,7 +34,7 @@ const QUERY_BUILDER_STEPS = [
     {
         getPortalTarget: () => qs(".GuiBuilder-data"),
         getPageFlagTarget: () => qsWithContent(".List-item", "Orders"),
-        shouldAllowEvent: (e) => qsWithContent(".List-item", "Orders").contains(e.target)
+        shouldAllowEvent: (e) => qsWithContent(".List-item > a", "Orders").contains(e.target)
     },
     {
         getPortalTarget: () => qs(".GuiBuilder-filtered-by"),
@@ -50,7 +50,7 @@ const QUERY_BUILDER_STEPS = [
     {
         getPortalTarget: () => qs(".GuiBuilder-filtered-by"),
         getPageFlagTarget: () => qsWithContent(".List-item", "Created At"),
-        shouldAllowEvent: (e) => qsWithContent(".List-item", "Created At").contains(e.target)
+        shouldAllowEvent: (e) => qsWithContent(".List-item > a", "Created At").contains(e.target)
     },
     {
         getPortalTarget: () => qs(".GuiBuilder-filtered-by"),
@@ -77,7 +77,7 @@ const QUERY_BUILDER_STEPS = [
     {
         getPortalTarget: () => qs(".Query-section-aggregation"),
         getPageFlagTarget: () => qsWithContent(".List-item", "Count of rows"),
-        shouldAllowEvent: (e) => qsWithContent(".List-item", "Count of rows").contains(e.target)
+        shouldAllowEvent: (e) => qsWithContent(".List-item > a", "Count of rows").contains(e.target)
     },
     {
         getPortalTarget: () => qs(".Query-section-breakout"),
@@ -99,7 +99,7 @@ const QUERY_BUILDER_STEPS = [
     {
         getPortalTarget: () => qs(".Query-section-breakout"),
         getPageFlagTarget: () => qsWithContent(".List-item", "Week"),
-        shouldAllowEvent: (e) => qsWithContent(".List-item", "Week").contains(e.target)
+        shouldAllowEvent: (e) => qsWithContent(".List-item > a", "Week").contains(e.target)
     },
     {
         getPortalTarget: () => qs(".RunButton"),

--- a/frontend/src/tutorial/TutorialModal.jsx
+++ b/frontend/src/tutorial/TutorialModal.jsx
@@ -2,6 +2,8 @@ import React, { Component, PropTypes } from "react";
 
 import Icon from "metabase/components/Icon.jsx";
 
+const ENABLE_BACK_BUTTON = false; // disabled due to possibility of getting in inconsistent states
+
 export default class TutorialModal extends Component {
     render() {
         const { modalStepIndex, modalStepCount } = this.props;
@@ -16,7 +18,7 @@ export default class TutorialModal extends Component {
                     {this.props.children}
                 </div>
                 <div className="flex">
-                    { modalStepIndex > 0 &&
+                    { ENABLE_BACK_BUTTON && modalStepIndex > 0 &&
                         <a className="text-grey-4 cursor-pointer" onClick={this.props.onBack}>back</a>
                     }
                     <span className="text-grey-4 flex-align-right">{modalStepIndex + 1} of {modalStepCount}</span>

--- a/frontend/src/tutorial/TutorialModal.jsx
+++ b/frontend/src/tutorial/TutorialModal.jsx
@@ -7,6 +7,8 @@ const ENABLE_BACK_BUTTON = false; // disabled due to possibility of getting in i
 export default class TutorialModal extends Component {
     render() {
         const { modalStepIndex, modalStepCount } = this.props;
+        let showStepCount = modalStepIndex != null;
+        let showBackButton = (ENABLE_BACK_BUTTON && modalStepIndex > 0);
         return (
             <div className="TutorialModalContent p2">
                 <div className="flex">
@@ -18,10 +20,8 @@ export default class TutorialModal extends Component {
                     {this.props.children}
                 </div>
                 <div className="flex">
-                    { ENABLE_BACK_BUTTON && modalStepIndex > 0 &&
-                        <a className="text-grey-4 cursor-pointer" onClick={this.props.onBack}>back</a>
-                    }
-                    <span className="text-grey-4 flex-align-right">{modalStepIndex + 1} of {modalStepCount}</span>
+                    { showBackButton && <a className="text-grey-4 cursor-pointer" onClick={this.props.onBack}>back</a> }
+                    { showStepCount && <span className="text-grey-4 flex-align-right">{modalStepIndex + 1} of {modalStepCount}</span> }
                 </div>
             </div>
         );


### PR DESCRIPTION
Resolves #1808

This fixes a few things:
1. Disables tutorial modal "back" button since it could lead to the QB state not matching the tutorial state
2. Don't update the URL when the QB tutorial is open. Hitting the browser back button will exit tutorial to previous state. Hitting "x" in a modal will update the URL with the current state of the Query Builder.
3. Tighten up some of the `shouldAllowEvent` selectors which were causing the tutorial to advance even though the correct element was not actually clicked.
