### PR TITLE
Allow native queries for MongoDB :scream_cat:

### DIFF
--- a/src/metabase/driver/druid.clj
+++ b/src/metabase/driver/druid.clj
@@ -72,7 +72,7 @@
                                (assoc (:query query)
                                       :settings (:settings query))))
 
-(defn- process-native [{database-id :database, {query :query} :native}]
+(defn- process-native [{database-id :database, {query :query} :native, :as outer-query}]
   {:pre [(integer? database-id) query]}
   (let-404 [details (sel :one :field [Database :details], :id database-id)]
     (let [query (if (string? query)
@@ -81,7 +81,7 @@
       ;; `annotate` happens automatically as part of the QP middleware for MBQL queries but not for native ones.
       ;; This behavior was originally so we could preserve column order for raw SQL queries.
       ;; Since Druid results come back as maps for each row there is no order to preserve so we can go ahead and re-use the MBQL-QP annotation code here.
-      (annotate/annotate query (qp/post-process-native query (do-query details query))))))
+      (annotate/annotate outer-query (qp/post-process-native query (do-query details query))))))
 
 
 ;;; ### Sync

--- a/src/metabase/driver/mongo/query_processor.clj
+++ b/src/metabase/driver/mongo/query_processor.clj
@@ -4,6 +4,7 @@
                      [string :as s])
             [clojure.tools.logging :as log]
             [clojure.walk :as walk]
+            [cheshire.core :as json]
             (monger [collection :as mc]
                     [operators :refer :all])
             [metabase.driver.mongo.util :refer [with-mongo-connection *mongo-connection* values->base-type]]
@@ -39,26 +40,25 @@
 
 ;; # NATIVE QUERY PROCESSOR
 
-(defn- eval-raw-command
-  "Evaluate raw MongoDB javascript code. This must be ran insided the body of a `with-mongo-connection`.
-
-     (with-mongo-connection [_ \"mongodb://localhost/test\"]
-       (eval-raw-command \"db.zips.findOne()\"))
-     -> {\"_id\" \"01001\", \"city\" \"AGAWAM\", ...}"
-  [^String command]
-  (assert *mongo-connection* "eval-raw-command must be ran inside the body of with-mongo-connection.")
-  (let [^CommandResult result (.doEval ^DB *mongo-connection* command nil)]
-      (when-not (.ok result)
-        (throw (.getException result)))
-      (let [{result "retval"} (PersistentArrayMap/create (.toMap result))]
-        result)))
-
 (defn process-and-run-native
   "Process and run a native MongoDB query."
-  [_ query]
-  (let [results (eval-raw-command (:query (:native query)))]
-    (if (sequential? results) results
-        [results])))
+  [{{query :query} :native, database :database, :as outer-query}]
+  {:pre [query]}
+  (let [query   (u/prog1 (if (string? query)
+                           (json/parse-string query keyword)
+                           query)
+                  (println "QUERY ->" <>))
+        results  (mc/aggregate *mongo-connection* "users" query
+                               :allow-disk-use true)]
+    ;; As with Druid, we want to use `annotate` on the results of native queries.
+    ;; Because the Generic SQL driver was written in ancient times, it has its own internal implementation of `annotate`
+    ;; (which preserves the order of columns in the results) and as a result the `annotate` middleware isn't applied for `:native` queries.
+    ;; Thus we need to manually run it ourself here.
+    ;; TODO - it would be nice if we could let the middleware take care of `annotate` for us. This will likely require a new `IDriver` method
+    ;; returns whether or not `annotate` should be done to native query results.
+    (annotate/annotate outer-query (if (sequential? results)
+                                     results
+                                     [results]))))
 
 
 ;;; # STRUCTURED QUERY PROCESSOR
@@ -398,14 +398,13 @@
 
 (defn process-and-run-structured
   "Process and run a structured MongoDB query."
-  [_ {database :database, {{source-table-name :name} :source-table} :query, :as query}]
+  [{database :database, {{source-table-name :name} :source-table} :query, :as query}]
   {:pre [(map? database)
          (string? source-table-name)]}
   (binding [*query* query]
     (let [generated-pipeline (generate-aggregation-pipeline (:query query))]
       (log-monger-form generated-pipeline)
-      (->> (with-mongo-connection [_ database]
-             (mc/aggregate *mongo-connection* source-table-name generated-pipeline
-                           :allow-disk-use true))
+      (->> (mc/aggregate *mongo-connection* source-table-name generated-pipeline
+                         :allow-disk-use true)
            unescape-names
            unstringify-dates))))


### PR DESCRIPTION
Since everybody polled prefered the Mongo Aggregation Pipeline as the native option here it is.

Implements #2072.
