### PR TITLE
actively close db connection pools when database is deleted

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -135,8 +135,10 @@
 (defendpoint DELETE "/:id"
   "Delete a `Database`."
   [id]
-  (write-check Database id)
-  (cascade-delete Database :id id))
+  (let-404 [db (Database id)]
+    (write-check db)
+    (u/prog1 (cascade-delete Database :id id)
+      (events/publish-event :database-delete db))))
 
 (defendpoint GET "/:id/metadata"
   "Get metadata about a `Database`, including all of its `Tables` and `Fields`.

--- a/src/metabase/events/driver_notifications.clj
+++ b/src/metabase/events/driver_notifications.clj
@@ -9,7 +9,7 @@
 
 (def ^:const ^:private driver-notifications-topics
   "The `Set` of event topics which are subscribed to for use in driver notifications."
-  #{:database-update})
+  #{:database-update :database-delete})
 
 (def ^:private driver-notifications-channel
   "Channel for receiving event notifications we want to subscribe to for driver notifications events."


### PR DESCRIPTION
fixes #2374

fire off an event when a database is deleted so that we can inform drivers and in the case of the generic-sql driver it can shutdown the connection pool for the db we deleted.
