### PR TITLE
remove unecessary flex declarations and min-height from modals

### DIFF
--- a/frontend/src/components/modal/modal.css
+++ b/frontend/src/components/modal/modal.css
@@ -43,26 +43,6 @@
     background-color: rgba(255, 255, 255, 0.6);
 }
 
-.Modal-body {
-    min-height: 200px;
-    display: flex;
-    flex-direction: column;
-}
-
-.Modal-content.Modal-content--small .Modal-body {
-    min-height: inherit; /* using inherit here to get around overly restrictive min-height settings */
-}
-
-.Modal-body .Form-inputs {
-    flex: 1;
-}
-
-.Modal-form {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-}
-
 /* TRANSITIONS */
 
 /* backdrop */


### PR DESCRIPTION
fixes #1215 

from http://philipwalton.com/articles/normalizing-cross-browser-flexbox-bugs/

> In IE 10-11, flex items ignore their parent container’s height if it’s set via the min-height property.

I don't know why we were setting a min-height on these modals to begin with or setting the display type to flex in this instance but after removing these declarations IE 10-11 modals seem to be working and everything looks fine. 
