### PR TITLE
Setting to make colorized logging optional

### DIFF
--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -26,7 +26,8 @@
    ;; Other Application Settings
    :mb-password-complexity "normal"
    ;:mb-password-length "8"
-   :max-session-age "20160"})                    ; session length in minutes (14 days)
+   :max-session-age "20160"                     ; session length in minutes (14 days)
+   :mb-colorize-logs "true"})
 
 
 (defn config-str

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -3,7 +3,6 @@
   (:gen-class)
   (:require [clojure.string :as s]
             [clojure.tools.logging :as log]
-            [colorize.core :as color]
             [ring.adapter.jetty :as ring-jetty]
             (ring.middleware [cookies :refer [wrap-cookies]]
                              [gzip :refer [wrap-gzip]]
@@ -101,9 +100,8 @@
                          (or hostname "localhost")
                          (when-not (= 80 port) (str ":" port))
                          "/setup/")]
-    (log/info (color/green "Please use the following url to setup your Metabase installation:\n\n"
-                           setup-url
-                           "\n\n"))))
+    (log/info (u/format-color 'green "Please use the following url to setup your Metabase installation:\n\n%s\n\n"
+                              setup-url))))
 
 (defn destroy
   "General application shutdown function which should be called once at application shuddown."

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -145,7 +145,7 @@
   "Test connection to database with DETAILS and throw an exception if we have any troubles connecting."
   [engine details]
   {:pre [(keyword? engine) (map? details)]}
-  (log/info (color/cyan "Verifying Database Connection ..."))
+  (log/info (u/format-color 'cyan "Verifying Database Connection ..."))
   (assert (binding [*allow-potentailly-unsafe-connections* true]
             (require 'metabase.driver)
             (@(resolve 'metabase.driver/can-connect-with-details?) engine details))

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -4,7 +4,6 @@
             [clojure.string :as s]
             [clojure.tools.logging :as log]
             [clojure.tools.namespace.find :as ns-find]
-            [colorize.core :as color]
             [korma.core :as k]
             [medley.core :as m]
             [metabase.db :refer [ins sel upd]]
@@ -265,7 +264,7 @@
   [^Keyword engine, driver-instance]
   {:pre [(keyword? engine) (map? driver-instance)]}
   (swap! registered-drivers assoc engine driver-instance)
-  (log/debug (format "Registered driver %s 🚚" (color/blue engine))))
+  (log/debug (format "Registered driver %s 🚚" (u/format-color 'blue engine))))
 
 (defn available-drivers
   "Info about available drivers."

--- a/src/metabase/driver/mongo/util.clj
+++ b/src/metabase/driver/mongo/util.clj
@@ -2,10 +2,10 @@
   "`*mongo-connection*`, `with-mongo-connection`, and other functions shared between several Mongo driver namespaces."
   (:require [clojure.string :as s]
             [clojure.tools.logging :as log]
-            [colorize.core :as color]
             (monger [core :as mg]
                     [credentials :as mcred])
-            [metabase.driver :as driver]))
+            (metabase [driver :as driver]
+                      [util :as u])))
 
 (def ^:const ^:private connection-timeout-ms
   "Number of milliseconds to wait when attempting to establish a Mongo connection.
@@ -62,7 +62,7 @@
                            (connect credentials)
                            (connect))
         mongo-connection (mg/get-db conn dbname)]
-    (log/debug (color/cyan "<< OPENED NEW MONGODB CONNECTION >>"))
+    (log/debug (u/format-color 'cyan "<< OPENED NEW MONGODB CONNECTION >>"))
     (try
       (binding [*mongo-connection* mongo-connection]
         (f *mongo-connection*))

--- a/src/metabase/events.clj
+++ b/src/metabase/events.clj
@@ -12,8 +12,8 @@
             [clojure.java.classpath :as classpath]
             [clojure.tools.logging :as log]
             [clojure.tools.namespace.find :as ns-find]
-            [colorize.core :as color]
-            [metabase.config :as config]))
+            (metabase [config :as config]
+                      [util :as u])))
 
 
 ;;; ## ---------------------------------------- LIFECYCLE ----------------------------------------
@@ -31,7 +31,7 @@
       (require ns-symb)
       ;; look for `events-init` function in the namespace and call it if it exists
       (when-let [init-fn (ns-resolve ns-symb 'events-init)]
-        (log/info "Starting events listener:" (color/blue ns-symb) "👂")
+        (log/info "Starting events listener:" (u/format-color 'blue ns-symb) "👂")
         (init-fn)))))
 
 (defn initialize-events!

--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -11,7 +11,7 @@
             [clojure.tools.logging :as log]
             [clojure.tools.namespace.find :as ns-find]
             [clojurewerkz.quartzite.scheduler :as qs]
-            [colorize.core :as color]))
+            [metabase.util :as u]))
 
 
 (defonce ^:private quartz-scheduler
@@ -22,7 +22,7 @@
   []
   (doseq [ns-symb (ns-find/find-namespaces (classpath/classpath))
           :when   (re-find #"^metabase\.task\." (name ns-symb))]
-    (log/info "Loading tasks namespace:" (color/blue ns-symb) "📆")
+    (log/info "Loading tasks namespace:" (u/format-color 'blue ns-symb) "📆")
     (require ns-symb)
     ;; look for `task-init` function in the namespace and call it if it exists
     (when-let [init-fn (ns-resolve ns-symb 'task-init)]

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -420,23 +420,23 @@
      ~@body
      ~'<>))
 
-(defn ^String format-color
+(def ^String ^{:style/indent 2} format-color
   "Like `format`, but uses a function in `colorize.core` to colorize the output.
    COLOR-SYMB should be a quoted symbol like `green`, `red`, `yellow`, `blue`,
    `cyan`, `magenta`, etc. See the entire list of avaliable colors
    [here](https://github.com/ibdknox/colorize/blob/master/src/colorize/core.clj).
 
      (format-color 'red \"Fatal error: %s\" error-message)"
-  {:style/indent 2}
-  ([color-symb x]
-   {:pre [(symbol? color-symb)]}
-   (if (config/config-bool :mb-colorize-logs)
-     ((ns-resolve 'colorize.core color-symb) x)
-     x))
-  ([color-symb format-string & args]
-   (if (config/config-bool :mb-colorize-logs)
-     (format-color color-symb (apply format format-string args))
-     (apply format format-string args))))
+  (if (config/config-bool :mb-colorize-logs)
+    (fn
+      ([color-symb x]
+       {:pre [(symbol? color-symb)]}
+       ((ns-resolve 'colorize.core color-symb) x))
+      ([color-symb format-string & args]
+       (format-color color-symb (apply format format-string args))))
+    (fn
+      ([_ x] x)
+      ([_ format-string & args] (apply format format-string args)))))
 
 (defn pprint-to-str
   "Returns the output of pretty-printing X as a string.


### PR DESCRIPTION
As I brought up in #1982. Color codes logs can be problematic for log aggregators with web views. This PR introduces a new configuration setting `MB_COLORIZE_LOGS`, which when set to false does not colorize any logs. It defaults to `true` so this should have zero impact as things are now unless the environment variable is set to `false`.

I have little clojure experience, but some Java and Emacs Lisp so please let me know how I can improve anything. Thanks!
