### PR TITLE
Make aggregation choices atomic

### DIFF
--- a/frontend/src/lib/query.js
+++ b/frontend/src/lib/query.js
@@ -214,53 +214,6 @@ var Query = {
                     query.aggregation[0] === "rows");
     },
 
-    // TODO: unit test
-    // predicate function to test if a given aggregation clause represents a metric
-    aggregationIsMetric(aggregation) {
-        return (aggregation && aggregation.length > 1 && aggregation[0] === "METRIC");
-    },
-
-    // TODO: unit test
-    // get the metricId from a metric aggregation clause
-    aggregationGetMetric(aggregation) {
-        if (aggregation && Query.aggregationIsMetric(aggregation)) {
-            return aggregation[1];
-        } else {
-            return null;
-        }
-    },
-
-    // TODO: unit test
-    // get the operator from a standard aggregation clause
-    aggregationGetOperator(aggregation) {
-        if (aggregation && !Query.aggregationIsMetric(aggregation) && aggregation.length > 0) {
-            return aggregation[0];
-        } else {
-            return null;
-        }
-    },
-
-    // TODO: unit test
-    // get the fieldId from a standard aggregation clause
-    aggregationGetField(aggregation) {
-        if (aggregation && !Query.aggregationIsMetric(aggregation) && aggregation.length > 1) {
-            return aggregation[1];
-        } else {
-            return null;
-        }
-    },
-
-    // TODO: unit test
-    // set the fieldId on a standard aggregation clause
-    aggregationSetField(aggregation, fieldId) {
-        if (aggregation && aggregation.length > 0 && aggregation[0]) {
-            return [aggregation[0], fieldId];
-        } else {
-            // TODO: is there a better failure response than just returning the aggregation unmodified??
-            return aggregation;
-        }
-    },
-
     updateAggregation(query, aggregationClause) {
         // when switching to or from "rows" aggregation clear out any sorting clauses
         if ((query.aggregation[0] === "rows" || aggregationClause[0] === "rows") && query.aggregation[0] !== aggregationClause[0]) {
@@ -628,6 +581,71 @@ var Query = {
             return <span>{description}</span>;
         } else {
             return description.join("");
+        }
+    }
+}
+
+export const AggregationClause = {
+
+    // predicate function to test if a given aggregation clause is fully formed
+    isValid(aggregation) {
+        if (aggregation && _.isArray(aggregation) &&
+                ((aggregation.length === 1 && aggregation[0] !== null) ||
+                 (aggregation.length === 2 && aggregation[0] !== null && aggregation[1] !== null))) {
+            return true;
+        }
+        return false;
+    },
+
+    // predicate function to test if the given aggregation clause represents a Bare Rows aggregation
+    isBareRows(aggregation) {
+        return AggregationClause.isValid(aggregation) && aggregation[0] === "rows";
+    },
+
+    // predicate function to test if a given aggregation clause represents a standard aggregation
+    isStandard(aggregation) {
+        return AggregationClause.isValid(aggregation) && aggregation[0] !== "METRIC";
+    },
+
+    // predicate function to test if a given aggregation clause represents a metric
+    isMetric(aggregation) {
+        return AggregationClause.isValid(aggregation) && aggregation[0] === "METRIC";
+    },
+
+    // get the metricId from a metric aggregation clause
+    getMetric(aggregation) {
+        if (aggregation && AggregationClause.isMetric(aggregation)) {
+            return aggregation[1];
+        } else {
+            return null;
+        }
+    },
+
+    // get the operator from a standard aggregation clause
+    getOperator(aggregation) {
+        if (aggregation && aggregation.length > 0 && aggregation[0] !== "METRIC") {
+            return aggregation[0];
+        } else {
+            return null;
+        }
+    },
+
+    // get the fieldId from a standard aggregation clause
+    getField(aggregation) {
+        if (aggregation && aggregation.length > 1 && aggregation[0] !== "METRIC") {
+            return aggregation[1];
+        } else {
+            return null;
+        }
+    },
+
+    // set the fieldId on a standard aggregation clause
+    setField(aggregation, fieldId) {
+        if (aggregation && aggregation.length > 0 && aggregation[0] && aggregation[0] !== "METRIC") {
+            return [aggregation[0], fieldId];
+        } else {
+            // TODO: is there a better failure response than just returning the aggregation unmodified??
+            return aggregation;
         }
     }
 }

