### PR TITLE
Check whether we should log HoneySQL form before doing so :honey_pot:

### DIFF
--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -270,7 +270,8 @@
   [driverr {inner-query :query}]
   {:pre [(map? inner-query)]}
   (u/prog1 (apply-clauses driverr {} inner-query)
-    (log/debug "HoneySQL Form: 🍯\n" (u/pprint-to-str 'cyan <>))))
+    (when-not qp/*disable-qp-logging*
+      (log/debug "HoneySQL Form: 🍯\n" (u/pprint-to-str 'cyan <>)))))
 
 (defn mbql->native
   "Transpile MBQL query into a native SQL statement."


### PR DESCRIPTION
Make sure to check value of  `*disable-qp-logging*` before logging HoneySQL form
