### PR TITLE
DB call counting :1234:

### DIFF
--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -96,7 +96,7 @@
 
 ;; ## MIGRATE
 
-(def ^:private ^:const changelog-file
+(def ^:private ^:const ^String changelog-file
   "migrations/liquibase.json")
 
 (defn migrate
@@ -262,6 +262,32 @@
   []
   ((quoting-style) @(resolve 'honeysql.format/quote-fns)))
 
+
+(def ^:private ^:dynamic *call-count*
+  "Atom used as a counter for DB calls when enabled.
+   This number isn't *perfectly* accurate, only mostly; DB calls made directly to JDBC or via old korma patterns won't be logged."
+  nil)
+
+(defn do-with-call-counting
+  "Execute F with DB call counting enabled. F is passed a single argument, a function that can be used to retrieve the current call count.
+   (It's probably more useful to use the macro form of this function, `with-call-counting`, instead.)"
+  {:style/indent 0}
+  [f]
+  (binding [*call-count* (atom 0)]
+    (f (partial deref *call-count*))))
+
+(defmacro with-call-counting
+  "Execute BODY and track the number of DB calls made inside it. CALL-COUNT-FN-BINDING is bound to a zero-arity function that can be used to fetch the current
+   DB call count.
+
+     (db/with-call-counting [call-count]
+       ...
+       (call-count))"
+  {:style/indent 1}
+  [[call-count-fn-binding] & body]
+  `(do-with-call-counting (fn [~call-count-fn-binding] ~@body)))
+
+
 (defn- honeysql->sql
   "Compile HONEYSQL-FORM to SQL.
   This returns a vector with the SQL string as its first item and prepared statement params as the remaining items."
@@ -271,7 +297,9 @@
   (u/prog1 (binding [hformat/*subquery?* false]
              (hsql/format honeysql-form, :quoting (quoting-style), :allow-dashed-names? true))
     (when-not *disable-db-logging*
-      (log/debug (str "DB Call: " (first <>))))))
+      (log/debug (str "DB Call: " (first <>)))
+      (when *call-count*
+        (swap! *call-count* inc)))))
 
 (defn query
   "Compile HONEYSQL-FROM and call `jdbc/query` against the Metabase database.

--- a/src/metabase/middleware.clj
+++ b/src/metabase/middleware.clj
@@ -235,7 +235,7 @@
 
 ;;; # ------------------------------------------------------------ LOGGING ------------------------------------------------------------
 
-(defn- log-response [{:keys [uri request-method]} {:keys [status body]} elapsed-time]
+(defn- log-response [{:keys [uri request-method]} {:keys [status body]} elapsed-time db-call-count]
   (let [log-error #(log/error %) ; these are macros so we can't pass by value :sad:
         log-debug #(log/debug %)
         log-warn  #(log/warn  %)
@@ -244,7 +244,7 @@
                                 (=  status 403) [true  'red   log-warn]
                                 (>= status 400) [true  'red   log-debug]
                                 :else           [false 'green log-debug])]
-    (log-fn (str (u/format-color color "%s %s %d (%s)" (.toUpperCase (name request-method)) uri status elapsed-time)
+    (log-fn (str (u/format-color color "%s %s %d (%s) (%d DB calls)" (.toUpperCase (name request-method)) uri status elapsed-time db-call-count)
                  ;; only print body on error so we don't pollute our environment by over-logging
                  (when (and error?
                             (or (string? body) (coll? body)))
@@ -257,5 +257,6 @@
     (if-not (api-call? request)
       (handler request)
       (let [start-time (System/nanoTime)]
-        (u/prog1 (handler request)
-          (log-response request <> (u/format-nanoseconds (- (System/nanoTime) start-time))))))))
+        (db/with-call-counting [call-count]
+          (u/prog1 (handler request)
+            (log-response request <> (u/format-nanoseconds (- (System/nanoTime) start-time)) (call-count))))))))

--- a/test/metabase/db_test.clj
+++ b/test/metabase/db_test.clj
@@ -9,3 +9,24 @@
 ;; parse all fields and query string arguments
 (expect {:type :postgres :user "tom" :password "1234" :host "localhost" :port "5432" :dbname "toms_cool_db" :ssl "true" :sslfactory "org.postgresql.ssl.NonValidatingFactory"}
   (db/parse-connection-string "postgres://tom:1234@localhost:5432/toms_cool_db?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory"))
+
+
+;;; call counting
+
+(expect
+  0
+  (db/with-call-counting [call-count]
+    (call-count)))
+
+(expect
+  1
+  (db/with-call-counting [call-count]
+    (db/select-one-count 'Database)
+    (call-count)))
+
+(expect
+  5
+  (db/with-call-counting [call-count]
+    (doseq [_ (range 5)]
+      (db/select-one-count 'Database))
+    (call-count)))


### PR DESCRIPTION
Simple macro for counting the number of calls made by the DB over a given period of time; use this to include the number of DB calls made by each API call in the logs.

``` clojure
(db/with-call-counting [call-count]
  (doseq [_ (range 5)]
    (db/select-one 'Database))
  (call-count)) ; -> 5
```

In action: 

![screen shot 2016-06-15 at 5 35 26 pm](https://cloud.githubusercontent.com/assets/1455846/16102184/0993a314-3322-11e6-8ae5-1a4c933db76d.png)

This is potentially useful in other places as well, e.g. tests. In the old Django days we had a few tests that counted DB calls made sure certain endpoints didn't suffer from the n+1 problem, which they did; Clojure Metabase makes dreams come true, so we don't need to worry about this problem (or rather, I have done the worrying already and made it nigh-impossible to write such code). But now we could worry about if we wanted! 🙀 
