### PR TITLE
Notify admins when Metabase upgrades are available

### DIFF
--- a/bin/update-version-info
+++ b/bin/update-version-info
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# Generate the version-info.json file which provides basic information about the latest versions of Metabase available.
+# This is used inside the Metabase application as a simple mechanism to be aware if an upgrade is available.
+
+build() {
+echo '{
+    "latest": {
+        "version": "v0.18.0",
+        "released": "2016-05-04T21:09:36.358Z",
+        "patch": false,
+        "highlights": [
+            "Notifications about available Metabase updates"
+        ]
+    },
+    "older": [
+        {
+            "version": "v0.17.1",
+            "released": "2016-05-04T21:09:36.358Z",
+            "patch": true,
+            "highlights": [
+                ""
+            ]
+        },
+        {
+            "version": "v0.17.0",
+            "released": "2016-05-04T21:09:36.358Z",
+            "patch": false,
+            "highlights": [
+                "Tags + Search for Saved Questions", 
+                "Calculated columns", 
+                "Faster Syncing of Metadata",
+                "Lots of database driver improvements and bug fixes"
+            ]
+        },
+        {
+            "version": "v0.16.1",
+            "released": "2016-05-04T21:09:36.358Z",
+            "patch": true,
+            "highlights": [
+                "Fixes for several time alignment issues (timezones)", 
+                "Resolved problem with SQL Server db connections"
+            ]
+        },
+        {
+            "version": "v0.16.0",
+            "released": "2016-05-04T21:09:36.358Z",
+            "patch": false,
+            "highlights": [
+                "Fullscreen (and fabulous) Dashboards", 
+                "Say hello to Metabot in Slack"
+            ]
+        }
+    ]
+}' > /tmp/version-info.json
+}
+
+upload() {
+    # send the current file to s3
+    aws s3 cp /tmp/version-info.json "s3://static.metabase.com/version-info.json"
+}
+
+publish() {
+    build && upload && rm /tmp/version-info.json 2> /dev/null
+}
+
+if [ "$1" ]; then
+    $1
+else
+    publish
+fi

--- a/frontend/src/admin/settings/components/SettingsEditor.jsx
+++ b/frontend/src/admin/settings/components/SettingsEditor.jsx
@@ -1,12 +1,12 @@
 import React, { Component, PropTypes } from "react";
 
 import MetabaseAnalytics from "metabase/lib/analytics";
-import MetabaseSettings from "metabase/lib/settings";
 
 import SettingsHeader from "./SettingsHeader.jsx";
 import SettingsSetting from "./SettingsSetting.jsx";
 import SettingsEmailForm from "./SettingsEmailForm.jsx";
 import SettingsSlackForm from "./SettingsSlackForm.jsx";
+import SettingsUpdatesForm from "./SettingsUpdatesForm.jsx";
 
 import _ from "underscore";
 import cx from 'classnames';
@@ -61,23 +61,6 @@ export default class SettingsEditor extends Component {
         this.updateSetting(setting, event.target.value);
     }
 
-    renderVersionUpdateNotice() {
-        let versionInfo = _.findWhere(this.props.settings, {key: "version-info"});
-        versionInfo = versionInfo ? JSON.parse(versionInfo.value) : null;
-
-        console.log(versionInfo);
-
-        if (!versionInfo || MetabaseSettings.get("version") === versionInfo.latest.version) {
-            return null;
-        } else {
-            return (
-                <div className="text-centered">
-                    Metabase {versionInfo.latest.version} is available!
-                </div>
-            );
-        }
-    }
-
     renderSettingsPane() {
         let section = this.props.sections[this.state.currentSection];
 
@@ -99,6 +82,18 @@ export default class SettingsEditor extends Component {
                         ref="slackForm"
                         elements={section.settings}
                         updateSlackSettings={this.props.updateSlackSettings}
+                    />
+                </div>
+            );
+        } else if (section.name === "Updates") {
+            return (
+                <div className="px2">
+                    <SettingsUpdatesForm
+                        ref="updatesForm"
+                        settings={this.props.settings}
+                        elements={section.settings}
+                        updateSetting={this.updateSetting}
+                        handleChangeEvent={this.handleChangeEvent}
                     />
                 </div>
             );
@@ -135,7 +130,6 @@ export default class SettingsEditor extends Component {
                 <ul className="AdminList-items pt1">
                     {sections}
                 </ul>
-                {this.renderVersionUpdateNotice()}
             </div>
         );
     }

