### PR TITLE
Fix object detail for PK field

### DIFF
--- a/frontend/src/metabase/lib/query_time.js
+++ b/frontend/src/metabase/lib/query_time.js
@@ -153,7 +153,7 @@ export function parseFieldBucketing(field, defaultUnit = null) {
     if (Array.isArray(field)) {
         if (field[0] === "datetime_field") {
             return field[3];
-        } if (field[0] === "fk->") {
+        } if (field[0] === "fk->" || field[0] === "field-id") {
             return defaultUnit;
         } else {
             console.warn("Unknown field format", field);
@@ -163,15 +163,15 @@ export function parseFieldBucketing(field, defaultUnit = null) {
 }
 
 export function parseFieldTarget(field) {
+    if (Number.isInteger(field)) return field;
+
     if (Array.isArray(field)) {
-        if (field[0] === "datetime_field") {
-            return field[1];
-        } if (field[0] === "fk->") {
-            return field;
-        } else {
-            console.warn("Unknown field format", field);
-        }
+        if (field[0] === "field-id")       return field[1];
+        if (field[0] === "fk->")           return field[1];
+        if (field[0] === "datetime_field") return parseFieldTarget(field[1]);
     }
+
+    console.warn("Unknown field format", field);
     return field;
 }
 

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -5,6 +5,7 @@ import _ from "underscore";
 import { isCardDirty } from "metabase/lib/card";
 import * as DataGrid from "metabase/lib/data_grid";
 import Query from "metabase/lib/query";
+import { parseFieldTarget } from "metabase/lib/query_time";
 
 
 export const uiControls                = state => state.uiControls;
@@ -32,7 +33,7 @@ export const tables = createSelector(
 	            return db.tables;
 	        }
     	}
-        
+
         return [];
     }
 );
@@ -49,7 +50,7 @@ export const isObjectDetail = createSelector(
 
 		let response = false;
 
-	    // NOTE: we specifically use only the query result here because we don't want the state of the 
+	    // NOTE: we specifically use only the query result here because we don't want the state of the
 	    //       visualization being shown (Object Details) to change as the query/card changes.
 
 	    // "rows" type query w/ an '=' filter against the PK column
@@ -79,7 +80,7 @@ export const isObjectDetail = createSelector(
 	                if (Array.isArray(filter) &&
 	                        filter.length === 3 &&
 	                        filter[0] === "=" &&
-	                        filter[1] === pkField &&
+   	                        parseFieldTarget(filter[1]) === pkField &&
 	                        filter[2] !== null) {
 	                    // well, all of our conditions have passed so we have an object detail query here
 	                    response = true;


### PR DESCRIPTION
Poor lil computer was confused because as we've all learned in school `["field-id" <id>] !== <id>`. Make sure we call `parseFieldTarget` so we can pull the ID out when comparing.

Fixes #2780
