### PR TITLE
Add section about configuring dashboard via URL

### DIFF
--- a/docs/users-guide/05-sharing-answers.md
+++ b/docs/users-guide/05-sharing-answers.md
@@ -73,6 +73,16 @@ Enabling auto refresh will re-run all the queries on the dashboard at the interv
 
 Combining fullscreen mode and auto refresh is a great way to keep your team in sync with your data throughout the day.
 
+## Configuring dashboard using URL
+
+It is possible to amend URL of the dashboard to automatically enter fullscreen, enable night mode or autorefresh the dashboard. This allows you to configure the dashboard even when you do not have any input access to the device where dashboard will be displayed, for example, scripted screens.
+
+To configure dashboard using URL address, you can append it with hash keys like `fullscreen`, `night`, or `refresh`. Consider this example:
+
+`https://metabase.mydomain.com/dash/2#refresh=60&fullscreen&night`
+
+This URL will make dashboard enter night mode, fullscreen and refresh every 60 seconds.
+
 ---
 
 Next, we'll offer up some suggestions on how to create useful dashboards, in our [Tips on Dashboards](06-dashboard-tips.md).


### PR DESCRIPTION
This PR adds documentation section about how to configure dashboard via URL address. 

Our example use case is that we have a big screen on the wall, to which it's rather difficult to access with mice and keyboard, so we can only show URL's there fed via SSH. Hence, pointing and clicking is not feasible. We would also like to maintain the setup even after we reboot the PI behind the screen. 

All of this is already possible but not very well documented - I had to figure out how to enable fullscreen by inspecting `document.location.hash` :D. This is an attempt to improve on the docs to make this a little more transparent.
- Wording might be improved. Not sure.
- It might or might not be the right doc for this content.
