### PR TITLE
Default date/time field unit to 'day' if time grouping is enabled

### DIFF
--- a/frontend/src/query_builder/FieldList.jsx
+++ b/frontend/src/query_builder/FieldList.jsx
@@ -179,6 +179,11 @@ export default class FieldList extends Component {
     onChange(item) {
         if (item.segment) {
             this.props.onFilterChange(item.value);
+        } else if (this.itemIsSelected(item)) {
+            // ensure if we select the same item we don't reset datetime_field's unit
+            this.props.onFieldChange(this.props.field);
+        }  else if (this.props.enableTimeGrouping && isDate(item.field)) {
+            this.props.onFieldChange(["datetime_field", item.value, "as", "day"]);
         } else {
             this.props.onFieldChange(item.value);
         }


### PR DESCRIPTION
Partial additional fix for #2531
