### PR TITLE
Cleanup deprecated React APIs / enforce more lint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,10 +31,10 @@
         "no-case-declarations": 0,
         "react/no-is-mounted": 2,
         "react/prefer-es6-class": 2,
+        "react/display-name": 1,
         "react/prop-types": 0,
         "react/no-did-mount-set-state": 0,
-        "react/no-did-update-set-state": 0,
-        "react/display-name": 0
+        "react/no-did-update-set-state": 0
     },
     "globals": {
         "angular": false

--- a/.eslintrc
+++ b/.eslintrc
@@ -30,7 +30,7 @@
         "no-fallthrough": 0,
         "no-case-declarations": 0,
         "react/prop-types": 0,
-        "react/no-is-mounted": 0,
+        "react/no-is-mounted": 2,
         "react/no-did-mount-set-state": 0,
         "react/no-did-update-set-state": 0,
         "react/display-name": 0

--- a/.eslintrc
+++ b/.eslintrc
@@ -29,8 +29,9 @@
         "new-cap": 0,
         "no-fallthrough": 0,
         "no-case-declarations": 0,
-        "react/prop-types": 0,
         "react/no-is-mounted": 2,
+        "react/prefer-es6-class": 2,
+        "react/prop-types": 0,
         "react/no-did-mount-set-state": 0,
         "react/no-did-update-set-state": 0,
         "react/display-name": 0

--- a/frontend/src/components/ActionButton.jsx
+++ b/frontend/src/components/ActionButton.jsx
@@ -2,42 +2,49 @@ import React, { Component, PropTypes } from "react";
 
 import Icon from "metabase/components/Icon.jsx";
 
+import { cancelable } from "metabase/lib/promise";
+
 import cx from "classnames";
+import _ from "underscore";
 
-export default React.createClass({
-    displayName: 'ActionButton',
-    propTypes: {
-        actionFn: PropTypes.func.isRequired
-    },
+export default class ActionButton extends Component {
+    constructor(props, context) {
+        super(props, context);
 
-    getDefaultProps: function() {
-        return {
-            normalText: "Save",
-            activeText: "Saving...",
-            failedText: "Save failed",
-            successText: "Saved",
-            className: 'Button'
-        };
-    },
-
-    getInitialState: function () {
-        return {
+        this.state = {
             active: false,
             result: null
         };
-    },
 
-    componentWillUnmount: function() {
+        _.bindAll(this, "onClick", "resetStateOnTimeout")
+    }
+
+    static propTypes = {
+        actionFn: PropTypes.func.isRequired
+    };
+
+    static defaultProps = {
+        className: "Button",
+        normalText: "Save",
+        activeText: "Saving...",
+        failedText: "Save failed",
+        successText: "Saved"
+    };
+
+    componentWillUnmount() {
         clearTimeout(this.timeout);
-    },
+        if (this.actionPromise) {
+            this.actionPromise.cancel();
+        }
+    }
 
-    resetStateOnTimeout: function() {
+    resetStateOnTimeout() {
         // clear any previously set timeouts then start a new one
         clearTimeout(this.timeout);
         this.timeout = setTimeout(() => this.replaceState(this.getInitialState()), 5000);
-    },
+    }
 
-    onClick: function(event) {
+    onClick(event) {
         event.preventDefault();
 
         // set state to active
@@ -47,51 +54,45 @@ export default React.createClass({
         });
 
         // run the function we want bound to this button
-        var component = this;
-        this.props.actionFn().then(function(success) {
-            component.setState({
+        this.actionPromise = cancelable(this.props.actionFn());
+        this.actionPromise.then((success) => {
+            this.setState({
                 active: false,
                 result: "success"
-            }, component.resetStateOnTimeout);
-        }, function(error) {
-            component.setState({
-                active: false,
-                result: "failed"
-            }, component.resetStateOnTimeout);
+            }, this.resetStateOnTimeout);
+        }, (error) => {
+            if (!error.isCanceled) {
+                this.setState({
+                    active: false,
+                    result: "failed"
+                }, this.resetStateOnTimeout);
+            }
         });
+    }
 
-        // TODO: timeout on success/failed state to reset back to normal state
-    },
-
-    buttonContent: function() {
-        if (this.state.active) {
-            // TODO: loading spinner
-            return this.props.activeText;
-        } else if (this.state.result === "success") {
-            return (
-                <span>
-                    <Icon name='check' width="12px" height="12px" />
-                    <span className="ml1">{this.props.successText}</span>
-                </span>
-            );
-        } else if (this.state.result === "failed") {
-            return this.props.failedText;
-        } else {
-            return this.props.normalText;
-        }
-    },
-
-    render: function() {
-        var buttonStateClasses = cx({
+    render() {
+        var buttonStateClasses = cx(this.props.className, {
             'Button--waiting': this.state.active,
             'Button--success': this.state.result === 'success',
             'Button--danger': this.state.result === 'failed'
         });
 
         return (
-            <button className={this.props.className + ' ' + buttonStateClasses} onClick={this.onClick}>
-                {this.buttonContent()}
+            <button className={buttonStateClasses} onClick={this.onClick}>
+                { this.state.active ?
+                    // TODO: loading spinner
+                    this.props.activeText
+                : this.state.result === "success" ?
+                    <span>
+                        <Icon name='check' width="12px" height="12px" />
+                        <span className="ml1">{this.props.successText}</span>
+                    </span>
+                : this.state.result === "failed" ?
+                    this.props.failedText
+                :
+                    this.props.normalText
+                }
             </button>
         );
     }
-});
+}

--- a/frontend/src/components/ActionButton.jsx
+++ b/frontend/src/components/ActionButton.jsx
@@ -27,16 +27,14 @@ export default React.createClass({
         };
     },
 
+    componentWillUnmount: function() {
+        clearTimeout(this.timeout);
+    },
+
     resetStateOnTimeout: function() {
         // clear any previously set timeouts then start a new one
         clearTimeout(this.timeout);
-
-        var component = this;
-        this.timeout = setTimeout(function() {
-            if (component.isMounted()) {
-                component.replaceState(component.getInitialState());
-            }
-        }.bind(this), 5000);
+        this.timeout = setTimeout(() => this.replaceState(this.getInitialState()), 5000);
     },
 
     onClick: function(event) {

--- a/frontend/src/components/BodyComponent.jsx
+++ b/frontend/src/components/BodyComponent.jsx
@@ -2,6 +2,8 @@ import React, { Component, PropTypes } from "react";
 import ReactDOM from "react-dom";
 
 export default ComposedComponent => class extends Component {
+    static displayName = "BodyComponent["+(ComposedComponent.displayName || ComposedComponent.name)+"]";
+
     componentWillMount() {
         this._element = document.createElement('div');
         document.body.appendChild(this._element);

--- a/frontend/src/components/ExplicitSize.jsx
+++ b/frontend/src/components/ExplicitSize.jsx
@@ -2,6 +2,8 @@ import React, { Component, PropTypes } from "react";
 import ReactDOM from "react-dom";
 
 export default ComposedComponent => class extends Component {
+    static displayName = "ExplicitSize["+(ComposedComponent.displayName || ComposedComponent.name)+"]";
+
     constructor(props, context) {
         super(props, context);
         this.state = {

--- a/frontend/src/components/HistoryModal.jsx
+++ b/frontend/src/components/HistoryModal.jsx
@@ -59,7 +59,6 @@ export default class HistoryModal extends Component {
     }
 
     revisionDescription(revision) {
-        console.log(revision);
         if (revision.is_creation) {
             return "First revision.";
         } else if (revision.is_reversion) {

--- a/frontend/src/components/Triggerable.jsx
+++ b/frontend/src/components/Triggerable.jsx
@@ -6,6 +6,8 @@ import cx from "classnames";
 // higher order component that takes a component which takes props "isOpen" and optionally "onClose"
 // and returns a component that renders a <a> element "trigger", and tracks whether that component is open or not
 export default ComposedComponent => class extends Component {
+    static displayName = "Triggerable["+(ComposedComponent.displayName || ComposedComponent.name)+"]";
+
     constructor(props, context) {
         super(props, context);
         this.state = {

--- a/frontend/src/dashboard/actions.js
+++ b/frontend/src/dashboard/actions.js
@@ -6,6 +6,7 @@ import { normalize, Schema, arrayOf } from "normalizr";
 
 import moment from "moment";
 import { augmentDatabase } from "metabase/lib/table";
+import { timeout } from "metabase/lib/promise";
 
 import MetabaseAnalytics from "metabase/lib/analytics";
 import { getPositionForNewDashCard } from "metabase/lib/dashboard_grid";
@@ -187,18 +188,3 @@ export const fetchDatabaseMetadata = createThunkAction(FETCH_DATABASE_METADATA, 
         return databaseMetadata;
     };
 });
-
-// promise helpers
-
-// if a promise doesn't resolve/reject within a given duration it will reject
-function timeout(promise, duration, error) {
-    return new Promise((resolve, reject) => {
-        promise.then(resolve, reject);
-        setTimeout(() => reject(error || new Error("Operation timed out")), duration);
-    });
-}
-
-// returns a promise that resolves after a given duration
-// function delay(duration) {
-//     return new Promise((resolve, reject) => setTimeout(resolve, duration));
-// }

--- a/frontend/src/lib/promise.js
+++ b/frontend/src/lib/promise.js
@@ -1,0 +1,30 @@
+// return a promise wrapping the provided one but with a "cancel" method
+export function cancelable(promise) {
+    let canceled = false;
+
+    const wrappedPromise = new Promise((resolve, reject) => {
+        promise.then(
+            (value) => canceled ? reject({ isCanceled: true }) : resolve(value),
+            (error) => canceled ? reject({ isCanceled: true }) : reject(error)
+        );
+    });
+
+    wrappedPromise.cancel = function() {
+        canceled = true;
+    };
+
+    return wrappedPromise;
+}
+
+// if a promise doesn't resolve/reject within a given duration it will reject
+export function timeout(promise, duration, error) {
+    return new Promise((resolve, reject) => {
+        promise.then(resolve, reject);
+        setTimeout(() => reject(error || new Error("Operation timed out")), duration);
+    });
+}
+
+// returns a promise that resolves after a given duration
+export function delay(duration) {
+    return new Promise((resolve, reject) => setTimeout(resolve, duration));
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,7 +38,7 @@ console.log("webpack env:", NODE_ENV)
 
 // Babel:
 var BABEL_CONFIG = {
-    cacheDirectory: true,
+    cacheDirectory: ".babel_cache",
     plugins: ['transform-decorators-legacy' ],
     presets: ['es2015', 'stage-0', 'react']
 };


### PR DESCRIPTION
- no more `React.createClass`, use ES6 classes
- no more `this.isMounted`, instead you should cancel async actions in `componentWillUnmount` using `cancelable` promise wrapper and `clearTimeout`/`clearInterval` etc. (https://facebook.github.io/react/blog/2015/12/16/ismounted-antipattern.html)
- require `displayName` on React components (including higher order components)
