### PR TITLE
Fix pulse table rendering due to dividing BigDecimals

### DIFF
--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -242,7 +242,7 @@
                                                :max-height       :10px
                                                :height           :10px
                                                :border-radius    :2px
-                                               :width            (str (float (* 100 (/ (bar-column row) max-value))) "%")})}
+                                               :width            (str (float (* 100 (/ (double (bar-column row)) max-value))) "%")})} ; cast to double to avoid "Non-terminating decimal expansion" errors
                           "&#160;"]])])
                    rows)]]))
 


### PR DESCRIPTION
Resolves #1714 for reals

I looked for other places we divide results and didn't see any in the pulse rendering code.
