### PR TITLE
Part 2 of Part 1 of the switch to HoneySQL :honey_pot:

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -38,7 +38,6 @@
                               (org-perms-case 1)
                               (post-insert 1)
                               (post-select 1)
-                              (post-update 1)
                               (pre-cascade-delete 1)
                               (pre-insert 1)
                               (pre-update 1)

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -10,6 +10,7 @@
                             (define-clojure-indent
                               (api-let 2)
                               (assert 1)
+                              (assoc 1)
                               (auto-parse 1)
                               (catch-api-exceptions 0)
                               (check 1)

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -21,7 +21,6 @@
                               (execute-query 1)
                               (execute-sql! 2)
                               (expect 0)
-                              (expect-eval-actual-first 1)
                               (expect-expansion 0)
                               (expect-let 1)
                               (expect-when-testing-engine 1)

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -203,7 +203,7 @@
   (write-check Card id)
   (let-404 [card (Card id)]
     (write-check card)
-    (u/prog1 (db/cascade-delete! Card id)
+    (u/prog1 (db/cascade-delete! Card,:id id)
       (events/publish-event :card-delete (assoc card :actor_id *current-user-id*)))))
 
 (defendpoint GET "/:id/favorite"
@@ -221,7 +221,7 @@
   "Unfavorite a Card."
   [card-id]
   (let-404 [id (db/select-one-id CardFavorite :card_id card-id, :owner_id *current-user-id*)]
-    (db/cascade-delete! CardFavorite id)))
+    (db/cascade-delete! CardFavorite, :id id)))
 
 (defendpoint POST "/:card-id/labels"
   "Update the set of `Labels` that apply to a `Card`."
@@ -231,7 +231,7 @@
   (let [[labels-to-remove labels-to-add] (data/diff (set (db/select-field :label_id CardLabel :card_id card-id))
                                                     (set label_ids))]
     (when (seq labels-to-remove)
-      (db/cascade-delete! CardLabel :label_id [:in labels-to-remove], :card_id card-id))
+      (db/cascade-delete! CardLabel, :label_id [:in labels-to-remove], :card_id card-id))
     (doseq [label-id labels-to-add]
       (db/insert! CardLabel :label_id label-id, :card_id card-id)))
   ;; TODO - Should this endpoint return something more useful instead ?

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -8,13 +8,12 @@
             [korma.core :as k]
             [medley.core :as m]
             [metabase.api.common.internal :refer :all]
-            [metabase.db :refer :all]
+            [metabase.db :as db]
             [metabase.models.interface :as models]
             [metabase.util :as u]
             [metabase.util.password :as password]))
 
-(declare check-403
-         check-404)
+(declare check-403 check-404)
 
 ;;; ## DYNAMIC VARIABLES
 ;; These get bound by middleware for each HTTP request.
