### PR TITLE
Fixes for load-from-h2 migration command

### DIFF
--- a/resources/log4j.properties
+++ b/resources/log4j.properties
@@ -18,7 +18,6 @@ log4j.appender.metabase=metabase.logger.Appender
 
 # customizations to logging by package
 log4j.logger.metabase=INFO
-log4j.logger.metabase.db=DEBUG
 log4j.logger.metabase.driver=DEBUG
 log4j.logger.metabase.query-processor=DEBUG
 log4j.logger.metabase.sync-database=DEBUG

--- a/src/metabase/cmd/load_from_h2.clj
+++ b/src/metabase/cmd/load_from_h2.clj
@@ -75,7 +75,11 @@
   (doseq [chunk (partition-all 300 objs)]
     (print (color/blue \.))
     (flush)
-    (k/insert e (k/values chunk)))
+    (k/insert e (k/values (if (= e DashboardCard)
+                            ;; mini-HACK to fix korma/h2 lowercasing these couple attributes
+                            ;; luckily this is the only place in our schema where we have camel case names
+                            (mapv #(set/rename-keys % {:sizex :sizeX, :sizey :sizeY}) chunk)
+                            chunk))))
   (println (color/green "[OK]")))
 
 (defn- insert-self-referencing-entity [e objs]


### PR DESCRIPTION
Turns out there were several things that needed to be addressed:
- Resolves #2632 where self-referencing columns caused FK constraint violation
- fixes an issue on postgres migrations where `:sizeX` and `:sizeY` column names were not getting handled properly
- manually updates the postgres sequence values after a migration to avoid duplicate key errors when running the app after a migration
- fixes an error with jdbc clob values not getting inserted properly on postgres databases

I've tried this out on both MySQL and Postgres and it's working for me in both cases at this point.
