### PR TITLE
add a very short delay to throttle test to try and avoid intermittent failures

### DIFF
--- a/test/metabase/api/common/throttle_test.clj
+++ b/test/metabase/api/common/throttle_test.clj
@@ -47,6 +47,7 @@
   ([n k]
    (let [attempt-once (fn []
                       (try
+                        (Thread/sleep 1)
                         (throttle/check test-throttler k)
                         :success
                         (catch Throwable e


### PR DESCRIPTION
resolves #1352 
