### PR TITLE
Don't default to grouping dates in raw data queries by day :calendar:

### DIFF
--- a/src/metabase/driver/query_processor.clj
+++ b/src/metabase/driver/query_processor.clj
@@ -181,7 +181,7 @@
                                            (resolve/resolve-table {source-table-id source-table}))]
                              (if (or (contains? #{:DateField :DateTimeField} (:base-type field))
                                      (contains? #{:timestamp_seconds :timestamp_milliseconds} (:special-type field)))
-                               (map->DateTimeField {:field field, :unit :day})
+                               (map->DateTimeField {:field field, :unit :default})
                                field)))]
               (if-not (seq fields)
                 (do (log/warn (format "Table '%s' has no Fields associated with it." (:name source-table)))

--- a/test/metabase/driver/query_processor_test.clj
+++ b/test/metabase/driver/query_processor_test.clj
@@ -116,7 +116,7 @@
                   :base_type    (expected-base-type->actual :DateTimeField)
                   :name         (format-name "last_login")
                   :display_name "Last Login"
-                  :unit         :day})))
+                  :unit         :default})))
 
 ;; #### venues
 (defn- venues-columns
@@ -136,13 +136,14 @@
                    :base_type    (id-field-type)
                    :name         (format-name "id")
                    :display_name "Id"}
-     :category_id {:extra_info   (if (fks-supported?) {:target_table_id (id :categories)}
-                                     {})
-                   :target       (if (fks-supported?) (-> (categories-col :id)
-                                                          (dissoc :target :extra_info :schema_name))
-                                     nil)
-                   :special_type (if (fks-supported?) :fk
-                                     :category)
+     :category_id {:extra_info   (if (fks-supported?)
+                                   {:target_table_id (id :categories)}
+                                   {})
+                   :target       (when (fks-supported?)
+                                   (dissoc (categories-col :id) :target :extra_info :schema_name))
+                   :special_type (if (fks-supported?)
+                                   :fk
+                                   :category)
                    :base_type    (expected-base-type->actual :IntegerField)
                    :name         (format-name "category_id")
                    :display_name "Category Id"}


### PR DESCRIPTION
Don't apply any grouping for "raw data" datetime fields by default as discussed earlier today. Fix for #2277 (is that the right issue, @agilliland ?)

This change was simpler than I thought it would be so should be g2g fort 0.16.1 .
