### PR TITLE
Better error logging when BigQuery times out :cry:

### DIFF
--- a/src/metabase/driver/bigquery.clj
+++ b/src/metabase/driver/bigquery.clj
@@ -175,12 +175,13 @@
 (defn- post-process-native
   ;; 99% of the time by the time this is called `.getJobComplete` will return `true`. On the off chance it doesn't, wait a few seconds for the job to finish.
   ([^QueryResponse response]
-   (post-process-native response 5))                     ; wait up to 5 seconds for `.getJobComplete` to return `true`
+   (post-process-native response 10))                                        ; wait up to 10 seconds for `.getJobComplete` to return `true`
   ([^QueryResponse response, ^Integer timeout-seconds]
    (when-not (.getJobComplete response)
-     (when (zero? timeout-seconds)                       ; if we've ran out of wait time throw an exception
-       (throw (Exception. (str (.getErrors response)))))
-     (Thread/sleep 1000)                                 ; otherwise sleep a second, try again, and decrement the remaining `timeout-seconds`
+     (when (zero? timeout-seconds)                                           ; if we've ran out of wait time throw an exception
+       (throw (Exception. (str "Query timed out: " (or (.getErrors response)
+                                                       response)))))
+     (Thread/sleep 1000)                                                     ; otherwise sleep a second, try again, and decrement the remaining `timeout-seconds`
      (post-process-native response (dec timeout-seconds)))
    (let [^TableSchema schema (.getSchema response)
          parsers             (for [^TableFieldSchema field (.getFields schema)]


### PR DESCRIPTION
Try to get to the root of CI / timeout issues
