### PR TITLE
Fix intermittent BigQuery test failures :unamused:

### DIFF
--- a/OSX/Metabase/Metabase-Info.plist
+++ b/OSX/Metabase/Metabase-Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.13.0.0</string>
+	<string>0.15.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>0.13.0.0</string>
+	<string>0.15.0.0</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
Through some strange black magic CircleCI occasionally accidentally runs two sets of tests at once. Give BigQuery datasets a randomly-generated prefix unique to the test run to prevent simultaneous tests from stomping over one another.
