### PR TITLE
Bump dependencies :new:

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,17 +13,17 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/core.async "0.2.374"]
                  [org.clojure/core.match "0.3.0-alpha4"]              ; optimized pattern matching library for Clojure
-                 [org.clojure/core.memoize "0.5.8"]                   ; needed by core.match; has useful FIFO, LRU, etc. caching mechanisms
+                 [org.clojure/core.memoize "0.5.9"]                   ; needed by core.match; has useful FIFO, LRU, etc. caching mechanisms
                  [org.clojure/data.csv "0.1.3"]                       ; CSV parsing / generation
                  [org.clojure/java.classpath "0.2.3"]
-                 [org.clojure/java.jdbc "0.4.2"]                      ; basic jdbc access from clojure
+                 [org.clojure/java.jdbc "0.5.8"]                      ; basic jdbc access from clojure
                  [org.clojure/math.numeric-tower "0.0.4"]             ; math functions like `ceil`
                  [org.clojure/tools.logging "0.3.1"]                  ; logging framework
                  [org.clojure/tools.namespace "0.2.10"]
                  [amalloy/ring-gzip-middleware "0.1.3"]               ; Ring middleware to GZIP responses if client can handle it
-                 [aleph "0.4.1-beta4"]                                ; Async HTTP library; WebSockets
-                 [cheshire "5.5.0"]                                   ; fast JSON encoding (used by Ring JSON middleware)
-                 [clj-http "2.1.0"                                    ; HTTP client
+                 [aleph "0.4.1"]                                      ; Async HTTP library; WebSockets
+                 [cheshire "5.6.1"]                                   ; fast JSON encoding (used by Ring JSON middleware)
+                 [clj-http "3.0.1"                                    ; HTTP client
                   :exclusions [commons-codec
                                commons-io
                                slingshot]]
@@ -37,39 +37,38 @@
                                ring/ring-core]]
                  [com.draines/postal "1.11.4"]                        ; SMTP library
                  [com.google.apis/google-api-services-bigquery        ; Google BigQuery Java Client Library
-                  "v2-rev277-1.21.0"]
+                  "v2-rev294-1.21.0"]
                  [com.h2database/h2 "1.4.191"]                        ; embedded SQL database
                  [com.mattbertolini/liquibase-slf4j "2.0.0"]          ; Java Migrations lib
                  [com.novemberain/monger "3.0.2"]                     ; MongoDB Driver
                  [compojure "1.5.0"]                                  ; HTTP Routing library built on Ring
                  [environ "1.0.2"]                                    ; easy environment management
                  [hiccup "1.0.5"]                                     ; HTML templating
-                 [korma "0.4.2"]                                      ; SQL lib
-                 [log4j/log4j "1.2.17"
+                 [korma "0.4.2"]                                      ; SQL generation
+                 [log4j/log4j "1.2.17"                                ; logging framework
                   :exclusions [javax.mail/mail
                                javax.jms/jms
                                com.sun.jdmk/jmxtools
                                com.sun.jmx/jmxri]]
-                 [medley "0.7.3"]                                     ; lightweight lib of useful functions
+                 [medley "0.7.4"]                                     ; lightweight lib of useful functions
                  [metabase/throttle "1.0.1"]                          ; Tools for throttling access to API endpoints and other code pathways
-                 [mysql/mysql-connector-java "5.1.38"]                ; MySQL JDBC driver
-                 [net.sf.cssbox/cssbox "4.11"
+                 [mysql/mysql-connector-java "6.0.2"]                 ; MySQL JDBC driver
+                 [net.sf.cssbox/cssbox "4.11"                         ; HTML / CSS rendering
                   :exclusions [org.slf4j/slf4j-api]]
                  [net.sourceforge.jtds/jtds "1.3.1"]                  ; Open Source SQL Server driver
-                 [org.xhtmlrenderer/flying-saucer-core "9.0.8"]
-                 [org.liquibase/liquibase-core "3.4.2"]               ; migration management (Java lib)
-                 [org.slf4j/slf4j-log4j12 "1.7.19"]
+                 [org.liquibase/liquibase-core "3.5.0"]               ; migration management (Java lib)
+                 [org.slf4j/slf4j-log4j12 "1.7.21"]                   ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
                  [org.yaml/snakeyaml "1.17"]                          ; YAML parser (required by liquibase)
                  [org.xerial/sqlite-jdbc "3.8.11.2"]                  ; SQLite driver
                  [postgresql "9.3-1102.jdbc41"]                       ; Postgres driver
-                 [prismatic/schema "1.0.5"]                           ; Data schema declaration and validation library
+                 [prismatic/schema "1.1.1"]                           ; Data schema declaration and validation library
                  [ring/ring-jetty-adapter "1.4.0"]                    ; Ring adapter using Jetty webserver (used to run a Ring server for unit tests)
                  [ring/ring-json "0.4.0"]                             ; Ring middleware for reading/writing JSON automatically
                  [stencil "0.5.0"]                                    ; Mustache templates for Clojure
                  [swiss-arrows "1.0.0"]]                              ; 'Magic wand' macro -<>, etc.
   :plugins [[lein-environ "1.0.2"]                                    ; easy access to environment variables
             [lein-ring "0.9.7"                                        ; start the HTTP server with 'lein ring server'
-             :exclusions [org.clojure/clojure]]]
+             :exclusions [org.clojure/clojure]]]                      ; TODO - should this be a dev dependency ?
   :main ^:skip-aot metabase.core
   :manifest {"Liquibase-Package" "liquibase.change,liquibase.changelog,liquibase.database,liquibase.parser,liquibase.precondition,liquibase.datatype,liquibase.serializer,liquibase.sqlgenerator,liquibase.executor,liquibase.snapshot,liquibase.logging,liquibase.diff,liquibase.structure,liquibase.structurecompare,liquibase.lockservice,liquibase.sdk,liquibase.ext"}
   :target-path "target/%s"

