### PR TITLE
Fix slow public-settings :unamused: 

### DIFF
--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -85,24 +85,23 @@
      :date   date}))
 
 (defn- version-info-from-properties-file []
-  (with-open [reader (io/reader (io/resource "version.properties"))]
-    (let [props (java.util.Properties.)]
-      (.load props reader)
-      (into {} (for [[k v] props]
-                 [(keyword k) v])))))
+  (when-let [props-file (io/resource "version.properties")]
+    (with-open [reader (io/reader props-file)]
+      (let [props (java.util.Properties.)]
+        (.load props reader)
+        (into {} (for [[k v] props]
+                   [(keyword k) v]))))))
 
-(defn mb-version-info
-  "Return information about the current version of Metabase.
+(def ^:const mb-version-info
+  "Information about the current version of Metabase.
    This comes from `resources/version.properties` for prod builds and is fetched from `git` via the `./bin/version` script for dev.
 
-     (mb-version) -> {:tag: \"v0.11.1\", :hash: \"afdf863\", :branch: \"about_metabase\", :date: \"2015-10-05\"}"
-  []
+     mb-version-info -> {:tag: \"v0.11.1\", :hash: \"afdf863\", :branch: \"about_metabase\", :date: \"2015-10-05\"}"
   (if (is-prod?)
     (version-info-from-properties-file)
     (version-info-from-shell-script)))
 
-(defn mb-version-string
-  "Return a formatted version string representing the currently running application."
-  []
-  (let [{:keys [tag hash branch date]} (mb-version-info)]
+(def ^:const mb-version-string
+  "A formatted version string representing the currently running application."
+  (let [{:keys [tag hash branch date]} mb-version-info]
     (format "%s (%s %s)" tag hash branch)))

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -56,19 +56,19 @@
   "The primary entry point to the HTTP server"
   (-> routes/routes
       (mb-middleware/log-api-call)
-      mb-middleware/add-security-headers              ; [METABASE] Add HTTP headers to API responses to prevent them from being cached
-      (wrap-json-body                                 ; extracts json POST body and makes it avaliable on request
+      mb-middleware/add-security-headers ; Add HTTP headers to API responses to prevent them from being cached
+      (wrap-json-body                    ; extracts json POST body and makes it avaliable on request
         {:keywords? true})
-      wrap-json-response                              ; middleware to automatically serialize suitable objects as JSON in responses
-      wrap-keyword-params                             ; converts string keys in :params to keyword keys
-      wrap-params                                     ; parses GET and POST params as :query-params/:form-params and both as :params
-      mb-middleware/bind-current-user                 ; Binds *current-user* and *current-user-id* if :metabase-user-id is non-nil
-      mb-middleware/wrap-current-user-id              ; looks for :metabase-session-id and sets :metabase-user-id if Session ID is valid
-      mb-middleware/wrap-api-key                      ; looks for a Metabase API Key on the request and assocs as :metabase-api-key
-      mb-middleware/wrap-session-id                   ; looks for a Metabase Session ID and assoc as :metabase-session-id
-      wrap-cookies                                    ; Parses cookies in the request map and assocs as :cookies
-      wrap-session                                    ; reads in current HTTP session and sets :session/key
-      wrap-gzip))                                     ; GZIP response if client can handle it
+      wrap-json-response                 ; middleware to automatically serialize suitable objects as JSON in responses
+      wrap-keyword-params                ; converts string keys in :params to keyword keys
+      wrap-params                        ; parses GET and POST params as :query-params/:form-params and both as :params
+      mb-middleware/bind-current-user    ; Binds *current-user* and *current-user-id* if :metabase-user-id is non-nil
+      mb-middleware/wrap-current-user-id ; looks for :metabase-session-id and sets :metabase-user-id if Session ID is valid
+      mb-middleware/wrap-api-key         ; looks for a Metabase API Key on the request and assocs as :metabase-api-key
+      mb-middleware/wrap-session-id      ; looks for a Metabase Session ID and assoc as :metabase-session-id
+      wrap-cookies                       ; Parses cookies in the request map and assocs as :cookies
+      wrap-session                       ; reads in current HTTP session and sets :session/key
+      wrap-gzip))                        ; GZIP response if client can handle it
 
 
 ;;; ## ---------------------------------------- LIFECYCLE ----------------------------------------
@@ -115,7 +115,7 @@
 (defn init!
   "General application initialization function which should be run once at application startup."
   []
-  (log/info (format "Starting Metabase version %s..." (config/mb-version-string)))
+  (log/info (format "Starting Metabase version %s..." config/mb-version-string))
   (reset! metabase-initialization-progress 0.1)
 
   ;; First of all, lets register a shutdown hook that will tidy things up for us on app exit
@@ -176,12 +176,12 @@
                                                     :key-password   (config/config-str :mb-jetty-ssl-keystore-password)
                                                     :truststore     (config/config-str :mb-jetty-ssl-truststore)
                                                     :trust-password (config/config-str :mb-jetty-ssl-truststore-password)})
-          jetty-config     (cond-> (m/filter-vals identity {:port           (config/config-int :mb-jetty-port)
-                                                            :host           (config/config-str :mb-jetty-host)
-                                                            :max-threads    (config/config-int :mb-jetty-maxthreads)
-                                                            :min-threads    (config/config-int :mb-jetty-minthreads)
-                                                            :max-queued     (config/config-int :mb-jetty-maxqueued)
-                                                            :max-idle-time  (config/config-int :mb-jetty-maxidletime)})
+          jetty-config     (cond-> (m/filter-vals identity {:port          (config/config-int :mb-jetty-port)
+                                                            :host          (config/config-str :mb-jetty-host)
+                                                            :max-threads   (config/config-int :mb-jetty-maxthreads)
+                                                            :min-threads   (config/config-int :mb-jetty-minthreads)
+                                                            :max-queued    (config/config-int :mb-jetty-maxqueued)
+                                                            :max-idle-time (config/config-int :mb-jetty-maxidletime)})
                              (config/config-str :mb-jetty-daemon) (assoc :daemon? (config/config-bool :mb-jetty-daemon))
                              (config/config-str :mb-jetty-ssl)    (-> (assoc :ssl? true)
                                                                       (merge jetty-ssl-config)))]

--- a/src/metabase/util/password.clj
+++ b/src/metabase/util/password.clj
@@ -45,9 +45,8 @@
                  (when (>= (occurances char-type) min-count)
                    (recur more)))))))
 
