### PR TITLE
Add unit test that checks whether load-from-h2 command will migrate all entities :sad:

### DIFF
--- a/test/metabase/cmd/load_from_h2_test.clj
+++ b/test/metabase/cmd/load_from_h2_test.clj
@@ -1,0 +1,26 @@
+(ns metabase.cmd.load-from-h2-test
+  (:require [clojure.java.classpath :as classpath]
+            [clojure.tools.namespace.find :as ns-find]
+            [expectations :refer :all]
+            metabase.cmd.load-from-h2
+            [metabase.models.interface :as models]))
+
+;; Check to make sure we're migrating all of our entities.
+;; This fetches the `metabase.cmd.load-from-h2/entities` and compares it all existing entities
+
+(defn- migrated-entity-names []
+  (set (map :name @(resolve 'metabase.cmd.load-from-h2/entities))))
+
+(defn- all-entity-names []
+  (set (for [ns       (ns-find/find-namespaces (classpath/classpath))
+             :when    (re-find #"^metabase\.models\." (name ns))
+             :when    (not (re-find #"test" (name ns)))
+             [_ varr] (do (require ns)
+                          (ns-interns ns))
+             :let     [entity (var-get varr)]
+             :when    (models/metabase-entity? entity)]
+         (:name entity))))
+
+(expect
+  (migrated-entity-names)
+  (all-entity-names))


### PR DESCRIPTION
Loop through interned vars and build a set of _all_ Metabase entity objects. Diff this with the set entities in `load-from-h2`. 

Right now we've been keeping this list up-to-date but this will catch us if we forget to add newly created models to the list in the future.
