### PR TITLE
Deduplicate card IDs in query :spades:

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -68,7 +68,7 @@
    Make sure cards are returned in the same order as CARD-IDS`; `[in card-ids]` won't preserve the order."
   [card-ids]
   {:pre [(every? integer? card-ids)]}
-  (let [card-id->card (db/select-id->obj Card, :id [:in card-ids], :archived false)]
+  (let [card-id->card (db/select-id->obj Card, :id [:in (set card-ids)], :archived false)]
     (filter identity (map card-id->card card-ids))))
 
 (defn- cards:recent


### PR DESCRIPTION
As spotted by @tlrobinson we have queries that look like 

```
SELECT * FROM "LABEL" WHERE ("ID" in (58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58))
```

which is silly. Deduplicate IDs before passing to the DB. This doesn't affect the results, but makes the query a little less redundant.
