### PR TITLE
Druid- Truncate of relative datetime should happen even if value of unit is 0

### DIFF
--- a/src/metabase/driver/druid/query_processor.clj
+++ b/src/metabase/driver/druid/query_processor.clj
@@ -44,9 +44,7 @@
   DateTimeField         (->rvalue [this] (->rvalue (:field this)))
   Value                 (->rvalue [this] (:value this))
   DateTimeValue         (->rvalue [{{unit :unit} :field, value :value}] (u/date->iso-8601 (u/date-trunc-or-extract unit value)))
-  RelativeDateTimeValue (->rvalue [{:keys [unit amount]}] (if (zero? amount)
-                                                            (u/date->iso-8601)
-                                                            (u/date->iso-8601 (u/date-trunc-or-extract unit (u/relative-date unit amount))))))
+  RelativeDateTimeValue (->rvalue [{:keys [unit amount]}] (u/date->iso-8601 (u/date-trunc-or-extract unit (u/relative-date unit amount)))))
 
 (defprotocol ^:private IDimensionOrMetric
   (^:private dimension-or-metric? [this]


### PR DESCRIPTION
Resolves #2218 
The relative datetime should be truncated to current "unit" even when the "value" is 0.
