### PR TITLE
Don't default to bucketing datetimes by day when sorting :calendar:

### DIFF
--- a/src/metabase/query_processor/resolve.clj
+++ b/src/metabase/query_processor/resolve.clj
@@ -103,7 +103,7 @@
       (if-not datetime-field?
         field
         (map->DateTimeField {:field field
-                             :unit  (or datetime-unit :day)})))
+                             :unit  (or datetime-unit :default)})))
     ;; If that fails just return ourselves as-is
     this))
 

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -485,7 +485,7 @@
      :cols    [(aggregate-col :count)]}
   (format-rows-by [int] (run-query checkins
                           (ql/aggregation (ql/count))
-                          (ql/filter (ql/between $date "2015-04-01" "2015-05-01")))))
+                          (ql/filter (ql/between (ql/datetime-field $date :day) "2015-04-01" "2015-05-01")))))
 
 ;; ### FILTER -- "OR", "<=", "="
 (expect-with-non-timeseries-dbs
@@ -859,8 +859,8 @@
     9)
   (count (rows (dataset sad-toucan-incidents
                  (run-query incidents
-                   (ql/filter (ql/and (ql/> $timestamp "2015-06-01")
-                                      (ql/< $timestamp "2015-06-03")))
+                   (ql/filter (ql/and (ql/> (ql/datetime-field $timestamp :day) "2015-06-01")
+                                      (ql/< (ql/datetime-field $timestamp :day) "2015-06-03")))
                    (ql/order-by (ql/asc $timestamp)))))))
 
 (expect-with-non-timeseries-dbs
@@ -905,7 +905,7 @@
   (->> (dataset sad-toucan-incidents
          (run-query incidents
            (ql/aggregation (ql/count))
-           (ql/breakout $timestamp)
+           (ql/breakout (ql/datetime-field $timestamp :day))
            (ql/limit 10)))
        rows (format-rows-by [identity int])))
 

--- a/test/metabase/timeseries_query_processor_test.clj
+++ b/test/metabase/timeseries_query_processor_test.clj
@@ -390,7 +390,7 @@
              ["2013-01-23+0000" 1]]}
   (data (data/run-query checkins
           (ql/aggregation (ql/count))
-          (ql/breakout $timestamp)
+          (ql/breakout (ql/datetime-field $timestamp :day))
           (ql/limit 5))))
 
 ;;; date bucketing - minute


### PR DESCRIPTION
Fixes part 2 of #2531.
