### PR TITLE
Field visibility type

### DIFF
--- a/frontend/src/admin/datamodel/components/database/ColumnItem.jsx
+++ b/frontend/src/admin/datamodel/components/database/ColumnItem.jsx
@@ -12,7 +12,6 @@ import _  from "underscore";
 export default class Column extends Component {
     constructor(props, context) {
         super(props, context);
-        this.isVisibilityType = this.isVisibilityType.bind(this);
         this.onDescriptionChange = this.onDescriptionChange.bind(this);
         this.onNameChange = this.onNameChange.bind(this);
         this.onSpecialTypeChange = this.onSpecialTypeChange.bind(this);
@@ -28,16 +27,6 @@ export default class Column extends Component {
         updateFieldSpecialType: PropTypes.func.isRequired,
         updateFieldTarget: PropTypes.func.isRequired
     };
-
-    isVisibilityType(visibility) {
-        switch(visibility.id) {
-            case "do_not_include": return (this.props.field.field_type === "sensitive");
-            case "everywhere": return (this.props.field.field_type !== "sensitive" && this.props.field.preview_display === true);
-            case "detail_views": return (this.props.field.field_type !== "sensitive" && this.props.field.preview_display === false);
-        }
-
-        return false;
-    }
 
     updateProperty(name, value) {
         this.props.field[name] = value;
@@ -57,24 +46,8 @@ export default class Column extends Component {
         this.updateProperty("description", event.target.value);
     }
 
-    onVisibilityChange(visibility) {
-        switch(visibility.id) {
-            case "do_not_include":
-                this.updateProperty("field_type", "sensitive");
-                return;
-            case "everywhere":
-                if (this.props.field.field_type === "sensitive") {
-                    this.props.field.field_type = "info";
-                }
-                this.updateProperty("preview_display", true);
-                return;
-            case "detail_views":
-                if (this.props.field.field_type === "sensitive") {
-                    this.props.field.field_type = "info";
-                }
-                this.updateProperty("preview_display", false);
-                return;
-        }
+    onVisibilityChange(type) {
+        this.updateProperty("visibility_type", type.id);
     }
 
     onTypeChange(type) {
@@ -123,7 +96,7 @@ export default class Column extends Component {
                                 <Select
                                     className="TableEditor-field-visibility block"
                                     placeholder="Select a field visibility"
-                                    value={_.find(MetabaseCore.field_visibility_types, this.isVisibilityType)}
+                                    value={_.find(MetabaseCore.field_visibility_types, (type) => type.id === this.props.field.visibility_type)}
                                     options={MetabaseCore.field_visibility_types}
                                     onChange={this.onVisibilityChange}
                                 />

--- a/frontend/src/card/card.controllers.js
+++ b/frontend/src/card/card.controllers.js
@@ -476,7 +476,7 @@ CardControllers.controller('CardDetail', [
                 } else {
                     isObjectDetail = false;
 
-                    // if we are display bare rows, filter out columns with preview_display = false
+                    // if we are display bare rows, filter out columns with visibility_type = details-only
                     if (Query.isStructured(dataset_query) &&
                             Query.isBareRowsAggregation(dataset_query.query)) {
                         queryResult.data = DataGrid.filterOnPreviewDisplay(queryResult.data);

--- a/frontend/src/lib/core.js
+++ b/frontend/src/lib/core.js
@@ -98,22 +98,18 @@ export const field_field_types = [{
     'id': 'dimension',
     'name': 'Dimension',
     'description': 'A high or low-cardinality numerical string value that is meant to be used as a grouping.'
-}, {
-    'id': 'sensitive',
-    'name': 'Sensitive Information',
-    'description': 'A field that should never be shown anywhere.'
 }];
 
 export const field_visibility_types = [{
-    'id': 'everywhere',
+    'id': 'normal',
     'name': 'Everywhere',
     'description': 'The default setting.  This field will be displayed normally in tables and charts.'
 }, {
-    'id': 'detail_views',
+    'id': 'details-only',
     'name': 'Only in Detail Views',
     'description': "This field will only be displayed when viewing the details of a single record. Use this for information that's lengthy or that isn't useful in a table or chart."
 }, {
-    'id': 'do_not_include',
+    'id': 'sensitive',
     'name': 'Do Not Include',
     'description': 'Metabase will never retrieve this field. Use this for sensitive or irrelevant information.'
 }];

--- a/frontend/src/lib/data_grid.js
+++ b/frontend/src/lib/data_grid.js
@@ -9,8 +9,8 @@ function compareNumbers(a, b) {
 
 var DataGrid = {
     filterOnPreviewDisplay: function(data) {
-        // find any columns where preview_display = false
-        var hiddenColumnIdxs = _.map(data.cols, function(col, idx) { if(!col.preview_display) return idx; });
+        // find any columns where visibility_type = details-only
+        var hiddenColumnIdxs = _.map(data.cols, function(col, idx) { if(col.visibility_type === "details-only") return idx; });
         hiddenColumnIdxs = _.filter(hiddenColumnIdxs, function(val) { return val !== undefined; });
 
         // filter out our data grid using the indexes of the hidden columns
@@ -25,7 +25,7 @@ var DataGrid = {
         });
 
         return {
-            cols: _.filter(data.cols, function(col) { return col.preview_display; }),
+            cols: _.filter(data.cols, function(col) { return col.visibility_type !== "details-only"; }),
             columns: _.map(data.cols, function(col) { return col.display_name; }),
             rows: filteredRows,
             rows_truncated: data.rows_truncated

--- a/resources/migrations/030_add_field_visibility_type.yaml
+++ b/resources/migrations/030_add_field_visibility_type.yaml
@@ -1,0 +1,16 @@
+databaseChangeLog:
+  - changeSet:
+      id: 30
+      author: agilliland
+      changes:
+        - addColumn:
+            tableName: metabase_field
+            columns:
+              - column:
+                  name: visibility_type
+                  type: varchar(32)
+                  value: sensitive
+                  constraints:
+                    nullable: true
+                    deferrable: false
+                    initiallyDeferred: false

--- a/resources/migrations/030_add_field_visibility_type.yaml
+++ b/resources/migrations/030_add_field_visibility_type.yaml
@@ -9,8 +9,12 @@ databaseChangeLog:
               - column:
                   name: visibility_type
                   type: varchar(32)
-                  value: sensitive
                   constraints:
                     nullable: true
                     deferrable: false
                     initiallyDeferred: false
+        - addNotNullConstraint:
+            columnDataType: varchar(32)
+            columnName: visibility_type
+            defaultNullValue: unset
+            tableName: metabase_field

--- a/resources/migrations/liquibase.json
+++ b/resources/migrations/liquibase.json
@@ -27,6 +27,7 @@
       {"include": {"file": "migrations/026_add_database_is_full_sync_field.yaml"}},
       {"include": {"file": "migrations/027_add_dashcardseries_table.yaml"}},
       {"include": {"file": "migrations/028_add_user_is_qbnewb.yaml"}},
-      {"include": {"file": "migrations/029_add_pulse_channel_schedule_frame.yaml"}}
+      {"include": {"file": "migrations/029_add_pulse_channel_schedule_frame.yaml"}},
+      {"include": {"file": "migrations/030_add_field_visibility_type.yaml"}}
   ]
 }

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -167,7 +167,7 @@
         fields (->> (sel :many [Field :name :base_type :special_type :table_id]                                 ; get all Fields with names that start with PREFIX
                          :table_id [in (keys table-id->name)]                                                   ; whose Table is in this DB
                          :name [like (str prefix "%")]
-                         :active true)
+                         :visibility_type [not-in ["sensitive" "retired"]])
                     (map (fn [{:keys [name base_type special_type table_id]}]                                    ; return them in the format
                            [name (str (table-id->name table_id) " " base_type (when special_type                ; [field_name "table_name base_type special_type"]
                                                                                 (str " " special_type)))])))]

--- a/src/metabase/api/field.clj
+++ b/src/metabase/api/field.clj
@@ -55,7 +55,7 @@
                                                 :field_type      field_type
                                                 :special_type    special_type
                                                 :visibility_type visibility_type}
-                                               (when display_name               {:display_name display_name}))))
+                                               (when display_name {:display_name display_name}))))
       (Field id))))
 
 (defendpoint GET "/:id/summary"

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -55,7 +55,6 @@
 (defendpoint GET "/:id/fields"
   "Get all `Fields` for `Table` with ID."
   [id]
-  ;; TODO: check that order doesn't change in a problematic way due to sorting by position
   (let-404 [table (Table id)]
     (read-check table)
     (sel :many Field :table_id id, :visibility_type [not-in ["sensitive" "retired"]], (k/order :name :ASC))))

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -55,8 +55,10 @@
 (defendpoint GET "/:id/fields"
   "Get all `Fields` for `Table` with ID."
   [id]
-  (read-check Table id)
-  (sel :many Field :table_id id, :active true, :field_type [not= "sensitive"], (k/order :name :ASC)))
+  ;; TODO: check that order doesn't change in a problematic way due to sorting by position
+  (let-404 [table (Table id)]
+    (read-check table)
+    (sel :many Field :table_id id, :visibility_type [not-in ["sensitive" "retired"]], (k/order :name :ASC))))
 
 (defendpoint GET "/:id/query_metadata"
   "Get metadata about a `Table` useful for running queries.
@@ -73,14 +75,14 @@
                                 ;; If someone passes include_sensitive_fields return hydrated :fields as-is
                                 identity
                                 ;; Otherwise filter out all :sensitive fields
-                                (partial filter (fn [{:keys [field_type]}]
-                                                  (not= (keyword field_type) :sensitive)))))))
+                                (partial filter (fn [{:keys [visibility_type]}]
+                                                  (not= (keyword visibility_type) :sensitive)))))))
 
 (defendpoint GET "/:id/fks"
   "Get all `ForeignKeys` whose destination is a `Field` that belongs to this `Table`."
   [id]
   (read-check Table id)
-  (let-404 [field-ids (sel :many :id Field :table_id id :active true)]
+  (let-404 [field-ids (sel :many :id Field :table_id id :visibility_type [not= "retired"])]
     (-> (sel :many ForeignKey :destination_id [in field-ids])
         ;; TODO - it's a little silly to hydrate both of these table objects
         (hydrate [:origin [:table :db]] [:destination :table]))))

--- a/src/metabase/driver/query_processor.clj
+++ b/src/metabase/driver/query_processor.clj
@@ -171,7 +171,7 @@
     (if (structured-query? query)
       (qp (if-not (should-add-implicit-fields? query)
             query
-            (let [fields (for [field (db/sel :many :fields [Field :name :display_name :base_type :special_type :preview_display :display_name :table_id :id :position :description]
+            (let [fields (for [field (db/sel :many :fields [Field :name :display_name :base_type :special_type :visibility_type :display_name :table_id :id :position :description]
                                              :table_id   source-table-id
                                              :visibility_type [not-in ["sensitive" "retired"]]
                                              :parent_id  nil

--- a/src/metabase/driver/query_processor.clj
+++ b/src/metabase/driver/query_processor.clj
@@ -172,11 +172,10 @@
       (qp (if-not (should-add-implicit-fields? query)
             query
             (let [fields (for [field (db/sel :many :fields [Field :name :display_name :base_type :special_type :preview_display :display_name :table_id :id :position :description]
-                                          :table_id   source-table-id
-                                          :active     true
-                                          :field_type [not= "sensitive"]
-                                          :parent_id  nil
-                                          (k/order :position :asc) (k/order :id :desc))]
+                                             :table_id   source-table-id
+                                             :visibility_type [not-in ["sensitive" "retired"]]
+                                             :parent_id  nil
+                                             (k/order :position :asc) (k/order :id :desc))]
                            (let [field (-> (resolve/rename-mb-field-keys field)
                                            map->Field
                                            (resolve/resolve-table {source-table-id source-table}))]

--- a/src/metabase/driver/query_processor.clj
+++ b/src/metabase/driver/query_processor.clj
@@ -172,9 +172,9 @@
       (qp (if-not (should-add-implicit-fields? query)
             query
             (let [fields (for [field (db/sel :many :fields [Field :name :display_name :base_type :special_type :visibility_type :display_name :table_id :id :position :description]
-                                             :table_id   source-table-id
+                                             :table_id        source-table-id
                                              :visibility_type [not-in ["sensitive" "retired"]]
-                                             :parent_id  nil
+                                             :parent_id       nil
                                              (k/order :position :asc) (k/order :id :desc))]
                            (let [field (-> (resolve/rename-mb-field-keys field)
                                            map->Field

--- a/src/metabase/driver/query_processor/annotate.clj
+++ b/src/metabase/driver/query_processor/annotate.clj
@@ -181,7 +181,7 @@
                            :field-display-name :display_name
                            :schema-name        :schema_name
                            :special-type       :special_type
-                           :preview-display    :preview_display
+                           :visibility-type    :visibility_type
                            :table-id           :table_id})
         (dissoc :position :clause-position :source :parent :parent-id :table-name))))
 
@@ -201,7 +201,7 @@
   ;; Fetch the destination Fields referenced by the ForeignKeys
   ([fields fk-ids id->dest-id]
    (when (seq id->dest-id)
-     (fk-field->dest-fn fields fk-ids id->dest-id (sel :many :id->fields [Field :id :name :display_name :table_id :description :base_type :special_type :preview_display]
+     (fk-field->dest-fn fields fk-ids id->dest-id (sel :many :id->fields [Field :id :name :display_name :table_id :description :base_type :special_type :visibility_type]
                                                        :id [in (vals id->dest-id)]))))
   ;; Return a function that will return the corresponding destination Field for a given Field
   ([fields fk-ids id->dest-id dest-id->field]

--- a/src/metabase/driver/query_processor/interface.clj
+++ b/src/metabase/driver/query_processor/interface.clj
@@ -64,6 +64,7 @@
                     field-display-name :- s/Str
                     base-type          :- (apply s/enum field/base-types)
                     special-type       :- (s/maybe (apply s/enum field/special-types))
+                    visibility-type    :- (apply s/enum field/visibility-types)
                     table-id           :- IntGreaterThanZero
                     schema-name        :- (s/maybe s/Str)
                     table-name         :- (s/maybe s/Str) ; TODO - Why is this `maybe` ?
@@ -71,8 +72,7 @@
                     description        :- (s/maybe s/Str)
                     parent-id          :- (s/maybe IntGreaterThanZero)
                     ;; Field once its resolved; FieldPlaceholder before that
-                    parent             :- s/Any
-                    preview-display    :- (s/maybe s/Bool)]
+                    parent             :- s/Any]
   clojure.lang.Named
   (getName [_] field-name) ; (name <field>) returns the *unqualified* name of the field, #obvi
 

--- a/src/metabase/driver/query_processor/resolve.clj
+++ b/src/metabase/driver/query_processor/resolve.clj
@@ -30,8 +30,8 @@
                           :name            :field-name
                           :display_name    :field-display-name
                           :special_type    :special-type
+                          :visibility_type :visibility-type
                           :base_type       :base-type
-                          :preview_display :preview-display
                           :table_id        :table-id
                           :parent_id       :parent-id}))
 
@@ -181,7 +181,7 @@
         ;; If there are no more Field IDs to resolve we're done.
         expanded-query-dict
         ;; Otherwise fetch + resolve the Fields in question
-        (let [fields (->> (sel :many :id->fields [field/Field :name :display_name :base_type :special_type :preview_display :table_id :parent_id :description]
+        (let [fields (->> (sel :many :id->fields [field/Field :name :display_name :base_type :special_type :visibility_type :table_id :parent_id :description]
                                :id [in field-ids])
                           (m/map-vals rename-mb-field-keys)
                           (m/map-vals #(assoc % :parent (when-let [parent-id (:parent-id %)]

--- a/src/metabase/driver/sync.clj
+++ b/src/metabase/driver/sync.clj
@@ -186,7 +186,8 @@
             ;; set Field metadata we may have detected
             (when (and id (or preview-display special-type))
               (upd-non-nil-keys Field id
-                :preview_display preview-display
+                ;; if a field marked `preview-display` as false then set the visibility type to `:details-only` (see models.field/visibility-types)
+                :visibility_type (when (false? preview-display) :details-only)
                 :special_type    special-type))
             ;; handle field values, setting them if applicable otherwise clearing them
             (if (and id values (< 0 (count (filter identity values))))
@@ -525,7 +526,7 @@ infer-field-special-type
 (defn- test:no-preview-display
   "If FIELD's is textual and its average length is too great, mark it so it isn't displayed in the UI."
   [driver field field-stats]
-  (if-not (and (:preview_display field)
+  (if-not (and (= :normal (:visibility_type field))
                (contains? #{:CharField :TextField} (:base_type field)))
     ;; this field isn't suited for this test
     field-stats

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -48,8 +48,7 @@
   "Possible values for `Field.field_type`."
   #{:metric      ; A number that can be added, graphed, etc.
     :dimension   ; A high or low-cardinality numerical string value that is meant to be used as a grouping
-    :info        ; Non-numerical value that is not meant to be used
-    :sensitive}) ; A Fields that should *never* be shown *anywhere*
+    :info})      ; Non-numerical value that is not meant to be used
 
 (def ^:const visibility-types
   "Possible values for `Field.visibility_type`."

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -51,11 +51,20 @@
     :info        ; Non-numerical value that is not meant to be used
     :sensitive}) ; A Fields that should *never* be shown *anywhere*
 
+(def ^:const visibility-types
+  "Possible values for `Field.visibility_type`."
+  #{:normal         ; Default setting.  field has no visibility restrictions.
+    :details-only   ; For long blob like columns such as JSON.  field is not shown in some places on the frontend.
+    :hidden         ; Lightweight hiding which removes field as a choice in most of the UI.  should still be returned in queries.
+    :sensitive      ; Strict removal of field from all places except data model listing.  queries should error if someone attempts to access.
+    :retired})      ; For fields that no longer exist in the physical db.  automatically set by Metabase.  QP should error if encountered in a query.
+
 (defn valid-metadata?
   "Predicate function that checks if the set of metadata types for a field are sensible."
-  [base-type field-type special-type]
+  [base-type field-type special-type visibility-type]
   (and (contains? base-types base-type)
        (contains? field-types field-type)
+       (contains? visibility-types visibility-type)
        (or (nil? special-type)
            (contains? special-types special-type))
        ;; this verifies that we have a numeric base-type when trying to use the unix timestamp transform (#824)
@@ -70,6 +79,7 @@
   (let [defaults {:active          true
                   :preview_display true
                   :field_type      :info
+                  :visibility_type :normal
                   :position        0
                   :display_name    (common/name->human-readable-name (:name field))}]
     (merge defaults field)))
@@ -117,7 +127,11 @@
 (extend (class Field)
   i/IEntity (merge i/IEntityDefaults
                    {:hydration-keys     (constantly [:destination :field :origin])
-                    :types              (constantly {:base_type :keyword, :field_type :keyword, :special_type :keyword, :description :clob})
+                    :types              (constantly {:base_type       :keyword
+                                                     :field_type      :keyword
+                                                     :special_type    :keyword
+                                                     :visibility_type :keyword
+                                                     :description     :clob})
                     :timestamped?       (constantly true)
                     :can-read?          (constantly true)
                     :can-write?         i/superuser?

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -28,11 +28,11 @@
 (defn field-should-have-field-values?
   "Should this `Field` be backed by a corresponding `FieldValues` object?"
   {:arglists '([field])}
-  [{:keys [base_type special_type field_type] :as field}]
-  {:pre [field_type
+  [{:keys [base_type special_type visibility_type] :as field}]
+  {:pre [visibility_type
          (contains? field :base_type)
          (contains? field :special_type)]}
-  (and (not= (keyword field_type) :sensitive)
+  (and (not (contains? #{:retired :sensitive :hidden :details-only} (keyword visibility_type)))
        (not (contains? #{:DateField :DateTimeField :TimeField} (keyword base_type)))
        (or (contains? #{:category :city :state :country :name} (keyword special_type))
            (= (keyword base_type) :BooleanField))))

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -47,7 +47,6 @@
   "Return the `FieldValues` for all `Fields` belonging to TABLE."
   {:hydrate :field_values, :arglists '([table])}
   [{:keys [id]}]
-  ;; TODO: any reason to return field-values for other visibility options?
   (let [field-ids (db/sel :many :id Field, :table_id id, :visibility_type "normal"
                           (k/order :position :asc)
                           (k/order :name :asc))]

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -31,7 +31,7 @@
 (defn ^:hydrate fields
   "Return the `FIELDS` belonging to TABLE."
   [{:keys [id]}]
-  (db/sel :many Field :table_id id, :active true, (k/order :position :ASC) (k/order :name :ASC)))
+  (db/sel :many Field :table_id id, :visibility_type [not= "retired"], (k/order :position :ASC) (k/order :name :ASC)))
 
 (defn ^:hydrate metrics
   "Retrieve the metrics for TABLE."
@@ -47,7 +47,8 @@
   "Return the `FieldValues` for all `Fields` belonging to TABLE."
   {:hydrate :field_values, :arglists '([table])}
   [{:keys [id]}]
-  (let [field-ids (db/sel :many :id Field, :table_id id, :active true, :field_type [not= "sensitive"]
+  ;; TODO: any reason to return field-values for other visibility options?
+  (let [field-ids (db/sel :many :id Field, :table_id id, :visibility_type "normal"
                           (k/order :position :asc)
                           (k/order :name :asc))]
     (db/sel :many :field->field [FieldValues :field_id :values] :field_id [in field-ids])))
@@ -56,7 +57,7 @@
   "Return the ID of the primary key `Field` for TABLE."
   {:hydrate :pk_field, :arglists '([table])}
   [{:keys [id]}]
-  (db/sel :one :id Field, :table_id id, :special_type "id"))
+  (db/sel :one :id Field, :table_id id, :special_type "id", :visibility_type [not-in ["sensitive" "retired"]]))
 
 (def ^{:arglists '([table])} database
   "Return the `Database` associated with this `Table`."

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -245,6 +245,7 @@
                                         :preview_display true
                                         :created_at      $
                                         :base_type       "BigIntegerField"
+                                        :visibility_type "normal"
                                         :parent_id       nil
                                         :values          []})
                                      (match-$ (Field (id :categories :name))
@@ -262,6 +263,7 @@
                                         :preview_display true
                                         :created_at      $
                                         :base_type       "TextField"
+                                        :visibility_type "normal"
                                         :parent_id       nil
                                         :values          []})]
                    :segments        []

--- a/test/metabase/api/field_test.clj
+++ b/test/metabase/api/field_test.clj
@@ -52,6 +52,7 @@
        :active          true
        :id              (id :users :name)
        :field_type      "info"
+       :visibility_type "normal"
        :position        0
        :preview_display true
        :created_at      $
@@ -84,6 +85,7 @@
               :active          true
               :id              $
               :field_type      "info"
+              :visibility_type "normal"
               :position        0
               :preview_display true
               :created_at      $

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -273,13 +273,13 @@
                             :updated_at      $
                             :active          true
                             :id              $
-                            :field_type      "sensitive"
+                            :field_type      "info"
                             :position        0
                             :target          nil
                             :preview_display true
                             :created_at      $
                             :base_type       "TextField"
-                            :visibility_type "normal"
+                            :visibility_type "sensitive"
                             :parent_id       nil})]
        :rows            15
        :updated_at      $

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -107,6 +107,7 @@
             :preview_display     true
             :created_at          $
             :base_type           "BigIntegerField"
+            :visibility_type     "normal"
             :parent_id           nil})
          (match-$ (Field (id :categories :name))
            {:description         nil
@@ -122,6 +123,7 @@
             :preview_display     true
             :created_at          $
             :base_type           "TextField"
+            :visibility_type     "normal"
             :parent_id           nil})]
   ((user->client :rasta) :get 200 (format "table/%d/fields" (id :categories))))
 
@@ -150,6 +152,7 @@
                             :preview_display true
                             :created_at      $
                             :base_type       "BigIntegerField"
+                            :visibility_type "normal"
                             :parent_id       nil})
                          (match-$ (Field (id :categories :name))
                            {:description     nil
@@ -166,6 +169,7 @@
                             :preview_display true
                             :created_at      $
                             :base_type       "TextField"
+                            :visibility_type "normal"
                             :parent_id       nil})]
        :field_values    {}
        :rows            75
@@ -224,6 +228,7 @@
                             :preview_display true
                             :created_at      $
                             :base_type       "BigIntegerField"
+                            :visibility_type "normal"
                             :parent_id       nil})
                          (match-$ (sel :one Field :id (id :users :last_login))
                            {:description     nil
@@ -240,6 +245,7 @@
                             :preview_display true
                             :created_at      $
                             :base_type       "DateTimeField"
+                            :visibility_type "normal"
                             :parent_id       nil})
                          (match-$ (sel :one Field :id (id :users :name))
                            {:description     nil
@@ -256,6 +262,7 @@
                             :preview_display true
                             :created_at      $
                             :base_type       "TextField"
+                            :visibility_type "normal"
                             :parent_id       nil})
                          (match-$ (sel :one Field :table_id (id :users) :name "PASSWORD")
                            {:description     nil
@@ -272,6 +279,7 @@
                             :preview_display true
                             :created_at      $
                             :base_type       "TextField"
+                            :visibility_type "normal"
                             :parent_id       nil})]
        :rows            15
        :updated_at      $
@@ -326,6 +334,7 @@
                             :preview_display true
                             :created_at      $
                             :base_type       "BigIntegerField"
+                            :visibility_type "normal"
                             :parent_id       nil})
                          (match-$ (Field (id :users :last_login))
                            {:description     nil
@@ -342,6 +351,7 @@
                             :preview_display true
                             :created_at      $
                             :base_type       "DateTimeField"
+                            :visibility_type "normal"
                             :parent_id       nil})
                          (match-$ (Field (id :users :name))
                            {:description     nil
@@ -358,6 +368,7 @@
                             :preview_display true
                             :created_at      $
                             :base_type       "TextField"
+                            :visibility_type "normal"
                             :parent_id       nil})]
        :rows            15
        :updated_at      $
@@ -445,6 +456,7 @@
                          :display_name    "User Id"
                          :description     nil
                          :base_type       "IntegerField"
+                         :visibility_type "normal"
                          :preview_display $
                          :position        $
                          :field_type      "info"
@@ -475,6 +487,7 @@
                          :display_name    "Id"
                          :description     nil
                          :base_type       "BigIntegerField"
+                         :visibility_type "normal"
                          :preview_display $
                          :position        $
                          :field_type      "info"

--- a/test/metabase/driver/query_processor_test.clj
+++ b/test/metabase/driver/query_processor_test.clj
@@ -75,7 +75,7 @@
   {:extra_info      {}
    :target          nil
    :description     nil
-   :preview_display true
+   :visibility_type :normal
    :schema_name     (default-schema)})
 
 (defn- categories-col
@@ -803,7 +803,7 @@
          (ql/order-by (ql/desc (ql/aggregate-field 0))))
        :data (format-rows-by [int (comp int math/round)])))
 
-;;; ### make sure that rows where preview_display = false are included and properly marked up
+;;; ### make sure that rows where visibility_type = details-only are included and properly marked up
 (expect-with-non-timeseries-dbs
   [(set (venues-cols))
    #{(venues-col :category_id)
@@ -812,16 +812,16 @@
      (venues-col :id)
      (venues-col :longitude)
      (-> (venues-col :price)
-         (assoc :preview_display false))}
+         (assoc :visibility_type :details-only))}
    (set (venues-cols))]
   (let [get-col-names (fn [] (-> (run-query venues
                                    (ql/order-by (ql/asc $id))
                                    (ql/limit 1))
                                  :data :cols set))]
     [(get-col-names)
-     (do (upd Field (id :venues :price) :preview_display false)
+     (do (upd Field (id :venues :price) :visibility_type :details-only)
          (get-col-names))
-     (do (upd Field (id :venues :price) :preview_display true)
+     (do (upd Field (id :venues :price) :visibility_type :normal)
          (get-col-names))]))
 
 

--- a/test/metabase/driver/sync_test.clj
+++ b/test/metabase/driver/sync_test.clj
@@ -94,7 +94,8 @@
               :position 0,
               :preview_display true,
               :display_name "Id",
-              :base_type :IntegerField}
+              :base_type :IntegerField,
+              :visibility_type :normal}
              {:description nil,
               :special_type nil,
               :name "studio",
@@ -104,7 +105,8 @@
               :position 0,
               :preview_display true,
               :display_name "Studio",
-              :base_type :TextField}
+              :base_type :TextField,
+              :visibility_type :normal}
              {:description nil,
               :special_type nil,
               :name "title",
@@ -114,7 +116,8 @@
               :position 0,
               :preview_display true,
               :display_name "Title",
-              :base_type :TextField}]}
+              :base_type :TextField,
+              :visibility_type :normal}]}
    {:schema nil
     :name   "studio"
     :display_name "Studio"
@@ -133,7 +136,8 @@
               :position 0,
               :preview_display true,
               :display_name "Name",
-              :base_type :TextField}
+              :base_type :TextField,
+              :visibility_type :normal}
              {:description nil,
               :special_type :id,
               :name "studio",
@@ -143,7 +147,8 @@
               :position 0,
               :preview_display true,
               :display_name "Studio",
-              :base_type :TextField}]}]
+              :base_type :TextField,
+              :visibility_type :normal}]}]
   (tu/with-temp Database [fake-db {:name    "sync-test"
                                    :engine  :sync-test
                                    :details {}}]
@@ -176,7 +181,8 @@
              :position 0,
              :preview_display true,
              :display_name "Id",
-             :base_type :IntegerField}
+             :base_type :IntegerField,
+             :visibility_type :normal}
             {:description nil,
              :special_type nil,
              :name "studio",
@@ -186,7 +192,8 @@
              :position 0,
              :preview_display true,
              :display_name "Studio",
-             :base_type :TextField}
+             :base_type :TextField,
+             :visibility_type :normal}
             {:description nil,
              :special_type nil,
              :name "title",
@@ -196,7 +203,8 @@
              :position 0,
              :preview_display true,
              :display_name "Title",
-             :base_type :TextField}]}
+             :base_type :TextField,
+             :visibility_type :normal}]}
   (tu/with-temp Database [fake-db {:name    "sync-test"
                                    :engine  :sync-test
                                    :details {}}]

--- a/test/metabase/models/field_test.clj
+++ b/test/metabase/models/field_test.clj
@@ -7,15 +7,17 @@
 
 
 ;; valid-metadata?
-(expect false (valid-metadata? nil nil nil))
-(expect false (valid-metadata? :IntegerField nil nil))
-(expect true (valid-metadata? :IntegerField :metric nil))
-(expect false (valid-metadata? :foo :metric nil))
-(expect false (valid-metadata? :IntegerField :foo nil))
-(expect true (valid-metadata? :IntegerField :metric :timestamp_seconds))
-(expect true (valid-metadata? :IntegerField :metric :timestamp_milliseconds))
-(expect false (valid-metadata? :DateTimeField :metric :timestamp_seconds))
-(expect false (valid-metadata? :DateTimeField :metric :timestamp_milliseconds))
+(expect false (valid-metadata? nil nil nil nil))
+(expect false (valid-metadata? :IntegerField nil nil nil))
+(expect false (valid-metadata? :IntegerField :metric nil nil))
+(expect true (valid-metadata? :IntegerField :metric nil :normal))
+(expect false (valid-metadata? :foo :metric nil :normal))
+(expect false (valid-metadata? :IntegerField :foo nil :normal))
+(expect false (valid-metadata? :IntegerField :metric nil :foo))
+(expect true (valid-metadata? :IntegerField :metric :timestamp_seconds :normal))
+(expect true (valid-metadata? :IntegerField :metric :timestamp_milliseconds :normal))
+(expect false (valid-metadata? :DateTimeField :metric :timestamp_seconds :normal))
+(expect false (valid-metadata? :DateTimeField :metric :timestamp_milliseconds :normal))
 
 
 ;; field-should-have-field-values?

--- a/test/metabase/models/field_test.clj
+++ b/test/metabase/models/field_test.clj
@@ -22,55 +22,64 @@
 
 ;; field-should-have-field-values?
 
-;; sensitive fields should always be excluded
-(expect false (field-should-have-field-values? {:base_type    :BooleanField
-                                                :special_type :category
-                                                :field_type   :sensitive}))
+;; retired/sensitive/hidden/details-only fields should always be excluded
+(expect false (field-should-have-field-values? {:base_type       :BooleanField
+                                                :special_type    :category
+                                                :visibility_type :retired}))
+(expect false (field-should-have-field-values? {:base_type       :BooleanField
+                                                :special_type    :category
+                                                :visibility_type :sensitive}))
+(expect false (field-should-have-field-values? {:base_type       :BooleanField
+                                                :special_type    :category
+                                                :visibility_type :hidden}))
+(expect false (field-should-have-field-values? {:base_type       :BooleanField
+                                                :special_type    :category
+                                                :visibility_type :details-only}))
 ;; date/time based fields should always be excluded
 (expect false (field-should-have-field-values? {:base_type    :DateField
                                                 :special_type :category
-                                                :field_type   :dimension}))
+                                                :visibility_type :normal}))
 (expect false (field-should-have-field-values? {:base_type    :DateTimeField
                                                 :special_type :category
-                                                :field_type   :dimension}))
+                                                :visibility_type :normal}))
 (expect false (field-should-have-field-values? {:base_type    :TimeField
                                                 :special_type :category
-                                                :field_type   :dimension}))
+                                                :visibility_type :normal}))
 ;; most special types should be excluded
 (expect false (field-should-have-field-values? {:base_type    :CharField
                                                 :special_type :image
-                                                :field_type   :dimension}))
+                                                :visibility_type :normal}))
 (expect false (field-should-have-field-values? {:base_type    :CharField
                                                 :special_type :id
-                                                :field_type   :dimension}))
+                                                :visibility_type :normal}))
 (expect false (field-should-have-field-values? {:base_type    :CharField
                                                 :special_type :fk
-                                                :field_type   :dimension}))
+                                                :visibility_type :normal}))
 (expect false (field-should-have-field-values? {:base_type    :CharField
                                                 :special_type :latitude
-                                                :field_type   :dimension}))
+                                                :visibility_type :normal}))
 (expect false (field-should-have-field-values? {:base_type    :CharField
                                                 :special_type :number
-                                                :field_type   :dimension}))
+                                                :visibility_type :normal}))
 (expect false (field-should-have-field-values? {:base_type    :CharField
                                                 :special_type :timestamp_milliseconds
-                                                :field_type   :dimension}))
+                                                :visibility_type :normal}))
 ;; boolean fields + category/city/state/country fields are g2g
 (expect true (field-should-have-field-values? {:base_type    :BooleanField
                                                :special_type :number
-                                               :field_type   :dimension}))
+                                               :visibility_type :normal}))
 (expect true (field-should-have-field-values? {:base_type    :CharField
                                                :special_type :category
-                                               :field_type   :dimension}))
+                                               :visibility_type :normal}))
 (expect true (field-should-have-field-values? {:base_type    :TextField
                                                :special_type :city
-                                               :field_type   :dimension}))
+                                               :visibility_type :normal}))
 (expect true (field-should-have-field-values? {:base_type    :TextField
                                                :special_type :state
-                                               :field_type   :dimension}))
+                                               :visibility_type :normal}))
 (expect true (field-should-have-field-values? {:base_type    :TextField
                                                :special_type :country
-                                               :field_type   :dimension}))
+                                               :visibility_type :normal}))
 (expect true (field-should-have-field-values? {:base_type    :TextField
                                                :special_type :name
-                                               :field_type   :dimension}))
+                                               :visibility_type :normal}))

