### PR TITLE
Skip casting a column if its unit is `:default` in the query

### DIFF
--- a/src/metabase/driver/bigquery.clj
+++ b/src/metabase/driver/bigquery.clj
@@ -255,7 +255,7 @@
 (defn- date [unit expr]
   {:pre [expr]}
   (case unit
-    :default         (kx/->timestamp expr)
+    :default         expr
     :minute          (trunc-with-format "%Y-%m-%d %H:%M:00" expr)
     :minute-of-hour  (kx/minute expr)
     :hour            (trunc-with-format "%Y-%m-%d %H:00:00" expr)

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -141,7 +141,7 @@
 
 (defn- date [_ unit expr]
   (case unit
-    :default         (kx/->timestamp expr)
+    :default         expr
     :minute          (trunc-with-format "yyyyMMddHHmm" expr)
     :minute-of-hour  (kx/minute expr)
     :hour            (trunc-with-format "yyyyMMddHH" expr)

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -83,7 +83,7 @@
 
 (defn- date [_ unit expr]
   (case unit
-    :default         (k/sqlfn :TIMESTAMP expr)
+    :default         expr
     :minute          (trunc-with-format "%Y-%m-%d %H:%i" expr)
     :minute-of-hour  (kx/minute expr)
     :hour            (trunc-with-format "%Y-%m-%d %H" expr)

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -118,7 +118,7 @@
 
 (defn- date [_ unit expr]
   (case unit
-    :default         (kx/->timestamp expr)
+    :default         expr
     :minute          (date-trunc :minute expr)
     :minute-of-hour  (extract-integer :minute expr)
     :hour            (date-trunc :hour expr)

--- a/src/metabase/driver/sqlite.clj
+++ b/src/metabase/driver/sqlite.clj
@@ -43,7 +43,7 @@
             (kx/literal (u/date->iso-8601 expr))
             expr)]
     (case unit
-      :default         (->datetime v)
+      :default         v
       :second          (->datetime (strftime "%Y-%m-%d %H:%M:%S" v))
       :minute          (->datetime (strftime "%Y-%m-%d %H:%M" v))
       :minute-of-hour  (kx/->integer (strftime "%M" v))

--- a/src/metabase/driver/sqlserver.clj
+++ b/src/metabase/driver/sqlserver.clj
@@ -80,7 +80,7 @@
   "See also the [jTDS SQL <-> Java types table](http://jtds.sourceforge.net/typemap.html)"
   [unit expr]
   (case unit
-    :default         (kx/->datetime expr)
+    :default         expr
     :minute          (kx/cast :SMALLDATETIME expr)
     :minute-of-hour  (date-part :minute expr)
     :hour            (kx/->datetime (kx/format "yyyy-MM-dd HH:00:00" expr))


### PR DESCRIPTION
fixes #2323

When we aren't actively trying to create a specific time grouping then we can skip casting the column completely and just use the value as-is.

This tweaks the SQL from ...

```
SELECT "PUBLIC"."ORDERS"."USER_ID" AS "USER_ID", "PUBLIC"."ORDERS"."TOTAL" AS "TOTAL", "PUBLIC"."ORDERS"."TAX" AS "TAX", "PUBLIC"."ORDERS"."SUBTOTAL" AS "SUBTOTAL", "PUBLIC"."ORDERS"."PRODUCT_ID" AS "PRODUCT_ID", "PUBLIC"."ORDERS"."ID" AS "ID", CAST("PUBLIC"."ORDERS"."CREATED_AT" AS TIMESTAMP) AS "CREATED_AT"
FROM "PUBLIC"."ORDERS"
ORDER BY CAST("PUBLIC"."ORDERS"."CREATED_AT" AS TIMESTAMP) DESC
LIMIT 2000
```

to ...

```
SELECT "PUBLIC"."ORDERS"."USER_ID" AS "USER_ID", "PUBLIC"."ORDERS"."TOTAL" AS "TOTAL", "PUBLIC"."ORDERS"."TAX" AS "TAX", "PUBLIC"."ORDERS"."SUBTOTAL" AS "SUBTOTAL", "PUBLIC"."ORDERS"."PRODUCT_ID" AS "PRODUCT_ID", "PUBLIC"."ORDERS"."ID" AS "ID", "PUBLIC"."ORDERS"."CREATED_AT" AS "CREATED_AT"
FROM "PUBLIC"."ORDERS"
ORDER BY "PUBLIC"."ORDERS"."CREATED_AT" ASC
LIMIT 2000
```