@@ -61,7 +60,7 @@
 (defn check-exists?
   "Check that object with ID exists in the DB, or throw a 404."
   [entity id]
-  (check-404 (exists? entity :id id)))
+  (check-404 (db/exists? entity, :id id)))
 
 (defn check-superuser
   "Check that `*current-user*` is a superuser or throw a 403."

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -30,7 +30,7 @@
   [:as {{:keys [name description public_perms]} :body}]
   {name         [Required NonEmptyString]
    public_perms [Required PublicPerms]}
-  (->> (db/ins Dashboard
+  (->> (db/insert! Dashboard
          :name         name
          :description  description
          :public_perms public_perms

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -21,7 +21,7 @@
   {f FilterOptionAllOrMine}
   (-> (case (or f :all)
         :all  (db/sel :many Dashboard (k/where (or {:creator_id *current-user-id*}
-                                                {:public_perms [> common/perms-none]})))
+                                                   {:public_perms [> common/perms-none]})))
         :mine (db/sel :many Dashboard :creator_id *current-user-id*))
       (hydrate :creator :can_read :can_write)))
 
@@ -31,10 +31,10 @@
   {name         [Required NonEmptyString]
    public_perms [Required PublicPerms]}
   (->> (db/ins Dashboard
-               :name name
-               :description description
-               :public_perms public_perms
-               :creator_id *current-user-id*)
+         :name         name
+         :description  description
+         :public_perms public_perms
+         :creator_id   *current-user-id*)
        (events/publish-event :dashboard-create)))
 
 (defendpoint GET "/:id"
@@ -53,7 +53,7 @@
   [id :as {{:keys [description name]} :body}]
   {name NonEmptyString}
   (write-check Dashboard id)
-  (check-500 (db/upd-non-nil-keys Dashboard id
+  (check-500 (db/update-non-nil-keys! Dashboard id
                :description description
                :name        name))
   (events/publish-event :dashboard-update (assoc (Dashboard id) :actor_id *current-user-id*)))

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -64,7 +64,7 @@
   (write-check Dashboard id)
   ;; TODO - it would be much more natural if `cascade-delete` returned the deleted entity instead of an api response
   (let [dashboard (db/sel :one Dashboard :id id)
-        result    (db/cascade-delete Dashboard :id id)]
+        result    (db/cascade-delete! Dashboard :id id)]
     (events/publish-event :dashboard-delete (assoc dashboard :actor_id *current-user-id*))
     result))
 

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -84,7 +84,7 @@
                            (boolean is_full_sync))]
     (if-not (false? (:valid details-or-error))
       ;; no error, proceed with creation
-      (let-500 [new-db (db/ins Database, :name name, :engine engine, :details details-or-error, :is_full_sync is_full_sync)]
+      (let-500 [new-db (db/insert! Database, :name name, :engine engine, :details details-or-error, :is_full_sync is_full_sync)]
         (events/publish-event :database-create new-db))
       ;; failed to connect, return error
       {:status 400

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -4,7 +4,7 @@
             [korma.core :as k]
             [metabase.api.common :refer :all]
             (metabase [config :as config]
-                      [db :refer :all]
+                      [db :as db]
                       [driver :as driver]
                       [events :as events]
                       [sample-data :as sample-data]
@@ -53,10 +53,10 @@
 (defendpoint GET "/"
   "Fetch all `Databases`."
   [include_tables]
-  (let [dbs (sel :many Database (k/order (k/sqlfn :LOWER :name)))]
+  (let [dbs (db/sel :many Database (k/order (k/sqlfn :LOWER :name)))]
     (if-not include_tables
       dbs
-      (let [db-id->tables (group-by :db_id (sel :many Table, :active true))]
+      (let [db-id->tables (group-by :db_id (db/sel :many Table, :active true))]
         (for [db dbs]
           (assoc db :tables (sort-by :name (get db-id->tables (:id db) []))))))))
 
@@ -84,7 +84,7 @@
                            (boolean is_full_sync))]
     (if-not (false? (:valid details-or-error))
       ;; no error, proceed with creation
-      (let-500 [new-db (ins Database :name name :engine engine :details details-or-error :is_full_sync is_full_sync)]
+      (let-500 [new-db (db/ins Database, :name name, :engine engine, :details details-or-error, :is_full_sync is_full_sync)]
         (events/publish-event :database-create new-db))
       ;; failed to connect, return error
       {:status 400
@@ -95,7 +95,7 @@
   []
   (check-superuser)
   (sample-data/add-sample-dataset!)
-  (sel :one Database :is_sample true))
+  (db/sel :one Database :is_sample true))
 
 (defendpoint GET "/:id"
   "Get `Database` with ID."
@@ -122,11 +122,11 @@
         (do
           ;; TODO: is there really a reason to let someone change the engine on an existing database?
           ;;       that seems like the kind of thing that will almost never work in any practical way
-          (check-500 (upd-non-nil-keys Database id
-                                       :name name
-                                       :engine engine
-                                       :details details
-                                       :is_full_sync is_full_sync))
+          (check-500 (db/update-non-nil-keys! Database id
+                       :name         name
+                       :engine       engine
+                       :details      details
+                       :is_full_sync is_full_sync))
           (events/publish-event :database-update (Database id)))
         ;; failed to connect, return error
         {:status 400
@@ -137,7 +137,7 @@
   [id]
   (let-404 [db (Database id)]
     (write-check db)
-    (u/prog1 (cascade-delete! Database :id id)
+    (u/prog1 (db/cascade-delete! Database :id id)
       (events/publish-event :database-delete db))))
 
 (defendpoint GET "/:id/metadata"
@@ -156,7 +156,7 @@
   [id prefix] ; TODO - should prefix be Required/NonEmptyString ?
   (read-check Database id)
   (let [prefix-len (count prefix)
-        table-id->name (->> (sel :many [Table :id :name] :db_id id :active true)                                             ; fetch all name + ID of all Tables for this DB
+        table-id->name (->> (db/sel :many [Table :id :name] :db_id id :active true)                                             ; fetch all name + ID of all Tables for this DB
                             (map (fn [{:keys [id name]}]                                                         ; make a map of Table ID -> Table Name
                                    {id name}))
                             (into {}))
@@ -166,7 +166,7 @@
                                             (= prefix (.substring table-name 0 prefix-len)))))
                              (map (fn [table-name]                                                               ; return them in the format [table_name "Table"]
                                     [table-name "Table"])))
-        fields (->> (sel :many [Field :name :base_type :special_type :table_id]                                 ; get all Fields with names that start with PREFIX
+        fields (->> (db/sel :many [Field :name :base_type :special_type :table_id]                                 ; get all Fields with names that start with PREFIX
                          :table_id [in (keys table-id->name)]                                                   ; whose Table is in this DB
                          :name [like (str prefix "%")]
                          :visibility_type [not-in ["sensitive" "retired"]])
@@ -179,14 +179,14 @@
   "Get a list of all `Tables` in `Database`."
   [id]
   (read-check Database id)
-  (sel :many Table :db_id id :active true (k/order :name)))
+  (db/sel :many Table :db_id id :active true (k/order :name)))
 
 (defendpoint GET "/:id/idfields"
   "Get a list of all primary key `Fields` for `Database`."
   [id]
   (read-check Database id)
-  (let [table_ids (sel :many :id Table :db_id id :active true)]
-    (sort-by #(:name (:table %)) (-> (sel :many Field :table_id [in table_ids] :special_type "id")
+  (let [table_ids (db/sel :many :id Table :db_id id :active true)]
+    (sort-by #(:name (:table %)) (-> (db/sel :many Field :table_id [in table_ids] :special_type "id")
                                      (hydrate :table)))))
 
 (defendpoint POST "/:id/sync"

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -137,7 +137,7 @@
   [id]
   (let-404 [db (Database id)]
     (write-check db)
-    (u/prog1 (cascade-delete Database :id id)
+    (u/prog1 (cascade-delete! Database :id id)
       (events/publish-event :database-delete db))))
 
 (defendpoint GET "/:id/metadata"

--- a/src/metabase/api/field.clj
+++ b/src/metabase/api/field.clj
@@ -1,6 +1,5 @@
 (ns metabase.api.field
   (:require [compojure.core :refer [GET PUT POST]]
-            [medley.core :as m]
             [metabase.api.common :refer :all]
             [metabase.db :as db]
             [metabase.db.metadata-queries :as metadata]
@@ -52,11 +51,11 @@
         (checkp (db/exists? Field :id fk_target_field_id)
           :fk_target_field_id "Invalid target field"))
       ;; update the Field.  start with keys that may be set to NULL then conditionally add other keys if they have values
-      (check-500 (m/mapply db/upd Field id (merge {:description        description
-                                                   :special_type       special_type
-                                                   :visibility_type    visibility_type
-                                                   :fk_target_field_id fk_target_field_id}
-                                                  (when display_name {:display_name display_name}))))
+      (check-500 (db/update! Field id (merge {:description        description
+                                              :special_type       special_type
+                                              :visibility_type    visibility_type
+                                              :fk_target_field_id fk_target_field_id}
+                                             (when display_name {:display_name display_name}))))
       (Field id))))
 
 (defendpoint GET "/:id/summary"
@@ -89,7 +88,7 @@
     (check (field-should-have-field-values? field)
       [400 "You can only update the mapped values of a Field whose 'special_type' is 'category'/'city'/'state'/'country' or whose 'base_type' is 'BooleanField'."])
     (if-let [field-values-id (db/sel :one :id FieldValues :field_id id)]
-      (check-500 (db/upd FieldValues field-values-id
+      (check-500 (db/update! FieldValues field-values-id
                    :human_readable_values values_map))
       (create-field-values-if-needed field values_map)))
   {:status :success})

--- a/src/metabase/api/field.clj
+++ b/src/metabase/api/field.clj
@@ -2,7 +2,7 @@
   (:require [compojure.core :refer [GET PUT POST]]
             [medley.core :as m]
             [metabase.api.common :refer :all]
-            [metabase.db :refer :all]
+            [metabase.db :as db]
             [metabase.db.metadata-queries :as metadata]
             (metabase.models [hydrate :refer [hydrate]]
                              [field :refer [Field] :as field]
@@ -49,13 +49,14 @@
       (check-400 (field/valid-metadata? (:base_type field) (:field_type field) special_type visibility_type))
       ;; validate that fk_target_field_id is a valid Field within the same database as our field
       (when fk_target_field_id
-        (checkp (exists? Field :id fk_target_field_id) :fk_target_field_id "Invalid target field"))
+        (checkp (db/exists? Field :id fk_target_field_id)
+          :fk_target_field_id "Invalid target field"))
       ;; update the Field.  start with keys that may be set to NULL then conditionally add other keys if they have values
-      (check-500 (m/mapply upd Field id (merge {:description        description
-                                                :special_type       special_type
-                                                :visibility_type    visibility_type
-                                                :fk_target_field_id fk_target_field_id}
-                                               (when display_name {:display_name display_name}))))
+      (check-500 (m/mapply db/upd Field id (merge {:description        description
+                                                   :special_type       special_type
+                                                   :visibility_type    visibility_type
+                                                   :fk_target_field_id fk_target_field_id}
+                                                  (when display_name {:display_name display_name}))))
       (Field id))))
 
 (defendpoint GET "/:id/summary"
@@ -87,8 +88,8 @@
     (write-check field)
     (check (field-should-have-field-values? field)
       [400 "You can only update the mapped values of a Field whose 'special_type' is 'category'/'city'/'state'/'country' or whose 'base_type' is 'BooleanField'."])
-    (if-let [field-values-id (sel :one :id FieldValues :field_id id)]
-      (check-500 (upd FieldValues field-values-id
+    (if-let [field-values-id (db/sel :one :id FieldValues :field_id id)]
+      (check-500 (db/upd FieldValues field-values-id
                    :human_readable_values values_map))
       (create-field-values-if-needed field values_map)))
   {:status :success})

--- a/src/metabase/api/label.clj
+++ b/src/metabase/api/label.clj
@@ -16,7 +16,7 @@
   [:as {{:keys [name icon]} :body}]
   {name [Required NonEmptyString]
    icon NonEmptyString}
-  (db/ins Label, :name name, :icon icon))
+  (db/insert! Label, :name name, :icon icon))
 
 (defendpoint PUT "/:id"
   "Update a `Label`. :label:"

--- a/src/metabase/api/label.clj
+++ b/src/metabase/api/label.clj
@@ -32,6 +32,6 @@
   "Delete a `Label`. :label:"
   [id]
   (write-check Label id)
-  (db/cascade-delete Label :id id))
+  (db/cascade-delete! Label :id id))
 
 (define-routes)

--- a/src/metabase/api/label.clj
+++ b/src/metabase/api/label.clj
@@ -2,7 +2,6 @@
   "`/api/label` endpoints."
   (:require [compojure.core :refer [GET POST DELETE PUT]]
             [korma.core :as k]
-            [medley.core :as m]
             [metabase.api.common :refer [defendpoint define-routes write-check]]
             [metabase.db :as db]
             [metabase.models.label :refer [Label]]))
@@ -25,7 +24,7 @@
   {name NonEmptyString
    icon NonEmptyString}
   (write-check Label id)
-  (m/mapply db/upd Label id body)
+  (db/update! Label id body)
   (Label id)) ; return the updated Label
 
 (defendpoint DELETE "/:id"

--- a/src/metabase/api/notify.clj
+++ b/src/metabase/api/notify.clj
@@ -2,7 +2,7 @@
   "/api/notify/* endpoints which receive inbound etl server notifications."
   (:require [compojure.core :refer [POST]]
             [metabase.api.common :refer :all]
-            [metabase.db :refer :all]
+            [metabase.db :as db]
             [metabase.driver :as driver]
             (metabase.models [database :refer [Database]]
                              [table :refer [Table]])
@@ -15,9 +15,9 @@
   [id :as {{:keys [table_id table_name]} :body}]
   (let-404 [database (Database id)]
     (cond
-      table_id (when-let [table (sel :one Table :db_id id :id (int table_id))]
+      table_id (when-let [table (db/sel :one Table, :db_id id, :id (int table_id))]
                  (future (sync-database/sync-table! table)))
-      table_name (when-let [table (sel :one Table :db_id id :name table_name)]
+      table_name (when-let [table (db/sel :one Table, :db_id id, :name table_name)]
                    (future (sync-database/sync-table! table)))
       :else (future (sync-database/sync-database! database))))
   {:success true})

--- a/src/metabase/api/pulse.clj
+++ b/src/metabase/api/pulse.clj
@@ -60,7 +60,7 @@
   "Delete a `Pulse`."
   [id]
   (let-404 [pulse (Pulse id)]
-    (u/prog1 (db/cascade-delete Pulse :id id)
+    (u/prog1 (db/cascade-delete! Pulse :id id)
       (events/publish-event :pulse-delete (assoc pulse :actor_id *current-user-id*)))))
 
 

--- a/src/metabase/api/revision.clj
+++ b/src/metabase/api/revision.clj
@@ -1,7 +1,7 @@
 (ns metabase.api.revision
   (:require [compojure.core :refer [GET POST]]
             [metabase.api.common :refer :all]
-            [metabase.db :refer [exists?]]
+            [metabase.db :as db]
             (metabase.models [card :refer [Card]]
                              [dashboard :refer [Dashboard]]
                              [revision :as revision])))
@@ -21,14 +21,14 @@
   "Get revisions of an object."
   [entity id]
   {entity Entity, id Integer}
-  (check-404 (exists? entity :id id))
+  (check-404 (db/exists? entity :id id))
   (revision/revisions+details entity id))
 
 (defendpoint POST "/revert"
   "Revert an object to a prior revision."
   [:as {{:keys [entity id revision_id]} :body}]
   {entity Entity, id Integer, revision_id Integer}
-  (check-404 (exists? revision/Revision :model (:name entity) :model_id id :id revision_id))
+  (check-404 (db/exists? revision/Revision :model (:name entity) :model_id id :id revision_id))
   (revision/revert
     :entity      entity
     :id          id

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -20,7 +20,7 @@
   "Generate a new `Session` for a given `User`.  Returns the newly generated session id value."
   [user-id]
   (u/prog1 (str (java.util.UUID/randomUUID))
-    (db/ins Session
+    (db/insert! Session
       :id      <>
       :user_id user-id)))
 

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -54,7 +54,7 @@
   [session_id]
   {session_id [Required NonEmptyString]}
   (check-exists? Session session_id)
-  (db/del Session, :id session_id))
+  (db/cascade-delete! Session, :id session_id))
 
 ;; Reset tokens:
 ;; We need some way to match a plaintext token with the a user since the token stored in the DB is hashed.

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -6,23 +6,23 @@
             [korma.core :as k]
             [throttle.core :as throttle]
             [metabase.api.common :refer :all]
-            [metabase.db :refer :all]
+            [metabase.db :as db]
             [metabase.email.messages :as email]
             [metabase.events :as events]
             (metabase.models [user :refer [User set-user-password set-user-password-reset-token]]
                              [session :refer [Session]]
                              [setting :as setting])
+            [metabase.util :as u]
             [metabase.util.password :as pass]))
 
 
 (defn- create-session
   "Generate a new `Session` for a given `User`.  Returns the newly generated session id value."
   [user-id]
-  (let [session-id (str (java.util.UUID/randomUUID))]
-    (ins Session
-         :id session-id
-         :user_id user-id)
-    session-id))
+  (u/prog1 (str (java.util.UUID/randomUUID))
+    (db/ins Session
+      :id      <>
+      :user_id user-id)))
 
 
 ;;; ## API Endpoints
@@ -38,7 +38,7 @@
    password [Required NonEmptyString]}
   (throttle/check (login-throttlers :ip-address) remote-address)
   (throttle/check (login-throttlers :email)      email)
-  (let [user (sel :one :fields [User :id :password_salt :password :last_login], :email email (k/where {:is_active true}))]
+  (let [user (db/sel :one :fields [User :id :password_salt :password :last_login], :email email (k/where {:is_active true}))]
     ;; Don't leak whether the account doesn't exist or the password was incorrect
     (when-not (and user
                    (pass/verify-password password (:password_salt user) (:password user)))
@@ -54,7 +54,7 @@
   [session_id]
   {session_id [Required NonEmptyString]}
   (check-exists? Session session_id)
-  (del Session :id session_id))
+  (db/del Session, :id session_id))
 
 ;; Reset tokens:
 ;; We need some way to match a plaintext token with the a user since the token stored in the DB is hashed.
@@ -74,7 +74,7 @@
   (throttle/check (forgot-password-throttlers :ip-address) remote-address)
   (throttle/check (forgot-password-throttlers :email)      email)
   ;; Don't leak whether the account doesn't exist, just pretend everything is ok
-  (when-let [user-id (sel :one :id User :email email)]
+  (when-let [user-id (db/sel :one :id User :email email)]
     (let [reset-token        (set-user-password-reset-token user-id)
           password-reset-url (str (@(ns-resolve 'metabase.core 'site-url) request) "/auth/reset_password/" reset-token)]
       (email/send-password-reset-email email server-name password-reset-url)
@@ -90,7 +90,7 @@
   [^String token]
   (when-let [[_ user-id] (re-matches #"(^\d+)_.+$" token)]
     (let [user-id (Integer/parseInt user-id)]
-      (when-let [{:keys [reset_token reset_triggered], :as user} (sel :one :fields [User :id :last_login :reset_triggered :reset_token] :id user-id)]
+      (when-let [{:keys [reset_token reset_triggered], :as user} (db/sel :one :fields [User :id :last_login :reset_triggered :reset_token] :id user-id)]
         ;; Make sure the plaintext token matches up with the hashed one for this user
         (when (try (creds/bcrypt-verify token reset_token)
                    (catch Throwable _))

--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -32,7 +32,7 @@
   (@(ns-resolve 'metabase.core 'site-url) request)
   ;; Now create the user
   (let [session-id (str (java.util.UUID/randomUUID))
-        new-user   (db/ins User
+        new-user   (db/insert! User
                      :email        email
                      :first_name   first_name
                      :last_name    last_name
@@ -46,14 +46,18 @@
     (setting/set :anon-tracking-enabled (or allow_tracking "true"))
     ;; setup database (if needed)
     (when (driver/is-engine? engine)
-      (->> (db/ins Database, :name name, :engine engine, :details details, :is_full_sync (if-not (nil? is_full_sync)
-                                                                                           is_full_sync
-                                                                                           true))
+      (->> (db/insert! Database
+             :name         name
+             :engine       engine
+             :details      details
+             :is_full_sync (if-not (nil? is_full_sync)
+                             is_full_sync
+                             true))
            (events/publish-event :database-create)))
     ;; clear the setup token now, it's no longer needed
     (setup/token-clear)
     ;; then we create a session right away because we want our new user logged in to continue the setup process
-    (db/ins Session
+    (db/insert! Session
       :id      session-id
       :user_id (:id new-user))
     ;; notify that we've got a new user in the system AND that this user logged in

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -49,7 +49,7 @@
                :display_name display_name
                :entity_type  entity_type
                :description  description))
-  (check-500 (db/upd Table id, :visibility_type visibility_type))
+  (check-500 (db/update! Table id, :visibility_type visibility_type))
   (Table id))
 
 (defendpoint GET "/:id/fields"
@@ -115,7 +115,7 @@
           ;; actual `Field` value selected above in order to ensure people don't accidentally update fields they
           ;; aren't supposed to or aren't allowed to.  e.g. without this the caller could update any field-id they want
           (when-let [{:keys [id]} (first (filter #(= field-id (:id %)) table-fields))]
-            (db/upd Field id, :position index)))
+            (db/update! Field id, :position index)))
         new_order))
     {:result "success"}))
 

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -3,7 +3,7 @@
   (:require [compojure.core :refer [GET POST PUT]]
             [korma.core :as k]
             [metabase.api.common :refer :all]
-            [metabase.db :refer :all]
+            [metabase.db :as db]
             [metabase.driver :as driver]
             (metabase.models [hydrate :refer :all]
                              [field :refer [Field]]
@@ -23,7 +23,7 @@
 (defendpoint GET "/"
   "Get all `Tables`."
   []
-  (-> (sel :many Table :active true (k/order :name :ASC))
+  (-> (db/sel :many Table, :active true, (k/order :name :ASC))
       (hydrate :db)
       ;; if for some reason a Table doesn't have rows set then set it to 0 so UI doesn't barf
       (#(map (fn [table]
@@ -45,11 +45,11 @@
    entity_type     TableEntityType,
    visibility_type TableVisibilityType}
   (write-check Table id)
-  (check-500 (upd-non-nil-keys Table id
-                               :display_name    display_name
-                               :entity_type     entity_type
-                               :description     description))
-  (check-500 (upd Table id :visibility_type visibility_type))
+  (check-500 (db/update-non-nil-keys! Table id
+               :display_name display_name
+               :entity_type  entity_type
+               :description  description))
+  (check-500 (db/upd Table id, :visibility_type visibility_type))
   (Table id))
 
 (defendpoint GET "/:id/fields"
@@ -57,7 +57,7 @@
   [id]
   (let-404 [table (Table id)]
     (read-check table)
-    (sel :many Field :table_id id, :visibility_type [not-in ["sensitive" "retired"]], (k/order :name :ASC))))
+    (db/sel :many Field :table_id id, :visibility_type [not-in ["sensitive" "retired"]], (k/order :name :ASC))))
 
 (defendpoint GET "/:id/query_metadata"
   "Get metadata about a `Table` useful for running queries.
@@ -82,8 +82,8 @@
   [id]
   (let-404 [table (Table id)]
     (read-check table)
-    (let [field-ids (sel :many :id Field :table_id id :visibility_type [not= "retired"])]
-      (for [origin-field (sel :many Field :fk_target_field_id [in field-ids])]
+    (let [field-ids (db/sel :many :id Field :table_id id :visibility_type [not= "retired"])]
+      (for [origin-field (db/sel :many Field :fk_target_field_id [in field-ids])]
         ;; it's silly to be hydrating some of these tables/dbs
         {:relationship   :Mt1
          :origin_id      (:id origin-field)
@@ -105,7 +105,7 @@
   [id :as {{:keys [new_order]} :body}]
   {new_order [Required ArrayOfIntegers]}
   (write-check Table id)
-  (let [table-fields (sel :many Field :table_id id)]
+  (let [table-fields (db/sel :many Field :table_id id)]
     ;; run a function over the `new_order` list which simply updates `Field` :position to the index in the vector
     ;; NOTE: we assume that all `Fields` in the table are represented in the array
     (dorun
@@ -115,7 +115,7 @@
           ;; actual `Field` value selected above in order to ensure people don't accidentally update fields they
           ;; aren't supposed to or aren't allowed to.  e.g. without this the caller could update any field-id they want
           (when-let [{:keys [id]} (first (filter #(= field-id (:id %)) table-fields))]
-            (upd Field id :position index)))
+            (db/upd Field id, :position index)))
         new_order))
     {:result "success"}))
 

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -79,8 +79,8 @@
   [id :as {{:keys [password old_password]} :body}]
   {password     [Required ComplexPassword]}
   (check-self-or-superuser id)
-  (let-404 [user (db/sel :one [User :password_salt :password] :id id :is_active true)]
-    (when (= id (:id @*current-user*))
+  (let-404 [user (db/sel :one [User :password_salt :password], :id id, :is_active true)]
+    (when (= id *current-user-id*)
       (checkp (creds/bcrypt-verify (str (:password_salt user) old_password) (:password user)) "old_password" "Invalid password")))
   (set-user-password id password)
   (User id))

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -62,8 +62,8 @@
    first_name NonEmptyString
    last_name  NonEmptyString}
   (check-self-or-superuser id)
-  (check-404 (exists? User :id id :is_active true))           ; only allow updates if the specified account is active
-  (check-400 (not (exists? User :email email :id [not= id]))) ; can't change email if it's already taken BY ANOTHER ACCOUNT
+  (check-404 (exists? User, :id id, :is_active true))            ; only allow updates if the specified account is active
+  (check-400 (not (exists? User, :email email, :id [:not= id]))) ; can't change email if it's already taken BY ANOTHER ACCOUNT
   (check-500 (upd-non-nil-keys User id
               :email        email
               :first_name   first_name

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -2,7 +2,7 @@
   (:require [cemerick.friend.credentials :as creds]
             [compojure.core :refer [defroutes GET DELETE POST PUT]]
             [metabase.api.common :refer :all]
-            [metabase.db :refer [sel upd upd-non-nil-keys exists?]]
+            [metabase.db :as db]
             [metabase.email.messages :as email]
             [metabase.models.user :refer [User create-user set-user-password set-user-password-reset-token form-password-reset-url]]))
 
@@ -16,7 +16,7 @@
 (defendpoint GET "/"
   "Fetch a list of all active `Users`. You must be a superuser to do this."
   []
-  (sel :many User :is_active true))
+  (db/sel :many User :is_active true))
 
 
 (defendpoint POST "/"
@@ -26,13 +26,13 @@
    last_name  [Required NonEmptyString]
    email      [Required Email]}
   (check-superuser)
-  (let [existing-user (sel :one [User :id :is_active] :email email)]
+  (let [existing-user (db/sel :one [User :id :is_active] :email email)]
     (cond
       ;; new user account, so create it
       (nil? existing-user) (create-user first_name last_name email :password password :send-welcome true :invitor @*current-user*)
       ;; this user already exists but is inactive, so simply reactivate the account
       (not (:is_active existing-user)) (do
-                                         (upd User (:id existing-user)
+                                         (db/upd User (:id existing-user)
                                            :first_name first_name
                                            :last_name last_name
                                            :is_active true
@@ -52,7 +52,7 @@
   "Fetch a `User`. You must be fetching yourself *or* be a superuser."
   [id]
   (check-self-or-superuser id)
-  (check-404 (sel :one User :id id, :is_active true)))
+  (check-404 (db/sel :one User :id id, :is_active true)))
 
 
 (defendpoint PUT "/:id"
@@ -62,15 +62,15 @@
    first_name NonEmptyString
    last_name  NonEmptyString}
   (check-self-or-superuser id)
-  (check-404 (exists? User, :id id, :is_active true))            ; only allow updates if the specified account is active
-  (check-400 (not (exists? User, :email email, :id [:not= id]))) ; can't change email if it's already taken BY ANOTHER ACCOUNT
-  (check-500 (upd-non-nil-keys User id
-              :email        email
-              :first_name   first_name
-              :last_name    last_name
-              :is_superuser (if (:is_superuser @*current-user*)
-                              is_superuser
-                              nil)))
+  (check-404 (db/exists? User, :id id, :is_active true)) ; only allow updates if the specified account is active
+  (check-400 (not (db/exists? User, :email email, :id [:not= id]))) ; can't change email if it's already taken BY ANOTHER ACCOUNT
+  (check-500 (db/update-non-nil-keys! User id
+               :email        email
+               :first_name   first_name
+               :last_name    last_name
+               :is_superuser (if (:is_superuser @*current-user*)
+                               is_superuser
+                               nil)))
   (User id))
 
 
@@ -79,7 +79,7 @@
   [id :as {{:keys [password old_password]} :body}]
   {password     [Required ComplexPassword]}
   (check-self-or-superuser id)
-  (let-404 [user (sel :one [User :password_salt :password] :id id :is_active true)]
+  (let-404 [user (db/sel :one [User :password_salt :password] :id id :is_active true)]
     (when (= id (:id @*current-user*))
       (checkp (creds/bcrypt-verify (str (:password_salt user) old_password) (:password user)) "old_password" "Invalid password")))
   (set-user-password id password)
@@ -90,7 +90,7 @@
   "Indicate that a user has been informed about the vast intricacies of 'the' QueryBuilder."
   [id]
   (check-self-or-superuser id)
-  (check-500 (upd User id :is_qbnewb false))
+  (check-500 (db/upd User id :is_qbnewb false))
   {:success true})
 
 
@@ -98,7 +98,7 @@
   "Resend the user invite email for a given user."
   [id]
   (check-superuser)
-  (when-let [user (sel :one User :id id :is_active true)]
+  (when-let [user (db/sel :one User :id id :is_active true)]
     (let [reset-token (set-user-password-reset-token id)
           ;; NOTE: the new user join url is just a password reset with an indicator that this is a first time user
           join-url    (str (form-password-reset-url reset-token) "#new")]
@@ -109,8 +109,8 @@
   "Disable a `User`.  This does not remove the `User` from the db and instead disables their account."
   [id]
   (check-superuser)
-  (check-500 (upd User id
-                  :is_active false))
+  (check-500 (db/upd User id
+               :is_active false))
   {:success true})
 
 

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -284,22 +284,6 @@
       ~@args)))
 
 
-;; ## INS
-
-(defn ^:deprecated ins
-  "Wrapper around `korma.core/insert` that renames the `:scope_identity()` keyword in output to `:id`
-   and automatically passes &rest KWARGS to `korma.core/values`.
-
-   Returns a newly created object by calling `sel`."
-  [entity & {:as kwargs}]
-  (let [vals         (models/do-pre-insert entity kwargs)
-        ;; take database-specific keys returned from a jdbc insert and map them to :id
-        {:keys [id]} (set/rename-keys (k/insert entity (k/values vals))
-                                      {(keyword "scope_identity()") :id
-                                       :generated_key               :id})]
-    (some-> id entity models/post-insert)))
-
-
 
 ;;; +------------------------------------------------------------------------------------------------------------------------+
 ;;; |                                         NEW HONEY-SQL BASED DB UTIL FUNCTIONS                                          |

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -338,18 +338,6 @@
     (some-> id entity models/post-insert)))
 
 
-;; ## EXISTS?
-
-(defmacro exists?
-  "Easy way to see if something exists in the db.
-
-    (exists? User :id 100)"
-  [entity & {:as kwargs}]
-  `(boolean (seq (k/select (i/entity->korma ~entity)
-                           (k/fields [:id])
-                           (k/where ~(if (seq kwargs) kwargs {}))
-                           (k/limit 1)))))
-
 ;; ## CASADE-DELETE
 
 (defn ^:deprecated -cascade-delete
@@ -605,17 +593,6 @@
    (insert! entity (apply array-map k v more))))
 
 
-;;; ## EXISTS?
-
-;; The new implementation of exists? is commented out for the time being until we re-work existing uses
-#_(defn exists?
-  "Easy way to see if something exists in the DB.
-    (db/exists? User :id 100)
-   NOTE: This only works for objects that have an `:id` field."
-  [entity & kvs]
-  (boolean (select-one entity (apply where (h/select :id) kvs))))
-
-
 ;;; ## SELECT
 
 ;; All of the following functions are based off of the old `sel` macro and can do things like select certain fields by wrapping ENTITY in a vector
@@ -722,6 +699,16 @@
   {:style/indent 2}
   [field entity & options]
   (apply select-field->field :id field entity options))
+
+
+;;; ## EXISTS?
+
+(defn exists?
+  "Easy way to see if something exists in the DB.
+    (db/exists? User :id 100)
+   NOTE: This only works for objects that have an `:id` field."
+  [entity & kvs]
+  (boolean (select-one entity (apply where (h/select :id) kvs))))
 
 
 ;;; ## CASADE-DELETE

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -220,17 +220,6 @@
     (> rows-affected 0)))
 
 
-;; ## DEL
-
-(defn ^:deprecated del
-  "Wrapper around `korma.core/delete` that makes it easier to delete a row given a single PK value.
-   Returns a `204 (No Content)` response dictionary."
-  [entity & {:as kwargs}]
-  (k/delete entity (k/where kwargs))
-  {:status 204
-   :body nil})
-
-
 ;; ## SEL
 
 (def ^:dynamic *disable-db-logging*
@@ -534,7 +523,9 @@
 
      (delete! 'Label)                ; delete all Labels
      (delete! Label :name \"Cam\")   ; delete labels where :name == \"Cam\"
-     (delete! Label {:name \"Cam\"}) ; for flexibility either a single map or kwargs are accepted"
+     (delete! Label {:name \"Cam\"}) ; for flexibility either a single map or kwargs are accepted
+
+   Most the time, you should use `cascade-delete!` instead, handles deletion of dependent objects via the entity's implementation of `pre-cascade-delete`."
   {:style/indent 1}
   ([entity]
    (delete! entity {}))
@@ -690,10 +681,12 @@
    which should delete any objects related the object about to be deleted.
    Returns a 204/nil reponse so it can be used directly in an API endpoint.
 
-     (cascade-delete! Database :id 1)"
+     (cascade-delete! Database :id 1)
+
+   TODO - this depends on objects having an `:id` column; consider a way to fix this for models like `Setting` that do not have one."
   {:style/indent 1}
   [entity & kvs]
-  (let [entity  (resolve-entity entity)]
+  (let [entity (resolve-entity entity)]
     (doseq [object (apply select entity kvs)]
       (models/pre-cascade-delete object)
       (delete! entity :id (:id object))))

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -219,13 +219,6 @@
       (models/post-update obj))
     (> rows-affected 0)))
 
-(defn ^:deprecated upd-non-nil-keys
-  "Calls `upd`, but filters out KWARGS with `nil` values."
-  {:style/indent 2}
-  [entity entity-id & {:as kwargs}]
-  (->> (m/filter-vals (complement nil?) kwargs)
-       (m/mapply upd entity entity-id)))
-
 
 ;; ## DEL
 

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -679,7 +679,7 @@
   "Easy way to see if something exists in the DB.
     (db/exists? User :id 100)
    NOTE: This only works for objects that have an `:id` field."
-  [entity & kvs]
+  ^Boolean [entity & kvs]
   (boolean (select-one entity (apply where (h/select :id) kvs))))
 
 

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -200,30 +200,10 @@
 
 ;; # ---------------------------------------- OLD UTILITY FUNCTIONS ----------------------------------------
 
-;; ## UPD
-
-(defn ^:deprecated upd
-  "Wrapper around `korma.core/update` that updates a single row by its id value and
-   automatically passes &rest KWARGS to `korma.core/set-fields`.
-
-     (upd User 123 :is_active false) ; updates user with id=123, setting is_active=false
-
-   Returns true if update modified rows, false otherwise."
-  [entity entity-id & {:as kwargs}]
-  {:pre [(integer? entity-id)]}
-  (let [obj           (models/do-pre-update entity (assoc kwargs :id entity-id))
-        rows-affected (k/update entity
-                                (k/set-fields (dissoc obj :id))
-                                (k/where {:id entity-id}))]
-    (when (> rows-affected 0)
-      (models/post-update obj))
-    (> rows-affected 0)))
-
-
 ;; ## SEL
 
-(def ^:dynamic *disable-db-logging*
-  "Should we disable logging for the `sel` macro? Normally `false`, but bind this to `true` to keep logging from getting too noisy during
+(def ^:dynamic ^Boolean *disable-db-logging*
+  "Should we disable logging for database queries? Normally `false`, but bind this to `true` to keep logging from getting too noisy during
    operations that require a lot of DB access, like the sync process."
   false)
 

--- a/src/metabase/db/migrations.clj
+++ b/src/metabase/db/migrations.clj
@@ -205,12 +205,12 @@
                     ;; add this table to the set of tables we've processed
                     (swap! processed-tables conj {:schema table-schema, :name table-name})
                     ;; create the RawTable
-                    (let [{raw-table-id :id} (db/ins RawTable
-                                               :database_id  database-id
-                                               :schema       table-schema
-                                               :name         table-name
-                                               :details      {}
-                                               :active       true)]
+                    (let [{raw-table-id :id} (db/insert! RawTable
+                                               :database_id database-id
+                                               :schema      table-schema
+                                               :name        table-name
+                                               :details     {}
+                                               :active      true)]
                       ;; update the Table and link it with the RawTable
                       (k/update Table
                         (k/set-fields {:raw_table_id raw-table-id})
@@ -226,12 +226,12 @@
                                 (k/set-fields {:visibility_type "retired"})
                                 (k/where      {:id field-id}))
                               ;; normal unmigrated field, so lets use it
-                              (let [{raw-column-id :id} (db/ins RawColumn
-                                                          :raw_table_id  raw-table-id
-                                                          :name          column-name
-                                                          :is_pk         (= :id (:special_type field))
-                                                          :details       {:base-type (:base_type field)}
-                                                          :active        true)]
+                              (let [{raw-column-id :id} (db/insert! RawColumn
+                                                          :raw_table_id raw-table-id
+                                                          :name         column-name
+                                                          :is_pk        (= :id (:special_type field))
+                                                          :details      {:base-type (:base_type field)}
+                                                          :active       true)]
                                 ;; update the Field and link it with the RawColumn
                                 (k/update Field
                                   (k/set-fields {:raw_column_id raw-column-id

--- a/src/metabase/db/migrations.clj
+++ b/src/metabase/db/migrations.clj
@@ -113,7 +113,7 @@
       (when (< 1 (count fks))
         (log/debug "Removing duplicate FK entries for" k)
         (doseq [duplicate-fk (drop-last fks)]
-          (db/del ForeignKey :id (:id duplicate-fk)))))))
+          (db/delete! ForeignKey, :id (:id duplicate-fk)))))))
 
 
 ;; Migrate dashboards to the new grid

--- a/src/metabase/db/migrations.clj
+++ b/src/metabase/db/migrations.clj
@@ -67,7 +67,7 @@
     (doseq [{id :id {:keys [type] :as dataset-query} :dataset_query} (db/sel :many [Card :id :dataset_query])]
       (when type
         ;; simply resave the card with the dataset query which will automatically set the database, table, and type
-        (db/upd Card id :dataset_query dataset-query)))))
+        (db/update! Card id, :dataset_query dataset-query)))))
 
 
 ;; Set the `:ssl` key in `details` to `false` for all existing MongoDB `Databases`.
@@ -75,7 +75,7 @@
 ;; Since Mongo did *not* support SSL, all existing Mongo DBs should actually have this key set to `false`.
 (defmigration set-mongodb-databases-ssl-false
   (doseq [{:keys [id details]} (db/sel :many :fields [Database :id :details] :engine "mongo")]
-    (db/upd Database id, :details (assoc details :ssl false))))
+    (db/update! Database id, :details (assoc details :ssl false))))
 
 
 ;; Set default values for :schema in existing tables now that we've added the column

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -4,7 +4,7 @@
             [clojure.tools.logging :as log]
             [clojure.tools.namespace.find :as ns-find]
             [medley.core :as m]
-            [metabase.db :refer [ins sel upd]]
+            [metabase.db :as db]
             (metabase.models [database :refer [Database]]
                              [query-execution :refer [QueryExecution]]
                              [setting :refer [defsetting]])
@@ -328,7 +328,7 @@
    (Databases aren't expected to change their types, and this optimization makes things a lot faster).
 
    This loads the corresponding driver if needed."
-  (let [db-id->engine (memoize (fn [db-id] (sel :one :field [Database :engine] :id db-id)))]
+  (let [db-id->engine (memoize (fn [db-id] (db/sel :one :field [Database :engine] :id db-id)))]
     (fn [db-id]
       (engine->driver (db-id->engine db-id)))))
 

--- a/src/metabase/driver/bigquery.clj
+++ b/src/metabase/driver/bigquery.clj
@@ -84,7 +84,7 @@
     (let [details (-> (merge details (fetch-access-and-refresh-tokens client-id client-secret auth-code))
                       (dissoc :auth-code))]
       (when id
-        (db/upd Database id :details details))
+        (db/update! Database id, :details details))
       (recur (assoc db :details details)))
     ;; Otherwise return credential as normal
     (doto (.build (doto (GoogleCredential$Builder.)

--- a/src/metabase/driver/druid.clj
+++ b/src/metabase/driver/druid.clj
@@ -3,7 +3,6 @@
   (:require [clojure.tools.logging :as log]
             [clj-http.client :as http]
             [cheshire.core :as json]
-            [metabase.db :refer [sel]]
             [metabase.driver :as driver]
             [metabase.driver.druid.query-processor :as qp]
             (metabase.models [field :as field]

--- a/src/metabase/events/activity_feed.clj
+++ b/src/metabase/events/activity_feed.clj
@@ -117,7 +117,7 @@
         "card"      (process-card-activity topic object)
         "dashboard" (process-dashboard-activity topic object)
         "install"   (when-not (db/exists? Activity)
-                      (db/ins Activity, :topic "install", :model "install"))
+                      (db/insert! Activity, :topic "install", :model "install"))
         "metric"    (process-metric-activity topic object)
         "pulse"     (process-pulse-activity topic object)
         "segment"   (process-segment-activity topic object)

--- a/src/metabase/events/last_login.clj
+++ b/src/metabase/events/last_login.clj
@@ -27,7 +27,7 @@
     (when-let [{object :item} last-login-event]
       ;; just make a simple attempt to set the `:last_login` for the given user to now
       (when-let [user-id (:user_id object)]
-        (db/upd User user-id :last_login (u/new-sql-timestamp))))
+        (db/update! User user-id, :last_login (u/new-sql-timestamp))))
     (catch Throwable e
       (log/warn (format "Failed to process sync-database event. %s" (:topic last-login-event)) e))))
 

--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -24,7 +24,7 @@
   "Simple base function for recording a view of a given `model` and `model-id` by a certain `user`."
   [model model-id user-id]
   ;; TODO - we probably want a little code that prunes old entries so that this doesn't get too big
-  (db/ins ViewLog
+  (db/insert! ViewLog
     :user_id  user-id
     :model    model
     :model_id model-id))

--- a/src/metabase/middleware.clj
+++ b/src/metabase/middleware.clj
@@ -6,7 +6,7 @@
             [korma.core :as k]
             [metabase.api.common :refer [*current-user* *current-user-id*]]
             [metabase.config :as config]
-            [metabase.db :refer [sel]]
+            [metabase.db :as db]
             (metabase.models [interface :as models]
                              [session :refer [Session]]
                              [setting :refer [defsetting]]
@@ -89,7 +89,7 @@
   (fn [request]
     (if-let [current-user-id (:metabase-user-id request)]
       (binding [*current-user-id* current-user-id
-                *current-user*    (delay (sel :one `[User ~@(models/default-fields User) :is_active :is_staff], :id current-user-id))]
+                *current-user*    (delay (db/sel :one `[User ~@(models/default-fields User) :is_active :is_staff], :id current-user-id))]
         (handler request))
       (handler request))))
 

--- a/src/metabase/models/activity.clj
+++ b/src/metabase/models/activity.clj
@@ -62,7 +62,7 @@
   [& {:keys [topic object details-fn database-id table-id user-id model model-id]}]
   {:pre [(keyword? topic)]}
   (let [object (or object {})]
-    (db/ins Activity
+    (db/insert! Activity
       :topic       topic
       :user_id     (or user-id (events/object->user-id object))
       :model       (or model (events/topic->model topic))

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -44,12 +44,12 @@
     []))
 
 (defn- pre-cascade-delete [{:keys [id]}]
-  (db/cascade-delete 'PulseCard :card_id id)
-  (db/cascade-delete 'Revision :model "Card", :model_id id)
-  (db/cascade-delete 'DashboardCardSeries :card_id id)
-  (db/cascade-delete 'DashboardCard :card_id id)
-  (db/cascade-delete 'CardFavorite :card_id id)
-  (db/cascade-delete 'CardLabel :card_id id))
+  (db/cascade-delete! 'PulseCard :card_id id)
+  (db/cascade-delete! 'Revision :model "Card", :model_id id)
+  (db/cascade-delete! 'DashboardCardSeries :card_id id)
+  (db/cascade-delete! 'DashboardCard :card_id id)
+  (db/cascade-delete! 'CardFavorite :card_id id)
+  (db/cascade-delete! 'CardLabel :card_id id))
 
 
 ;;; ## ---------------------------------------- REVISIONS ----------------------------------------

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -17,8 +17,8 @@
   (sel :many DashboardCard, :dashboard_id id, (k/order :created_at :asc)))
 
 (defn- pre-cascade-delete [{:keys [id]}]
-  (cascade-delete 'Revision :model "Dashboard" :model_id id)
-  (cascade-delete DashboardCard :dashboard_id id))
+  (cascade-delete! 'Revision :model "Dashboard" :model_id id)
+  (cascade-delete! DashboardCard :dashboard_id id))
 
 
 (i/defentity Dashboard :report_dashboard)

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -1,7 +1,6 @@
 (ns metabase.models.dashboard
   (:require [clojure.data :refer [diff]]
             [korma.core :as k]
-            [medley.core :as m]
             [metabase.db :as db]
             (metabase.models [dashboard-card :refer [DashboardCard] :as dashboard-card]
                              [interface :as i]
@@ -49,7 +48,7 @@
   "Revert a `Dashboard` to the state defined by SERIALIZED-DASHBOARD."
   [dashboard-id user-id serialized-dashboard]
   ;; Update the dashboard description / name / permissions
-  (m/mapply db/upd Dashboard dashboard-id (dissoc serialized-dashboard :cards))
+  (db/update! Dashboard dashboard-id, (dissoc serialized-dashboard :cards))
   ;; Now update the cards as needed
   (let [serialized-cards    (:cards serialized-dashboard)
         id->serialized-card (zipmap (map :id serialized-cards) serialized-cards)

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -2,7 +2,7 @@
   (:require [clojure.data :refer [diff]]
             [korma.core :as k]
             [medley.core :as m]
-            [metabase.db :refer :all]
+            [metabase.db :as db]
             (metabase.models [dashboard-card :refer [DashboardCard] :as dashboard-card]
                              [interface :as i]
                              [revision :as revision])
@@ -14,11 +14,11 @@
   "Return the `DashboardCards` associated with DASHBOARD, in the order they were created."
   {:hydrate :ordered_cards, :arglists '([dashboard])}
   [{:keys [id]}]
-  (sel :many DashboardCard, :dashboard_id id, (k/order :created_at :asc)))
+  (db/sel :many DashboardCard, :dashboard_id id, (k/order :created_at :asc)))
 
 (defn- pre-cascade-delete [{:keys [id]}]
-  (cascade-delete! 'Revision :model "Dashboard" :model_id id)
-  (cascade-delete! DashboardCard :dashboard_id id))
+  (db/cascade-delete! 'Revision :model "Dashboard" :model_id id)
+  (db/cascade-delete! DashboardCard :dashboard_id id))
 
 
 (i/defentity Dashboard :report_dashboard)
@@ -49,11 +49,11 @@
   "Revert a `Dashboard` to the state defined by SERIALIZED-DASHBOARD."
   [dashboard-id user-id serialized-dashboard]
   ;; Update the dashboard description / name / permissions
-  (m/mapply upd Dashboard dashboard-id (dissoc serialized-dashboard :cards))
+  (m/mapply db/upd Dashboard dashboard-id (dissoc serialized-dashboard :cards))
   ;; Now update the cards as needed
   (let [serialized-cards    (:cards serialized-dashboard)
         id->serialized-card (zipmap (map :id serialized-cards) serialized-cards)
-        current-cards       (sel :many :fields [DashboardCard :sizeX :sizeY :row :col :id :card_id], :dashboard_id dashboard-id)
+        current-cards       (db/sel :many :fields [DashboardCard :sizeX :sizeY :row :col :id :card_id], :dashboard_id dashboard-id)
         id->current-card    (zipmap (map :id current-cards) current-cards)
         all-dashcard-ids    (concat (map :id serialized-cards)
                                     (map :id current-cards))]

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -112,13 +112,13 @@
   (let [{:keys [sizeX sizeY row col series]} (merge {:sizeX 2, :sizeY 2, :series []}
                                                     dashboard-card)]
     (kdb/transaction
-      (let [{:keys [id] :as dashboard-card} (db/ins DashboardCard
-                                                    :dashboard_id dashboard_id
-                                                    :card_id      card_id
-                                                    :sizeX        sizeX
-                                                    :sizeY        sizeY
-                                                    :row          row
-                                                    :col          col)]
+      (let [{:keys [id] :as dashboard-card} (db/insert! DashboardCard
+                                              :dashboard_id dashboard_id
+                                              :card_id      card_id
+                                              :sizeX        sizeX
+                                              :sizeY        sizeY
+                                              :row          row
+                                              :col          col)]
         ;; add series to the DashboardCard
         (update-dashboard-card-series dashboard-card series)
         ;; return the full DashboardCard (and record our create event)

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -94,7 +94,7 @@
     (kdb/transaction
       ;; update the dashcard itself (positional attributes)
       (when (and sizeX sizeY row col)
-        (db/upd DashboardCard id :sizeX sizeX :sizeY sizeY :row row :col col))
+        (db/update! DashboardCard id, :sizeX sizeX, :sizeY sizeY, :row row, :col col))
       ;; update series (only if they changed)
       (when (not= series (db/sel :many :field [DashboardCardSeries :card_id] :dashboardcard_id id (k/order :position :asc)))
         (update-dashboard-card-series dashboard-card series))

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -23,7 +23,7 @@
     (merge defaults dashcard)))
 
 (defn- pre-cascade-delete [{:keys [id]}]
-  (db/cascade-delete 'DashboardCardSeries :dashboardcard_id id))
+  (db/cascade-delete! 'DashboardCardSeries :dashboardcard_id id))
 
 (u/strict-extend (class DashboardCard)
   i/IEntity
@@ -78,7 +78,7 @@
          (sequential? card-ids)
          (every? integer? card-ids)]}
   ;; first off, just delete all series on the dashboard card (we add them again below)
-  (db/cascade-delete DashboardCardSeries :dashboardcard_id id)
+  (db/cascade-delete! DashboardCardSeries :dashboardcard_id id)
   ;; now just insert all of the series that were given to us
   (when-not (empty? card-ids)
     (let [cards (map-indexed (fn [idx itm] {:dashboardcard_id id :card_id itm :position idx}) card-ids)]
@@ -133,5 +133,5 @@
   {:pre [(map? dashboard-card)
          (integer? user-id)]}
   (let [{:keys [id]} (dashboard dashboard-card)]
-    (db/cascade-delete DashboardCard :id (:id dashboard-card))
+    (db/cascade-delete! DashboardCard :id (:id dashboard-card))
     (events/publish-event :dashboard-remove-cards {:id id :actor_id user-id :dashcards [dashboard-card]})))

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -2,7 +2,7 @@
   (:require [cheshire.generate :refer [add-encoder encode-map]]
             [korma.core :as k]
             [metabase.api.common :refer [*current-user*]]
-            [metabase.db :refer [cascade-delete sel]]
+            [metabase.db :refer [cascade-delete! sel]]
             [metabase.models.interface :as i]
             [metabase.util :as u]))
 
@@ -19,9 +19,9 @@
                                         []))))
 
 (defn- pre-cascade-delete [{:keys [id]}]
-  (cascade-delete 'Card  :database_id id)
-  (cascade-delete 'Table :db_id id)
-  (cascade-delete 'RawTable :database_id id))
+  (cascade-delete! 'Card  :database_id id)
+  (cascade-delete! 'Table :db_id id)
+  (cascade-delete! 'RawTable :database_id id))
 
 (defn ^:hydrate tables
   "Return the `Tables` associated with this `Database`."

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -2,7 +2,7 @@
   (:require [cheshire.generate :refer [add-encoder encode-map]]
             [korma.core :as k]
             [metabase.api.common :refer [*current-user*]]
-            [metabase.db :refer [cascade-delete! sel]]
+            [metabase.db :as db]
             [metabase.models.interface :as i]
             [metabase.util :as u]))
 
@@ -19,14 +19,14 @@
                                         []))))
 
 (defn- pre-cascade-delete [{:keys [id]}]
-  (cascade-delete! 'Card  :database_id id)
-  (cascade-delete! 'Table :db_id id)
-  (cascade-delete! 'RawTable :database_id id))
+  (db/cascade-delete! 'Card  :database_id id)
+  (db/cascade-delete! 'Table :db_id id)
+  (db/cascade-delete! 'RawTable :database_id id))
 
 (defn ^:hydrate tables
   "Return the `Tables` associated with this `Database`."
   [{:keys [id]}]
-  (sel :many 'Table :db_id id, :active true, (k/order :display_name :ASC)))
+  (db/sel :many 'Table :db_id id, :active true, (k/order :display_name :ASC)))
 
 (u/strict-extend (class Database)
   i/IEntity

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -88,10 +88,10 @@
     (merge defaults field)))
 
 (defn- pre-cascade-delete [{:keys [id]}]
-  (db/cascade-delete Field :parent_id id)
-  (db/cascade-delete ForeignKey (k/where (or (= :origin_id id)
-                                             (= :destination_id id))))
-  (db/cascade-delete 'FieldValues :field_id id))
+  (db/cascade-delete! Field :parent_id id)
+  (db/cascade-delete! ForeignKey {:where [:or [:= :origin_id id]
+                                          [:= :destination_id id]]})
+  (db/cascade-delete! 'FieldValues :field_id id))
 
 (defn ^:hydrate target
   "Return the FK target `Field` that this `Field` points to."

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -203,7 +203,7 @@
               (last matching-pattern)))))))
 
 
-(defn update-field
+(defn update-field!
   "Update an existing `Field` from the given FIELD-DEF."
   [{:keys [id], :as existing-field} {field-name :name, :keys [base-type special-type pk? parent-id]}]
   (let [updated-field (assoc existing-field
@@ -219,28 +219,28 @@
         [is-diff? _ _] (d/diff updated-field existing-field)]
     ;; if we have a different base-type or special-type, then update
     (when is-diff?
-      (db/upd Field id
-              :display_name (:display_name updated-field)
-              :base_type    base-type
-              :special_type (:special_type updated-field)
-              :parent_id    parent-id))
+      (db/update! Field id
+        :display_name (:display_name updated-field)
+        :base_type    base-type
+        :special_type (:special_type updated-field)
+        :parent_id    parent-id))
     ;; return the updated field when we are done
     updated-field))
 
 
-(defn create-field
+(defn create-field!
   "Create a new `Field` from the given FIELD-DEF."
   [table-id {field-name :name, :keys [base-type special-type pk? parent-id raw-column-id]}]
   {:pre [(integer? table-id)
          (string? field-name)
          (contains? base-types base-type)]}
   (db/ins Field
-          :table_id       table-id
-          :raw_column_id  raw-column-id
-          :name           field-name
-          :display_name   (common/name->human-readable-name field-name)
-          :base_type      base-type
-          :special_type   (or special-type
-                              (when pk? :id)
-                              (infer-field-special-type field-name base-type))
-          :parent_id      parent-id))
+    :table_id      table-id
+    :raw_column_id raw-column-id
+    :name          field-name
+    :display_name  (common/name->human-readable-name field-name)
+    :base_type     base-type
+    :special_type  (or special-type
+                       (when pk? :id)
+                       (infer-field-special-type field-name base-type))
+    :parent_id     parent-id))

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -234,7 +234,7 @@
   {:pre [(integer? table-id)
          (string? field-name)
          (contains? base-types base-type)]}
-  (db/ins Field
+  (db/insert! Field
     :table_id      table-id
     :raw_column_id raw-column-id
     :name          field-name

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -54,7 +54,7 @@
   {:pre [(integer? field-id)
          (field-should-have-field-values? field)]}
   (if-let [field-values (db/sel :one FieldValues :field_id field-id)]
-    (db/upd FieldValues (:id field-values)
+    (db/update! FieldValues (:id field-values)
       :values ((resolve 'metabase.db.metadata-queries/field-distinct-values) field))
     (create-field-values field)))
 
@@ -75,7 +75,7 @@
   {:pre [(integer? field-id)
          (coll? values)]}
   (if-let [field-values (db/sel :one FieldValues :field_id field-id)]
-    (db/upd FieldValues (:id field-values) :values values)
+    (db/update! FieldValues (:id field-values), :values values)
     (db/ins FieldValues :field_id field-id, :values values)))
 
 (defn clear-field-values

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -1,6 +1,6 @@
 (ns metabase.models.field-values
   (:require [clojure.tools.logging :as log]
-            [metabase.db :refer [ins sel upd cascade-delete]]
+            [metabase.db :as db]
             [metabase.models.interface :as i]
             [metabase.util :as u]))
 
@@ -43,7 +43,7 @@
   [{field-id :id, field-name :name, :as field} & [human-readable-values]]
   {:pre [(integer? field-id)]}
   (log/debug (format "Creating FieldValues for Field %s..." (or field-name field-id))) ; use field name if available
-  (ins FieldValues
+  (db/ins FieldValues
     :field_id              field-id
     :values                ((resolve 'metabase.db.metadata-queries/field-distinct-values) field)
     :human_readable_values human-readable-values))
@@ -53,8 +53,8 @@
   [{field-id :id, :as field}]
   {:pre [(integer? field-id)
          (field-should-have-field-values? field)]}
-  (if-let [field-values (sel :one FieldValues :field_id field-id)]
-    (upd FieldValues (:id field-values)
+  (if-let [field-values (db/sel :one FieldValues :field_id field-id)]
+    (db/upd FieldValues (:id field-values)
       :values ((resolve 'metabase.db.metadata-queries/field-distinct-values) field))
     (create-field-values field)))
 
@@ -66,7 +66,7 @@
   [{field-id :id :as field} & [human-readable-values]]
   {:pre [(integer? field-id)]}
   (when (field-should-have-field-values? field)
-    (or (sel :one FieldValues :field_id field-id)
+    (or (db/sel :one FieldValues :field_id field-id)
         (create-field-values field human-readable-values))))
 
 (defn save-field-values
@@ -74,12 +74,12 @@
   [field-id values]
   {:pre [(integer? field-id)
          (coll? values)]}
-  (if-let [field-values (sel :one FieldValues :field_id field-id)]
-    (upd FieldValues (:id field-values) :values values)
-    (ins FieldValues :field_id field-id, :values values)))
+  (if-let [field-values (db/sel :one FieldValues :field_id field-id)]
+    (db/upd FieldValues (:id field-values) :values values)
+    (db/ins FieldValues :field_id field-id, :values values)))
 
 (defn clear-field-values
   "Remove the `FieldValues` for FIELD-ID."
   [field-id]
   {:pre [(integer? field-id)]}
-  (cascade-delete FieldValues :field_id field-id))
+  (db/cascade-delete! FieldValues :field_id field-id))

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -43,7 +43,7 @@
   [{field-id :id, field-name :name, :as field} & [human-readable-values]]
   {:pre [(integer? field-id)]}
   (log/debug (format "Creating FieldValues for Field %s..." (or field-name field-id))) ; use field name if available
-  (db/ins FieldValues
+  (db/insert! FieldValues
     :field_id              field-id
     :values                ((resolve 'metabase.db.metadata-queries/field-distinct-values) field)
     :human_readable_values human-readable-values))
@@ -76,7 +76,7 @@
          (coll? values)]}
   (if-let [field-values (db/sel :one FieldValues :field_id field-id)]
     (db/update! FieldValues (:id field-values), :values values)
-    (db/ins FieldValues :field_id field-id, :values values)))
+    (db/insert! FieldValues :field_id field-id, :values values)))
 
 (defn clear-field-values
   "Remove the `FieldValues` for FIELD-ID."

--- a/src/metabase/models/hydrate.clj
+++ b/src/metabase/models/hydrate.clj
@@ -3,7 +3,7 @@
   (:require [clojure.java.classpath :as classpath]
             [clojure.tools.namespace.find :as ns-find]
             [medley.core :as m]
-            [metabase.db :refer [sel]]
+            [metabase.db :as db]
             [metabase.models.interface :as i]
             [metabase.util :as u]))
 
@@ -180,7 +180,7 @@
          ids        (set (for [result results
                                :when  (not (get result dest-key))]
                            (source-key result)))
-         objs       (into {} (for [obj (sel :many entity :id [in ids])]
+         objs       (into {} (for [obj (db/sel :many entity :id [in ids])]
                                {(:id obj) obj}))]
      (for [{source-id source-key :as result} results]
        (if (get result dest-key)

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -42,7 +42,7 @@
   "Methods model classes should implement; all except for `can-read?` and `can-write?` have default implementations in `IEntityDefaults`.
    Internal models that don't participate in permissions checking don't need to implement `can-read?`/`can-write?`."
   (pre-insert [this]
-    "Gets called by `ins` immediately before inserting a new object immediately before the korma `insert` call.
+    "Gets called by `insert!` immediately before inserting a new object immediately before the SQL `INSERT` call.
      This provides an opportunity to do things like encode JSON or provide default values for certain fields.
 
          (pre-insert [_ query]
@@ -50,29 +50,21 @@
              (merge defaults query))) ; set some default values")
 
   (post-insert [this]
-    "Gets called by `ins` after an object is inserted into the DB. (This object is fetched via `sel`).
+    "Gets called by `insert!` after an object is inserted into the DB. (This object is fetched via `select`).
      A good place to do asynchronous tasks such as creating related objects.
      Implementations should return the newly created object.")
 
   (pre-update [this]
-    "Called by `upd` before DB operations happen. A good place to set updated values for fields like `updated_at`, or serialize maps into JSON.")
-
-  (post-update [this]
-    "Called by `upd` after a SQL `UPDATE` *succeeds*. (This gets called with whatever the output of `pre-update` was).
-
-     A good place to schedule asynchronous tasks, such as creating a `FieldValues` object for a `Field`
-     when it is marked with `special_type` `:category`.
-
-     The output of this function is ignored.")
+    "Called by `update!` before DB operations happen. A good place to set updated values for fields like `updated_at`.")
 
   (post-select [this]
-    "Called on the results from a call to `sel`. Default implementation doesn't do anything, but
+    "Called on the results from a call to `select`. Default implementation doesn't do anything, but
      you can provide custom implementations to do things like add hydrateable keys or remove sensitive fields.")
 
   (pre-cascade-delete [this]
-    "Called by `cascade-delete` for each matching object that is about to be deleted.
+    "Called by `cascade-delete!` for each matching object that is about to be deleted.
      Implementations should delete any objects related to this object by recursively
-     calling `cascade-delete`.
+     calling `cascade-delete!`.
 
      The output of this function is ignored.
 
@@ -95,10 +87,10 @@
      *  `publicly-writeable?`")
 
   (default-fields ^clojure.lang.Sequential [this]
-    "Return a sequence of keyword field names that should be fetched by default when calling `sel` or invoking the entity (e.g., `(Database 1)`).")
+    "Return a sequence of keyword field names that should be fetched by default when calling `select` or invoking the entity (e.g., `(Database 1)`).")
 
   (timestamped? ^Boolean [this]
-    "Should `:created_at` and `:updated_at` be updated when calling `ins`, and `:updated_at` when calling `upd`? Default is `false`.")
+    "Should `:created_at` and `:updated_at` be updated when calling `insert!`, and `:updated_at` when calling `update!`? Default is `false`.")
 
   (hydration-keys ^clojure.lang.Sequential [this]
     "Return a sequence of keyword field names that should be hydrated to this model. For example, `User` might inclide `:creator`, which means `hydrate`
@@ -194,7 +186,6 @@
    :pre-insert         identity
    :post-insert        identity
    :pre-update         identity
-   :post-update        (constantly nil)
    :post-select        identity
    :pre-cascade-delete (constantly nil)})
 

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -77,7 +77,7 @@
      The output of this function is ignored.
 
         (pre-cascade-delete [_ {database-id :id :as database}]
-          (cascade-delete Card :database_id database-id)
+          (cascade-delete! Card :database_id database-id)
           ...)")
 
   (^{:hydrate :can_read} can-read? ^Boolean [instance], ^Boolean [entity, ^Integer id]

--- a/src/metabase/models/label.clj
+++ b/src/metabase/models/label.clj
@@ -22,7 +22,7 @@
                              (assert-unique-slug <>))))))         ; otherwise check to make sure the new slug is unique
 
 (defn- pre-cascade-delete [{:keys [id]}]
-  (db/cascade-delete 'CardLabel :label_id id))
+  (db/cascade-delete! 'CardLabel :label_id id))
 
 (u/strict-extend (class Label)
   i/IEntity

--- a/src/metabase/models/metric.clj
+++ b/src/metabase/models/metric.clj
@@ -75,13 +75,13 @@
          (string? metric-name)
          (integer? creator-id)
          (map? definition)]}
-  (let [metric (db/ins Metric
-                  :table_id    table-id
-                  :creator_id  creator-id
-                  :name        metric-name
-                  :description description
-                  :is_active   true
-                  :definition  definition)]
+  (let [metric (db/insert! Metric
+                 :table_id    table-id
+                 :creator_id  creator-id
+                 :name        metric-name
+                 :description description
+                 :is_active   true
+                 :definition  definition)]
     (-> (events/publish-event :metric-create metric)
         (hydrate :creator))))
 

--- a/src/metabase/models/metric.clj
+++ b/src/metabase/models/metric.clj
@@ -123,7 +123,7 @@
          (integer? user-id)
          (string? revision_message)]}
   ;; update the metric itself
-  (db/upd Metric id
+  (db/update! Metric id
     :name        name
     :description description
     :definition  definition)
@@ -142,7 +142,7 @@
          (integer? user-id)
          (string? revision-message)]}
   ;; make Metric not active
-  (db/upd Metric id :is_active false)
+  (db/update! Metric id, :is_active false)
   ;; retrieve the updated metric (now retired)
   (u/prog1 (retrieve-metric id)
     (events/publish-event :metric-delete (assoc <> :actor_id user-id, :revision_message revision-message))))

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -25,8 +25,8 @@
   (db/sel :many PulseChannel, :pulse_id id))
 
 (defn- pre-cascade-delete [{:keys [id]}]
-  (db/cascade-delete PulseCard :pulse_id id)
-  (db/cascade-delete PulseChannel :pulse_id id))
+  (db/cascade-delete! PulseCard :pulse_id id)
+  (db/cascade-delete! PulseChannel :pulse_id id))
 
 (defn ^:hydrate cards
   "Return the `Cards` assoicated with this PULSE."
@@ -63,7 +63,7 @@
          (sequential? card-ids)
          (every? integer? card-ids)]}
   ;; first off, just delete any cards associated with this pulse (we add them again below)
-  (db/cascade-delete PulseCard :pulse_id id)
+  (db/cascade-delete! PulseCard :pulse_id id)
   ;; now just insert all of the cards that were given to us
   (when-not (empty? card-ids)
     (let [cards (map-indexed (fn [idx itm] {:pulse_id id :card_id itm :position idx}) card-ids)]
@@ -84,7 +84,7 @@
       ;; 1. in channels, NOT in db-channels = CREATE
       (and channel (not existing-channel))  (pulse-channel/create-pulse-channel channel)
       ;; 2. NOT in channels, in db-channels = DELETE
-      (and (nil? channel) existing-channel) (db/cascade-delete PulseChannel :id (:id existing-channel))
+      (and (nil? channel) existing-channel) (db/cascade-delete! PulseChannel :id (:id existing-channel))
       ;; 3. in channels, in db-channels = UPDATE
       (and channel existing-channel)        (pulse-channel/update-pulse-channel channel)
       ;; 4. NOT in channels, NOT in db-channels = NO-OP

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -138,7 +138,7 @@
          (every? map? channels)]}
   (kdb/transaction
     ;; update the pulse itself
-    (db/upd Pulse id :name name)
+    (db/update! Pulse id, :name name)
     ;; update cards (only if they changed)
     (when (not= cards (db/sel :many :field [PulseCard :card_id] :pulse_id id (k/order :position :asc)))
       (update-pulse-cards pulse cards))

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -162,7 +162,7 @@
          (coll? channels)
          (every? map? channels)]}
   (kdb/transaction
-    (let [{:keys [id] :as pulse} (db/ins Pulse
+    (let [{:keys [id] :as pulse} (db/insert! Pulse
                                    :creator_id creator-id
                                    :name pulse-name)]
       ;; add card-ids to the Pulse

--- a/src/metabase/models/pulse_channel.clj
+++ b/src/metabase/models/pulse_channel.clj
@@ -232,18 +232,18 @@
          (coll? recipients)
          (every? map? recipients)]}
   (let [recipients-by-type (group-by integer? (filter identity (map #(or (:id %) (:email %)) recipients)))
-        {:keys [id]} (db/ins PulseChannel
-                       :pulse_id         pulse_id
-                       :channel_type     channel_type
-                       :details          (cond-> details
-                                           (supports-recipients? channel_type) (assoc :emails (get recipients-by-type false)))
-                       :schedule_type    schedule_type
-                       :schedule_hour    (when (not= schedule_type :hourly)
-                                           schedule_hour)
-                       :schedule_day     (when (contains? #{:weekly :monthly} schedule_type)
-                                           schedule_day)
-                       :schedule_frame   (when (= schedule_type :monthly)
-                                           schedule_frame))]
+        {:keys [id]} (db/insert! PulseChannel
+                       :pulse_id       pulse_id
+                       :channel_type   channel_type
+                       :details        (cond-> details
+                                         (supports-recipients? channel_type) (assoc :emails (get recipients-by-type false)))
+                       :schedule_type  schedule_type
+                       :schedule_hour  (when (not= schedule_type :hourly)
+                                         schedule_hour)
+                       :schedule_day   (when (contains? #{:weekly :monthly} schedule_type)
+                                         schedule_day)
+                       :schedule_frame (when (= schedule_type :monthly)
+                                         schedule_frame))]
     (when (and (supports-recipients? channel_type) (seq (get recipients-by-type true)))
       (update-recipients! id (get recipients-by-type true)))
     ;; return the id of our newly created channel

--- a/src/metabase/models/pulse_channel.clj
+++ b/src/metabase/models/pulse_channel.clj
@@ -118,7 +118,7 @@
                 (k/where {:id [in (k/subselect PulseChannelRecipient (k/fields :user_id) (k/where {:pulse_channel_id id}))]}))))
 
 (defn- pre-cascade-delete [{:keys [id]}]
-  (db/cascade-delete PulseChannelRecipient :pulse_channel_id id))
+  (db/cascade-delete! PulseChannelRecipient :pulse_channel_id id))
 
 (u/strict-extend (class PulseChannel)
   i/IEntity (merge i/IEntityDefaults

--- a/src/metabase/models/pulse_channel.clj
+++ b/src/metabase/models/pulse_channel.clj
@@ -206,9 +206,9 @@
          (coll? recipients)
          (every? map? recipients)]}
   (let [recipients-by-type (group-by integer? (filter identity (map #(or (:id %) (:email %)) recipients)))]
-    (db/upd PulseChannel id
+    (db/update! PulseChannel id
       :details        (cond-> details
-                              (supports-recipients? channel_type) (assoc :emails (get recipients-by-type false)))
+                        (supports-recipients? channel_type) (assoc :emails (get recipients-by-type false)))
       :enabled        enabled
       :schedule_type  schedule_type
       :schedule_hour  (when (not= schedule_type :hourly)

--- a/src/metabase/models/raw_column.clj
+++ b/src/metabase/models/raw_column.clj
@@ -13,7 +13,7 @@
     (merge defaults table)))
 
 (defn- pre-cascade-delete [{:keys [id]}]
-  (db/cascade-delete RawColumn :fk_target_column_id id))
+  (db/cascade-delete! RawColumn :fk_target_column_id id))
 
 (u/strict-extend (class RawColumn)
   i/IEntity (merge i/IEntityDefaults

--- a/src/metabase/models/raw_table.clj
+++ b/src/metabase/models/raw_table.clj
@@ -13,8 +13,8 @@
     (merge defaults table)))
 
 (defn- pre-cascade-delete [{:keys [id]}]
-  (db/cascade-delete 'Table :raw_table_id id)
-  (db/cascade-delete RawColumn :raw_table_id id))
+  (db/cascade-delete! 'Table :raw_table_id id)
+  (db/cascade-delete! RawColumn :raw_table_id id))
 
 (u/strict-extend (class RawTable)
   i/IEntity (merge i/IEntityDefaults

--- a/src/metabase/models/revision.clj
+++ b/src/metabase/models/revision.clj
@@ -129,7 +129,7 @@
         object (serialize-instance entity id object)]
     ;; make sure we still have a map after calling out serialization function
     (assert (map? object))
-    (db/ins Revision
+    (db/insert! Revision
       :model        (:name entity)
       :model_id     id
       :user_id      user-id
@@ -155,7 +155,7 @@
       (revert-to-revision entity id user-id serialized-instance)
       ;; Push a new revision to record this change
       (let [last-revision (db/sel :one Revision, :model (:name entity), :model_id id, (k/order :id :DESC))
-            new-revision  (db/ins Revision
+            new-revision  (db/insert! Revision
                             :model        (:name entity)
                             :model_id     id
                             :user_id      user-id

--- a/src/metabase/models/revision.clj
+++ b/src/metabase/models/revision.clj
@@ -111,7 +111,7 @@
   [entity id]
   {:pre [(i/metabase-entity? entity) (integer? id)]}
   (when-let [old-revisions (seq (drop max-revisions (db/sel :many :id Revision, :model (:name entity), :model_id id, (k/order :timestamp :DESC))))]
-    (db/cascade-delete Revision :id [in old-revisions])))
+    (db/cascade-delete! Revision :id [:in old-revisions])))
 
 (defn push-revision
   "Record a new `Revision` for ENTITY with ID.

--- a/src/metabase/models/revision.clj
+++ b/src/metabase/models/revision.clj
@@ -1,7 +1,6 @@
 (ns metabase.models.revision
   (:require [clojure.data :as data]
             [korma.core :as k]
-            [medley.core :as m]
             [metabase.db :as db]
             (metabase.models [hydrate :refer [hydrate]]
                              [interface :as i]
@@ -36,7 +35,7 @@
 (defn default-revert-to-revision
   "Default implementation of `revert-to-revision` which simply does an update using the values from `serialized-instance`."
   [entity id user-id serialized-instance]
-  (m/mapply db/upd entity id serialized-instance))
+  (db/update! entity id, serialized-instance))
 
 (defn default-diff-map
   "Default implementation of `diff-map` which simply uses clojures `data/diff` function and sets the keys `:before` and `:after`."

--- a/src/metabase/models/segment.clj
+++ b/src/metabase/models/segment.clj
@@ -76,7 +76,7 @@
    Returns true if `Segment` exists and is active, false otherwise."
   [id]
   {:pre [(integer? id)]}
-  (db/exists? Segment :id id :is_active true))
+  (db/exists? Segment, :id id, :is_active true))
 
 (defn retrieve-segment
   "Fetch a single `Segment` by its ID value."

--- a/src/metabase/models/segment.clj
+++ b/src/metabase/models/segment.clj
@@ -61,7 +61,7 @@
          (string? segment-name)
          (integer? creator-id)
          (map? definition)]}
-  (let [segment (db/ins Segment
+  (let [segment (db/insert! Segment
                   :table_id    table-id
                   :creator_id  creator-id
                   :name        segment-name

--- a/src/metabase/models/segment.clj
+++ b/src/metabase/models/segment.clj
@@ -91,8 +91,7 @@
   ([table-id]
     (retrieve-segments table-id :active))
   ([table-id state]
-   {:pre [(integer? table-id)
-          (keyword? state)]}
+   {:pre [(integer? table-id) (keyword? state)]}
    (-> (if (= :all state)
          (db/sel :many Segment :table_id table-id (k/order :name :ASC))
          (db/sel :many Segment :table_id table-id :is_active (if (= :active state) true false) (k/order :name :ASC)))
@@ -109,15 +108,12 @@
          (integer? user-id)
          (string? revision_message)]}
   ;; update the segment itself
-  (db/upd Segment id
+  (db/update! Segment id
     :name        name
     :description description
     :definition  definition)
-  (let [segment (retrieve-segment id)]
-    ;; fire off an event
-    (events/publish-event :segment-update (assoc segment :actor_id user-id :revision_message revision_message))
-    ;; return the updated segment
-    segment))
+  (u/prog1 (retrieve-segment id)
+    (events/publish-event :segment-update (assoc <> :actor_id user-id, :revision_message revision_message))))
 
 (defn delete-segment
   "Delete a `Segment`.
@@ -131,10 +127,7 @@
          (integer? user-id)
          (string? revision-message)]}
   ;; make Segment not active
-  (db/upd Segment id :is_active false)
+  (db/update! Segment id, :is_active false)
   ;; retrieve the updated segment (now retired)
-  (let [segment (retrieve-segment id)]
-    ;; fire off an event
-    (events/publish-event :segment-delete (assoc segment :actor_id user-id :revision_message revision-message))
-    ;; return the updated segment
-    segment))
+  (u/prog1 (retrieve-segment id)
+    (events/publish-event :segment-delete (assoc <> :actor_id user-id, :revision_message revision-message))))

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -4,7 +4,7 @@
             [environ.core :as env]
             [korma.core :as k]
             [metabase.config :as config]
-            [metabase.db :refer [exists? sel del], :as db]
+            [metabase.db :as db]
             [metabase.events :as events]
             [metabase.models [common :as common]
                              [interface :as i]]
@@ -71,7 +71,7 @@
   (restore-cache-if-needed)
   (if (contains? @cached-setting->value k)
     (@cached-setting->value k)
-    (let [v (sel :one :field [Setting :value] :key (name k))]
+    (let [v (db/sel :one :field [Setting :value] :key (name k))]
       (swap! cached-setting->value assoc k v)
       v)))
 
@@ -117,7 +117,7 @@
   {:pre [(keyword? k)]}
   (restore-cache-if-needed)
   (swap! cached-setting->value dissoc k)
-  (del Setting :key (name k)))
+  (db/del Setting :key (name k)))
 
 (defn set-all
   "Set the value of several `Settings` at once.
@@ -246,7 +246,7 @@
    :admin_email           (get :admin-email)
    :report_timezone       (get :report-timezone)
    :timezone_short        (short-timezone-name (get :report-timezone))
-   :has_sample_dataset    (exists? 'Database, :is_sample true)})
+   :has_sample_dataset    (db/exists? 'Database, :is_sample true)})
 
 
 ;;; # IMPLEMENTATION
@@ -254,7 +254,7 @@
 (defn- restore-cache-if-needed []
   (when-not @cached-setting->value
     (db/setup-db-if-needed)
-    (reset! cached-setting->value (into {} (for [{k :key, v :value} (sel :many Setting)]
+    (reset! cached-setting->value (into {} (for [{k :key, v :value} (db/sel :many Setting)]
                                              {(keyword k) v})))))
 
 (def ^:private cached-setting->value

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -114,7 +114,7 @@
 (defn create-table
   "Create `Table` with the data from TABLE-DEF."
   [database-id {schema-name :schema, table-name :name, raw-table-id :raw-table-id, visibility-type :visibility-type}]
-  (db/ins Table
+  (db/insert! Table
     :db_id           database-id
     :raw_table_id    raw-table-id
     :schema          schema-name

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -105,7 +105,7 @@
                         :display_name (or display_name (common/name->human-readable-name table-name)))]
     ;; the only thing we need to update on a table is the :display_name, if it never got set
     (when (nil? display_name)
-      (db/upd Table id
+      (db/update! Table id
         :display_name (:display_name updated-table)))
     ;; always return the table when we are done
     updated-table))

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -25,9 +25,9 @@
     (merge defaults table)))
 
 (defn- pre-cascade-delete [{:keys [id]}]
-  (db/cascade-delete Segment :table_id id)
-  (db/cascade-delete Metric :table_id id)
-  (db/cascade-delete Field :table_id id))
+  (db/cascade-delete! Segment :table_id id)
+  (db/cascade-delete! Metric :table_id id)
+  (db/cascade-delete! Field :table_id id))
 
 (defn ^:hydrate fields
   "Return the `FIELDS` belonging to TABLE."

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -75,13 +75,13 @@
   {:pre [(string? first-name)
          (string? last-name)
          (string? email-address)]}
-  (when-let [new-user (db/ins User
-                        :email email-address
+  (when-let [new-user (db/insert! User
+                        :email      email-address
                         :first_name first-name
-                        :last_name last-name
-                        :password (if (not (nil? password))
-                                    password
-                                    (str (java.util.UUID/randomUUID))))]
+                        :last_name  last-name
+                        :password   (if (not (nil? password))
+                                      password
+                                      (str (java.util.UUID/randomUUID))))]
     (when send-welcome
       (let [reset-token (set-user-password-reset-token (:id new-user))
             ;; NOTE: the new user join url is just a password reset with an indicator that this is a first time user

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -65,9 +65,7 @@
 
 ;; ## Related Functions
 
-(declare create-user
-         form-password-reset-url
-         set-user-password
+(declare form-password-reset-url
          set-user-password-reset-token)
 
 (defn create-user
@@ -98,20 +96,20 @@
   (let [salt (.toString (java.util.UUID/randomUUID))
         password (creds/hash-bcrypt (str salt password))]
     ;; NOTE: any password change expires the password reset token
-    (db/upd User user-id
-      :password_salt salt
-      :password password
-      :reset_token nil
+    (db/update! User user-id
+      :password_salt   salt
+      :password        password
+      :reset_token     nil
       :reset_triggered nil)))
 
 (defn set-user-password-reset-token
   "Updates a given `User` and generates a password reset token for them to use.  Returns the url for password reset."
   [user-id]
   {:pre [(integer? user-id)]}
-  (let [reset-token (str user-id \_ (java.util.UUID/randomUUID))]
-    (db/upd User user-id, :reset_token reset-token, :reset_triggered (System/currentTimeMillis))
-    ;; return the token
-    reset-token))
+  (u/prog1 (str user-id \_ (java.util.UUID/randomUUID))
+    (db/update! User user-id
+      :reset_token     <>
+      :reset_triggered (System/currentTimeMillis))))
 
 (defn form-password-reset-url
   "Generate a properly formed password reset url given a password reset token."

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -43,14 +43,14 @@
     (or first_name last_name) (assoc :common_name (str first_name " " last_name))))
 
 (defn- pre-cascade-delete [{:keys [id]}]
-  (db/cascade-delete 'Session :user_id id)
-  (db/cascade-delete 'Dashboard :creator_id id)
-  (db/cascade-delete 'Card :creator_id id)
-  (db/cascade-delete 'Pulse :creator_id id)
-  (db/cascade-delete 'Activity :user_id id)
-  (db/cascade-delete 'ViewLog :user_id id)
-  (db/cascade-delete 'Segment :creator_id id)
-  (db/cascade-delete 'Metric :creator_id id))
+  (db/cascade-delete! 'Session :user_id id)
+  (db/cascade-delete! 'Dashboard :creator_id id)
+  (db/cascade-delete! 'Card :creator_id id)
+  (db/cascade-delete! 'Pulse :creator_id id)
+  (db/cascade-delete! 'Activity :user_id id)
+  (db/cascade-delete! 'ViewLog :user_id id)
+  (db/cascade-delete! 'Segment :creator_id id)
+  (db/cascade-delete! 'Metric :creator_id id))
 
 (u/strict-extend (class User)
   i/IEntity

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -611,4 +611,4 @@
       (db/update! QueryExecution id query-execution)
       query-execution)
     ;; first time saving execution, so insert it
-    (m/mapply db/ins QueryExecution query-execution)))
+    (db/insert! QueryExecution query-execution)))

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -604,11 +604,11 @@
 
 (defn save-query-execution
   "Save (or update) a `QueryExecution`."
-  [{:keys [id] :as query-execution}]
+  [{:keys [id], :as query-execution}]
   (if id
     ;; execution has already been saved, so update it
     (do
-      (m/mapply db/upd QueryExecution id query-execution)
+      (db/update! QueryExecution id query-execution)
       query-execution)
     ;; first time saving execution, so insert it
     (m/mapply db/ins QueryExecution query-execution)))

--- a/src/metabase/query_processor/annotate.clj
+++ b/src/metabase/query_processor/annotate.clj
@@ -2,7 +2,7 @@
   (:require [clojure.set :as set]
             [clojure.tools.logging :as log]
             [medley.core :as m]
-            [metabase.db :refer [sel]]
+            [metabase.db :as db]
             [metabase.models.field :refer [Field]]
             [metabase.query-processor.interface :as i]
             [metabase.util :as u]))
@@ -213,14 +213,14 @@
   ;; Fetch the ForeignKey objects whose origin is in the returned Fields, create a map of origin-field-id->destination-field-id
   ([fields fk-ids]
    (when (seq fk-ids)
-     (fk-field->dest-fn fields fk-ids (sel :many :field->field [Field :id :fk_target_field_id]
-                                           :id                 [in fk-ids]
-                                           :fk_target_field_id [not= nil]))))
+     (fk-field->dest-fn fields fk-ids (db/sel :many :field->field [Field :id :fk_target_field_id]
+                                              :id                 [in fk-ids]
+                                              :fk_target_field_id [not= nil]))))
   ;; Fetch the destination Fields referenced by the ForeignKeys
   ([fields fk-ids id->dest-id]
    (when (seq id->dest-id)
-     (fk-field->dest-fn fields fk-ids id->dest-id (sel :many :id->fields [Field :id :name :display_name :table_id :description :base_type :special_type :visibility_type]
-                                                       :id [in (vals id->dest-id)]))))
+     (fk-field->dest-fn fields fk-ids id->dest-id (db/sel :many :id->fields [Field :id :name :display_name :table_id :description :base_type :special_type :visibility_type]
+                                                          :id [in (vals id->dest-id)]))))
   ;; Return a function that will return the corresponding destination Field for a given Field
   ([fields fk-ids id->dest-id dest-id->field]
    (fn [{:keys [id]}]

--- a/src/metabase/sample_data.clj
+++ b/src/metabase/sample_data.clj
@@ -22,11 +22,11 @@
                             (s/replace #"^file:" "zip:")        ; to connect to an H2 DB inside a JAR just replace file: with zip:
                             (s/replace #"\.mv\.db$" "")         ; strip the .mv.db suffix from the path
                             (str ";USER=GUEST;PASSWORD=guest")) ; specify the GUEST user account created for the DB
-                db      (db/ins Database
-                                :name      sample-dataset-name
-                                :details   {:db h2-file}
-                                :engine    :h2
-                                :is_sample true)]
+                db      (db/insert! Database
+                          :name      sample-dataset-name
+                          :details   {:db h2-file}
+                          :engine    :h2
+                          :is_sample true)]
             (sync-database/sync-database! db))))
       (catch Throwable e
         (log/error (u/format-color 'red "Failed to load sample dataset: %s" (.getMessage e)))))))

--- a/src/metabase/sync_database/analyze.clj
+++ b/src/metabase/sync_database/analyze.clj
@@ -174,15 +174,15 @@
 
 (defn analyze-table-data-shape!
   "Analyze the data shape for a single `Table`."
-  [driver {table-id :id, :as tbl}]
+  [driver {table-id :id, :as table}]
   (let [new-field-ids (set (db/sel :many :id field/Field, :table_id table-id, :visibility_type [not= "retired"], :last_analyzed nil))]
     ;; TODO: this call should include the database
-    (when-let [table-stats (u/prog1 (driver/analyze-table driver tbl new-field-ids)
+    (when-let [table-stats (u/prog1 (driver/analyze-table driver table new-field-ids)
                              (when <>
                                (schema/validate i/AnalyzeTable <>)))]
       ;; update table row count
       (when (:row_count table-stats)
-        (db/upd table/Table table-id :rows (:row_count table-stats)))
+        (db/update! table/Table table-id, :rows (:row_count table-stats)))
 
       ;; update individual fields
       (doseq [{:keys [id preview-display special-type values]} (:fields table-stats)]

--- a/src/metabase/sync_database/analyze.clj
+++ b/src/metabase/sync_database/analyze.clj
@@ -188,7 +188,7 @@
       (doseq [{:keys [id preview-display special-type values]} (:fields table-stats)]
         ;; set Field metadata we may have detected
         (when (and id (or preview-display special-type))
-          (db/upd-non-nil-keys field/Field id
+          (db/update-non-nil-keys! field/Field id
             ;; if a field marked `preview-display` as false then set the visibility type to `:details-only` (see models.field/visibility-types)
             :visibility_type (when (false? preview-display) :details-only)
             :special_type    special-type))

--- a/src/metabase/sync_database/introspect.clj
+++ b/src/metabase/sync_database/introspect.clj
@@ -67,7 +67,7 @@
               :details details
               :active  true)
             ;; must be a new column, insert it
-            (db/ins RawColumn
+            (db/insert! RawColumn
               :raw_table_id id
               :name         column-name
               :is_pk        is_pk
@@ -79,7 +79,7 @@
   [database-id {table-name :name, table-schema :schema, :keys [details fields]}]
   {:pre [(integer? database-id) (string? table-name)]}
   (log/debug (u/format-color 'cyan "Found new table: %s" (named-table table-schema table-name)))
-  (let [table (db/ins RawTable
+  (let [table (db/insert! RawTable
                 :database_id  database-id
                 :schema       table-schema
                 :name         table-name

--- a/src/metabase/sync_database/introspect.clj
+++ b/src/metabase/sync_database/introspect.clj
@@ -35,7 +35,7 @@
         (when-let [dest-table-id (db/sel :one :field [RawTable :id], :database_id database-id, :schema (:schema dest-table), :name (:name dest-table))]
           (when-let [dest-column-id (db/sel :one :id RawColumn, :raw_table_id dest-table-id, :name dest-column-name)]
             (log/debug (u/format-color 'cyan "Marking foreign key '%s.%s' -> '%s.%s'." (named-table table) fk-column-name (named-table dest-table) dest-column-name))
-            (db/upd RawColumn source-column-id
+            (db/update! RawColumn source-column-id
               :fk_target_column_id dest-column-id)))))))
 
 (defn- save-all-table-columns!
@@ -51,7 +51,7 @@
       (doseq [[column-name {column-id :id}] (sort-by :name existing-columns)]
         (when-not (some #(= column-name (:name %)) columns)
           (log/debug (u/format-color 'cyan "Marked column %s as inactive." column-name))
-          (db/upd RawColumn column-id :active false)))
+          (db/update! RawColumn column-id, :active false)))
 
       ;; insert or update the remaining columns
       (doseq [{column-name :name, :keys [base-type pk? special-type details]} (sort-by :name columns)]
@@ -61,18 +61,18 @@
               is_pk   (true? pk?)]
           (if-let [{column-id :id} (get existing-columns column-name)]
             ;; column already exists, update it
-            (db/upd RawColumn column-id
-              :name      column-name
-              :is_pk     is_pk
-              :details   details
-              :active    true)
+            (db/update! RawColumn column-id
+              :name    column-name
+              :is_pk   is_pk
+              :details details
+              :active  true)
             ;; must be a new column, insert it
             (db/ins RawColumn
-              :raw_table_id  id
-              :name          column-name
-              :is_pk         is_pk
-              :details       details
-              :active        true)))))))
+              :raw_table_id id
+              :name         column-name
+              :is_pk        is_pk
+              :details      details
+              :active       true)))))))
 
 (defn- create-raw-table!
   "Create a new `RawTable`, includes saving all specified `:columns`."
@@ -93,9 +93,9 @@
   [{table-id :id, :as table} {:keys [details fields]}]
   ;; NOTE: the schema+name of a table makes up the natural key and cannot be modified on update
   ;;       if they were to be different we'd simply assume that's a new table instead
-  (db/upd RawTable table-id
-    :details  (or details {})
-    :active   true)
+  (db/update! RawTable table-id
+    :details (or details {})
+    :active  true)
   ;; save columns
   (save-all-table-columns! table fields))
 

--- a/src/metabase/sync_database/sync.clj
+++ b/src/metabase/sync_database/sync.clj
@@ -23,7 +23,7 @@
     ;; TODO: eventually limit this to just "core" schema tables
     (when-let [source-field-id (db/sel :one :id Field, :raw_column_id fk-source-id, :visibility_type [not= "retired"])]
       (when-let [target-field-id (db/sel :one :id Field, :raw_column_id fk-target-id, :visibility_type [not= "retired"])]
-        (db/upd Field source-field-id
+        (db/update! Field source-field-id
           :special_type       :fk
           :fk_target_field_id target-field-id)))))
 
@@ -91,9 +91,9 @@
                               :special-type (keyword (:special-type details))))]
         (if-let [existing-field (get existing-fields raw-column-id)]
           ;; field already exists, so we UPDATE it
-          (field/update-field existing-field column)
+          (field/update-field! existing-field column)
           ;; looks like a new field, so we CREATE it
-          (field/create-field table-id (assoc column :raw-column-id raw-column-id)))))))
+          (field/create-field! table-id (assoc column :raw-column-id raw-column-id)))))))
 
 
 (defn retire-tables!

--- a/src/metabase/sync_database/sync_dynamic.clj
+++ b/src/metabase/sync_database/sync_dynamic.clj
@@ -30,10 +30,10 @@
         ;; NOTE: this recursively creates fields until we hit the end of the nesting
         (if-let [existing-field (existing-field-name->field (:name nested-field-def))]
           ;; field already exists, so we UPDATE it
-          (cond-> (field/update-field existing-field nested-field-def)
+          (cond-> (field/update-field! existing-field nested-field-def)
                   nested-fields (save-nested-fields! nested-fields))
           ;; looks like a new field, so we CREATE it
-          (cond-> (field/create-field table-id nested-field-def)
+          (cond-> (field/create-field! table-id nested-field-def)
                   nested-fields (save-nested-fields! nested-fields)))))))
 
 
@@ -51,10 +51,10 @@
     (doseq [{field-name :name, :keys [nested-fields], :as field-def} field-defs]
       (if-let [existing-field (get field-name->field field-name)]
         ;; field already exists, so we UPDATE it
-        (cond-> (field/update-field existing-field field-def)
+        (cond-> (field/update-field! existing-field field-def)
                 nested-fields (save-nested-fields! nested-fields))
         ;; looks like a new field, so we CREATE it
-        (cond-> (field/create-field table-id field-def)
+        (cond-> (field/create-field! table-id field-def)
                 nested-fields (save-nested-fields! nested-fields))))))
 
 

--- a/test/metabase/api/activity_test.clj
+++ b/test/metabase/api/activity_test.clj
@@ -21,11 +21,11 @@
 
 ; NOTE: timestamp matching was being a real PITA so I cheated a bit.  ideally we'd fix that
 (expect-let [_         (k/delete Activity)
-             activity1 (db/ins Activity
+             activity1 (db/insert! Activity
                          :topic     "install"
                          :details   {}
                          :timestamp (u/->Timestamp "2015-09-09T12:13:14.888Z"))
-             activity2 (db/ins Activity
+             activity2 (db/insert! Activity
                          :topic     "dashboard-create"
                          :user_id   (user->id :crowberto)
                          :model     "dashboard"
@@ -34,7 +34,7 @@
                                      :name         "Bwahahaha"
                                      :public_perms 2}
                          :timestamp (u/->Timestamp "2015-09-10T18:53:01.632Z"))
-             activity3 (db/ins Activity
+             activity3 (db/insert! Activity
                          :topic     "user-joined"
                          :user_id   (user->id :rasta)
                          :model     "user"
@@ -152,7 +152,7 @@
                    :description (:description card2)
                    :display     (name (:display card2))}}]
   (let [create-view (fn [user model model-id]
-                      (db/ins ViewLog
+                      (db/insert! ViewLog
                         :user_id  user
                         :model    model
                         :model_id model-id

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -159,10 +159,10 @@
                                      :features        (mapv name (driver/features (driver/engine->driver :postgres)))}))))
       (do
         ;; Delete all the randomly created Databases we've made so far
-        (db/cascade-delete Database :id [not-in (set (filter identity
-                                                             (for [engine datasets/all-valid-engines]
-                                                               (datasets/when-testing-engine engine
-                                                                 (:id (get-or-create-test-data-db! (driver/engine->driver engine)))))))])
+        (db/cascade-delete! Database :id [:not-in (filter identity
+                                                          (for [engine datasets/all-valid-engines]
+                                                            (datasets/when-testing-engine engine
+                                                              (:id (get-or-create-test-data-db! (driver/engine->driver engine))))))])
         ;; Add an extra DB so we have something to fetch besides the Test DB
         (create-db db-name)
         ;; Now hit the endpoint
@@ -185,27 +185,27 @@
                      :features        (mapv name (driver/features (driver/engine->driver :postgres)))})]
                  (filter identity (for [engine datasets/all-valid-engines]
                                     (datasets/when-testing-engine engine
-                                                                  (let [database (get-or-create-test-data-db! (driver/engine->driver engine))]
-                                                                    (match-$ database
-                                                                      {:created_at      $
-                                                                       :engine          (name $engine)
-                                                                       :id              $
-                                                                       :updated_at      $
-                                                                       :name            "test-data"
-                                                                       :is_sample       false
-                                                                       :is_full_sync    true
-                                                                       :organization_id nil
-                                                                       :description     nil
-                                                                       :tables          (->> (db/sel :many Table :db_id (:id database))
-                                                                                             (mapv table-details)
-                                                                                             (sort-by :name))
-                                                                       :features        (mapv name (driver/features (driver/engine->driver engine)))})))))))
+                                      (let [database (get-or-create-test-data-db! (driver/engine->driver engine))]
+                                        (match-$ database
+                                          {:created_at      $
+                                           :engine          (name $engine)
+                                           :id              $
+                                           :updated_at      $
+                                           :name            "test-data"
+                                           :is_sample       false
+                                           :is_full_sync    true
+                                           :organization_id nil
+                                           :description     nil
+                                           :tables          (->> (db/sel :many Table :db_id (:id database))
+                                                                 (mapv table-details)
+                                                                 (sort-by :name))
+                                           :features        (mapv name (driver/features (driver/engine->driver engine)))})))))))
     (do
       ;; Delete all the randomly created Databases we've made so far
-      (db/cascade-delete Database :id [not-in (set (filter identity
-                                                        (for [engine datasets/all-valid-engines]
-                                                          (datasets/when-testing-engine engine
-                                                                                        (:id (get-or-create-test-data-db! (driver/engine->driver engine)))))))])
+      (db/cascade-delete! Database :id [:not-in (set (filter identity
+                                                             (for [engine datasets/all-valid-engines]
+                                                               (datasets/when-testing-engine engine
+                                                                 (:id (get-or-create-test-data-db! (driver/engine->driver engine)))))))])
       ;; Add an extra DB so we have something to fetch besides the Test DB
       (create-db db-name)
       ;; Now hit the endpoint

--- a/test/metabase/api/field_test.clj
+++ b/test/metabase/api/field_test.clj
@@ -183,7 +183,8 @@
        :updated_at            $
        :created_at            $
        :id                    $})
-  (do (db/upd FieldValues (:id (field->field-values :venues :price)) :human_readable_values nil) ; clear out existing human_readable_values in case they're set
+  (do (db/update! FieldValues (:id (field->field-values :venues :price))
+        :human_readable_values nil) ; clear out existing human_readable_values in case they're set
       ((user->client :rasta) :get 200 (format "field/%d/values" (id :venues :price)))))
 
 ;; Should return nothing for a field whose special_type is *not* :category
@@ -216,18 +217,19 @@
 
 ;; Check that we can unset values
 (tu/expect-eval-actual-first
-    [{:status "success"}
-     (tu/match-$ (db/sel :one FieldValues :field_id (id :venues :price))
-       {:field_id              (id :venues :price)
-        :human_readable_values {}
-        :values                [1 2 3 4]
-        :updated_at            $
-        :created_at            $
-        :id                    $})]
-  [(do (db/upd FieldValues (:id (field->field-values :venues :price)) :human_readable_values {:1 "$" ; make sure they're set
-                                                                                           :2 "$$"
-                                                                                           :3 "$$$"
-                                                                                           :4 "$$$$"})
+  [{:status "success"}
+   (tu/match-$ (db/sel :one FieldValues :field_id (id :venues :price))
+     {:field_id              (id :venues :price)
+      :human_readable_values {}
+      :values                [1 2 3 4]
+      :updated_at            $
+      :created_at            $
+      :id                    $})]
+  [(do (db/update! FieldValues (:id (field->field-values :venues :price))
+         :human_readable_values {:1 "$" ; make sure they're set
+                                 :2 "$$"
+                                 :3 "$$$"
+                                 :4 "$$$$"})
        ((user->client :crowberto) :post 200 (format "field/%d/value_map_update" (id :venues :price))
         {:values_map {}}))
    ((user->client :rasta) :get 200 (format "field/%d/values" (id :venues :price)))])

--- a/test/metabase/api/label_test.clj
+++ b/test/metabase/api/label_test.clj
@@ -1,7 +1,7 @@
 (ns metabase.api.label-test
   "Tests for `/api/label` endpoints."
   (:require [expectations :refer [expect]]
-            [metabase.db :refer [cascade-delete]]
+            [metabase.db :as db]
             [metabase.models.label :refer [Label]]
             [metabase.test.data.users :refer [user->client]]
             [metabase.test.util :refer [expect-with-temp]]
@@ -19,7 +19,7 @@
   {:name "Warning: May Contain Toucans!!", :slug "warning__may_contain_toucans__", :icon nil}
   (u/prog1 (dissoc ((user->client :rasta) :post 200 "label", {:name "Warning: May Contain Toucans!!"})
                    :id)
-    (cascade-delete Label :slug (:slug <>))))
+    (db/cascade-delete! Label :slug (:slug <>))))
 
 ;;; PUT /api/label/:id -- update a label. Make sure new slug is generated
 (expect-with-temp [Label [{label-id :id} {:name "Toucan-Approved"}]]

--- a/test/metabase/api/pulse_test.clj
+++ b/test/metabase/api/pulse_test.clj
@@ -17,7 +17,7 @@
 ;; ## Helper Fns
 
 (defn- new-card! []
-  (db/ins Card
+  (db/insert! Card
     :name                   (random-name)
     :creator_id             (user->id :crowberto)
     :public_perms           common/perms-readwrite

--- a/test/metabase/api/pulse_test.clj
+++ b/test/metabase/api/pulse_test.clj
@@ -36,7 +36,7 @@
 
 (defn- delete-existing-pulses! []
   (doseq [pulse-id (db/sel :many :id Pulse)]
-    (db/cascade-delete Pulse :id pulse-id)))
+    (db/cascade-delete! Pulse :id pulse-id)))
 
 (defn- user-details [user]
   (match-$ user

--- a/test/metabase/api/revision_test.clj
+++ b/test/metabase/api/revision_test.clj
@@ -134,7 +134,7 @@
     (create-dashboard-revision dash true)
     (let [dashcard (db/ins DashboardCard :dashboard_id id :card_id (:id card))]
       (create-dashboard-revision dash false)
-      (db/del DashboardCard :id (:id dashcard)))
+      (db/delete! DashboardCard, :id (:id dashcard)))
     (create-dashboard-revision dash false)
     (let [[_ {previous-revision-id :id}] (revisions Dashboard id)]
       ;; Revert to the previous revision

--- a/test/metabase/api/revision_test.clj
+++ b/test/metabase/api/revision_test.clj
@@ -84,7 +84,7 @@
   (do
     (create-card-revision card true)
     (create-card-revision (assoc card :name "something else") false)
-    (db/ins Revision
+    (db/insert! Revision
       :model        (:name Card)
       :model_id     id
       :user_id      (user->id :rasta)
@@ -132,7 +132,7 @@
     :description  nil}]
   (do
     (create-dashboard-revision dash true)
-    (let [dashcard (db/ins DashboardCard :dashboard_id id :card_id (:id card))]
+    (let [dashcard (db/insert! DashboardCard :dashboard_id id :card_id (:id card))]
       (create-dashboard-revision dash false)
       (db/delete! DashboardCard, :id (:id dashcard)))
     (create-dashboard-revision dash false)

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -14,7 +14,7 @@
 ;; Test that we can login
 (expect-eval-actual-first
     (db/sel :one :fields [Session :id] :user_id (user->id :rasta))
-  (do (db/del Session :user_id (user->id :rasta))                  ; delete all other sessions for the bird first
+  (do (db/delete! Session, :user_id (user->id :rasta))             ; delete all other sessions for the bird first
       (client :post 200 "session" (user->credentials :rasta))))
 
 ;; Test for required params

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -11,7 +11,8 @@
             (metabase.test.data [dataset-definitions :as defs]
                                 [datasets :as datasets]
                                 [users :refer :all])
-            [metabase.test.util :refer [match-$ expect-eval-actual-first resolve-private-fns]]))
+            [metabase.test.util :refer [match-$ expect-eval-actual-first resolve-private-fns]]
+            [metabase.util :as u]))
 
 (resolve-private-fns metabase.models.table pk-field-id)
 
@@ -437,10 +438,9 @@
 
 ;; ## PUT /api/table/:id
 (expect-eval-actual-first
-    (match-$ (let [table (Table (id :users))]
+    (match-$ (u/prog1 (Table (id :users))
                ;; reset Table back to its original state
-               (db/upd Table (id :users) :display_name "Users" :entity_type nil :visibility_type nil :description nil)
-               table)
+               (db/update! Table (id :users), :display_name "Users", :entity_type nil, :visibility_type nil, :description nil))
       {:description     "What a nice table!"
        :entity_type     "person"
        :visibility_type "hidden"
@@ -566,7 +566,7 @@
     (assert (= 0 (:position (db/sel :one :fields [Field :position] :id (:id categories-name-field)))))
     (assert (= 1 (:position (db/sel :one :fields [Field :position] :id (:id categories-id-field)))))
     ;; put the values back to their previous state
-    (db/upd Field (:id categories-name-field) :position 0)
-    (db/upd Field (:id categories-id-field) :position 0)
+    (db/update! Field (:id categories-name-field), :position 0)
+    (db/update! Field (:id categories-id-field),   :position 0)
     ;; return our origin api response for validation
     api-response))

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -220,7 +220,7 @@
 ;; Test that a User can change their password
 (expect-let [creds                 {:email    "abc@metabase.com"
                                     :password "def"}
-             {:keys [id password]} (db/ins User
+             {:keys [id password]} (db/insert! User
                                      :first_name "test"
                                      :last_name  "user"
                                      :email      "abc@metabase.com"

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -61,7 +61,7 @@
   (do
     ;; Delete all the other random Users we've created so far
     (let [user-ids (set (map user->id [:crowberto :rasta :lucky :trashbird]))]
-      (db/cascade-delete User :id [not-in user-ids]))
+      (db/cascade-delete! User :id [:not-in user-ids]))
     ;; Now do the request
     (set ((user->client :rasta) :get 200 "user")))) ; as a set since we don't know what order the results will come back in
 

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -97,7 +97,7 @@
        :is_qbnewb    true})
     (when-let [user (create-user-api rand-name)]
       ;; create a random user then set them to :inactive
-      (db/upd User (:id user)
+      (db/update! User (:id user)
         :is_active false
         :is_superuser true)
       ;; then try creating the same user again

--- a/test/metabase/driver/generic_sql/connection_test.clj
+++ b/test/metabase/driver/generic_sql/connection_test.clj
@@ -1,8 +1,6 @@
 (ns metabase.driver.generic-sql.connection-test
   (:require [expectations :refer :all]
-            [metabase.db :refer [sel]]
             [metabase.driver :as driver]
-            [metabase.models.database :refer [Database]]
             [metabase.test.data :refer :all]))
 
 ;; ## TESTS FOR CAN-CONNECT?

--- a/test/metabase/driver/generic_sql/native_test.clj
+++ b/test/metabase/driver/generic_sql/native_test.clj
@@ -1,6 +1,6 @@
 (ns metabase.driver.generic-sql.native-test
   (:require [expectations :refer :all]
-            [metabase.db :refer [ins cascade-delete]]
+            [metabase.db :as db]
             [metabase.models.database :refer [Database]]
             [metabase.query-processor :as qp]
             [metabase.test.data :refer :all]))
@@ -47,8 +47,8 @@
 (expect "Running SQL queries against H2 databases using the default (admin) database user is forbidden."
   ;; Insert a fake Database. It doesn't matter that it doesn't actually exist since query processing should
   ;; fail immediately when it realizes this DB doesn't have a USER
-  (let [db (ins Database :name "Fake-H2-DB", :engine "h2", :details {:db "mem:fake-h2-db"})]
+  (let [db (db/ins Database, :name "Fake-H2-DB", :engine "h2", :details {:db "mem:fake-h2-db"})]
     (try (:error (qp/process-query {:database (:id db)
                                     :type     :native
                                     :native   {:query "SELECT 1;"}}))
-         (finally (cascade-delete Database :name "Fake-H2-DB")))))
+         (finally (db/cascade-delete! Database :name "Fake-H2-DB")))))

--- a/test/metabase/driver/generic_sql/native_test.clj
+++ b/test/metabase/driver/generic_sql/native_test.clj
@@ -47,7 +47,7 @@
 (expect "Running SQL queries against H2 databases using the default (admin) database user is forbidden."
   ;; Insert a fake Database. It doesn't matter that it doesn't actually exist since query processing should
   ;; fail immediately when it realizes this DB doesn't have a USER
-  (let [db (db/ins Database, :name "Fake-H2-DB", :engine "h2", :details {:db "mem:fake-h2-db"})]
+  (let [db (db/insert! Database, :name "Fake-H2-DB", :engine "h2", :details {:db "mem:fake-h2-db"})]
     (try (:error (qp/process-query {:database (:id db)
                                     :type     :native
                                     :native   {:query "SELECT 1;"}}))

--- a/test/metabase/driver/mongo_test.clj
+++ b/test/metabase/driver/mongo_test.clj
@@ -2,7 +2,7 @@
   "Tests for Mongo driver."
   (:require [expectations :refer :all]
             [korma.core :as k]
-            [metabase.db :refer :all]
+            [metabase.db :as db]
             [metabase.driver :as driver]
             (metabase.models [database :refer [Database]]
                              [field :refer [Field]]
@@ -138,7 +138,7 @@
      {:rows 1000, :active true, :name "checkins"}
      {:rows 15,   :active true, :name "users"}
      {:rows 100,  :active true, :name "venues"}]
-  (sel :many :fields [Table :name :active :rows] :db_id (:id (mongo-db)) (k/order :name)))
+  (db/sel :many :fields [Table :name :active :rows], :db_id (:id (mongo-db)), (k/order :name)))
 
 ;; Test that Fields got synced correctly, and types are correct
 (expect-when-testing-mongo
@@ -159,5 +159,5 @@
       {:special_type :name,      :base_type :TextField,     :name "name"}
       {:special_type :category,  :base_type :IntegerField,  :name "price"}]]
     (for [nm table-names]
-      (sel :many :fields [Field :name :base_type :special_type], :active true, :table_id (:id (table-name->table nm))
-           (k/order :name))))
+      (db/sel :many :fields [Field :name :base_type :special_type], :active true, :table_id (:id (table-name->table nm))
+              (k/order :name))))

--- a/test/metabase/events/activity_feed_test.clj
+++ b/test/metabase/events/activity_feed_test.clj
@@ -23,21 +23,21 @@
   "Simple helper function which creates a series of test objects for use in the tests"
   []
   (let [rand-name (random-name)
-        user      (db/ins User
+        user      (db/insert! User
                     :email      (str rand-name "@metabase.com")
                     :first_name rand-name
                     :last_name  rand-name
                     :password   rand-name)
         ;; i don't know why, but the below `ins` doesn't return an object :(
-        session   (db/ins Session
+        session   (db/insert! Session
                     :id      rand-name
                     :user_id (:id user))
-        dashboard (db/ins Dashboard
+        dashboard (db/insert! Dashboard
                     :name         rand-name
                     :description  rand-name
                     :creator_id   (:id user)
                     :public_perms 2)
-        card      (db/ins Card
+        card      (db/insert! Card
                     :name                   rand-name
                     :creator_id             (:id user)
                     :public_perms           2
@@ -46,29 +46,29 @@
                                              :type     :query
                                              :query    {:source_table (id :categories)}}
                     :visualization_settings {})
-        dashcard  (db/ins DashboardCard
+        dashcard  (db/insert! DashboardCard
                     :card_id      (:id card)
                     :dashboard_id (:id dashboard))
-        pulse     (db/ins Pulse
+        pulse     (db/insert! Pulse
                     :creator_id   (:id user)
                     :name         rand-name
                     :public_perms 2)
-        database  (db/ins Database
+        database  (db/insert! Database
                     :name      "Activity Database"
                     :engine    :yeehaw
                     :details   {}
                     :is_sample false)
-        table     (db/ins Table
+        table     (db/insert! Table
                     :name   "Activity Table"
                     :db_id  (:id database)
                     :active true)
-        segment   (db/ins Segment
+        segment   (db/insert! Segment
                     :creator_id  (:id user)
                     :table_id    (:id table)
                     :name        "Activity Segment"
                     :description "Something worth reading"
                     :definition  {:a "b"})
-        metric   (db/ins Metric
+        metric   (db/insert! Metric
                     :creator_id  (:id user)
                     :table_id    (:id table)
                     :name        "Activity Metric"

--- a/test/metabase/events/last_login_test.clj
+++ b/test/metabase/events/last_login_test.clj
@@ -10,7 +10,7 @@
 
 (defn- create-test-user []
   (let [rand-name (random-name)]
-    (db/ins User
+    (db/insert! User
       :email      (str rand-name "@metabase.com")
       :first_name rand-name
       :last_name  rand-name

--- a/test/metabase/events/revision_test.clj
+++ b/test/metabase/events/revision_test.clj
@@ -157,8 +157,8 @@
 ;; :dashboard-reposition-cards
 (expect-let [{dashboard-id :id :as dashboard} (create-test-dashboard)
              {card-id :id}                    (create-test-card)
-             dashcard                         (db/ins DashboardCard :card_id card-id :dashboard_id dashboard-id)
-             _                                (db/upd DashboardCard (:id dashcard) :sizeX 4)]
+             dashcard                         (u/prog1 (db/ins DashboardCard :card_id card-id :dashboard_id dashboard-id)
+                                                (db/update! DashboardCard (:id <>), :sizeX 4))]
   {:model        "Dashboard"
    :model_id     dashboard-id
    :user_id      (user->id :crowberto)

--- a/test/metabase/events/revision_test.clj
+++ b/test/metabase/events/revision_test.clj
@@ -20,7 +20,7 @@
 
 (defn- create-test-card []
   (let [rand-name (random-name)]
-    (db/ins Card
+    (db/insert! Card
       :name                   rand-name
       :description            rand-name
       :public_perms           2
@@ -49,7 +49,7 @@
 
 (defn- create-test-dashboard []
   (let [rand-name (random-name)]
-    (db/ins Dashboard
+    (db/insert! Dashboard
       :name                   rand-name
       :description            rand-name
       :public_perms           2
@@ -120,7 +120,7 @@
 ;; :dashboard-add-cards
 (expect-let [{dashboard-id :id :as dashboard} (create-test-dashboard)
              {card-id :id}                    (create-test-card)
-             dashcard                         (db/ins DashboardCard :card_id card-id :dashboard_id dashboard-id)]
+             dashcard                         (db/insert! DashboardCard :card_id card-id :dashboard_id dashboard-id)]
   {:model        "Dashboard"
    :model_id     dashboard-id
    :user_id      (user->id :crowberto)
@@ -138,7 +138,7 @@
 ;; :dashboard-remove-cards
 (expect-let [{dashboard-id :id :as dashboard} (create-test-dashboard)
              {card-id :id}                    (create-test-card)
-             dashcard                         (db/ins DashboardCard :card_id card-id :dashboard_id dashboard-id)
+             dashcard                         (db/insert! DashboardCard :card_id card-id :dashboard_id dashboard-id)
              _                                (db/delete! DashboardCard, :id (:id dashcard))]
   {:model        "Dashboard"
    :model_id     dashboard-id
@@ -157,7 +157,7 @@
 ;; :dashboard-reposition-cards
 (expect-let [{dashboard-id :id :as dashboard} (create-test-dashboard)
              {card-id :id}                    (create-test-card)
-             dashcard                         (u/prog1 (db/ins DashboardCard :card_id card-id :dashboard_id dashboard-id)
+             dashcard                         (u/prog1 (db/insert! DashboardCard :card_id card-id :dashboard_id dashboard-id)
                                                 (db/update! DashboardCard (:id <>), :sizeX 4))]
   {:model        "Dashboard"
    :model_id     dashboard-id

--- a/test/metabase/events/revision_test.clj
+++ b/test/metabase/events/revision_test.clj
@@ -139,7 +139,7 @@
 (expect-let [{dashboard-id :id :as dashboard} (create-test-dashboard)
              {card-id :id}                    (create-test-card)
              dashcard                         (db/ins DashboardCard :card_id card-id :dashboard_id dashboard-id)
-             _                                (db/del DashboardCard :id (:id dashcard))]
+             _                                (db/delete! DashboardCard, :id (:id dashcard))]
   {:model        "Dashboard"
    :model_id     dashboard-id
    :user_id      (user->id :crowberto)

--- a/test/metabase/events/view_log_test.clj
+++ b/test/metabase/events/view_log_test.clj
@@ -12,7 +12,7 @@
 
 (defn- create-test-user []
   (let [rand-name (random-name)]
-    (db/ins User
+    (db/insert! User
       :email      (str rand-name "@metabase.com")
       :first_name rand-name
       :last_name  rand-name

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -18,9 +18,9 @@
     (let [get-dashboard-count (fn [] (dashboard-count (Card card-id)))]
 
       [(get-dashboard-count)
-       (do (db/ins DashboardCard :card_id card-id, :dashboard_id (:id (create-dash (random-name))))
+       (do (db/insert! DashboardCard :card_id card-id, :dashboard_id (:id (create-dash (random-name))))
            (get-dashboard-count))
-       (do (db/ins DashboardCard :card_id card-id, :dashboard_id (:id (create-dash (random-name))))
+       (do (db/insert! DashboardCard :card_id card-id, :dashboard_id (:id (create-dash (random-name))))
            (get-dashboard-count))])))
 
 

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -1,6 +1,6 @@
 (ns metabase.models.card-test
   (:require [expectations :refer :all]
-            [metabase.db :refer [ins]]
+            [metabase.db :as db]
             (metabase.models [card :refer :all]
                              [dashboard-card :refer [DashboardCard]])
             [metabase.test.data.users :refer :all]
@@ -18,9 +18,9 @@
     (let [get-dashboard-count (fn [] (dashboard-count (Card card-id)))]
 
       [(get-dashboard-count)
-       (do (ins DashboardCard :card_id card-id, :dashboard_id (:id (create-dash (random-name))))
+       (do (db/ins DashboardCard :card_id card-id, :dashboard_id (:id (create-dash (random-name))))
            (get-dashboard-count))
-       (do (ins DashboardCard :card_id card-id, :dashboard_id (:id (create-dash (random-name))))
+       (do (db/ins DashboardCard :card_id card-id, :dashboard_id (:id (create-dash (random-name))))
            (get-dashboard-count))])))
 
 

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -149,7 +149,7 @@
           serialized-dashboard (serialize-dashboard dashboard)]
       ;; delete the dashcard and modify the dash attributes
       (dashboard-card/delete-dashboard-card dashboard-card (user->id :rasta))
-      (db/upd Dashboard dashboard-id
+      (db/update! Dashboard dashboard-id
         :name        "Revert Test"
         :description "something")
       ;; capture our updated dashboard state

--- a/test/metabase/models/dependency_test.clj
+++ b/test/metabase/models/dependency_test.clj
@@ -97,7 +97,7 @@
      :dependent_on_model "test"
      :dependent_on_id    2}}
   (do
-    (db/ins Dependency
+    (db/insert! Dependency
       :model              "Mock"
       :model_id           1
       :dependent_on_model "test"

--- a/test/metabase/models/label_test.clj
+++ b/test/metabase/models/label_test.clj
@@ -8,11 +8,11 @@
 ;; and update the name to something that will produce the same slug ("cam") without getting a "name already taken" exception
 (expect
   (with-temp Label [{:keys [id]} {:name "Cam"}]
-    (db/upd Label id, :name "cam")))
+    (db/update! Label id, :name "cam")))
 
 ;; We SHOULD still see an exception if we try to give something a name that produces a slug that's already been taken
 (expect
   clojure.lang.ExceptionInfo
   (with-temp* [Label [{:keys [id]} {:name "Cam"}]
                Label [_            {:name "Rasta"}]]
-    (db/upd Label id, :name "rasta")))
+    (db/update! Label id, :name "rasta")))

--- a/test/metabase/models/pulse_test.clj
+++ b/test/metabase/models/pulse_test.clj
@@ -63,8 +63,8 @@
                                                               :details  {:other  "stuff"
                                                                          :emails ["foo@bar.com"]}}]
                   Card         [{card-id :id}                {:name "Test Card"}]]
-    (db/ins PulseCard, :pulse_id pulse-id, :card_id card-id, :position 0)
-    (db/ins PulseChannelRecipient, :pulse_channel_id channel-id, :user_id (user->id :rasta))
+    (db/insert! PulseCard, :pulse_id pulse-id, :card_id card-id, :position 0)
+    (db/insert! PulseChannelRecipient, :pulse_channel_id channel-id, :user_id (user->id :rasta))
     (-> (dissoc (retrieve-pulse pulse-id) :id :pulse_id :created_at :updated_at)
         (update :creator  (u/rpartial dissoc :date_joined :last_login))
         (update :cards    (fn [cards] (for [card cards]

--- a/test/metabase/models/setting_test.clj
+++ b/test/metabase/models/setting_test.clj
@@ -1,7 +1,7 @@
 (ns metabase.models.setting-test
   (:require [expectations :refer :all]
             [medley.core :as m]
-            [metabase.db :refer [sel]]
+            [metabase.db :as db]
             [metabase.models.setting :refer [defsetting Setting] :as setting]
             (metabase.test [data :refer :all]
                            [util :refer :all])))
@@ -21,10 +21,10 @@
 (defn db-fetch-setting
   "Fetch `Setting` value from the DB to verify things work as we expect."
   [setting-name]
-  (sel :one :field [Setting :value] :key (name setting-name)))
+  (db/sel :one :field [Setting :value], :key (name setting-name)))
 
 (defn setting-exists? [setting-name]
-  (boolean (sel :one Setting :key (name setting-name))))
+  (boolean (Setting :key (name setting-name))))
 
 (defn set-settings [setting-1-value setting-2-value]
   (test-setting-1 setting-1-value)

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -943,9 +943,9 @@
                                    (ql/limit 1))
                                  :data :cols set))]
     [(get-col-names)
-     (do (db/upd Field (id :venues :price) :visibility_type :details-only)
+     (do (db/update! Field (id :venues :price), :visibility_type :details-only)
          (get-col-names))
-     (do (db/upd Field (id :venues :price) :visibility_type :normal)
+     (do (db/update! Field (id :venues :price), :visibility_type :normal)
          (get-col-names))]))
 
 

--- a/test/metabase/sync_database/sync_dynamic_test.clj
+++ b/test/metabase/sync_database/sync_dynamic_test.clj
@@ -294,7 +294,7 @@
       (introspect/introspect-database-and-update-raw-tables! driver db)
       ;; stub out the Table we are going to sync for real below
       (let [raw-table-id (db/sel :one :id RawTable, :database_id database-id, :name "transactions")
-            tbl          (db/ins Table
+            tbl          (db/insert! Table
                            :db_id        database-id
                            :raw_table_id raw-table-id
                            :name         "transactions"

--- a/test/metabase/sync_database/sync_test.clj
+++ b/test/metabase/sync_database/sync_test.clj
@@ -77,7 +77,7 @@
     ;; setup a couple things we'll use in the test
     (introspect/introspect-database-and-update-raw-tables! (moviedb/->MovieDbDriver) db)
     (let [raw-table-id (db/sel :one :id RawTable, :database_id database-id, :name "movies")
-          table        (db/ins Table
+          table        (db/insert! Table
                          :db_id        database-id
                          :raw_table_id raw-table-id
                          :name         "movies"
@@ -341,7 +341,7 @@
 
       ;; stub out the Table we are going to sync for real below
       (let [raw-table-id (db/sel :one :id RawTable, :database_id database-id, :name "roles")
-            tbl          (db/ins Table
+            tbl          (db/insert! Table
                            :db_id        database-id
                            :raw_table_id raw-table-id
                            :name         "roles"

--- a/test/metabase/sync_database/sync_test.clj
+++ b/test/metabase/sync_database/sync_test.clj
@@ -259,12 +259,12 @@
      :last_analyzed      false
      :created_at         true
      :updated_at         true}]]
-  (tu/with-temp* [Database    [{database-id :id}]
-                  RawTable   [{raw-table-id :id, :as table} {:database_id database-id}]
+  (tu/with-temp* [Database  [{database-id :id}]
+                  RawTable  [{raw-table-id :id, :as table} {:database_id database-id}]
                   RawColumn [{raw-column-id1 :id} {:raw_table_id raw-table-id, :name "First", :is_pk true, :details {:base-type "IntegerField"}}]
                   RawColumn [{raw-column-id2 :id} {:raw_table_id raw-table-id, :name "Second", :details {:special-type :category, :base-type "TextField"}}]
                   RawColumn [{raw-column-id3 :id} {:raw_table_id raw-table-id, :name "Third", :details {:base-type "BooleanField"}}]
-                  Table          [{table-id :id, :as tbl} {:db_id database-id, :raw_table_id raw-table-id}]]
+                  Table     [{table-id :id, :as tbl} {:db_id database-id, :raw_table_id raw-table-id}]]
     (let [get-fields #(->> (db/sel :many Field :table_id table-id (k/order :id))
                            (mapv tu/boolean-ids-and-timestamps)
                            (mapv (fn [m]
@@ -280,13 +280,13 @@
          first-sync
          ;; now add another column and modify the first
          (do
-           (db/upd RawColumn raw-column-id1 :is_pk false, :details {:base-type "DecimalField"})
+           (db/update! RawColumn, raw-column-id1 :is_pk false, :details {:base-type "DecimalField"})
            (save-table-fields! tbl)
            (get-fields))
          ;; now disable the first column
          (do
-           (db/upd RawColumn raw-column-id1 :active false)
-           (db/upd RawColumn raw-column-id3 :is_pk true)
+           (db/update! RawColumn raw-column-id1, :active false)
+           (db/update! RawColumn raw-column-id3, :is_pk true)
            (save-table-fields! tbl)
            (get-fields))]))))
 

--- a/test/metabase/sync_database_test.clj
+++ b/test/metabase/sync_database_test.clj
@@ -342,16 +342,16 @@
     [;; Special type should be :id to begin with
      (get-special-type)
      ;; Clear out the special type
-     (do (db/upd field/Field (id :venues :id) :special_type nil)
+     (do (db/update! field/Field (id :venues :id), :special_type nil)
          (get-special-type))
      ;; Calling sync-table! should set the special type again
      (do (sync-table! @venues-table)
          (get-special-type))
      ;; sync-table! should *not* change the special type of fields that are marked with a different type
-     (do (db/upd field/Field (id :venues :id) :special_type :latitude)
+     (do (db/update! field/Field (id :venues :id), :special_type :latitude)
          (get-special-type))
      ;; Make sure that sync-table runs set-table-pks-if-needed!
-     (do (db/upd field/Field (id :venues :id) :special_type nil)
+     (do (db/update! field/Field (id :venues :id), :special_type nil)
          (sync-table! @venues-table)
          (get-special-type))]))
 
@@ -379,7 +379,7 @@
     [ ;; FK should exist to start with
      (get-special-type-and-fk-exists?)
      ;; Clear out FK / special_type
-     (do (db/upd field/Field field-id :special_type nil, :fk_target_field_id nil)
+     (do (db/update! field/Field field-id, :special_type nil, :fk_target_field_id nil)
          (get-special-type-and-fk-exists?))
      ;; Run sync-table and they should be set again
      (let [table (table/Table (id :checkins))]
@@ -413,7 +413,7 @@
     [ ;; 1. Check that we have expected field values to start with
      (get-field-values)
      ;; 2. Update the FieldValues, remove one of the values that should be there
-     (do (db/upd FieldValues (get-field-values-id) :values [1 2 3])
+     (do (db/update! FieldValues (get-field-values-id), :values [1 2 3])
          (get-field-values))
      ;; 3. Now re-sync the table and make sure the value is back
      (do (sync-table! @venues-table)

--- a/test/metabase/sync_database_test.clj
+++ b/test/metabase/sync_database_test.clj
@@ -399,7 +399,7 @@
     [ ;; 1. Check that we have expected field values to start with
      (get-field-values)
      ;; 2. Delete the Field values, make sure they're gone
-     (do (db/cascade-delete FieldValues :id (get-field-values-id))
+     (do (db/cascade-delete! FieldValues :id (get-field-values-id))
          (get-field-values))
      ;; 3. Now re-sync the table and make sure they're back
      (do (sync-table! @venues-table)

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -218,7 +218,7 @@
    (remove-database! *data-loader* database-definition))
   ([dataset-loader ^DatabaseDefinition database-definition]
    ;; Delete the Metabase Database and associated objects
-   (db/cascade-delete Database :id (:id (i/metabase-instance database-definition (i/engine dataset-loader))))
+   (db/cascade-delete! Database :id (:id (i/metabase-instance database-definition (i/engine dataset-loader))))
 
    ;; now delete the DBMS database
    (i/destroy-db! dataset-loader database-definition)))

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -201,13 +201,13 @@
                                                                      (u/pprint-to-str field-definition))))))]
                      (when field-type
                        (log/debug (format "SET FIELD TYPE %s.%s -> %s" table-name field-name field-type))
-                       (db/upd Field (:id @field) :field_type (name field-type)))
+                       (db/update! Field (:id @field) :field_type (name field-type)))
                      (when visibility-type
                        (log/debug (format "SET VISIBILITY TYPE %s.%s -> %s" table-name field-name visibility-type))
-                       (db/upd Field (:id @field) :visibility_type (name visibility-type)))
+                       (db/update! Field (:id @field) :visibility_type (name visibility-type)))
                      (when special-type
                        (log/debug (format "SET SPECIAL TYPE %s.%s -> %s" table-name field-name special-type))
-                       (db/upd Field (:id @field) :special_type (name special-type)))))))
+                       (db/update! Field (:id @field) :special_type (name special-type)))))))
              db))))))
 
 (defn remove-database!

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -178,7 +178,7 @@
            (i/create-db! dataset-loader database-definition)
 
            ;; Add DB object to Metabase DB
-           (let [db (db/ins Database
+           (let [db (db/insert! Database
                       :name    database-name
                       :engine  (name engine)
                       :details (i/database->connection-details dataset-loader :db database-definition))]

--- a/test/metabase/test/data/mysql.clj
+++ b/test/metabase/test/data/mysql.clj
@@ -36,7 +36,7 @@
 (u/strict-extend MySQLDriver
   generic/IGenericSQLDatasetLoader
   (merge generic/DefaultsMixin
-         {:execute-sql!              generic/sequentially-execute-sql!                  ; TODO - we might be able to do SQL all at once by setting `allowMultiQueries=true` on the connection string
+         {:execute-sql!              generic/sequentially-execute-sql!              ; TODO - we might be able to do SQL all at once by setting `allowMultiQueries=true` on the connection string
           :field-base-type->sql-type (u/drop-first-arg field-base-type->sql-type)
           :load-data!                generic/load-data-all-at-once!
           :pk-sql-type               (constantly "INTEGER NOT NULL AUTO_INCREMENT")

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -40,7 +40,7 @@
                :password "birdseed"
                :active   false}})
 
-(def ^:private usernames
+(def ^:private ^:const usernames
   (set (keys user->info)))
 
 ;; ## Public functions for working with Users

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -123,7 +123,7 @@
   [& {:keys [email first last password superuser active]
       :or {superuser false
            active    true}}]
-  {:pre [(string? email) (string? first) (string? last) (string? password) (m/boolean? superuser)]}
+  {:pre [(string? email) (string? first) (string? last) (string? password) (m/boolean? superuser) (m/boolean? active)]}
   (or (db/sel :one User :email email)
       (db/insert! User
         :email        email

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -53,7 +53,7 @@
                     :last_name  (random-name)
                     :email      (.toLowerCase ^String (str first-name "@metabase.com"))
                     :password   first-name}]
-    (m/mapply db/ins User (merge defaults kwargs))))
+    (db/insert! User (merge defaults kwargs))))
 
 (defn fetch-user
   "Fetch the User object associated with USERNAME.
@@ -125,7 +125,7 @@
            active    true}}]
   {:pre [(string? email) (string? first) (string? last) (string? password) (m/boolean? superuser)]}
   (or (db/sel :one User :email email)
-      (db/ins User
+      (db/insert! User
         :email        email
         :first_name   first
         :last_name    last

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -73,6 +73,7 @@
 
 (defmacro expect-eval-actual-first
   "Identical to `expect` but evaluates `actual` first (instead of evaluating `expected` first)."
+  {:style/indent 0}
   [expected actual]
   (let [fn-name (gensym)]
     `(def ~(vary-meta fn-name assoc :expectation true)
@@ -199,7 +200,7 @@
     (try
       (f temp-object)
       (finally
-        (db/cascade-delete entity :id (:id temp-object))))))
+        (db/cascade-delete! entity :id (:id temp-object))))))
 
 
 ;;; # with-temp

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -2,7 +2,6 @@
   "Helper functions and macros for writing unit tests."
   (:require [cheshire.core :as json]
             [expectations :refer :all]
-            [medley.core :as m]
             [metabase.db :as db]
             (metabase.models [card :refer [Card]]
                              [common :as common]
@@ -195,8 +194,8 @@
 (defn do-with-temp
   "Internal implementation of `with-temp` (don't call this directly)."
   [entity attributes f]
-  (let [temp-object (m/mapply db/ins entity (merge (with-temp-defaults entity)
-                                                   attributes))]
+  (let [temp-object (db/insert! entity (merge (with-temp-defaults entity)
+                                              attributes))]
     (try
       (f temp-object)
       (finally

--- a/test/metabase/test_setup.clj
+++ b/test/metabase/test_setup.clj
@@ -85,7 +85,7 @@
       (core/initialization-complete!)
       ;; If test setup fails exit right away
       (catch Throwable e
-        (log/error (u/format-color 'red "Test setup failed: %s\n%s" e (u/pprint-to-str (.getStackTrace e))))
+        (log/error (u/format-color 'red "Test setup failed: %s\n%s" e (u/pprint-to-str (vec (.getStackTrace e)))))
         (System/exit -1)))
 
     @start-jetty!))


### PR DESCRIPTION
This PR removes the old `upd`, `del`, `ins`, `cascade-delete`, and `upd-non-nil-keys` functions & macros and reworks places where they were used with the new functions `update!`, `delete!`, `insert!`, `cascade-delete!`, and `update-non-nil-keys!`, respectively. 

The semantics are almost identical but the new functions use HoneySQL instead of Korma. The new functions are a little easier to understand and more flexible.

Since the `sel` macro is used in a lot of places I will open [a separate PR](https://github.com/metabase/metabase/tree/honeysql-4) after this is merged to switch uses of that over.