--- a/frontend/src/admin/settings/components/SettingsEditor.jsx
+++ b/frontend/src/admin/settings/components/SettingsEditor.jsx
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from "react";
 
 import MetabaseAnalytics from "metabase/lib/analytics";
+import MetabaseSettings from "metabase/lib/settings";
 
 import SettingsHeader from "./SettingsHeader.jsx";
 import SettingsSetting from "./SettingsSetting.jsx";
@@ -112,14 +113,23 @@ export default class SettingsEditor extends Component {
 
     renderSettingsSections() {
         const sections = _.map(this.props.sections, (section, idx) => {
-            const classes = cx("AdminList-item", "flex", "align-center", "no-decoration", {
+            const classes = cx("AdminList-item", "flex", "align-center", "justify-between", "no-decoration", {
                 "selected": this.state.currentSection === idx
             });
+
+            // if this is the Updates section && there is a new version then lets add a little indicator
+            let newVersionIndicator;
+            if (section.name === "Updates" && MetabaseSettings.newVersionAvailable(this.props.settings)) {
+                newVersionIndicator = (
+                    <span style={{padding: "4px 8px 4px 8px"}} className="bg-brand rounded text-white text-bold h6">1</span>
+                );
+            }
 
             return (
                 <li key={section.name}>
                     <a href="#" className={classes} onClick={this.selectSection.bind(null, idx)}>
-                        {section.name}
+                        <span>{section.name}</span>
+                        {newVersionIndicator}
                     </a>
                 </li>
             );

--- a/frontend/src/admin/settings/components/SettingsEditor.jsx
+++ b/frontend/src/admin/settings/components/SettingsEditor.jsx
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from "react";
 
 import MetabaseAnalytics from "metabase/lib/analytics";
+import MetabaseSettings from "metabase/lib/settings";
 
 import SettingsHeader from "./SettingsHeader.jsx";
 import SettingsSetting from "./SettingsSetting.jsx";
@@ -60,6 +61,23 @@ export default class SettingsEditor extends Component {
         this.updateSetting(setting, event.target.value);
     }
 
+    renderVersionUpdateNotice() {
+        let versionInfo = _.findWhere(this.props.settings, {key: "version-info"});
+        versionInfo = versionInfo ? JSON.parse(versionInfo.value) : null;
+
+        console.log(versionInfo);
+
+        if (!versionInfo || MetabaseSettings.get("version") === versionInfo.latest.version) {
+            return null;
+        } else {
+            return (
+                <div className="text-centered">
+                    Metabase {versionInfo.latest.version} is available!
+                </div>
+            );
+        }
+    }
+
     renderSettingsPane() {
         let section = this.props.sections[this.state.currentSection];
 
@@ -117,6 +135,7 @@ export default class SettingsEditor extends Component {
                 <ul className="AdminList-items pt1">
                     {sections}
                 </ul>
+                {this.renderVersionUpdateNotice()}
             </div>
         );
     }

--- a/frontend/src/admin/settings/components/SettingsUpdatesForm.jsx
+++ b/frontend/src/admin/settings/components/SettingsUpdatesForm.jsx
@@ -1,155 +1,32 @@
 import React, { Component, PropTypes } from "react";
 
-import MetabaseAnalytics from "metabase/lib/analytics";
 import MetabaseSettings from "metabase/lib/settings";
-import MetabaseUtils from "metabase/lib/utils";
-import SettingsEmailFormElement from "./SettingsEmailFormElement.jsx";
 import SettingsSetting from "./SettingsSetting.jsx";
 
-import Icon from "metabase/components/Icon.jsx";
-
-import RetinaImage from "react-retina-image";
-
-import cx from "classnames";
 import _ from "underscore";
+
 
 export default class SettingsUpdatesForm extends Component {
 
-    constructor(props, context) {
-        super(props, context);
-
-        this.state = {
-            formData: {},
-            submitting: "default",
-            valid: false,
-            validationErrors: {}
-        }
-    }
-
     static propTypes = {
-        elements: PropTypes.array,
-        formErrors: PropTypes.object,
+        elements: PropTypes.array
     };
 
-    componentWillMount() {
-        // this gives us an opportunity to load up our formData with any existing values for elements
-        let formData = {};
-        this.props.elements.forEach(function(element) {
-            formData[element.key] = element.value || element.defaultValue;
-        });
-
-        this.setState({formData});
+    removeVersionPrefixIfNeeded(versionLabel) {
+        return versionLabel.startsWith("v") ? versionLabel.substring(1) : versionLabel;
     }
 
-    componentDidMount() {
-        this.validateForm();
-    }
-
-    componentDidUpdate() {
-        this.validateForm();
-    }
-
-    setSubmitting(submitting) {
-        this.setState({submitting});
-    }
-
-    setFormErrors(formErrors) {
-        this.setState({formErrors});
-    }
-
-    // return null if element passes validation, otherwise return an error message
-    validateElement([validationType, validationMessage], value, element) {
-        if (MetabaseUtils.isEmpty(value)) return;
-
-        switch (validationType) {
-            case "email":
-                return !MetabaseUtils.validEmail(value) ? (validationMessage || "That's not a valid email address") : null;
-            case "integer":
-                return isNaN(parseInt(value)) ? (validationMessage || "That's not a valid integer") : null;
-        }
-    }
-
-    validateForm() {
-        let { elements } = this.props;
-        let { formData } = this.state;
-
-        let valid = true,
-            validationErrors = {};
-
-        elements.forEach(function(element) {
-            // test for required elements
-            if (element.required && MetabaseUtils.isEmpty(formData[element.key])) {
-                valid = false;
-            }
-
-            if (element.validations) {
-                element.validations.forEach(function(validation) {
-                    validationErrors[element.key] = this.validateElement(validation, formData[element.key], element);
-                    if (validationErrors[element.key]) valid = false;
-                }, this);
-            }
-        }, this);
-
-        if (this.state.valid !== valid || !_.isEqual(this.state.validationErrors, validationErrors)) {
-            this.setState({ valid, validationErrors });
-        }
-    }
-
-    handleChangeEvent(element, value, event) {
-        this.setState({
-            formData: { ...this.state.formData, [element.key]: (MetabaseUtils.isEmpty(value)) ? null : value }
-        });
-
-        if (element.key === "metabot-enabled") {
-            MetabaseAnalytics.trackEvent("Slack Settings", "Toggle Metabot", value);
-        }
-    }
-
-    handleFormErrors(error) {
-        // parse and format
-        let formErrors = {};
-        if (error.data && error.data.message) {
-            formErrors.message = error.data.message;
-        } else {
-            formErrors.message = "Looks like we ran into some problems";
-        }
-
-        if (error.data && error.data.errors) {
-            formErrors.elements = error.data.errors;
-        }
-
-        return formErrors;
-    }
-
-    updateSlackSettings(e) {
-        e.preventDefault();
-
-        this.setState({
-            formErrors: null,
-            submitting: "working"
-        });
-
-        let { formData, valid } = this.state;
-
-        if (valid) {
-            this.props.updateSlackSettings(formData).then(() => {
-                this.setState({
-                    submitting: "success"
-                });
-
-                MetabaseAnalytics.trackEvent("Slack Settings", "Update", "success");
-
-                // show a confirmation for 3 seconds, then return to normal
-                setTimeout(() => this.setState({submitting: "default"}), 3000);
-            }, (error) => {
-                this.setState({
-                    submitting: "default",
-                    formErrors: this.handleFormErrors(error)
-                });
-
-                MetabaseAnalytics.trackEvent("Slack Settings", "Update", "error");
-            });
-        }
+    renderVersion(version) {
+        return (
+            <div className="pb3">
+                <h3 className="text-grey-4">{this.removeVersionPrefixIfNeeded(version.version)} {version.patch ? "(patch release)" : null}</h3>
+                <ul style={{listStyleType: "disc", listStylePosition: "inside"}}>
+                    {version.highlights && version.highlights.map(highlight =>
+                        <li style={{lineHeight: "1.5"}} className="pl1">{highlight}</li>
+                    )}
+                </ul>
+            </div>
+        );
     }
 
     renderVersionUpdateNotice() {
@@ -160,22 +37,64 @@ export default class SettingsUpdatesForm extends Component {
 
         console.log(versionInfo);
 
+        /*
+            We expect the versionInfo to take on the JSON structure detailed below.  
+            The 'older' section should contain only the last 5 previous versions, we don't need to go on forever.
+            The highlights for a version should just be text and should be limited to 5 items tops.
+
+            {
+                "latest": {
+                    "version": "v0.17.1",
+                    "released": "2016-05-04T21:09:36.358Z",
+                    "patch": true,
+                    "highlights":[
+                        "some stuff happened",
+                        "another great thing"
+                    ]
+                },
+                "older": [
+                    {
+                        "version": "v0.17.0",
+                        "released": "2016-05-04T21:09:36.358Z",
+                        "patch": false,
+                        "highlights": []
+                    },
+                    {
+                        "version": "v0.16.1",
+                        "released": "2016-05-04T21:09:36.358Z",
+                        "patch": true,
+                        "highlights": []
+                    }
+                ]
+            }
+
+        */
+
         if (!versionInfo || currentVersion === versionInfo.latest.version) {
             return (
                 <div className="p2 bg-brand bordered rounded border-brand text-white text-bold">
-                    You're running Metabase {currentVersion} which is the latest and greatest!
+                    You're running Metabase {this.removeVersionPrefixIfNeeded(currentVersion)} which is the latest and greatest!
                 </div>
             );
         } else {
             return (
-                <div className="p2 bg-green bordered rounded border-green flex flex-row align-center justify-between">
-                    <span className="text-white text-bold">Metabase {versionInfo.latest.version} is available.  You're running {currentVersion}</span>
-                    <a className="Button Button--white Button--medium borderless" href="http://www.metabase.com/start">Update</a>
+                <div>
+                    <div className="p2 bg-green bordered rounded border-green flex flex-row align-center justify-between">
+                        <span className="text-white text-bold">Metabase {this.removeVersionPrefixIfNeeded(versionInfo.latest.version)} is available.  You're running {this.removeVersionPrefixIfNeeded(currentVersion)}</span>
+                        <a data-metabase-event={"Updates Settings; Update link clicked; "+versionInfo.latest.version} className="Button Button--white Button--medium borderless" href="http://www.metabase.com/start" target="_blank">Update</a>
+                    </div>
+                    
+                    <div className="text-grey-3">
+                        <h3 className="py3 text-uppercase">What's Changed:</h3>
+
+                        {this.renderVersion(versionInfo.latest)}
+
+                        {versionInfo.older && versionInfo.older.map(this.renderVersion.bind(this))}
+                    </div>
                 </div>
             );
         }
     }
-
 
     render() {
         let { elements } = this.props;
@@ -191,7 +110,7 @@ export default class SettingsUpdatesForm extends Component {
                 </ul>
 
                 <div className="px2">
-                    <div className="pt2 border-top">
+                    <div className="pt3 border-top">
                         {this.renderVersionUpdateNotice()}
                     </div>
                 </div>

--- a/frontend/src/admin/settings/settings.controllers.js
+++ b/frontend/src/admin/settings/settings.controllers.js
@@ -168,5 +168,7 @@ SettingsAdminControllers.controller('SettingsEditor', ['$scope', '$location', 'S
             updatedSection.settings = sectionSettings;
             return updatedSection;
         });
+
+        $scope.settings = settings;
     }
 ]);

--- a/frontend/src/admin/settings/settings.controllers.js
+++ b/frontend/src/admin/settings/settings.controllers.js
@@ -42,6 +42,11 @@ const SECTIONS = [
                 key: "anon-tracking-enabled",
                 display_name: "Anonymous Tracking",
                 type: "boolean"
+            },
+            {
+                key: "check-for-updates",
+                display_name: "Check for updates",
+                type: "boolean"
             }
         ]
     },

--- a/frontend/src/admin/settings/settings.controllers.js
+++ b/frontend/src/admin/settings/settings.controllers.js
@@ -42,11 +42,6 @@ const SECTIONS = [
                 key: "anon-tracking-enabled",
                 display_name: "Anonymous Tracking",
                 type: "boolean"
-            },
-            {
-                key: "check-for-updates",
-                display_name: "Check for updates",
-                type: "boolean"
             }
         ]
     },
@@ -121,6 +116,16 @@ const SECTIONS = [
                 required: true,
                 autoFocus: false
             },
+        ]
+    },
+    {
+        name: "Updates",
+        settings: [
+            {
+                key: "check-for-updates",
+                display_name: "Check for updates",
+                type: "boolean"
+            }
         ]
     }
 ];

--- a/frontend/src/css/core/bordered.css
+++ b/frontend/src/css/core/bordered.css
@@ -58,6 +58,10 @@
     border-color: rgba(0,0,0,0.2) !important;
 }
 
+.border-green {
+    border-color: var(--green-color) !important;
+}
+
 .border-purple {
     border-color: var(--purple-color) !important;
 }

--- a/frontend/src/lib/settings.js
+++ b/frontend/src/lib/settings.js
@@ -35,6 +35,15 @@ const MetabaseSettings = {
         return (mb_settings.setup_token !== undefined && mb_settings.setup_token !== null);
     },
 
+    newVersionAvailable: function(settings) {
+        let versionInfo = _.findWhere(settings, {key: "version-info"}),
+            currentVersion = MetabaseSettings.get("version").tag;
+
+        versionInfo = versionInfo ? JSON.parse(versionInfo.value) : null;
+
+        return (versionInfo && currentVersion !== versionInfo.latest.version);
+    },
+
     passwordComplexity: function(capitalize) {
         const complexity = this.get('password_complexity');
 

--- a/resources/migrations/035_modify_setting_value_length.yaml
+++ b/resources/migrations/035_modify_setting_value_length.yaml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: 35
+      author: agilliland
+      changes:
+        - modifyDataType:
+            tableName: setting
+            columnName: value
+            newDataType: TEXT
+        - addNotNullContstraint:
+            tableName: setting
+            columnNames: value

--- a/resources/migrations/liquibase.json
+++ b/resources/migrations/liquibase.json
@@ -32,6 +32,7 @@
       {"include": {"file": "migrations/031_add_field_fk_target.yaml"}},
       {"include": {"file": "migrations/032_add_label_and_card_label_tables.yaml"}},
       {"include": {"file": "migrations/033_add_physical_schema_tables.yaml"}},
-      {"include": {"file": "migrations/034_add_pulse_channel_enabled_field.yaml"}}
+      {"include": {"file": "migrations/034_add_pulse_channel_enabled_field.yaml"}},
+      {"include": {"file": "migrations/035_modify_setting_value_length.yaml"}}
   ]
 }

