### PR TITLE
Fix Slack Pulse unicode handling :robot: :earth_americas: 

### DIFF
--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -170,7 +170,7 @@
 (defn- render-to-png
   [^String html, ^ByteArrayOutputStream os, width]
   (let [is            (ByteArrayInputStream. (.getBytes html StandardCharsets/UTF_8))
-        doc-source    (StreamDocumentSource. is nil "text/html")
+        doc-source    (StreamDocumentSource. is nil "text/html; charset=utf-8")
         parser        (DefaultDOMSource. doc-source)
         doc           (.parse parser)
         window-size   (Dimension. width 1)


### PR DESCRIPTION
Before & After

![screen shot 2016-02-25 at 4 55 14 pm](https://cloud.githubusercontent.com/assets/1455846/13339856/9ace72f8-dbe0-11e5-9906-3db400b7ed48.png)

Resolves #2027
