### PR TITLE
Fix slack pulses :scream_cat:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ bin/release/aws-eb/metabase-aws-eb.zip
 *.sqlite
 /reset-password-artifacts
 /.env
+/npm-debug.log

--- a/src/metabase/integrations/slack.clj
+++ b/src/metabase/integrations/slack.clj
@@ -108,10 +108,10 @@
   [file filename channels]
   {:pre [(string? filename)
          (string? channels)]}
-  (let [response (http/post (str slack-api-baseurl "/files.upload") {:multipart [["token" (slack-token)]
-                                                                                 ["file" file]
-                                                                                 ["filename" filename]
-                                                                                 ["channels" channels]]
+  (let [response (http/post (str slack-api-baseurl "/files.upload") {:multipart [{:name "token",    :content (slack-token)}
+                                                                                 {:name "file",     :content file}
+                                                                                 {:name "filename", :content filename}
+                                                                                 {:name "channels", :content channels}]
                                                                      :as :json})]
     (if (= 200 (:status response))
       (get-in (:body response) [:file :url_private])


### PR DESCRIPTION
The `http/post` syntax for multipart uploads changed when I updated the `clj-http` dependency from ancient version `0.3.0` to `2.1.0`. Fix this!

On another note: we should really have unit tests for pulses!