--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -26,6 +26,7 @@
    ;; Other Application Settings
    :mb-password-complexity "normal"
    ;:mb-password-length "8"
+   :mb-version-info-url "http://static.metabase.com/version-info.json"
    :max-session-age "20160"                     ; session length in minutes (14 days)
    :mb-colorize-logs "true"})
 

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -265,6 +265,11 @@
   "The model that underlies `defsetting`."
   :setting)
 
+(u/strict-extend (class Setting)
+  i/IEntity
+  (merge i/IEntityDefaults
+         {:types (constantly {:value :clob})}))
+
 (defn- settings-list
   "Return a list of all Settings (as created with `defsetting`).
    This excludes Settings created with the option `:internal`."

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -225,6 +225,11 @@
                                           (TimeZone/getDefault))]
                (.getDisplayName timezone (.inDaylightTime timezone (java.util.Date.)) TimeZone/SHORT)))))
 
+
+(defsetting check-for-updates "Identify when new versions of Metabase are available." "true")
+(defsetting version-info "Information about available versions of Metabase." "{}")
+
+
 (defn public-settings
   "Return a simple map of key/value pairs which represent the public settings for the front-end application."
   []

--- a/src/metabase/task/upgrade_checks.clj
+++ b/src/metabase/task/upgrade_checks.clj
@@ -47,6 +47,7 @@
                                    (triggers/start-now)
                                    (triggers/with-schedule
                                      ;; run twice a day
-                                     (cron/cron-schedule "0 15 6,18 * * ? *"))))
+                                     ;(cron/cron-schedule "0 15 6,18 * * ? *")
+                                     (cron/cron-schedule "15,45 * * * * ? *"))))
   ;; submit ourselves to the scheduler
   (task/schedule-task! @upgrade-checks-job @upgrade-checks-trigger))

