### PR TITLE
Validate metadata combos

### DIFF
--- a/frontend/src/admin/datamodel/components/database/ColumnItem.jsx
+++ b/frontend/src/admin/datamodel/components/database/ColumnItem.jsx
@@ -4,6 +4,7 @@ import Input from "metabase/components/Input.jsx";
 import Select from "metabase/components/Select.jsx";
 
 import * as MetabaseCore from "metabase/lib/core";
+import { isNumeric } from "metabase/lib/schema_metadata";
 
 import _  from "underscore";
 
@@ -106,6 +107,10 @@ export default class Column extends Component {
 
         let specialTypes = MetabaseCore.field_special_types.slice(0);
         specialTypes.push({'id': null, 'name': 'No special type', 'section': 'Other'});
+        // if we don't have a numeric base-type then prevent the options for unix timestamp conversion (#823)
+        if (!isNumeric(this.props.field)) {
+            specialTypes = specialTypes.filter((f) => !(f.id && f.id.startsWith("timestamp_")));
+        }
 
         return (
             <li className="mt1 mb3">

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -53,6 +53,19 @@
     :info        ; Non-numerical value that is not meant to be used
     :sensitive}) ; A Fields that should *never* be shown *anywhere*
 
+(defn valid-metadata?
+  "Predicate function that checks if the set of metadata types for a field are sensible."
+  [base-type field-type special-type]
+  (and (contains? base-types base-type)
+       (contains? field-types field-type)
+       (or (nil? special-type)
+           (contains? special-types special-type))
+       ;; this verifies that we have a numeric base-type when trying to use the unix timestamp transform (#824)
+       (or (nil? special-type)
+           (not (contains? #{:timestamp_milliseconds :timestamp_seconds} special-type))
+           (contains? #{:BigIntegerField :DecimalField :FloatField :IntegerField} base-type))))
+
+
 (i/defentity Field :metabase_field)
 
 (defn- pre-insert [field]

--- a/test/metabase/api/field_test.clj
+++ b/test/metabase/api/field_test.clj
@@ -1,17 +1,18 @@
 (ns metabase.api.field-test
   (:require [expectations :refer :all]
-            [metabase.db :refer :all]
+            [metabase.db :as db]
+            [metabase.models.database :refer [Database]]
             (metabase.models [field :refer [Field]]
                              [field-values :refer [FieldValues]]
                              [table :refer [Table]])
             [metabase.test.data :refer :all]
             [metabase.test.data.users :refer :all]
-            [metabase.test.util :refer [match-$ expect-eval-actual-first]]))
+            [metabase.test.util :as tu]))
 
 ;; Helper Fns
 
 (defn- db-details []
-  (match-$ (db)
+  (tu/match-$ (db)
     {:created_at      $
      :engine          "h2"
      :id              $
@@ -26,10 +27,10 @@
 
 ;; ## GET /api/field/:id
 (expect
-    (match-$ (Field (id :users :name))
+    (tu/match-$ (Field (id :users :name))
       {:description     nil
        :table_id        (id :users)
-       :table           (match-$ (Table (id :users))
+       :table           (tu/match-$ (Table (id :users))
                           {:description     nil
                            :entity_type     nil
                            :visibility_type nil
@@ -68,10 +69,10 @@
 ;; ## PUT /api/field/:id
 ;; Check that we can update a Field
 ;; TODO - this should NOT be modifying a field from our test data, we should create new data to mess with
-(expect-eval-actual-first
-    (match-$ (let [field (Field (id :venues :latitude))]
+(tu/expect-eval-actual-first
+    (tu/match-$ (let [field (Field (id :venues :latitude))]
                ;; this is sketchy. But return the Field back to its unmodified state so it won't affect other unit tests
-               (upd Field (id :venues :latitude) :special_type "latitude")
+               (db/upd Field (id :venues :latitude) :special_type "latitude")
                ;; match against the modified Field
                field)
              {:description     nil
@@ -90,22 +91,43 @@
               :parent_id       nil})
   ((user->client :crowberto) :put 200 (format "field/%d" (id :venues :latitude)) {:special_type :fk}))
 
+(expect
+  ["Invalid Request."
+   nil]
+  (tu/with-temp Database [{database-id :id} {:name      "Field Test"
+                                             :engine    :yeehaw
+                                             :details   {}
+                                             :is_sample false}]
+    (tu/with-temp Table [{table-id :id} {:name   "Field Test"
+                                         :db_id  database-id
+                                         :active true}]
+      (tu/with-temp Field [{field-id :id} {:table_id    table-id
+                                           :name        "Field Test"
+                                           :base_type   :TextField
+                                           :field_type  :info
+                                           :active      true
+                                           :preview_display true
+                                           :position    1}]
+        [((user->client :crowberto) :put 400 (format "field/%d" field-id) {:special_type :timestamp_seconds})
+         (db/sel :one :field [Field :special_type] :id field-id)]))))
+
+
 (defn- field->field-values
   "Fetch the `FieldValues` object that corresponds to a given `Field`."
   [table-kw field-kw]
-  (sel :one FieldValues :field_id (id table-kw field-kw)))
+  (db/sel :one FieldValues :field_id (id table-kw field-kw)))
 
 ;; ## GET /api/field/:id/values
 ;; Should return something useful for a field that has special_type :category
-(expect-eval-actual-first
-    (match-$ (field->field-values :venues :price)
+(tu/expect-eval-actual-first
+    (tu/match-$ (field->field-values :venues :price)
       {:field_id              (id :venues :price)
        :human_readable_values {}
        :values                [1 2 3 4]
        :updated_at            $
        :created_at            $
        :id                    $})
-  (do (upd FieldValues (:id (field->field-values :venues :price)) :human_readable_values nil) ; clear out existing human_readable_values in case they're set
+  (do (db/upd FieldValues (:id (field->field-values :venues :price)) :human_readable_values nil) ; clear out existing human_readable_values in case they're set
       ((user->client :rasta) :get 200 (format "field/%d/values" (id :venues :price)))))
 
 ;; Should return nothing for a field whose special_type is *not* :category
@@ -118,9 +140,9 @@
 ;; ## POST /api/field/:id/value_map_update
 
 ;; Check that we can set values
-(expect-eval-actual-first
+(tu/expect-eval-actual-first
     [{:status "success"}
-     (match-$ (sel :one FieldValues :field_id (id :venues :price))
+     (tu/match-$ (db/sel :one FieldValues :field_id (id :venues :price))
        {:field_id              (id :venues :price)
         :human_readable_values {:1 "$"
                                 :2 "$$"
@@ -137,16 +159,16 @@
    ((user->client :rasta) :get 200 (format "field/%d/values" (id :venues :price)))])
 
 ;; Check that we can unset values
-(expect-eval-actual-first
+(tu/expect-eval-actual-first
     [{:status "success"}
-     (match-$ (sel :one FieldValues :field_id (id :venues :price))
+     (tu/match-$ (db/sel :one FieldValues :field_id (id :venues :price))
        {:field_id              (id :venues :price)
         :human_readable_values {}
         :values                [1 2 3 4]
         :updated_at            $
         :created_at            $
         :id                    $})]
-  [(do (upd FieldValues (:id (field->field-values :venues :price)) :human_readable_values {:1 "$" ; make sure they're set
+  [(do (db/upd FieldValues (:id (field->field-values :venues :price)) :human_readable_values {:1 "$" ; make sure they're set
                                                                                            :2 "$$"
                                                                                            :3 "$$$"
                                                                                            :4 "$$$$"})

--- a/test/metabase/models/field_test.clj
+++ b/test/metabase/models/field_test.clj
@@ -6,6 +6,18 @@
             [metabase.test.data :refer :all]))
 
 
+;; valid-metadata?
+(expect false (valid-metadata? nil nil nil))
+(expect false (valid-metadata? :IntegerField nil nil))
+(expect true (valid-metadata? :IntegerField :metric nil))
+(expect false (valid-metadata? :foo :metric nil))
+(expect false (valid-metadata? :IntegerField :foo nil))
+(expect true (valid-metadata? :IntegerField :metric :timestamp_seconds))
+(expect true (valid-metadata? :IntegerField :metric :timestamp_milliseconds))
+(expect false (valid-metadata? :DateTimeField :metric :timestamp_seconds))
+(expect false (valid-metadata? :DateTimeField :metric :timestamp_milliseconds))
+
+
 ;; field-should-have-field-values?
 
 ;; sensitive fields should always be excluded


### PR DESCRIPTION
resolves #824 
- prevent the UI selection of a timestamp_\* transform if the base-type isn't numeric
- validate the metadata choice at the api on field update as well and return a 400 on bad metadata configs.
