### PR TITLE
Fix updating a label name :unamused:

### DIFF
--- a/src/metabase/models/label.clj
+++ b/src/metabase/models/label.clj
@@ -14,11 +14,12 @@
   (assoc label :slug (u/prog1 (u/slugify label-name)
                        (assert-unique-slug <>))))
 
-(defn- pre-update [{label-name :name, :as label}]
+(defn- pre-update [{label-name :name, id :id, :as label}]
   (if-not label-name
     label
     (assoc label :slug (u/prog1 (u/slugify label-name)
-                         (assert-unique-slug <>)))))
+                         (or (db/exists? Label, :slug <>, :id id) ; if slug hasn't changed no need to check for uniqueness
+                             (assert-unique-slug <>))))))         ; otherwise check to make sure the new slug is unique
 
 (defn- pre-cascade-delete [{:keys [id]}]
   (db/cascade-delete 'CardLabel :label_id id))

--- a/test/metabase/models/label_test.clj
+++ b/test/metabase/models/label_test.clj
@@ -1,0 +1,18 @@
+(ns metabase.models.label-test
+  (:require [expectations :refer :all]
+            [metabase.db :as db]
+            [metabase.models.label :refer [Label]]
+            [metabase.test.util :refer [with-temp with-temp*]]))
+
+;; Check that we can create a label with the name "Cam" (slug "cam")
+;; and update the name to something that will produce the same slug ("cam") without getting a "name already taken" exception
+(expect
+  (with-temp Label [{:keys [id]} {:name "Cam"}]
+    (db/upd Label id, :name "cam")))
+
+;; We SHOULD still see an exception if we try to give something a name that produces a slug that's already been taken
+(expect
+  clojure.lang.ExceptionInfo
+  (with-temp* [Label [{:keys [id]} {:name "Cam"}]
+               Label [_            {:name "Rasta"}]]
+    (db/upd Label id, :name "rasta")))


### PR DESCRIPTION
Don't throw an error if updating a label doesn't change its slug. Includes unit test 😒 

Fixes #2432
