### PR TITLE
Pulse render fixes

### DIFF
--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -377,12 +377,17 @@
         aggregation (-> card :dataset_query :query :aggregation first)]
     (cond
       (or (= aggregation :rows)
-          (contains? #{:pin_map :state :country} (:display card)))        nil
-      (zero? row-count)                                                   :empty
-      (and (= col-count 1) (= row-count 1))                               :scalar
-      (and (= col-count 2) (datetime-field? col-1) (number-field? col-2)) :sparkline
-      (and (= col-count 2) (number-field? col-2))                         :bar
-      :else                                                               :table)))
+          (contains? #{:pin_map :state :country} (:display card))) nil
+      (zero? row-count)             :empty
+      (and (= col-count 1)
+           (= row-count 1))         :scalar
+      (and (= col-count 2)
+           (> row-count 1)
+           (datetime-field? col-1)
+           (number-field? col-2))   :sparkline
+      (and (= col-count 2)
+           (number-field? col-2))   :bar
+      :else                         :table)))
 
 (defn render-pulse-card
   [card data render-img include-title include-buttons]

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -1,7 +1,8 @@
 (ns metabase.pulse
   (:require [clojure.java.io :as io]
             (clojure [pprint :refer [cl-format]]
-                     [string :refer [upper-case]])
+                     [string :refer [upper-case]]
+                     [stacktrace :refer [print-stack-trace]])
             [clojure.tools.logging :as log]
             (clj-time [coerce :as c]
                       [core :as t]
@@ -415,10 +416,12 @@
                              :font-weight 700})}
         "We were unable to display this card." [:br] "Please view this card in Metabase."])]
     (catch Throwable e
-      (log/warn (str "Pulse card render error:" e))
+      (log/warn "Pulse card render error:")
+      (print-stack-trace e)
       [:div {:style (style font-style
                            {:color       "#EF8C8C"
-                            :font-weight 700})}
+                            :font-weight 700
+                            :padding     "16px"})}
        "An error occurred while displaying this card."])))
 
 

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -325,12 +325,12 @@
         xmin   (apply min xs)
         xmax   (apply max xs)
         xrange (- xmax xmin)
-        xs'    (map #(/ (- % xmin) xrange) xs)
+        xs'    (map #(/ (float (- % xmin)) xrange) xs)
         ys     (map second rows)
         ymin   (apply min ys)
         ymax   (apply max ys)
         yrange (max 1 (- ymax ymin)) ; `(max 1 ...)` so we don't divide by zero
-        ys'    (map #(/ (- % ymin) yrange) ys)
+        ys'    (map #(/ (float (- % ymin)) yrange) ys) ; cast to float to avoid "Non-terminating decimal expansion" errors
         rows'  (reverse (take-last 2 rows))
         values (map (comp format-number second) rows')
         labels (format-timestamp-pair (map first rows') (first cols))]

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -1,8 +1,8 @@
 (ns metabase.pulse
   (:require [clojure.java.io :as io]
             (clojure [pprint :refer [cl-format]]
-                     [string :refer [upper-case]]
-                     [stacktrace :refer [print-stack-trace]])
+                     [stacktrace :refer [print-stack-trace]]
+                     [string :refer [upper-case]])
             [clojure.tools.logging :as log]
             (clj-time [coerce :as c]
                       [core :as t]
@@ -325,12 +325,12 @@
         xmin   (apply min xs)
         xmax   (apply max xs)
         xrange (- xmax xmin)
-        xs'    (map #(/ (float (- % xmin)) xrange) xs)
+        xs'    (map #(/ (double (- % xmin)) xrange) xs)
         ys     (map second rows)
         ymin   (apply min ys)
         ymax   (apply max ys)
         yrange (max 1 (- ymax ymin)) ; `(max 1 ...)` so we don't divide by zero
-        ys'    (map #(/ (float (- % ymin)) yrange) ys) ; cast to float to avoid "Non-terminating decimal expansion" errors
+        ys'    (map #(/ (double (- % ymin)) yrange) ys) ; cast to double to avoid "Non-terminating decimal expansion" errors
         rows'  (reverse (take-last 2 rows))
         values (map (comp format-number second) rows')
         labels (format-timestamp-pair (map first rows') (first cols))]
@@ -426,7 +426,7 @@
       [:div {:style (style font-style
                            {:color       "#EF8C8C"
                             :font-weight 700
-                            :padding     "16px"})}
+                            :padding     :16px})}
        "An error occurred while displaying this card."])))
 
 


### PR DESCRIPTION
Resolves #1714 and a few other things.

I was able to reproduce using data @agilliland sent me. Also the problem was not limited to SQL questions, equivalent query builder questions also failed.

It looks like the problem was due to dividing two BigDecimals that resulted in a repeating decimal, e.x. `(/ (new java.math.BigDecimal 1) (new java.math.BigDecimal 3))`. Casting the values to `float` fixes this.
