### PR TITLE
Allow joins for BigQuery

### DIFF
--- a/src/metabase/driver/bigquery.clj
+++ b/src/metabase/driver/bigquery.clj
@@ -310,16 +310,17 @@
   (-> (k/create-entity (k/raw (format "[%s.%s]" dataset-id table-name)))
       (k/database korma-db)))
 
-;; Make the dataset-id the "schema" of every field in the query because BigQuery can't figure out fields that are qualified with their just their table name
-(defn- add-dataset-id-to-fields [{{{:keys [dataset-id]} :details} :database, :as query}]
+;; Make the dataset-id the "schema" of every field or table in the query because otherwise BigQuery can't figure out where things is from
+(defn- qualify-fields-and-tables-with-dataset-id [{{{:keys [dataset-id]} :details} :database, :as query}]
   (walk/postwalk (fn [x]
-                   (if (instance? metabase.query_processor.interface.Field x)
-                     (assoc x :schema-name dataset-id)
-                     x))
-                 query))
+                   (cond
+                     (instance? metabase.query_processor.interface.Field x)     (assoc x :schema-name dataset-id) ; TODO - it is inconvenient that we use different keys for `schema` across different
+                     (instance? metabase.query_processor.interface.JoinTable x) (assoc x :schema      dataset-id) ; classes. We should one day refactor to use the same key everywhere.
+                     :else                                                      x))
+                 (assoc-in query [:query :source-table :schema] dataset-id)))
 
 (defn- korma-form [query entity]
-  (sqlqp/build-korma-form driver (add-dataset-id-to-fields query) entity))
+  (sqlqp/build-korma-form driver (qualify-fields-and-tables-with-dataset-id query) entity))
 
 (defn- korma-form->sql [korma-form]
   {:pre [(map? korma-form)]}
@@ -443,6 +444,12 @@
                                                :display-name "Auth Code"
                                                :placeholder  "4/HSk-KtxkSzTt61j5zcbee2Rmm5JHkRFbL5gD5lgkXek"
                                                :required     true}])
+          ;; Don't enable foreign keys when testing because BigQuery *doesn't* have a notion of foreign keys. Joins are still allowed, which puts us in a weird position, however;
+          ;; people can manually specifiy "foreign key" relationships in admin and everything should work correctly.
+          ;; Since we can't infer any "FK" relationships during sync our normal FK tests are not appropriate for BigQuery, so they're disabled for the time being.
+          ;; TODO - either write BigQuery-speciifc tests for FK functionality or add additional code to manually set up these FK relationships for FK tables
+          :features              (constantly (when-not config/is-test?
+                                               #{:foreign-keys}))
           :field-values-lazy-seq (u/drop-first-arg field-values-lazy-seq)
           :process-native        (u/drop-first-arg process-native)
           :process-structured    (u/drop-first-arg process-structured)}))

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -8,8 +8,8 @@
                    [db :as kdb])
             (korma.sql [engine :as kengine]
                        [fns :as kfns])
-            [metabase.config :as config]
-            [metabase.driver :as driver]
+            (metabase [config :as config]
+                      [driver :as driver])
             [metabase.driver.generic-sql :as sql]
             [metabase.query-processor :as qp]
             metabase.query-processor.interface
@@ -314,14 +314,14 @@
 (defn process-structured
   "Convert QUERY into a korma `select` form, execute it, and annotate the results."
   [driver {{:keys [source-table]} :query, database :database, settings :settings, :as outer-query}]
-  (let [timezone     (:report-timezone settings)
-        entity       ((resolve 'metabase.driver.generic-sql/korma-entity) database source-table)
-        korma-form   (build-korma-form driver outer-query entity)
-        f             (partial k/exec korma-form)
-        f             (fn []
-                        (kdb/with-db (:db entity)
-                          (if (seq timezone)
-                            (do-with-timezone driver timezone f)
-                            (f))))]
+  (let [timezone   (:report-timezone settings)
+        entity     ((resolve 'metabase.driver.generic-sql/korma-entity) database source-table)
+        korma-form (build-korma-form driver outer-query entity)
+        f          (partial k/exec korma-form)
+        f          (fn []
+                     (kdb/with-db (:db entity)
+                       (if (seq timezone)
+                         (do-with-timezone driver timezone f)
+                         (f))))]
     (log-korma-form korma-form)
     (do-with-try-catch f)))

--- a/src/metabase/query_processor/interface.clj
+++ b/src/metabase/query_processor/interface.clj
@@ -46,7 +46,8 @@
 (s/defrecord JoinTable [source-field :- JoinTableField
                         pk-field     :- JoinTableField
                         table-id     :- IntGreaterThanZero
-                        table-name   :- s/Str])
+                        table-name   :- s/Str
+                        schema       :- (s/maybe s/Str)])
 
 ;;; # ------------------------------------------------------------ PROTOCOLS ------------------------------------------------------------
 


### PR DESCRIPTION
As mentioned in #2472 BigQuery has no notion of Foreign Keys but joins can be done if the columns are marked up appropriately in admin. 

Fixes #2472.
