### PR TITLE
Return column :source in QP results :information_source:

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -41,7 +41,6 @@
                               (pre-insert 1)
                               (pre-update 1)
                               (project 1)
-                              (qp-expect-with-all-engines 1)
                               (qp-expect-with-engines 1)
                               (query-with-temp-db 1)
                               (resolve-private-fns 1)

--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -105,8 +105,9 @@ export const isBoolean = isFieldType.bind(null, BOOLEAN);
 export const isString = isFieldType.bind(null, STRING);
 export const isSummable = isFieldType.bind(null, SUMMABLE);
 export const isCategory = isFieldType.bind(null, CATEGORY);
-export const isDimension = () => true;
-export const isMetric = (col) => isNumeric(col)
+
+export const isDimension = (col) => (col && col.source !== "aggregation");
+export const isMetric    = (col) => (col && col.source !== "breakout") && isNumeric(col);
 
 // operator argument constructors:
 

--- a/src/metabase/query_processor/annotate.clj
+++ b/src/metabase/query_processor/annotate.clj
@@ -201,7 +201,7 @@
                            :special-type       :special_type
                            :visibility-type    :visibility_type
                            :table-id           :table_id})
-        (dissoc :position :clause-position :source :parent :parent-id :table-name :fk-field-id))))
+        (dissoc :position :clause-position :parent :parent-id :table-name :fk-field-id))))
 
 (defn- fk-field->dest-fn
   "Fetch fk info and return a function that returns the destination Field of a given Field."

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -53,7 +53,7 @@
   [{:data         {:rows    [[1000]]
                    :columns ["count"]
                    :cols    [{:base_type "IntegerField", :special_type "number", :name "count", :display_name "count", :id nil, :table_id nil,
-                              :description nil, :target nil, :extra_info {}}]
+                              :description nil, :target nil, :extra_info {}, :source "aggregation"}]
                    :native_form true}
     :row_count    1
     :status       "completed"
@@ -146,7 +146,7 @@
     :result {:data         {:rows    [[1000]]
                             :columns ["count"]
                             :cols    [{:base_type "IntegerField", :special_type "number", :name "count", :display_name "count", :id nil, :table_id nil,
-                                       :description nil, :target nil, :extra_info {}}]
+                                       :description nil, :target nil, :extra_info {}, :source "aggregation"}]
                             :native_form true}
              :row_count    1
              :status       "completed"

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -39,7 +39,9 @@
      ~expected
      ~actual))
 
