### PR TITLE
Better type checking for our clojure protocols & types :cherries:

### DIFF
--- a/src/metabase/driver/bigquery.clj
+++ b/src/metabase/driver/bigquery.clj
@@ -370,11 +370,13 @@
 
 (def ^:private driver (BigQueryDriver.))
 
-(extend BigQueryDriver
+(u/strict-extend BigQueryDriver
   sql/ISQLDriver
   (merge (sql/ISQLDriverDefaultsMixin)
          {:apply-breakout            (u/drop-first-arg apply-breakout)
           :apply-order-by            (u/drop-first-arg apply-order-by)
+          :column->base-type         (constantly nil)                           ; these two are actually not applicable
+          :connection-details->spec  (constantly nil)                           ; since we don't use JDBC
           :current-datetime-fn       (constantly (k/sqlfn* :CURRENT_TIMESTAMP))
           :date                      (u/drop-first-arg date)
           :field->alias              (u/drop-first-arg field->alias)

--- a/src/metabase/driver/druid.clj
+++ b/src/metabase/driver/druid.clj
@@ -165,7 +165,7 @@
   clojure.lang.Named
   (getName [_] "Druid"))
 
-(extend DruidDriver
+(u/strict-extend DruidDriver
   driver/IDriver
   (merge driver/IDriverDefaultsMixin
          {:can-connect?          can-connect?

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -201,9 +201,9 @@
 (defn features
   "Default implementation of `IDriver` `features` for SQL drivers."
   [driver]
-  (set (cond-> [:foreign-keys
-                :standard-deviation-aggregations]
-         (set-timezone-sql driver) (conj :set-timezone))))
+  (cond-> #{:standard-deviation-aggregations
+            :foreign-keys}
+    (set-timezone-sql driver) (conj :set-timezone)))
 
 
 ;;; ## Database introspection methods used by sync process

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -64,12 +64,11 @@
   AgFieldRef
   (formatted [_]
     (let [{:keys [aggregation-type]} (:aggregation (:query *query*))]
-      (case aggregation-type
-        :avg      :avg
-        :count    :count
-        :distinct :count
-        :stddev   :stddev
-        :sum      :sum)))
+      ;; For some arcane reason we name the results of a distinct aggregation "count",
+      ;; everything else is named the same as the aggregation
+      (if (= aggregation-type :distinct)
+        :count
+        aggregation-type)))
 
   Value
   (formatted [value] (sql/prepare-value (driver) value))

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -7,6 +7,7 @@
             [metabase.driver :as driver]
             [metabase.driver.generic-sql :as sql]
             [metabase.models.database :refer [Database]]
+            [metabase.util :as u]
             [metabase.util.korma-extensions :as kx]))
 
 (defn- column->base-type [_ column-type]
@@ -196,7 +197,7 @@
   clojure.lang.Named
   (getName [_] "H2"))
 
-(extend H2Driver
+(u/strict-extend H2Driver
   driver/IDriver
   (merge (sql/IDriverSQLDefaultsMixin)
          {:date-interval                     date-interval
@@ -213,7 +214,6 @@
           :column->base-type         column->base-type
           :connection-details->spec  connection-details->spec
           :date                      date
-          :date-interval             date-interval
           :string-length-fn          (constantly :LENGTH)
           :unix-timestamp->timestamp unix-timestamp->timestamp}))
 

--- a/src/metabase/driver/mongo.clj
+++ b/src/metabase/driver/mongo.clj
@@ -159,7 +159,7 @@
   clojure.lang.Named
   (getName [_] "MongoDB"))
 
-(extend MongoDriver
+(u/strict-extend MongoDriver
   driver/IDriver
   (merge driver/IDriverDefaultsMixin
          {:analyze-table                     analyze-table

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -140,7 +140,7 @@
   clojure.lang.Named
   (getName [_] "MySQL"))
 
-(extend MySQLDriver
+(u/strict-extend MySQLDriver
   driver/IDriver
   (merge (sql/IDriverSQLDefaultsMixin)
          {:date-interval                     date-interval

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -186,7 +186,7 @@
           :string-length-fn          (constantly :CHAR_LENGTH)
           :unix-timestamp->timestamp unix-timestamp->timestamp}))
 
-(extend PostgresDriver
+(u/strict-extend PostgresDriver
   driver/IDriver
   (merge (sql/IDriverSQLDefaultsMixin)
          {:date-interval                     date-interval

--- a/src/metabase/driver/query_processor/expand.clj
+++ b/src/metabase/driver/query_processor/expand.clj
@@ -116,7 +116,8 @@
 (def ^:ql ^{:arglists '([f])} cum-sum  "Aggregation clause. Return the cumulative sum of the values of F." (partial ag-with-field :cumulative-sum))
 
 (defn ^:ql stddev
-  "Aggregation clause. Return the standard deviation of values of F."
+  "Aggregation clause. Return the standard deviation of values of F.
+   Requires the feature `:standard-deviation-aggregations`."
   [f]
   (i/assert-driver-supports :standard-deviation-aggregations)
   (ag-with-field :stddev f))

--- a/src/metabase/driver/query_processor/resolve.clj
+++ b/src/metabase/driver/query_processor/resolve.clj
@@ -56,8 +56,8 @@
    :resolve-field       (fn [this _] this)
    :resolve-table       (fn [this _] this)})
 
-(extend Object IResolve IResolveDefaults)
-(extend nil    IResolve IResolveDefaults)
+(u/strict-extend Object IResolve IResolveDefaults)
+(u/strict-extend nil    IResolve IResolveDefaults)
 
 
 ;;; ## ------------------------------------------------------------ FIELD ------------------------------------------------------------
@@ -84,7 +84,7 @@
            :table-name  (:name table)
            :schema-name (:schema table))))
 
-(extend Field
+(u/strict-extend Field
   IResolve (merge IResolveDefaults
                   {:unresolved-field-id field-unresolved-field-id
                    :resolve-field       field-resolve-field
@@ -107,7 +107,7 @@
     ;; If that fails just return ourselves as-is
     this))
 
-(extend FieldPlaceholder
+(u/strict-extend FieldPlaceholder
   IResolve (merge IResolveDefaults
                   {:unresolved-field-id :field-id
                    :fk-field-id         :fk-field-id
@@ -147,7 +147,7 @@
       (throw (Exception. (format "Unable to resolve field: %s" field-placeholder))))
     (parse-value resolved-field value)))
 
-(extend ValuePlaceholder
+(u/strict-extend ValuePlaceholder
   IResolve (merge IResolveDefaults
                   {:resolve-field value-ph-resolve-field}))
 

--- a/src/metabase/driver/redshift.clj
+++ b/src/metabase/driver/redshift.clj
@@ -5,8 +5,9 @@
                    [db :as kdb])
             (metabase [config :as config]
                       [driver :as driver])
-            [metabase.driver.generic-sql :as sql]
-            [metabase.driver.postgres :as postgres]
+            (metabase.driver [generic-sql :as sql]
+                             [postgres :as postgres])
+            [metabase.util :as u]
             [metabase.util.korma-extensions :as kx]))
 
 (defn- connection-details->spec [_ details]
@@ -55,7 +56,7 @@
   clojure.lang.Named
   (getName [_] "Amazon Redshift"))
 
-(extend RedshiftDriver
+(u/strict-extend RedshiftDriver
   driver/IDriver
   (merge (sql/IDriverSQLDefaultsMixin)
          {:date-interval       date-interval

--- a/src/metabase/driver/sqlite.clj
+++ b/src/metabase/driver/sqlite.clj
@@ -103,7 +103,7 @@
   clojure.lang.Named
   (getName [_] "SQLite"))
 
-(extend SQLiteDriver
+(u/strict-extend SQLiteDriver
   driver/IDriver
   (merge (sql/IDriverSQLDefaultsMixin)
          {:date-interval  date-interval

--- a/src/metabase/driver/sqlserver.clj
+++ b/src/metabase/driver/sqlserver.clj
@@ -4,6 +4,7 @@
                    [db :as kdb])
             [metabase.driver :as driver]
             [metabase.driver.generic-sql :as sql]
+            [metabase.util :as u]
             [metabase.util.korma-extensions :as kx])
   (:import net.sourceforge.jtds.jdbc.Driver)) ; need to import this in order to load JDBC driver
 
@@ -129,7 +130,7 @@
   clojure.lang.Named
   (getName [_] "SQL Server"))
 
-(extend SQLServerDriver
+(u/strict-extend SQLServerDriver
   driver/IDriver
   (merge (sql/IDriverSQLDefaultsMixin)
          {:date-interval  date-interval

--- a/src/metabase/models/activity.clj
+++ b/src/metabase/models/activity.clj
@@ -29,7 +29,7 @@
     "segment"   (db/exists? Segment,   :id model_id, :is_active true)
                  nil))
 
-(extend (class Activity)
+(u/strict-extend (class Activity)
   i/IEntity
   (merge i/IEntityDefaults
          {:types       (constantly {:details :json, :topic :keyword})

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -5,7 +5,8 @@
             (metabase.models [dependency :as dependency]
                              [interface :as i]
                              [revision :as revision])
-            [metabase.query :as q]))
+            (metabase [query :as q]
+                      [util :as u])))
 
 (def ^:const display-types
   "Valid values of `Card.display_type`."
@@ -73,7 +74,7 @@
      :Segment (q/extract-segment-ids (:query dataset_query))}))
 
 
-(extend (class Card)
+(u/strict-extend (class Card)
   i/IEntity
   (merge i/IEntityDefaults
          {:hydration-keys     (constantly [:card])

--- a/src/metabase/models/card_favorite.clj
+++ b/src/metabase/models/card_favorite.clj
@@ -1,9 +1,10 @@
 (ns metabase.models.card-favorite
-  (:require [metabase.models.interface :as i]))
+  (:require [metabase.models.interface :as i]
+            [metabase.util :as u]))
 
 (i/defentity CardFavorite :report_cardfavorite)
 
-(extend (class CardFavorite)
+(u/strict-extend (class CardFavorite)
   i/IEntity
   (merge i/IEntityDefaults
          {:timestamped? (constantly true)}))

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -23,7 +23,7 @@
 
 (i/defentity Dashboard :report_dashboard)
 
-(extend (class Dashboard)
+(u/strict-extend (class Dashboard)
   i/IEntity
   (merge i/IEntityDefaults
          {:timestamped?       (constantly true)
@@ -111,7 +111,7 @@
                build-sentence)))))
 
 
-(extend (class Dashboard)
+(u/strict-extend (class Dashboard)
   revision/IRevisioned
   (merge revision/IRevisionedDefaults
          {:serialize-instance (fn [_ _ dashboard] (serialize-dashboard dashboard))

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -24,7 +24,7 @@
 (defn- pre-cascade-delete [{:keys [id]}]
   (db/cascade-delete 'DashboardCardSeries :dashboardcard_id id))
 
-(extend (class DashboardCard)
+(u/strict-extend (class DashboardCard)
   i/IEntity
   (merge i/IEntityDefaults
          {:timestamped?       (constantly true)

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -3,7 +3,8 @@
             [korma.core :as k]
             [metabase.api.common :refer [*current-user*]]
             [metabase.db :refer [cascade-delete sel]]
-            [metabase.models.interface :as i]))
+            [metabase.models.interface :as i]
+            [metabase.util :as u]))
 
 (def ^:const protected-password
   "The string to replace passwords with when serializing Databases."
@@ -26,7 +27,7 @@
   [{:keys [id]}]
   (sel :many 'Table :db_id id, :active true, (k/order :display_name :ASC)))
 
-(extend (class Database)
+(u/strict-extend (class Database)
   i/IEntity
   (merge i/IEntityDefaults
          {:hydration-keys     (constantly [:database :db])

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -4,7 +4,8 @@
             (metabase.models [common :as common]
                              [field-values :refer [FieldValues]]
                              [foreign-key :refer [ForeignKey]]
-                             [interface :as i])))
+                             [interface :as i])
+            [metabase.util :as u]))
 
 (def ^:const special-types
   "Possible values for `Field.special_type`."
@@ -114,7 +115,7 @@
     (let [dest-id (sel :one :field [ForeignKey :destination_id] :origin_id id)]
       (Field dest-id))))
 
-(extend (class Field)
+(u/strict-extend (class Field)
   i/IEntity (merge i/IEntityDefaults
                    {:hydration-keys     (constantly [:destination :field :origin])
                     :types              (constantly {:base_type :keyword, :field_type :keyword, :special_type :keyword, :description :clob})

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -8,7 +8,7 @@
 
 (i/defentity FieldValues :metabase_fieldvalues)
 
-(extend (class FieldValues)
+(u/strict-extend (class FieldValues)
   i/IEntity
   (merge i/IEntityDefaults
          {:timestamped? (constantly true)

--- a/src/metabase/models/foreign_key.clj
+++ b/src/metabase/models/foreign_key.clj
@@ -1,5 +1,6 @@
 (ns metabase.models.foreign-key
-  (:require [metabase.models.interface :as i]))
+  (:require [metabase.models.interface :as i]
+            [metabase.util :as u]))
 
 (def ^:const relationships
   "Valid values for `ForeginKey.relationship`."
@@ -7,7 +8,7 @@
 
 (i/defentity ForeignKey :metabase_foreignkey)
 
-(extend (class ForeignKey)
+(u/strict-extend (class ForeignKey)
   i/IEntity
   (merge i/IEntityDefaults
          {:types        (constantly {:relationship :keyword})

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -250,7 +250,7 @@
    The record type automatically extends `IEntity` with `IEntityDefaults`, but you may call `extend` again if you need to
    override default behaviors:
 
-     (extend (class User)             ; it's somewhat more readable to write `(class User)` instead `UserInstance`
+     (u/strict-extend (class User)             ; it's somewhat more readable to write `(class User)` instead `UserInstance`
        IEntity (merge IEntityDefaults
                       {...}))
 
@@ -271,7 +271,7 @@
          (~'invoke [this#]     (invoke-entity-or-instance this#))
          (~'invoke [this# id#] (invoke-entity-or-instance this# id#)))
 
-       (extend ~instance
+       (u/strict-extend ~instance
          IEntity        IEntityDefaults
          ICreateFromMap {:map-> (u/drop-first-arg ~map->instance)})
 

--- a/src/metabase/models/metric.clj
+++ b/src/metabase/models/metric.clj
@@ -12,7 +12,7 @@
 
 (i/defentity Metric :metric)
 
-(extend (class Metric)
+(u/strict-extend (class Metric)
   i/IEntity
   (merge i/IEntityDefaults
          {:types         (constantly {:definition :json, :description :clob})
@@ -42,7 +42,7 @@
                   (get-in base-diff [:before :definition])) (assoc :definition {:before (get-in metric1 [:definition])
                                                                                 :after  (get-in metric2 [:definition])})))))
 
-(extend (class Metric)
+(u/strict-extend (class Metric)
   revision/IRevisioned
   (merge revision/IRevisionedDefaults
          {:serialize-instance serialize-metric
@@ -58,7 +58,7 @@
   (when definition
     {:Segment (q/extract-segment-ids definition)}))
 
-(extend (class Metric)
+(u/strict-extend (class Metric)
   dependency/IDependent
   {:dependencies metric-dependencies})
 

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -9,7 +9,8 @@
                              [hydrate :refer :all]
                              [interface :as i]
                              [pulse-card :refer [PulseCard]]
-                             [pulse-channel :refer [PulseChannel] :as pulse-channel])))
+                             [pulse-channel :refer [PulseChannel] :as pulse-channel])
+            [metabase.util :as u]))
 
 
 (i/defentity Pulse :pulse)
@@ -36,7 +37,7 @@
             (k/where {:pulse_card.pulse_id id})
             (k/order :pulse_card.position :asc)))
 
-(extend (class Pulse)
+(u/strict-extend (class Pulse)
   i/IEntity
   (merge i/IEntityDefaults
          {:hydration-keys     (constantly [:pulse])

--- a/src/metabase/models/pulse_channel.clj
+++ b/src/metabase/models/pulse_channel.clj
@@ -2,11 +2,12 @@
   (:require [clojure.set :as set]
             [cheshire.generate :refer [add-encoder encode-map]]
             [korma.core :as k]
+            [medley.core :as m]
             [metabase.db :as db]
             (metabase.models [pulse-channel-recipient :refer [PulseChannelRecipient]]
                              [interface :as i]
                              [user :refer [User]])
-            [medley.core :as m]))
+            [metabase.util :as u]))
 
 
 ;; ## Static Definitions
@@ -118,13 +119,13 @@
 (defn- pre-cascade-delete [{:keys [id]}]
   (db/cascade-delete PulseChannelRecipient :pulse_channel_id id))
 
-(extend (class PulseChannel)
+(u/strict-extend (class PulseChannel)
   i/IEntity (merge i/IEntityDefaults
                    {:hydration-keys     (constantly [:pulse_channel])
                     :types              (constantly {:details :json, :channel_type :keyword, :schedule_type :keyword, :schedule_frame :keyword})
                     :timestamped?       (constantly true)
                     :can-read?          (constantly true)
-                    :can-write          i/superuser?
+                    :can-write?         i/superuser?
                     :pre-cascade-delete pre-cascade-delete}))
 
 

--- a/src/metabase/models/query_execution.clj
+++ b/src/metabase/models/query_execution.clj
@@ -1,5 +1,6 @@
 (ns metabase.models.query-execution
-  (:require [metabase.models.interface :as i]))
+  (:require [metabase.models.interface :as i]
+            [metabase.util :as u]))
 
 
 (i/defentity QueryExecution :query_queryexecution)
@@ -8,7 +9,7 @@
   ;; sadly we have 2 ways to reference the row count :(
   (assoc query-execution :row_count (or result_rows 0)))
 
-(extend (class QueryExecution)
+(u/strict-extend (class QueryExecution)
   i/IEntity
   (merge i/IEntityDefaults
          {:default-fields (constantly [:id :uuid :version :json_query :raw_query :status :started_at :finished_at :running_time :error :result_rows])

--- a/src/metabase/models/revision.clj
+++ b/src/metabase/models/revision.clj
@@ -66,7 +66,7 @@
 
 (i/defentity Revision :revision)
 
-(extend (class Revision)
+(u/strict-extend (class Revision)
   i/IEntity
   (merge i/IEntityDefaults
          {:types        (constantly {:object :json})

--- a/src/metabase/models/segment.clj
+++ b/src/metabase/models/segment.clj
@@ -10,7 +10,7 @@
 
 (i/defentity Segment :segment)
 
-(extend (class Segment)
+(u/strict-extend (class Segment)
   i/IEntity
   (merge i/IEntityDefaults
          {:types           (constantly {:definition :json, :description :clob})
@@ -42,7 +42,7 @@
                                                                                 :after  (get-in segment2 [:definition])})))))
 
 
-(extend (class Segment)
+(u/strict-extend (class Segment)
   revision/IRevisioned
   (merge revision/IRevisionedDefaults
          {:serialize-instance serialize-segment

--- a/src/metabase/models/session.clj
+++ b/src/metabase/models/session.clj
@@ -11,7 +11,7 @@
 (defn- pre-insert [session]
   (assoc session :created_at (u/new-sql-timestamp)))
 
-(extend (class Session)
+(u/strict-extend (class Session)
   i/IEntity
   (merge i/IEntityDefaults
          {:pre-insert pre-insert}))

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -7,7 +7,8 @@
                              [field-values :refer [FieldValues]]
                              [interface :as i]
                              [metric :refer [Metric retrieve-metrics]]
-                             [segment :refer [Segment retrieve-segments]])))
+                             [segment :refer [Segment retrieve-segments]])
+            [metabase.util :as u]))
 
 (def ^:const entity-types
   "Valid values for `Table.entity_type` (field may also be `nil`)."
@@ -62,7 +63,7 @@
   "Return the `Database` associated with this `Table`."
   (comp Database :db_id))
 
-(extend (class Table)
+(u/strict-extend (class Table)
   i/IEntity (merge i/IEntityDefaults
                    {:hydration-keys     (constantly [:table])
                     :types              (constantly {:entity_type :keyword, :visibility_type :keyword, :description :clob})

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -52,7 +52,7 @@
   (db/cascade-delete 'Segment :creator_id id)
   (db/cascade-delete 'Metric :creator_id id))
 
-(extend (class User)
+(u/strict-extend (class User)
   i/IEntity
   (merge i/IEntityDefaults
          {:default-fields     (constantly [:id :email :date_joined :first_name :last_name :last_login :is_superuser :is_qbnewb])

--- a/src/metabase/models/view_log.clj
+++ b/src/metabase/models/view_log.clj
@@ -9,7 +9,7 @@
   (let [defaults {:timestamp (u/new-sql-timestamp)}]
     (merge defaults log-entry)))
 
-(extend (class ViewLog)
+(u/strict-extend (class ViewLog)
   i/IEntity (merge i/IEntityDefaults
                    {:can-read?  i/publicly-readable?
                     :can-write? i/publicly-writeable?

--- a/test/metabase/driver/sync_test.clj
+++ b/test/metabase/driver/sync_test.clj
@@ -15,8 +15,7 @@
             (metabase.test [data :refer :all]
                            [util :refer [resolve-private-fns] :as tu])
             (metabase.test.data [datasets :as datasets]
-                                [interface :refer [create-database-definition]])
-            [metabase.util :as u]))
+                                [interface :refer [create-database-definition]])))
 
 (def sync-test-tables
   {"movie"  {:name "movie"

--- a/test/metabase/test/data/bigquery.clj
+++ b/test/metabase/test/data/bigquery.clj
@@ -192,7 +192,7 @@
 
 ;;; # ------------------------------------------------------------ IDatasetLoader ------------------------------------------------------------
 
-(extend BigQueryDriver
+(u/strict-extend BigQueryDriver
   i/IDatasetLoader
   (merge i/IDatasetLoaderDefaultsMixin
          {:engine                       (constantly :bigquery)

--- a/test/metabase/test/data/druid.clj
+++ b/test/metabase/test/data/druid.clj
@@ -16,7 +16,7 @@
    :port (Integer/parseInt (or (env :mb-druid-port)
                                (throw (Exception. "In order to test Druid, you must specify `MB_DRUID_PORT`."))))})
 
-(extend DruidDriver
+(u/strict-extend DruidDriver
   i/IDatasetLoader
   (merge i/IDatasetLoaderDefaultsMixin
          {:engine                       (constantly :druid)

--- a/test/metabase/test/data/h2.clj
+++ b/test/metabase/test/data/h2.clj
@@ -6,7 +6,8 @@
                    [db :as kdb])
             metabase.driver.h2
             (metabase.test.data [generic-sql :as generic]
-                                [interface :as i]))
+                                [interface :as i])
+            [metabase.util :as u])
   (:import metabase.driver.h2.H2Driver))
 
 (def ^:private ^:const field-base-type->sql-type
@@ -66,7 +67,7 @@
    (format "GRANT ALL ON %s TO GUEST;" (quote-name this table-name))))
 
 
-(extend H2Driver
+(u/strict-extend H2Driver
   generic/IGenericSQLDatasetLoader
   (let [{:keys [execute-sql!], :as mixin} generic/DefaultsMixin]
     (merge mixin

--- a/test/metabase/test/data/mongo.clj
+++ b/test/metabase/test/data/mongo.clj
@@ -3,7 +3,8 @@
                     [core :as mg])
             metabase.driver.mongo
             [metabase.driver.mongo.util :refer [with-mongo-connection]]
-            [metabase.test.data.interface :as i])
+            [metabase.test.data.interface :as i]
+            [metabase.util :as u])
   (:import metabase.driver.mongo.MongoDriver))
 
 (defn- database->connection-details
@@ -40,7 +41,7 @@
               (catch com.mongodb.MongoException _))))))))
 
 
-(extend MongoDriver
+(u/strict-extend MongoDriver
   i/IDatasetLoader
   (merge i/IDatasetLoaderDefaultsMixin
          {:create-db!                   create-db!

--- a/test/metabase/test/data/mysql.clj
+++ b/test/metabase/test/data/mysql.clj
@@ -4,7 +4,8 @@
             [environ.core :refer [env]]
             metabase.driver.mysql
             (metabase.test.data [generic-sql :as generic]
-                                [interface :as i]))
+                                [interface :as i])
+            [metabase.util :as u])
   (:import metabase.driver.mysql.MySQLDriver))
 
 (def ^:private ^:const field-base-type->sql-type
@@ -32,7 +33,7 @@
 (defn- quote-name [_ nm]
   (str \` nm \`))
 
-(extend MySQLDriver
+(u/strict-extend MySQLDriver
   generic/IGenericSQLDatasetLoader
   (merge generic/DefaultsMixin
          {:execute-sql!              generic/sequentially-execute-sql!

--- a/test/metabase/test/data/postgres.clj
+++ b/test/metabase/test/data/postgres.clj
@@ -3,7 +3,8 @@
   (:require [environ.core :refer [env]]
             metabase.driver.postgres
             (metabase.test.data [generic-sql :as generic]
-                                [interface :as i]))
+                                [interface :as i])
+            [metabase.util :as u])
   (:import metabase.driver.postgres.PostgresDriver))
 
 (def ^:private ^:const field-base-type->sql-type
@@ -29,7 +30,7 @@
          (when (= context :db)
            {:db database-name})))
 
-(extend PostgresDriver
+(u/strict-extend PostgresDriver
   generic/IGenericSQLDatasetLoader
   (merge generic/DefaultsMixin
          {:drop-table-if-exists-sql  generic/drop-table-if-exists-cascade-sql

--- a/test/metabase/test/data/redshift.clj
+++ b/test/metabase/test/data/redshift.clj
@@ -58,7 +58,7 @@
   ([_ _ table-name field-name]
    [session-schema-name table-name field-name]))
 
-(extend RedshiftDriver
+(u/strict-extend RedshiftDriver
   generic/IGenericSQLDatasetLoader
   (merge generic/DefaultsMixin
          {:create-db-sql             (constantly nil)

--- a/test/metabase/test/data/sqlite.clj
+++ b/test/metabase/test/data/sqlite.clj
@@ -33,7 +33,7 @@
                           [k (u/cond-as-> v v
                                (instance? java.util.Date v) (k/raw (format "DATETIME('%s')" (u/date->iso-8601 v))))]))))))
 
-(extend SQLiteDriver
+(u/strict-extend SQLiteDriver
   generic/IGenericSQLDatasetLoader
   (merge generic/DefaultsMixin
          {:add-fk-sql                (constantly nil) ; TODO - fix me

--- a/test/metabase/test/data/sqlserver.clj
+++ b/test/metabase/test/data/sqlserver.clj
@@ -7,7 +7,8 @@
                              sqlserver)
             (metabase.test.data [datasets :as datasets]
                                 [generic-sql :as generic]
-                                [interface :as i]))
+                                [interface :as i])
+            [metabase.util :as u])
   (:import metabase.driver.sqlserver.SQLServerDriver))
 
 (def ^:private ^:const field-base-type->sql-type
@@ -81,7 +82,7 @@
    [(+suffix db-name) "dbo" table-name field-name]))
 
 
-(extend SQLServerDriver
+(u/strict-extend SQLServerDriver
   generic/IGenericSQLDatasetLoader
   (merge generic/DefaultsMixin
          {:drop-db-if-exists-sql     drop-db-if-exists-sql
@@ -97,8 +98,7 @@
                                             (create-db! this dbdef))
             :database->connection-details database->connection-details
             :default-schema               (constantly "dbo")
-            :engine                       (constantly :sqlserver)
-            :sum-field-type               (constantly :IntegerField)})))
+            :engine                       (constantly :sqlserver)})))
 
 
 (defn- cleanup-leftover-dbs


### PR DESCRIPTION
Add a new function to `metabase.util` called `strict-extend` that should be used in place of normal `extend`.

`strict-extend` checks to make sure all required methods are provided, and that all provided methods are in the protocol. This has already caught a few bugs in our codebase with methods being added to the wrong method map or being named incorrectly.
