### PR TITLE
change the driver's nice name to "MySQL / MariaDB"

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -147,7 +147,7 @@
 
 (defrecord MySQLDriver []
   clojure.lang.Named
-  (getName [_] "MySQL"))
+  (getName [_] "MySQL / MariaDB"))
 
 (u/strict-extend MySQLDriver
   driver/IDriver


### PR DESCRIPTION
Resolves #2581 
