### PR TITLE
use explicit icon size

### DIFF
--- a/frontend/src/questions/components/LabelIcon.jsx
+++ b/frontend/src/questions/components/LabelIcon.jsx
@@ -13,7 +13,7 @@ const LabelIcon = ({ icon = "", size = 18, className, style }) =>
     : icon.charAt(0) === "#" ?
         <span className={cx(S.icon, S.colorIcon, className)} style={{ backgroundColor: icon, width: size, height: size }}></span>
     :
-        <Icon className={cx(S.icon, className)} name={icon} />
+        <Icon className={cx(S.icon, className)} name={icon} width={16} height={16} />
 
 LabelIcon.propTypes = {
     className:  PropTypes.string,


### PR DESCRIPTION
unembiggens the embiggened icons in saved questions (https://github.com/metabase/metabase/commit/671c4489d1d41d0a393f901b21ff87e550e466fa might be why they recently jumped in size)

this doesn't address the ghostly fattening itself, just puts them back at a reasonable size while we explore that.
