### PR TITLE
refactor app mount point to remove flex context by default

### DIFF
--- a/frontend/src/admin/datamodel/components/database/MetadataEditor.jsx
+++ b/frontend/src/admin/datamodel/components/database/MetadataEditor.jsx
@@ -99,7 +99,7 @@ export default class MetadataEditor extends Component {
             );
         }
         return (
-            <div className="MetadataEditor flex flex-column flex-full p3">
+            <div className="MetadataEditor full-height p3">
                 <MetadataHeader
                     ref="header"
                     databaseId={this.props.databaseId}
@@ -108,7 +108,7 @@ export default class MetadataEditor extends Component {
                     isShowingSchema={this.state.isShowingSchema}
                     toggleShowSchema={this.toggleShowSchema}
                 />
-                <div className="MetadataEditor-main flex flex-row flex-full mt2">
+              <div className="MetadataEditor-main flex flex-row flex-full mt2 full-height">
                     <MetadataTablePicker
                         tableId={this.props.tableId}
                         tables={(this.props.databaseMetadata) ? this.props.databaseMetadata.tables : []}

--- a/frontend/src/admin/datamodel/components/database/MetadataHeader.jsx
+++ b/frontend/src/admin/datamodel/components/database/MetadataHeader.jsx
@@ -58,11 +58,11 @@ export default class MetadataHeader extends Component {
 
     render() {
         return (
-            <div className="MetadataEditor-header clearfix">
-                <div className="MetadataEditor-headerSection h2 mb2 float-left">
+            <div className="MetadataEditor-header flex align-center flex-no-shrink">
+                <div className="MetadataEditor-headerSection py2 h2">
                     <span className="text-grey-4">Current database:</span> {this.renderDbSelector()}
                 </div>
-                <div className="MetadataEditor-headerSection float-right flex align-center">
+                <div className="MetadataEditor-headerSection flex flex-align-right align-center flex-no-shrink">
                     <SaveStatus ref="status" />
                     <span className="mr1">Show original schema</span>
                     <Toggle value={this.props.isShowingSchema} onChange={this.props.toggleShowSchema} />

--- a/frontend/src/admin/datamodel/components/database/MetadataSchemaList.jsx
+++ b/frontend/src/admin/datamodel/components/database/MetadataSchemaList.jsx
@@ -32,7 +32,7 @@ export default class MetadataSchemaList extends Component {
 
         let filteredSchemas = searchRegex ? schemas.filter((s) => searchRegex.test(s.name)) : schemas;
         return (
-            <div className="MetadataEditor-table-list AdminList">
+            <div className="MetadataEditor-table-list AdminList flex-no-shrink">
                 <div className="AdminList-search">
                     <Icon name="search" width="16" height="16"/>
                     <input

--- a/frontend/src/admin/datamodel/datamodel.module.js
+++ b/frontend/src/admin/datamodel/datamodel.module.js
@@ -4,7 +4,7 @@ angular
 ])
 .config(['$routeProvider', function ($routeProvider) {
     var metadataRoute = {
-        template: '<div class="flex flex-column flex-full" mb-react-component="MetadataEditor"></div>',
+        template: '<div class="full-height spread" mb-react-component="MetadataEditor"></div>',
         controller: 'MetadataEditor',
         resolve: {
             databases: ['Metabase', function(Metabase) {

--- a/frontend/src/admin/settings/components/SettingsEditor.jsx
+++ b/frontend/src/admin/settings/components/SettingsEditor.jsx
@@ -113,7 +113,7 @@ export default class SettingsEditor extends Component {
         });
 
         return (
-            <div className="MetadataEditor-table-list AdminList">
+            <div className="MetadataEditor-table-list AdminList flex-no-shrink">
                 <ul className="AdminList-items pt1">
                     {sections}
                 </ul>
@@ -123,7 +123,7 @@ export default class SettingsEditor extends Component {
 
     render() {
         return (
-            <div className="MetadataEditor flex flex-column flex-full p4">
+            <div className="MetadataEditor full-height flex flex-column flex-full p4">
                 <SettingsHeader ref="header" />
                 <div className="MetadataEditor-main flex flex-row flex-full mt2">
                     {this.renderSettingsSections()}

--- a/frontend/src/admin/settings/components/SettingsHeader.jsx
+++ b/frontend/src/admin/settings/components/SettingsHeader.jsx
@@ -5,7 +5,7 @@ import SaveStatus from "metabase/components/SaveStatus.jsx";
 export default class SettingsHeader extends Component {
     render() {
         return (
-            <div className="MetadataEditor-header clearfix relative">
+            <div className="MetadataEditor-header clearfix relative flex-no-shrink">
                 <div className="MetadataEditor-headerSection float-left h2 text-grey-4">
                     Settings
                 </div>

--- a/frontend/src/admin/settings/settings.module.js
+++ b/frontend/src/admin/settings/settings.module.js
@@ -5,7 +5,7 @@ var SettingsAdmin = angular.module('metabase.admin.settings', [
 
 SettingsAdmin.config(['$routeProvider', function($routeProvider) {
     $routeProvider.when('/admin/settings/', {
-        template: '<div class="flex flex-column flex-full" mb-react-component="SettingsEditor"></div>',
+        template: '<div mb-react-component="SettingsEditor" class="spread"></div>',
         controller: 'SettingsEditor',
         resolve: {
             settings: ['Settings', async function(Settings) {

--- a/frontend/src/admin/settings/settings.module.js
+++ b/frontend/src/admin/settings/settings.module.js
@@ -5,7 +5,7 @@ var SettingsAdmin = angular.module('metabase.admin.settings', [
 
 SettingsAdmin.config(['$routeProvider', function($routeProvider) {
     $routeProvider.when('/admin/settings/', {
-        template: '<div mb-react-component="SettingsEditor" class="spread"></div>',
+        template: '<div mb-react-component="SettingsEditor" class="full-height"></div>',
         controller: 'SettingsEditor',
         resolve: {
             settings: ['Settings', async function(Settings) {

--- a/frontend/src/card/components/SavedQuestions.jsx
+++ b/frontend/src/card/components/SavedQuestions.jsx
@@ -11,18 +11,18 @@ export default class SavedQuestions extends Component {
 
     render() {
         return (
-            <div className="flex flex-column flex-full">
-                <div className="relative felx flex-column flex-full md-pl4">
-                    <div className="HomeLayout">
-                        <div className="HomeLayout-mainColumn">
-                            <div style={{paddingLeft: "0.75rem"}} className="pt4 h2 text-normal">Saved Questions</div>
+            <div className="full">
+                  <div className="flex">
+                      <div className="wrapper">
+                          <div className="Layout-mainColumn">
+                            <div className="pt4 h2 text-normal">Saved Questions</div>
                             <Cards {...this.props} />
-                        </div>
-                    </div>
-                    <div className="HomeLayout-sidebar">
-                        <CardFilters {...this.props} />
-                    </div>
-                </div>
+                          </div>
+                      </div>
+                      <div className="Layout-sidebar flex-no-shrink">
+                          <CardFilters {...this.props} />
+                      </div>
+                  </div>
             </div>
         );
     }

--- a/frontend/src/css/core/layout.css
+++ b/frontend/src/css/core/layout.css
@@ -23,8 +23,13 @@
     }
 }
 
-/* height */
+/* set height full relative to the parent */
 .full-height {
+  height: 100%;
+}
+
+/* set height to that of the viewport */
+.viewport-height {
   height: 100vh;
 }
 

--- a/frontend/src/css/core/layout.css
+++ b/frontend/src/css/core/layout.css
@@ -80,3 +80,12 @@
         max-width: var(--sm-width);
     }
 }
+
+/* fully fit the parent element - use as a base for app-y pages like QB or settings */
+.spread {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}

--- a/frontend/src/css/home.css
+++ b/frontend/src/css/home.css
@@ -220,6 +220,7 @@
       margin-right: 346px;
   }
   .HomeLayout-sidebar {
+      min-height: 100vh;
       width: 346px;
       background-color: #F9FBFC;
       border-left: 2px solid var(--border-color);

--- a/frontend/src/css/home.css
+++ b/frontend/src/css/home.css
@@ -39,29 +39,6 @@
     }
 }
 
-.HomeTab {
-    background-color: rgba(255, 255, 255, 0.2);
-    border-radius: 4px 4px 0 0;
-    text-decoration: none;
-    padding: 0.55rem 1rem;
-    transition: background .15s linear;
-}
-
-@media screen and (--breakpoint-min-sm) {
-    .HomeTab {
-        padding: 0.65rem 1.35rem;
-    }
-}
-
-.HomeTab:hover {
-    background-color: rgba(255, 255, 255, 0.4);
-    cursor: pointer;
-}
-
-.HomeTab.HomeTab--active {
-    background-color: #fff;
-}
-
 .bullet {
     position: relative;
     margin-left: 1.2em;

--- a/frontend/src/css/home.css
+++ b/frontend/src/css/home.css
@@ -11,15 +11,10 @@
   background-position-y: -15px;
 }
 
-.Main {
-    height: 100%;
-    z-index: 1;
-    position: relative;
-}
-
 .NavItem {
     border-radius: 8px;
 }
+
 .NavItem:hover, .NavItem.NavItem--selected {
     background-color: rgba(255, 255, 255, 0.08);
 }

--- a/frontend/src/css/home.css
+++ b/frontend/src/css/home.css
@@ -12,6 +12,7 @@
 }
 
 .Main {
+    height: 100%;
     z-index: 1;
     position: relative;
 }

--- a/frontend/src/css/home.css
+++ b/frontend/src/css/home.css
@@ -215,21 +215,16 @@
     line-height: 1.4;
 }
 
-@media screen and (--breakpoint-min-md) {
-  .HomeLayout {
-      margin-right: 346px;
-  }
-  .HomeLayout-sidebar {
-      min-height: 100vh;
-      width: 346px;
-      background-color: #F9FBFC;
-      border-left: 2px solid var(--border-color);
-  }
-  .HomeLayout-mainColumn {
-      max-width: 700px;
-      margin-left: auto;
-      margin-right: auto;
-  }
+.Layout-sidebar {
+  min-height: 100vh;
+  width: 346px;
+  background-color: #F9FBFC;
+  border-left: 2px solid var(--border-color);
+}
+.Layout-mainColumn {
+  max-width: 700px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .Sidebar-header {

--- a/frontend/src/css/home.css
+++ b/frontend/src/css/home.css
@@ -220,10 +220,6 @@
       margin-right: 346px;
   }
   .HomeLayout-sidebar {
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      right: 0;
       width: 346px;
       background-color: #F9FBFC;
       border-left: 2px solid var(--border-color);

--- a/frontend/src/css/query_builder.css
+++ b/frontend/src/css/query_builder.css
@@ -8,6 +8,7 @@
 
 #react_qb_viz {
     z-index: 1;
+    flex-grow: 1;
 }
 
 /* @layout */

--- a/frontend/src/css/query_builder.css
+++ b/frontend/src/css/query_builder.css
@@ -2,12 +2,7 @@
     --selection-color: #ccdff6;
 }
 
-#react_qb_editor {
-    z-index: 2;
-}
-
 #react_qb_viz {
-    z-index: 1;
     flex-grow: 1;
 }
 

--- a/frontend/src/dashboard/components/AddSeriesModal.jsx
+++ b/frontend/src/dashboard/components/AddSeriesModal.jsx
@@ -205,19 +205,19 @@ export default class AddSeriesModal extends Component {
         })).filter(s => !!s.data);
 
         return (
-            <div className="absolute top left bottom right flex">
+            <div className="spread flex">
                 <div className="flex flex-column flex-full">
                     <div className="flex-no-shrink h3 pl4 pt4 pb1 text-bold">Edit data</div>
                     <div className="flex-full mx1 relative">
                         <Visualization
-                            className="absolute top left bottom right"
+                            className="spread"
                             series={series}
                             isDashboard={true}
                             isMultiseries={true}
                             onRemoveSeries={this.onRemoveSeries}
                         />
                         { this.state.state &&
-                            <div className="absolute top left bottom right flex layout-centered" style={{ backgroundColor: "rgba(255,255,255,0.80)" }}>
+                            <div className="spred flex layout-centered" style={{ backgroundColor: "rgba(255,255,255,0.80)" }}>
                                 { this.state.state === "loading" ?
                                     <div className="h3 rounded bordered p3 bg-white shadowed">Applying Question</div>
                                 : this.state.state === "incompatible" ?

--- a/frontend/src/dashboard/components/Dashboard.jsx
+++ b/frontend/src/dashboard/components/Dashboard.jsx
@@ -63,7 +63,7 @@ export default class Dashboard extends Component {
         let { dashboard } = this.props;
         let { error } = this.state;
         return (
-            <LoadingAndErrorWrapper className="Dashboard full-height" loading={!dashboard} error={error}>
+            <LoadingAndErrorWrapper className="Dashboard viewport-height" loading={!dashboard} error={error}>
             {() =>
                 <div className="full" style={{ overflowX: "hidden" }}>
                     <header className="bg-white border-bottom relative z2">

--- a/frontend/src/home/components/Homepage.jsx
+++ b/frontend/src/home/components/Homepage.jsx
@@ -64,12 +64,12 @@ export default class Homepage extends Component {
                 </div>
                 <div className="flex">
                     <div className="wrapper">
-                        <div className="HomeLayout-mainColumn pl2">
+                        <div className="Layout-mainColumn pl2">
                           <div className="pt4 h2 text-normal ml2">Activity</div>
                           <Activity {...this.props} />
                         </div>
                     </div>
-                    <div className="HomeLayout-sidebar flex-no-shrink">
+                    <div className="Layout-sidebar flex-no-shrink">
                       <RecentViews {...this.props} />
                     </div>
                 </div>

--- a/frontend/src/home/components/Homepage.jsx
+++ b/frontend/src/home/components/Homepage.jsx
@@ -9,6 +9,16 @@ import Smile from './Smile.jsx';
 import NewUserOnboardingModal from './NewUserOnboardingModal.jsx';
 
 export default class Homepage extends Component {
+
+    static propTypes = {
+        onChangeLocation: PropTypes.func.isRequired,
+        showOnboarding: PropTypes.bool.isRequired,
+        user: PropTypes.object.isRequired,
+        activity: PropTypes.array,
+        fetchActivity: PropTypes.func.isRequired,
+        fetchRecentViews: PropTypes.func.isRequired
+    };
+
     constructor(props, context) {
         super(props, context);
 
@@ -24,19 +34,8 @@ export default class Homepage extends Component {
         };
     }
 
-    static propTypes = {
-        onChangeLocation: PropTypes.func.isRequired,
-        showOnboarding: PropTypes.bool.isRequired,
-        user: PropTypes.object.isRequired,
-        activity: PropTypes.array,
-        fetchActivity: PropTypes.func.isRequired,
-        fetchRecentViews: PropTypes.func.isRequired
-    };
-
     completeOnboarding() {
-        this.setState({
-            onboarding: false
-        });
+        this.setState({ onboarding: false });
     }
 
     render() {
@@ -46,18 +45,19 @@ export default class Homepage extends Component {
             <div className="full">
                 { this.state.onboarding ?
                     <Modal>
-                        <NewUserOnboardingModal user={user} closeFn={() => (this.completeOnboarding())}></NewUserOnboardingModal>
+                        <NewUserOnboardingModal
+                            user={user}
+                            closeFn={() => (this.completeOnboarding())}
+                        />
                     </Modal>
-                : null}
+                : null }
 
                 <div className="CheckBg bg-brand text-white md-pl4">
-                    <div className="HomeLayout">
-                        <div className="HomeLayout-mainColumn">
+                    <div style={{marginRight: 346}}>
+                        <div className="Layout-mainColumn">
                             <header style={this.styles.headerGreeting} className="flex align-center pb4 pt1">
-                                <span className="float-left mr1">
-                                    <Smile />
-                                </span>
-                                <span>{this.state.greeting}</span>
+                                <Smile />
+                                <div className="ml2">{this.state.greeting}</div>
                             </header>
                         </div>
                     </div>

--- a/frontend/src/home/components/Homepage.jsx
+++ b/frontend/src/home/components/Homepage.jsx
@@ -43,7 +43,7 @@ export default class Homepage extends Component {
         const { user } = this.props;
 
         return (
-            <div className="flex flex-column flex-full">
+            <div className="flex full-height flex-column flex-full">
                 { this.state.onboarding ?
                     <Modal>
                         <NewUserOnboardingModal user={user} closeFn={() => (this.completeOnboarding())}></NewUserOnboardingModal>
@@ -62,7 +62,7 @@ export default class Homepage extends Component {
                         </div>
                     </div>
                 </div>
-                <div className="relative felx flex-column flex-full md-pl4">
+                <div className="relative full-height flex flex-column flex-full md-pl4">
                     <div className="HomeLayout">
                         <div className="HomeLayout-mainColumn">
                             <div style={{paddingLeft: "0.75rem"}} className="pt4 h2 text-normal">Activity</div>

--- a/frontend/src/home/components/Homepage.jsx
+++ b/frontend/src/home/components/Homepage.jsx
@@ -43,7 +43,7 @@ export default class Homepage extends Component {
         const { user } = this.props;
 
         return (
-            <div className="flex full-height flex-column flex-full">
+            <div className="full">
                 { this.state.onboarding ?
                     <Modal>
                         <NewUserOnboardingModal user={user} closeFn={() => (this.completeOnboarding())}></NewUserOnboardingModal>
@@ -62,15 +62,15 @@ export default class Homepage extends Component {
                         </div>
                     </div>
                 </div>
-                <div className="relative full-height flex flex-column flex-full md-pl4">
-                    <div className="HomeLayout">
-                        <div className="HomeLayout-mainColumn">
-                            <div style={{paddingLeft: "0.75rem"}} className="pt4 h2 text-normal">Activity</div>
-                            <Activity {...this.props} />
+                <div className="flex">
+                    <div className="wrapper">
+                        <div className="HomeLayout-mainColumn pl2">
+                          <div className="pt4 h2 text-normal ml2">Activity</div>
+                          <Activity {...this.props} />
                         </div>
                     </div>
-                    <div className="HomeLayout-sidebar">
-                        <RecentViews {...this.props} />
+                    <div className="HomeLayout-sidebar flex-no-shrink">
+                      <RecentViews {...this.props} />
                     </div>
                 </div>
             </div>

--- a/frontend/src/home/home.module.js
+++ b/frontend/src/home/home.module.js
@@ -4,7 +4,7 @@ var Home = angular.module('metabase.home', [
 
 Home.config(['$routeProvider', function($routeProvider) {
     $routeProvider.when('/', {
-        template:   '<div mb-redux-component class="flex flex-column flex-full" />',
+        template:   '<div mb-redux-component class="full-height" />',
         controller: 'Homepage',
         resolve: {
             appState: ["AppState", function(AppState) {

--- a/frontend/src/query_builder/QueryVisualization.jsx
+++ b/frontend/src/query_builder/QueryVisualization.jsx
@@ -218,7 +218,7 @@ export default class QueryVisualization extends Component {
 
         if(this.props.isRunning) {
             loading = (
-                <div className="Loading absolute top left bottom right flex flex-column layout-centered text-brand z2">
+                <div className="Loading spread flex flex-column layout-centered text-brand z2">
                     <LoadingSpinner />
                     <h2 className="Loading-message text-brand text-uppercase mt3">Doing science...</h2>
                 </div>

--- a/frontend/src/setup/components/Setup.jsx
+++ b/frontend/src/setup/components/Setup.jsx
@@ -45,7 +45,7 @@ export default class Setup extends Component {
 
         if (activeStep === WELCOME_STEP_NUMBER) {
             return (
-                <div className="relative flex flex-full layout-centered">
+                <div className="relative full-height flex flex-full layout-centered">
                     <div className="wrapper wrapper--trim text-centered">
                         <LogoIcon className="text-brand mb4" width={89} height={118}></LogoIcon>
                         <div className="relative z2 text-centered ml-auto mr-auto" style={{maxWidth: 550}}>

--- a/frontend/src/setup/setup.module.js
+++ b/frontend/src/setup/setup.module.js
@@ -3,7 +3,7 @@ var Setup = angular.module('metabase.setup', ['metabase.setup.controllers']);
 Setup.config(['$routeProvider', function($routeProvider) {
 
     $routeProvider.when('/setup/', {
-        template: '<div mb-redux-component class="flex flex-column flex-full" />',
+        template: '<div mb-redux-component class="full-height" />',
         controller: 'SetupController',
         resolve: {
             appState: ["AppState", function(AppState) {

--- a/resources/frontend_client/app/auth/partials/forgot_password.html
+++ b/resources/frontend_client/app/auth/partials/forgot_password.html
@@ -1,4 +1,4 @@
-<div class="bg-white flex flex-column  flex-full md-layout-centered">
+<div class="full-height bg-white flex flex-column flex-full md-layout-centered">
     <div class="wrapper">
         <div class="Login-wrapper Grid Grid--full md-Grid--1of2">
             <div class="Grid-cell flex layout-centered text-brand">

--- a/resources/frontend_client/app/auth/partials/login.html
+++ b/resources/frontend_client/app/auth/partials/login.html
@@ -1,4 +1,4 @@
-<div class="bg-white flex flex-full flex-column md-layout-centered">
+<div class="full-height bg-white flex flex-column flex-full md-layout-centered">
     <div class="wrapper">
         <div class="Login-wrapper Grid Grid--full md-Grid--1of2">
             <div class="Grid-cell flex layout-centered text-brand">

--- a/resources/frontend_client/app/auth/partials/password_reset.html
+++ b/resources/frontend_client/app/auth/partials/password_reset.html
@@ -1,4 +1,4 @@
-<div class="bg-white flex flex-column flex-full layout-centered">
+<div class="full-height bg-white flex flex-column flex-full md-layout-centered">
     <div class="wrapper">
         <div class="Login-wrapper Grid  Grid--full md-Grid--1of2">
             <div class="Grid-cell flex layout-centered text-brand">

--- a/resources/frontend_client/app/auth/partials/password_reset_token_expired.html
+++ b/resources/frontend_client/app/auth/partials/password_reset_token_expired.html
@@ -1,4 +1,4 @@
-<div class="bg-white flex flex-column flex-full layout-centered">
+<div class="full-height bg-white flex flex-column flex-full md-layout-centered">
     <div class="wrapper">
         <div class="Login-wrapper Grid  Grid--full md-Grid--1of2">
             <div class="Grid-cell flex layout-centered text-brand">

--- a/resources/frontend_client/app/card/partials/card_detail.html
+++ b/resources/frontend_client/app/card/partials/card_detail.html
@@ -1,4 +1,4 @@
-<div class="QueryBuilder flex flex-column bg-white absolute top left bottom right" ng-class="{ 'QueryBuilder--showDataReference': isShowingDataReference }">
+<div class="QueryBuilder flex flex-column bg-white spread" ng-class="{ 'QueryBuilder--showDataReference': isShowingDataReference }">
     <div id="react_qb_header"></div>
     <div id="react_qb_editor" class="z2"></div>
     <div id="react_qb_viz" class="flex z1"></div>

--- a/resources/frontend_client/app/card/partials/card_detail.html
+++ b/resources/frontend_client/app/card/partials/card_detail.html
@@ -1,7 +1,7 @@
 <div class="QueryBuilder flex flex-column bg-white absolute top left bottom right" ng-class="{ 'QueryBuilder--showDataReference': isShowingDataReference }">
     <div id="react_qb_header"></div>
-    <div id="react_qb_editor"></div>
-    <div id="react_qb_viz" class="flex"></div>
+    <div id="react_qb_editor" class="z2"></div>
+    <div id="react_qb_viz" class="flex z1"></div>
 </div>
 <div class="DataReference" id="react_data_reference"></div>
 <div id="react_qb_tutorial"></div>

--- a/resources/frontend_client/app/card/partials/card_detail.html
+++ b/resources/frontend_client/app/card/partials/card_detail.html
@@ -1,8 +1,8 @@
-<div class="QueryBuilder flex flex-column flex-full bg-white" ng-class="{ 'QueryBuilder--showDataReference': isShowingDataReference }">
+<div class="QueryBuilder flex flex-column bg-white absolute top left bottom right" ng-class="{ 'QueryBuilder--showDataReference': isShowingDataReference }">
     <div id="react_qb_header"></div>
     <div id="react_qb_editor"></div>
-    <div id="react_qb_viz" class="flex flex-full"></div>
+    <div id="react_qb_viz" class="flex"></div>
 </div>
-<div class="DataReference flex flex-full" id="react_data_reference"></div>
+<div class="DataReference" id="react_data_reference"></div>
 <div id="react_qb_tutorial"></div>
 <div id="react_qbnewb_modal"></div>

--- a/resources/frontend_client/app/not_found.html
+++ b/resources/frontend_client/app/not_found.html
@@ -1,4 +1,4 @@
-<div class="layout-centered flex full-height">
+<div class="layout-centered flex viewport-height">
     <div class="p4 text-bold">
         <h1 class="text-brand text-light mb3">We're a little lost...</h1>
         <p class="h4 mb1">The page you asked for couldn't be found.</p>

--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -15,8 +15,7 @@
 
     <body ng-controller="Metabase">
         <div class="Nav" ng-controller="Nav" mb-react-component="Navbar"></div>
-
-        <main class="Main flex flex-column flex-full" ng-view></main>
+        <main class="Main" ng-view></main>
     </body>
 
     <script type="text/javascript">

--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -15,7 +15,7 @@
 
     <body ng-controller="Metabase">
         <div class="Nav" ng-controller="Nav" mb-react-component="Navbar"></div>
-        <main class="Main" ng-view></main>
+        <main class="relative full-height z1" ng-view></main>
     </body>
 
     <script type="text/javascript">


### PR DESCRIPTION
setting a global display context of flex seems a bit aggro for an app as big as metabase. this PR removes that context by default and is also meant to clean up and refactor any views that may have relied on this context to set their own context. context. context. context.
#### views needing refactor after removing the context
- [x] query builder
- [x] object detail 
- [x] logged out auth
- [x] admin panel views with sidebar elements
- [x] setup flow?