-(defmacro ^:private qp-expect-with-all-engines [data q-form & post-process-fns]
+(defmacro ^:private qp-expect-with-all-engines
+  {:style/indent 0}
+  [data q-form & post-process-fns]
   `(expect-with-non-timeseries-dbs
      {:status    :completed
       :row_count ~(count (:rows data))
@@ -72,7 +74,12 @@
    :target          nil
    :description     nil
    :visibility_type :normal
-   :schema_name     (default-schema)})
+   :schema_name     (default-schema)
+   :source          :fields})
+
+(defn- target-field [field]
+  (when (fks-supported?)
+    (dissoc field :target :extra_info :schema_name :source)))
 
 (defn- categories-col
   "Return column information for the `categories` column named by keyword COL."
@@ -135,8 +142,7 @@
      :category_id {:extra_info   (if (fks-supported?)
                                    {:target_table_id (id :categories)}
                                    {})
-                   :target       (when (fks-supported?)
-                                   (dissoc (categories-col :id) :target :extra_info :schema_name))
+                   :target       (target-field (categories-col :id))
                    :special_type (if (fks-supported?)
                                    :fk
                                    :category)
@@ -180,9 +186,7 @@
                 :display_name "ID"}
      :venue_id {:extra_info   (if (fks-supported?) {:target_table_id (id :venues)}
                                   {})
-                :target       (if (fks-supported?) (-> (venues-col :id)
-                                                       (dissoc :target :extra_info :schema_name))
-                                  nil)
+                :target       (target-field (venues-col :id))
                 :special_type (when (fks-supported?)
                                 :fk)
                 :base_type    (expected-base-type->actual :IntegerField)
@@ -190,9 +194,7 @@
                 :display_name "Venue ID"}
      :user_id  {:extra_info   (if (fks-supported?) {:target_table_id (id :users)}
                                   {})
-                :target       (if (fks-supported?) (-> (users-col :id)
-                                                       (dissoc :target :extra_info :schema_name))
-                                  nil)
+                :target       (target-field (users-col :id))
                 :special_type (if (fks-supported?) :fk
                                   :category)
                 :base_type    (expected-base-type->actual :IntegerField)
@@ -217,6 +219,7 @@
               :id           nil
               :table_id     nil
               :description  nil
+              :source       :aggregation
               :extra_info   {}
               :target       nil}))
   ([ag-col-kw {:keys [base_type special_type]}]
@@ -226,10 +229,14 @@
     :id           nil
     :table_id     nil
     :description  nil
+    :source       :aggregation
     :extra_info   {}
     :target       nil
     :name         (name ag-col-kw)
     :display_name (name ag-col-kw)}))
+
+(defn- breakout-col [column]
+  (assoc column :source :breakout))
 
 (defn boolean-native-form
   "Convert :native_form attribute to a boolean to make test results comparisons easier"
@@ -297,73 +304,73 @@
 ;;; ------------------------------------------------------------ "COUNT" AGGREGATION ------------------------------------------------------------
 
 (qp-expect-with-all-engines
-    {:rows    [[100]]
-     :columns ["count"]
-     :cols    [(aggregate-col :count)]
+    {:rows        [[100]]
+     :columns     ["count"]
+     :cols        [(aggregate-col :count)]
      :native_form true}
-  (->> (run-query venues
-         (ql/aggregation (ql/count)))
-       boolean-native-form
-       (format-rows-by [int])))
+    (->> (run-query venues
+           (ql/aggregation (ql/count)))
+         boolean-native-form
+         (format-rows-by [int])))
 
 
 ;;; ------------------------------------------------------------ "SUM" AGGREGATION ------------------------------------------------------------
 (qp-expect-with-all-engines
-    {:rows    [[203]]
-     :columns ["sum"]
-     :cols    [(aggregate-col :sum (venues-col :price))]
+    {:rows        [[203]]
+     :columns     ["sum"]
+     :cols        [(aggregate-col :sum (venues-col :price))]
      :native_form true}
-  (->> (run-query venues
-         (ql/aggregation (ql/sum $price)))
-       boolean-native-form
-       (format-rows-by [int])))
+    (->> (run-query venues
+           (ql/aggregation (ql/sum $price)))
+         boolean-native-form
+         (format-rows-by [int])))
 
 
 ;;; ------------------------------------------------------------ "AVG" AGGREGATION ------------------------------------------------------------
 (qp-expect-with-all-engines
-    {:rows    [[35.5059]]
-     :columns ["avg"]
-     :cols    [(aggregate-col :avg (venues-col :latitude))]
+    {:rows        [[35.5059]]
+     :columns     ["avg"]
+     :cols        [(aggregate-col :avg (venues-col :latitude))]
      :native_form true}
-  (->> (run-query venues
-         (ql/aggregation (ql/avg $latitude)))
-       boolean-native-form
-       (format-rows-by [(partial u/round-to-decimals 4)])))
+    (->> (run-query venues
+           (ql/aggregation (ql/avg $latitude)))
+         boolean-native-form
+         (format-rows-by [(partial u/round-to-decimals 4)])))
 
 
 ;;; ------------------------------------------------------------ "DISTINCT COUNT" AGGREGATION ------------------------------------------------------------
 (qp-expect-with-all-engines
-    {:rows    [[15]]
-     :columns ["count"]
-     :cols    [(aggregate-col :count)]
+    {:rows        [[15]]
+     :columns     ["count"]
+     :cols        [(aggregate-col :count)]
      :native_form true}
-  (->> (run-query checkins
-                  (ql/aggregation (ql/distinct $user_id)))
-       boolean-native-form
-       (format-rows-by [int])))
+    (->> (run-query checkins
+           (ql/aggregation (ql/distinct $user_id)))
+         boolean-native-form
+         (format-rows-by [int])))
 
 
 ;;; ------------------------------------------------------------ "ROWS" AGGREGATION ------------------------------------------------------------
 ;; Test that a rows aggregation just returns rows as-is.
 (qp-expect-with-all-engines
-    {:rows    [[ 1 "Red Medicine"                  4 10.0646 -165.374 3]
-               [ 2 "Stout Burgers & Beers"        11 34.0996 -118.329 2]
-               [ 3 "The Apple Pan"                11 34.0406 -118.428 2]
-               [ 4 "Wurstküche"                   29 33.9997 -118.465 2]
-               [ 5 "Brite Spot Family Restaurant" 20 34.0778 -118.261 2]
-               [ 6 "The 101 Coffee Shop"          20 34.1054 -118.324 2]
-               [ 7 "Don Day Korean Restaurant"    44 34.0689 -118.305 2]
-               [ 8 "25°"                          11 34.1015 -118.342 2]
-               [ 9 "Krua Siri"                    71 34.1018 -118.301 1]
-               [10 "Fred 62"                      20 34.1046 -118.292 2]]
-     :columns (venues-columns)
-     :cols    (venues-cols)
+    {:rows        [[ 1 "Red Medicine"                  4 10.0646 -165.374 3]
+                   [ 2 "Stout Burgers & Beers"        11 34.0996 -118.329 2]
+                   [ 3 "The Apple Pan"                11 34.0406 -118.428 2]
+                   [ 4 "Wurstküche"                   29 33.9997 -118.465 2]
+                   [ 5 "Brite Spot Family Restaurant" 20 34.0778 -118.261 2]
+                   [ 6 "The 101 Coffee Shop"          20 34.1054 -118.324 2]
+                   [ 7 "Don Day Korean Restaurant"    44 34.0689 -118.305 2]
+                   [ 8 "25°"                          11 34.1015 -118.342 2]
+                   [ 9 "Krua Siri"                    71 34.1018 -118.301 1]
+                   [10 "Fred 62"                      20 34.1046 -118.292 2]]
+     :columns     (venues-columns)
+     :cols        (venues-cols)
      :native_form true}
-  (->> (run-query venues
-                  (ql/limit 10)
-                  (ql/order-by (ql/asc $id)))
-       boolean-native-form
-       formatted-venues-rows))
+    (->> (run-query venues
+           (ql/limit 10)
+           (ql/order-by (ql/asc $id)))
+         boolean-native-form
+         formatted-venues-rows))
 
 
 ;;; ------------------------------------------------------------ "PAGE" CLAUSE ------------------------------------------------------------
@@ -578,7 +585,7 @@
     {:rows    [[1 31] [2 70] [3 75] [4 77] [5 69] [6 70] [7 76] [8 81] [9 68] [10 78] [11 74] [12 59] [13 76] [14 62] [15 34]],
      :columns [(format-name "user_id")
                "count"]
-     :cols    [(checkins-col :user_id)
+     :cols    [(breakout-col (checkins-col :user_id))
                (aggregate-col :count)]
      :native_form true}
   (->> (run-query checkins
@@ -591,7 +598,7 @@
 ;;; BREAKOUT w/o AGGREGATION
 ;; This should act as a "distinct values" query and return ordered results
 (qp-expect-with-all-engines
-    {:cols    [(checkins-col :user_id)]
+    {:cols    [(breakout-col (checkins-col :user_id))]
      :columns [(format-name "user_id")]
      :rows    [[1] [2] [3] [4] [5] [6] [7] [8] [9] [10]]
      :native_form true}
@@ -609,8 +616,8 @@
      :columns [(format-name "user_id")
                (format-name "venue_id")
                "count"]
-     :cols    [(checkins-col :user_id)
-               (checkins-col :venue_id)
+     :cols    [(breakout-col (checkins-col :user_id))
+               (breakout-col (checkins-col :venue_id))
                (aggregate-col :count)]
      :native_form true}
   (->> (run-query checkins
@@ -627,8 +634,8 @@
      :columns [(format-name "user_id")
                (format-name "venue_id")
                "count"]
-     :cols    [(checkins-col :user_id)
-               (checkins-col :venue_id)
+     :cols    [(breakout-col (checkins-col :user_id))
+               (breakout-col (checkins-col :venue_id))
                (aggregate-col :count)]
      :native_form true}
   (->> (run-query checkins
@@ -651,16 +658,16 @@
 ;; Apply an arbitrary max-results on the query and ensure our results size is appropriately constrained
 (expect 1234
   (->> (((resolve 'metabase.query-processor/limit) identity) {:constraints {:max-results 1234}
-                                                                     :query       {:aggregation {:aggregation-type :count}}
-                                                                     :rows        (repeat [:ok])})
+                                                              :query       {:aggregation {:aggregation-type :count}}
+                                                              :rows        (repeat [:ok])})
        :rows
        count))
 
 ;; Apply a max-results-bare-rows limit specifically on :rows type query
 (expect [46 46]
   (let [res (((resolve 'metabase.query-processor/limit) identity) {:constraints {:max-results 46}
-                                                                          :query       {:aggregation {:aggregation-type :rows}}
-                                                                          :rows        (repeat [:ok])})]
+                                                                   :query       {:aggregation {:aggregation-type :rows}}
+                                                                   :rows        (repeat [:ok])})]
     [(->> res :rows count)
      (->> res :query :limit)]))
 
@@ -674,7 +681,7 @@
      :cols    [(aggregate-col :sum (users-col :id))]
      :native_form true}
   (->> (run-query users
-                  (ql/aggregation (ql/cum-sum $id)))
+         (ql/aggregation (ql/cum-sum $id)))
        boolean-native-form
        (format-rows-by [int])))
 
@@ -686,55 +693,55 @@
      :cols    [(users-col :id)]
      :native_form true}
     (->> (run-query users
-                    (ql/aggregation (ql/cum-sum $id))
-                    (ql/breakout $id))
+           (ql/aggregation (ql/cum-sum $id))
+           (ql/breakout $id))
          boolean-native-form
          (format-rows-by [int])))
 
 
 ;;; Cumulative sum w/ a different breakout field
 (qp-expect-with-all-engines
-    {:rows    [["Broen Olujimi"        14]
-               ["Conchúr Tihomir"      21]
-               ["Dwight Gresham"       34]
-               ["Felipinho Asklepios"  36]
-               ["Frans Hevel"          46]
-               ["Kaneonuskatew Eiran"  49]
-               ["Kfir Caj"             61]
-               ["Nils Gotam"           70]
-               ["Plato Yeshua"         71]
-               ["Quentin Sören"        76]
-               ["Rüstem Hebel"         91]
-               ["Shad Ferdynand"       97]
-               ["Simcha Yan"          101]
-               ["Spiros Teofil"       112]
-               ["Szymon Theutrich"    120]]
-     :columns [(format-name "name")
-               "sum"]
-     :cols    [(users-col :name)
-               (aggregate-col :sum (users-col :id))]
-     :native_form true}
+  {:rows        [["Broen Olujimi"        14]
+                 ["Conchúr Tihomir"      21]
+                 ["Dwight Gresham"       34]
+                 ["Felipinho Asklepios"  36]
+                 ["Frans Hevel"          46]
+                 ["Kaneonuskatew Eiran"  49]
+                 ["Kfir Caj"             61]
+                 ["Nils Gotam"           70]
+                 ["Plato Yeshua"         71]
+                 ["Quentin Sören"        76]
+                 ["Rüstem Hebel"         91]
+                 ["Shad Ferdynand"       97]
+                 ["Simcha Yan"          101]
+                 ["Spiros Teofil"       112]
+                 ["Szymon Theutrich"    120]]
+   :columns     [(format-name "name")
+                 "sum"]
+   :cols        [(breakout-col (users-col :name))
+                 (aggregate-col :sum (users-col :id))]
+   :native_form true}
   (->> (run-query users
-                  (ql/aggregation (ql/cum-sum $id))
-                  (ql/breakout $name))
+         (ql/aggregation (ql/cum-sum $id))
+         (ql/breakout $name))
        boolean-native-form
        (format-rows-by [str int])))
 
 
 ;;; Cumulative sum w/ a different breakout field that requires grouping
 (qp-expect-with-all-engines
-    {:columns [(format-name "price")
-               "sum"]
-     :cols    [(venues-col :price)
-               (aggregate-col :sum (venues-col :id))]
-     :rows    [[1 1211]
-               [2 4066]
-               [3 4681]
-               [4 5050]]
-     :native_form true}
+  {:columns     [(format-name "price")
+                 "sum"]
+   :cols        [(breakout-col (venues-col :price))
+                 (aggregate-col :sum (venues-col :id))]
+   :rows        [[1 1211]
+                 [2 4066]
+                 [3 4681]
+                 [4 5050]]
+   :native_form true}
   (->> (run-query venues
-                  (ql/aggregation (ql/cum-sum $id))
-                  (ql/breakout $price))
+         (ql/aggregation (ql/cum-sum $id))
+         (ql/breakout $price))
        boolean-native-form
        (format-rows-by [int int])))
 
@@ -759,47 +766,47 @@
 
 ;;; Cumulative count w/ a different breakout field
 (qp-expect-with-all-engines
-    {:rows    [["Broen Olujimi"        1]
-               ["Conchúr Tihomir"      2]
-               ["Dwight Gresham"       3]
-               ["Felipinho Asklepios"  4]
-               ["Frans Hevel"          5]
-               ["Kaneonuskatew Eiran"  6]
-               ["Kfir Caj"             7]
-               ["Nils Gotam"           8]
-               ["Plato Yeshua"         9]
-               ["Quentin Sören"       10]
-               ["Rüstem Hebel"        11]
-               ["Shad Ferdynand"      12]
-               ["Simcha Yan"          13]
-               ["Spiros Teofil"       14]
-               ["Szymon Theutrich"    15]]
-     :columns [(format-name "name")
-               "count"]
-     :cols    [(users-col :name)
-               (cumulative-count-col users-col :id)]
-     :native_form true}
+  {:rows        [["Broen Olujimi"        1]
+                 ["Conchúr Tihomir"      2]
+                 ["Dwight Gresham"       3]
+                 ["Felipinho Asklepios"  4]
+                 ["Frans Hevel"          5]
+                 ["Kaneonuskatew Eiran"  6]
+                 ["Kfir Caj"             7]
+                 ["Nils Gotam"           8]
+                 ["Plato Yeshua"         9]
+                 ["Quentin Sören"       10]
+                 ["Rüstem Hebel"        11]
+                 ["Shad Ferdynand"      12]
+                 ["Simcha Yan"          13]
+                 ["Spiros Teofil"       14]
+                 ["Szymon Theutrich"    15]]
+   :columns     [(format-name "name")
+                 "count"]
+   :cols        [(breakout-col (users-col :name))
+                 (cumulative-count-col users-col :id)]
+   :native_form true}
   (->> (run-query users
-                  (ql/aggregation (ql/cum-count))
-                  (ql/breakout $name))
+         (ql/aggregation (ql/cum-count))
+         (ql/breakout $name))
        boolean-native-form
        (format-rows-by [str int])))
 
 
 ;;; Cumulative count w/ a different breakout field that requires grouping
 (qp-expect-with-all-engines
-    {:columns [(format-name "price")
-               "count"]
-     :cols    [(venues-col :price)
-               (cumulative-count-col venues-col :id)]
-     :rows    [[1 22]
-               [2 81]
-               [3 94]
-               [4 100]]
-     :native_form true}
+  {:columns     [(format-name "price")
+                 "count"]
+   :cols        [(breakout-col (venues-col :price))
+                 (cumulative-count-col venues-col :id)]
+   :rows        [[1 22]
+                 [2 81]
+                 [3 94]
+                 [4 100]]
+   :native_form true}
   (->> (run-query venues
-                  (ql/aggregation (ql/cum-count))
-                  (ql/breakout $price))
+         (ql/aggregation (ql/cum-count))
+         (ql/breakout $price))
        boolean-native-form
        (format-rows-by [int int])))
 
@@ -807,9 +814,9 @@
 ;;; ------------------------------------------------------------ STDDEV AGGREGATION ------------------------------------------------------------
 
 (qp-expect-with-engines (engines-that-support :standard-deviation-aggregations)
-  {:columns ["stddev"]
-   :cols    [(aggregate-col :stddev (venues-col :latitude))]
-   :rows    [[3.4]]
+  {:columns     ["stddev"]
+   :cols        [(aggregate-col :stddev (venues-col :latitude))]
+   :rows        [[3.4]]
    :native_form true}
   (-> (run-query venues
         (ql/aggregation (ql/stddev $latitude)))
@@ -830,71 +837,71 @@
 
 ;;; order_by aggregate ["count"]
 (qp-expect-with-all-engines
-  {:columns [(format-name "price")
-             "count"]
-   :rows    [[4  6]
-             [3 13]
-             [1 22]
-             [2 59]]
-   :cols    [(venues-col :price)
-             (aggregate-col :count)]
+  {:columns     [(format-name "price")
+                 "count"]
+   :rows        [[4  6]
+                 [3 13]
+                 [1 22]
+                 [2 59]]
+   :cols        [(breakout-col (venues-col :price))
+                 (aggregate-col :count)]
    :native_form true}
   (->> (run-query venues
-                  (ql/aggregation (ql/count))
-                  (ql/breakout $price)
-                  (ql/order-by (ql/asc (ql/aggregate-field 0))))
+         (ql/aggregation (ql/count))
+         (ql/breakout $price)
+         (ql/order-by (ql/asc (ql/aggregate-field 0))))
        boolean-native-form
        (format-rows-by [int int])))
 
 
 ;;; order_by aggregate ["sum" field-id]
 (qp-expect-with-all-engines
-  {:columns [(format-name "price")
-             "sum"]
-   :rows    [[2 2855]
-             [1 1211]
-             [3  615]
-             [4  369]]
-   :cols    [(venues-col :price)
-             (aggregate-col :sum (venues-col :id))]
+  {:columns     [(format-name "price")
+                 "sum"]
+   :rows        [[2 2855]
+                 [1 1211]
+                 [3  615]
+                 [4  369]]
+   :cols        [(breakout-col (venues-col :price))
+                 (aggregate-col :sum (venues-col :id))]
    :native_form true}
   (->> (run-query venues
-                  (ql/aggregation (ql/sum $id))
-                  (ql/breakout $price)
-                  (ql/order-by (ql/desc (ql/aggregate-field 0))))
+         (ql/aggregation (ql/sum $id))
+         (ql/breakout $price)
+         (ql/order-by (ql/desc (ql/aggregate-field 0))))
        boolean-native-form
        (format-rows-by [int int])))
 
 
 ;;; order_by aggregate ["distinct" field-id]
 (qp-expect-with-all-engines
-  {:columns [(format-name "price")
-             "count"]
-   :rows    [[4  6]
-             [3 13]
-             [1 22]
-             [2 59]]
-   :cols    [(venues-col :price)
-             (aggregate-col :count)]
+  {:columns     [(format-name "price")
+                 "count"]
+   :rows        [[4  6]
+                 [3 13]
+                 [1 22]
+                 [2 59]]
+   :cols        [(breakout-col (venues-col :price))
+                 (aggregate-col :count)]
    :native_form true}
   (->> (run-query venues
-                  (ql/aggregation (ql/distinct $id))
-                  (ql/breakout $price)
-                  (ql/order-by (ql/asc (ql/aggregate-field 0))))
+         (ql/aggregation (ql/distinct $id))
+         (ql/breakout $price)
+         (ql/order-by (ql/asc (ql/aggregate-field 0))))
        boolean-native-form
        (format-rows-by [int int])))
 
 
 ;;; order_by aggregate ["avg" field-id]
 (expect-with-non-timeseries-dbs
-  {:columns [(format-name "price")
-             "avg"]
-   :rows    [[3 22]
-             [2 28]
-             [1 32]
-             [4 53]]
-   :cols    [(venues-col :price)
-             (aggregate-col :avg (venues-col :category_id))]
+  {:columns     [(format-name "price")
+                 "avg"]
+   :rows        [[3 22]
+                 [2 28]
+                 [1 32]
+                 [4 53]]
+   :cols        [(breakout-col (venues-col :price))
+                 (aggregate-col :avg (venues-col :category_id))]
    :native_form true}
   (->> (run-query venues
          (ql/aggregation (ql/avg $category_id))
@@ -907,14 +914,14 @@
 ;; SQRT calculations are always NOT EXACT (normal behavior) so round everything to the nearest int.
 ;; Databases might use different versions of SQRT implementations
 (datasets/expect-with-engines (engines-that-support :standard-deviation-aggregations)
-  {:columns [(format-name "price")
-             "stddev"]
-   :rows    [[3 (if (contains? #{:mysql :crate} *engine*) 25 26)]
-             [1 24]
-             [2 21]
-             [4 (if (contains? #{:mysql :crate} *engine*) 14 15)]]
-   :cols    [(venues-col :price)
-             (aggregate-col :stddev (venues-col :category_id))]
+  {:columns     [(format-name "price")
+                 "stddev"]
+   :rows        [[3 (if (contains? #{:mysql :crate} *engine*) 25 26)]
+                 [1 24]
+                 [2 21]
+                 [4 (if (contains? #{:mysql :crate} *engine*) 14 15)]]
+   :cols        [(breakout-col (venues-col :price))
+                 (aggregate-col :stddev (venues-col :category_id))]
    :native_form true}
   (->> (run-query venues
          (ql/aggregation (ql/stddev $category_id))
@@ -933,8 +940,7 @@
      (venues-col :latitude)
      (venues-col :id)
      (venues-col :longitude)
-     (-> (venues-col :price)
-         (assoc :visibility_type :details-only))}
+     (assoc (venues-col :price) :visibility_type :details-only)}
    (set (venues-cols))]
   (let [get-col-names (fn [] (-> (run-query venues
                                    (ql/order-by (ql/asc $id))
@@ -950,26 +956,26 @@
 ;;; ------------------------------------------------------------ :sensitive fields ------------------------------------------------------------
 ;;; Make sure :sensitive information fields are never returned by the QP
 (qp-expect-with-all-engines
-    {:columns (->columns "id" "name" "last_login")
-     :cols    [(users-col :id)
-               (users-col :name)
-               (users-col :last_login)],
-     :rows    [[ 1 "Plato Yeshua"]
-               [ 2 "Felipinho Asklepios"]
-               [ 3 "Kaneonuskatew Eiran"]
-               [ 4 "Simcha Yan"]
-               [ 5 "Quentin Sören"]
-               [ 6 "Shad Ferdynand"]
-               [ 7 "Conchúr Tihomir"]
-               [ 8 "Szymon Theutrich"]
-               [ 9 "Nils Gotam"]
-               [10 "Frans Hevel"]
-               [11 "Spiros Teofil"]
-               [12 "Kfir Caj"]
-               [13 "Dwight Gresham"]
-               [14 "Broen Olujimi"]
-               [15 "Rüstem Hebel"]]
-     :native_form true}
+  {:columns     (->columns "id" "name" "last_login")
+   :cols        [(users-col :id)
+                 (users-col :name)
+                 (users-col :last_login)],
+   :rows        [[ 1 "Plato Yeshua"]
+                 [ 2 "Felipinho Asklepios"]
+                 [ 3 "Kaneonuskatew Eiran"]
+                 [ 4 "Simcha Yan"]
+                 [ 5 "Quentin Sören"]
+                 [ 6 "Shad Ferdynand"]
+                 [ 7 "Conchúr Tihomir"]
+                 [ 8 "Szymon Theutrich"]
+                 [ 9 "Nils Gotam"]
+                 [10 "Frans Hevel"]
+                 [11 "Spiros Teofil"]
+                 [12 "Kfir Caj"]
+                 [13 "Dwight Gresham"]
+                 [14 "Broen Olujimi"]
+                 [15 "Rüstem Hebel"]]
+   :native_form true}
   ;; Filter out the timestamps from the results since they're hard to test :/
   (-> (run-query users
         (ql/order-by (ql/asc $id)))
@@ -1217,12 +1223,12 @@
 ;;; Nested Field in BREAKOUT
 ;; Let's see how many tips we have by source.service
 (datasets/expect-with-engines (engines-that-support :nested-fields)
-  {:rows    [["facebook"   107]
-             ["flare"      105]
-             ["foursquare" 100]
-             ["twitter"     98]
-             ["yelp"        90]]
-   :columns ["source.service" "count"]
+  {:rows        [["facebook"   107]
+                 ["flare"      105]
+                 ["foursquare" 100]
+                 ["twitter"     98]
+                 ["yelp"        90]]
+   :columns     ["source.service" "count"]
    :native_form true}
   (->> (dataset geographical-tips
          (run-query tips


### PR DESCRIPTION
Implements #2729 

This implementation is slightly different from the original request but was the quickest to implement since we already had this information internally but were just discarding it before seriailzation. 

Columns now come back with a new `:source` attribute which will be `:aggregation`, `:breakout`, or `:fields`, depending on why the column is there. So that should be everything needed @tlrobinson 