--- a/test/metabase/models/field_values_test.clj
+++ b/test/metabase/models/field_values_test.clj
@@ -11,27 +11,35 @@
 
 (expect true
   (field-should-have-field-values? {:special_type :category
-                                    :field_type :info
+                                    :visibility_type :normal
                                     :base_type :TextField}))
 
 (expect false
   (field-should-have-field-values? {:special_type :category
-                                    :field_type :sensitive
+                                    :visibility_type :sensitive
+                                    :base_type :TextField}))
+(expect false
+  (field-should-have-field-values? {:special_type :category
+                                    :visibility_type :hidden
+                                    :base_type :TextField}))
+(expect false
+  (field-should-have-field-values? {:special_type :category
+                                    :visibility_type :details-only
                                     :base_type :TextField}))
 
 (expect false
   (field-should-have-field-values? {:special_type nil
-                                    :field_type :info
+                                    :visibility_type :normal
                                     :base_type :TextField}))
 
 (expect true
   (field-should-have-field-values? {:special_type "country"
-                                    :field_type :info
+                                    :visibility_type :normal
                                     :base_type :TextField}))
 
 (expect true
   (field-should-have-field-values? {:special_type nil
-                                    :field_type :info
+                                    :visibility_type :normal
                                     :base_type "BooleanField"}))
 
 

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -175,7 +175,7 @@
                                                                        table-name
                                                                        (u/pprint-to-str (dissoc table-definition :rows))
                                                                        (u/pprint-to-str (sel :many :fields [Table :schema :name], :db_id (:id db))))))))]
