### PR TITLE
Object count caching [Proof of Concept]

### DIFF
--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -65,7 +65,7 @@
 (defn check-superuser
   "Check that `*current-user*` is a superuser or throw a 403."
   []
-  (check-403 (db/exists? 'User, :id *current-user-id*, :is_superuser true)))
+  (check-403 (db/select-one-field :is_superuser 'User, :id *current-user-id*)))
 
 
 ;;; #### checkp- functions: as in "check param". These functions expect that you pass a symbol so they can throw exceptions w/ relevant error messages.


### PR DESCRIPTION
Implements simple caching layer for calls like `(db/count Database)` and `(db/exists? Label)`. We don't do these in too many places but the admin checklist #2638 would definitely benefit from this as it would reduce the number of DB calls the endpoint makes from 10 to 1.
