### PR TITLE
Disable field type

### DIFF
--- a/frontend/src/admin/datamodel/components/database/ColumnItem.jsx
+++ b/frontend/src/admin/datamodel/components/database/ColumnItem.jsx
@@ -16,7 +16,6 @@ export default class Column extends Component {
         this.onNameChange = this.onNameChange.bind(this);
         this.onSpecialTypeChange = this.onSpecialTypeChange.bind(this);
         this.onTargetChange = this.onTargetChange.bind(this);
-        this.onTypeChange = this.onTypeChange.bind(this);
         this.onVisibilityChange = this.onVisibilityChange.bind(this);
     }
 
@@ -48,10 +47,6 @@ export default class Column extends Component {
 
     onVisibilityChange(type) {
         this.updateProperty("visibility_type", type.id);
-    }
-
-    onTypeChange(type) {
-        this.updateProperty("field_type", type.id);
     }
 
     onSpecialTypeChange(special_type) {
@@ -99,15 +94,6 @@ export default class Column extends Component {
                                     value={_.find(MetabaseCore.field_visibility_types, (type) => type.id === this.props.field.visibility_type)}
                                     options={MetabaseCore.field_visibility_types}
                                     onChange={this.onVisibilityChange}
-                                />
-                            </div>
-                            <div className="flex-full px1">
-                                <Select
-                                    className="TableEditor-field-type block"
-                                    placeholder="Select a field type"
-                                    value={_.find(MetabaseCore.field_field_types, (type) => type.id === this.props.field.field_type)}
-                                    options={MetabaseCore.field_field_types}
-                                    onChange={this.onTypeChange}
                                 />
                             </div>
                             <div className="flex-full px1">

--- a/frontend/src/admin/datamodel/components/database/ColumnsList.jsx
+++ b/frontend/src/admin/datamodel/components/database/ColumnsList.jsx
@@ -20,7 +20,6 @@ export default class ColumnsList extends Component {
                     <div style={{minWidth: 420}} className="float-left px1">Column</div>
                     <div className="flex clearfix">
                         <div className="flex-half px1">Visibility</div>
-                        <div className="flex-half px1">Type</div>
                         <div className="flex-half px1">Details</div>
                     </div>
                 </div>

--- a/frontend/src/admin/datamodel/components/database/ColumnsList.jsx
+++ b/frontend/src/admin/datamodel/components/database/ColumnsList.jsx
@@ -20,7 +20,7 @@ export default class ColumnsList extends Component {
                     <div style={{minWidth: 420}} className="float-left px1">Column</div>
                     <div className="flex clearfix">
                         <div className="flex-half px1">Visibility</div>
-                        <div className="flex-half px1">Details</div>
+                        <div className="flex-half px1">Type</div>
                     </div>
                 </div>
                 <ol className="border-top border-bottom">

--- a/frontend/src/lib/schema_metadata.js
+++ b/frontend/src/lib/schema_metadata.js
@@ -52,6 +52,7 @@ const TYPES = {
         special: ["category"],
         include: [LOCATION]
     },
+    // NOTE: this is defunct right now.  see definition of isDimension below.
     [DIMENSION]: {
         field: ["dimension"],
         include: [DATE_TIME, CATEGORY, ENTITY]
@@ -100,7 +101,7 @@ export const isBoolean = isFieldType.bind(null, BOOLEAN);
 export const isString = isFieldType.bind(null, STRING);
 export const isSummable = isFieldType.bind(null, SUMMABLE);
 export const isCategory = isFieldType.bind(null, CATEGORY);
-export const isDimension = isFieldType.bind(null, DIMENSION);
+export const isDimension = () => true;
 
 
 // operator argument constructors:

--- a/src/metabase/api/field.clj
+++ b/src/metabase/api/field.clj
@@ -39,20 +39,17 @@
 
 (defendpoint PUT "/:id"
   "Update `Field` with ID."
-  [id :as {{:keys [field_type special_type visibility_type description display_name]} :body}]
-  {field_type      FieldType
-   special_type    FieldSpecialType
+  [id :as {{:keys [special_type visibility_type description display_name]} :body}]
+  {special_type    FieldSpecialType
    visibility_type FieldVisibilityType
    display_name    NonEmptyString}
   (let-404 [field (Field id)]
     (write-check field)
-    (let [field_type      (or field_type (:field_type field))
-          special_type    (or special_type (:special_type field))
+    (let [special_type    (or special_type (:special_type field))
           visibility_type (or visibility_type (:visibility_type field))]
-      (check-400 (field/valid-metadata? (:base_type field) field_type special_type visibility_type))
+      (check-400 (field/valid-metadata? (:base_type field) (:field_type field) special_type visibility_type))
       ;; update the Field.  start with keys that may be set to NULL then conditionally add other keys if they have values
       (check-500 (m/mapply upd Field id (merge {:description     description
-                                                :field_type      field_type
                                                 :special_type    special_type
                                                 :visibility_type visibility_type}
                                                (when display_name {:display_name display_name}))))


### PR DESCRIPTION
Remove the use of `field-type` from the code for now by:
1. deleting the dropdown from the frontend data model editing page
2. modifying the isDimension() function to just return all fields
3. preventing the field-type from being modified via the api

Note that the field still exists as part of the app and all the normal default logic to pick it is part of the sync code, it's just that it won't have any other impact on the functionality of the app.  A little down the road if we are sure we don't need this type we can permanently remove it.
