### PR TITLE
Add -server to JVM options :yum:

### DIFF
--- a/bin/docker/run_metabase.sh
+++ b/bin/docker/run_metabase.sh
@@ -26,7 +26,7 @@ fi
 
 
 # Setup Java Options
-JAVA_OPTS="-Dlogfile.path=target/log -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
+JAVA_OPTS="-Dlogfile.path=target/log -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -server"
 
 if [ ! -z "$JAVA_TIMEZONE" ]; then
   JAVA_OPTS="${JAVA_OPTS} -Duser.timezone=${JAVA_TIMEZONE}"

--- a/deploy/aws-eb-docker/run_metabase.sh
+++ b/deploy/aws-eb-docker/run_metabase.sh
@@ -16,4 +16,4 @@ export MB_DB_PORT=$RDS_PORT
 # TODO: dynamically determine type, probably using the port number
 export MB_DB_TYPE=postgres
 
-exec java -Dlogfile.path=target/log -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -jar /app/metabase.jar
+exec java -Dlogfile.path=target/log -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -server -jar /app/metabase.jar

--- a/project.clj
+++ b/project.clj
@@ -114,6 +114,7 @@
                    :jvm-opts ["-Dlogfile.path=target/log"
                               "-Xms1024m"                             ; give JVM a decent heap size to start with
                               "-Xmx2048m"                             ; hard limit of 2GB so we stop hitting the 4GB container limit on CircleCI
+                              "-server"                               ; Run JVM in server mode as opposed to client -- see http://stackoverflow.com/questions/198577/real-differences-between-java-server-and-java-client for a good explanation of this
                               "-XX:+CMSClassUnloadingEnabled"         ; let Clojure's dynamically generated temporary classes be GC'ed from PermGen
                               "-XX:+UseConcMarkSweepGC"]              ; Concurrent Mark Sweep GC needs to be used for Class Unloading (above)
                    :aot [metabase.logger]}                            ; Log appender class needs to be compiled for log4j to use it


### PR DESCRIPTION
`-server` tunes JVM for servery stuff (which we're using it for) as opposed to clienty stuff (`-client`, the default option)

[Here's a good explanation](http://stackoverflow.com/questions/198577/real-differences-between-java-server-and-java-client) of the differences for the unfamiliar and curious
