### PR TITLE
Fix table sorting when clicking column header

### DIFF
--- a/frontend/src/card/card.controllers.js
+++ b/frontend/src/card/card.controllers.js
@@ -185,7 +185,7 @@ CardControllers.controller('CardDetail', [
                     } else if (column.unit != null) {
                         field = ["datetime_field", column.id, "as", column.unit];
                     } else {
-                        field = ["field-id", column.id];
+                        field = column.id;
                     }
 
                     let dataset_query = card.dataset_query,


### PR DESCRIPTION
Resolves #2438 but I'm not sure this is the correct fix. It looks like we're supposed be using "field-id" (though bare ids still work for `order_by` clauses). If that's the case we should update `lib/query.js` instead (in particular `isRegularField` only recognizes a bare number as a field, so `cleanQuery` is removing the sort clause because it thinks it's incomplete)