-(defn active-password-complexity
+(def ^:const active-password-complexity
   "The currently configured description of the password complexity rules being enforced"
-  []
   (merge (complexity->char-type->min (config/config-kw :mb-password-complexity))
          ;; Setting MB_PASSWORD_LENGTH overrides the default :total for a given password complexity class
          (when-let [min-len (config/config-int :mb-password-length)]
@@ -55,7 +54,7 @@
 
 (def ^{:arglists '([password])} is-complex?
   "Check if a given password meets complexity standards for the application."
-  (partial password-has-char-counts? (active-password-complexity)))
+  (partial password-has-char-counts? active-password-complexity))
 
 
 (defn verify-password


### PR DESCRIPTION
API call takes a much more reasonable ~600µs now.

![screen shot 2016-01-27 at 9 42 21 pm](https://cloud.githubusercontent.com/assets/1455846/12636145/2e5da844-c53f-11e5-9035-9a0cf9918a6a.png)
-  Convert several things that were functions to constants. Some of these functions like `mb-version-info` read a properties file or ran a script on _every call_! (~50ms)
-  Minor improvements to how `nil` `Settings` are cached. (~2ms)
-  This is bad bad bad!:
  
  ``` clojure
  (some? (sel :one 'Database :is_sample true)) ;; fetches the ENTIRE OBJECT
  ```
  
  Use `exists?` instead: (~2ms)
  
  ``` clojure
  (exists? 'Database, :is_sample true)
  ```

Fixes #1835
