### PR TITLE
Don't apply magic sorting to BigQuery native queries :imp:

### DIFF
--- a/src/metabase/driver/bigquery.clj
+++ b/src/metabase/driver/bigquery.clj
@@ -351,7 +351,7 @@
         results (if mbql?
                   (post-process-mbql dataset-id table-name results)
                   (update results :columns (partial map keyword)))]
-    (assoc results :annotate? true)))
+    (assoc results :annotate? mbql?)))
 
 ;; This provides an implementation of `prepare-value` that prevents HoneySQL from converting forms to prepared statement parameters (`?`)
 ;; TODO - Move this into `metabase.driver.generic-sql` and document it as an alternate implementation for `prepare-value` (?)

--- a/test/metabase/driver/bigquery_test.clj
+++ b/test/metabase/driver/bigquery_test.clj
@@ -77,3 +77,15 @@
                              :type     :native
                              :database (data/id)})
           [:data :rows]))
+
+
+;; make sure that BigQuery native queries maintain the column ordering specified in the SQL -- post-processing ordering shouldn't apply (Issue #2821)
+(expect-with-engine :bigquery
+  ["venue_id" "user_id" "checkins_id"]
+  (get-in (qp/process-query {:native   {:query (apply format "SELECT [%stest_data.checkins.venue_id] AS [venue_id], [%stest_data.checkins.user_id] AS [user_id], [%stest_data.checkins.id] AS [checkins_id]
+                                                              FROM [%stest_data.checkins]
+                                                              LIMIT 2"
+                                                      (repeat 4 bq-data/unique-prefix))}
+                             :type     :native
+                             :database (data/id)})
+          [:data :columns]))


### PR DESCRIPTION
One-line fix plus a new unit test.

Fixes #2821
