### PR TITLE
Expose additional string filter options in QB :yum: #1422

### DIFF
--- a/frontend/src/lib/schema_metadata.js
+++ b/frontend/src/lib/schema_metadata.js
@@ -256,7 +256,10 @@ const OPERATORS_BY_TYPE_ORDERED = {
         { name: "=",       verboseName: "Is" },
         { name: "!=",      verboseName: "Is not" },
         { name: "IS_NULL", verboseName: "Is empty", advanced: true },
-        { name: "NOT_NULL",verboseName: "Not empty", advanced: true }
+        { name: "NOT_NULL",verboseName: "Not empty", advanced: true },
+        { name: "STARTS_WITH",verboseName: "Starts with", advanced: true},
+        { name: "ENDS_WITH",verboseName: "Ends with", advanced: true},
+        { name: "CONTAINS",verboseName: "Contains", advanced: true}
     ],
     [DATE_TIME]: [
         { name: "=",       verboseName: "Is" },
@@ -299,7 +302,7 @@ const MORE_VERBOSE_NAMES = {
     "less than": "is less than",
     "greater than": "is greater than",
     "less than or equal to": "is less than or equal to",
-    "greater than or equal to": "is greater than or equal to",
+    "greater than or equal to": "is greater than or equal to"
 }
 
 function getOperators(field, table) {

--- a/frontend/src/lib/schema_metadata.js
+++ b/frontend/src/lib/schema_metadata.js
@@ -242,54 +242,54 @@ const OPERATORS = {
 // ordered list of operators and metadata per type
 const OPERATORS_BY_TYPE_ORDERED = {
     [NUMBER]: [
-        { name: "=",       verboseName: "Equal" },
-        { name: "!=",      verboseName: "Not equal" },
-        { name: ">",       verboseName: "Greater than" },
-        { name: "<",       verboseName: "Less than" },
-        { name: "BETWEEN", verboseName: "Between" },
-        { name: ">=",      verboseName: "Greater than or equal to", advanced: true },
-        { name: "<=",      verboseName: "Less than or equal to", advanced: true },
-        { name: "IS_NULL", verboseName: "Is empty", advanced: true },
-        { name: "NOT_NULL",verboseName: "Not empty", advanced: true }
+        { name: "=",           verboseName: "Equal" },
+        { name: "!=",          verboseName: "Not equal" },
+        { name: ">",           verboseName: "Greater than" },
+        { name: "<",           verboseName: "Less than" },
+        { name: "BETWEEN",     verboseName: "Between" },
+        { name: ">=",          verboseName: "Greater than or equal to", advanced: true },
+        { name: "<=",          verboseName: "Less than or equal to", advanced: true },
+        { name: "IS_NULL",     verboseName: "Is empty", advanced: true },
+        { name: "NOT_NULL",    verboseName: "Not empty", advanced: true }
     ],
     [STRING]: [
-        { name: "=",       verboseName: "Is" },
-        { name: "!=",      verboseName: "Is not" },
-        { name: "IS_NULL", verboseName: "Is empty", advanced: true },
-        { name: "NOT_NULL",verboseName: "Not empty", advanced: true },
-        { name: "STARTS_WITH",verboseName: "Starts with", advanced: true},
-        { name: "ENDS_WITH",verboseName: "Ends with", advanced: true},
-        { name: "CONTAINS",verboseName: "Contains", advanced: true}
+        { name: "=",           verboseName: "Is" },
+        { name: "!=",          verboseName: "Is not" },
+        { name: "CONTAINS",    verboseName: "Contains"},
+        { name: "IS_NULL",     verboseName: "Is empty", advanced: true },
+        { name: "NOT_NULL",    verboseName: "Not empty", advanced: true },
+        { name: "STARTS_WITH", verboseName: "Starts with", advanced: true},
+        { name: "ENDS_WITH",   verboseName: "Ends with", advanced: true}
     ],
     [DATE_TIME]: [
-        { name: "=",       verboseName: "Is" },
-        { name: "<",       verboseName: "Before" },
-        { name: ">",       verboseName: "After" },
-        { name: "BETWEEN", verboseName: "Between" },
-        { name: "IS_NULL", verboseName: "Is empty", advanced: true },
-        { name: "NOT_NULL",verboseName: "Not empty", advanced: true }
+        { name: "=",           verboseName: "Is" },
+        { name: "<",           verboseName: "Before" },
+        { name: ">",           verboseName: "After" },
+        { name: "BETWEEN",     verboseName: "Between" },
+        { name: "IS_NULL",     verboseName: "Is empty", advanced: true },
+        { name: "NOT_NULL",    verboseName: "Not empty", advanced: true }
     ],
     [LOCATION]: [
-        { name: "=",       verboseName: "Is" },
-        { name: "!=",      verboseName: "Is not" },
-        { name: "IS_NULL", verboseName: "Is empty", advanced: true },
-        { name: "NOT_NULL",verboseName: "Not empty", advanced: true }
+        { name: "=",           verboseName: "Is" },
+        { name: "!=",          verboseName: "Is not" },
+        { name: "IS_NULL",     verboseName: "Is empty", advanced: true },
+        { name: "NOT_NULL",    verboseName: "Not empty", advanced: true }
     ],
     [COORDINATE]: [
-        { name: "=",       verboseName: "Is" },
-        { name: "!=",      verboseName: "Is not" },
-        { name: "INSIDE",  verboseName: "Inside" }
+        { name: "=",           verboseName: "Is" },
+        { name: "!=",          verboseName: "Is not" },
+        { name: "INSIDE",      verboseName: "Inside" }
     ],
     [BOOLEAN]: [
-        { name: "=",       verboseName: "Is", multi: false, defaults: [true] },
-        { name: "IS_NULL", verboseName: "Is empty" },
-        { name: "NOT_NULL",verboseName: "Not empty" }
+        { name: "=",           verboseName: "Is", multi: false, defaults: [true] },
+        { name: "IS_NULL",     verboseName: "Is empty" },
+        { name: "NOT_NULL",    verboseName: "Not empty" }
     ],
     [UNKNOWN]: [
-        { name: "=",       verboseName: "Is" },
-        { name: "!=",      verboseName: "Is not" },
-        { name: "IS_NULL", verboseName: "Is empty", advanced: true },
-        { name: "NOT_NULL",verboseName: "Not empty", advanced: true }
+        { name: "=",           verboseName: "Is" },
+        { name: "!=",          verboseName: "Is not" },
+        { name: "IS_NULL",     verboseName: "Is empty", advanced: true },
+        { name: "NOT_NULL",    verboseName: "Not empty", advanced: true }
     ]
 };
 


### PR DESCRIPTION
Expose [`starts-with`](https://github.com/metabase/metabase/wiki/Query-Language-'98#starts-with-filter), [`ends-with`](https://github.com/metabase/metabase/wiki/Query-Language-'98#ends-with-filter), and [`contains`](https://github.com/metabase/metabase/wiki/Query-Language-'98#contains-filter) string filters in the Query Builder.

Implements #1422 
