### PR TITLE
Linty fixes :ghost:

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -49,6 +49,7 @@
                               (qp-expect-with-engines 1)
                               (query-with-temp-db 1)
                               (resolve-private-fns 1)
+                              (select 1)
                               (symbol-macrolet 1)
                               (sync-in-context 2)
                               (upd 2)

--- a/project.clj
+++ b/project.clj
@@ -80,10 +80,14 @@
          :destroy metabase.core/destroy}
   :eastwood {:exclude-namespaces [:test-paths
                                   metabase.driver.generic-sql]        ; ISQLDriver causes Eastwood to fail. Skip this ns until issue is fixed: https://github.com/jonase/eastwood/issues/191
-             :add-linters [:unused-private-vars]
-             :exclude-linters [:constant-test                         ; korma macros generate some forms with if statements that are always logically true or false
-                               :suspicious-expression                 ; core.match macros generate some forms like (and expr) which is "suspicious"
-                               :unused-ret-vals]}                     ; gives too many false positives for functions with side-effects like conj!
+             :add-linters [:unused-private-vars
+                           ;; These linters are pretty useful but give a few false positives and can't be selectively disabled. See https://github.com/jonase/eastwood/issues/192
+                           ;; and https://github.com/jonase/eastwood/issues/193
+                           ;; It's still useful to re-enable them and run them every once in a while because they catch a lot of actual errors too. Keep an eye on the issues above
+                           ;; and re-enable them if they ever get resolved
+                           #_:unused-locals
+                           #_:unused-namespaces]
+             :exclude-linters [:constant-test]}                       ; gives us false positives with forms like (when config/is-test? ...)
   :docstring-checker {:include [#"^metabase"]
                       :exclude [#"test"
                                 #"^metabase\.sample-data$"

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -121,7 +121,7 @@
 (defendpoint DELETE "/:card-id/favorite"
   "Unfavorite a Card."
   [card-id]
-  (let-404 [{:keys [id] :as card-favorite} (sel :one CardFavorite :card_id card-id :owner_id *current-user-id*)]
+  (let-404 [id (sel :one :id CardFavorite :card_id card-id, :owner_id *current-user-id*)]
     (del CardFavorite :id id)))
 
 (define-routes)

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -177,14 +177,14 @@
 
 ;; #### GENERIC 400 RESPONSE HELPERS
 (def ^:private ^:const generic-400 [400 "Invalid Request."])
-(defn     check-400 "Throw a 400 if TEST is false."                                                         [tst]    (check tst generic-400))
+(defn     check-400 "Throw a `400` if ARG is `false` or `nil`, otherwise return as-is."                     [arg]    (check arg generic-400))
 (defmacro let-400   "Bind a form as with `let`; throw a 400 if it is `nil` or `false`."                     [& body] `(api-let   ~generic-400 ~@body))
 (defmacro ->400     "If form is `nil` or `false`, throw a 400; otherwise thread it through BODY via `->`."  [& body] `(api->     ~generic-400 ~@body))
 (defmacro ->>400    "If form is `nil` or `false`, throw a 400; otherwise thread it through BODY via `->>`." [& body] `(api->>    ~generic-400 ~@body))
 
 ;; #### GENERIC 404 RESPONSE HELPERS
 (def ^:private ^:const generic-404 [404 "Not found."])
-(defn     check-404 "Throw a 404 if TEST is false."                                                         [tst]    (check tst generic-404))
+(defn     check-404 "Throw a `404` if ARG is `false` or `nil`, otherwise return as-is."                     [arg]    (check arg generic-404))
 (defmacro let-404   "Bind a form as with `let`; throw a 404 if it is `nil` or `false`."                     [& body] `(api-let   ~generic-404 ~@body))
 (defmacro ->404     "If form is `nil` or `false`, throw a 404; otherwise thread it through BODY via `->`."  [& body] `(api->     ~generic-404 ~@body))
 (defmacro ->>404    "If form is `nil` or `false`, throw a 404; otherwise thread it through BODY via `->>`." [& body] `(api->>    ~generic-404 ~@body))
@@ -192,7 +192,7 @@
 ;; #### GENERIC 403 RESPONSE HELPERS
 ;; If you can't be bothered to write a custom error message
 (def ^:private ^:const generic-403 [403 "You don't have permissions to do that."])
-(defn     check-403 "Throw a 403 if TEST is false."                                                         [tst]     (check tst generic-403))
+(defn     check-403 "Throw a `403` if ARG is `false` or `nil`, otherwise return as-is."                     [arg]     (check arg generic-403))
 (defmacro let-403   "Bind a form as with `let`; throw a 403 if it is `nil` or `false`."                     [& body] `(api-let   ~generic-403 ~@body))
 (defmacro ->403     "If form is `nil` or `false`, throw a 403; otherwise thread it through BODY via `->`."  [& body] `(api->     ~generic-403 ~@body))
 (defmacro ->>403    "If form is `nil` or `false`, throw a 403; otherwise thread it through BODY via `->>`." [& body] `(api->>    ~generic-403 ~@body))
@@ -200,7 +200,7 @@
 ;; #### GENERIC 500 RESPONSE HELPERS
 ;; For when you don't feel like writing something useful
 (def ^:private ^:const generic-500 [500 "Internal server error."])
-(defn     check-500 "Throw a 500 if TEST is false."                                                         [tst]    (check tst generic-500))
+(defn     check-500 "Throw a `500` if ARG is `false` or `nil`, otherwise return as-is."                     [arg]    (check arg generic-500))
 (defmacro let-500   "Bind a form as with `let`; throw a 500 if it is `nil` or `false`."                     [& body] `(api-let   ~generic-500 ~@body))
 (defmacro ->500     "If form is `nil` or `false`, throw a 500; otherwise thread it through BODY via `->`."  [& body] `(api->     ~generic-500 ~@body))
 (defmacro ->>500    "If form is `nil` or `false`, throw a 500; otherwise thread it through BODY via `->>`." [& body] `(api->>    ~generic-500 ~@body))

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -62,7 +62,7 @@
 
 (defendpoint POST "/"
   "Add a new `Database`."
-  [:as {{:keys [name engine details is_full_sync] :as body} :body}]
+  [:as {{:keys [name engine details is_full_sync]} :body}]
   {name         [Required NonEmptyString]
    engine       [Required DBEngine]
    details      [Required Dict]}

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -3,12 +3,11 @@
   (:require [clojure.data.csv :as csv]
             [compojure.core :refer [GET POST]]
             [metabase.api.common :refer :all]
-            [metabase.db :as db]
-            [metabase.driver :as driver]
-            [metabase.driver.query-processor :refer [structured-query?]]
-            [metabase.models.card :refer [Card]]
-            [metabase.models.database :refer [Database]]
-            [metabase.models.hydrate :refer [hydrate]]
+            (metabase [db :as db]
+                      [driver :as driver])
+            (metabase.models [card :refer [Card]]
+                             [database :refer [Database]]
+                             [hydrate :refer [hydrate]])
             [metabase.util :as u]))
 
 (def ^:const api-max-results-bare-rows

--- a/src/metabase/api/field.clj
+++ b/src/metabase/api/field.clj
@@ -7,8 +7,7 @@
             (metabase.models [hydrate :refer [hydrate]]
                              [field :refer [Field] :as field]
                              [field-values :refer [FieldValues create-field-values-if-needed field-should-have-field-values?]]
-                             [foreign-key :refer [ForeignKey] :as fk])
-            [metabase.util :as u]))
+                             [foreign-key :refer [ForeignKey] :as fk])))
 
 (defannotation FieldSpecialType
   "Param must be a valid `Field` special type."
@@ -96,7 +95,7 @@
 (defendpoint POST "/:id/value_map_update"
   "Update the human-readable values for a `Field` whose special type is `category`/`city`/`state`/`country`
    or whose base type is `BooleanField`."
-  [id :as {{:keys [fieldId values_map]} :body}] ; WTF is the reasoning behind client passing fieldId in POST params?
+  [id :as {{:keys [values_map]} :body}]
   {values_map [Required Dict]}
   (let-404 [field (Field id)]
     (write-check field)

--- a/src/metabase/api/foreignkey.clj
+++ b/src/metabase/api/foreignkey.clj
@@ -3,8 +3,7 @@
   (:require [compojure.core :refer [DELETE]]
             [metabase.api.common :refer :all]
             [metabase.db :as db]
-            (metabase.models [foreign-key :refer [ForeignKey]])
-            [metabase.driver :as driver]))
+            (metabase.models [foreign-key :refer [ForeignKey]])))
 
 (defendpoint DELETE "/:id"
   "Delete a `ForeignKey`."

--- a/src/metabase/api/metric.clj
+++ b/src/metabase/api/metric.clj
@@ -10,25 +10,25 @@
 
 (defendpoint POST "/"
   "Create a new `Metric`."
-  [:as {{:keys [name description table_id definition] :as body} :body}]
+  [:as {{:keys [name description table_id definition]} :body}]
   {name       [Required NonEmptyString]
    table_id   [Required Integer]
    definition [Required Dict]}
   (check-superuser)
   (checkp #(db/exists? Table :id table_id) "table_id" "Table does not exist.")
-  (->500 (metric/create-metric table_id name description *current-user-id* definition)))
+  (check-500 (metric/create-metric table_id name description *current-user-id* definition)))
 
 
 (defendpoint GET "/:id"
   "Fetch `Metric` with ID."
   [id]
   (check-superuser)
-  (->404 (metric/retrieve-metric id)))
+  (check-404 (metric/retrieve-metric id)))
 
 
 (defendpoint PUT "/:id"
   "Update a `Metric` with ID."
-  [id :as {{:keys [name description definition revision_message] :as body} :body}]
+  [id :as {{:keys [name description definition revision_message]} :body}]
   {name             [Required NonEmptyString]
    revision_message [Required NonEmptyString]
    definition       [Required Dict]}

--- a/src/metabase/api/notify.clj
+++ b/src/metabase/api/notify.clj
@@ -11,7 +11,7 @@
 (defendpoint POST "/db/:id"
   "Notification about a potential schema change to one of our `Databases`.
   Caller can optionally specify a `:table_id` or `:table_name` in the body to limit updates to a single `Table`."
-  [id :as {{:keys [table_id table_name] :as body} :body}]
+  [id :as {{:keys [table_id table_name]} :body}]
   (let-404 [database (Database id)]
     (cond
       table_id (when-let [table (sel :one Table :db_id id :id (int table_id))]

--- a/src/metabase/api/pulse.clj
+++ b/src/metabase/api/pulse.clj
@@ -25,24 +25,24 @@
 
 (defendpoint POST "/"
   "Create a new `Pulse`."
-  [:as {{:keys [name cards channels] :as body} :body}]
+  [:as {{:keys [name cards channels]} :body}]
   {name     [Required NonEmptyString]
    cards    [Required ArrayOfMaps]
    channels [Required ArrayOfMaps]}
   ;; prevent more than 5 cards
   ;; limit channel types to :email and :slack
-  (->500 (pulse/create-pulse name *current-user-id* (filter identity (map :id cards)) channels)))
+  (check-500 (pulse/create-pulse name *current-user-id* (filter identity (map :id cards)) channels)))
 
 
 (defendpoint GET "/:id"
   "Fetch `Pulse` with ID."
   [id]
-  (->404 (pulse/retrieve-pulse id)))
+  (check-404 (pulse/retrieve-pulse id)))
 
 
 (defendpoint PUT "/:id"
   "Update a `Pulse` with ID."
-  [id :as {{:keys [name cards channels] :as body} :body}]
+  [id :as {{:keys [name cards channels]} :body}]
   {name     [Required NonEmptyString]
    cards    [Required ArrayOfMaps]
    channels [Required ArrayOfMaps]}

--- a/src/metabase/api/segment.clj
+++ b/src/metabase/api/segment.clj
@@ -10,25 +10,25 @@
 
 (defendpoint POST "/"
   "Create a new `Segment`."
-  [:as {{:keys [name description table_id definition] :as body} :body}]
+  [:as {{:keys [name description table_id definition]} :body}]
   {name       [Required NonEmptyString]
    table_id   [Required Integer]
    definition [Required Dict]}
   (check-superuser)
   (checkp #(db/exists? Table :id table_id) "table_id" "Table does not exist.")
-  (->500 (segment/create-segment table_id name description *current-user-id* definition)))
+  (check-500 (segment/create-segment table_id name description *current-user-id* definition)))
 
 
 (defendpoint GET "/:id"
   "Fetch `Segment` with ID."
   [id]
   (check-superuser)
-  (->404 (segment/retrieve-segment id)))
+  (check-404 (segment/retrieve-segment id)))
 
 
 (defendpoint PUT "/:id"
   "Update a `Segment` with ID."
-  [id :as {{:keys [name description definition revision_message] :as body} :body}]
+  [id :as {{:keys [name description definition revision_message]} :body}]
   {name             [Required NonEmptyString]
    revision_message [Required NonEmptyString]
    definition       [Required Dict]}

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -3,7 +3,6 @@
   (:require [clojure.tools.logging :as log]
             [cemerick.friend.credentials :as creds]
             [compojure.core :refer [defroutes GET POST DELETE]]
-            [hiccup.core :refer [html]]
             [korma.core :as k]
             [throttle.core :as throttle]
             [metabase.api.common :refer :all]
@@ -34,7 +33,7 @@
 
 (defendpoint POST "/"
   "Login."
-  [:as {{:keys [email password] :as body} :body, remote-address :remote-addr}]
+  [:as {{:keys [email password]} :body, remote-address :remote-addr}]
   {email    [Required Email]
    password [Required NonEmptyString]}
   (throttle/check (login-throttlers :ip-address) remote-address)

--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -21,7 +21,7 @@
 (defendpoint POST "/"
   "Special endpoint for creating the first user during setup.
    This endpoint both creates the user AND logs them in and returns a session ID."
-  [:as {{:keys [token] {:keys [name engine details is_full_sync]} :database {:keys [first_name last_name email password]} :user {:keys [allow_tracking site_name]} :prefs} :body, :as request}]
+  [:as {{:keys [token] {:keys [name engine details is_full_sync]} :database, {:keys [first_name last_name email password]} :user, {:keys [allow_tracking site_name]} :prefs} :body, :as request}]
   {token      [Required SetupToken]
    site_name  [Required NonEmptyString]
    first_name [Required NonEmptyString]
@@ -63,7 +63,7 @@
 
 (defendpoint POST "/validate"
   "Validate that we can connect to a database given a set of details."
-  [:as {{{:keys [engine] {:keys [host port] :as details} :details} :details token :token} :body}]
+  [:as {{{:keys [engine] {:keys [host port] :as details} :details} :details, token :token} :body}]
   {token      [Required SetupToken]
    engine     [Required DBEngine]}
   (let [engine           (keyword engine)

--- a/src/metabase/api/slack.clj
+++ b/src/metabase/api/slack.clj
@@ -1,8 +1,6 @@
 (ns metabase.api.slack
   "/api/slack endpoints"
-  (:require [clojure.set :as set]
-            [clojure.tools.logging :as log]
-            [compojure.core :refer [PUT]]
+  (:require [compojure.core :refer [PUT]]
             [metabase.api.common :refer :all]
             [metabase.config :as config]
             [metabase.integrations.slack :as slack]))

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -5,7 +5,6 @@
             [metabase.api.common :refer :all]
             [metabase.db :refer :all]
             (metabase.models [hydrate :refer :all]
-                             [database :refer [Database]]
                              [field :refer [Field]]
                              [foreign-key :refer [ForeignKey]]
                              [table :refer [Table] :as table])

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -21,7 +21,7 @@
 
 (defendpoint POST "/"
   "Create a new `User`."
-  [:as {{:keys [first_name last_name email password]} :body :as request}]
+  [:as {{:keys [first_name last_name email password]} :body}]
   {first_name [Required NonEmptyString]
    last_name  [Required NonEmptyString]
    email      [Required Email]}
@@ -57,7 +57,7 @@
 
 (defendpoint PUT "/:id"
   "Update a `User`."
-  [id :as {{:keys [email first_name last_name is_superuser] :as body} :body}]
+  [id :as {{:keys [email first_name last_name is_superuser]} :body}]
   {email      [Required Email]
    first_name NonEmptyString
    last_name  NonEmptyString}
@@ -65,12 +65,12 @@
   (check-404 (exists? User :id id :is_active true))           ; only allow updates if the specified account is active
   (check-400 (not (exists? User :email email :id [not= id]))) ; can't change email if it's already taken BY ANOTHER ACCOUNT
   (check-500 (upd-non-nil-keys User id
-                               :email email
-                               :first_name first_name
-                               :last_name last_name
-                               :is_superuser (if (:is_superuser @*current-user*)
-                                               is_superuser
-                                               nil)))
+              :email        email
+              :first_name   first_name
+              :last_name    last_name
+              :is_superuser (if (:is_superuser @*current-user*)
+                              is_superuser
+                              nil)))
   (User id))
 
 

--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -78,5 +78,5 @@
 
 (def ^:const mb-version-string
   "A formatted version string representing the currently running application."
-  (let [{:keys [tag hash branch date]} mb-version-info]
+  (let [{:keys [tag hash branch]} mb-version-info]
     (format "%s (%s %s)" tag hash branch)))

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -24,7 +24,6 @@
                       [task :as task]
                       [util :as u])
             (metabase.models [setting :refer [defsetting]]
-                             [database :refer [Database]]
                              [user :refer [User]])))
 
 ;; ## CONFIG

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -5,7 +5,6 @@
             (clojure [set :as set]
                      [string :as s]
                      [walk :as walk])
-            [colorize.core :as color]
             (korma [core :as k]
                    [db :as kdb])
             [medley.core :as m]
@@ -215,6 +214,7 @@
 
 (defn upd-non-nil-keys
   "Calls `upd`, but filters out KWARGS with `nil` values."
+  {:style/indent 2}
   [entity entity-id & {:as kwargs}]
   (->> (m/filter-vals (complement nil?) kwargs)
        (m/mapply upd entity entity-id)))

--- a/src/metabase/db/metadata_queries.clj
+++ b/src/metabase/db/metadata_queries.clj
@@ -2,8 +2,7 @@
   "Predefined MBQL queries for getting metadata about an external database."
   (:require [metabase.driver :as driver]
             [metabase.driver.query-processor.expand :as ql]
-            [metabase.models.field :as field]
-            [metabase.util :as u]))
+            [metabase.models.field :as field]))
 
 (defn- qp-query [db-id query]
   (-> (driver/process-query

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -1,7 +1,6 @@
 (ns metabase.driver
   (:require [clojure.java.classpath :as classpath]
             [clojure.math.numeric-tower :as math]
-            [clojure.string :as s]
             [clojure.tools.logging :as log]
             [clojure.tools.namespace.find :as ns-find]
             [korma.core :as k]
@@ -426,8 +425,7 @@
 
     :executed_by [int]               (user_id of caller)"
   {:arglists '([query options])}
-  [query {:keys [executed_by]
-          :as options}]
+  [query {:keys [executed_by]}]
   {:pre [(integer? executed_by)]}
   (let [query-execution {:uuid              (.toString (java.util.UUID/randomUUID))
                          :executor_id       executed_by

--- a/src/metabase/driver/druid/query_processor.clj
+++ b/src/metabase/driver/druid/query_processor.clj
@@ -44,9 +44,9 @@
   DateTimeField         (->rvalue [this] (->rvalue (:field this)))
   Value                 (->rvalue [this] (:value this))
   DateTimeValue         (->rvalue [{{unit :unit} :field, value :value}] (u/date->iso-8601 (u/date-trunc-or-extract unit value)))
-  RelativeDateTimeValue (->rvalue [{:keys [unit amount], :as this}]     (if (zero? amount)
-                                                                          (u/date->iso-8601)
-                                                                          (u/date->iso-8601 (u/date-trunc-or-extract unit (u/relative-date unit amount))))))
+  RelativeDateTimeValue (->rvalue [{:keys [unit amount]}] (if (zero? amount)
+                                                            (u/date->iso-8601)
+                                                            (u/date->iso-8601 (u/date-trunc-or-extract unit (u/relative-date unit amount))))))
 
 (defprotocol ^:private IDimensionOrMetric
   (^:private dimension-or-metric? [this]
@@ -65,10 +65,10 @@
                   :granularity :all
                   :context     {:timeout 60000}}]
     {::select     (merge defaults {:queryType  :select
-                                   :pagingSpec {:threshold 100 #_qp/absolute-max-results}})
+                                   :pagingSpec {:threshold qp/absolute-max-results}})
      ::timeseries (merge defaults {:queryType :timeseries})
      ::topN       (merge defaults {:queryType :topN
-                                   :threshold 100 #_qp/absolute-max-results})
+                                   :threshold qp/absolute-max-results})
      ::groupBy    (merge defaults {:queryType :groupBy})}))
 
 
@@ -189,7 +189,7 @@
   Object (->dimension-rvalue [this] (->rvalue this))
   ;; :timestamp is a special case, and we need to do an 'extraction' against the secret special value :__time to get at it
   DateTimeField
-  (->dimension-rvalue [{:keys [unit], :as this}]
+  (->dimension-rvalue [{:keys [unit]}]
     {:type         :extraction
      :dimension    :__time
      :outputName   :timestamp
@@ -295,27 +295,26 @@
 
 (defn- parse-filter-subclause:intervals [{:keys [filter-type field value] :as filter}]
   (when (instance? DateTimeField field)
-    (let [field (->rvalue field)]
-      (case filter-type
-        ;; BETWEEN "2015-12-09", "2015-12-11" -> ["2015-12-09/2015-12-12"], because BETWEEN is inclusive
-        :between  (let [{:keys [min-val max-val]} filter]
-                    (make-intervals min-val (i/add-date-time-units max-val 1)))
-        ;; =  "2015-12-11" -> ["2015-12-11/2015-12-12"]
-        :=        (make-intervals value (i/add-date-time-units value 1))
-        ;; != "2015-12-11" -> ["-5000/2015-12-11", "2015-12-12/5000"]
-        :!=       (make-intervals nil value, (i/add-date-time-units value 1) nil)
-        ;; >  "2015-12-11" -> ["2015-12-12/5000"]
-        :>        (make-intervals (i/add-date-time-units value 1) nil)
-        ;; >= "2015-12-11" -> ["2015-12-11/5000"]
-        :>=       (make-intervals value nil)
-        ;; <  "2015-12-11" -> ["-5000/2015-12-11"]
-        :<        (make-intervals nil value)
-        ;; <= "2015-12-11" -> ["-5000/2015-12-12"]
-        :<=       (make-intervals nil (i/add-date-time-units value 1))
-        ;; This is technically allowed by the QL here but doesn't make sense since every Druid event has a timestamp. Just ignore it
-        :is-null  (log/warn (u/format-color 'red "WARNING: timestamps can never be nil. Ignoring IS_NULL filter for timestamp."))
-        ;; :timestamp is always non-nil so nothing to do here
-        :not-null nil))))
+    (case filter-type
+      ;; BETWEEN "2015-12-09", "2015-12-11" -> ["2015-12-09/2015-12-12"], because BETWEEN is inclusive
+      :between  (let [{:keys [min-val max-val]} filter]
+                  (make-intervals min-val (i/add-date-time-units max-val 1)))
+      ;; =  "2015-12-11" -> ["2015-12-11/2015-12-12"]
+      :=        (make-intervals value (i/add-date-time-units value 1))
+      ;; != "2015-12-11" -> ["-5000/2015-12-11", "2015-12-12/5000"]
+      :!=       (make-intervals nil value, (i/add-date-time-units value 1) nil)
+      ;; >  "2015-12-11" -> ["2015-12-12/5000"]
+      :>        (make-intervals (i/add-date-time-units value 1) nil)
+      ;; >= "2015-12-11" -> ["2015-12-11/5000"]
+      :>=       (make-intervals value nil)
+      ;; <  "2015-12-11" -> ["-5000/2015-12-11"]
+      :<        (make-intervals nil value)
+      ;; <= "2015-12-11" -> ["-5000/2015-12-12"]
+      :<=       (make-intervals nil (i/add-date-time-units value 1))
+      ;; This is technically allowed by the QL here but doesn't make sense since every Druid event has a timestamp. Just ignore it
+      :is-null  (log/warn (u/format-color 'red "WARNING: timestamps can never be nil. Ignoring IS_NULL filter for timestamp."))
+      ;; :timestamp is always non-nil so nothing to do here
+      :not-null nil)))
 
 (defn- parse-filter-clause:intervals [{:keys [compound-type subclauses], :as clause}]
   (if-not compound-type
@@ -417,7 +416,7 @@
 
 (defmulti ^:private handle-page query-type-dispatch-fn)
 
-(defmethod handle-page ::query [_ {{page-num :page items-per-page :items, :as page-clause} :page} druid-query]
+(defmethod handle-page ::query [_ {page-clause :page} druid-query]
   (when page-clause
     (log/warn (u/format-color 'red "WARNING: 'page' is not yet implemented."))))
 

--- a/src/metabase/driver/generic_sql/native.clj
+++ b/src/metabase/driver/generic_sql/native.clj
@@ -2,8 +2,6 @@
   "The `native` query processor."
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.tools.logging :as log]
-            (korma [core :as korma]
-                   db)
             [metabase.db :refer [sel]]
             [metabase.driver :as driver]
             [metabase.driver.generic-sql :as sql]
@@ -17,7 +15,7 @@
 
 (defn process-and-run
   "Process and run a native (raw SQL) QUERY."
-  [driver {{sql :query} :native, database-id :database, settings :settings, :as query}]
+  [driver {{sql :query} :native, database-id :database, settings :settings}]
   (try (let [database (sel :one :fields [Database :engine :details] :id database-id)
              db-conn  (sql/db->jdbc-connection-spec database)]
 

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -1,24 +1,20 @@
 (ns metabase.driver.generic-sql.query-processor
   "The Query Processor is responsible for translating the Metabase Query Language into korma SQL forms."
-  (:require [clojure.core.match :refer [match]]
-            [clojure.java.jdbc :as jdbc]
-            (clojure [pprint :as pprint]
-                     [string :as s]
+  (:require [clojure.java.jdbc :as jdbc]
+            (clojure [string :as s]
                      [walk :as walk])
             [clojure.tools.logging :as log]
             (korma [core :as k]
                    [db :as kdb])
-            (korma.sql [fns :as kfns]
-                       [utils :as utils])
+            (korma.sql [engine :as kengine]
+                       [fns :as kfns])
             [metabase.config :as config]
             [metabase.driver :as driver]
             [metabase.driver.generic-sql :as sql]
             [metabase.driver.query-processor :as qp]
             metabase.driver.query-processor.interface
             [metabase.util :as u]
-            [metabase.util.korma-extensions :as kx]
-            [korma.sql.utils :as kutils]
-            [korma.sql.engine :as kengine])
+            [metabase.util.korma-extensions :as kx])
   (:import java.sql.Timestamp
            java.util.Date
            (metabase.driver.query_processor.interface AgFieldRef

--- a/src/metabase/driver/mongo.clj
+++ b/src/metabase/driver/mongo.clj
@@ -1,14 +1,9 @@
 (ns metabase.driver.mongo
   "MongoDB Driver."
-  (:require [clojure.core.reducers :as r]
-            [clojure.set :as set]
-            [clojure.tools.logging :as log]
-            [colorize.core :as color]
-            [medley.core :as m]
+  (:require [clojure.set :as set]
             (monger [collection :as mc]
                     [command :as cmd]
                     [conversion :as conv]
-                    [core :as mg]
                     [db :as mdb]
                     [query :as mq])
             [metabase.driver :as driver]

--- a/src/metabase/driver/mongo/query_processor.clj
+++ b/src/metabase/driver/mongo/query_processor.clj
@@ -1,23 +1,15 @@
 (ns metabase.driver.mongo.query-processor
   (:refer-clojure :exclude [find sort])
-  (:require [clojure.core.match :refer [match]]
-            (clojure [set :as set]
+  (:require (clojure [set :as set]
                      [string :as s])
             [clojure.tools.logging :as log]
             [clojure.walk :as walk]
-            [colorize.core :as color]
             (monger [collection :as mc]
-                    [core :as mg]
-                    [db :as mdb]
-                    [operators :refer :all]
-                    [query :refer :all])
-            (metabase [config :as config]
-                      [db :refer :all])
+                    [operators :refer :all])
             [metabase.driver.query-processor :as qp]
             (metabase.driver.query-processor [annotate :as annotate]
                                              [interface :refer [qualified-name-components map->DateTimeField map->DateTimeValue]])
             [metabase.driver.mongo.util :refer [with-mongo-connection *mongo-connection* values->base-type]]
-            [metabase.models.field :as field]
             [metabase.util :as u])
   (:import java.sql.Timestamp
            java.util.Date
@@ -219,7 +211,7 @@
         :year            (extract :year))))
 
   RelativeDateTimeValue
-  (->rvalue [{:keys [amount unit field], :as this}]
+  (->rvalue [{:keys [amount unit field]}]
     (->rvalue (map->DateTimeValue {:value (u/relative-date (or unit :day) amount)
                                        :field field}))))
 

--- a/src/metabase/driver/mongo/util.clj
+++ b/src/metabase/driver/mongo/util.clj
@@ -1,7 +1,6 @@
 (ns metabase.driver.mongo.util
   "`*mongo-connection*`, `with-mongo-connection`, and other functions shared between several Mongo driver namespaces."
-  (:require [clojure.string :as s]
-            [clojure.tools.logging :as log]
+  (:require [clojure.tools.logging :as log]
             (monger [core :as mg]
                     [credentials :as mcred])
             (metabase [driver :as driver]

--- a/src/metabase/driver/query_processor.clj
+++ b/src/metabase/driver/query_processor.clj
@@ -13,9 +13,7 @@
                                              [interface :refer :all]
                                              [macros :as macros]
                                              [resolve :as resolve])
-            (metabase.models [field :refer [Field], :as field]
-                             [foreign-key :refer [ForeignKey]]
-                             [setting :as setting])
+            [metabase.models.field :refer [Field], :as field]
             [metabase.util :as u])
   (:import (schema.utils NamedError ValidationError)))
 
@@ -109,7 +107,7 @@
 (defn- pre-add-settings [qp]
   (fn [{:keys [driver] :as query}]
     (let [settings {:report-timezone (when (driver/driver-supports? driver :set-timezone)
-                                       (let [report-tz (setting/get :report-timezone)]
+                                       (let [report-tz (driver/report-timezone)]
                                          (when-not (empty? report-tz)
                                            report-tz)))}]
       (->> (u/filter-nil-values settings)

--- a/src/metabase/driver/query_processor/annotate.clj
+++ b/src/metabase/driver/query_processor/annotate.clj
@@ -1,7 +1,5 @@
 (ns metabase.driver.query-processor.annotate
-  (:refer-clojure :exclude [==])
-  (:require (clojure [set :as set]
-                     [string :as s])
+  (:require [clojure.set :as set]
             [clojure.tools.logging :as log]
             [medley.core :as m]
             [metabase.db :refer [sel]]
@@ -86,7 +84,7 @@
 
 (defn- add-aggregate-field-if-needed
   "Add a Field containing information about an aggregate column such as `:count` or `:distinct` if needed."
-  [{{ag-type :aggregation-type, ag-field :field, :as ag} :aggregation} fields]
+  [{{ag-type :aggregation-type, ag-field :field} :aggregation} fields]
   (if (or (not ag-type)
           (= ag-type :rows))
     fields

--- a/src/metabase/driver/query_processor/expand.clj
+++ b/src/metabase/driver/query_processor/expand.clj
@@ -336,7 +336,7 @@
   "Specify which 'page' of results to fetch (offset and limit the results).
 
      (page {} {:page 1, :items 20}) ; fetch first 20 rows"
-  [query {:keys [page items], :as page-clause} :- (s/maybe i/Page)]
+  [query page-clause :- (s/maybe i/Page)]
   (if page-clause
     (assoc query :page page-clause)
     query))

--- a/src/metabase/driver/query_processor/macros.clj
+++ b/src/metabase/driver/query_processor/macros.clj
@@ -47,7 +47,7 @@
     ;; we have an aggregation clause, so lets see if we are using a METRIC
     (if-let [metric-def (match (get-in query-dict [:query :aggregation])
                                ["METRIC" (metric-id :guard integer?)] (db/sel :one :field [metabase.models.metric/Metric :definition] :id metric-id)
-                               other                                  nil)]
+                               _                                      nil)]
       ;; we have a metric, so merge its definition into the existing query-dict
       (-> query-dict
           (assoc-in [:query :aggregation] (:aggregation metric-def))

--- a/src/metabase/driver/query_processor/resolve.clj
+++ b/src/metabase/driver/query_processor/resolve.clj
@@ -231,7 +231,7 @@
 
 (defn- resolve-tables
   "Resolve the `Tables` in an EXPANDED-QUERY-DICT."
-  [{{source-table-id :source-table} :query, database-id :database, :keys [table-ids fk-field-ids], :as expanded-query-dict}]
+  [{{source-table-id :source-table} :query, :keys [table-ids fk-field-ids], :as expanded-query-dict}]
   {:pre [(integer? source-table-id)]}
   (let [table-ids       (conj table-ids source-table-id)
         table-id->table (sel :many :id->fields [Table :schema :name :id], :id [in table-ids])

--- a/src/metabase/driver/redshift.clj
+++ b/src/metabase/driver/redshift.clj
@@ -3,7 +3,6 @@
   (:require [clojure.java.jdbc :as jdbc]
             (korma [core :as k]
                    [db :as kdb])
-            [korma.sql.utils :as kutils]
             (metabase [config :as config]
                       [driver :as driver])
             [metabase.driver.generic-sql :as sql]

--- a/src/metabase/driver/sqlite.clj
+++ b/src/metabase/driver/sqlite.clj
@@ -1,9 +1,7 @@
 (ns metabase.driver.sqlite
-  (:require (clojure [set :as set]
-                     [string :as s])
+  (:require [clojure.set :as set]
             (korma [core :as k]
                    [db :as kdb])
-            [korma.sql.utils :as kutils]
             [metabase.config :as config]
             [metabase.driver :as driver]
             [metabase.driver.generic-sql :as sql]

--- a/src/metabase/driver/sqlserver.clj
+++ b/src/metabase/driver/sqlserver.clj
@@ -2,7 +2,6 @@
   (:require [clojure.string :as s]
             (korma [core :as k]
                    [db :as kdb])
-            [korma.sql.utils :as kutils]
             [metabase.driver :as driver]
             [metabase.driver.generic-sql :as sql]
             [metabase.util.korma-extensions :as kx])

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -3,7 +3,6 @@
    NOTE: we want to keep this about email formatting, so don't put heavy logic here RE: building data for emails."
   (:require [hiccup.core :refer [html]]
             [stencil.core :as stencil]
-            [stencil.loader :as loader]
             [metabase.email :as email]
             [metabase.models.setting :as setting]
             [metabase.pulse :as p]
@@ -12,7 +11,7 @@
                            [urls :as url])))
 
 ;; NOTE: uncomment this in development to disable template caching
-;; (loader/set-cache (clojure.core.cache/ttl-cache-factory {} :ttl 0))
+;; (stencil.loader/set-cache (clojure.core.cache/ttl-cache-factory {} :ttl 0))
 
 ;;; ### Public Interface
 

--- a/src/metabase/events.clj
+++ b/src/metabase/events.clj
@@ -94,8 +94,7 @@
   (async/go-loop []
     ;; try/catch here to get possible exceptions thrown by core.async trying to read from the channel
     (try
-      (let [evt (async/<! channel)]
-        (handler-fn evt))
+      (handler-fn (async/<! channel))
       (catch Throwable e
         (log/error "Unexpected error listening on events" e)))
     (recur)))

--- a/src/metabase/events/activity_feed.clj
+++ b/src/metabase/events/activity_feed.clj
@@ -6,7 +6,6 @@
             (metabase.models [activity :refer [Activity], :as activity]
                              [card :refer [Card]]
                              [dashboard :refer [Dashboard]]
-                             [database :refer [Database]]
                              [interface :as models]
                              [session :refer [Session first-session-for-user]]
                              [table :as table])))
@@ -57,7 +56,7 @@
                                   ;; we expect that the object has just a dashboard :id at the top level
                                   ;; plus a `:dashcards` attribute which is a vector of the cards added/removed
                                   (-> (db/sel :one [Dashboard :description :name :public_perms], :id (events/object->model-id topic obj))
-                                      (assoc :dashcards (for [{:keys [id card_id], :as dashcard} dashcards]
+                                      (assoc :dashcards (for [{:keys [id card_id]} dashcards]
                                                           (-> (db/sel :one [Card :name :description :public_perms], :id card_id)
                                                               (assoc :id id)
                                                               (assoc :card_id card_id))))))]
@@ -69,24 +68,6 @@
                     :dashboard-delete       create-delete-details
                     :dashboard-add-cards    add-remove-card-details
                     :dashboard-remove-cards add-remove-card-details))))
-
-;; disabled for now as it's overly verbose in the feed
-;(defn- process-database-activity [topic object]
-;  (let [database            (db/sel :one Database :id (events/object->model-id topic object))
-;        object              (merge object (select-keys database [:name :description :engine]))
-;        database-details-fn (fn [obj] (-> obj
-;                                          (assoc :status "started")
-;                                          (dissoc :database_id :custom_id)))
-;        database-table-fn   (fn [obj] {:database-id (events/object->model-id topic obj)})]
-;    ;; NOTE: we are skipping any handling of activity for sample databases
-;    (when (= false (:is_sample database))
-;      (case topic
-;        :database-sync-begin (record-activity :database-sync object database-details-fn database-table-fn)
-;        :database-sync-end   (let [{activity-id :id} (db/sel :one Activity :custom_id (:custom_id object))]
-;                               (db/upd Activity activity-id
-;                                 :details (-> object
-;                                              (assoc :status "completed")
-;                                              (dissoc :database_id :custom_id))))))))
 
 (defn- process-metric-activity [topic object]
   (let [details-fn  #(select-keys % [:name :description :revision_message])

--- a/src/metabase/events/last_login.clj
+++ b/src/metabase/events/last_login.clj
@@ -24,7 +24,7 @@
   [last-login-event]
   ;; try/catch here to prevent individual topic processing exceptions from bubbling up.  better to handle them here.
   (try
-    (when-let [{topic :topic object :item} last-login-event]
+    (when-let [{object :item} last-login-event]
       (log/info object)
       ;; just make a simple attempt to set the `:last_login` for the given user to now
       (when-let [user-id (:user_id object)]

--- a/src/metabase/integrations/slack.clj
+++ b/src/metabase/integrations/slack.clj
@@ -24,7 +24,7 @@
   (boolean (seq (slack-token))))
 
 
-(defn- handle-response [{:keys [status body], :as response}]
+(defn- handle-response [{:keys [status body]}]
   (let [body (json/parse-string body keyword)]
     (if (and (= 200 status) (:ok body))
       body

--- a/src/metabase/middleware.clj
+++ b/src/metabase/middleware.clj
@@ -1,11 +1,9 @@
 (ns metabase.middleware
   "Metabase-specific middleware functions & configuration."
   (:require [clojure.tools.logging :as log]
-            [clojure.walk :as walk]
             (cheshire factory
                       [generate :refer [add-encoder encode-str encode-nil]])
             [korma.core :as k]
-            [medley.core :refer [filter-vals map-vals]]
             [metabase.api.common :refer [*current-user* *current-user-id*]]
             [metabase.config :as config]
             [metabase.db :refer [sel]]

--- a/src/metabase/models/activity.clj
+++ b/src/metabase/models/activity.clj
@@ -3,19 +3,16 @@
                       [events :as events])
             (metabase.models [card :refer [Card]]
                              [dashboard :refer [Dashboard]]
-                             [database :refer [Database]]
                              [interface :as i]
                              [metric :refer [Metric]]
                              [pulse :refer [Pulse]]
-                             [segment :refer [Segment]]
-                             [table :refer [Table]]
-                             [user :refer [User]])
+                             [segment :refer [Segment]])
             [metabase.util :as u]))
 
 
 (i/defentity Activity :activity)
 
-(defn- pre-insert [{:keys [details] :as activity}]
+(defn- pre-insert [activity]
   (let [defaults {:timestamp (u/new-sql-timestamp)
                   :details {}}]
     (merge defaults activity)))

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -1,12 +1,10 @@
 (ns metabase.models.card
-  (:require [clojure.core.match :refer [match]]
-            [korma.core :as k]
+  (:require [korma.core :as k]
             [medley.core :as m]
             [metabase.db :as db]
             (metabase.models [dependency :as dependency]
                              [interface :as i]
-                             [revision :as revision]
-                             [user :refer [User]])
+                             [revision :as revision])
             [metabase.query :as q]))
 
 (def ^:const display-types
@@ -68,7 +66,7 @@
 
 (defn card-dependencies
   "Calculate any dependent objects for a given `Card`."
-  [this id {:keys [dataset_query] :as instance}]
+  [this id {:keys [dataset_query]}]
   (when (and dataset_query
              (= :query (keyword (:type dataset_query))))
     {:Metric  (q/extract-metric-ids (:query dataset_query))

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -3,11 +3,9 @@
             [korma.core :as k]
             [medley.core :as m]
             [metabase.db :refer :all]
-            (metabase.models [common :refer :all]
-                             [dashboard-card :refer [DashboardCard] :as dashboard-card]
+            (metabase.models [dashboard-card :refer [DashboardCard] :as dashboard-card]
                              [interface :as i]
-                             [revision :as revision]
-                             [user :refer [User]])
+                             [revision :as revision])
             [metabase.models.revision.diff :refer [build-sentence]]
             [metabase.util :as u]))
 

--- a/src/metabase/models/dashboard_card_series.clj
+++ b/src/metabase/models/dashboard_card_series.clj
@@ -1,7 +1,5 @@
 (ns metabase.models.dashboard-card-series
-  (:require [metabase.db :refer [sel]]
-            (metabase.models [card :refer [Card]]
-                             [interface :as i])))
+  (:require [metabase.models.interface :as i]))
 
 
 (i/defentity DashboardCardSeries :dashboardcard_series)

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -2,7 +2,6 @@
   (:require [korma.core :as k]
             [metabase.db :refer :all]
             (metabase.models [common :as common]
-                             [database :refer [Database]]
                              [field-values :refer [FieldValues]]
                              [foreign-key :refer [ForeignKey]]
                              [interface :as i])))
@@ -88,7 +87,7 @@
 
 (defn qualified-name-components
   "Return the pieces that represent a path to FIELD, of the form `[table-name parent-fields-name* field-name]`."
-  [{field-name :name, table-id :table_id, parent-id :parent_id, :as field}]
+  [{field-name :name, table-id :table_id, parent-id :parent_id}]
   (conj (if-let [parent (Field parent-id)]
           (qualified-name-components parent)
           [(sel :one :field ['Table :name], :id table-id)])

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -15,8 +15,8 @@
   (:is_superuser @@(resolve 'metabase.api.common/*current-user*)))
 
 (defn- creator?
-  "Did the current user create OBJ?"
-  [{:keys [creator_id], :as obj}]
+  "Did the current user create this object?"
+  [{:keys [creator_id]}]
   {:pre [creator_id]}
   (= creator_id @(resolve 'metabase.api.common/*current-user-id*)))
 

--- a/src/metabase/models/metric.clj
+++ b/src/metabase/models/metric.clj
@@ -1,14 +1,11 @@
 (ns metabase.models.metric
   (:require [korma.core :as k]
-            [metabase.config :as config]
             [metabase.db :as db]
             [metabase.events :as events]
-            (metabase.models [common :refer [perms-readwrite]]
-                             [dependency :as dependency]
+            (metabase.models [dependency :as dependency]
                              [hydrate :refer :all]
                              [interface :as i]
-                             [revision :as revision]
-                             [user :refer [User]])
+                             [revision :as revision])
             [metabase.query :as q]
             [metabase.util :as u]))
 
@@ -57,7 +54,7 @@
 
 (defn metric-dependencies
   "Calculate any dependent objects for a given `Metric`."
-  [this id {:keys [definition] :as instance}]
+  [this id {:keys [definition]}]
   (when definition
     {:Segment (q/extract-segment-ids definition)}))
 

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -1,6 +1,5 @@
 (ns metabase.models.pulse
-  (:require [clojure.tools.logging :as log]
-            (korma [core :as k]
+  (:require (korma [core :as k]
                    [db :as kdb])
             [medley.core :as m]
             [metabase.db :as db]
@@ -10,8 +9,7 @@
                              [hydrate :refer :all]
                              [interface :as i]
                              [pulse-card :refer [PulseCard]]
-                             [pulse-channel :refer [PulseChannel] :as pulse-channel]
-                             [user :refer [User]])))
+                             [pulse-channel :refer [PulseChannel] :as pulse-channel])))
 
 
 (i/defentity Pulse :pulse)

--- a/src/metabase/models/pulse_channel.clj
+++ b/src/metabase/models/pulse_channel.clj
@@ -110,7 +110,7 @@
 
 (defn ^:hydrate recipients
   "Return the `PulseChannelRecipients` associated with this PULSE-CHANNEL."
-  [{:keys [id creator_id details] :as pulse-channel}]
+  [{:keys [id details]}]
   (into (mapv (partial array-map :email) (:emails details))
         (db/sel :many [User :id :email :first_name :last_name]
                 (k/where {:id [in (k/subselect PulseChannelRecipient (k/fields :user_id) (k/where {:pulse_channel_id id}))]}))))
@@ -130,6 +130,7 @@
 
 ;; ## Persistence Functions
 
+;; TODO - fix docstring !!
 (defn retrieve-scheduled-channels
   "Fetch all `PulseChannels` that are scheduled to run at a given time described by HOUR, WEEKDAY, MONTHDAY, and MONTHWEEK.
 
@@ -143,10 +144,10 @@
      * WEEKLY scheduled channels are included if the WEEKDAY & HOUR match.
      * MONTHLY scheduled channels are included if the MONTHDAY, MONTHWEEK, WEEKDAY, & HOUR all match."
   [hour weekday monthday monthweek]
-  [:pre [(integer? hour)
-         (day-of-week? weekday)
+  {:pre [(or (integer? hour) (nil? hour))
+         (or (day-of-week? weekday) (nil? weekday))
          (contains? #{:first :last :mid :other} monthday)
-         (contains? #{:first :last :other} monthweek)]]
+         (contains? #{:first :last :other} monthweek)]}
   (let [schedule-frame              (cond
                                       (= :mid monthday)    (name :mid)
                                       (= :first monthweek) (name :first)

--- a/src/metabase/models/revision.clj
+++ b/src/metabase/models/revision.clj
@@ -3,7 +3,6 @@
             [korma.core :as k]
             [medley.core :as m]
             [metabase.db :as db]
-            [metabase.api.common :refer [*current-user-id* let-404]]
             (metabase.models [hydrate :refer [hydrate]]
                              [interface :as i]
                              [user :refer [User]])

--- a/src/metabase/models/segment.clj
+++ b/src/metabase/models/segment.clj
@@ -2,11 +2,9 @@
   (:require [korma.core :as k]
             [metabase.db :as db]
             [metabase.events :as events]
-            (metabase.models [common :refer [perms-readwrite]]
-                             [hydrate :refer :all]
+            (metabase.models [hydrate :refer [hydrate]]
                              [interface :as i]
-                             [revision :as revision]
-                             [user :refer [User]])
+                             [revision :as revision])
             [metabase.util :as u]))
 
 

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -58,7 +58,13 @@
   "Fetch value of `Setting`, first trying our cache, or fetching the value
    from the DB if that fails. (Cached lookup time is ~60µs, compared to ~1800µs for DB lookup)
 
-   Unlike using the setting getter fn, this will *not* return default values or values specified by env vars."
+     (get :mandrill-api-key)
+
+   Unlike using the setting getter fn, this will *not* return default values or values specified by env vars.
+
+   Prefer using the automatically generated getter function unless absolutely necessary:
+
+     (mandrill-api-key)"
   [k]
   {:pre [(keyword? k)]}
   (restore-cache-if-needed)
@@ -88,9 +94,9 @@
 
     (set :mandrill-api-key \"xyz123\")
 
-   Prefer using the setting directly instead:
+   Don't use this directly unless absolutely neccesary! Prefer using the setting directly instead:
 
-    (mandrill-api-key \"xyz123\")"
+     (mandrill-api-key \"xyz123\")"
   [k v]
   {:pre [(keyword? k)
          (string? v)]}
@@ -113,9 +119,9 @@
   (del Setting :key (name k)))
 
 (defn set-all
-  "Set the value of a `Setting`.
+  "Set the value of several `Settings` at once.
 
-    (set :mandrill-api-key \"xyz123\")"
+    (set-all {:mandrill-api-key \"xyz123\", :another-setting \"ABC\"})"
   [settings]
   {:pre [(map? settings)]}
   (doseq [k (keys settings)]

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -23,7 +23,7 @@
   (let [defaults {:display_name (common/name->human-readable-name (:name table))}]
     (merge defaults table)))
 
-(defn- pre-cascade-delete [{:keys [id] :as table}]
+(defn- pre-cascade-delete [{:keys [id]}]
   (db/cascade-delete Segment :table_id id)
   (db/cascade-delete Metric :table_id id)
   (db/cascade-delete Field :table_id id))

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -7,7 +7,6 @@
                       [core :as t]
                       [format :as f])
             [hiccup.core :refer [html h]]
-            [metabase.models.setting :as setting]
             [metabase.util.urls :as urls])
   (:import (java.awt BasicStroke Color Dimension RenderingHints)
            java.awt.image.BufferedImage
@@ -245,7 +244,7 @@
                    rows)]]))
 
 (defn- render-truncation-warning
-  [card {:keys [cols rows] :as data} rows-limit cols-limit]
+  [card {:keys [cols rows]} rows-limit cols-limit]
   (if (or (> (count rows) rows-limit)
           (> (count cols) cols-limit))
     [:div {:style (style {:padding-top :16px})}
@@ -281,7 +280,7 @@
      (render-truncation-warning card data rows-limit 2)]))
 
 (defn- render:scalar
-  [card {:keys [cols rows] :as data}]
+  [card {:keys [cols rows]}]
   [:div {:style (style scalar-style)}
    (-> rows first first (format-cell (first cols)) h)])
 
@@ -310,11 +309,12 @@
                  (- (last yt) sparkline-dot-radius)
                  (* 2 sparkline-dot-radius)
                  (* 2 sparkline-dot-radius)))
-    (ImageIO/write image "png" os)
+    (when-not (ImageIO/write image "png" os)                    ; returns `true` if successful -- see JavaDoc
+      (throw (Exception. "No approprate image writer found!")))
     (.toByteArray os)))
 
 (defn- render:sparkline
-  [card {:keys [rows cols] :as data}]
+  [card {:keys [rows cols]}]
   (let [xs     (for [row  rows
                      :let [x (first row)]]
                  (if (instance? Date x)
@@ -360,8 +360,7 @@
 (defn- render-image-with-filename [^String filename]
   (*render-img-fn* (IOUtils/toByteArray (io/input-stream (io/resource filename)))))
 
-(defn- render:empty
-  [card {:keys [rows cols] :as data}]
+(defn- render:empty [_ _]
   [:div {:style (style {:text-align :center})}
    [:img {:style (style {:width :104px})
           :src   (render-image-with-filename "frontend_client/app/img/pulse_no_results@2x.png")}]

--- a/src/metabase/sample_data.clj
+++ b/src/metabase/sample_data.clj
@@ -4,13 +4,12 @@
             [clojure.tools.logging :as log]
             (metabase [db :as db]
                       [driver :as driver])
-            (metabase.models [setting :refer [defsetting]]
-                             [database :refer [Database]])
+            [metabase.models.database :refer [Database]]
             [metabase.util :as u]))
 
 
-(def ^:const sample-dataset-name "Sample Dataset")
-(def ^:const sample-dataset-filename "sample-dataset.db.mv.db")
+(def ^:private ^:const sample-dataset-name     "Sample Dataset")
+(def ^:private ^:const sample-dataset-filename "sample-dataset.db.mv.db")
 
 (defn add-sample-dataset! []
   (when-not (db/sel :one Database :is_sample true)

--- a/src/metabase/task/send_pulses.clj
+++ b/src/metabase/task/send_pulses.clj
@@ -1,27 +1,24 @@
 (ns metabase.task.send-pulses
   "Tasks related to running `Pulses`."
   (:require [clojure.tools.logging :as log]
-            [cheshire.core :as json]
             (clojurewerkz.quartzite [jobs :as jobs]
                                     [triggers :as triggers])
             [clojurewerkz.quartzite.schedule.cron :as cron]
-            [clj-time.core :as time]
-            [clj-time.predicates :as timepr]
+            (clj-time [core :as time]
+                      [predicates :as timepr])
             [metabase.api.common :refer [let-404]]
-            [metabase.db :as db]
-            [metabase.driver :as driver]
-            [metabase.email :as email]
+            (metabase [driver :as driver]
+                      [email :as email])
             [metabase.email.messages :as messages]
             [metabase.integrations.slack :as slack]
             (metabase.models [card :refer [Card]]
-                             [hydrate :refer :all]
-                             [pulse :refer [Pulse] :as pulse]
+                             [pulse :refer [Pulse], :as pulse]
                              [pulse-channel :as pulse-channel]
                              [setting :as setting])
-            [metabase.task :as task]
-            [metabase.util :as u]
-            [metabase.util.urls :as urls]
-            [metabase.pulse :as p]))
+            (metabase [pulse :as p]
+                      [task :as task]
+                      [util :as u])
+            [metabase.util.urls :as urls]))
 
 
 (declare send-pulses!)
@@ -77,7 +74,7 @@
                                    (triggers/start-now)
                                    (triggers/with-schedule
                                      ;; run at the top of every hour
-                                     (cron/schedule (cron/cron-schedule "0 0 * * * ? *")))))
+                                     (cron/cron-schedule "0 0 * * * ? *"))))
   ;; submit ourselves to the scheduler
   (task/schedule-task! @send-pulses-job @send-pulses-trigger))
 
@@ -155,11 +152,11 @@
    hour of the day and day of the week according to the defined reporting timezone, or UTC.  We then find all `Pulses`
    that are scheduled to run and send them."
   [hour weekday monthday monthweek]
-  [:pre [(integer? hour)
+  {:pre [(integer? hour)
          (and (< 0 hour) (> 23 hour))
          (pulse-channel/day-of-week? weekday)
          (contains? #{:first :last :mid :other} monthday)
-         (contains? #{:first :last :other} monthweek)]]
+         (contains? #{:first :last :other} monthweek)]}
   (let [channels-by-pulse (group-by :pulse_id (pulse-channel/retrieve-scheduled-channels hour weekday monthday monthweek))]
     (doseq [pulse-id (keys channels-by-pulse)]
       (try

--- a/src/metabase/task/sync_databases.clj
+++ b/src/metabase/task/sync_databases.clj
@@ -3,8 +3,7 @@
             (clojurewerkz.quartzite [jobs :as jobs]
                                     [triggers :as triggers])
             [clojurewerkz.quartzite.schedule.cron :as cron]
-            (metabase [config :as config]
-                      [db :as db]
+            (metabase [db :as db]
                       [driver :as driver]
                       [task :as task])
             [metabase.models.database :refer [Database]]))
@@ -39,6 +38,6 @@
                                    (triggers/start-now)
                                    (triggers/with-schedule
                                      ;; run at midnight daily
-                                     (cron/schedule (cron/cron-schedule "0 0 0 * * ? *")))))
+                                     (cron/cron-schedule "0 0 0 * * ? *"))))
   ;; submit ourselves to the scheduler
   (task/schedule-task! @sync-databases-job @sync-databases-trigger))

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -7,7 +7,7 @@
             [clj-time.core :as t]
             [clj-time.coerce :as coerce]
             [clj-time.format :as time]
-            [colorize.core :as color]
+            colorize.core
             [metabase.config :as config])
   (:import clojure.lang.Keyword
            (java.net Socket
@@ -487,7 +487,7 @@
   [^Throwable e]
   (when e
     (when-let [stacktrace (.getStackTrace e)]
-      (vec (for [frame (.getStackTrace e)
+      (vec (for [frame stacktrace
                  :let  [s (str frame)]
                  :when (re-find #"metabase" s)]
              (s/replace s #"^metabase\." ""))))))

--- a/src/metabase/util/password.clj
+++ b/src/metabase/util/password.clj
@@ -9,7 +9,7 @@
     (count-occurrences \"GoodPw!!\")
       -> {:total  8, :lower 4, :upper 2, :letter 6, :digit 0, :special 2}"
   [password]
-  (loop [[^Character c & more] password, {:keys [total, lower, upper, letter, digit, special], :as counts} {:total 0, :lower 0, :upper 0, :letter 0, :digit 0, :special 0}]
+  (loop [[^Character c & more] password, {:keys [lower, upper, letter, digit, special], :as counts} {:total 0, :lower 0, :upper 0, :letter 0, :digit 0, :special 0}]
     (if-not c counts
       (recur more (merge (update counts :total inc)
                          (cond


### PR DESCRIPTION
Remove some unused namespace :requires and local variable bindings I found by temporarily enabling some experimental Eastwood linters. Unfortunately we can't leave them enabled because they have a few bugs, e.g. issues with false positives 
