### PR TITLE
when there is an error downloading a CSV just return a 500 w/ a plain text error message instead of a JSON document.

### DIFF
--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -36,13 +36,13 @@
         columns (map name columns)]                         ; turn keywords into strings, otherwise we get colons in our output
     (if (= status :completed)
       ;; successful query, send CSV file
-      {:status 200
-       :body (with-out-str
-               (csv/write-csv *out* (into [columns] rows)))
+      {:status  200
+       :body    (with-out-str
+                  (csv/write-csv *out* (into [columns] rows)))
        :headers {"Content-Type" "text/csv"
                  "Content-Disposition" (str "attachment; filename=\"query_result_" (u/date->iso-8601) ".csv\"")}}
       ;; failed query, send error message
       {:status 500
-       :body response})))
+       :body   (:error response)})))
 
 (define-routes)


### PR DESCRIPTION
fixes #584 
