### PR TITLE
Prepend info about query execution to SQL :information_desk_person: :…

### DIFF
--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -12,11 +12,11 @@
             [metabase.query-processor :as qp]
             [metabase.util :as u]))
 
-(def ^:const api-max-results-bare-rows
+(def ^:private ^:const api-max-results-bare-rows
   "Maximum number of rows to return specifically on :rows type queries via the API."
   2000)
 
-(def ^:const api-max-results
+(def ^:private ^:const api-max-results
   "General maximum number of rows to return from an API query."
   10000)
 
@@ -65,6 +65,7 @@
        :body   (:error response)})))
 
 
+;; TODO - AFAIK this endpoint is no longer used. Remove it? </3
 (defendpoint GET "/card/:id"
   "Execute the MQL query for a given `Card` and retrieve both the `Card` and the execution results as JSON.
    This is a convenience endpoint which simplifies the normal 2 api calls to fetch the `Card` then execute its query."

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -144,17 +144,21 @@
     "*OPTIONAL*. Return a humanized (user-facing) version of an connection error message string.
      Generic error messages are provided in the constant `connection-error-messages`; return one of these whenever possible.")
 
-  (mbql->native ^java.util.Map [this, ^Map query]
+  (mbql->native ^java.util.Map [this, ^Map query, ^String remark]
     "Transpile an MBQL structured query into the appropriate native query form.
 
-  The input query will be a fully expanded MBQL query (https://github.com/metabase/metabase/wiki/Expanded-Queries) with
+  The input QUERY will be a [fully-expanded MBQL query](https://github.com/metabase/metabase/wiki/Expanded-Queries) with
   all the necessary pieces of information to build a properly formatted native query for the given database.
+
+  REMARK contains general information about the query and user who ran it; if possible, a driver should include this at the begging of the native form
+  so as to help DBAs identify queries originating from Metabase (see [issue #2386](https://github.com/metabase/metabase/issues/2386) for further discussion).
 
   The result of this function will be passed directly into calls to `execute-query`.
 
   For example, a driver like Postgres would build a valid SQL expression and return a map such as:
 
-       {:query \"SELECT * FROM my_table\"}")
+       {:query \"-- [Contents of `remark`]
+                 SELECT * FROM my_table\"}")
 
   (notify-database-updated [this, ^DatabaseInstance database]
     "*OPTIONAL*. Notify the driver that the attributes of the DATABASE have changed.  This is specifically relevant in

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -144,20 +144,20 @@
     "*OPTIONAL*. Return a humanized (user-facing) version of an connection error message string.
      Generic error messages are provided in the constant `connection-error-messages`; return one of these whenever possible.")
 
-  (mbql->native ^java.util.Map [this, ^Map query, ^String remark]
+  (mbql->native ^java.util.Map [this, ^Map query]
     "Transpile an MBQL structured query into the appropriate native query form.
 
   The input QUERY will be a [fully-expanded MBQL query](https://github.com/metabase/metabase/wiki/Expanded-Queries) with
   all the necessary pieces of information to build a properly formatted native query for the given database.
 
-  REMARK contains general information about the query and user who ran it; if possible, a driver should include this at the begging of the native form
-  so as to help DBAs identify queries originating from Metabase (see [issue #2386](https://github.com/metabase/metabase/issues/2386) for further discussion).
+  If the underlying query language supports remarks or comments, the driver should use `query->remark` to generate an appropriate message and include that in an appropriate place;
+  alternatively a driver might directly include the query's `:info` dictionary if the underlying language is JSON-based.
 
   The result of this function will be passed directly into calls to `execute-query`.
 
   For example, a driver like Postgres would build a valid SQL expression and return a map such as:
 
-       {:query \"-- [Contents of `remark`]
+       {:query \"-- [Contents of `(query->remark query)`]
                  SELECT * FROM my_table\"}")
 
   (notify-database-updated [this, ^DatabaseInstance database]

--- a/src/metabase/driver/bigquery.clj
+++ b/src/metabase/driver/bigquery.clj
@@ -15,6 +15,7 @@
                              [field :as field]
                              [table :as table])
             [metabase.sync-database.analyze :as analyze]
+            [metabase.query-processor :as qp]
             metabase.query-processor.interface
             [metabase.util :as u]
             [metabase.util.honeysql-extensions :as hx])
@@ -331,12 +332,12 @@
     (for [row rows]
       (zipmap columns row))))
 
-(defn- mbql->native [{{{:keys [dataset-id]} :details, :as database} :database, {{table-name :name} :source-table} :query, :as outer-query} remark]
+(defn- mbql->native [{{{:keys [dataset-id]} :details, :as database} :database, {{table-name :name} :source-table} :query, :as outer-query}]
   {:pre [(map? database) (seq dataset-id) (seq table-name)]}
   (binding [sqlqp/*query* outer-query]
     (let [honeysql-form (honeysql-form outer-query)
           sql           (honeysql-form->sql honeysql-form)]
-      {:query      (str "-- " remark "\n" sql)
+      {:query      (str "-- " (qp/query->remark outer-query) "\n" sql)
        :table-name table-name
        :mbql?      true})))
 

--- a/src/metabase/driver/bigquery.clj
+++ b/src/metabase/driver/bigquery.clj
@@ -331,12 +331,12 @@
     (for [row rows]
       (zipmap columns row))))
 
-(defn- mbql->native [{{{:keys [dataset-id]} :details, :as database} :database, {{table-name :name} :source-table} :query, :as outer-query}]
+(defn- mbql->native [{{{:keys [dataset-id]} :details, :as database} :database, {{table-name :name} :source-table} :query, :as outer-query} remark]
   {:pre [(map? database) (seq dataset-id) (seq table-name)]}
   (binding [sqlqp/*query* outer-query]
     (let [honeysql-form (honeysql-form outer-query)
           sql           (honeysql-form->sql honeysql-form)]
-      {:query      sql
+      {:query      (str "-- " remark "\n" sql)
        :table-name table-name
        :mbql?      true})))
 

--- a/src/metabase/driver/druid/query_processor.clj
+++ b/src/metabase/driver/druid/query_processor.clj
@@ -521,7 +521,7 @@
 
 (defn mbql->native
   "Transpile an MBQL (inner) query into a native form suitable for a Druid DB."
-  [query remark]
+  [query]
   ;; Merge `:settings` into the inner query dict so the QP has access to it
   (let [mbql-query (assoc (:query query)
                      :settings (:settings query))]

--- a/src/metabase/driver/druid/query_processor.clj
+++ b/src/metabase/driver/druid/query_processor.clj
@@ -521,7 +521,7 @@
 
 (defn mbql->native
   "Transpile an MBQL (inner) query into a native form suitable for a Druid DB."
-  [query]
+  [query remark]
   ;; Merge `:settings` into the inner query dict so the QP has access to it
   (let [mbql-query (assoc (:query query)
                      :settings (:settings query))]

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -272,11 +272,11 @@
 
 (defn mbql->native
   "Transpile MBQL query into a native SQL statement."
-  [driver {inner-query :query, database :database, :as outer-query} remark]
+  [driver {inner-query :query, database :database, :as outer-query}]
   (binding [*query* outer-query]
     (let [honeysql-form (build-honeysql-form driver outer-query)
           [sql & args]  (sql/honeysql-form->sql+args driver honeysql-form)]
-      {:query  (str "-- " remark "\n" sql)
+      {:query  (str "-- " (qp/query->remark outer-query) "\n" sql)
        :params args})))
 
 

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -272,11 +272,11 @@
 
 (defn mbql->native
   "Transpile MBQL query into a native SQL statement."
-  [driver {inner-query :query, database :database, :as outer-query}]
+  [driver {inner-query :query, database :database, :as outer-query} remark]
   (binding [*query* outer-query]
     (let [honeysql-form (build-honeysql-form driver outer-query)
           [sql & args]  (sql/honeysql-form->sql+args driver honeysql-form)]
-      {:query  sql
+      {:query  (str "-- " remark "\n" sql)
        :params args})))
 
 

--- a/src/metabase/driver/mongo/query_processor.clj
+++ b/src/metabase/driver/mongo/query_processor.clj
@@ -380,7 +380,7 @@
 
 (defn mbql->native
   "Process and run an MBQL query."
-  [{database :database, {{source-table-name :name} :source-table} :query, :as query} remark]
+  [{database :database, {{source-table-name :name} :source-table} :query, :as query}]
   {:pre [(map? database)
          (string? source-table-name)]}
   (binding [*query* query]

--- a/src/metabase/driver/mongo/query_processor.clj
+++ b/src/metabase/driver/mongo/query_processor.clj
@@ -326,7 +326,9 @@
 
 ;;; # process + run
 
-(defn- generate-aggregation-pipeline [query]
+(defn- generate-aggregation-pipeline
+  "Generate the aggregation pipeline. Returns a sequence of maps representing each stage."
+  [query]
   (loop [pipeline [], [f & more] [add-initial-projection
                                   handle-filter
                                   handle-breakout+aggregation
@@ -378,7 +380,7 @@
 
 (defn mbql->native
   "Process and run an MBQL query."
-  [{database :database, {{source-table-name :name} :source-table} :query, :as query}]
+  [{database :database, {{source-table-name :name} :source-table} :query, :as query} remark]
   {:pre [(map? database)
          (string? source-table-name)]}
   (binding [*query* query]

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -571,8 +571,9 @@
                                             :query-hash  (hash query)
                                             :query-type (if (mbql-query? query) "MBQL" "native")})]
     (try
-      (query-complete query-execution (u/prog1 (process-query query)
-                                        (assert-valid-query-result <>)))
+      (let [result (process-query query)]
+        (assert-valid-query-result result)
+        (query-complete query-execution result))
       (catch Throwable e
         (log/error (u/format-color 'red "Query failure: %s" (.getMessage e)))
         (query-fail query-execution (.getMessage e))))))


### PR DESCRIPTION
Prepend some general information about query being ran as a comment to the beginning of queries for SQL DBs (I couldn't figure out how to do this for Mongo or Druid).

e.g.

``` sql
-- Metabase:: userID: 2 executionID: 170cbab5-090b-4be5-b286-1168f9439b5a queryType: MBQL queryHash: 1005045833
SELECT "PUBLIC"."ORDERS"."USER_ID" AS "USER_ID", [...]
FROM "PUBLIC"."ORDERS" 
LIMIT 1
```

Implements #2386 
