### PR TITLE
Don't fetch *current-user* just to check superuser status :racing_car:

### DIFF
--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -65,7 +65,7 @@
 (defn check-superuser
   "Check that `*current-user*` is a superuser or throw a 403."
   []
-  (check-403 (:is_superuser @*current-user*)))
+  (check-403 (db/exists? 'User, :id *current-user-id*, :is_superuser true)))
 
 
 ;;; #### checkp- functions: as in "check param". These functions expect that you pass a symbol so they can throw exceptions w/ relevant error messages.


### PR DESCRIPTION
Lots of API endpoints check whether the current user is a superuser via the aptly-named `check-superuser` function. 

This was done by resolving the `*current-user*` delay attached to every API request. My thoughts were that this would save us from hitting the DB twice in case we needed other current user information in the endpoints. This turned out to only be the case in a couple of API endpoints and wasteful for the other 2 dozen.

So I'm estimating this will make Metabase at least 1% faster. Yay 🎉 
