### PR TITLE
use alpine as base image and subsequently fix npm build failures

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.babel_cache/*
+docs/*
+OSX/*
+target/*
+
+**metabase.jar

--- a/bin/docker/Dockerfile
+++ b/bin/docker/Dockerfile
@@ -1,9 +1,12 @@
-FROM java:openjdk-7-jre
+FROM java:openjdk-7-jre-alpine
 
-ENV LC_ALL C
-ENV LANG C.UTF-8
-ENV DEBIAN_FRONTEND noninteractive
-ENV DEBCONF_NONINTERACTIVE_SEEN true
+# need bash
+RUN apk add --update bash
+
+# fix broken cacerts
+RUN apk add --update java-cacerts && \
+    rm -f /usr/lib/jvm/default-jvm/jre/lib/security/cacerts && \
+    ln -s /etc/ssl/certs/java/cacerts /usr/lib/jvm/default-jvm/jre/lib/security/cacerts
 
 # add Metabase jar
 COPY ./metabase.jar /app/
@@ -11,6 +14,9 @@ COPY ./metabase.jar /app/
 # add our run script to the image
 COPY ./run_metabase.sh /app/
 RUN chmod 755 /app/run_metabase.sh
+
+# tidy up
+RUN rm -rf /tmp/* /var/cache/apk/*
 
 # expose our default runtime port
 EXPOSE 3000


### PR DESCRIPTION
This PR switches us to using a much smaller base image as well as fixes the npm build issue. Our docker users will thank us for cutting the image size in half. :smile:

Image size comparison

```
$ docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
metabase-build      latest              bb3c4a5bb87f        2 minutes ago       181.7 MB
metabase-head       latest              f849b89960c7        3 minutes ago       1.026 GB
metabase/metabase   latest              8841f16fbc1b        2 weeks ago         397.1 MB
alpine              3.3                 70c557e50ed6        2 weeks ago         4.798 MB
```
