### PR TITLE
fix issue with saving modal calling method on null value

### DIFF
--- a/frontend/src/components/SaveQuestionModal.jsx
+++ b/frontend/src/components/SaveQuestionModal.jsx
@@ -81,7 +81,7 @@ export default class SaveQuestionModal extends Component {
 
         card.name = details.name.trim();
         // since description is optional, it can be null, so check for a description before trimming it
-        details.description ? card.description = details.description.trim() : details.description;
+        card.details = details.description ? details.description.trim() : null;
         card.public_perms = 2; // public read/write
 
         if (details.saveType === "create") {

--- a/frontend/src/components/SaveQuestionModal.jsx
+++ b/frontend/src/components/SaveQuestionModal.jsx
@@ -80,7 +80,8 @@ export default class SaveQuestionModal extends Component {
         let card = this.props.card;
 
         card.name = details.name.trim();
-        card.description = details.description.trim();
+        // since description is optional, it can be null, so check for a description before trimming it
+        details.description ? card.description = details.description.trim() : details.description;
         card.public_perms = 2; // public read/write
 
         if (details.saveType === "create") {


### PR DESCRIPTION
@agilliland let me know if this looks ok. Because description is optional when saving a question the trim method was failing in cases where it was missing and causing saves to fail.

Did a check and both new saves and existing / replacing seem to be working fine again.
