### PR TITLE
shorten the TTL on the sql driver connection pools from 3 hours down to 1 hour.

### DIFF
--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -92,7 +92,7 @@
    (fn [spec]
      (log/debug (u/format-color 'magenta "Creating new connection pool..."))
      (kdb/connection-pool (assoc spec :minimum-pool-size 1)))
-   :ttl/threshold (* 3 60 60 1000)))
+   :ttl/threshold (* 60 60 1000)))
 
 (defn db->jdbc-connection-spec
   "Return a JDBC connection spec for DATABASE. Normally this will have a C3P0 pool as its datasource, unless the database is `short-lived`."

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -91,7 +91,11 @@
   (memoize/ttl
    (fn [spec]
      (log/debug (u/format-color 'magenta "Creating new connection pool..."))
-     (kdb/connection-pool (assoc spec :minimum-pool-size 1)))
+     (kdb/connection-pool (assoc spec :minimum-pool-size           3
+                                      ;; prevent broken connections closed by dbs by testing them every 3 mins
+                                      :idle-connection-test-period (* 3 60)
+                                      ;; prevent overly large pools by condensing them when connections are idle for 15m+
+                                      :excess-timeout              (* 15 60))))
    :ttl/threshold (* 60 60 1000)))
 
 (defn db->jdbc-connection-spec


### PR DESCRIPTION
This is meant to provide some relief for #1702 by reducing the likelihood that connections sit in the connection pool for several hours.  I think we can consider reducing this further, but for now 1 hour is fine.