-                 (doseq [{:keys [field-name field-type special-type], :as field-definition} (:field-definitions table-definition)]
+                 (doseq [{:keys [field-name field-type visibility-type special-type], :as field-definition} (:field-definitions table-definition)]
                    (let [field (delay (or (i/metabase-instance field-definition @table)
                                           (throw (Exception. (format "Field '%s' not loaded from definition:\n"
                                                                      field-name
@@ -183,6 +183,9 @@
                      (when field-type
                        (log/debug (format "SET FIELD TYPE %s.%s -> %s" table-name field-name field-type))
                        (upd Field (:id @field) :field_type (name field-type)))
+                     (when visibility-type
+                       (log/debug (format "SET VISIBILITY TYPE %s.%s -> %s" table-name field-name visibility-type))
+                       (upd Field (:id @field) :visibility_type (name visibility-type)))
                      (when special-type
                        (log/debug (format "SET SPECIAL TYPE %s.%s -> %s" table-name field-name special-type))
                        (upd Field (:id @field) :special_type (name special-type)))))))

--- a/test/metabase/test/data/dataset_definitions/test-data.edn
+++ b/test/metabase/test/data/dataset_definitions/test-data.edn
@@ -28,7 +28,7 @@
             :base-type  :DateTimeField}
            {:field-name "password"
             :base-type  :CharField
-            :field-type :sensitive}]
+            :visibility-type :sensitive}]
   [["Plato Yeshua" #inst "2014-04-01T08:30" "4be68cda-6fd5-4ba7-944e-2b475600bda5"]
    ["Felipinho Asklepios" #inst "2014-12-05T15:15" "5bb19ad9-f3f8-421f-9750-7d398e38428d"]
    ["Kaneonuskatew Eiran" #inst "2014-11-06T16:15" "a329ccfe-b99c-42eb-9c93-cb9adc3eb1ab"]

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -15,6 +15,7 @@
                             ^Keyword base-type
                             ^Keyword field-type
                             ^Keyword special-type
+                            ^Keyword visibility-type
                             ^Keyword fk])
 
 (defrecord TableDefinition [^String table-name
@@ -117,7 +118,7 @@
 
 (defn create-field-definition
   "Create a new `FieldDefinition`; verify its values."
-  ^FieldDefinition [{:keys [field-name base-type field-type special-type fk], :as field-definition-map}]
+  ^FieldDefinition [{:keys [field-name base-type field-type special-type visibility-type fk], :as field-definition-map}]
   (assert (or (contains? field/base-types base-type)
               (and (map? base-type)
                    (string? (:native base-type))))
@@ -125,6 +126,8 @@
          "Field base-type should be either a valid base type like :TextField or be some native type wrapped in a map, like {:native \"JSON\"}."))
   (when field-type
     (assert (contains? field/field-types field-type)))
+  (when visibility-type
+    (assert (contains? field/visibility-types visibility-type)))
   (when special-type
     (assert (contains? field/special-types special-type)))
   (map->FieldDefinition field-definition-map))


### PR DESCRIPTION
Does a few things to bring a bit more consistency to the way we handle the visibility choices on a Field
- add a new attribute `visibility_type` on the field which is required
- replace boolean field `active` with the visibility type `retired`
- replace the `preview_display` field with visibility_types `normal` and `details-only`
- replace the field_type `sensitive` with a visibility_type for `sensitive`

The logic behind the use of these fields is the same, but accessing and using the information is much simpler now.
