### PR TITLE
Simple script to deploy current branch to Heroku

### DIFF
--- a/bin/heroku/deploy
+++ b/bin/heroku/deploy
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ $# -gt 0 ]; then
+    heroku_app_name="$1"
+else
+    heroku_app_name="metabase-$(git rev-parse --abbrev-ref HEAD)"
+fi
+
+if ! heroku ps -a "$heroku_app_name" > /dev/null; then
+    heroku apps:create -n --addons "heroku-postgresql:hobby-dev" "$heroku_app_name"
+    heroku buildpacks:clear -a "$heroku_app_name"
+    heroku buildpacks:add "https://github.com/heroku/heroku-buildpack-nodejs" -a "$heroku_app_name"
+    heroku buildpacks:add "https://github.com/heroku/heroku-buildpack-clojure" -a "$heroku_app_name"
+fi
+
+time git push -f "https://git.heroku.com/$heroku_app_name.git" HEAD:master
+
+heroku open -a "$heroku_app_name"


### PR DESCRIPTION
In a Metabase repo just run:

```
./bin/heroku/deploy $HEROKU_APP_NAME
```

to deploy HEAD to a Heroku app named `$HEROKU_APP_NAME` (it will automatically try to create an app configured for Metabase with that name if the app doesn't already exist)

If you leave off `$HEROKU_APP_NAME` it will default to a Heroku app named `metabase-$BRANCH_NAME` where `$BRANCH_NAME` is the name of the currently checked out git branch.
