### PR TITLE
Temporarily disable new metadata queries tests for redshift/crate :cry:

### DIFF
--- a/test/metabase/db/metadata_queries_test.clj
+++ b/test/metabase/db/metadata_queries_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.db.metadata-queries-test
-  (:require [expectations :refer :all]
+  (:require [clojure.set :as set]
+            [expectations :refer :all]
             [metabase.db :as db]
             [metabase.db.metadata-queries :refer :all]
             (metabase.models [field :refer [Field]]
@@ -9,30 +10,33 @@
             [metabase.test.data.datasets :as datasets]))
 
 
+;; Redshift & Crate tests are randomly failing -- see https://github.com/metabase/metabase/issues/2767
+(def ^:private ^:const metadata-queries-test-engines
+  (set/difference  qp-test/non-timeseries-engines #{:redshift :crate}))
 
 ;; ### FIELD-DISTINCT-COUNT
-; (datasets/expect-with-engines qp-test/non-timeseries-engines
-;   100
-;   (field-distinct-count (Field (id :checkins :venue_id))))
+(datasets/expect-with-engines metadata-queries-test-engines
+  100
+  (field-distinct-count (Field (id :checkins :venue_id))))
 
-; (datasets/expect-with-engines qp-test/non-timeseries-engines
-;   15
-;   (field-distinct-count (Field (id :checkins :user_id))))
+(datasets/expect-with-engines metadata-queries-test-engines
+  15
+  (field-distinct-count (Field (id :checkins :user_id))))
 
 
 ;; ### FIELD-COUNT
-; (datasets/expect-with-engines qp-test/non-timeseries-engines
-;   1000
-;   (field-count (Field (id :checkins :venue_id))))
+(datasets/expect-with-engines metadata-queries-test-engines
+  1000
+  (field-count (Field (id :checkins :venue_id))))
 
 
 ;; ### TABLE-ROW-COUNT
-; (datasets/expect-with-engines qp-test/non-timeseries-engines
-;   1000
-;   (table-row-count (Table (id :checkins))))
+(datasets/expect-with-engines metadata-queries-test-engines
+  1000
+  (table-row-count (Table (id :checkins))))
 
 
 ;; ### FIELD-DISTINCT-VALUES
-; (datasets/expect-with-engines qp-test/non-timeseries-engines
-;   [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15]
-;   (field-distinct-values (Field (id :checkins :user_id))))
+(datasets/expect-with-engines metadata-queries-test-engines
+  [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15]
+  (field-distinct-values (Field (id :checkins :user_id))))


### PR DESCRIPTION
Until I can figure out why they're failing in #2767
