### PR TITLE
added support for subcolumns / nested columns

### DIFF
--- a/src/metabase/driver/crate.clj
+++ b/src/metabase/driver/crate.clj
@@ -58,6 +58,8 @@
 (defn- string-length-fn [field-key]
   (hsql/call :char_length field-key))
 
+(defn- field->alias [field]
+  (str \" (name field) \"))
 
 (defrecord CrateDriver []
   clojure.lang.Named
@@ -82,7 +84,9 @@
           :apply-filter              qp/apply-filter
           :date                      crate-util/date
           :unix-timestamp->timestamp crate-util/unix-timestamp->timestamp
-          :current-datetime-fn       (constantly now)}))
+          :current-datetime-fn       (constantly now)
+          :quote-style               :ansi
+          :field->alias              (u/drop-first-arg field->alias)}))
 
 
 (driver/register-driver! :crate (CrateDriver.))


### PR DESCRIPTION
Nested columns are now listed as fields in filters and grouping if
the jdbc property `showsubcolumns=true` is set:

e.g. `//localhost:4300?showsubcolumns=true`
