### PR TITLE
increase ttl to 6 hours on pool and revert min pool size to 1

### DIFF
--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -97,12 +97,12 @@
   (memoize/ttl
    (fn [spec]
      (log/debug (u/format-color 'magenta "Creating new connection pool..."))
-     (kdb/connection-pool (assoc spec :minimum-pool-size           3
+     (kdb/connection-pool (assoc spec :minimum-pool-size           1
                                       ;; prevent broken connections closed by dbs by testing them every 3 mins
                                       :idle-connection-test-period (* 3 60)
                                       ;; prevent overly large pools by condensing them when connections are idle for 15m+
                                       :excess-timeout              (* 15 60))))
-   :ttl/threshold (* 60 60 1000)))
+   :ttl/threshold (* 6 60 60 1000)))
 
 (defn db->jdbc-connection-spec
   "Return a JDBC connection spec for DATABASE. Normally this will have a C3P0 pool as its datasource, unless the database is `short-lived`."


### PR DESCRIPTION
having observed the new settings in production for a while now it's clear they are actually just making things worse regarding the piling up of stale db connections.  so this moves the min pool size back to 1 and bumps the old ttl of the pool from 3 hours to 6 hours.
