### PR TITLE
Reduce intermittent CI failure rate

### DIFF
--- a/src/metabase/driver/mongo/util.clj
+++ b/src/metabase/driver/mongo/util.clj
@@ -14,7 +14,7 @@
 
    Don't set the timeout too low -- I've have Circle fail when the timeout was 1000ms
    on *one* occasion."
-  1500)
+  3000)
 
 (def ^:dynamic ^com.mongodb.DB *mongo-connection*
   "Connection to a Mongo database.

--- a/test/metabase/test/data/bigquery.clj
+++ b/test/metabase/test/data/bigquery.clj
@@ -115,9 +115,9 @@
                                          (.set data (name k) v))
                                        (doto (TableDataInsertAllRequest$Rows.)
                                          (.setJson data))))))))
-  ;; Wait up to 15 seconds for all the rows to be loaded and become available by BigQuery
+  ;; Wait up to 30 seconds for all the rows to be loaded and become available by BigQuery
   (let [expected-row-count (count row-maps)]
-    (loop [seconds-to-wait-for-load 15]
+    (loop [seconds-to-wait-for-load 30]
       (let [actual-row-count (table-row-count dataset-id table-id)]
         (cond
           (= expected-row-count actual-row-count) :ok
@@ -182,12 +182,9 @@
     (try (destroy-dataset! database-name)
          (catch Throwable _))
     (create-dataset! database-name)
-    (u/pdoseq [tabledef table-definitions]
+    (doseq [tabledef table-definitions]
       (load-tabledef! database-name tabledef)))
   (println (u/format-color 'green "[OK]")))
-
-(defn- destroy-db! [{:keys [database-name]}]
-  #_(destroy-dataset! (normalize-name database-name)))
 
 
 ;;; # ------------------------------------------------------------ IDatasetLoader ------------------------------------------------------------
@@ -198,4 +195,4 @@
          {:engine                       (constantly :bigquery)
           :database->connection-details (u/drop-first-arg database->connection-details)
           :create-db!                   (u/drop-first-arg create-db!)
-          :destroy-db!                  (u/drop-first-arg destroy-db!)}))
+          :destroy-db!                  (constantly nil)}))


### PR DESCRIPTION
A couple of minor changes that should reduce the number of intermittent CI failures.
1.  Give MongoDB a slightly longer connection timeout
2.  It looks like most of our BigQuery failures actually happened while loading test data. Change logic to load data sequentially rather than in parallel to reduce load. 
3.  Increase max wait time for BigQuery to finish processing newly loaded data
