### PR TITLE
Add load/dump debug functions for query builder

### DIFF
--- a/frontend/src/card/card.controllers.js
+++ b/frontend/src/card/card.controllers.js
@@ -983,5 +983,24 @@ CardControllers.controller('CardDetail', [
         }
 
         init();
+
+        // for debugging visualizations allow dumping/loading of visualization state from JavaScript console
+        window.dumpQueryBuilderState = function() {
+            return {
+                card: card,
+                data: queryResult
+            };
+        };
+
+        window.loadQueryBuilderState = function(state) {
+            card = state.card;
+            queryResult = state.data;
+            renderAll();
+        };
+
+        $scope.$on("$destroy", function() {
+            delete window.dumpQueryBuilderState;
+            delete window.loadQueryBuilderState;
+        })
     }
 ]);


### PR DESCRIPTION
This will allow us to dump the card + data state of the query builder to make it easier to debug visualization issues.

In the console do:

```
copy(JSON.stringify(dumpQueryBuilderState()))
```

Then paste to a gist or whatever. Then someone else can do the following (with the JSON pasted in the "...")

```
loadQueryBuilderState(...)
```

to view the exact same visualization.

However the query builder UI itself won't work. This is just for debugging the visualizations itself.