--- a/frontend/src/lib/query.js
+++ b/frontend/src/lib/query.js
@@ -214,6 +214,53 @@ var Query = {
                     query.aggregation[0] === "rows");
     },
 
+    // TODO: unit test
+    // predicate function to test if a given aggregation clause represents a metric
+    aggregationIsMetric(aggregation) {
+        return (aggregation && aggregation.length > 1 && aggregation[0] === "METRIC");
+    },
+
+    // TODO: unit test
+    // get the metricId from a metric aggregation clause
+    aggregationGetMetric(aggregation) {
+        if (aggregation && Query.aggregationIsMetric(aggregation)) {
+            return aggregation[1];
+        } else {
+            return null;
+        }
+    },
+
+    // TODO: unit test
+    // get the operator from a standard aggregation clause
+    aggregationGetOperator(aggregation) {
+        if (aggregation && !Query.aggregationIsMetric(aggregation) && aggregation.length > 0) {
+            return aggregation[0];
+        } else {
+            return null;
+        }
+    },
+
+    // TODO: unit test
+    // get the fieldId from a standard aggregation clause
+    aggregationGetField(aggregation) {
+        if (aggregation && !Query.aggregationIsMetric(aggregation) && aggregation.length > 1) {
+            return aggregation[1];
+        } else {
+            return null;
+        }
+    },
+
+    // TODO: unit test
+    // set the fieldId on a standard aggregation clause
+    aggregationSetField(aggregation, fieldId) {
+        if (aggregation && aggregation.length > 0 && aggregation[0]) {
+            return [aggregation[0], fieldId];
+        } else {
+            // TODO: is there a better failure response than just returning the aggregation unmodified??
+            return aggregation;
+        }
+    },
+
     updateAggregation(query, aggregationClause) {
         // when switching to or from "rows" aggregation clear out any sorting clauses
         if ((query.aggregation[0] === "rows" || aggregationClause[0] === "rows") && query.aggregation[0] !== aggregationClause[0]) {

--- a/frontend/src/lib/schema_metadata.js
+++ b/frontend/src/lib/schema_metadata.js
@@ -340,37 +340,44 @@ var Aggregators = [{
     "name": "Raw data",
     "short": "rows",
     "description": "Just a table with the rows in the answer, no additional operations.",
-    "validFieldsFilters": []
+    "validFieldsFilters": [],
+    "requiresField": false
 }, {
     "name": "Count of rows",
     "short": "count",
     "description": "Total number of rows in the answer.",
-    "validFieldsFilters": []
+    "validFieldsFilters": [],
+    "requiresField": false
 }, {
     "name": "Sum of ...",
     "short": "sum",
     "description": "Sum of all the values of a column.",
-    "validFieldsFilters": [summableFields]
+    "validFieldsFilters": [summableFields],
+    "requiresField": true
 }, {
     "name": "Average of ...",
     "short": "avg",
     "description": "Average of all the values of a column",
-    "validFieldsFilters": [summableFields]
+    "validFieldsFilters": [summableFields],
+    "requiresField": true
 }, {
     "name": "Number of distinct values of ...",
     "short": "distinct",
     "description":  "Number of unique values of a column among all the rows in the answer.",
-    "validFieldsFilters": [allFields]
+    "validFieldsFilters": [allFields],
+    "requiresField": true
 }, {
     "name": "Cumulative sum of ...",
     "short": "cum_sum",
     "description": "Additive sum of all the values of a column.\ne.x. total revenue over time.",
-    "validFieldsFilters": [summableFields]
+    "validFieldsFilters": [summableFields],
+    "requiresField": true
 }, {
     "name": "Standard deviation of ...",
     "short": "stddev",
     "description": "Number which expresses how much the values of a column vary among all rows in the answer.",
     "validFieldsFilters": [summableFields],
+    "requiresField": true,
     "requiredDriverFeature": "standard-deviation-aggregations"
 }];
 
@@ -389,11 +396,14 @@ function populateFields(aggregator, fields) {
         'fields': _.map(aggregator.validFieldsFilters, function(validFieldsFilterFn) {
             return validFieldsFilterFn(fields);
         }),
-        'validFieldsFilters': aggregator.validFieldsFilters
+        'validFieldsFilters': aggregator.validFieldsFilters,
+        "requiresField": aggregator.requiresField,
+        "requiredDriverFeature": aggregator.requiredDriverFeature
     };
 }
 
-function getAggregators(table) {
+// TODO: unit test
+export function getAggregators(table) {
     const supportedAggregations = Aggregators.filter(function (agg) {
         if (agg.requiredDriverFeature && table.db && !_.contains(table.db.features, agg.requiredDriverFeature)) {
             return false;
@@ -404,6 +414,11 @@ function getAggregators(table) {
     return _.map(supportedAggregations, function(aggregator) {
         return populateFields(aggregator, table.fields);
     });
+}
+
+// TODO: unit test
+export function getAggregator(short) {
+    return _.findWhere(Aggregators, { short: short });
 }
 
 function getBreakouts(fields) {

--- a/frontend/src/query_builder/AggregationPopover.jsx
+++ b/frontend/src/query_builder/AggregationPopover.jsx
@@ -8,6 +8,7 @@ import Icon from "metabase/components/Icon.jsx";
 import Tooltip from "metabase/components/Tooltip.jsx";
 
 import Query from "metabase/lib/query";
+import { AggregationClause } from "metabase/lib/query";
 
 import _ from "underscore";
 
@@ -18,7 +19,7 @@ export default class AggregationPopover extends Component {
 
         this.state = {
             aggregation: (props.isNew ? [] : props.aggregation),
-            choosingField: (props.aggregation && props.aggregation.length > 1 && !Query.aggregationIsMetric(props.aggregation))
+            choosingField: (props.aggregation && props.aggregation.length > 1 && AggregationClause.isStandard(props.aggregation))
         };
 
         _.bindAll(this, "commitAggregation", "onPickAggregation", "onPickField", "onClearAggregation");
@@ -53,7 +54,7 @@ export default class AggregationPopover extends Component {
     }
 
     onPickField(fieldId) {
-        this.commitAggregation(Query.aggregationSetField(this.state.aggregation, fieldId));
+        this.commitAggregation(AggregationClause.setField(this.state.aggregation, fieldId));
     }
 
     onClearAggregation() {
@@ -105,10 +106,10 @@ export default class AggregationPopover extends Component {
         const { aggregation, choosingField } = this.state;
 
         let selectedAggregation;
-        if (Query.aggregationIsMetric(aggregation)) {
-            selectedAggregation = _.findWhere(tableMetadata.metrics, { id: Query.aggregationGetMetric(aggregation) });
-        } else if (Query.aggregationGetOperator(aggregation)) {
-            selectedAggregation = _.findWhere(availableAggregations, { short: Query.aggregationGetOperator(aggregation) });
+        if (AggregationClause.isMetric(aggregation)) {
+            selectedAggregation = _.findWhere(tableMetadata.metrics, { id: AggregationClause.getMetric(aggregation) });
+        } else if (AggregationClause.getOperator(aggregation)) {
+            selectedAggregation = _.findWhere(availableAggregations, { short: AggregationClause.getOperator(aggregation) });
         }
 
         let sections = [{

--- a/frontend/src/query_builder/AggregationPopover.jsx
+++ b/frontend/src/query_builder/AggregationPopover.jsx
@@ -153,7 +153,7 @@ export default class AggregationPopover extends Component {
             const [agg, fieldId] = aggregation;
             return (
                 <div style={{width: 300}}>
-                    <div className="FilterPopover-header text-grey-3 p1 mt1 flex align-center">
+                    <div className="text-grey-3 p1 py2 border-bottom flex align-center">
                         <a className="cursor-pointer flex align-center" onClick={this.onClearAggregation}>
                             <Icon name="chevronleft" width="18" height="18"/>
                             <h3 className="inline-block pl1">{selectedAggregation.name}</h3>

--- a/frontend/src/query_builder/AggregationPopover.jsx
+++ b/frontend/src/query_builder/AggregationPopover.jsx
@@ -1,0 +1,173 @@
+import React, { Component, PropTypes } from "react";
+
+import AccordianList from "./AccordianList.jsx";
+import FieldList from './FieldList.jsx';
+import QueryDefinitionTooltip from "./QueryDefinitionTooltip.jsx";
+
+import Icon from "metabase/components/Icon.jsx";
+import Tooltip from "metabase/components/Tooltip.jsx";
+
+import Query from "metabase/lib/query";
+
+import _ from "underscore";
+
+
+export default class AggregationPopover extends Component {
+    constructor(props, context) {
+        super(props, context);
+
+        this.state = {
+            aggregation: (props.isNew ? [] : props.aggregation),
+            choosingField: (props.aggregation && props.aggregation.length > 1 && !Query.aggregationIsMetric(props.aggregation))
+        };
+
+        _.bindAll(this, "commitAggregation", "onPickAggregation", "onPickField", "onClearAggregation");
+    }
+
+    static propTypes = {
+        isNew: PropTypes.bool,
+        aggregation: PropTypes.array,
+        availableAggregations: PropTypes.array.isRequired,
+        onCommitAggregation: PropTypes.func.isRequired,
+        onClose: PropTypes.func.isRequired,
+        tableMetadata: PropTypes.object.isRequired
+    };
+
+
+    commitAggregation(aggregation) {
+        this.props.onCommitAggregation(aggregation);
+        this.props.onClose();
+    }
+
+    onPickAggregation(agg) {
+        // check if this aggregation requires a field, if so then force user to pick that now, otherwise we are done
+        if (agg.aggregation && agg.aggregation.requiresField) {
+            this.setState({
+                aggregation: agg.value,
+                choosingField: true
+            });
+        } else {
+            // this includse picking a METRIC or picking an aggregation which doesn't require a field
+            this.commitAggregation(agg.value);
+        }
+    }
+
+    onPickField(fieldId) {
+        this.commitAggregation(Query.aggregationSetField(this.state.aggregation, fieldId));
+    }
+
+    onClearAggregation() {
+        this.setState({
+            choosingField: false
+        });
+    }
+
+    getAggregationFieldOptions(aggOperator) {
+        // NOTE: we don't use getAggregator() here because availableAggregations has the table.fields populated on the aggregation options
+        const aggOptions = this.props.availableAggregations.filter((o) => o.short === aggOperator);
+        if (aggOptions && aggOptions.length > 0) {
+            return Query.getFieldOptions(this.props.tableMetadata.fields, true, aggOptions[0].validFieldsFilters[0])
+        }
+    }
+
+    itemIsSelected(item) {
+        const { aggregation } = this.props;
+        return (aggregation[0] === item.value[0] && (aggregation[0] !== "METRIC" || aggregation[1] === item.value[1]));
+    }
+
+    renderItemExtra(item, itemIndex) {
+        if (item.aggregation && item.aggregation.description) {
+            return (
+                <div className="p1">
+                    <Tooltip tooltipElement={item.aggregation.description}>
+                        <span className="QuestionTooltipTarget" />
+                    </Tooltip>
+                </div>
+            );
+        } else if (item.metric) {
+            return this.renderMetricTooltip(item.metric);
+        }
+    }
+
+    renderMetricTooltip(metric) {
+        let { tableMetadata } = this.props;
+        return (
+            <div className="p1">
+                <Tooltip tooltipElement={<QueryDefinitionTooltip object={metric} tableMetadata={tableMetadata} />}>
+                    <span className="QuestionTooltipTarget" />
+                </Tooltip>
+            </div>
+        );
+    }
+
+    render() {
+        const { availableAggregations, tableMetadata } = this.props;
+        const { aggregation, choosingField } = this.state;
+
+        let selectedAggregation;
+        if (Query.aggregationIsMetric(aggregation)) {
+            selectedAggregation = _.findWhere(tableMetadata.metrics, { id: Query.aggregationGetMetric(aggregation) });
+        } else if (Query.aggregationGetOperator(aggregation)) {
+            selectedAggregation = _.findWhere(availableAggregations, { short: Query.aggregationGetOperator(aggregation) });
+        }
+
+        let sections = [{
+            name: "Metabasics",
+            items: availableAggregations.map(aggregation => ({
+                name: aggregation.name,
+                value: [aggregation.short].concat(aggregation.fields.map(field => null)),
+                aggregation: aggregation
+            })),
+            icon: "table2"
+        }];
+        if (tableMetadata.metrics && tableMetadata.metrics.length > 0) {
+            sections.push({
+                name: "Common Metrics",
+                items: tableMetadata.metrics.filter((mtrc) => mtrc.is_active === true || (selectedAggregation && selectedAggregation.id === mtrc.id)).map(metric => ({
+                    name: metric.name,
+                    value: ["METRIC", metric.id],
+                    metric: metric
+                })),
+                icon: "star-outline"
+            });
+        }
+
+        if (sections.length === 1) {
+            sections[0].name = null
+        }
+
+        if (!choosingField) {
+            return (
+                <AccordianList
+                    className="text-green"
+                    sections={sections}
+                    onChange={this.onPickAggregation}
+                    itemIsSelected={this.itemIsSelected.bind(this)}
+                    renderSectionIcon={(s) => <Icon name={s.icon} width="18" height="18" />}
+                    renderItemExtra={this.renderItemExtra.bind(this)}
+                />
+            );
+
+        } else {
+            const [agg, fieldId] = aggregation;
+            return (
+                <div style={{width: 300}}>
+                    <div className="FilterPopover-header text-grey-3 p1 mt1 flex align-center">
+                        <a className="cursor-pointer flex align-center" onClick={this.onClearAggregation}>
+                            <Icon name="chevronleft" width="18" height="18"/>
+                            <h3 className="inline-block pl1">{selectedAggregation.name}</h3>
+                        </a>
+                    </div>
+                    <FieldList
+                        className={"text-green"}
+                        tableMetadata={tableMetadata}
+                        field={fieldId}
+                        fieldOptions={this.getAggregationFieldOptions(agg)}
+                        onFieldChange={this.onPickField}
+                        enableTimeGrouping={false}
+                    />
+                </div>
+            );
+        }
+    }
+}

--- a/frontend/src/query_builder/AggregationWidget.jsx
+++ b/frontend/src/query_builder/AggregationWidget.jsx
@@ -63,12 +63,12 @@ export default class AggregationWidget extends Component {
         let selectedAggregation = getAggregator(AggregationClause.getOperator(aggregation));
         return (
             <div onClick={this.open} className="Query-section Query-section-aggregation cursor-pointer">
-                <span className="View-section-aggregation QueryOption p1">{selectedAggregation ? selectedAggregation.name.replace(" of ...", "") : "Choose an aggregation"}</span>
+                <span className="View-section-aggregation QueryOption py1 pl1">{selectedAggregation ? selectedAggregation.name.replace(" of ...", "") : "Choose an aggregation"}</span>
                 {aggregation.length > 1 &&
-                    <div className="flex align-center">
-                        <span className="text-bold">of</span>
+                    <div className="View-section-aggregation flex align-center">
+                        <span style={{paddingRight: "4px", paddingLeft: "4px"}} className="text-bold">of</span>
                         <FieldName
-                            className="View-section-aggregation-target SelectionModule p1"
+                            className="View-section-aggregation-target SelectionModule py1 pr1"
                             tableMetadata={tableMetadata}
                             field={fieldId}
                             fieldOptions={Query.getFieldOptions(tableMetadata.fields, true)}

--- a/frontend/src/query_builder/AggregationWidget.jsx
+++ b/frontend/src/query_builder/AggregationWidget.jsx
@@ -6,6 +6,7 @@ import FieldName from './FieldName.jsx';
 import Popover from "metabase/components/Popover.jsx";
 
 import Query from "metabase/lib/query";
+import { AggregationClause } from "metabase/lib/query";
 import { getAggregator, getAggregators } from "metabase/lib/schema_metadata";
 
 import cx from "classnames";
@@ -57,9 +58,9 @@ export default class AggregationWidget extends Component {
 
     renderStandardAggregation() {
         const { aggregation, tableMetadata } = this.props;
-        const fieldId = Query.aggregationGetField(aggregation);
+        const fieldId = AggregationClause.getField(aggregation);
 
-        let selectedAggregation = getAggregator(Query.aggregationGetOperator(aggregation));
+        let selectedAggregation = getAggregator(AggregationClause.getOperator(aggregation));
         return (
             <div onClick={this.open} className="Query-section Query-section-aggregation cursor-pointer">
                 <span className="View-section-aggregation QueryOption p1">{selectedAggregation ? selectedAggregation.name.replace(" of ...", "") : "Choose an aggregation"}</span>
@@ -80,7 +81,7 @@ export default class AggregationWidget extends Component {
 
     renderMetricAggregation() {
         const { aggregation, tableMetadata } = this.props;
-        const metricId = Query.aggregationGetMetric(aggregation);
+        const metricId = AggregationClause.getMetric(aggregation);
 
         let selectedMetric = _.findWhere(tableMetadata.metrics, { id: metricId });
         return (
@@ -124,7 +125,7 @@ export default class AggregationWidget extends Component {
         return (
             <div className={cx("Query-section Query-section-aggregation", { "selected": this.state.isOpen })}>
                 <div>
-                    {Query.aggregationIsMetric(aggregation) ?
+                    {AggregationClause.isMetric(aggregation) ?
                         this.renderMetricAggregation()
                     :
                         this.renderStandardAggregation()

--- a/frontend/test/unit/lib/query.spec.js
+++ b/frontend/test/unit/lib/query.spec.js
@@ -1,7 +1,7 @@
 /*eslint-env jasmine */
 
 import Query from "metabase/lib/query";
-import { createQuery } from "metabase/lib/query";
+import { createQuery, AggregationClause } from "metabase/lib/query";
 
 
 describe('Query', () => {
@@ -241,6 +241,128 @@ describe('Query', () => {
             };
             Query.removeDimension(query, 0);
             expect(query.order_by).toBe(undefined);
+        });
+    });
+});
+
+
+describe('AggregationClause', () => {
+
+    describe('isValid', () => {
+        it("should fail on bad clauses", () => {
+            expect(AggregationClause.isValid(undefined)).toEqual(false);
+            expect(AggregationClause.isValid(null)).toEqual(false);
+            expect(AggregationClause.isValid([])).toEqual(false);
+            expect(AggregationClause.isValid([null])).toEqual(false);
+            expect(AggregationClause.isValid("ab")).toEqual(false);
+            expect(AggregationClause.isValid(["foo", null])).toEqual(false);
+            expect(AggregationClause.isValid(["a", "b", "c"])).toEqual(false);
+        });
+
+        it("should succeed on good clauses", () => {
+            expect(AggregationClause.isValid(["METRIC", 123])).toEqual(true);
+            expect(AggregationClause.isValid(["rows"])).toEqual(true);
+            expect(AggregationClause.isValid(["sum", 456])).toEqual(true);
+        });
+    });
+
+    describe('isBareRows', () => {
+        it("should fail on bad clauses", () => {
+            expect(AggregationClause.isBareRows(undefined)).toEqual(false);
+            expect(AggregationClause.isBareRows(null)).toEqual(false);
+            expect(AggregationClause.isBareRows([])).toEqual(false);
+            expect(AggregationClause.isBareRows([null])).toEqual(false);
+            expect(AggregationClause.isBareRows("ab")).toEqual(false);
+            expect(AggregationClause.isBareRows(["foo", null])).toEqual(false);
+            expect(AggregationClause.isBareRows(["a", "b", "c"])).toEqual(false);
+            expect(AggregationClause.isBareRows(["METRIC", 123])).toEqual(false);
+            expect(AggregationClause.isBareRows(["sum", 456])).toEqual(false);
+        });
+
+        it("should succeed on good clauses", () => {
+            expect(AggregationClause.isBareRows(["rows"])).toEqual(true);
+        });
+    });
+
+    describe('isStandard', () => {
+        it("should fail on bad clauses", () => {
+            expect(AggregationClause.isStandard(undefined)).toEqual(false);
+            expect(AggregationClause.isStandard(null)).toEqual(false);
+            expect(AggregationClause.isStandard([])).toEqual(false);
+            expect(AggregationClause.isStandard([null])).toEqual(false);
+            expect(AggregationClause.isStandard("ab")).toEqual(false);
+            expect(AggregationClause.isStandard(["foo", null])).toEqual(false);
+            expect(AggregationClause.isStandard(["a", "b", "c"])).toEqual(false);
+            expect(AggregationClause.isStandard(["METRIC", 123])).toEqual(false);
+        });
+
+        it("should succeed on good clauses", () => {
+            expect(AggregationClause.isStandard(["rows"])).toEqual(true);
+            expect(AggregationClause.isStandard(["sum", 456])).toEqual(true);
+        });
+    });
+
+    describe('isMetric', () => {
+        it("should fail on bad clauses", () => {
+            expect(AggregationClause.isMetric(undefined)).toEqual(false);
+            expect(AggregationClause.isMetric(null)).toEqual(false);
+            expect(AggregationClause.isMetric([])).toEqual(false);
+            expect(AggregationClause.isMetric([null])).toEqual(false);
+            expect(AggregationClause.isMetric("ab")).toEqual(false);
+            expect(AggregationClause.isMetric(["foo", null])).toEqual(false);
+            expect(AggregationClause.isMetric(["a", "b", "c"])).toEqual(false);
+            expect(AggregationClause.isMetric(["rows"])).toEqual(false);
+            expect(AggregationClause.isMetric(["sum", 456])).toEqual(false);
+        });
+
+        it("should succeed on good clauses", () => {
+            expect(AggregationClause.isMetric(["METRIC", 123])).toEqual(true);
+        });
+    });
+
+    describe('getMetric', () => {
+        it("should succeed on good clauses", () => {
+            expect(AggregationClause.getMetric(["METRIC", 123])).toEqual(123);
+        });
+
+        it("should be null on non-metric clauses", () => {
+            expect(AggregationClause.getMetric(["sum", 123])).toEqual(null);
+        });
+    });
+
+    describe('getOperator', () => {
+        it("should succeed on good clauses", () => {
+            expect(AggregationClause.getOperator(["rows"])).toEqual("rows");
+            expect(AggregationClause.getOperator(["sum", 123])).toEqual("sum");
+        });
+
+        it("should be null on metric clauses", () => {
+            expect(AggregationClause.getOperator(["METRIC", 123])).toEqual(null);
+        });
+    });
+
+    describe('getField', () => {
+        it("should succeed on good clauses", () => {
+            expect(AggregationClause.getField(["sum", 123])).toEqual(123);
+        });
+
+        it("should be null on clauses w/out a field", () => {
+            expect(AggregationClause.getField(["rows"])).toEqual(null);
+        });
+
+        it("should be null on metric clauses", () => {
+            expect(AggregationClause.getField(["METRIC", 123])).toEqual(null);
+        });
+    });
+
+    describe('setField', () => {
+        it("should succeed on good clauses", () => {
+            expect(AggregationClause.setField(["avg"], 123)).toEqual(["avg", 123]);
+            expect(AggregationClause.setField(["sum", null], 123)).toEqual(["sum", 123]);
+        });
+
+        it("should return unmodified on metric clauses", () => {
+            expect(AggregationClause.setField(["METRIC", 123], 456)).toEqual(["METRIC", 123]);
         });
     });
 });


### PR DESCRIPTION
fixes #1503 

update the AggregationWidget so that the process of picking an aggregation is fully atomic.  this is specifically relevant to cases where a field needs to be chosen in addition to the aggregation operator.

the end result of this update is that it's no longer possible for the query to be modified in such a way that it contains an incomplete, and hence broken, aggregation clause.
