### PR TITLE
Fix load-from-h2 command :wrench:

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -65,7 +65,7 @@
                  [org.yaml/snakeyaml "1.17"]                          ; YAML parser (required by liquibase)
                  [org.xerial/sqlite-jdbc "3.8.11.2"]                  ; SQLite driver
                  [postgresql "9.3-1102.jdbc41"]                       ; Postgres driver
-                 [io.crate/crate-jdbc "1.13.0"]                       ; Crate JDBC driver (DON'T UPDATE THESE YET -- THEY CAUSE TESTS TO FAIL!)
+                 [io.crate/crate-jdbc "1.13.0"]                       ; Crate JDBC driver
                  [io.crate/crate-client "0.55.2"]                     ; Crate Java client (used by Crate JDBC)
                  [prismatic/schema "1.1.2"]                           ; Data schema declaration and validation library
                  [ring/ring-jetty-adapter "1.5.0"]                    ; Ring adapter using Jetty webserver (used to run a Ring server for unit tests)

--- a/src/metabase/cmd/load_from_h2.clj
+++ b/src/metabase/cmd/load_from_h2.clj
@@ -79,19 +79,32 @@
   "Active database connection to the target database we are loading into."
   nil)
 
-;; TODO - `e` is a bad variable name! This should be something like `entity`
-(defn- insert-entity! [e objs]
-  (print (u/format-color 'blue "Transfering %d instances of %s..." (count objs) (:name e))) ; TODO - I don't think the print+flush is working as intended :/
+
+(defn- insert-entity! [entity objs]
+  (print (u/format-color 'blue "Transfering %d instances of %s..." (count objs) (:name entity))) ; TODO - I don't think the print+flush is working as intended :/
   (flush)
-  ;; The connection closes prematurely on occasion when we're inserting thousands of rows at once. Break into smaller chunks so connection stays alive
-  (doseq [chunk (partition-all 300 objs)]
-    (print (color/blue \.))
-    (flush)
-    (jdbc/insert-multi! *target-db-connection* (:table e) (if (= e DashboardCard)
-                                                            ;; mini-HACK to fix h2 lowercasing these couple attributes
-                                                            ;; luckily this is the only place in our schema where we have camel case names
-                                                            (mapv #(set/rename-keys % {:sizex :sizeX, :sizey :sizeY}) chunk)
-                                                            chunk)))
+  (let [ks         (keys (first objs))
+        ;; 1) `:sizeX` and `:sizeY` come out of H2 as `:sizex` and `:sizey` because of automatic lowercasing; fix the names of these before putting into the new DB
+        ;; 2) Need to wrap the column names in quotes because Postgres automatically lowercases unquoted identifiers
+        quote-char (case (config/config-kw :mb-db-type)
+                     :postgres \"
+                     :mysql    \`)
+        cols       (for [k ks]
+                     (str quote-char (name (case k
+                                             :sizex :sizeX
+                                             :sizey :sizeY
+                                             k)) quote-char))]
+    ;; The connection closes prematurely on occasion when we're inserting thousands of rows at once. Break into smaller chunks so connection stays alive
+    (doseq [chunk (partition-all 300 objs)]
+      (print (color/blue \.))
+      (flush)
+      (try
+        (jdbc/insert-multi! *target-db-connection* (:table entity) cols (for [row chunk]
+                                                                          (map row ks)))
+
+        (catch java.sql.SQLException e
+          (jdbc/print-sql-exception-chain e)
+          (throw e)))))
   (println (color/green "[OK]")))
 
 (defn- insert-self-referencing-entity! [e objs]


### PR DESCRIPTION
This was just an issue of Postgres automatically lowercasing unquoted identifiers. Our DB schema has two camelcased columns (`sizeX` and `sizeY` in `DashboardCard`) (why?) that cause trouble because of that.

Fixes #2910
