### PR TITLE
DeCLOBify Field descriptions :yum:

### DIFF
--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -106,7 +106,7 @@
 (extend (class Field)
   i/IEntity (merge i/IEntityDefaults
                    {:hydration-keys     (constantly [:destination :field :origin])
-                    :types              (constantly {:base_type :keyword, :field_type :keyword, :special_type :keyword})
+                    :types              (constantly {:base_type :keyword, :field_type :keyword, :special_type :keyword, :description :clob})
                     :timestamped?       (constantly true)
                     :can-read?          (constantly true)
                     :can-write?         i/superuser?


### PR DESCRIPTION
automatically de-CLOBIFY `Field.description` when it comes out of the DB by specifying type key `:clob` which [I added](https://github.com/metabase/metabase/pull/1740/files#diff-0b4ac23d5d66b8d2a35d92eadb034e26R130) in #1740