--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
                  [org.clojure/core.memoize "0.5.9"]                   ; needed by core.match; has useful FIFO, LRU, etc. caching mechanisms
                  [org.clojure/data.csv "0.1.3"]                       ; CSV parsing / generation
                  [org.clojure/java.classpath "0.2.3"]
-                 [org.clojure/java.jdbc "0.5.8"]                      ; basic jdbc access from clojure
+                 [org.clojure/java.jdbc "0.4.2"]                      ; basic jdbc access from clojure. *** DON'T UPDATE THIS UNTIL KORMA IS UPDATED TO STOP USING DEPRECATED FN SIGNATURES ***
                  [org.clojure/math.numeric-tower "0.0.4"]             ; math functions like `ceil`
                  [org.clojure/tools.logging "0.3.1"]                  ; logging framework
                  [org.clojure/tools.namespace "0.2.10"]
@@ -52,7 +52,7 @@
                                com.sun.jmx/jmxri]]
                  [medley "0.7.4"]                                     ; lightweight lib of useful functions
                  [metabase/throttle "1.0.1"]                          ; Tools for throttling access to API endpoints and other code pathways
-                 [mysql/mysql-connector-java "6.0.2"]                 ; MySQL JDBC driver
+                 [mysql/mysql-connector-java "5.1.38"]                ; MySQL JDBC driver *** DON'T UPDATE THIS YET - NEW VERSION IS JAVA 8+ ONLY: http://dev.mysql.com/doc/connector-j/6.0/en/connector-j-whats-new.html ***
                  [net.sf.cssbox/cssbox "4.11"                         ; HTML / CSS rendering
                   :exclusions [org.slf4j/slf4j-api]]
                  [net.sourceforge.jtds/jtds "1.3.1"]                  ; Open Source SQL Server driver
@@ -93,7 +93,7 @@
                                 #"^metabase\.sample-data$"
                                 #"^metabase\.http-client$"]}
   :profiles {:dev {:dependencies [[org.clojure/tools.nrepl "0.2.12"]  ; REPL <3
-                                  [expectations "2.1.3"]              ; unit tests
+                                  [expectations "2.1.3"]              ; unit tests *** DON'T UPDATE THIS UNTIL WE REMOVE USES OF DEPRECATED EXPECT-LET IN THE CODEBASE ***
                                   [ring/ring-mock "0.3.0"]]
                    :plugins [[docstring-checker "1.0.0"]              ; Check that all public vars have docstrings. Run with 'lein docstring-checker'
                              [jonase/eastwood "0.2.3"

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -237,7 +237,7 @@
   (let [all-schemas (set (map :table_schem (jdbc/result-set-seq (.getSchemas metadata))))
         schemas     (set/difference all-schemas (excluded-schemas driver))]
     (set (for [schema     schemas
-               table-name (mapv :table_name (jdbc/result-set-seq (.getTables metadata nil schema nil (into-array String ["TABLE", "VIEW"]))))]
+               table-name (mapv :table_name (jdbc/result-set-seq (.getTables metadata nil schema "%" (into-array String ["TABLE", "VIEW"]))))] ; tablePattern "%" = match all tables
            {:name   table-name
             :schema schema}))))
 
@@ -246,7 +246,7 @@
    Fetch *all* Tables, then filter out ones whose schema is in `excluded-schemas` Clojure-side."
   [driver, ^DatabaseMetaData metadata]
   (set (for [table (filter #(not (contains? (excluded-schemas driver) (:table_schem %)))
-                           (jdbc/result-set-seq (.getTables metadata nil nil nil (into-array String ["TABLE", "VIEW"]))))]
+                           (jdbc/result-set-seq (.getTables metadata nil nil "%" (into-array String ["TABLE", "VIEW"]))))] ; tablePattern "%" = match all tables
          {:name   (:table_name table)
           :schema (:table_schem table)})))
 


### PR DESCRIPTION
Bump Clojure dependencies to latest & greatest. 

Remove `flying-saucer-core` dependency which isn't used.

The new Clojure JDBC library deprecated some of our usage patterns so it is a little bit complain-y but we have plenty of time to fix those before the release.
