### PR TITLE
Use today's date as Metabase "built on" date :calendar:

### DIFF
--- a/bin/version
+++ b/bin/version
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-VERSION="v0.17.0"
+VERSION="v0.17.1"
 
 # dynamically pull more interesting stuff from latest git commit
 HASH=$(git show-ref --head --hash=7 head)            # first 7 letters of hash should be enough; that's what GitHub uses
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
-DATE=$(git log -1 --pretty=%ad --date=short)
+DATE=$(date --rfc-3339=date)
 
 
 # Return the version string used to describe this version of Metabase.


### PR DESCRIPTION
``` bash
date --rfc-3339=date
```

works on BSD and Linux while it looks like

``` bash
date --iso-8601
```

is BSD-only

Bump version number `0.17.0` -> `0.17.1` while we're at it 
