### PR TITLE
Add missing docstings :unamused:

### DIFF
--- a/src/metabase/logger.clj
+++ b/src/metabase/logger.clj
@@ -1,11 +1,11 @@
 (ns metabase.logger
-  (:require [clj-time.core :as t]
-            [clj-time.coerce :as coerce]
-            [clj-time.format :as time]
-            [amalloy.ring-buffer :refer [ring-buffer]])
+  (:require [amalloy.ring-buffer :refer [ring-buffer]]
+            (clj-time [core :as t]
+                      [coerce :as coerce]
+                      [format :as time]))
   (:gen-class
-    :extends org.apache.log4j.AppenderSkeleton
-    :name metabase.logger.Appender)
+   :extends org.apache.log4j.AppenderSkeleton
+   :name metabase.logger.Appender)
   (:import (org.apache.log4j.spi LoggingEvent)))
 
 (def ^:private ^:const max-log-entries 2500)
@@ -21,8 +21,9 @@
 (def ^:private formatter (time/formatter "MMM dd HH:mm:ss" (t/default-time-zone)))
 
 (defn -append
-  "docstring"
-  [_ ^LoggingEvent event]
+  "Append a new EVENT to the `messages` atom.
+   [Overrides an `AppenderSkeleton` method](http://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/AppenderSkeleton.html#append(org.apache.log4j.spi.LoggingEvent))"
+  [_, ^LoggingEvent event]
   (let [ts    (time/unparse formatter (coerce/from-long (.getTimeStamp event)))
         level (.getLevel event)
         fqns  (.getLoggerName event)
@@ -31,11 +32,13 @@
     nil))
 
 (defn -close
-  "docstring"
+  "No-op if something tries to close this logging appender.
+   [Overrides an `Appender` method](http://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/Appender.html#close())"
   [_]
   nil)
 
 (defn -requiresLayout
-  "docstring"
+  "The MB logger doesn't require a layout.
+  [Overrides an `Appender` method](http://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/Appender.html#getLayout())"
   [_]
   false)


### PR DESCRIPTION
Fix some code where the docstrings were literally just `"docstring"`.
