### PR TITLE
handle password resets where no email is configured

### DIFF
--- a/frontend/src/metabase/auth/auth.controllers.js
+++ b/frontend/src/metabase/auth/auth.controllers.js
@@ -76,6 +76,8 @@ AuthControllers.controller('ForgotPassword', ['$scope', '$cookies', '$location',
 
     $scope.sentNotification = false;
 
+    $scope.emailConfigured = MetabaseSettings.isEmailConfigured()
+
     $scope.sendResetNotification = function(email) {
         Session.forgot_password({
             'email': email

--- a/resources/frontend_client/app/auth/partials/forgot_password.html
+++ b/resources/frontend_client/app/auth/partials/forgot_password.html
@@ -4,31 +4,39 @@
             <div class="Grid-cell flex layout-centered text-brand">
                 <mb-logo-icon class="Logo my4 sm-my0" width="66px" height="85px"></mb-logo-icon>
             </div>
-            <div class="Grid-cell" ng-show="!sentNotification">
-                <form class="ForgotForm bg-white Form-new bordered rounded shadowed" name="form" novalidate>
-                    <h3 class="Login-header Form-offset mb3">Forgot password</h3>
-
-                    <mb-form-message form="form"></mb-form-message>
-
-                    <div class="Form-field" mb-form-field="email">
-                        <mb-form-label display-name="Email address" field-name="email"></mb-form-label>
-                        <input class="Form-input Form-offset full" name="email" placeholder="The email you use for your Metabase account" type="text" ng-model="email" required autofocus>
-                        <span class="Form-charm"></span>
-                    </div>
-
-                    <div class="Form-actions">
-                        <button class="Button" ng-class="{'Button--primary': form.$valid}" ng-click="sendResetNotification(email)" ng-disabled="!form.$valid">
-                            Send password reset email
-                        </button>
-                    </div>
-                </form>
+            <div class="Grid-cell" ng-show="!emailConfigured">
+                <div class="text-centered bordered rounded shadowed p4">
+                    <h3 class="my4">Please contact an administrator to have them reset your password</h3>
+                    <a class="link block mb4" href="/auth/login">Back to login</a>
+                </div>
             </div>
-            <div class="Grid-cell" ng-show="sentNotification">
-                <div class="SuccessGroup bg-white bordered rounded shadowed">
-                    <div class="SuccessMark">
-                        <mb-icon name="check"></mb-icon>
+            <div class="Grid-cell" ng-show="emailConfigured">
+                <div ng-show="!sentNotification">
+                    <form class="ForgotForm bg-white Form-new bordered rounded shadowed" name="form" novalidate>
+                        <h3 class="Login-header Form-offset mb3">Forgot password</h3>
+
+                        <mb-form-message form="form"></mb-form-message>
+
+                        <div class="Form-field" mb-form-field="email">
+                            <mb-form-label display-name="Email address" field-name="email"></mb-form-label>
+                            <input class="Form-input Form-offset full" name="email" placeholder="The email you use for your Metabase account" type="text" ng-model="email" required autofocus>
+                            <span class="Form-charm"></span>
+                        </div>
+
+                        <div class="Form-actions">
+                            <button class="Button" ng-class="{'Button--primary': form.$valid}" ng-click="sendResetNotification(email)" ng-disabled="!form.$valid">
+                                Send password reset email
+                            </button>
+                        </div>
+                    </form>
+                </div>
+                <div ng-show="sentNotification">
+                    <div class="SuccessGroup bg-white bordered rounded shadowed">
+                        <div class="SuccessMark">
+                            <mb-icon name="check"></mb-icon>
+                        </div>
+                        <p class="SuccessText">Check your email for instructions on how to reset your password.</p>
                     </div>
-                    <p class="SuccessText">Check your email for instructions on how to reset your password.</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Addresses #2701

So far this minor tweak checks to see if the instance has email configured and if so simply displays to the user that they'll need to contact their instance admin to have their password reset. (We should try and make this better over time, but at the very least we're not falsely indicating that they should be expecting a phantom email).

Handling the case where we're in the Mac App (via window.OSX) and trigger the Mac App password reset flow via the link rather than the normal forgot page transition will ship in #2717 
