### PR TITLE
Retain title on pulse cards with errors

### DIFF
--- a/src/metabase/api/pulse.clj
+++ b/src/metabase/api/pulse.clj
@@ -100,7 +100,7 @@
           data      (:data result)
           card-type (render/detect-pulse-card-type card data)
           card-html (html (binding [render/*include-title* true]
-                            (render/render-pulse-card card data)))]
+                            (render/render-pulse-card card result)))]
       {:id              id
        :pulse_card_type card-type
        :pulse_card_html card-html
@@ -111,9 +111,9 @@
   [id]
   (let [card (Card id)]
     (read-check Database (:database (:dataset_query card)))
-    (let [data (:data (qp/dataset-query (:dataset_query card) {:executed_by *current-user-id*}))
+    (let [result (qp/dataset-query (:dataset_query card) {:executed_by *current-user-id*})
           ba   (binding [render/*include-title* true]
-                 (render/render-pulse-card-to-png card data))]
+                 (render/render-pulse-card-to-png card result))]
       {:status 200, :headers {"Content-Type" "image/png"}, :body (new java.io.ByteArrayInputStream ba) })))
 
 (defendpoint POST "/test"

--- a/src/metabase/api/pulse.clj
+++ b/src/metabase/api/pulse.clj
@@ -86,10 +86,10 @@
   [id]
   (let [card (Card id)]
     (read-check Database (:database (:dataset_query card)))
-    (let [data (:data (qp/dataset-query (:dataset_query card) {:executed_by *current-user-id*}))]
+    (let [result (qp/dataset-query (:dataset_query card) {:executed_by *current-user-id*})]
       {:status 200, :body (html [:html [:body {:style "margin: 0;"} (binding [render/*include-title* true
                                                                               render/*include-buttons* true]
-                                                                      (render/render-pulse-card card data))]])})))
+                                                                      (render/render-pulse-card card result))]])})))
 
 (defendpoint GET "/preview_card_info/:id"
   "Get JSON object containing HTML rendering of a `Card` with ID and other information."

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -45,8 +45,8 @@
   "Create an attachment in Slack for a given Card by rendering its result into an image and uploading it."
   [card-results]
   (when-let [{channel-id :id} (slack/get-or-create-files-channel!)]
-    (doall (for [{{card-id :id, card-name :name, :as card} :card, {:keys [data]} :result} card-results]
-             (let [image-byte-array (render/render-pulse-card-to-png card data)
+    (doall (for [{{card-id :id, card-name :name, :as card} :card, result :result} card-results]
+             (let [image-byte-array (render/render-pulse-card-to-png card result)
                    slack-file-url   (slack/upload-file! image-byte-array "image.png" channel-id)]
                {:title      card-name
                 :title_link (urls/card-url card-id)

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -397,41 +397,40 @@
       :else                                                        :table)))
 
 (defn render-pulse-card
-  "Render a single CARD for a `Pulse`. DATA is the `:data` from QP results (I think)."
-  [card result]
+  "Render a single CARD for a `Pulse`. RESULT is the QP results."
+  [card {:keys [data error]}]
   (try
-    (when (:error result)
-      (throw (Exception. "Card has errors")))
-    (let [data (:data result)]
-      [:a {:href   (card-href card)
-           :target "_blank"
-           :style  (style section-style
-                          {:margin          :16px
-                           :margin-bottom   :16px
-                           :display         :block
-                           :text-decoration :none})}
-       (when *include-title*
-         [:table {:style (style {:margin-bottom :8px
-                                 :width         :100%})}
-          [:tbody
-           [:tr
-            [:td [:span {:style header-style}
-                  (-> card :name h)]]
-            [:td {:style (style {:text-align :right})}
-             (when *include-buttons*
-               [:img {:style (style {:width :16px})
-                      :width 16
-                      :src   (render-image-with-filename "frontend_client/app/img/external_link.png")}])]]]])
-       (case (detect-pulse-card-type card data)
-         :empty     (render:empty     card data)
-         :scalar    (render:scalar    card data)
-         :sparkline (render:sparkline card data)
-         :bar       (render:bar       card data)
-         :table     (render:table     card data)
-         [:div {:style (style font-style
-                              {:color       "#F9D45C"
-                               :font-weight 700})}
-          "We were unable to display this card." [:br] "Please view this card in Metabase."])])
+    (when error
+      (throw (Exception. (str "Card has errors: " error))))
+    [:a {:href   (card-href card)
+         :target "_blank"
+         :style  (style section-style
+                        {:margin          :16px
+                         :margin-bottom   :16px
+                         :display         :block
+                         :text-decoration :none})}
+     (when *include-title*
+       [:table {:style (style {:margin-bottom :8px
+                               :width         :100%})}
+        [:tbody
+         [:tr
+          [:td [:span {:style header-style}
+                (-> card :name h)]]
+          [:td {:style (style {:text-align :right})}
+           (when *include-buttons*
+             [:img {:style (style {:width :16px})
+                    :width 16
+                    :src   (render-image-with-filename "frontend_client/app/img/external_link.png")}])]]]])
+     (case (detect-pulse-card-type card data)
+       :empty     (render:empty     card data)
+       :scalar    (render:scalar    card data)
+       :sparkline (render:sparkline card data)
+       :bar       (render:bar       card data)
+       :table     (render:table     card data)
+       [:div {:style (style font-style
+                            {:color       "#F9D45C"
+                             :font-weight 700})}
+        "We were unable to display this card." [:br] "Please view this card in Metabase."])]
     (catch Throwable e
       (log/warn "Pulse card render error:" e)
       [:div {:style (style font-style

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -396,7 +396,7 @@
            (number-field? col-2))                                  :bar
       :else                                                        :table)))
 
-(defn render-pulse-card-container
+(defn- render-pulse-card-container
   [card content]
   [:a {:href   (card-href card)
        :target "_blank"

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -396,48 +396,55 @@
            (number-field? col-2))                                  :bar
       :else                                                        :table)))
 
+(defn render-pulse-card-container
+  [card content]
+  [:a {:href   (card-href card)
+       :target "_blank"
+       :style  (style section-style
+                      {:margin          :16px
+                       :margin-bottom   :16px
+                       :display         :block
+                       :text-decoration :none})}
+   (when *include-title*
+     [:table {:style (style {:margin-bottom :8px
+                             :width         :100%})}
+      [:tbody
+       [:tr
+        [:td [:span {:style header-style}
+              (-> card :name h)]]
+        [:td {:style (style {:text-align :right})}
+         (when *include-buttons*
+           [:img {:style (style {:width :16px})
+                  :width 16
+                  :src   (render-image-with-filename "frontend_client/app/img/external_link.png")}])]]]])
+    content])
+
 (defn render-pulse-card
   "Render a single CARD for a `Pulse`. RESULT is the QP results."
   [card {:keys [data error]}]
   (try
     (when error
       (throw (Exception. (str "Card has errors: " error))))
-    [:a {:href   (card-href card)
-         :target "_blank"
-         :style  (style section-style
-                        {:margin          :16px
-                         :margin-bottom   :16px
-                         :display         :block
-                         :text-decoration :none})}
-     (when *include-title*
-       [:table {:style (style {:margin-bottom :8px
-                               :width         :100%})}
-        [:tbody
-         [:tr
-          [:td [:span {:style header-style}
-                (-> card :name h)]]
-          [:td {:style (style {:text-align :right})}
-           (when *include-buttons*
-             [:img {:style (style {:width :16px})
-                    :width 16
-                    :src   (render-image-with-filename "frontend_client/app/img/external_link.png")}])]]]])
-     (case (detect-pulse-card-type card data)
-       :empty     (render:empty     card data)
-       :scalar    (render:scalar    card data)
-       :sparkline (render:sparkline card data)
-       :bar       (render:bar       card data)
-       :table     (render:table     card data)
-       [:div {:style (style font-style
-                            {:color       "#F9D45C"
-                             :font-weight 700})}
-        "We were unable to display this card." [:br] "Please view this card in Metabase."])]
+    (let [content (case (detect-pulse-card-type card data)
+                    :empty     (render:empty     card data)
+                    :scalar    (render:scalar    card data)
+                    :sparkline (render:sparkline card data)
+                    :bar       (render:bar       card data)
+                    :table     (render:table     card data)
+                    [:div {:style (style font-style
+                                         {:color       "#F9D45C"
+                                          :font-weight 700})}
+                     "We were unable to display this card." [:br] "Please view this card in Metabase."])]
+      (render-pulse-card-container card content))
     (catch Throwable e
       (log/warn "Pulse card render error:" e)
-      [:div {:style (style font-style
-                           {:color       "#EF8C8C"
-                            :font-weight 700
-                            :padding     :16px})}
-       "An error occurred while displaying this card."])))
+      (let [content [:div {:style (style font-style
+                                         {:color       "#EF8C8C"
+                                          :font-weight 700
+                                          :padding     :16px})}
+                     "An error occurred while displaying this card."]]
+        (render-pulse-card-container card content)))))
+
 
 
 (defn render-pulse-section

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -456,5 +456,5 @@
 (defn render-pulse-card-to-png
   "Render a PULSE-CARD as a PNG. DATA is the `:data` from a QP result (I think...)"
 
-  [pulse-card data]
-  (render-html-to-png (render-pulse-card pulse-card data) card-width))
+  [pulse-card result]
+  (render-html-to-png (render-pulse-card pulse-card result) card-width))

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -398,8 +398,10 @@
 
 (defn render-pulse-card
   "Render a single CARD for a `Pulse`. DATA is the `:data` from QP results (I think)."
-  [card data]
+  [card result]
   (try
+    (if (:error result) (throw (Exception. "Card has errors")))
+    (let [data (:data result)]
     [:a {:href   (card-href card)
          :target "_blank"
          :style  (style section-style
@@ -428,7 +430,7 @@
        [:div {:style (style font-style
                             {:color       "#F9D45C"
                              :font-weight 700})}
-        "We were unable to display this card." [:br] "Please view this card in Metabase."])]
+        "We were unable to display this card." [:br] "Please view this card in Metabase."])])
     (catch Throwable e
       (log/warn "Pulse card render error:" e)
       [:div {:style (style font-style

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -400,37 +400,38 @@
   "Render a single CARD for a `Pulse`. DATA is the `:data` from QP results (I think)."
   [card result]
   (try
-    (if (:error result) (throw (Exception. "Card has errors")))
+    (when (:error result)
+      (throw (Exception. "Card has errors")))
     (let [data (:data result)]
-    [:a {:href   (card-href card)
-         :target "_blank"
-         :style  (style section-style
-                        {:margin          :16px
-                         :margin-bottom   :16px
-                         :display         :block
-                         :text-decoration :none})}
-     (when *include-title*
-       [:table {:style (style {:margin-bottom :8px
-                               :width         :100%})}
-        [:tbody
-         [:tr
-          [:td [:span {:style header-style}
-                (-> card :name h)]]
-          [:td {:style (style {:text-align :right})}
-           (when *include-buttons*
-             [:img {:style (style {:width :16px})
-                    :width 16
-                    :src   (render-image-with-filename "frontend_client/app/img/external_link.png")}])]]]])
-     (case (detect-pulse-card-type card data)
-       :empty     (render:empty     card data)
-       :scalar    (render:scalar    card data)
-       :sparkline (render:sparkline card data)
-       :bar       (render:bar       card data)
-       :table     (render:table     card data)
-       [:div {:style (style font-style
-                            {:color       "#F9D45C"
-                             :font-weight 700})}
-        "We were unable to display this card." [:br] "Please view this card in Metabase."])])
+      [:a {:href   (card-href card)
+           :target "_blank"
+           :style  (style section-style
+                          {:margin          :16px
+                           :margin-bottom   :16px
+                           :display         :block
+                           :text-decoration :none})}
+       (when *include-title*
+         [:table {:style (style {:margin-bottom :8px
+                                 :width         :100%})}
+          [:tbody
+           [:tr
+            [:td [:span {:style header-style}
+                  (-> card :name h)]]
+            [:td {:style (style {:text-align :right})}
+             (when *include-buttons*
+               [:img {:style (style {:width :16px})
+                      :width 16
+                      :src   (render-image-with-filename "frontend_client/app/img/external_link.png")}])]]]])
+       (case (detect-pulse-card-type card data)
+         :empty     (render:empty     card data)
+         :scalar    (render:scalar    card data)
+         :sparkline (render:sparkline card data)
+         :bar       (render:bar       card data)
+         :table     (render:table     card data)
+         [:div {:style (style font-style
+                              {:color       "#F9D45C"
+                               :font-weight 700})}
+          "We were unable to display this card." [:br] "Please view this card in Metabase."])])
     (catch Throwable e
       (log/warn "Pulse card render error:" e)
       [:div {:style (style font-style

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -399,7 +399,6 @@
 (defn render-pulse-card
   "Render a single CARD for a `Pulse`. RESULT is the QP results."
   [card {:keys [data error]}]
-
   [:a {:href   (card-href card)
        :target "_blank"
        :style  (style section-style

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -396,8 +396,10 @@
            (number-field? col-2))                                  :bar
       :else                                                        :table)))
 
-(defn- render-pulse-card-container
-  [card content]
+(defn render-pulse-card
+  "Render a single CARD for a `Pulse`. RESULT is the QP results."
+  [card {:keys [data error]}]
+
   [:a {:href   (card-href card)
        :target "_blank"
        :style  (style section-style
@@ -417,34 +419,26 @@
            [:img {:style (style {:width :16px})
                   :width 16
                   :src   (render-image-with-filename "frontend_client/app/img/external_link.png")}])]]]])
-    content])
-
-(defn render-pulse-card
-  "Render a single CARD for a `Pulse`. RESULT is the QP results."
-  [card {:keys [data error]}]
   (try
     (when error
       (throw (Exception. (str "Card has errors: " error))))
-    (let [content (case (detect-pulse-card-type card data)
-                    :empty     (render:empty     card data)
-                    :scalar    (render:scalar    card data)
-                    :sparkline (render:sparkline card data)
-                    :bar       (render:bar       card data)
-                    :table     (render:table     card data)
-                    [:div {:style (style font-style
-                                         {:color       "#F9D45C"
-                                          :font-weight 700})}
-                     "We were unable to display this card." [:br] "Please view this card in Metabase."])]
-      (render-pulse-card-container card content))
+    (case (detect-pulse-card-type card data)
+      :empty     (render:empty     card data)
+      :scalar    (render:scalar    card data)
+      :sparkline (render:sparkline card data)
+      :bar       (render:bar       card data)
+      :table     (render:table     card data)
+      [:div {:style (style font-style
+                           {:color       "#F9D45C"
+                            :font-weight 700})}
+       "We were unable to display this card." [:br] "Please view this card in Metabase."])
     (catch Throwable e
       (log/warn "Pulse card render error:" e)
-      (let [content [:div {:style (style font-style
-                                         {:color       "#EF8C8C"
-                                          :font-weight 700
-                                          :padding     :16px})}
-                     "An error occurred while displaying this card."]]
-        (render-pulse-card-container card content)))))
-
+      [:div {:style (style font-style
+                           {:color       "#EF8C8C"
+                            :font-weight 700
+                            :padding     :16px})}
+       "An error occurred while displaying this card."]))])
 
 
 (defn render-pulse-section


### PR DESCRIPTION
Resolves #2148 

Before:
![screen shot 2016-06-27 at 17 01 58](https://cloud.githubusercontent.com/assets/6934200/16399618/e9357c94-3c88-11e6-8b72-66a8af220b2e.png)

After:
![screen shot 2016-06-27 at 16 59 21](https://cloud.githubusercontent.com/assets/6934200/16399581/ad7bfade-3c88-11e6-819c-a0ae9c6d016a.png)

(The card title I used was "Invalid Question")

Also addresses an issue where cards with errors display as empty on the pulse/preview_cards endpoint.
