### PR TITLE
remove custom query executor

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -65,8 +65,8 @@
                  [org.yaml/snakeyaml "1.17"]                          ; YAML parser (required by liquibase)
                  [org.xerial/sqlite-jdbc "3.8.11.2"]                  ; SQLite driver
                  [postgresql "9.3-1102.jdbc41"]                       ; Postgres driver
-                 [io.crate/crate-jdbc "1.11.0"]                       ; Crate JDBC driver (DON'T UPDATE THESE YET -- THEY CAUSE TESTS TO FAIL!)
-                 [io.crate/crate-client "0.54.7"]                     ; Crate Java client (used by Crate JDBC)
+                 [io.crate/crate-jdbc "1.12.3"]                       ; Crate JDBC driver (DON'T UPDATE THESE YET -- THEY CAUSE TESTS TO FAIL!)
+                 [io.crate/crate-client "0.54.11"]                     ; Crate Java client (used by Crate JDBC)
                  [prismatic/schema "1.1.2"]                           ; Data schema declaration and validation library
                  [ring/ring-jetty-adapter "1.5.0"]                    ; Ring adapter using Jetty webserver (used to run a Ring server for unit tests)
                  [ring/ring-json "0.4.0"]                             ; Ring middleware for reading/writing JSON automatically

--- a/src/metabase/driver/crate.clj
+++ b/src/metabase/driver/crate.clj
@@ -71,7 +71,6 @@
           :details-fields (constantly [{:name         "hosts"
                                         :display-name "Hosts"
                                         :default      "//localhost:4300"}])
-          :execute-query  qp/execute-query
           :features       (fn [this]
                             (set/difference (sql/features this)
                                             #{:foreign-keys}))})

--- a/src/metabase/driver/crate/query_processor.clj
+++ b/src/metabase/driver/crate/query_processor.clj
@@ -1,10 +1,7 @@
 (ns metabase.driver.crate.query-processor
-  (:require [clojure.java.jdbc :as jdbc]
-            [honeysql.helpers :as h]
-            [metabase.driver.generic-sql :as sql]
+  (:require [honeysql.helpers :as h]
             [metabase.driver.generic-sql.query-processor :as qp]
-            [metabase.query-processor.interface :as i])
-  (:import (metabase.query_processor.interface ComparisonFilter CompoundFilter)))
+            [metabase.query-processor.interface :as i]))
 
 (defn- rewrite-between
   "Rewrite [:between <field> <min> <max>] -> [:and [:>= <field> <min>] [:<= <field> <max>]]"
@@ -32,23 +29,3 @@
   "Apply custom generic SQL filter. This is the place to perform query rewrites."
   [_ honeysql-form {clause :filter}]
   (h/where honeysql-form (filter-clause->predicate clause)))
-
-(defn execute-query
-  "Execute a query against Crate database.
-
-   We specifically write out own `execute-query` function to avoid the autoCommit(false) call."
-  [_ {:keys [database], {sql :query, params :params} :native}]
-  (try (let [db-conn (sql/db->jdbc-connection-spec database)]
-         (jdbc/with-db-connection [t-conn db-conn]
-           (let [statement        (if params
-                                    (into [sql] params)
-                                    sql)
-                 [columns & rows] (jdbc/query t-conn statement {:identifiers identity, :as-arrays? true})]
-             {:rows    (or rows [])
-              :columns columns})))
-       (catch java.sql.SQLException e
-         (let [^String message (or (->> (.getMessage e)     ; error message comes back like 'Column "ZID" not found; SQL statement: ... [error-code]' sometimes
-                                        (re-find #"^(.*);") ; the user already knows the SQL, and error code is meaningless
-                                        second)             ; so just return the part of the exception that is relevant
-                                   (.getMessage e))]
-           (throw (Exception. message))))))


### PR DESCRIPTION
since Crate JDBC v1.12 that supports to set a `strict` mode (default:
false) to be compliant with the JDBC spec. This prevents from throwing
an `UnsupportedFeatureException` if `autocommit(false)` is called.
