### PR TITLE
Added error handling for dashboard cards

### DIFF
--- a/frontend/src/metabase/dashboard/dashboard.js
+++ b/frontend/src/metabase/dashboard/dashboard.js
@@ -157,8 +157,7 @@ export const fetchCardData = createThunkAction(FETCH_CARD_DATA, function(card, d
           result = await MetabaseApi.dataset(datasetQuery);
         }
         catch (error) {
-          clearTimeout(slowCardTimer);
-          return { dashcard_id: dashcard.id, card_id: card.id, result: { error } };
+          result = { error };
         }
 
         clearTimeout(slowCardTimer);

--- a/frontend/src/metabase/dashboard/dashboard.js
+++ b/frontend/src/metabase/dashboard/dashboard.js
@@ -114,12 +114,12 @@ const CLEAR_CARD_DATA = "CLEAR_CARD_DATA";
 export const clearCardData = createAction(CLEAR_CARD_DATA, (cardId, dashcardId) => ({ cardId, dashcardId }));
 
 export async function fetchDataOrError(dataPromise) {
-  try {
-    return await dataPromise;
-  }
-  catch (error) {
-    return { error };
-  }
+    try {
+        return await dataPromise;
+    }
+    catch (error) {
+        return { error };
+    }
 }
 
 export const fetchCardData = createThunkAction(FETCH_CARD_DATA, function(card, dashcard, clearExisting = false) {
@@ -161,7 +161,7 @@ export const fetchCardData = createThunkAction(FETCH_CARD_DATA, function(card, d
             }
         }, DATASET_SLOW_TIMEOUT);
 
-        result = await fetchDataOrError(Promise.reject({data: {message: 'test'}}));
+        result = await fetchDataOrError(MetabaseApi.dataset(datasetQuery));
 
         clearTimeout(slowCardTimer);
         return { dashcard_id: dashcard.id, card_id: card.id, result };

--- a/frontend/src/metabase/dashboard/dashboard.js
+++ b/frontend/src/metabase/dashboard/dashboard.js
@@ -152,7 +152,23 @@ export const fetchCardData = createThunkAction(FETCH_CARD_DATA, function(card, d
             }
         }, DATASET_SLOW_TIMEOUT);
 
-        result = await MetabaseApi.dataset(datasetQuery);
+
+        try {
+          // result = await MetabaseApi.dataset(datasetQuery);
+          // mocking an angular $http response 504 object
+          // not sure if this is the exact shape and content, but hopefully close enough
+          result = await Promise.reject({
+            status: 504,
+            statusText: "GATEWAY_TIMEOUT",
+            data: {
+              message: "Failed to load resource: the server responded with a status of 504 (GATEWAY_TIMEOUT)"
+            }
+          });
+        }
+        catch (error) {
+          clearTimeout(slowCardTimer);
+          return { dashcard_id: dashcard.id, card_id: card.id, result: { error } };
+        }
 
         clearTimeout(slowCardTimer);
         return { dashcard_id: dashcard.id, card_id: card.id, result };

--- a/frontend/src/metabase/dashboard/dashboard.js
+++ b/frontend/src/metabase/dashboard/dashboard.js
@@ -154,16 +154,7 @@ export const fetchCardData = createThunkAction(FETCH_CARD_DATA, function(card, d
 
 
         try {
-          // result = await MetabaseApi.dataset(datasetQuery);
-          // mocking an angular $http response 504 object
-          // not sure if this is the exact shape and content, but hopefully close enough
-          result = await Promise.reject({
-            status: 504,
-            statusText: "GATEWAY_TIMEOUT",
-            data: {
-              message: "Failed to load resource: the server responded with a status of 504 (GATEWAY_TIMEOUT)"
-            }
-          });
+          result = await MetabaseApi.dataset(datasetQuery);
         }
         catch (error) {
           clearTimeout(slowCardTimer);

--- a/frontend/src/metabase/dashboard/dashboard.js
+++ b/frontend/src/metabase/dashboard/dashboard.js
@@ -113,6 +113,15 @@ const updateDashcardId = createAction(UPDATE_DASHCARD_ID, (oldDashcardId, newDas
 const CLEAR_CARD_DATA = "CLEAR_CARD_DATA";
 export const clearCardData = createAction(CLEAR_CARD_DATA, (cardId, dashcardId) => ({ cardId, dashcardId }));
 
+export async function fetchDataOrError(dataPromise) {
+  try {
+    return await dataPromise;
+  }
+  catch (error) {
+    return { error };
+  }
+}
+
 export const fetchCardData = createThunkAction(FETCH_CARD_DATA, function(card, dashcard, clearExisting = false) {
     return async function(dispatch, getState) {
         if (clearExisting) {
@@ -152,13 +161,7 @@ export const fetchCardData = createThunkAction(FETCH_CARD_DATA, function(card, d
             }
         }, DATASET_SLOW_TIMEOUT);
 
-
-        try {
-          result = await MetabaseApi.dataset(datasetQuery);
-        }
-        catch (error) {
-          result = { error };
-        }
+        result = await fetchDataOrError(Promise.reject({data: {message: 'test'}}));
 
         clearTimeout(slowCardTimer);
         return { dashcard_id: dashcard.id, card_id: card.id, result };

--- a/frontend/test/unit/dashboard/dashboard.spec.js
+++ b/frontend/test/unit/dashboard/dashboard.spec.js
@@ -1,0 +1,32 @@
+import { fetchDataOrError } from 'metabase/dashboard/dashboard';
+
+describe("Dashboard", () => {
+    describe("fetchDataOrError()", () => {
+        it("should return data on successful fetch", async () => {
+            const data = {
+                series: [1, 2, 3]
+            };
+
+            const successfulFetch = Promise.resolve(data);
+
+            const result = await fetchDataOrError(successfulFetch);
+            expect(result.error).toBeUndefined();
+            expect(result).toEqual(data);
+        });
+
+        it("should return map with error key on failed fetch", async () => {
+            const error = {
+                status: 504,
+                statusText: "GATEWAY_TIMEOUT",
+                data: {
+                    message: "Failed to load resource: the server responded with a status of 504 (GATEWAY_TIMEOUT)"
+                }
+            };
+
+            const failedFetch = Promise.reject(error);
+
+            const result = await fetchDataOrError(failedFetch);
+            expect(result.error).toEqual(error);
+        });
+    });
+});


### PR DESCRIPTION
Resolves #2845 

Before:
![screen shot 2016-06-28 at 14 01 58](https://cloud.githubusercontent.com/assets/6934200/16432235/ea6f10e2-3d38-11e6-873a-befae8da47ae.png)

After:
![screen shot 2016-06-28 at 13 59 46](https://cloud.githubusercontent.com/assets/6934200/16432171/b34b3fc8-3d38-11e6-8a16-2edf078c469a.png)

Note that the dashboard can only display the generic error message due to https://github.com/metabase/metabase/blob/master/frontend/src/metabase/visualizations/components/Visualization.jsx#L135. Full message from errors should be displayed in the question page if the user clicks through.
