### PR TITLE
Faster launch time by compiling w/ elide-meta :notes:

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -94,7 +94,8 @@
                                        "-Dmb.jetty.port=3010"
                                        "-Dmb.api.key=test-api-key"
                                        "-Xverify:none"]}              ; disable bytecode verification when running tests so they start slightly faster
-             :uberjar {:aot :all}
+             :uberjar {:aot :all
+                       :jvm-opts ["-Dclojure.compiler.elide-meta=[:doc :added :file :line]"]}
              :generate-sample-dataset {:dependencies [[faker "0.2.2"]                   ; Fake data generator -- port of Perl/Ruby
                                                       [incanter/incanter-core "1.9.0"]] ; Satistical functions like normal distibutions}})
                                        :source-paths ["sample_dataset"]

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -7,7 +7,8 @@
             [clj-time.coerce :as coerce]
             [clj-time.format :as time]
             [colorize.core :as color]
-            [medley.core :as m])
+            [medley.core :as m]
+            [metabase.config :as config])
   (:import clojure.lang.Keyword
            (java.net Socket
                      InetSocketAddress
@@ -369,11 +370,10 @@
 (defn require-dox-in-this-namespace
   "Throw an exception if any public interned symbol in this namespace is missing a docstring."
   []
-  (->> (ns-publics *ns*)
-       (map (fn [[symb varr]]
-              (when-not (:doc (meta varr))
-                (throw (Exception. (format "All public symbols in %s are required to have a docstring, but %s is missing one." (.getName *ns*) symb))))))
-       dorun))
+  (when-not config/is-prod?
+    (doseq [[symb varr] (ns-publics *ns*)
+            :when       (not (:doc (meta varr)))]
+      (throw (Exception. (format "All public symbols in %s are required to have a docstring, but %s is missing one." (.getName *ns*) symb))))))
 
 (defmacro pdoseq
   "(Almost) just like `doseq` but runs in parallel. Doesn't support advanced binding forms like `:let` or `:when` and only supports a single binding </3"


### PR DESCRIPTION
Strip out metadata that's not needed when running uberjar using Clojure 1.8's new [`elide-meta`](http://clojure.org/reference/compilation#_elide_meta) compiler option. Faster start times and slightly smaller JAR size
