### PR TITLE
return an empty vector in the case where a query results in no rows.

### DIFF
--- a/src/metabase/driver/crate/query_processor.clj
+++ b/src/metabase/driver/crate/query_processor.clj
@@ -47,7 +47,7 @@
                              (into [sql] params)
                              sql)]
              (let [[columns & rows] (jdbc/query t-conn statement, :identifiers identity, :as-arrays? true)]
-               {:rows    rows
+               {:rows    (or rows [])
                 :columns columns}))))
        (catch java.sql.SQLException e
          (let [^String message (or (->> (.getMessage e)     ; error message comes back like 'Column "ZID" not found; SQL statement: ... [error-code]' sometimes

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -328,7 +328,7 @@
                                  (into [sql] params)
                                  sql)]
                  (let [[columns & rows] (jdbc/query t-conn statement, :identifiers identity, :as-arrays? true)]
-                   {:rows    rows
+                   {:rows    (or rows [])
                     :columns columns}))
 
                ;; Rollback any changes made during this transaction just to be extra-double-sure JDBC doesn't try to commit them automatically for us


### PR DESCRIPTION
fixes #2645
