### PR TITLE
New dashboard grid size [WIP]

### DIFF
--- a/frontend/src/dashboard/actions.js
+++ b/frontend/src/dashboard/actions.js
@@ -51,6 +51,10 @@ const MetabaseApi = new AngularResourceProxy("Metabase", ["dataset", "db_metadat
 const CardApi = new AngularResourceProxy("Card", ["list", "delete"]);
 const RevisionApi = new AngularResourceProxy("Revision", ["list", "revert"]);
 
+// FIXME: REMOVE SCALING ONCE WE ADD A DB MIGRATION TO SCALE DASHCARD SIZES
+const FIXME_DASHCARD_X_SCALE = 2;
+const FIXME_DASHCARD_Y_SCALE = 2;
+
 // action creators
 
 export const setEditingDashboard = createAction(SET_EDITING_DASHBOARD);
@@ -105,6 +109,17 @@ export const fetchCardData = createThunkAction(FETCH_CARD_DATA, function(card) {
 export const fetchDashboard = createThunkAction(FETCH_DASHBOARD, function(id) {
     return async function(dispatch, getState) {
         let result = await DashboardApi.get({ dashId: id });
+        // FIXME: REMOVE SCALING ONCE WE ADD A DB MIGRATION TO SCALE DASHCARD SIZES
+        result = {
+            ...result,
+            ordered_cards: result.ordered_cards.map((dc) => ({
+                ...dc,
+                row: dc.row * FIXME_DASHCARD_Y_SCALE,
+                col: dc.col * FIXME_DASHCARD_X_SCALE,
+                sizeX: dc.sizeX * FIXME_DASHCARD_X_SCALE,
+                sizeY: dc.sizeY * FIXME_DASHCARD_Y_SCALE
+            }))
+        };
         return normalize(result, dashboard);
     };
 });
@@ -143,7 +158,15 @@ export const saveDashboard = createThunkAction(SAVE_DASHBOARD, function(dashId) 
 
         // reposition the cards
         if (_.some(updatedDashcards, (dc) => dc.isDirty || dc.isAdded)) {
-            let cards = updatedDashcards.map(({ id, row, col, sizeX, sizeY, series }) => ({ id, row, col, sizeX, sizeY, series }));
+            let cards = updatedDashcards.map(({ id, row, col, sizeX, sizeY, series }) => ({
+                id,
+                // FIXME: REMOVE SCALING ONCE WE ADD A DB MIGRATION TO SCALE DASHCARD SIZES
+                row: Math.floor(row / FIXME_DASHCARD_Y_SCALE),
+                col: Math.floor(col / FIXME_DASHCARD_X_SCALE),
+                sizeX: Math.floor(sizeX / FIXME_DASHCARD_X_SCALE),
+                sizeY: Math.floor(sizeY / FIXME_DASHCARD_Y_SCALE),
+                series
+            }));
             var result = await DashboardApi.reposition_cards({ dashId, cards });
             if (result.status !== "ok") {
                 throw new Error(result.status);

--- a/frontend/src/dashboard/components/Dashboard.jsx
+++ b/frontend/src/dashboard/components/Dashboard.jsx
@@ -46,6 +46,7 @@ export default class Dashboard extends Component {
                 this.props.addCardToDashboard({ dashId: this.props.selectedDashboard, cardId: this.props.addCardOnLoad });
             }
         } catch (error) {
+            console.error(error)
             if (error.status === 404) {
                 this.props.onChangeLocation("/404");
             } else {

--- a/frontend/src/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/dashboard/components/DashboardGrid.jsx
@@ -201,7 +201,7 @@ export default class DashboardGrid extends Component {
                 onLayoutChange={(...args) => this.onLayoutChange(...args)}
                 onDrag={(...args) => this.onDrag(...args)}
                 onDragStop={(...args) => this.onDragStop(...args)}
-                showGrid={isEditing}
+                isEditing={isEditing}
             >
                 {dashboard.ordered_cards.map(dc =>
                     <div key={dc.id} className="DashCard" onMouseDownCapture={this.onDashCardMouseDown}>

--- a/frontend/src/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/dashboard/components/DashboardGrid.jsx
@@ -13,15 +13,9 @@ import AddSeriesModal from "./AddSeriesModal.jsx";
 import _ from "underscore";
 import cx from "classnames";
 
-// const GRID_WIDTH = 12;
-// const GRID_ASPECT_RATIO = 4 / 3;
-// const GRID_MARGIN = 6;
-
-const GRID_WIDTH = 6;
-const GRID_ASPECT_RATIO = 1;
-const GRID_MARGIN = 10;
-
-
+const GRID_WIDTH = 12;
+const GRID_ASPECT_RATIO = 4 / 3;
+const GRID_MARGIN = 6;
 
 export default class DashboardGrid extends Component {
     constructor(props, context) {

--- a/frontend/src/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/dashboard/components/DashboardGrid.jsx
@@ -21,6 +21,14 @@ const GRID_WIDTH = 6;
 const GRID_ASPECT_RATIO = 1;
 const GRID_MARGIN = 10;
 
+function compareDashcardPosition(a, b) {
+    if (a.row < b.row) { return -1; }
+    if (a.row > b.row) { return  1; }
+    if (a.col < b.col) { return -1; }
+    if (a.col > b.col) { return  1; }
+    return 0;
+}
+
 export default class DashboardGrid extends Component {
     constructor(props, context) {
         super(props, context);
@@ -51,6 +59,7 @@ export default class DashboardGrid extends Component {
 
     componentWillReceiveProps(nextProps) {
         this.setState({
+            dashcards: nextProps.dashboard.ordered_cards.sort(compareDashcardPosition),
             layout: this.getLayout(nextProps)
         });
     }
@@ -172,14 +181,14 @@ export default class DashboardGrid extends Component {
     }
 
     renderMobile() {
-        const { dashboard, isEditing } = this.props;
-        const { width } = this.state;
+        const { isEditing } = this.props;
+        const { width, dashcards } = this.state;
         return (
             <div
                 className={cx("DashboardGrid", { "Dash--editing": isEditing, "Dash--dragging": this.state.isDragging })}
                 style={{ margin: 0 }}
             >
-                {dashboard.ordered_cards.map(dc =>
+                {dashcards.map(dc =>
                     <div key={dc.id} className="DashCard" style={{ left: 10, width: width - 20, marginTop: 10, marginBottom: 10, height: width / (6 / 4)}}>
                         <DashCard
                             dashcard={dc}
@@ -197,8 +206,8 @@ export default class DashboardGrid extends Component {
     }
 
     renderGrid() {
-        const { dashboard, isEditing } = this.props;
-        const { width } = this.state;
+        const { isEditing } = this.props;
+        const { width, dashcards } = this.state;
         const rowHeight = Math.floor(width / GRID_WIDTH / GRID_ASPECT_RATIO);
         return (
             <GridLayout
@@ -212,7 +221,7 @@ export default class DashboardGrid extends Component {
                 onDragStop={(...args) => this.onDragStop(...args)}
                 isEditing={isEditing}
             >
-                {dashboard.ordered_cards.map(dc =>
+                {dashcards.map(dc =>
                     <div key={dc.id} className="DashCard" onMouseDownCapture={this.onDashCardMouseDown}>
                         <DashCard
                             dashcard={dc}

--- a/frontend/src/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/dashboard/components/DashboardGrid.jsx
@@ -201,6 +201,7 @@ export default class DashboardGrid extends Component {
                 onLayoutChange={(...args) => this.onLayoutChange(...args)}
                 onDrag={(...args) => this.onDrag(...args)}
                 onDragStop={(...args) => this.onDragStop(...args)}
+                showGrid={isEditing}
             >
                 {dashboard.ordered_cards.map(dc =>
                     <div key={dc.id} className="DashCard" onMouseDownCapture={this.onDashCardMouseDown}>

--- a/frontend/src/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/dashboard/components/DashboardGrid.jsx
@@ -13,6 +13,14 @@ import AddSeriesModal from "./AddSeriesModal.jsx";
 import _ from "underscore";
 import cx from "classnames";
 
+// const GRID_WIDTH = 12;
+// const GRID_ASPECT_RATIO = 4 / 3;
+// const GRID_MARGIN = 6;
+
+const GRID_WIDTH = 6;
+const GRID_ASPECT_RATIO = 1;
+const GRID_MARGIN = 10;
+
 export default class DashboardGrid extends Component {
     constructor(props, context) {
         super(props, context);
@@ -191,12 +199,13 @@ export default class DashboardGrid extends Component {
     renderGrid() {
         const { dashboard, isEditing } = this.props;
         const { width } = this.state;
-        const rowHeight = Math.floor(width / 6);
+        const rowHeight = Math.floor(width / GRID_WIDTH / GRID_ASPECT_RATIO);
         return (
             <GridLayout
                 className={cx("DashboardGrid", { "Dash--editing": isEditing, "Dash--dragging": this.state.isDragging })}
                 layout={this.state.layout}
-                cols={6}
+                cols={GRID_WIDTH}
+                margin={GRID_MARGIN}
                 rowHeight={rowHeight}
                 onLayoutChange={(...args) => this.onLayoutChange(...args)}
                 onDrag={(...args) => this.onDrag(...args)}

--- a/frontend/src/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/dashboard/components/DashboardGrid.jsx
@@ -21,13 +21,7 @@ const GRID_WIDTH = 6;
 const GRID_ASPECT_RATIO = 1;
 const GRID_MARGIN = 10;
 
-function compareDashcardPosition(a, b) {
-    if (a.row < b.row) { return -1; }
-    if (a.row > b.row) { return  1; }
-    if (a.col < b.col) { return -1; }
-    if (a.col > b.col) { return  1; }
-    return 0;
-}
+
 
 export default class DashboardGrid extends Component {
     constructor(props, context) {
@@ -35,6 +29,7 @@ export default class DashboardGrid extends Component {
 
         this.state = {
             layout: this.getLayout(props),
+            dashcards: this.getSortedDashcards(props),
             removeModalDashCard: null,
             addSeriesModalDashCard: null,
             width: 0,
@@ -59,7 +54,7 @@ export default class DashboardGrid extends Component {
 
     componentWillReceiveProps(nextProps) {
         this.setState({
-            dashcards: nextProps.dashboard.ordered_cards.sort(compareDashcardPosition),
+            dashcards: this.getSortedDashcards(nextProps),
             layout: this.getLayout(nextProps)
         });
     }
@@ -80,6 +75,16 @@ export default class DashboardGrid extends Component {
         if (changes && changes.length > 0) {
             MetabaseAnalytics.trackEvent("Dashboard", "Layout Changed");
         }
+    }
+
+    getSortedDashcards(props) {
+        return props.dashboard && props.dashboard.ordered_cards.sort((a, b) => {
+            if (a.row < b.row) { return -1; }
+            if (a.row > b.row) { return  1; }
+            if (a.col < b.col) { return -1; }
+            if (a.col > b.col) { return  1; }
+            return 0;
+        });
     }
 
     getLayoutForDashCard(dc) {
@@ -188,7 +193,7 @@ export default class DashboardGrid extends Component {
                 className={cx("DashboardGrid", { "Dash--editing": isEditing, "Dash--dragging": this.state.isDragging })}
                 style={{ margin: 0 }}
             >
-                {dashcards.map(dc =>
+                {dashcards && dashcards.map(dc =>
                     <div key={dc.id} className="DashCard" style={{ left: 10, width: width - 20, marginTop: 10, marginBottom: 10, height: width / (6 / 4)}}>
                         <DashCard
                             dashcard={dc}
@@ -221,7 +226,7 @@ export default class DashboardGrid extends Component {
                 onDragStop={(...args) => this.onDragStop(...args)}
                 isEditing={isEditing}
             >
-                {dashcards.map(dc =>
+                {dashcards && dashcards.map(dc =>
                     <div key={dc.id} className="DashCard" onMouseDownCapture={this.onDashCardMouseDown}>
                         <DashCard
                             dashcard={dc}

--- a/frontend/src/dashboard/components/grid/GridLayout.jsx
+++ b/frontend/src/dashboard/components/grid/GridLayout.jsx
@@ -219,17 +219,21 @@ export default class GridLayout extends Component {
     }
 
     render() {
-        const { className, layout, cols, rowHeight, showGrid } = this.props;
+        const { className, layout, cols, isEditing } = this.props;
 
         let cellSize = this.getCellSize();
         let bottom = Math.max(...layout.map(l => l.y + l.h));
 
-        let width = cellSize.width * cols;
-        let height = (bottom + 3) * rowHeight;
         let backgroundImage;
-        if (showGrid) {
+        if (isEditing) {
+            // render grid as a background image:
             backgroundImage  = this.getGridBackground();
+            // add some rows to provide place to drag to:
+            bottom += 8;
         }
+
+        let width = cellSize.width * cols;
+        let height = cellSize.height * bottom;
 
         return (
             <div className={className} style={{ position: "relative", width, height, backgroundImage }}>

--- a/frontend/src/dashboard/components/grid/GridLayout.jsx
+++ b/frontend/src/dashboard/components/grid/GridLayout.jsx
@@ -173,12 +173,11 @@ export default class GridLayout extends Component {
 
     getStyleForLayout(l) {
         let cellSize = this.getCellSize();
-        let margin = l.i === "placeholder" ? -MARGIN : MARGIN;
         return {
-            width: cellSize.width * l.w - margin,
-            height: cellSize.height * l.h - margin,
-            left: cellSize.width * l.x + margin / 2,
-            top: cellSize.height * l.y + margin / 2
+            width: cellSize.width * l.w - MARGIN,
+            height: cellSize.height * l.h - MARGIN,
+            left: cellSize.width * l.x + MARGIN / 2,
+            top: cellSize.height * l.y + MARGIN / 2
         };
     }
 
@@ -214,14 +213,26 @@ export default class GridLayout extends Component {
         }
     }
 
-    render() {
-        const { className, layout, rowHeight } = this.props;
+    getGridBackground() {
+        let cellSize = this.getCellSize();
+        return `url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='${cellSize.width}' height='${cellSize.height}'><rect stroke='rgba(0, 0, 0, 0.117647)' stroke-width='1' fill='none' x='${MARGIN / 2 + 1.5}' y='${MARGIN / 2 + 1.5}' width='${cellSize.width - MARGIN - 3}' height='${cellSize.height - MARGIN - 3}'/></svg>")`;
+    }
 
+    render() {
+        const { className, layout, cols, rowHeight, showGrid } = this.props;
+
+        let cellSize = this.getCellSize();
         let bottom = Math.max(...layout.map(l => l.y + l.h));
-        let totalHeight = (bottom + 3) * rowHeight;
+
+        let width = cellSize.width * cols;
+        let height = (bottom + 3) * rowHeight;
+        let backgroundImage;
+        if (showGrid) {
+            backgroundImage  = this.getGridBackground();
+        }
 
         return (
-            <div className={className} style={{ position: "relative", height: totalHeight }}>
+            <div className={className} style={{ position: "relative", width, height, backgroundImage }}>
                 {this.props.children.map(child =>
                     this.renderChild(child)
                 )}

--- a/frontend/src/dashboard/components/grid/GridLayout.jsx
+++ b/frontend/src/dashboard/components/grid/GridLayout.jsx
@@ -5,8 +5,6 @@ import GridItem from "./GridItem.jsx";
 
 import _ from "underscore";
 
-const MARGIN = 10;
-
 export default class GridLayout extends Component {
     constructor(props, context) {
         super(props, context);
@@ -158,26 +156,28 @@ export default class GridLayout extends Component {
 
     getCellSize() {
         return {
-            width: this.state.width / this.props.cols,
+            width: Math.floor(this.state.width / this.props.cols),
             height: this.props.rowHeight
         };
     }
 
     getMinSize() {
+        let { margin } = this.props;
         let cellSize = this.getCellSize();
         return {
-            width: cellSize.width - MARGIN,
-            height: cellSize.height - MARGIN
+            width: cellSize.width - margin,
+            height: cellSize.height - margin
         }
     }
 
     getStyleForLayout(l) {
+        let { margin } = this.props;
         let cellSize = this.getCellSize();
         return {
-            width: cellSize.width * l.w - MARGIN,
-            height: cellSize.height * l.h - MARGIN,
-            left: cellSize.width * l.x + MARGIN / 2,
-            top: cellSize.height * l.y + MARGIN / 2
+            width: cellSize.width * l.w - margin,
+            height: cellSize.height * l.h - margin,
+            left: cellSize.width * l.x + margin / 2,
+            top: cellSize.height * l.y + margin / 2
         };
     }
 
@@ -214,8 +214,9 @@ export default class GridLayout extends Component {
     }
 
     getGridBackground() {
+        let { margin } = this.props;
         let cellSize = this.getCellSize();
-        return `url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='${cellSize.width}' height='${cellSize.height}'><rect stroke='rgba(0, 0, 0, 0.117647)' stroke-width='1' fill='none' x='${MARGIN / 2 + 1.5}' y='${MARGIN / 2 + 1.5}' width='${cellSize.width - MARGIN - 3}' height='${cellSize.height - MARGIN - 3}'/></svg>")`;
+        return `url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='${cellSize.width}' height='${cellSize.height}'><rect stroke='rgba(0, 0, 0, 0.117647)' stroke-width='1' fill='none' x='${margin / 2 + 1.5}' y='${margin / 2 + 1.5}' width='${cellSize.width - margin - 3}' height='${cellSize.height - margin - 3}'/></svg>")`;
     }
 
     render() {


### PR DESCRIPTION
- [x] Show grid when editing
- [x] Change grid width from 6 to 12 cells wide
- [x] Change grid aspect ratio from 1:1 to 4:3
- [ ] Migrate/version legacy dashcards (need to multiply `col` and `sizeX` by 2, `row` and `sizeY` by 2 to maintain approximate existing size and aspect ratio)
- [x] Don't expand grid rows beyond bottom card unless editing (resolves #2055)
- [x] Display dashcards in same order in 1D mobile layout as 2D grid layout (resolves #1024)