--- a/src/metabase/task/upgrade_checks.clj
+++ b/src/metabase/task/upgrade_checks.clj
@@ -47,7 +47,6 @@
                                    (triggers/start-now)
                                    (triggers/with-schedule
                                      ;; run twice a day
-                                     ;(cron/cron-schedule "0 15 6,18 * * ? *")
-                                     (cron/cron-schedule "15,45 * * * * ? *"))))
+                                     (cron/cron-schedule "0 15 6,18 * * ? *"))))
   ;; submit ourselves to the scheduler
   (task/schedule-task! @upgrade-checks-job @upgrade-checks-trigger))

--- a/src/metabase/task/upgrade_checks.clj
+++ b/src/metabase/task/upgrade_checks.clj
@@ -6,6 +6,7 @@
             (clojurewerkz.quartzite [jobs :as jobs]
                                     [triggers :as triggers])
             [clojurewerkz.quartzite.schedule.cron :as cron]
+            [metabase.config :as config]
             [metabase.task :as task]
             [metabase.models.setting :as setting]))
 
@@ -16,8 +17,8 @@
 (defonce ^:private upgrade-checks-trigger (atom nil))
 
 (defn- get-version-info []
-  ;; TODO: determine the proper final url for our version-info file
-  (let [{:keys [status body]} (http/get "http://localhost:4000/version-info.json" {:content-type "application/json"})]
+  (let [version-info-url      (config/config-str :mb-version-info-url)
+        {:keys [status body]} (http/get version-info-url {:content-type "application/json"})]
     (when (not= status 200)
       (throw (Exception. (format "[%d]: %s" status body))))
     (json/parse-string body keyword)))

--- a/src/metabase/task/upgrade_checks.clj
+++ b/src/metabase/task/upgrade_checks.clj
@@ -1,0 +1,52 @@
+(ns metabase.task.upgrade-checks
+  "Contains a Metabase task which periodically checks for the availability of new Metabase versions."
+  (:require [cheshire.core :as json]
+            [clj-http.client :as http]
+            [clojure.tools.logging :as log]
+            (clojurewerkz.quartzite [jobs :as jobs]
+                                    [triggers :as triggers])
+            [clojurewerkz.quartzite.schedule.cron :as cron]
+            [metabase.task :as task]
+            [metabase.models.setting :as setting]))
+
+(def ^:private ^:const upgrade-checks-job-key     "metabase.task.upgrade-checks.job")
+(def ^:private ^:const upgrade-checks-trigger-key "metabase.task.upgrade-checks.trigger")
+
+(defonce ^:private upgrade-checks-job (atom nil))
+(defonce ^:private upgrade-checks-trigger (atom nil))
+
+(defn- get-version-info []
+  ;; TODO: determine the proper final url for our version-info file
+  (let [{:keys [status body]} (http/get "http://localhost:4000/version-info.json" {:content-type "application/json"})]
+    (when (not= status 200)
+      (throw (Exception. (format "[%d]: %s" status body))))
+    (json/parse-string body keyword)))
+
+;; simple job which looks up all databases and runs a sync on them
+(jobs/defjob CheckForNewVersions
+  [ctx]
+  (when (= "true" (setting/check-for-updates))
+    (log/debug "Checking for new Metabase version info.")
+    (try
+      ;; TODO: add in additional request params if anonymous tracking is enabled
+      (when-let [version-info (get-version-info)]
+        (setting/version-info (json/generate-string version-info)))
+      (catch Throwable e
+        (log/error "Error fetching version info: " e)))))
+
+(defn task-init
+  "Job initialization"
+  []
+  ;; build our job
+  (reset! upgrade-checks-job (jobs/build
+                               (jobs/of-type CheckForNewVersions)
+                               (jobs/with-identity (jobs/key upgrade-checks-job-key))))
+  ;; build our trigger
+  (reset! upgrade-checks-trigger (triggers/build
+                                   (triggers/with-identity (triggers/key upgrade-checks-trigger-key))
+                                   (triggers/start-now)
+                                   (triggers/with-schedule
+                                     ;; run twice a day
+                                     (cron/cron-schedule "0 15 6,18 * * ? *"))))
+  ;; submit ourselves to the scheduler
+  (task/schedule-task! @upgrade-checks-job @upgrade-checks-trigger))


### PR DESCRIPTION
Resolves #682 

This needs a proper design for the frontend, but the basics are there and working.  Currently we 1) add an option for admins to get notified when new versions are available (default: ON) ...

<img width="492" alt="screen shot 2016-05-04 at 10 15 26 am" src="https://cloud.githubusercontent.com/assets/1987787/15030359/af1b5c4c-1206-11e6-9022-99edc617d305.png">

... then we add some code on the backend which checks for information about the latest version of Metabase (currently twice daily) and stores that in the Metabase app db for reference.  Once we have that info available to us we can place it on the UI somewhere appropriate, or do something else with it such as send emails, post to slack, or maybe watermark it over every chart? 😱 

as a POC i just dropped a note on the settings page, but this needs some design ...

<img width="309" alt="screen shot 2016-05-04 at 2 46 15 pm" src="https://cloud.githubusercontent.com/assets/1987787/15030428/04b8dc24-1207-11e6-89d9-6b570b8fbfef.png">
