### PR TITLE
Small fix for sample dataset syncing :honey_pot:

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -98,7 +98,6 @@
                                :deprecations]}                        ; Turn this off temporarily until we finish removing self-deprecated DB functions & macros like `upd`, `del`, and `sel`
   :docstring-checker {:include [#"^metabase"]
                       :exclude [#"test"
-                                #"^metabase\.sample-data$"
                                 #"^metabase\.http-client$"]}
   :profiles {:dev {:dependencies [[org.clojure/tools.nrepl "0.2.12"]  ; REPL <3
                                   [expectations "2.1.3"]              ; unit tests *** DON'T UPDATE THIS UNTIL WE REMOVE USES OF DEPRECATED EXPECT-LET IN THE CODEBASE ***

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -234,9 +234,9 @@
 
 (defn- table-rows-seq [driver database table]
   (let [pk-field (field/Field (table/pk-field-id table))]
-    (query driver database table {:select   [:*]
-                                  :order-by (when pk-field
-                                              [[(qualify+escape table pk-field) :asc]])})))
+    (query driver database table (merge {:select   [:*]}
+                                        (when pk-field
+                                          {:order-by [[(qualify+escape table pk-field) :asc]]})))))
 
 (defn- field-avg-length
   [driver field]
@@ -275,11 +275,11 @@
         db          (table/database table)
         field-k     (qualify+escape table field)
         pk-field    (field/Field (table/pk-field-id table))
-        results     (map :is_url (query driver db table {:select   [[(hsql/call :like field-k (hx/literal "http%://_%.__%")) :is_url]]
-                                                         :where    [:not= field-k nil]
-                                                         :order-by (when pk-field
-                                                                     [[(qualify+escape table pk-field) :asc]])
-                                                         :limit    driver/max-sync-lazy-seq-results}))
+        results     (map :is_url (query driver db table (merge {:select   [[(hsql/call :like field-k (hx/literal "http%://_%.__%")) :is_url]]
+                                                                :where    [:not= field-k nil]
+                                                                :limit    driver/max-sync-lazy-seq-results}
+                                                               (when pk-field
+                                                                 {:order-by [[(qualify+escape table pk-field) :asc]]}))))
         total-count (count results)
         url-count   (count (filter #(or (true? %) (= % 1)) results))]
     (url-percentage url-count total-count)))

--- a/src/metabase/sample_data.clj
+++ b/src/metabase/sample_data.clj
@@ -11,7 +11,9 @@
 (def ^:private ^:const sample-dataset-name     "Sample Dataset")
 (def ^:private ^:const sample-dataset-filename "sample-dataset.db.mv.db")
 
-(defn add-sample-dataset! []
+(defn add-sample-dataset!
+  "Add the sample dataset as a Metabase DB if it doesn't already exist."
+  []
   (when-not (db/exists? Database :is_sample true)
     (try
       (log/info "Loading sample dataset...")
@@ -29,12 +31,14 @@
                           :is_sample true)]
             (sync-database/sync-database! db))))
       (catch Throwable e
-        (log/error (u/format-color 'red "Failed to load sample dataset: %s" (.getMessage e)))))))
+        (log/error (u/format-color 'red "Failed to load sample dataset: %s\n%s" (.getMessage e) (u/pprint-to-str (u/filtered-stacktrace e))))))))
 
-(defn update-sample-dataset-if-needed! []
+(defn update-sample-dataset-if-needed!
+  "Re-sync the sample dataset DB if it exists."
+  []
   ;; TODO - it would be a bit nicer if we skipped this when the data hasn't changed
   (when-let [db (Database :is_sample true)]
     (try
       (sync-database/sync-database! db)
       (catch Throwable e
-        (log/error (u/format-color 'red "Failed to update sample dataset: %s" (.getMessage e)))))))
+        (log/error (u/format-color 'red "Failed to update sample dataset: %s\n%s" (.getMessage e) (u/pprint-to-str (u/filtered-stacktrace e))))))))

--- a/src/metabase/sync_database.clj
+++ b/src/metabase/sync_database.clj
@@ -85,7 +85,9 @@
       (when full-sync?
         (analyze/analyze-data-shape-for-tables! driver database)))
 
-    (events/publish-event :database-sync-end {:database_id (:id database) :custom_id tracking-hash :running_time (int (/ (- (System/nanoTime) start-time) 1000000.0))}) ; convert to ms
+    (events/publish-event :database-sync-end {:database_id  (:id database)
+                                              :custom_id    tracking-hash
+                                              :running_time (int (/ (- (System/nanoTime) start-time) 1000000.0))}) ; convert to ms
     (log/info (u/format-color 'magenta "Finished syncing %s database '%s'. (%s)" (name driver) (:name database)
                               (u/format-nanoseconds (- (System/nanoTime) start-time))))))
 


### PR DESCRIPTION
Don't try to order by PK field if one doesn't exist when syncing the sample dataset. Add some extra error logging.
