### PR TITLE
Prevent Java icon from popping up in dock when running OS X app :coffee:

### DIFF
--- a/OSX/Metabase/Backend/MetabaseTask.m
+++ b/OSX/Metabase/Backend/MetabaseTask.m
@@ -94,7 +94,8 @@
 		self.task.launchPath		= JREPath();
 		self.task.environment		= @{@"MB_DB_FILE": DBPath(),
 										@"MB_JETTY_PORT": @(self.port)};
-		self.task.arguments			= @[@"-jar", UberjarPath()];
+		self.task.arguments			= @[@"-Djava.awt.headless=true",
+										@"-jar", UberjarPath()];
 				
 		__weak MetabaseTask *weakSelf = self;
 		self.task.terminationHandler = ^(NSTask *task){

--- a/project.clj
+++ b/project.clj
@@ -70,6 +70,7 @@
   :main ^:skip-aot metabase.core
   :manifest {"Liquibase-Package" "liquibase.change,liquibase.changelog,liquibase.database,liquibase.parser,liquibase.precondition,liquibase.datatype,liquibase.serializer,liquibase.sqlgenerator,liquibase.executor,liquibase.snapshot,liquibase.logging,liquibase.diff,liquibase.structure,liquibase.structurecompare,liquibase.lockservice,liquibase.sdk,liquibase.ext"}
   :target-path "target/%s"
+  :jvm-opts ["-Djava.awt.headless=true"]                              ; prevent Java icon from randomly popping up in dock when running `lein ring server`
   :javac-options ["-target" "1.7", "-source" "1.7"]
   :uberjar-name "metabase.jar"
   :ring {:handler metabase.core/app


### PR DESCRIPTION
Fix minor annoyance where opening the Mac App would cause a Java icon to show up in the dock as well
