### PR TITLE
Report Timezone setting warning

### DIFF
--- a/frontend/src/admin/settings/components/SettingsSetting.jsx
+++ b/frontend/src/admin/settings/components/SettingsSetting.jsx
@@ -81,7 +81,10 @@ export default class SettingsSetting extends Component {
         return (
             <li className="m2 mb4">
                 <div className="text-grey-4 text-bold text-uppercase">{setting.display_name}</div>
-                <div className="text-grey-4 my1">{setting.description}</div>
+                <div className="text-grey-4 my1">
+                    {setting.description}
+                    {setting.note && <div>{setting.note}</div>}
+                </div>
                 <div className="flex">{control}</div>
             </li>
         );

--- a/frontend/src/admin/settings/settings.controllers.js
+++ b/frontend/src/admin/settings/settings.controllers.js
@@ -33,7 +33,8 @@ const SECTIONS = [
                     { name: "Database Default", value: "" },
                     ...MetabaseSettings.get('timezones')
                 ],
-                placeholder: "Select a timezone"
+                placeholder: "Select a timezone",
+                note: "Not all databases support timezones, in which case this setting won't take effect."
             },
             {
                 key: "anon-tracking-enabled",


### PR DESCRIPTION
This was added as part of #2015 

provide a small warning about the Report Timezone on the settings page and the fact that it won't work on databases that don't have timezone support.
