### PR TITLE
restore proper icon defaults

### DIFF
--- a/frontend/src/components/Icon.jsx
+++ b/frontend/src/components/Icon.jsx
@@ -29,11 +29,11 @@ export default class Icon extends Component {
         if (!icon) {
             return <span className="hide" />;
         } else if (icon.img) {
-            return (<RetinaImage forceOriginalDimensions={false} {...defaultProps} {...icon.attrs} {...this.props} src={icon.img} />);
+            return (<RetinaImage forceOriginalDimensions={false} {...icon.attrs} {...defaultProps} {...this.props} src={icon.img} />);
         } else if (icon.svg) {
-            return (<svg {...defaultProps} {...icon.attrs} {...this.props} dangerouslySetInnerHTML={{__html: icon.svg}}></svg>);
+            return (<svg  {...icon.attrs} {...defaultProps} {...this.props} dangerouslySetInnerHTML={{__html: icon.svg}}></svg>);
         } else {
-            return (<svg {...defaultProps} {...icon.attrs} {...this.props}><path d={icon.path} /></svg>);
+            return (<svg {...icon.attrs} {...defaultProps}  {...this.props}><path d={icon.path} /></svg>);
         }
     }
 }

--- a/frontend/src/components/Icon.jsx
+++ b/frontend/src/components/Icon.jsx
@@ -21,19 +21,14 @@ export default class Icon extends Component {
     render() {
         const icon = loadIcon(this.props.name);
 
-        const defaultProps = {
-            width: 16,
-            height: 16
-        };
-
         if (!icon) {
             return <span className="hide" />;
         } else if (icon.img) {
-            return (<RetinaImage forceOriginalDimensions={false} {...icon.attrs} {...defaultProps} {...this.props} src={icon.img} />);
+            return (<RetinaImage forceOriginalDimensions={false} {...icon.attrs} {...this.props} src={icon.img} />);
         } else if (icon.svg) {
-            return (<svg  {...icon.attrs} {...defaultProps} {...this.props} dangerouslySetInnerHTML={{__html: icon.svg}}></svg>);
+            return (<svg  {...icon.attrs} {...this.props} dangerouslySetInnerHTML={{__html: icon.svg}}></svg>);
         } else {
-            return (<svg {...icon.attrs} {...defaultProps}  {...this.props}><path d={icon.path} /></svg>);
+            return (<svg {...icon.attrs} {...this.props}><path d={icon.path} /></svg>);
         }
     }
 }

--- a/frontend/src/icon_paths.js
+++ b/frontend/src/icon_paths.js
@@ -195,8 +195,8 @@ export function loadIcon(name) {
     var icon = {
         attrs: {
             className: 'Icon Icon-' + name,
-            width: '32px',
-            height: '32px',
+            width: '16px',
+            height: '16px',
             viewBox: '0 0 32 32',
             fill: 'currentcolor'
         },


### PR DESCRIPTION
flip order of spread so the icon components defaults override the icon defs when applying attributes. restores 16px default icon size

fixes #2417 
