### PR TITLE
and provides a default of returning null if the BreakoutWidget doesn't have enough input to render the widget.

### DIFF
--- a/frontend/src/query_builder/BreakoutWidget.jsx
+++ b/frontend/src/query_builder/BreakoutWidget.jsx
@@ -91,6 +91,9 @@ export default class BreakoutWidget extends Component {
                     {this.renderPopover()}
                 </div>
             );
+        } else {
+            // this needs to be here to prevent React error (#2304)
+            return null;
         }
     }
 }


### PR DESCRIPTION
fixes #2304 
