### PR TITLE
Fix syncing sample dataset :disappointed:

### DIFF
--- a/sample_dataset/metabase/sample_dataset/generate.clj
+++ b/sample_dataset/metabase/sample_dataset/generate.clj
@@ -181,16 +181,14 @@
 (defn- max-date [& dates]
   {:pre [(every? (partial instance? Date) dates)]
    :post [(instance? Date %)]}
-  (let [d (Date.)]
-    (.setTime d (apply max (map #(.getTime ^Date %) dates)))
-    d))
+  (doto (Date.)
+    (.setTime (apply max (map #(.getTime ^Date %) dates)))))
 
 (defn- min-date [& dates]
   {:pre [(every? (partial instance? Date) dates)]
    :post [(instance? Date %)]}
-  (let [d (Date.)]
-    (.setTime d (apply min (map #(.getTime ^Date %) dates)))
-    d))
+  (doto (Date.)
+    (.setTime (apply min (map #(.getTime ^Date %) dates)))))
 
 (defn random-order [{:keys [state], :as ^Person person} {:keys [price], :as product}]
   {:pre [(string? state)

--- a/src/metabase/db/migrations.clj
+++ b/src/metabase/db/migrations.clj
@@ -201,7 +201,7 @@
                 ;; this check gaurds against any table that appears in the schema multiple times
                 (if (contains? @processed-tables {:schema table-schema, :name table-name})
                   ;; this is a dupe of this table, retire it and it's fields
-                  (table/retire-tables #{table-id})
+                  (table/retire-tables! #{table-id})
                   ;; this is the first time we are encountering this table, so migrate it
                   (do
                     ;; add this table to the set of tables we've processed

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -8,9 +8,12 @@
                       [db :as db])
             (metabase.models [database :refer [Database]]
                              [query-execution :refer [QueryExecution]]
+                             raw-table
                              [setting :refer [defsetting]])
             [metabase.util :as u])
-  (:import clojure.lang.Keyword))
+  (:import clojure.lang.Keyword
+           metabase.models.database.DatabaseInstance
+           metabase.models.raw_table.RawTableInstance))
 
 
 ;;; ## INTERFACE + CONSTANTS
@@ -183,10 +186,10 @@
          (with-connection [_ database]
            (f)))")
 
-  (table-rows-seq ^clojure.lang.Sequential [this, ^DatabaseInstance database, ^Map table]
-    "*OPTIONAL*. Return a sequence of all the rows in a given TABLE.
-     The TABLE argument is a Map that requires the `:name` key as the table name and optionally uses the `:schema` key for databases that support schemas.
-     Currently, this is only used for iterating over the values in a `_metabase_metadata` table. As such, the results are not expected to be returned lazily."))
+  (table-rows-seq ^clojure.lang.Sequential [this, ^DatabaseInstance database, ^RawTableInstance raw-table]
+    "*OPTIONAL*. Return a sequence of *all* the rows in a given RAW-TABLE.
+     Currently, this is only used for iterating over the values in a `_metabase_metadata` table. As such, the results are not expected to be returned lazily.
+     There is no expectation that the results be returned in any given order."))
 
 
 (defn- percent-valid-urls

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -8,12 +8,11 @@
                       [db :as db])
             (metabase.models [database :refer [Database]]
                              [query-execution :refer [QueryExecution]]
-                             raw-table
                              [setting :refer [defsetting]])
             [metabase.util :as u])
   (:import clojure.lang.Keyword
            metabase.models.database.DatabaseInstance
-           metabase.models.raw_table.RawTableInstance))
+           metabase.models.field.FieldInstance))
 
 
 ;;; ## INTERFACE + CONSTANTS
@@ -54,7 +53,7 @@
     "*OPTIONAL*. Return a map containing information that provides optional analysis values for TABLE.
      Output should match the `AnalyzeTable` schema.")
 
-  (can-connect? ^Boolean [this, ^Map details-map]
+  (can-connect? ^Boolean [this, ^java.util.Map details-map]
     "Check whether we can connect to a `Database` with DETAILS-MAP and perform a simple query. For example, a SQL database might
      try running a query like `SELECT 1;`. This function should return `true` or `false`.")
 
@@ -111,7 +110,7 @@
 
           Is this property required? Defaults to `false`.")
 
-  (execute-query ^java.util.Map [this, ^Map query]
+  (execute-query ^java.util.Map [this, ^java.util.Map query]
     "Execute a query against the database and return the results.
 
   The query passed in will contain:
@@ -148,7 +147,7 @@
     "*OPTIONAL*. Return a humanized (user-facing) version of an connection error message string.
      Generic error messages are provided in the constant `connection-error-messages`; return one of these whenever possible.")
 
-  (mbql->native ^java.util.Map [this, ^Map query]
+  (mbql->native ^java.util.Map [this, ^java.util.Map query]
     "Transpile an MBQL structured query into the appropriate native query form.
 
   The input QUERY will be a [fully-expanded MBQL query](https://github.com/metabase/metabase/wiki/Expanded-Queries) with
@@ -168,7 +167,7 @@
     "*OPTIONAL*. Notify the driver that the attributes of the DATABASE have changed.  This is specifically relevant in
      the event that the driver was doing some caching or connection pooling.")
 
-  (process-query-in-context [this, ^IFn qp]
+  (process-query-in-context [this, ^clojure.lang.IFn qp]
     "*OPTIONAL*. Similar to `sync-in-context`, but for running queries rather than syncing. This should be used to do things like open DB connections
      that need to remain open for the duration of post-processing. This function follows a middleware pattern and is injected into the QP
      middleware stack immediately after the Query Expander; in other words, it will receive the expanded query.
@@ -178,7 +177,7 @@
          (fn [query]
            (qp query)))")
 
-  (sync-in-context [this, ^DatabaseInstance database, ^IFn f]
+  (sync-in-context [this, ^DatabaseInstance database, ^clojure.lang.IFn f]
     "*OPTIONAL*. Drivers may provide this function if they need to do special setup before a sync operation such as `sync-database!`. The sync
      operation itself is encapsulated as the lambda F, which must be called with no arguments.
 
@@ -186,8 +185,8 @@
          (with-connection [_ database]
            (f)))")
 
-  (table-rows-seq ^clojure.lang.Sequential [this, ^DatabaseInstance database, ^RawTableInstance raw-table]
-    "*OPTIONAL*. Return a sequence of *all* the rows in a given RAW-TABLE.
+  (table-rows-seq ^clojure.lang.Sequential [this, ^DatabaseInstance database, ^java.util.Map table]
+    "*OPTIONAL*. Return a sequence of *all* the rows in a given TABLE, which is guaranteed to have at least `:name` and `:schema` keys.
      Currently, this is only used for iterating over the values in a `_metabase_metadata` table. As such, the results are not expected to be returned lazily.
      There is no expectation that the results be returned in any given order."))
 

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -7,6 +7,7 @@
             (metabase [config :as config]
                       [db :as db])
             (metabase.models [database :refer [Database]]
+                             field
                              [query-execution :refer [QueryExecution]]
                              [setting :refer [defsetting]])
             [metabase.util :as u])

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -19,7 +19,6 @@
            java.util.Map
            (clojure.lang Keyword PersistentVector)
            com.mchange.v2.c3p0.ComboPooledDataSource
-           metabase.models.raw_table.RawTableInstance
            (metabase.query_processor.interface Field Value)))
 
 (defprotocol ISQLDriver
@@ -236,9 +235,8 @@
     (fetch-page 0)))
 
 
-(defn- table-rows-seq [driver database, ^RawTableInstance raw-table]
-  {:pre [(instance? RawTableInstance raw-table)]}
-  (query driver database raw-table {:select [:*]}))
+(defn- table-rows-seq [driver database table]
+  (query driver database table {:select [:*]}))
 
 (defn- field-avg-length
   [driver field]
@@ -277,9 +275,9 @@
         db          (table/database table)
         field-k     (qualify+escape table field)
         pk-field    (field/Field (table/pk-field-id table))
-        results     (map :is_url (query driver db table (merge {:select   [[(hsql/call :like field-k (hx/literal "http%://_%.__%")) :is_url]]
-                                                                :where    [:not= field-k nil]
-                                                                :limit    driver/max-sync-lazy-seq-results}
+        results     (map :is_url (query driver db table (merge {:select [[(hsql/call :like field-k (hx/literal "http%://_%.__%")) :is_url]]
+                                                                :where  [:not= field-k nil]
+                                                                :limit  driver/max-sync-lazy-seq-results}
                                                                (when pk-field
                                                                  {:order-by [[(qualify+escape table pk-field) :asc]]}))))
         total-count (count results)

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -83,7 +83,7 @@
   (db/select-one-field :db_id Table, :id table-id))
 
 
-(defn retire-tables
+(defn retire-tables!
   "Retire all `Tables` in the list of TABLE-IDs along with all of each tables `Fields`."
   [table-ids]
   {:pre [(set? table-ids) (every? integer? table-ids)]}
@@ -95,7 +95,7 @@
     (db/update-where! Field {:table_id [:in table-ids]}
       :visibility_type "retired")))
 
-(defn update-table
+(defn update-table!
   "Update `Table` with the data from TABLE-DEF."
   [{:keys [id display_name], :as existing-table} {table-name :name}]
   {:pre [(integer? id)]}
@@ -109,7 +109,7 @@
     updated-table))
 
 
-(defn create-table
+(defn create-table!
   "Create `Table` with the data from TABLE-DEF."
   [database-id {schema-name :schema, table-name :name, raw-table-id :raw-table-id, visibility-type :visibility-type}]
   (db/insert! Table

--- a/src/metabase/sync_database/introspect.clj
+++ b/src/metabase/sync_database/introspect.clj
@@ -82,7 +82,6 @@
                 :name         table-name
                 :details      (or details {})
                 :active       true)]
-    ;; save columns
     (save-all-table-columns! table fields)))
 
 (defn- update-raw-table!

--- a/test/metabase/driver/generic_sql_test.clj
+++ b/test/metabase/driver/generic_sql_test.clj
@@ -106,9 +106,9 @@
    {:name "The Apple Pan",                :price 2, :category_id 11, :id 3}
    {:name "Wurstküche",                   :price 2, :category_id 29, :id 4}
    {:name "Brite Spot Family Restaurant", :price 2, :category_id 20, :id 5}]
-  (for [row (take 5 (table-rows-seq datasets/*driver*
-                                    (db/select-one 'Database :id (id))
-                                    (db/select-one 'Table :id (id :venues))))]
+  (for [row (take 5 (sort-by :id (table-rows-seq datasets/*driver*
+                                                 (db/select-one 'Database :id (id))
+                                                 (db/select-one 'RawTable :id (db/select-one-field :raw_table_id 'Table, :id (id :venues))))))]
     (dissoc row :latitude :longitude))) ; different DBs use different precisions for these
 
 ;;; FIELD-PERCENT-URLS


### PR DESCRIPTION
Fixes #2706.

This was ultimately caused by `metabase.driver/table-rows-seq` expecting a `Table` but getting passed a `RawTable`; it was fetching a primary key `Field` whose `table_id` was the `id` of the aforementioned **`RawTable`** (:scream:). This wasn't caught in tests because in some cases their IDs matched (e.g. `RawTable 4 <-> Table 4`); when syncing the sample dataset, this wasn't the case, exposing the bug.

Added additional checks and reworked code to work as intended.
