### PR TITLE
Fix mongo type information for native queries :keyboard:

### DIFF
--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -338,6 +338,7 @@
    This loads the corresponding driver if needed."
   (let [db-id->engine (memoize (fn [db-id] (db/select-one-field :engine Database, :id db-id)))]
     (fn [db-id]
+      {:pre [db-id]}
       (engine->driver (db-id->engine db-id)))))
 
 

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -286,7 +286,8 @@
   (contains? (features driver) feature))
 
 (defn class->base-type
-  "Return the `Field.base_type` that corresponds to a given class returned by the DB."
+  "Return the `Field.base_type` that corresponds to a given class returned by the DB.
+   This is used to infer the types of results that come back from native queries."
   [klass]
   (or ({Boolean                         :BooleanField
         Double                          :FloatField

--- a/src/metabase/driver/druid/query_processor.clj
+++ b/src/metabase/driver/druid/query_processor.clj
@@ -532,7 +532,7 @@
 
 (defn execute-query
   "Execute a query for a Druid DB."
-  [do-query {database :database, {:keys [query query-type]} :native}]
+  [do-query {database :database, {:keys [query query-type mbql?]} :native}]
   {:pre [database query]}
   (let [details    (:details database)
         query      (if (string? query)
@@ -546,4 +546,4 @@
     {:columns   columns
      :rows      (for [row results]
                   (mapv row columns))
-     :annotate? true}))
+     :annotate? mbql?}))

--- a/src/metabase/driver/mongo/query_processor.clj
+++ b/src/metabase/driver/mongo/query_processor.clj
@@ -413,4 +413,4 @@
     {:columns   columns
      :rows      (for [row results]
                   (mapv row columns))
-     :annotate? true}))
+     :annotate? mbql?}))

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -168,7 +168,7 @@
       (qp query))))
 
 (defn- pre-expand-resolve
-  "Transforms an MBQL into an expanded form with more information and structure.  Also resolves references to fields, tables,
+  "Transforms an MBQL into an expanded form with more information and structure. Also resolves references to fields, tables,
    etc, into their concrete details which are necessary for query formation by the executing driver."
   [qp]
   (fn [{database-id :database, :as query}]
@@ -198,14 +198,15 @@
 
 
 (defn- format-rows [{:keys [report-timezone]} rows]
-  (for [row rows]
-    (for [v row]
-      (if (u/is-temporal? v)
-        ;; NOTE: if we don't have an explicit report-timezone then use the JVM timezone
-        ;;       this ensures alignment between the way dates are processed by JDBC and our returned data
-        ;;       GH issues: #2282, #2035
-        (u/->iso-8601-datetime v (or report-timezone (System/getProperty "user.timezone")))
-        v))))
+  (let [timezone (or report-timezone (System/getProperty "user.timezone"))]
+    (for [row rows]
+      (for [v row]
+        (if (u/is-temporal? v)
+          ;; NOTE: if we don't have an explicit report-timezone then use the JVM timezone
+          ;;       this ensures alignment between the way dates are processed by JDBC and our returned data
+          ;;       GH issues: #2282, #2035
+          (u/->iso-8601-datetime v timezone)
+          v)))))
 
 (defn- post-format-rows
   "Format individual query result values as needed.  Ex: format temporal values as iso8601 strings w/ timezone."
@@ -454,6 +455,16 @@
   ^String [{{:keys [executed-by uuid query-hash query-type], :as info} :info}]
   (format "Metabase:: userID: %s executionID: %s queryType: %s queryHash: %s" executed-by uuid query-type query-hash))
 
+(defn- infer-column-types
+  "Infer the types of columns by looking at the first value for each in the results, and add the relevant information in `:cols`.
+   This is used for native queries, which don't have the type information from the original `Field` objects used in the query, which is added to the results by `annotate`."
+  [results]
+  (assoc results
+    :columns (mapv name (:columns results))
+    :cols    (vec (for [[column first-value] (partition 2 (interleave (:columns results) (first (:rows results))))]
+                    {:name      (name column)
+                     :base_type (driver/class->base-type (type first-value))}))))
+
 (defn- run-query
   "The end of the QP middleware which actually executes the query on the driver.
 
@@ -473,10 +484,7 @@
         raw-result   (driver/execute-query (:driver query) native-query)
         query-result (if-not (or (mbql-query? query)
                                  (:annotate? raw-result))
-                       (assoc raw-result :columns (mapv name (:columns raw-result))
-                                         :cols    (for [[column first-value] (partition 2 (interleave (:columns raw-result) (first (:rows raw-result))))]
-                                                    {:name      (name column)
-                                                     :base_type (driver/class->base-type (type first-value))}))
+                       (infer-column-types raw-result)
                        (annotate/annotate query raw-result))]
     (assoc query-result :native_form native-form)))
 
