### PR TITLE
show the table schema (if appropriate) on the FK target field selector.

### DIFF
--- a/frontend/src/admin/datamodel/components/database/ColumnItem.jsx
+++ b/frontend/src/admin/datamodel/components/database/ColumnItem.jsx
@@ -4,6 +4,7 @@ import Input from "metabase/components/Input.jsx";
 import Select from "metabase/components/Select.jsx";
 
 import * as MetabaseCore from "metabase/lib/core";
+import { titleize, humanize } from "metabase/lib/formatting";
 import { isNumeric } from "metabase/lib/schema_metadata";
 
 import _  from "underscore";
@@ -99,7 +100,7 @@ export default class Column extends Component {
                     placeholder="Select a target"
                     value={this.props.field.target && _.find(this.props.idfields, (field) => field.id === this.props.field.target.id)}
                     options={this.props.idfields}
-                    optionNameFn={(field) => field.displayName}
+                    optionNameFn={(field) => field.table.schema && field.table.schema !== "public" ? titleize(humanize(field.table.schema))+"."+field.displayName : field.displayName}
                     onChange={this.onTargetChange}
                 />
             );


### PR DESCRIPTION
In order to provide some relief for users suffering from #1963 this provides the schema name in addition to the table -> field in the FK target selector on the data model page.

<img width="178" alt="screen shot 2016-02-24 at 5 48 50 pm" src="https://cloud.githubusercontent.com/assets/1987787/13307273/f69c87cc-db1e-11e5-88cd-73ab3a0545f0.png">
