### PR TITLE
Bump Clojure JDBC version :honey_pot:

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,8 +15,8 @@
                  [org.clojure/core.match "0.3.0-alpha4"]              ; optimized pattern matching library for Clojure
                  [org.clojure/core.memoize "0.5.9"]                   ; needed by core.match; has useful FIFO, LRU, etc. caching mechanisms
                  [org.clojure/data.csv "0.1.3"]                       ; CSV parsing / generation
-                 [org.clojure/java.classpath "0.2.3"]
-                 [org.clojure/java.jdbc "0.4.2"]                      ; basic jdbc access from clojure. *** DON'T UPDATE THIS UNTIL KORMA IS UPDATED TO STOP USING DEPRECATED FN SIGNATURES ***
+                 [org.clojure/java.classpath "0.2.3"]                 ; examine the Java classpath from Clojure programs
+                 [org.clojure/java.jdbc "0.6.1"]                      ; basic JDBC access from Clojure
                  [org.clojure/math.numeric-tower "0.0.4"]             ; math functions like `ceil`
                  [org.clojure/tools.logging "0.3.1"]                  ; logging framework
                  [org.clojure/tools.namespace "0.2.10"]

--- a/sample_dataset/metabase/sample_dataset/generate.clj
+++ b/sample_dataset/metabase/sample_dataset/generate.clj
@@ -390,14 +390,14 @@
        (assert (keyword? table))
        (assert (sequential? rows))
        (let [table-name (s/upper-case (name table))]
-         (apply jdbc/insert! db table-name (for [row rows]
+         (jdbc/insert-multi! db table-name (for [row rows]
                                              (into {} (for [[k v] (seq row)]
                                                         {(s/upper-case (name k)) v}))))))
 
      ;; Insert the _metabase_metadata table
      (println "Inserting _metabase_metadata...")
      (jdbc/execute! db ["CREATE TABLE \"_METABASE_METADATA\" (\"KEYPATH\" VARCHAR(255), \"VALUE\" VARCHAR(255), PRIMARY KEY (\"KEYPATH\"));"])
-     (apply jdbc/insert! db "_METABASE_METADATA" (reduce concat (for [[table-name {table-description :description, columns :columns}] annotations]
+     (jdbc/insert-multi! db "_METABASE_METADATA" (reduce concat (for [[table-name {table-description :description, columns :columns}] annotations]
                                                                   (let [table-name (s/upper-case (name table-name))]
                                                                     (conj (for [[column-name kvs] columns
                                                                                 [k v]             kvs]

--- a/src/metabase/cmd/load_from_h2.clj
+++ b/src/metabase/cmd/load_from_h2.clj
@@ -89,7 +89,7 @@
   (doseq [chunk (partition-all 300 objs)]
     (print (color/blue \.))
     (flush)
-    (apply jdbc/insert! *target-db-connection* (:table e) (if (= e DashboardCard)
+    (jdbc/insert-multi! *target-db-connection* (:table e) (if (= e DashboardCard)
                                                             ;; mini-HACK to fix h2 lowercasing these couple attributes
                                                             ;; luckily this is the only place in our schema where we have camel case names
                                                             (mapv #(set/rename-keys % {:sizex :sizeX, :sizey :sizeY}) chunk)

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -367,8 +367,8 @@
 (defn query
   "Compile HONEYSQL-FROM and call `jdbc/query` against the Metabase database.
    Options are passed along to `jdbc/query`."
-  [honeysql-form & options]
-  (apply jdbc/query (db-connection) (honeysql->sql honeysql-form) options))
+  [honeysql-form & {:as options}]
+  (jdbc/query (db-connection) (honeysql->sql honeysql-form) options))
 
 
 (defn entity->table-name
@@ -445,8 +445,8 @@
 (defn execute!
   "Compile HONEYSQL-FORM and call `jdbc/execute!` against the Metabase DB.
    OPTIONS are passed directly to `jdbc/execute!` and can be things like `:multi?` (default `false`) or `:transaction?` (default `true`)."
-  [honeysql-form & options]
-  (apply jdbc/execute! (db-connection) (honeysql->sql honeysql-form) options))
+  [honeysql-form & {:as options}]
+  (jdbc/execute! (db-connection) (honeysql->sql honeysql-form) options))
 
 (defn- where
   "Generate a HoneySQL `where` form using key-value args.
@@ -577,7 +577,7 @@
   {:pre [(sequential? row-maps) (every? map? row-maps)]}
   (when (seq row-maps)
     (let [entity (resolve-entity entity)]
-      (map (insert-id-key) (apply jdbc/insert! (db-connection) (entity->table-name entity) (concat row-maps [:entities (quote-fn)]))))))
+      (map (insert-id-key) (jdbc/insert-multi! (db-connection) (entity->table-name entity) row-maps {:entities (quote-fn)})))))
 
 (defn insert-many!
   "Insert several new rows into the Database. Resolves ENTITY, and calls `pre-insert` on each of the ROW-MAPS.

--- a/src/metabase/driver/crate/query_processor.clj
+++ b/src/metabase/driver/crate/query_processor.clj
@@ -40,12 +40,12 @@
   [_ {:keys [database], {sql :query, params :params} :native}]
   (try (let [db-conn (sql/db->jdbc-connection-spec database)]
          (jdbc/with-db-connection [t-conn db-conn]
-           (let [statement (if params
-                             (into [sql] params)
-                             sql)]
-             (let [[columns & rows] (jdbc/query t-conn statement, :identifiers identity, :as-arrays? true)]
-               {:rows    (or rows [])
-                :columns columns}))))
+           (let [statement        (if params
+                                    (into [sql] params)
+                                    sql)
+                 [columns & rows] (jdbc/query t-conn statement {:identifiers identity, :as-arrays? true})]
+             {:rows    (or rows [])
+              :columns columns})))
        (catch java.sql.SQLException e
          (let [^String message (or (->> (.getMessage e)     ; error message comes back like 'Column "ZID" not found; SQL statement: ... [error-code]' sometimes
                                         (re-find #"^(.*);") ; the user already knows the SQL, and error code is meaningless

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -297,7 +297,7 @@
   [{sql :query, params :params, remark :remark} connection]
   (let [sql              (str "-- " remark "\n" (hx/unescape-dots sql))
         statement        (into [sql] params)
-        [columns & rows] (jdbc/query connection statement, :identifiers identity, :as-arrays? true)]
+        [columns & rows] (jdbc/query connection statement {:identifiers identity, :as-arrays? true})]
     {:rows    (or rows [])
      :columns columns}))
 

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -135,7 +135,7 @@
     (jdbc/execute! (sql/connection-details->spec driver (i/database->connection-details driver :server nil))
                    ["DROP DATABASE IF EXISTS materialized_views_test;
                      CREATE DATABASE materialized_views_test;"]
-                   :transaction? false)
+                   {:transaction? false})
     (let [details (i/database->connection-details driver :db {:database-name "materialized_views_test", :short-lived? true})]
       (jdbc/execute! (sql/connection-details->spec driver details)
                      ["DROP MATERIALIZED VIEW IF EXISTS test_mview;

--- a/test/metabase/test/data/crate.clj
+++ b/test/metabase/test/data/crate.clj
@@ -42,13 +42,13 @@
    the calls the resulting function with the rows to insert."
   [& wrap-insert-fns]
   (fn [driver dbdef tabledef]
-    (let [insert!   ((apply comp wrap-insert-fns) (fn [row-or-rows]
-                                                    (apply jdbc/insert!
-                                                           (generic/database->spec driver :db dbdef)
-                                                           (keyword (:table-name tabledef))
-                                                           :transaction? false
-                                                           (escape-field-names row-or-rows))))
-          rows      (apply list (generic/load-data-get-rows driver dbdef tabledef))]
+    (let [insert! ((apply comp wrap-insert-fns) (fn [row-or-rows]
+                                                  (jdbc/insert-multi!
+                                                    (generic/database->spec driver :db dbdef)
+                                                    (keyword (:table-name tabledef))
+                                                    (escape-field-names row-or-rows)
+                                                    {:transaction? false})))
+          rows    (apply list (generic/load-data-get-rows driver dbdef tabledef))]
       (insert! rows))))
 
 (def ^:private database->connection-details

--- a/test/metabase/test/data/generic_sql.clj
+++ b/test/metabase/test/data/generic_sql.clj
@@ -252,7 +252,7 @@
       ;; Remove excess semicolons, otherwise snippy DBs like Oracle will barf
       (let [sql (s/replace sql #";+" ";")]
         (try
-          (jdbc/execute! (database->spec driver context dbdef) [sql] :transaction? false, :multi? true)
+          (jdbc/execute! (database->spec driver context dbdef) [sql] {:transaction? false, :multi? true})
           (catch java.sql.SQLException e
             (println "Error executing SQL:" sql)
             (println (format "Caught SQLException:\n%s"

--- a/test/metabase/test/data/sqlserver.clj
+++ b/test/metabase/test/data/sqlserver.clj
@@ -117,7 +117,6 @@
         (doseq [db leftover-dbs]
           (try
             (println (format "Deleting leftover SQL Server DB '%s'..." db))
-            ;; (jdbc/execute! connection-spec [(drop-db-if-exists-sql nil {:database-name db})])
             ;; Don't try to kill other connections to this DB with SET SINGLE_USER -- some other instance (eg CI) might be using it
             (jdbc/execute! connection-spec [(format "DROP DATABASE \"%s\";" db)])
             (println "[ok]")


### PR DESCRIPTION
Now that [korma has been excised](https://github.com/metabase/metabase/pull/2855) we can finally bump the Clojure JDBC lib from 0.4.2 to 0.6.1. yay 🍯 