@@ -543,7 +551,7 @@
 ;;; |                                     DATASET-QUERY PUBLIC API                                       |
 ;;; +----------------------------------------------------------------------------------------------------+
 
-(declare query-fail query-complete save-query-execution)
+(declare query-fail query-complete save-query-execution!)
 
 (defn- assert-valid-query-result [query-result]
   (when-not (contains? query-result :status)
@@ -600,7 +608,7 @@
         (log/error (u/format-color 'red "Query failure: %s\n%s" (.getMessage e) (u/pprint-to-str (u/filtered-stacktrace e))))
         (query-fail query-execution (.getMessage e))))))
 
-(defn query-fail
+(defn- query-fail
   "Save QueryExecution state and construct a failed query response"
   [query-execution error-message]
   (let [updates {:status       :failed
@@ -611,7 +619,7 @@
     (-> query-execution
         (dissoc :start_time_millis)
         (merge updates)
-        save-query-execution
+        save-query-execution!
         (dissoc :raw_query :result_rows :version)
         ;; this is just for the response for clien
         (assoc :error     error-message
@@ -620,7 +628,7 @@
                            :cols    []
                            :columns []}))))
 
-(defn query-complete
+(defn- query-complete
   "Save QueryExecution state and construct a completed (successful) query response"
   [query-execution query-result]
   ;; record our query execution and format response
@@ -631,12 +639,12 @@
                          (:start_time_millis query-execution))
         :result_rows  (get query-result :row_count 0))
       (dissoc :start_time_millis)
-      save-query-execution
+      save-query-execution!
       ;; at this point we've saved and we just need to massage things into our final response format
       (dissoc :error :raw_query :result_rows :version)
       (merge query-result)))
 
