### PR TITLE
make contract between icon border and icon explicit

### DIFF
--- a/frontend/src/components/Icon.jsx
+++ b/frontend/src/components/Icon.jsx
@@ -8,13 +8,13 @@ import { loadIcon } from 'metabase/icon_paths';
 export default class Icon extends Component {
     static propTypes = {
       name: PropTypes.string.isRequired,
-      width: React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.number,
+      width: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number,
       ]),
-      height: React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.number,
+      height: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number,
       ]),
     }
 

--- a/frontend/src/components/Icon.jsx
+++ b/frontend/src/components/Icon.jsx
@@ -1,12 +1,28 @@
 /*eslint-disable react/no-danger */
 
 import React, { Component, PropTypes } from "react";
-
 import RetinaImage from "react-retina-image";
 
 import { loadIcon } from 'metabase/icon_paths';
 
 export default class Icon extends Component {
+    static propTypes = {
+      name: PropTypes.string.isRequired,
+      width: React.PropTypes.oneOfType([
+        React.PropTypes.string,
+        React.PropTypes.number,
+      ]),
+      height: React.PropTypes.oneOfType([
+        React.PropTypes.string,
+        React.PropTypes.number,
+      ]),
+    }
+
+    static defaultProps = {
+      width: 16,
+      height: 16
+    }
+
     render() {
         var icon = loadIcon(this.props.name);
         if (icon.img) {

--- a/frontend/src/components/IconBorder.jsx
+++ b/frontend/src/components/IconBorder.jsx
@@ -1,7 +1,6 @@
 import React, { Component, PropTypes } from "react";
-import ReactDOM from "react-dom";
-
 import cx from "classnames";
+import Icon from 'metabase/components/Icon.jsx'
 
 /*
 Creates a bordered container for an <Icon /> component
@@ -14,12 +13,6 @@ usage:
 */
 
 export default class IconBorder extends Component {
-    constructor(props, context) {
-        super(props, context);
-        this.state = {
-            childWidth: 0
-        };
-    }
 
     static propTypes = {
         borderWidth: PropTypes.string,
@@ -27,6 +20,7 @@ export default class IconBorder extends Component {
         borderColor: PropTypes.string,
         borderRadius: PropTypes.string,
         style: PropTypes.object,
+        children: PropTypes.instanceOf(Icon)
     };
 
     static defaultProps = {
@@ -37,30 +31,23 @@ export default class IconBorder extends Component {
         style: {},
     };
 
-    componentDidMount() {
-        this.setState({
-            childWidth: ReactDOM.findDOMNode(this.refs.child).offsetWidth
-        });
-    }
-
     render() {
         const { borderWidth, borderStyle, borderColor, borderRadius, className, style, children } = this.props;
-        const width = this.state.childWidth;
+        const size = parseInt(children.props.width, 10) * 2
         const styles = {
-            width: width * 2,
-            height: width * 2,
+            width: size,
+            height: size,
             borderWidth: borderWidth,
             borderStyle: borderStyle,
             borderColor: borderColor,
             borderRadius: borderRadius,
-            lineHeight: '1px', /* HACK this is dumb but it centers the icon in the border */
             ...style
         }
 
         return (
-            <span className={cx("flex layout-centered", className)} style={styles}>
-                <span ref="child">{children}</span>
-            </span>
+            <div className={cx('flex layout-centered', className)} style={styles}>
+              {children}
+            </div>
         );
     }
 }


### PR DESCRIPTION
resolves #2092 

In certain instances the icon border component wasn't always able to properly get the width of the child component via refs.

Since an `<IconBorder />` component should only ever accept an `<Icon />` component and an `<Icon />` component should always have a width and a height as props, we can use those values to calculate the border rather than using refs and component lifecycle to get the offsetHeight in the DOM after rendering. This makes width and height reliable values and allows us to use flexbox and layout-centered to center the icon in the space as before. 

In order to make all of this copacetic, we set default props and explicit PropTypes for both Icon and IconBorder
