### PR TITLE
Tiniest tweak for sync error logging :shower:

### DIFF
--- a/src/metabase/task/sync_databases.clj
+++ b/src/metabase/task/sync_databases.clj
@@ -28,7 +28,7 @@
         ;; at midnight we run the full sync
         (sync-database/sync-database! database :full-sync? true))
       (catch Throwable e
-        (log/error "Error syncing database: " (:id database) e)))))
+        (log/error (format "Error syncing database %d: " (:id database)) e)))))
 
 (defn task-init
   "Automatically called during startup; start the job for syncing databases."


### PR DESCRIPTION
Fix some confusion as to the purpose of the DB ID.
###### BEFORE

> 07-06 16:52:49 ERROR task.sync-databases :: Error syncing database:  279 #error {
###### AFTER

> 07-06 16:52:49 ERROR task.sync-databases :: Error syncing database 279: #error {