-(defn save-query-execution
+(defn- save-query-execution!
   "Save (or update) a `QueryExecution`."
   [{:keys [id], :as query-execution}]
   (if id

--- a/test/metabase/driver/bigquery_test.clj
+++ b/test/metabase/driver/bigquery_test.clj
@@ -81,8 +81,8 @@
 
 ;; make sure that BigQuery native queries maintain the column ordering specified in the SQL -- post-processing ordering shouldn't apply (Issue #2821)
 (expect-with-engine :bigquery
-  {:cols    ["venue_id" "user_id" "checkins_id"]
-   :columns [{:name "venue_id",    :base_type :IntegerField}
+  {:columns ["venue_id" "user_id" "checkins_id"]
+   :cols    [{:name "venue_id",    :base_type :IntegerField}
              {:name "user_id",     :base_type :IntegerField}
              {:name "checkins_id", :base_type :IntegerField}]}
   (select-keys (:data (qp/process-query {:native   {:query (apply format "SELECT [%stest_data.checkins.venue_id] AS [venue_id], [%stest_data.checkins.user_id] AS [user_id], [%stest_data.checkins.id] AS [checkins_id]

--- a/test/metabase/driver/bigquery_test.clj
+++ b/test/metabase/driver/bigquery_test.clj
@@ -85,10 +85,10 @@
    :columns [{:name "venue_id",    :base_type :IntegerField}
              {:name "user_id",     :base_type :IntegerField}
              {:name "checkins_id", :base_type :IntegerField}]}
-  (dissoc (:data (qp/process-query {:native   {:query (apply format "SELECT [%stest_data.checkins.venue_id] AS [venue_id], [%stest_data.checkins.user_id] AS [user_id], [%stest_data.checkins.id] AS [checkins_id]
-                                                                     FROM [%stest_data.checkins]
-                                                                     LIMIT 2"
-                                                             (repeat 4 bq-data/unique-prefix))}
-                                    :type     :native
-                                    :database (data/id)}))
-          :rows))
+  (select-keys (:data (qp/process-query {:native   {:query (apply format "SELECT [%stest_data.checkins.venue_id] AS [venue_id], [%stest_data.checkins.user_id] AS [user_id], [%stest_data.checkins.id] AS [checkins_id]
+                                                                          FROM [%stest_data.checkins]
+                                                                          LIMIT 2"
+                                                                  (repeat 4 bq-data/unique-prefix))}
+                                         :type     :native
+                                         :database (data/id)}))
+               [:cols :columns]))

--- a/test/metabase/driver/bigquery_test.clj
+++ b/test/metabase/driver/bigquery_test.clj
@@ -81,11 +81,14 @@
 
 ;; make sure that BigQuery native queries maintain the column ordering specified in the SQL -- post-processing ordering shouldn't apply (Issue #2821)
 (expect-with-engine :bigquery
-  ["venue_id" "user_id" "checkins_id"]
-  (get-in (qp/process-query {:native   {:query (apply format "SELECT [%stest_data.checkins.venue_id] AS [venue_id], [%stest_data.checkins.user_id] AS [user_id], [%stest_data.checkins.id] AS [checkins_id]
+  {:cols    ["venue_id" "user_id" "checkins_id"]
+   :columns [{:name "venue_id",    :base_type :IntegerField}
+             {:name "user_id",     :base_type :IntegerField}
+             {:name "checkins_id", :base_type :IntegerField}]}
+  (dissoc (qp/process-query {:native   {:query (apply format "SELECT [%stest_data.checkins.venue_id] AS [venue_id], [%stest_data.checkins.user_id] AS [user_id], [%stest_data.checkins.id] AS [checkins_id]
                                                               FROM [%stest_data.checkins]
                                                               LIMIT 2"
                                                       (repeat 4 bq-data/unique-prefix))}
                              :type     :native
                              :database (data/id)})
-          [:data :columns]))
+          :rows))

--- a/test/metabase/driver/bigquery_test.clj
+++ b/test/metabase/driver/bigquery_test.clj
@@ -85,10 +85,10 @@
    :columns [{:name "venue_id",    :base_type :IntegerField}
              {:name "user_id",     :base_type :IntegerField}
              {:name "checkins_id", :base_type :IntegerField}]}
-  (dissoc (qp/process-query {:native   {:query (apply format "SELECT [%stest_data.checkins.venue_id] AS [venue_id], [%stest_data.checkins.user_id] AS [user_id], [%stest_data.checkins.id] AS [checkins_id]
-                                                              FROM [%stest_data.checkins]
-                                                              LIMIT 2"
-                                                      (repeat 4 bq-data/unique-prefix))}
-                             :type     :native
-                             :database (data/id)})
+  (dissoc (:data (qp/process-query {:native   {:query (apply format "SELECT [%stest_data.checkins.venue_id] AS [venue_id], [%stest_data.checkins.user_id] AS [user_id], [%stest_data.checkins.id] AS [checkins_id]
+                                                                     FROM [%stest_data.checkins]
+                                                                     LIMIT 2"
+                                                             (repeat 4 bq-data/unique-prefix))}
+                                    :type     :native
+                                    :database (data/id)}))
           :rows))

--- a/test/metabase/driver/druid_test.clj
+++ b/test/metabase/driver/druid_test.clj
@@ -27,12 +27,12 @@
                :rows        [["2013-01-03T08:00:00.000Z" "931" "Simcha Yan" "1" "Kinaree Thai Bistro"       1]
                              ["2013-01-10T08:00:00.000Z" "285" "Kfir Caj"   "2" "Ruen Pair Thai Restaurant" 1]]
                :annotate?   nil
-               :cols        [{:name "timestamp", :base_type :TextField}
-                             {:name "id", :base_type :TextField}
-                             {:name "user_name", :base_type :TextField}
+               :cols        [{:name "timestamp",   :base_type :TextField}
+                             {:name "id",          :base_type :TextField}
+                             {:name "user_name",   :base_type :TextField}
                              {:name "venue_price", :base_type :TextField}
-                             {:name "venue_name", :base_type :TextField}
-                             {:name "count", :base_type :IntegerField}]
+                             {:name "venue_name",  :base_type :TextField}
+                             {:name "count",       :base_type :IntegerField}]
                :native_form {:query native-query}}}
   (metabase.test.data.datasets/with-engine :druid
     (timeseries-qp-test/with-flattened-dbdef

--- a/test/metabase/driver/druid_test.clj
+++ b/test/metabase/driver/druid_test.clj
@@ -1,0 +1,41 @@
+(ns metabase.driver.druid-test
+  (:require [cheshire.core :as json]
+            [expectations :refer :all]
+            [metabase.query-processor :as qp]
+            [metabase.test.data :as data]
+            [metabase.test.data.datasets :refer [expect-with-engine]]
+            [metabase.timeseries-query-processor-test :as timeseries-qp-test]))
+
+(def ^:const ^:private native-query
+  (json/generate-string
+    {:intervals   ["1900-01-01/2100-01-01"]
+     :granularity :all
+     :queryType   :select
+     :pagingSpec  {:threshold 2}
+     :dataSource  :checkins
+     :dimensions  [:venue_price
+                   :venue_name
+                   :user_name
+                   :id]
+     :metrics     [:count]}))
+
+;; test druid native queries
+(expect-with-engine :druid
+  {:row_count 2
+   :status    :completed
+   :data      {:columns     ["timestamp" "id" "user_name" "venue_price" "venue_name" "count"]
+               :rows        [["2013-01-03T08:00:00.000Z" "931" "Simcha Yan" "1" "Kinaree Thai Bistro"       1]
+                             ["2013-01-10T08:00:00.000Z" "285" "Kfir Caj"   "2" "Ruen Pair Thai Restaurant" 1]]
+               :annotate?   nil
+               :cols        [{:name "timestamp", :base_type :TextField}
+                             {:name "id", :base_type :TextField}
+                             {:name "user_name", :base_type :TextField}
+                             {:name "venue_price", :base_type :TextField}
+                             {:name "venue_name", :base_type :TextField}
+                             {:name "count", :base_type :IntegerField}]
+               :native_form {:query native-query}}}
+  (metabase.test.data.datasets/with-engine :druid
+    (timeseries-qp-test/with-flattened-dbdef
+      (qp/process-query {:native   {:query native-query}
+                         :type     :native
+                         :database (data/id)}))))

--- a/test/metabase/driver/mongo_test.clj
+++ b/test/metabase/driver/mongo_test.clj
@@ -78,6 +78,7 @@
   {:status    :completed
    :row_count 1
    :data      {:rows        [[1]]
+               :annotate?   nil
                :columns     ["count"]
                :cols        [{:name "count", :base_type :IntegerField}]
                :native_form {:collection "venues"

--- a/test/metabase/driver/mongo_test.clj
+++ b/test/metabase/driver/mongo_test.clj
@@ -14,7 +14,7 @@
 
 ;; ## Logic for selectively running mongo
 
-(defmacro expect-when-testing-mongo [expected actual]
+(defmacro expect-when-testing-mongo {:style/indent 0} [expected actual]
   `(datasets/expect-when-testing-engine :mongo
      ~expected
      ~actual))
@@ -75,13 +75,13 @@
     {\"$project\": {\"_id\": false, \"count\": true}}]")
 
 (expect-when-testing-mongo
-  {:status :completed
+  {:status    :completed
    :row_count 1
-   :data {:rows [[1]]
-          :columns ["count"]
-          :cols [{:description nil, :table_id nil, :special_type nil, :name "count", :extra_info {}, :id nil, :target nil, :display_name "count", :preview-display true, :base_type :UnknownField}]
-          :native_form {:collection "venues"
-                        :query      native-query}}}
+   :data      {:rows        [[1]]
+               :columns     ["count"]
+               :cols        [{:name "count", :base_type :IntegerField}]
+               :native_form {:collection "venues"
+                             :query      native-query}}}
   (qp/process-query {:native   {:query      native-query
                                 :collection "venues"}
                      :type     :native
@@ -91,11 +91,11 @@
 
 ;; DESCRIBE-DATABASE
 (expect-when-testing-mongo
-    {:tables #{{:schema nil, :name "checkins"}
-               {:schema nil, :name "categories"}
-               {:schema nil, :name "users"}
-               {:schema nil, :name "venues"}}}
-    (driver/describe-database (MongoDriver.) (mongo-db)))
+  {:tables #{{:schema nil, :name "checkins"}
+             {:schema nil, :name "categories"}
+             {:schema nil, :name "users"}
+             {:schema nil, :name "venues"}}}
+  (driver/describe-database (MongoDriver.) (mongo-db)))
 
 ;; DESCRIBE-TABLE
 (expect-when-testing-mongo

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -119,6 +119,7 @@
   (i/format-name *driver* (name nm)))
 
 (defn- get-table-id-or-explode [db-id table-name]
+  {:pre [(integer? db-id) (u/string-or-keyword? table-name)]}
   (let [table-name (format-name table-name)]
     (or (db/select-one-id Table, :db_id db-id, :name table-name)
         (throw (Exception. (format "No Table '%s' found for Database %d.\nFound: %s" table-name db-id
@@ -240,7 +241,9 @@
   (reset! loader->loaded-db-def #{}))
 
 
-(defn do-with-temp-db [^DatabaseDefinition dbdef f]
+(defn do-with-temp-db
+  "Execute F with DBDEF loaded as the current dataset. F takes a single argument, the `DatabaseInstance` that was loaded and synced from DBDEF."
+  [^DatabaseDefinition dbdef, f]
   (let [loader *driver*
         dbdef  (i/map->DatabaseDefinition (assoc dbdef :short-lived? true))]
     (swap! loader->loaded-db-def conj [loader dbdef])


### PR DESCRIPTION
Turns out BigQuery + Druid type information were broken in 0.18 as well. Fix those as well 😻 

Fixes #2732
