### PR TITLE
so that the dot for the most recent data point is always placed over the most recent value in the sparkline.

### DIFF
--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -316,11 +316,16 @@
 
 (defn- render:sparkline
   [_ {:keys [rows cols]}]
-  (let [xs     (for [row  rows
+  (let [ft-row (if (datetime-field? (first cols))
+                 #(.getTime ^Date (u/->Timestamp %))
+                 identity)
+        rows   (if (> (ft-row (first (first rows)))
+                      (ft-row (first (last rows))))
+                 (reverse rows)
+                 rows)
+        xs     (for [row  rows
                      :let [x (first row)]]
-                 (if (datetime-field? (first cols))
-                   (.getTime ^Date (u/->Timestamp x))
-                   x))
+                 (ft-row x))
         xmin   (apply min xs)
         xmax   (apply max xs)
         xrange (- xmax xmin)


### PR DESCRIPTION
fixes #2037
