### PR TITLE
Don't require spaces between operators & fields in expressions

### DIFF
--- a/frontend/src/metabase/lib/expressions.js
+++ b/frontend/src/metabase/lib/expressions.js
@@ -134,6 +134,12 @@ function tokenizeExpression(expressionString) {
         currentToken.value += c;
     }
 
+    // Replace operators in expressionString making sure the operators have exactly one space before and after
+    VALID_OPERATORS.forEach(function(operator) {
+        let regex = new RegExp("\\s*[\\" + operator + "]\\s*");
+        expressionString = expressionString.replace(regex, ' ' + operator + ' ');
+    });
+
     for (; i < expressionString.length; i++) {
         let c = expressionString.charAt(i);
 


### PR DESCRIPTION
Credit goes to @MrMauricioLeite for the original PR (#2631)

Fixes #2629.
