### PR TITLE
Backport various improvements from BigQuery driver branch :flushed:

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -3,16 +3,17 @@
   (:require [compojure.core :refer [GET POST PUT DELETE]]
             [korma.core :as k]
             [metabase.api.common :refer :all]
-            [metabase.db :refer :all]
-            [metabase.driver :as driver]
-            [metabase.events :as events]
+            (metabase [config :as config]
+                      [db :refer :all]
+                      [driver :as driver]
+                      [events :as events]
+                      [sample-data :as sample-data]
+                      [util :as u])
             (metabase.models common
                              [hydrate :refer [hydrate]]
                              [database :refer [Database protected-password]]
                              [field :refer [Field]]
-                             [table :refer [Table]])
-            [metabase.sample-data :as sample-data]
-            [metabase.util :as u]))
+                             [table :refer [Table]])))
 
 (defannotation DBEngine
   "Param must be a valid database engine type, e.g. `h2` or `postgres`."
@@ -22,7 +23,7 @@
 (defn test-database-connection
   "Try out the connection details for a database and useful error message if connection fails, returns `nil` if connection succeeds."
   [engine {:keys [host port] :as details}]
-  (when (not (metabase.config/is-test?))
+  (when-not config/is-test?
     (let [engine           (keyword engine)
           details          (assoc details :engine engine)
           response-invalid (fn [field m] {:valid false

--- a/src/metabase/api/email.clj
+++ b/src/metabase/api/email.clj
@@ -58,7 +58,7 @@
   (let [email-settings (select-keys settings (keys mb-to-smtp-settings))
         smtp-settings  (-> (set/rename-keys email-settings mb-to-smtp-settings)
                            (assoc :port (Integer/parseInt (:email-smtp-port settings))))
-        response       (if-not (config/is-test?)
+        response       (if-not config/is-test?
                          ;; in normal conditions, validate connection
                          (email/test-smtp-connection smtp-settings)
                          ;; for unit testing just respond with a success message

--- a/src/metabase/api/slack.clj
+++ b/src/metabase/api/slack.clj
@@ -22,7 +22,7 @@
   {settings [Required Dict]}
   (check-superuser)
   (let [slack-token (:slack-token settings)
-        response    (if-not (config/is-test?)
+        response    (if-not config/is-test?
                       ;; in normal conditions, validate connection
                       (slack-api-get slack-token "channels.list" {:exclude_archived 1})
                       ;; for unit testing just respond with a success message

--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -55,23 +55,9 @@
                [k (config-str k)])))
 
 
-(defn config-match
-  "Retrieves all configuration values whose key begin with a specified prefix.
-   The returned map will strip the prefix from the key names.
-   All returned values will be Strings.
-
-   For example if you wanted all of Java's internal environment config values:
-   * (config-match \"java-\") -> {:version \"25.25-b02\" :info \"mixed mode\"}"
-  [prefix]
-  (let [prefix-regex (re-pattern (str ":" prefix ".*"))]
-    (->> (merge
-          (m/filter-keys (fn [k] (re-matches prefix-regex (str k))) app-defaults)
-          (m/filter-keys (fn [k] (re-matches prefix-regex (str k))) environ/env))
-      (m/map-keys (fn [k] (let [kstr (str k)] (keyword (subs kstr (+ 1 (count prefix))))))))))
-
-(defn ^Boolean is-dev?  [] (= :dev  (config-kw :mb-run-mode)))
-(defn ^Boolean is-prod? [] (= :prod (config-kw :mb-run-mode)))
-(defn ^Boolean is-test? [] (= :test (config-kw :mb-run-mode)))
+(def ^:const ^Boolean is-dev?  (= :dev  (config-kw :mb-run-mode)))
+(def ^:const ^Boolean is-prod? (= :prod (config-kw :mb-run-mode)))
+(def ^:const ^Boolean is-test? (= :test (config-kw :mb-run-mode)))
 
 
 ;;; Version stuff
@@ -79,10 +65,7 @@
 
 (defn- version-info-from-shell-script []
   (let [[tag hash branch date] (-> (shell/sh "./bin/version") :out s/trim (s/split #" "))]
-    {:tag    tag
-     :hash   hash
-     :branch branch
-     :date   date}))
+    {:tag tag, :hash hash, :branch branch, :date date}))
 
 (defn- version-info-from-properties-file []
   (when-let [props-file (io/resource "version.properties")]
@@ -97,7 +80,7 @@
    This comes from `resources/version.properties` for prod builds and is fetched from `git` via the `./bin/version` script for dev.
 
      mb-version-info -> {:tag: \"v0.11.1\", :hash: \"afdf863\", :branch: \"about_metabase\", :date: \"2015-10-05\"}"
-  (if (is-prod?)
+  (if is-prod?
     (version-info-from-properties-file)
     (version-info-from-shell-script)))
 

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -5,6 +5,7 @@
             (clojure [set :as set]
                      [string :as s]
                      [walk :as walk])
+            [colorize.core :as color]
             [environ.core :refer [env]]
             (korma [core :as k]
                    [db :as kdb])
@@ -145,12 +146,12 @@
   "Test connection to database with DETAILS and throw an exception if we have any troubles connecting."
   [engine details]
   {:pre [(keyword? engine) (map? details)]}
-  (log/info "Verifying Database Connection ...")
+  (log/info (color/cyan "Verifying Database Connection ..."))
   (assert (binding [*allow-potentailly-unsafe-connections* true]
             (require 'metabase.driver)
             (@(resolve 'metabase.driver/can-connect-with-details?) engine details))
     "Unable to connect to Metabase DB.")
-  (log/info "Verify Database Connection ... CHECK"))
+  (log/info (str "Verify Database Connection ... ✅")))
 
 (defn setup-db
   "Do general perparation of database by validating that we can connect.
@@ -175,7 +176,7 @@
                      "\n\n"
                      "Once your database is updated try running the application again.\n"))
       (throw (java.lang.Exception. "Database requires manual upgrade."))))
-  (log/info "Database Migrations Current ... CHECK")
+  (log/info "Database Migrations Current ... ✅")
 
   ;; Establish our 'default' Korma DB Connection
   (kdb/default-connection (kdb/create-db (jdbc-details db-details)))

--- a/src/metabase/driver/druid.clj
+++ b/src/metabase/driver/druid.clj
@@ -158,7 +158,7 @@
                          (field-values-lazy-seq details table-name field-name total-items-fetched paging-identifiers)))))))
 
 
-;;; ### DriverDriver Class Definition
+;;; ### DruidrDriver Class Definition
 
 (defrecord DruidDriver []
   clojure.lang.Named
@@ -167,19 +167,18 @@
 (extend DruidDriver
   driver/IDriver
   (merge driver/IDriverDefaultsMixin
-         {:analyze-table             (constantly nil)       ; TODO: we should fill this out at some point
-          :describe-database         describe-database
-          :describe-table            describe-table
-          :can-connect?              can-connect?
-          :details-fields            (constantly [{:name         "host"
-                                                   :display-name "Host"
-                                                   :default      "http://localhost"}
-                                                  {:name         "port"
-                                                   :display-name "Broker node port"
-                                                   :type         :integer
-                                                   :default      8082}])
-          :field-values-lazy-seq     field-values-lazy-seq
-          :process-native            process-native
-          :process-structured        process-structured}))
+         {:can-connect?          can-connect?
+          :describe-database     describe-database
+          :describe-table        describe-table
+          :details-fields        (constantly [{:name         "host"
+                                               :display-name "Host"
+                                               :default      "http://localhost"}
+                                              {:name         "port"
+                                               :display-name "Broker node port"
+                                               :type         :integer
+                                               :default      8082}])
+          :field-values-lazy-seq field-values-lazy-seq
+          :process-native        process-native
+          :process-structured    process-structured}))
 
 (driver/register-driver! :druid (DruidDriver.))

--- a/src/metabase/driver/generic_sql/native.clj
+++ b/src/metabase/driver/generic_sql/native.clj
@@ -47,8 +47,8 @@
                ;; Rollback any changes made during this transaction just to be extra-double-sure JDBC doesn't try to commit them automatically for us
                (finally (.rollback jdbc-connection))))))
        (catch java.sql.SQLException e
-         (let [^String message (or (->> (.getMessage e) ; error message comes back like 'Column "ZID" not found; SQL statement: ... [error-code]' sometimes
+         (let [^String message (or (->> (.getMessage e)     ; error message comes back like 'Column "ZID" not found; SQL statement: ... [error-code]' sometimes
                                         (re-find #"^(.*);") ; the user already knows the SQL, and error code is meaningless
-                                        second) ; so just return the part of the exception that is relevant
+                                        second)             ; so just return the part of the exception that is relevant
                                    (.getMessage e))]
            (throw (Exception. message))))))

--- a/src/metabase/driver/mongo/query_processor.clj
+++ b/src/metabase/driver/mongo/query_processor.clj
@@ -239,8 +239,6 @@
         v     (case filter-type
                 :between     {$gte (->rvalue (:min-val filter))
                               $lte (->rvalue (:max-val filter))}
-                :is-null     {$exists false}
-                :not-null    {$exists true}
                 :contains    (re-pattern value)
                 :starts-with (re-pattern (str \^ value))
                 :ends-with   (re-pattern (str value \$))

--- a/src/metabase/driver/query_processor/interface.clj
+++ b/src/metabase/driver/query_processor/interface.clj
@@ -68,6 +68,9 @@
                     ;; Field once its resolved; FieldPlaceholder before that
                     parent             :- s/Any
                     preview-display    :- (s/maybe s/Bool)]
+  clojure.lang.Named
+  (getName [_] field-name) ; (name <field>) returns the *unqualified* name of the field, #obvi
+
   IField
   (qualified-name-components [this]
     (conj (if parent
@@ -97,7 +100,9 @@
 
 ;; wrapper around Field
 (s/defrecord DateTimeField [field :- Field
-                            unit  :- DatetimeFieldUnit])
+                            unit  :- DatetimeFieldUnit]
+  clojure.lang.Named
+  (getName [_] (name field)))
 
 ;; Value is the expansion of a value within a QL clause
 ;; Information about the associated Field is included for convenience

--- a/src/metabase/driver/redshift.clj
+++ b/src/metabase/driver/redshift.clj
@@ -91,7 +91,7 @@
           :unix-timestamp->timestamp unix-timestamp->timestamp}
          ;; HACK ! When we test against Redshift we use a session-unique schema so we can run simultaneous tests against a single remote host;
          ;; when running tests tell the sync process to ignore all the other schemas
-         (when (config/is-test?)
+         (when config/is-test?
            {:excluded-schemas (memoize
                                (fn [_]
                                  (require 'metabase.test.data.redshift)

--- a/src/metabase/driver/sqlite.clj
+++ b/src/metabase/driver/sqlite.clj
@@ -119,7 +119,7 @@
                                             #{:standard-deviation-aggregations}
                                             ;; HACK SQLite doesn't support ALTER TABLE ADD CONSTRAINT FOREIGN KEY and I don't have all day to work around this
                                             ;; so for now we'll just skip the foreign key stuff in the tests.
-                                            (when (config/is-test?)
+                                            (when config/is-test?
                                               #{:foreign-keys})))})
   sql/ISQLDriver
   (merge (sql/ISQLDriverDefaultsMixin)

--- a/src/metabase/events/activity_feed.clj
+++ b/src/metabase/events/activity_feed.clj
@@ -2,7 +2,6 @@
   (:require [clojure.core.async :as async]
             [clojure.tools.logging :as log]
             [metabase.db :as db]
-            [metabase.config :as config]
             [metabase.events :as events]
             (metabase.models [activity :refer [Activity], :as activity]
                              [card :refer [Card]]
@@ -150,7 +149,5 @@
 ;;; ## ---------------------------------------- LIFECYLE ----------------------------------------
 
 
-(defn events-init []
-  (when-not (config/is-test?)
-    (log/info "Starting activity-feed events listener")
-    (events/start-event-listener activity-feed-topics activity-feed-channel process-activity-event)))
+(defn- events-init []
+  (events/start-event-listener activity-feed-topics activity-feed-channel process-activity-event))

--- a/src/metabase/events/dependencies.clj
+++ b/src/metabase/events/dependencies.clj
@@ -1,7 +1,6 @@
 (ns metabase.events.dependencies
   (:require [clojure.core.async :as async]
             [clojure.tools.logging :as log]
-            [metabase.config :as config]
             [metabase.events :as events]
             (metabase.models [card :refer [Card]]
                              [dependency :refer [IDependent] :as dependency]
@@ -48,7 +47,5 @@
 ;;; ## ---------------------------------------- LIFECYLE ----------------------------------------
 
 
-(defn events-init []
-  (when-not (config/is-test?)
-    (log/info "Starting dependencies events listener")
-    (events/start-event-listener dependencies-topics dependencies-channel process-dependencies-event)))
+(defn- events-init []
+  (events/start-event-listener dependencies-topics dependencies-channel process-dependencies-event))

--- a/src/metabase/events/last_login.clj
+++ b/src/metabase/events/last_login.clj
@@ -1,7 +1,6 @@
 (ns metabase.events.last-login
   (:require [clojure.core.async :as async]
             [clojure.tools.logging :as log]
-            [metabase.config :as config]
             [metabase.db :as db]
             [metabase.events :as events]
             [metabase.models.user :refer [User]]
@@ -38,7 +37,5 @@
 ;;; ## ---------------------------------------- LIFECYLE ----------------------------------------
 
 
-(defn events-init []
-  (when-not (config/is-test?)
-    (log/info "Starting last-login events listener")
-    (events/start-event-listener last-login-topics last-login-channel process-last-login-event)))
+(defn- events-init []
+  (events/start-event-listener last-login-topics last-login-channel process-last-login-event))

--- a/src/metabase/events/notifications.clj
+++ b/src/metabase/events/notifications.clj
@@ -1,7 +1,6 @@
 (ns metabase.events.notifications
   (:require [clojure.core.async :as async]
             [clojure.tools.logging :as log]
-            [metabase.config :as config]
             [metabase.db :as db]
             [metabase.email.messages :as messages]
             [metabase.events :as events]
@@ -93,7 +92,5 @@
 ;;; ## ---------------------------------------- LIFECYLE ----------------------------------------
 
 
-(defn events-init []
-  (when-not (config/is-test?)
-    (log/info "Starting notifications events listener")
-    (events/start-event-listener notifications-topics notifications-channel process-notifications-event)))
+(defn- events-init []
+  (events/start-event-listener notifications-topics notifications-channel process-notifications-event))

--- a/src/metabase/events/revision.clj
+++ b/src/metabase/events/revision.clj
@@ -1,7 +1,6 @@
 (ns metabase.events.revision
   (:require [clojure.core.async :as async]
             [clojure.tools.logging :as log]
-            [metabase.config :as config]
             [metabase.events :as events]
             (metabase.models [card :refer [Card]]
                              [dashboard :refer [Dashboard]]
@@ -78,7 +77,5 @@
 ;;; ## ---------------------------------------- LIFECYLE ----------------------------------------
 
 
-(defn events-init []
-  (when-not (config/is-test?)
-    (log/info "Starting revision events listener")
-    (events/start-event-listener revisions-topics revisions-channel process-revision-event)))
+(defn- events-init []
+  (events/start-event-listener revisions-topics revisions-channel process-revision-event))

--- a/src/metabase/events/sync_database.clj
+++ b/src/metabase/events/sync_database.clj
@@ -1,7 +1,6 @@
 (ns metabase.events.sync-database
   (:require [clojure.core.async :as async]
             [clojure.tools.logging :as log]
-            [metabase.config :as config]
             [metabase.db :as db]
             [metabase.driver :as driver]
             [metabase.events :as events]
@@ -41,7 +40,5 @@
 ;;; ## ---------------------------------------- LIFECYLE ----------------------------------------
 
 
-(defn events-init []
-  (when-not (config/is-test?)
-    (log/info "Starting database sync events listener")
-    (events/start-event-listener sync-database-topics sync-database-channel process-sync-database-event)))
+(defn- events-init []
+  (events/start-event-listener sync-database-topics sync-database-channel process-sync-database-event))

--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -1,7 +1,6 @@
 (ns metabase.events.view-log
   (:require [clojure.core.async :as async]
             [clojure.tools.logging :as log]
-            [metabase.config :as config]
             [metabase.db :as db]
             [metabase.events :as events]
             [metabase.models.view-log :refer [ViewLog]]))
@@ -47,7 +46,5 @@
 ;;; ## ---------------------------------------- LIFECYLE ----------------------------------------
 
 
-(defn events-init []
-  (when-not (config/is-test?)
-    (log/info "Starting view-log events listener")
-    (events/start-event-listener view-counts-topics view-counts-channel process-view-count-event)))
+(defn- events-init []
+  (events/start-event-listener view-counts-topics view-counts-channel process-view-count-event))

--- a/src/metabase/middleware.clj
+++ b/src/metabase/middleware.clj
@@ -147,7 +147,8 @@
                                                                     "*.gstatic.com"
                                                                     "js.intercomcdn.com"
                                                                     "*.intercom.io"
-                                                                    (when (config/is-dev?) "localhost:8080")]
+                                                                    (when config/is-dev?
+                                                                      "localhost:8080")]
                                                       :style-src   ["'unsafe-inline'"
                                                                     "'self'"
                                                                     "fonts.googleapis.com"]
@@ -159,7 +160,8 @@
                                                                     "metabase.us10.list-manage.com"
                                                                     "*.intercom.io"
                                                                     "wss://*.intercom.io" ; allow websockets as well
-                                                                    (when (config/is-dev?) "localhost:8080 ws://localhost:8080")]}]
+                                                                    (when config/is-dev?
+                                                                      "localhost:8080 ws://localhost:8080")]}]
                                           (format "%s %s; " (name k) (apply str (interpose " " vs)))))})
 
 (defsetting ssl-certificate-public-key

--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -7,29 +7,26 @@
    `task-init` function which accepts zero arguments.  This function is dynamically resolved and called
    exactly once when the application goes through normal startup procedures.  Inside this function you
    can do any work needed and add your task to the scheduler as usual via `schedule-task!`."
-  (:require clojure.java.classpath
+  (:require [clojure.java.classpath :as classpath]
             [clojure.tools.logging :as log]
             [clojure.tools.namespace.find :as ns-find]
-            [clojurewerkz.quartzite.scheduler :as qs]))
+            [clojurewerkz.quartzite.scheduler :as qs]
+            [colorize.core :as color]))
 
 
 (defonce ^:private quartz-scheduler
   (atom nil))
 
-(defn- find-and-load-tasks
+(defn- find-and-load-tasks!
   "Search Classpath for namespaces that start with `metabase.tasks.`, then `require` them so initialization can happen."
   []
-  (->> (ns-find/find-namespaces (clojure.java.classpath/classpath))
-       (filter (fn [ns-symb]
-                 (re-find #"^metabase\.task\." (name ns-symb))))
-       set
-       (map (fn [events-ns]
-              (log/info "\tloading tasks namespace: " events-ns)
-              (require events-ns)
-              ;; look for `task-init` function in the namespace and call it if it exists
-              (when-let [init-fn (ns-resolve events-ns 'task-init)]
-                (init-fn))))
-       dorun))
+  (doseq [ns-symb (ns-find/find-namespaces (classpath/classpath))
+          :when   (re-find #"^metabase\.task\." (name ns-symb))]
+    (log/info "Loading tasks namespace:" (color/blue ns-symb) "📆")
+    (require ns-symb)
+    ;; look for `task-init` function in the namespace and call it if it exists
+    (when-let [init-fn (ns-resolve ns-symb 'task-init)]
+      (init-fn))))
 
 (defn start-scheduler!
   "Start our Quartzite scheduler which allows jobs to be submitted and triggers to begin executing."
@@ -39,7 +36,7 @@
     ;; keep a reference to our scheduler
     (reset! quartz-scheduler (-> (qs/initialize) qs/start))
     ;; look for job/trigger definitions
-    (find-and-load-tasks)))
+    (find-and-load-tasks!)))
 
 (defn stop-scheduler!
   "Stop our Quartzite scheduler and shutdown any running executions."

--- a/src/metabase/task/send_pulses.clj
+++ b/src/metabase/task/send_pulses.clj
@@ -43,8 +43,7 @@
                                 :id)]
     (send-pulses curr-hour curr-weekday)))
 
-(defn task-init []
-  (log/info "Submitting send-pulses task to scheduler")
+(defn- task-init []
   ;; build our job
   (reset! send-pulses-job (jobs/build
                                (jobs/of-type SendPulses)

--- a/src/metabase/task/sync_databases.clj
+++ b/src/metabase/task/sync_databases.clj
@@ -26,8 +26,7 @@
         (catch Exception e
           (log/error "Error syncing database: " (:id database) e))))))
 
-(defn task-init []
-  (log/info "Submitting sync-database task to scheduler")
+(defn- task-init []
   ;; build our job
   (reset! sync-databases-job (jobs/build
                                (jobs/of-type SyncDatabases)

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -441,7 +441,7 @@
      (format-color 'red \"Fatal error: %s\" error-message)"
   ^String [color-symb format-string & args]
   {:pre [(symbol? color-symb)]}
-  ((ns-resolve 'colorize.core color-symb) (apply format format-string args)))
+  ((ns-resolve 'colorize.core color-symb) (apply format (str format-string) args)))
 
 (defn pprint-to-str
   "Returns the output of pretty-printing X as a string.

--- a/src/metabase/util/korma_extensions.clj
+++ b/src/metabase/util/korma_extensions.clj
@@ -76,7 +76,7 @@
   [operator & args]
   (apply infix operator (for [arg args]
                           (cond-> arg
-                            (integer? arg) k/raw))))
+                            (number? arg) k/raw))))
 
 (def ^{:arglists '([& exprs])}  +  (partial math-infix "+"))
 (def ^{:arglists '([& exprs])}  -  (partial math-infix "-"))
@@ -84,10 +84,12 @@
 (def ^{:arglists '([& exprs])}  *  (partial math-infix "*"))
 (def ^{:arglists '([& exprs])} mod (partial math-infix "%"))
 
-(defn inc [x] (+ x 1))
-(defn dec [x] (- x 1))
+(defn inc "Add 1 to X."        [x] (+ x 1))
+(defn dec "Subtract 1 from X." [x] (- x 1))
 
-(defn literal [s]
+(defn literal
+  "Wrap keyword or string S in single quotes and a korma `raw` form."
+  [s]
   (k/raw (str \' (name s) \')))
 
 (defn cast
@@ -99,18 +101,18 @@
 (defn format [format-str expr]
   (k/sqlfn :FORMAT expr (literal format-str)))
 
-(defn ->date                     [x] (cast :DATE x))
-(defn ->datetime                 [x] (cast :DATETIME x))
-(defn ->timestamp                [x] (cast :TIMESTAMP x))
-(defn ->timestamp-with-time-zone [x] (cast "TIMESTAMP WITH TIME ZONE" x))
-(defn ->integer                  [x] (cast :INTEGER x))
+(defn ->date                     "CAST X to a `DATE`."                     [x] (cast :DATE x))
+(defn ->datetime                 "CAST X to a `DATETIME`."                 [x] (cast :DATETIME x))
+(defn ->timestamp                "CAST X to a `TIMESTAMP`."                [x] (cast :TIMESTAMP x))
+(defn ->timestamp-with-time-zone "CAST X to a `TIMESTAMP WITH TIME ZONE`." [x] (cast "TIMESTAMP WITH TIME ZONE" x))
+(defn ->integer                  "CAST X to a `INTEGER`."                  [x] (cast :INTEGER x))
 
 ;;; Random SQL fns. Not all DBs support all these!
-(def ^{:arglists '([& exprs])} floor   (partial k/sqlfn* :FLOOR))
-(def ^{:arglists '([& exprs])} hour    (partial k/sqlfn* :HOUR))
-(def ^{:arglists '([& exprs])} minute  (partial k/sqlfn* :MINUTE))
-(def ^{:arglists '([& exprs])} week    (partial k/sqlfn* :WEEK))
-(def ^{:arglists '([& exprs])} month   (partial k/sqlfn* :MONTH))
-(def ^{:arglists '([& exprs])} quarter (partial k/sqlfn* :QUARTER))
-(def ^{:arglists '([& exprs])} year    (partial k/sqlfn* :YEAR))
-(def ^{:arglists '([& exprs])} concat  (partial k/sqlfn* :CONCAT))
+(def ^{:arglists '([& exprs])} floor   "SQL `FLOOR` function."  (partial k/sqlfn* :FLOOR))
+(def ^{:arglists '([& exprs])} hour    "SQL `HOUR` function."   (partial k/sqlfn* :HOUR))
+(def ^{:arglists '([& exprs])} minute  "SQL `MINUTE` function." (partial k/sqlfn* :MINUTE))
+(def ^{:arglists '([& exprs])} week    "SQL `WEEK` function."   (partial k/sqlfn* :WEEK))
+(def ^{:arglists '([& exprs])} month   "SQL `MONTH` function."  (partial k/sqlfn* :MONTH))
+(def ^{:arglists '([& exprs])} quarter "SQL `QUARTER` function."(partial k/sqlfn* :QUARTER))
+(def ^{:arglists '([& exprs])} year    "SQL `YEAR` function."   (partial k/sqlfn* :YEAR))
+(def ^{:arglists '([& exprs])} concat  "SQL `CONCAT` function." (partial k/sqlfn* :CONCAT))


### PR DESCRIPTION
Backport a bunch of random minor tweaks and fixes made in the `bigquery_driver_wip` branch to keep the scope of that PR more reasonable.
-  Make `is-prod?`/`is-test?`/`is-dev?` constants
-  Remove unused imports in `metabase/api/database.clj`
-  Remove unused `config-match` function
-  Add default implementation for `analyze-table`
-  Improve docstrings for `process-native` and `process-structured` by including expected structure of their responses
-  Fix typo in comment in `metabase/driver/druid.clj`
-  Fix excess whitespace in `metabase/driver/druid.clj`
-  Fix arguments in wrong order in protocol declaration of `unix-timestamp->timestamp`
-  Fix misaligned comments in `src/metabase/driver/generic_sql/native.clj`
-  Simplify code for preparing objects in SQL query processor 
-  Simplify korma form logged by SQL query processor (i.e. `korma.core$do_query` instead of `#object[korma.core$do_query korma.core$do_query @ 0x0f431267]`)
-  Increase pprint width for logging queries, expanded queries, and korma forms, making logging more concise
-  Make `events-init` functions private
-  Addidtional docstrings form most of the functions in `metabase.util.korma-extensions`
