### PR TITLE
Fix sent pulse to Private Channels

### DIFF
--- a/src/metabase/api/pulse.clj
+++ b/src/metabase/api/pulse.clj
@@ -73,12 +73,14 @@
     {:channels (if-not (get-in chan-types [:slack :configured])
                  ;; no Slack integration, so we are g2g
                  chan-types
-                 ;; if we have Slack enabled build a dynamic list of channels/users
+                 ;; if we have Slack enabled build a dynamic list of channels/users/groups
                  (let [slack-channels (for [channel (slack/channels-list)]
                                         (str \# (:name channel)))
                        slack-users    (for [user (slack/users-list)]
-                                        (str \@ (:name user)))]
-                   (assoc-in chan-types [:slack :fields 0 :options] (concat slack-channels slack-users))))}))
+                                        (str \@ (:name user)))
+                       slack-groups   (for [group (slack/groups-list)]
+                                        (str \# (:name group)))]
+                   (assoc-in chan-types [:slack :fields 0 :options] (concat (sort (concat slack-channels slack-groups)) slack-users))))}))
 
 
 (defendpoint GET "/preview_card/:id"

--- a/src/metabase/integrations/slack.clj
+++ b/src/metabase/integrations/slack.clj
@@ -53,6 +53,10 @@
   "Calls Slack api `users.list` function and returns the list of available users."
   (comp :members (partial GET :users.list)))
 
+(def ^{:arglists '([& {:as args}])} groups-list
+  "Calls Slack api `groups.list` function and returns the list of available groups."
+  (comp :groups (partial GET :groups.list)))
+
 (defn- create-files-channel!
   "Convenience function for creating our Metabase files channel to store file uploads."
   []


### PR DESCRIPTION
The slack list private groups at another end point. **https://api.slack.com/methods/groups.list**
Issue https://github.com/metabase/metabase/issues/2694
###### TODO
-  [x] Sign our [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
