### PR TITLE
Allow Settings to have types

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsEmailFormElement.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsEmailFormElement.jsx
@@ -66,7 +66,7 @@ export default class SettingsEmailFormElement extends Component {
     }
 
     renderToggleInput(element) {
-        const on = (element.value == null ? element.default : element.value) === "true";
+        const on = (element.value == null ? element.default : element.value) === true;
         return (
             <div className="flex align-center pt1">
                 <Toggle value={on} onChange={this.props.handleChangeEvent.bind(null, element, on ? "false" : "true")}/>

--- a/frontend/src/metabase/admin/settings/components/SettingsSetting.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsSetting.jsx
@@ -56,7 +56,7 @@ export default class SettingsSetting extends Component {
     }
 
     renderToggleInput(setting) {
-        var on = (setting.value == null ? setting.default : setting.value) === "true";
+        const on = (setting.value == null ? setting.default : setting.value) === true;
         return (
             <div className="flex align-center pt1">
                 <Toggle value={on} onChange={!this.props.disabled ? this.props.updateSetting.bind(null, setting, on ? "false" : "true") : null}/>

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
@@ -33,10 +33,10 @@ export default class SettingsUpdatesForm extends Component {
         let versionInfo = _.findWhere(this.props.settings, {key: "version-info"}),
             currentVersion = MetabaseSettings.get("version").tag;
 
-        versionInfo = versionInfo ? JSON.parse(versionInfo.value) : null;
+        if (versionInfo) versionInfo = versionInfo.value;
 
         /*
-            We expect the versionInfo to take on the JSON structure detailed below.  
+            We expect the versionInfo to take on the JSON structure detailed below.
             The 'older' section should contain only the last 5 previous versions, we don't need to go on forever.
             The highlights for a version should just be text and should be limited to 5 items tops.
 
@@ -81,7 +81,7 @@ export default class SettingsUpdatesForm extends Component {
                         <span className="text-white text-bold">Metabase {this.removeVersionPrefixIfNeeded(versionInfo.latest.version)} is available.  You're running {this.removeVersionPrefixIfNeeded(currentVersion)}</span>
                         <a data-metabase-event={"Updates Settings; Update link clicked; "+versionInfo.latest.version} className="Button Button--white Button--medium borderless" href="http://www.metabase.com/start" target="_blank">Update</a>
                     </div>
-                    
+
                     <div className="text-grey-3">
                         <h3 className="py3 text-uppercase">What's Changed:</h3>
 

--- a/frontend/src/metabase/lib/settings.js
+++ b/frontend/src/metabase/lib/settings.js
@@ -43,7 +43,7 @@ const MetabaseSettings = {
         let versionInfo = _.findWhere(settings, {key: "version-info"}),
             currentVersion = MetabaseSettings.get("version").tag;
 
-        versionInfo = versionInfo ? JSON.parse(versionInfo.value) : null;
+        if (versionInfo) versionInfo = versionInfo.value;
 
         return (versionInfo && currentVersion !== versionInfo.latest.version);
     },

--- a/src/metabase/api/email.clj
+++ b/src/metabase/api/email.clj
@@ -65,7 +65,7 @@
                          {:error :SUCCESS})]
     (if (= :SUCCESS (:error response))
       ;; test was good, save our settings
-      (setting/set-all email-settings)
+      (setting/set-many! email-settings)
       ;; test failed, return response message
       {:status 500
        :body   (humanize-error-messages response)})))

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -12,7 +12,8 @@
             [metabase.events :as events]
             (metabase.models [user :refer [User set-user-password! set-user-password-reset-token!], :as user]
                              [session :refer [Session]]
-                             [setting :refer [defsetting], :as setting])
+                             [setting :refer [defsetting]])
+            [metabase.public-settings :as public-settings]
             [metabase.util :as u]
             [metabase.util.password :as pass]))
 
@@ -124,7 +125,7 @@
 (defendpoint GET "/properties"
   "Get all global properties and their values. These are the specific `Settings` which are meant to be public."
   []
-  (setting/public-settings))
+  (public-settings/public-settings))
 
 
 ;;; ------------------------------------------------------------ GOOGLE AUTH ------------------------------------------------------------

--- a/src/metabase/api/setting.clj
+++ b/src/metabase/api/setting.clj
@@ -8,15 +8,15 @@
   "Get all `Settings` and their values. You must be a superuser to do this."
   []
   (check-superuser)
-  (setting/all-with-descriptions))
+  (setting/all))
 
 (defendpoint PUT "/"
   "Update multiple `Settings` values.  You must be a superuser to do this."
   [:as {settings :body}]
   {settings [Required Dict]}
   (check-superuser)
-  (setting/set-all settings)
-  (setting/all-with-descriptions))
+  (setting/set-many! settings)
+  (setting/all))
 
 (defendpoint GET "/:key"
   "Fetch a single `Setting`. You must be a superuser to do this."
@@ -31,13 +31,14 @@
   [key :as {{:keys [value]} :body}]
   {key Required}
   (check-superuser)
-  (setting/set* (keyword key) value))
+  (setting/set! key value))
 
+;; TODO - this endpoint is ultimately unneccesary because you can just PUT nil instead
 (defendpoint DELETE "/:key"
   "Delete a `Setting`. You must be a superuser to do this."
   [key]
   {key Required}
   (check-superuser)
-  (setting/delete (keyword key)))
+  (setting/set! key nil))
 
 (define-routes)

--- a/src/metabase/api/setting.clj
+++ b/src/metabase/api/setting.clj
@@ -23,7 +23,11 @@
   [key]
   {key Required}
   (check-superuser)
-  (setting/get (keyword key)))
+  (let [k (keyword key)
+        v (setting/get k)]
+    ;; for security purposes, don't return value of a setting if it was defined via env var
+    (when (not= v (setting/env-var-value k))
+      v)))
 
 (defendpoint PUT "/:key"
   "Create/update a `Setting`. You must be a superuser to do this.
@@ -39,6 +43,7 @@
   [key]
   {key Required}
   (check-superuser)
-  (setting/set! key nil))
+  (setting/set! key nil)
+  {:status 204, :body nil})
 
 (define-routes)

--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -43,9 +43,9 @@
     ;; this results in a second db call, but it avoids redundant password code so figure it's worth it
     (set-user-password! (:id new-user) password)
     ;; set a couple preferences
-    (setting/set :site-name site_name)
-    (setting/set :admin-email email)
-    (setting/set :anon-tracking-enabled (or allow_tracking "true"))
+    (setting/set! :site-name site_name)
+    (setting/set! :admin-email email)
+    (setting/set! :anon-tracking-enabled (or allow_tracking true))
     ;; setup database (if needed)
     (when (driver/is-engine? engine)
       (->> (db/insert! Database

--- a/src/metabase/api/slack.clj
+++ b/src/metabase/api/slack.clj
@@ -16,7 +16,7 @@
     ;; just check that channels.list doesn't throw an exception (a.k.a. that the token works)
     (when-not config/is-test?
       (slack/GET :channels.list, :exclude_archived 1, :token slack-token))
-    (setting/set-all slack-settings)
+    (setting/set-many! slack-settings)
     {:ok true}
     (catch clojure.lang.ExceptionInfo info
       {:status 400, :body (ex-data info)})))

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -27,15 +27,24 @@
             (metabase.models [setting :refer [defsetting]]
                              [user :refer [User]])))
 
-;; ## CONFIG
+;;; CONFIG
 
-(defsetting site-name "The name used for this instance of Metabase." "Metabase")
+;; TODO - Should the be moved to `metabase.public-settings` ?
 
-(defsetting -site-url "The base URL of this Metabase instance, e.g. \"http://metabase.my-company.com\"")
+(defsetting site-name
+  "The name used for this instance of Metabase."
+  :default "Metabase")
 
-(defsetting admin-email "The email address users should be referred to if they encounter a problem.")
+(defsetting -site-url
+  "The base URL of this Metabase instance, e.g. \"http://metabase.my-company.com\"")
 
-(defsetting anon-tracking-enabled "Enable the collection of anonymous usage data in order to help Metabase improve." "true")
+(defsetting admin-email
+  "The email address users should be referred to if they encounter a problem.")
+
+(defsetting anon-tracking-enabled
+  "Enable the collection of anonymous usage data in order to help Metabase improve."
+  :type   :boolean
+  :default true)
 
 (defn site-url
   "Fetch the site base URL that should be used for password reset emails, etc.
@@ -55,7 +64,7 @@
 (def app
   "The primary entry point to the HTTP server"
   (-> routes/routes
-      (mb-middleware/log-api-call)
+      mb-middleware/log-api-call
       mb-middleware/add-security-headers ; Add HTTP headers to API responses to prevent them from being cached
       (wrap-json-body                    ; extracts json POST body and makes it avaliable on request
         {:keywords? true})

--- a/src/metabase/db/migrations.clj
+++ b/src/metabase/db/migrations.clj
@@ -97,7 +97,7 @@
     (when-let [email (db/select-one-field :email 'User
                        :is_superuser true
                        :is_active    true)]
-      (setting/set :admin-email email))))
+      (setting/set! :admin-email email))))
 
 
 ;; Remove old `database-sync` activity feed entries

--- a/src/metabase/integrations/slack.clj
+++ b/src/metabase/integrations/slack.clj
@@ -7,7 +7,7 @@
 
 
 ;; Define a setting which captures our Slack api token
-(defsetting slack-token "Slack API bearer token obtained from https://api.slack.com/web#authentication" nil)
+(defsetting slack-token "Slack API bearer token obtained from https://api.slack.com/web#authentication")
 
 (def ^:private ^:const ^String slack-api-base-url "https://slack.com/api")
 (def ^:private ^:const ^String files-channel-name "metabase_files")

--- a/src/metabase/metabot.clj
+++ b/src/metabase/metabot.clj
@@ -11,12 +11,15 @@
                       [stream :as s])
             [metabase.db :as db]
             [metabase.integrations.slack :as slack]
-            [metabase.models.setting :as setting]
-            [metabase.pulse :as pulse]
-            [metabase.util :as u]
+            [metabase.models.setting :refer [defsetting], :as setting]
+            (metabase [pulse :as pulse]
+                      [util :as u])
             [metabase.util.urls :as urls]))
 
-(setting/defsetting metabot-enabled "Enable Metabot, which lets you search for and view your saved questions directly via Slack." "true")
+(defsetting metabot-enabled
+  "Enable Metabot, which lets you search for and view your saved questions directly via Slack."
+  :type    :boolean
+  :default true)
 
 ;;; # ------------------------------------------------------------ Metabot Command Handlers ------------------------------------------------------------
 
@@ -250,7 +253,7 @@
    This will spin up a background thread that opens and maintains a Slack WebSocket connection."
   []
   (when (and (setting/get :slack-token)
-             (= "true" (metabot-enabled)))
+             (metabot-enabled))
     (log/info "Starting MetaBot WebSocket monitor thread...")
     (start-websocket-monitor!)))
 

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -56,7 +56,7 @@
 (def ^:private SettingDefinition
   {:setting-name s/Keyword
    :description  s/Str            ; used for docstring and is user-facing in the admin panel
-   :default      (s/maybe s/Str)  ; this is a string because in the DB all settings are stored as strings; different getters can handle type conversion *from* string
+   :default      s/Any            ; this is a string because in the DB all settings are stored as strings; different getters can handle type conversion *from* string
    :setting-type Type             ; :string or :boolean
    :getter       clojure.lang.IFn
    :setter       clojure.lang.IFn
@@ -129,7 +129,7 @@
   (let [setting (resolve-setting setting-or-name)
         v       (or (db-value setting)
                     (env-var-value setting)
-                    (:default setting))]
+                    (str (:default setting)))]
     (when (seq v)
       v)))
 
@@ -223,8 +223,7 @@
              (merge {:setting-name setting-name
                      :description  nil
                      :setting-type setting-type
-                     :default      (when default
-                                     (str default))
+                     :default      default
                      :getter       (partial (default-getter-for-type setting-type) setting-name)
                      :setter       (partial (default-setter-for-type setting-type) setting-name)
                      :internal?    false}

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -321,14 +321,6 @@
   ;; irrelevant changes (to other settings) are made.
   (events/publish-event :settings-update settings))
 
-
-(defn- obfuscated-env-var-value
-  "If SETTING was set via env var, return an obfuscated string like `USING $MB_MY_SETTING`.
-   This is meant to be user-facing (it is shown in the admin panel settings page)."
-  ^String [setting]
-  (when (env-var-value setting)
-    (format "Using $%s" (env-var-name setting))))
-
 (defn all
   "Return a sequence of Settings maps, including value and description.
    (For security purposes, this doesn't return the value of a setting if it was set via env var)."
@@ -339,17 +331,6 @@
      :value       (when (not= v (env-var-value setting))
                     v)
      :description (:description setting)
-     :default     (or (obfuscated-env-var-value setting)
-                      (:default setting))}))
-
-
-(defn- settings-list
-  "Return a list of all Settings (as created with `defsetting`).
-   This excludes Settings created with the option `:internal?`."
-  []
-  (for [[k setting] @registered-settings
-        :when       (not (:internal? setting))]
-    {:key         k
-     :description (:description setting)
-     :default     (or (obfuscated-env-var-value setting)
+     :default     (or (when (env-var-value setting)
+                        (format "Using $%s" (env-var-name setting)))
                       (:default setting))}))

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -230,7 +230,7 @@
                                                    (dissoc setting :name :type :default))))
     (s/validate SettingDefinition <>)
     (swap! registered-settings assoc setting-name <>)
-    (println "Registered Setting" setting-name))) ; NOCOMMIT
+    (println "Registered Setting" setting-name "\n" (u/pprint-to-str <>)))) ; NOCOMMIT
 
 
 
@@ -312,14 +312,15 @@
 (defn all
   "Return a sequence of Settings maps, including value and description."
   []
-  (restore-cache-if-needed!)
-  (let [registered @registered-settings]
-    (for [[k v] @cache
-          :let  [info (get registered k)]]
-      {:key         (keyword k)
-       :value       v
-       :description (:description info)
-       :default     (:default info)})))
+  (println "ALL!" (sort (keys @registered-settings))) ; NOCOMMIT
+  (for [[k setting] @registered-settings
+        :let        [v       (get k)
+                     default (:default setting)]]
+    {:key         k
+     :value       (when (not= v default)
+                    v)
+     :description (:description setting)
+     :default     default}))
 
 
 (defn- settings-list

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -1,166 +1,266 @@
 (ns metabase.models.setting
-  (:refer-clojure :exclude [get set])
-  (:require (clojure [string :as s]
-                     [walk :as walk])
+  "Settings are a fast and simple way to create a setting that can be set
+   from the admin page. They are saved to the Database, but intelligently
+   cached internally for super-fast lookups.
+
+   Define a new Setting with `defsetting` (optionally supplying a default value, type, or custom getters & setters):
+
+      (defsetting mandrill-api-key \"API key for Mandrill\")
+
+   The setting and docstr will then be auto-magically accessible from the admin page.
+
+   You can also set the value via the corresponding env var, which looks like
+   `MB_MANDRILL_API_KEY`, where the name of the setting is converted to uppercase and dashes to underscores.
+
+   The var created with `defsetting` can be used as a getter/setter, or you can
+   use `get` and `set!`:
+
+       (require '[metabase.models.setting :as setting])
+
+       (setting/get :mandrill-api-key)           ; only returns values set explicitly from SuperAdmin
+       (mandrill-api-key)                        ; returns value set in SuperAdmin, OR value of corresponding env var, OR the default value, if any (in that order)
+
+       (setting/set! :mandrill-api-key \"NEW_KEY\")
+       (mandrill-api-key \"NEW_KEY\")
+
+       (setting/set! :mandrill-api-key nil)
+       (mandrill-api-key nil)
+
+   Get a map of all Settings:
+
+      (setting/all)"
+  (:refer-clojure :exclude [get])
+  (:require [clojure.string :as str]
             [environ.core :as env]
-            [metabase.config :as config]
-            [metabase.db :as db]
-            [metabase.events :as events]
-            [metabase.models [common :as common]
-                             [interface :as i]]
-            [metabase.setup :as setup]
-            [metabase.util :as u]
-            [metabase.util.password :as password])
-  (:import java.util.TimeZone))
+            [medley.core :as m]
+            [schema.core :as s]
+            (metabase [db :as db]
+                      [events :as events])
+            [metabase.models.interface :as i]
+            [metabase.util :as u]))
 
-;; Settings are a fast + simple way to create a setting that can be set
-;; from the SuperAdmin page. They are saved to the Database, but intelligently
-;; cached internally for super-fast lookups.
-;;
-;; Define a new Setting with `defsetting` (optionally supplying a default value):
-;;
-;;    (defsetting mandrill-api-key "API key for Mandrill")
-;;
-;; The setting and docstr will then be auto-magically accessible from the SuperAdmin page.
-;;
-;; You can also set the value via the corresponding env var, which looks like
-;; `MB_MANDRILL_API_KEY`, where the name of the setting is converted to uppercase and dashes to underscores.
-;;
-;; The var created with `defsetting` can be used as a getter/setter, or you can
-;; use `get`/`set`/`delete`:
-;;
-;;     (require '[metabase.models.setting :as setting])
-;;
-;;     (setting/get :mandrill-api-key)           ; only returns values set explicitly from SuperAdmin
-;;     (mandrill-api-key)                        ; returns value set in SuperAdmin, OR value of corresponding env var, OR the default value, if any (in that order)
-;;
-;;     (setting/set :mandrill-api-key "NEW_KEY")
-;;     (mandrill-api-key "NEW_KEY")
-;;
-;;     (setting/delete :mandrill-api-key)
-;;     (mandrill-api-key nil)
-;;
-;; Get a map of all Settings:
-;;
-;;    (setting/all)
 
-(declare Setting
-         cached-setting->value
-         restore-cache-if-needed
-         settings-list)
+(i/defentity Setting
+  "The model that underlies `defsetting`."
+  :setting)
 
-;;; # PUBLIC
+(u/strict-extend (class Setting)
+  i/IEntity
+  (merge i/IEntityDefaults
+         {:types (constantly {:value :clob})}))
 
-;;; ## ACCESSORS
 
-;;; ### GET
+(def ^:private Type
+  (s/enum :string :boolean))
 
-(defn get
-  "Fetch value of `Setting`, first trying our cache, or fetching the value
-   from the DB if that fails. (Cached lookup time is ~60µs, compared to ~1800µs for DB lookup)
+(s/defrecord SettingDefinition [setting-name :- s/Keyword
+                                description  :- s/Str            ; used for docstring and is user-facing in the admin panel
+                                default      :- (s/maybe s/Str)  ; this is a string because in the DB all settings are stored as strings; different getters can handle type conversion *from* string
+                                setting-type :- Type             ; :string or :boolean
+                                getter       :- clojure.lang.IFn
+                                setter       :- clojure.lang.IFn
+                                internal?    :- s/Bool]          ; should the API never return this setting? (default: false)
+  clojure.lang.Named
+  (getName [_] (name setting-name)))
 
-     (get :mandrill-api-key)
+(defonce ^:private registered-settings
+  (atom {}))
 
-   Unlike using the setting getter fn, this will *not* return default values or values specified by env vars.
+(s/defn ^:private ^:always-validate resolve-setting :- SettingDefinition
+  [setting-or-name]
+  (if (instance? SettingDefinition setting-or-name)
+    setting-or-name
+    (let [k (keyword setting-or-name)]
+      (or (@registered-settings k)
+          (throw (Exception. (format "Setting %s does not exist.\nFound: %s" k (sort (keys @registered-settings)))))))))
 
-   Prefer using the automatically generated getter function unless absolutely necessary:
 
-     (mandrill-api-key)"
-  [k]
-  {:pre [(keyword? k)]}
-  (restore-cache-if-needed)
-  (if (contains? @cached-setting->value k)
-    (@cached-setting->value k)
-    (let [v (db/select-one-field :value Setting, :key (name k))]
-      (swap! cached-setting->value assoc k v)
+;;; ------------------------------------------------------------ cache ------------------------------------------------------------
+
+;; Cache is a 1:1 mapping of what's in the DB
+;; Cached lookup time is ~60µs, compared to ~1800µs for DB lookup
+
+(def ^:private cache
+  (atom nil))
+
+(defn- restore-cache-if-needed! []
+  (when-not @cache
+    (reset! cache (u/prog1 (db/select-field->field :key :value Setting)
+                    (println "Restored cache:\n" (u/pprint-to-str 'green <>))))))
+
+
+;;; ------------------------------------------------------------ get ------------------------------------------------------------
+
+(defn- env-var-name
+  "Get the env var corresponding to SETTING-OR-NAME.
+   (This is used primarily for documentation purposes)."
+  ^String [setting-or-name]
+  (let [setting (resolve-setting setting-or-name)]
+    (str "MB_" (str/upper-case (str/replace (name setting) "-" "_")))))
+
+(defn get-from-env-var
+  "Get the value of SETTING-OR-NAME from the corresponding env var, if any.
+   The name of the Setting is converted to uppercase and dashes to underscores;
+   for example, a setting named `default-domain` can be set with the env var `MB_DEFAULT_DOMAIN`."
+  [setting-or-name]
+  (let [setting (resolve-setting setting-or-name)]
+    (env/env (keyword (str "mb-" (name setting))))))
+
+(defn- get-from-db [setting-or-name]
+  (restore-cache-if-needed!)
+  (clojure.core/get @cache (name (resolve-setting setting-or-name))))
+
+
+(defn get-string
+  "Get string value of SETTING-OR-NAME. This is the default getter for `String` settings; valuBis fetched as follows:
+
+   1.  From corresponding env var, if any;
+   2.  From the database, if a value is present;
+   3.  The default value, if one was specified.
+
+   If the fetched value is an empty string it is considered to be unset and this function returns `nil`."
+  ^String [setting-or-name]
+  (let [setting (resolve-setting setting-or-name)
+        v       (or (u/prog1 (get-from-env-var setting)
+                      (when <> (println "get-from-env-var" <>))) ; NOCOMMIT
+                    (u/prog1 (get-from-db setting)
+                      (when <> (println "get-from-db" <>)))
+                    (u/prog1 (:default setting)
+                      (when <> (println ":default" <>))))]
+    (when (seq v)
       v)))
 
-(defn- get-from-env-var
-  "Given a `Setting` like `:mandrill-api-key`, return the value of the corresponding env var,
-   e.g. `MB_MANDRILL_API_KEY`."
-  [setting-key]
-  (env/env (keyword (str "mb-" (name setting-key)))))
+(defn- string->boolean [string-value]
+  (when (seq string-value)
+    (case (str/lower-case string-value)
+      "true"  true
+      "false" false
+      (throw (Exception. "Invalid value for string: must be either \"true\" or \"false\" (case-insensitive).")))))
 
-(defn get*
-  "Get the value of a `Setting`. Unlike `get`, this also includes values from env vars. Like `get`, this does not return default values."
-  [setting-key]
-  (or (get setting-key)
-      (get-from-env-var setting-key)))
+(defn get-boolean
+  "Get boolean value of (presumably `:boolean`) SETTING-OR-NAME. This is the default getter for `:boolean` settings.
+   Returns one of the following values:
+
+   *  `nil`   if string value of SETTING-OR-NAME is unset (or empty)
+   *  `true`  if *lowercased* string value of SETTING-OR-NAME is `true`
+   *  `false` if *lowercased* string value of SETTING-OR-NAME is `false`."
+  ^Boolean [setting-or-name]
+  (string->boolean (get-string setting-or-name)))
+
+(def ^:private default-getter-for-type
+  {:string  get-string
+   :boolean get-boolean})
+
+(defn get
+  "Fetch the value of SETTING-OR-NAME. What this means depends on the Setting's `:getter`; by default, this looks for first for a corresponding env var,
+   then checks the cache, then returns the default value of the Setting, if any."
+  [setting-or-name]
+  (println "get" (u/format-color 'blue (name setting-or-name))) ; NOCOMMIT
+  ((:getter (resolve-setting setting-or-name))))
 
 
-;;; ### SET / DELETE
+;;; ------------------------------------------------------------ set! ------------------------------------------------------------
 
-;; TODO - this should be renamed `delete!`
-(defn delete
-  "Clear the value of a `Setting`."
-  [k]
-  {:pre [(keyword? k)]}
-  (restore-cache-if-needed)
-  (swap! cached-setting->value dissoc k)
-  (db/delete! Setting, :key (name k))
-  {:status 204, :body nil})
+(s/defn ^:always-validate set-string!
+  "Set string value of SETTING-OR-NAME. A `nil` or empty NEW-VALUE can be passed to unset (i.e., delete) SETTING-OR-NAME."
+  [setting-or-name, new-value :- (s/maybe s/Str)]
+  (let [new-value    (when (seq new-value)
+                       new-value)
+        setting      (resolve-setting setting-or-name)
+        setting-name (name setting)]
+    (restore-cache-if-needed!)
+    ;; write to DB
+    (cond
+      (not new-value)                 (db/delete! Setting :key setting-name)
+      ;; if there's a value in the cache then the row already exists in the DB; update that
+      (contains? @cache setting-name) (db/update-where! Setting {:key setting-name}
+                                        :value new-value)
+      ;; if there's nothing in the cache then the row doesn't exist, insert a new one
+      :else                           (db/insert! Setting
+                                        :key  setting-name
+                                        :value new-value))
+    ;; update cached value
+    (if new-value
+      (swap! cache assoc  setting-name new-value)
+      (swap! cache dissoc setting-name))
+    new-value))
 
-;; TODO - rename this `set!`
-(defn set
-  "Set the value of a `Setting`.
+(defn set-boolean!
+  "Set the value of boolean SETTING-OR-NAME. NEW-VALUE can be nil, a boolean, or a string representation of one, such as `\"true\"` or `\"false\"` (these strings are case-insensitive)."
+  [setting-or-name new-value]
+  (set-string! setting-or-name (if (string? new-value)
+                                 (set-boolean! setting-or-name (string->boolean new-value))
+                                 (case new-value
+                                   true  "true"
+                                   false "false"
+                                   nil   nil))))
+
+(def ^:private default-setter-for-type
+  {:string  set-string!
+   :boolean set-boolean!})
+
+(defn set!
+  "Set the value of SETTING-OR-NAME. What this means depends on the Setting's `:setter`; by default, this just updates the Settings cache and writes its value to the DB.
 
     (set :mandrill-api-key \"xyz123\")
 
-   Don't use this directly unless absolutely neccesary! Prefer using the setting directly instead:
+   Style note: prefer using the setting directly instead:
 
      (mandrill-api-key \"xyz123\")"
-  [k v]
-  {:pre [(keyword? k) (string? v)]}
-  (if (get k)
-    (db/update-where! Setting {:key (name k)}
-      :value v)
-    (db/insert! Setting
-      :key   (name k)
-      :value v))
-  (restore-cache-if-needed)
-  (swap! cached-setting->value assoc k v)
-  v)
-
-;; TODO - rename this `set-all!`
-(defn set-all
-  "Set the value of several `Settings` at once.
-
-    (set-all {:mandrill-api-key \"xyz123\", :another-setting \"ABC\"})"
-  [settings]
-  {:pre [(map? settings)]}
-  (doseq [k (keys settings)]
-    (if-let [v (clojure.core/get settings k)]
-      (set k v)
-      (delete k)))
-  (events/publish-event :settings-update settings))
-
-;; TODO - Rename to `set-or-delete!`
-(defn set*
-  "Set the value of a `Setting`, deleting it if VALUE is `nil` or an empty string."
-  [setting-key value]
-  (if (or (not value)
-          (and (string? value)
-               (not (seq value))))
-    (delete setting-key)
-    (set setting-key value)))
+  [setting-or-name new-value]
+  (println (u/format-color 'magenta "%s -> %s" (name setting-or-name) new-value)) ; NOCOMMIT
+  ((:setter (resolve-setting setting-or-name)) new-value))
 
 
-;;; ## DEFSETTING
+;;; ------------------------------------------------------------ register-setting! ------------------------------------------------------------
 
-(defn- setting-extra-dox
-  "Generate some extra documentation for a `Setting`."
-  [symb default-value]
-  (str (format "`%s` is a `Setting`. You can get its value by calling\n\n" symb)
-       (format  "    (%s)\n\n" symb)
-       "and set its value by calling\n\n"
-       (format "    (%s <new-value>)\n\n" symb)
-       (format "You can also set its value with the env var `MB_%s`.\n"
-               (s/upper-case (s/replace (name symb) #"-" "_")))
-       "Clear its value by calling\n\n"
-       (format "    (%s nil)\n\n" symb)
-       (format "Its default value is `%s`." (if (nil? default-value)
-                                              "nil"
-                                              default-value))))
+(defn register-setting!
+  "Register a new `Setting` with a map of `SettingDefinition` attributes.
+   This is used internally be `defsetting`; you shouldn't need to use it yourself."
+  [{setting-name :name, setting-type :type, default :default, :as setting}]
+  (u/prog1 (let [setting-type (s/validate Type (or setting-type :string))]
+             (strict-map->SettingDefinition (merge {:setting-name setting-name
+                                                    :description  nil
+                                                    :setting-type setting-type
+                                                    :default      (when default
+                                                                    (str default))
+                                                    :getter       (partial (default-getter-for-type setting-type) setting-name)
+                                                    :setter       (partial (default-setter-for-type setting-type) setting-name)
+                                                    :internal?    false}
+                                                   (dissoc setting :name :type :default))))
+    (s/validate SettingDefinition <>)
+    (swap! registered-settings assoc setting-name <>)
+    (println "Registered Setting" setting-name))) ; NOCOMMIT
+
+
+
+;;; ------------------------------------------------------------ defsetting macro ------------------------------------------------------------
+
+(defn metadata-for-setting-fn
+  "Create metadata for the function automatically generated by `defsetting`."
+  [^SettingDefinition {:keys [default setting-type], :as setting}]
+  {:arglists '([] [new-value])
+   :doc      (str (format "`%s` is a %s `Setting`. You can get its value by calling\n\n" (name setting) (name setting-type))
+                  (format  "    (%s)\n\n" (name setting))
+                  "and set its value by calling\n\n"
+                  (format "    (%s <new-value>)\n\n" (name setting))
+                  (format "You can also set its value with the env var `%s`.\n" (env-var-name setting))
+                  "Clear its value by calling\n\n"
+                  (format "    (%s nil)\n\n" (name setting))
+                  (format "Its default value is `%s`." (if (nil? default)
+                                                         "nil"
+                                                         default)))})
+
+(defn setting-fn
+  "Create the automatically defined getter/setter function for settings defined by `defsetting`."
+  [^SettingDefinition setting]
+  (fn
+    ([]
+     (get setting))
+    ([new-value]
+     ;; need to qualify this or otherwise the reader gets this confused with the set! used for things like (set! *warn-on-reflection* true)
+     ;; :refer-clojure :exclude doesn't seem to work in this case
+     (metabase.models.setting/set! setting new-value))))
 
 (defmacro defsetting
   "Defines a new `Setting` that will be added to the DB at some point in the future.
@@ -174,117 +274,62 @@
    A setting can be set from the SuperAdmin page or via the corresponding env var,
    eg. `MB_MANDRILL_API_KEY` for the example above.
 
-   You may optionally pass any of the kwarg OPTIONS below, which are kept as part of the
-   metadata of the `Setting` under the key `::options`:
+   You may optionally pass any of the OPTIONS below:
 
-   *  `:internal` - This `Setting` is for internal use and shouldn't be exposed in the UI (i.e., not
-                    returned by the corresponding endpoints). Default: `false`
+   *  `:default` - The default value of the setting. (default: `nil`)
+   *  `:type` - Either `:string` (default) or `:boolean`. Non-string settings have special default getters and setters that automatically coerce values to the correct types.
+   *  `:internal?` - This `Setting` is for internal use and shouldn't be exposed in the UI (i.e., not
+                     returned by the corresponding endpoints). Default: `false`
    *  `:getter` - A custom getter fn, which takes no arguments. Overrides the default implementation.
    *  `:setter` - A custom setter fn, which takes a single argument. Overrides the default implementation."
-  [nm description & [default-value & {:as options}]]
-  {:pre [(symbol? nm)
-         (string? description)]}
-  (let [setting-key (keyword nm)
-        value       (gensym "value")]
-    `(defn ~nm ~(str description "\n\n" (setting-extra-dox nm default-value))
-       {:arglists       '~'([] [new-value])
-        ::description   ~description
-        ::is-setting?   true
-        ::default-value ~default-value
-        ::options       ~options}
-       ([]       ~(if (:getter options)
-                    `(~(:getter options))
-                    `(or (get* ~setting-key)
-                         ~default-value)))
-       ([~value] ~(if (:setter options)
-                    `(~(:setter options) ~value)
-                    `(set* ~setting-key ~value))))))
+  {:style/indent 1}
+  [setting-symb description & {:as options}]
+  {:pre [(symbol? setting-symb) (string? description)]}
+  `(let [setting# (register-setting! (assoc ~options
+                                       :name ~(keyword setting-symb)
+                                       :description ~description))]
+     (-> (def ~setting-symb (setting-fn setting#))
+         (alter-meta! merge (metadata-for-setting-fn setting#)))))
 
 
-;;; ## ALL SETTINGS (ETC)
+;;; ------------------------------------------------------------ EXTRA UTIL FNS ------------------------------------------------------------
+
+(defn set-many!
+  "Set the value of several `Settings` at once.
+
+    (set-all {:mandrill-api-key \"xyz123\", :another-setting \"ABC\"})"
+  [settings]
+  {:pre [(map? settings)]}
+  (doseq [[k v] settings]
+    (metabase.models.setting/set! k v))
+  ;; TODO - This event is no longer neccessary or desirable. This is used in only a single place, to stop or restart the MetaBot when settings are updated;
+  ;; this only works if the setting is updated via this specific function. Instead, we should define a custom setter for the relevant setting that additionally
+  ;; performs the desired operations when the value is updated. This pattern is easier to understand, works no matter how the setting is changed, and doesn't run when
+  ;; irrelevant changes (to other settings) are made.
+  (events/publish-event :settings-update settings))
+
 
 (defn all
-  "Return a map of all *defined* `Settings`.
-
-    (all) -> {:mandrill-api-key ...}"
-  []
-  (restore-cache-if-needed)
-  @cached-setting->value)
-
-(defn all-with-descriptions
   "Return a sequence of Settings maps, including value and description."
   []
-  (let [settings (all)]
-    (->> (settings-list)
-         (map (fn [{k :key, :as setting}]
-                (assoc setting
-                       :value (k settings))))
-         (sort-by :key))))
+  (restore-cache-if-needed!)
+  (let [registered @registered-settings]
+    (for [[k v] @cache
+          :let  [info (get registered k)]]
+      {:key         (keyword k)
+       :value       v
+       :description (:description info)
+       :default     (:default info)})))
 
-(def ^:private ^{:arglists '([timezone-name])} short-timezone-name
-  "Get a short display name (e.g. `PST`) for `report-timezone`, or fall back to the System default if it's not set."
-  (memoize (fn [^String timezone-name]
-             (let [^TimeZone timezone (or (when (seq timezone-name)
-                                            (TimeZone/getTimeZone timezone-name))
-                                          (TimeZone/getDefault))]
-               (.getDisplayName timezone (.inDaylightTime timezone (java.util.Date.)) TimeZone/SHORT)))))
-
-
-(defsetting check-for-updates "Identify when new versions of Metabase are available." "true")
-(defsetting version-info "Information about available versions of Metabase." "{}")
-
-
-(defn public-settings
-  "Return a simple map of key/value pairs which represent the public settings for the front-end application."
-  []
-  {:ga_code               "UA-60817802-1"
-   :password_complexity   password/active-password-complexity
-   :timezones             common/timezones
-   :version               config/mb-version-info
-   :engines               ((resolve 'metabase.driver/available-drivers))
-   :setup_token           (setup/token-value)
-   :anon_tracking_enabled (let [tracking? (get :anon-tracking-enabled)]
-                            (or (nil? tracking?) (= "true" tracking?)))
-   :site_name             (get :site-name)
-   :email_configured      ((resolve 'metabase.email/email-configured?))
-   :admin_email           (get :admin-email)
-   :report_timezone       (get :report-timezone)
-   :timezone_short        (short-timezone-name (get :report-timezone))
-   :has_sample_dataset    (db/exists? 'Database, :is_sample true)
-   :google_auth_client_id (get :google-auth-client-id)})
-
-
-;;; # IMPLEMENTATION
-
-(defn- restore-cache-if-needed []
-  (when-not @cached-setting->value
-    (db/setup-db-if-needed)
-    (reset! cached-setting->value (walk/keywordize-keys (db/select-field->field :key :value Setting)))))
-
-(def ^:private cached-setting->value
-  "Map of setting name (keyword) -> string value, as they exist in the DB."
-  (atom nil))
-
-(i/defentity Setting
-  "The model that underlies `defsetting`."
-  :setting)
-
-(u/strict-extend (class Setting)
-  i/IEntity
-  (merge i/IEntityDefaults
-         {:types (constantly {:value :clob})}))
 
 (defn- settings-list
   "Return a list of all Settings (as created with `defsetting`).
-   This excludes Settings created with the option `:internal`."
+   This excludes Settings created with the option `:internal?`."
   []
-  (for [namespce (all-ns)
-        [_ varr] (ns-interns namespce)
-        :let     [{k :name, description ::description, default ::default-value, :as metta} (meta varr)]
-        :when    (and (::is-setting? metta)
-                      (not (get-in metta [::options :internal])))]
-    {:key         (keyword k)
-     :description description
-     :default     (or (when (get-from-env-var k)
-                        (format "Using $MB_%s" (s/upper-case (s/replace (name k) "-" "_"))))
-                      default)}))
+  (for [[k setting] @registered-settings
+        :when       (not (:internal? setting))]
+    {:key         k
+     :description (:description setting)
+     :default     (or (when (get-from-env-var setting)
+                        (format "Using $%s" (env-var-name setting)))
+                      (:default setting))}))

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -15,7 +15,8 @@
 ;; TODO - define a JSON type ?
 (defsetting version-info
   "Information about available versions of Metabase."
-  :default "{}")
+  :type    :json
+  :default {})
 
 
 (defn- short-timezone-name*

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -1,0 +1,48 @@
+(ns metabase.public-settings
+  (:require (metabase [config :as config]
+                      [db :as db])
+            (metabase.models [common :as common]
+                             [setting :refer [defsetting], :as setting])
+            [metabase.setup :as setup]
+            [metabase.util.password :as password])
+  (:import java.util.TimeZone))
+
+(defsetting check-for-updates
+  "Identify when new versions of Metabase are available."
+  :type    :boolean
+  :default true)
+
+;; TODO - define a JSON type ?
+(defsetting version-info
+  "Information about available versions of Metabase."
+  :default "{}")
+
+
+(defn- short-timezone-name*
+  "Get a short display name (e.g. `PST`) for `report-timezone`, or fall back to the System default if it's not set."
+  [^String timezone-name]
+  (let [^TimeZone timezone (or (when (seq timezone-name)
+                                 (TimeZone/getTimeZone timezone-name))
+                               (TimeZone/getDefault))]
+    (.getDisplayName timezone (.inDaylightTime timezone (java.util.Date.)) TimeZone/SHORT)))
+
+(def ^:private short-timezone-name (memoize short-timezone-name*))
+
+
+(defn public-settings
+  "Return a simple map of key/value pairs which represent the public settings for the front-end application."
+  []
+  {:ga_code               "UA-60817802-1"
+   :password_complexity   password/active-password-complexity
+   :timezones             common/timezones
+   :version               config/mb-version-info
+   :engines               ((resolve 'metabase.driver/available-drivers))
+   :setup_token           (setup/token-value)
+   :anon_tracking_enabled (setting/get :anon-tracking-enabled)
+   :site_name             (setting/get :site-name)
+   :email_configured      ((resolve 'metabase.email/email-configured?))
+   :admin_email           (setting/get :admin-email)
+   :report_timezone       (setting/get :report-timezone)
+   :timezone_short        (short-timezone-name (setting/get :report-timezone))
+   :has_sample_dataset    (db/exists? 'Database, :is_sample true)
+   :google_auth_client_id (setting/get :google-auth-client-id)})

--- a/src/metabase/routes.clj
+++ b/src/metabase/routes.clj
@@ -6,13 +6,13 @@
             [ring.util.response :as resp]
             [stencil.core :as stencil]
             [metabase.api.routes :as api]
-            [metabase.models.setting :as setting]))
+            [metabase.public-settings :as public-settings]))
 
 (defn- index [_]
   (-> (if ((resolve 'metabase.core/initialized?))
         (stencil/render-string (slurp (or (io/resource "frontend_client/index.html")
                                           (throw (Exception. "Cannot find './resources/frontend_client/index.html'. Did you remember to build the Metabase frontend?"))))
-                               {:bootstrap_json (json/generate-string (setting/public-settings))})
+                               {:bootstrap_json (json/generate-string (public-settings/public-settings))})
         (slurp (io/resource "frontend_client/init.html")))
       resp/response
       (resp/content-type "text/html")))

--- a/src/metabase/task/follow_up_emails.clj
+++ b/src/metabase/task/follow_up_emails.clj
@@ -23,7 +23,11 @@
 (defonce ^:private follow-up-emails-job (atom nil))
 (defonce ^:private follow-up-emails-trigger (atom nil))
 
-(setting/defsetting follow-up-email-sent "have we sent a follow up email to the instance admin?" false :internal true)
+(setting/defsetting follow-up-email-sent
+  "have we sent a follow up email to the instance admin?"
+  :type      :boolean
+  :default   false
+  :internal? true)
 
 
 (def ^:private ^:const abandonment-emails-job-key     "metabase.task.abandonment-emails.job")
@@ -31,7 +35,11 @@
 (defonce ^:private abandonment-emails-job (atom nil))
 (defonce ^:private abandonment-emails-trigger (atom nil))
 
-(setting/defsetting abandonment-email-sent "have we sent an abandonment email to the instance admin?" false :internal true)
+(setting/defsetting abandonment-email-sent
+  "have we sent an abandonment email to the instance admin?"
+  :type      :boolean
+  :default   false
+  :internal? true)
 
 ;; 2 weeks of inactivity after 30 days of total install
 ;;
@@ -108,7 +116,7 @@
     (catch Throwable t
       (log/error "Problem sending follow-up email" t))
     (finally
-      (setting/set :follow-up-email-sent "true"))))
+      (setting/set! :follow-up-email-sent true))))
 
 (defn- send-abandonment-email!
   "Send an email to the instance admin about why Metabase usage has died down."
@@ -128,4 +136,4 @@
           (catch Throwable t
             (log/error "Problem sending abandonment email" t))
           (finally
-            (setting/set :abandonment-email-sent "true")))))))
+            (setting/set! :abandonment-email-sent "true")))))))

--- a/src/metabase/task/upgrade_checks.clj
+++ b/src/metabase/task/upgrade_checks.clj
@@ -6,9 +6,9 @@
             (clojurewerkz.quartzite [jobs :as jobs]
                                     [triggers :as triggers])
             [clojurewerkz.quartzite.schedule.cron :as cron]
-            [metabase.config :as config]
-            [metabase.task :as task]
-            [metabase.models.setting :as setting]))
+            (metabase [config :as config]
+                      [public-settings :as public-settings]
+                      [task :as task])))
 
 (def ^:private ^:const upgrade-checks-job-key     "metabase.task.upgrade-checks.job")
 (def ^:private ^:const upgrade-checks-trigger-key "metabase.task.upgrade-checks.trigger")
@@ -26,12 +26,12 @@
 ;; simple job which looks up all databases and runs a sync on them
 (jobs/defjob CheckForNewVersions
   [ctx]
-  (when (= "true" (setting/check-for-updates))
+  (when (public-settings/check-for-updates)
     (log/debug "Checking for new Metabase version info.")
     (try
       ;; TODO: add in additional request params if anonymous tracking is enabled
       (when-let [version-info (get-version-info)]
-        (setting/version-info (json/generate-string version-info)))
+        (public-settings/version-info (json/generate-string version-info)))
       (catch Throwable e
         (log/error "Error fetching version info: " e)))))
 

--- a/src/metabase/task/upgrade_checks.clj
+++ b/src/metabase/task/upgrade_checks.clj
@@ -31,7 +31,7 @@
     (try
       ;; TODO: add in additional request params if anonymous tracking is enabled
       (when-let [version-info (get-version-info)]
-        (public-settings/version-info (json/generate-string version-info)))
+        (public-settings/version-info version-info))
       (catch Throwable e
         (log/error "Error fetching version info: " e)))))
 

--- a/src/metabase/task/upgrade_checks.clj
+++ b/src/metabase/task/upgrade_checks.clj
@@ -1,8 +1,8 @@
 (ns metabase.task.upgrade-checks
   "Contains a Metabase task which periodically checks for the availability of new Metabase versions."
-  (:require [cheshire.core :as json]
+  (:require [clojure.tools.logging :as log]
+            [cheshire.core :as json]
             [clj-http.client :as http]
-            [clojure.tools.logging :as log]
             (clojurewerkz.quartzite [jobs :as jobs]
                                     [triggers :as triggers])
             [clojurewerkz.quartzite.schedule.cron :as cron]
@@ -10,11 +10,11 @@
                       [public-settings :as public-settings]
                       [task :as task])))
 
-(def ^:private ^:const upgrade-checks-job-key     "metabase.task.upgrade-checks.job")
-(def ^:private ^:const upgrade-checks-trigger-key "metabase.task.upgrade-checks.trigger")
+(def ^:private ^:const job-key     "metabase.task.upgrade-checks.job")
+(def ^:private ^:const trigger-key "metabase.task.upgrade-checks.trigger")
 
-(defonce ^:private upgrade-checks-job (atom nil))
-(defonce ^:private upgrade-checks-trigger (atom nil))
+(defonce ^:private job     (atom nil))
+(defonce ^:private trigger (atom nil))
 
 (defn- get-version-info []
   (let [version-info-url      (config/config-str :mb-version-info-url)
@@ -39,15 +39,15 @@
   "Job initialization"
   []
   ;; build our job
-  (reset! upgrade-checks-job (jobs/build
-                               (jobs/of-type CheckForNewVersions)
-                               (jobs/with-identity (jobs/key upgrade-checks-job-key))))
+  (reset! job (jobs/build
+               (jobs/of-type CheckForNewVersions)
+               (jobs/with-identity (jobs/key job-key))))
   ;; build our trigger
-  (reset! upgrade-checks-trigger (triggers/build
-                                   (triggers/with-identity (triggers/key upgrade-checks-trigger-key))
-                                   (triggers/start-now)
-                                   (triggers/with-schedule
-                                     ;; run twice a day
-                                     (cron/cron-schedule "0 15 6,18 * * ? *"))))
+  (reset! trigger (triggers/build
+                   (triggers/with-identity (triggers/key trigger-key))
+                   (triggers/start-now)
+                   (triggers/with-schedule
+                     ;; run twice a day
+                     (cron/cron-schedule "0 15 6,18 * * ? *"))))
   ;; submit ourselves to the scheduler
-  (task/schedule-task! @upgrade-checks-job @upgrade-checks-trigger))
+  (task/schedule-task! @job @trigger))

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -8,7 +8,7 @@
             [metabase.test.data :refer :all]
             (metabase.test.data [datasets :as datasets]
                                 [users :refer :all])
-            [metabase.test.util :refer [match-$ random-name expect-eval-actual-first], :as tu]
+            [metabase.test.util :refer [match-$ random-name], :as tu]
             [metabase.util :as u]))
 
 ;; HELPER FNS

--- a/test/metabase/api/email_test.clj
+++ b/test/metabase/api/email_test.clj
@@ -30,7 +30,7 @@
                                                                    :email-smtp-password "gobble gobble"
                                                                    :email-from-address  "eating@hungry.com"})
         new-settings  (email-settings)
-        _             (setting/set-all orig-settings)]
+        _             (setting/set-many! orig-settings)]
     new-settings))
 
 

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -7,6 +7,7 @@
             [metabase.http-client :refer :all]
             (metabase.models [session :refer [Session]]
                              [user :refer [User]])
+            [metabase.public-settings :as public-settings]
             [metabase.test.data :refer :all]
             [metabase.test.data.users :refer :all]
             [metabase.util :as u]
@@ -172,7 +173,7 @@
 
 ;; GET /session/properties
 (expect
-  (vec (keys (metabase.models.setting/public-settings)))
+  (vec (keys (public-settings/public-settings)))
   (vec (keys ((user->client :rasta) :get 200 "session/properties"))))
 
 

--- a/test/metabase/api/setting_test.clj
+++ b/test/metabase/api/setting_test.clj
@@ -9,10 +9,10 @@
             [metabase.test.data.users :refer :all]))
 
 ;; ## Helper Fns
-(defn- fetch-all-settings  []
-  (for [setting ((user->client :crowberto) :get 200 "setting")
-        :when   (re-find #"^test-setting-\d$" (name (:key setting)))]
-    setting))
+(defn- fetch-test-settings  []
+  (sort-by :key (for [setting ((user->client :crowberto) :get 200 "setting")
+                      :when   (re-find #"^test-setting-\d$" (name (:key setting)))]
+                  setting)))
 
 (defn- fetch-setting [setting-name]
   ((user->client :crowberto) :get 200 (format "setting/%s" (name setting-name))))
@@ -23,7 +23,7 @@
  [{:key "test-setting-1", :value nil,     :description "Test setting - this only shows up in dev (1)", :default "Using $MB_TEST_SETTING_1"}
   {:key "test-setting-2", :value "FANCY", :description "Test setting - this only shows up in dev (2)", :default "[Default Value]"}]
  (do (set-settings! nil "FANCY")
-     (fetch-all-settings)))
+     (fetch-test-settings)))
 
 ;; Check that non-superusers are denied access
 (expect "You don't have permissions to do that."
@@ -37,7 +37,7 @@
   {:key "test-setting-2", :value "Great gobs of goose shit!?", :description "Test setting - this only shows up in dev (2)", :default "[Default Value]"}]
  (do ((user->client :crowberto) :put 200 "setting" {:test-setting-1 "Jackpot!"
                                                     :test-setting-2 "Great gobs of goose shit!?"})
-     (fetch-all-settings)))
+     (fetch-test-settings)))
 
 ;; Check that non-superusers are denied access
 (expect

--- a/test/metabase/api/setting_test.clj
+++ b/test/metabase/api/setting_test.clj
@@ -1,30 +1,29 @@
 (ns metabase.api.setting-test
   (:require [expectations :refer :all]
             (metabase.models [setting :as setting]
-                             [setting-test :refer [set-settings
+                             [setting-test :refer [set-settings!
                                                    setting-exists?
                                                    test-setting-1
                                                    test-setting-2]])
-            (metabase.test [data :refer :all]
-                           [util :refer :all])
+            [metabase.test.data :refer :all]
             [metabase.test.data.users :refer :all]))
 
 ;; ## Helper Fns
-(defn fetch-all-settings  []
-  (filter (fn [{k :key}]
-            (re-find #"^test-setting-\d$" (name k)))
-          ((user->client :crowberto) :get 200 "setting")))
+(defn- fetch-all-settings  []
+  (for [setting ((user->client :crowberto) :get 200 "setting")
+        :when   (re-find #"^test-setting-\d$" (name (:key setting)))]
+    setting))
 
-(defn fetch-setting [setting-name]
+(defn- fetch-setting [setting-name]
   ((user->client :crowberto) :get 200 (format "setting/%s" (name setting-name))))
 
 ;; ## GET /api/setting
 ;; Check that we can fetch all Settings for Org
-(expect-eval-actual-first
-    [{:key "test-setting-1", :value nil,     :description "Test setting - this only shows up in dev (1)", :default "Using $MB_TEST_SETTING_1"}
-     {:key "test-setting-2", :value "FANCY", :description "Test setting - this only shows up in dev (2)", :default "[Default Value]"}]
-    (do (set-settings nil "FANCY")
-        (fetch-all-settings)))
+(expect
+ [{:key "test-setting-1", :value nil,     :description "Test setting - this only shows up in dev (1)", :default "Using $MB_TEST_SETTING_1"}
+  {:key "test-setting-2", :value "FANCY", :description "Test setting - this only shows up in dev (2)", :default "[Default Value]"}]
+ (do (set-settings! nil "FANCY")
+     (fetch-all-settings)))
 
 ;; Check that non-superusers are denied access
 (expect "You don't have permissions to do that."
@@ -33,44 +32,45 @@
 
 ;; ## PUT /api/setting
 ;; Check that we can update multiple Settings
-(expect-eval-actual-first
-  [{:key "test-setting-1", :value "Jackpot!",     :description "Test setting - this only shows up in dev (1)", :default "Using $MB_TEST_SETTING_1"}
-   {:key "test-setting-2", :value "Great gobs of goose shit!?", :description "Test setting - this only shows up in dev (2)", :default "[Default Value]"}]
-  (do ((user->client :crowberto) :put 200 "setting" {:test-setting-1 "Jackpot!"
-                                                     :test-setting-2 "Great gobs of goose shit!?"})
-      (fetch-all-settings)))
+(expect
+ [{:key "test-setting-1", :value "Jackpot!",                   :description "Test setting - this only shows up in dev (1)", :default "Using $MB_TEST_SETTING_1"}
+  {:key "test-setting-2", :value "Great gobs of goose shit!?", :description "Test setting - this only shows up in dev (2)", :default "[Default Value]"}]
+ (do ((user->client :crowberto) :put 200 "setting" {:test-setting-1 "Jackpot!"
+                                                    :test-setting-2 "Great gobs of goose shit!?"})
+     (fetch-all-settings)))
 
 ;; Check that non-superusers are denied access
-(expect "You don't have permissions to do that."
+(expect
+  "You don't have permissions to do that."
   ((user->client :rasta) :put 403 "setting" {:test-setting-1 "Something dangerous ..."}))
 
 
 ;; ## GET /api/setting/:key
 ;; Test that we can fetch a single setting
-(expect-eval-actual-first
-    "OK!"
-    (do (test-setting-2 "OK!")
-        (fetch-setting :test-setting-2)))
+(expect
+ "OK!"
+ (do (test-setting-2 "OK!")
+     (fetch-setting :test-setting-2)))
 
 
 ;; ## PUT /api/setting/:key
-(expect-eval-actual-first
-    ["NICE!"
-     "NICE!"]
-  (do ((user->client :crowberto) :put 200 "setting/test-setting-1" {:value "NICE!"})
-      [(test-setting-1)
-       (fetch-setting :test-setting-1)]))
+(expect
+ ["NICE!"
+  "NICE!"]
+ (do ((user->client :crowberto) :put 200 "setting/test-setting-1" {:value "NICE!"})
+     [(test-setting-1)
+      (fetch-setting :test-setting-1)]))
 
 ;; ## Check non-superuser can't set a Setting
 (expect "You don't have permissions to do that."
   ((user->client :rasta) :put 403 "setting/test-setting-1" {:value "NICE!"}))
 
 ;; ## DELETE /api/setting/:key
-(expect-eval-actual-first
-    ["ABCDEFG"
-     nil
-     false]
-  (do ((user->client :crowberto) :delete 204 "setting/test-setting-1")
-      [(test-setting-1)
-       (fetch-setting :test-setting-1)
-       (setting-exists? :test-setting-1)]))
+(expect
+ ["ABCDEFG"
+  nil
+  false]
+ (do ((user->client :crowberto) :delete 204 "setting/test-setting-1")
+     [(test-setting-1)
+      (fetch-setting :test-setting-1)
+      (setting-exists? :test-setting-1)]))

--- a/test/metabase/api/setting_test.clj
+++ b/test/metabase/api/setting_test.clj
@@ -2,7 +2,7 @@
   (:require [expectations :refer :all]
             (metabase.models [setting :as setting]
                              [setting-test :refer [set-settings!
-                                                   setting-exists?
+                                                   setting-exists-in-db?
                                                    test-setting-1
                                                    test-setting-2]])
             [metabase.test.data :refer :all]
@@ -10,9 +10,9 @@
 
 ;; ## Helper Fns
 (defn- fetch-test-settings  []
-  (sort-by :key (for [setting ((user->client :crowberto) :get 200 "setting")
-                      :when   (re-find #"^test-setting-\d$" (name (:key setting)))]
-                  setting)))
+  (for [setting ((user->client :crowberto) :get 200 "setting")
+        :when   (re-find #"^test-setting-\d$" (name (:key setting)))]
+    setting))
 
 (defn- fetch-setting [setting-name]
   ((user->client :crowberto) :get 200 (format "setting/%s" (name setting-name))))
@@ -67,10 +67,10 @@
 
 ;; ## DELETE /api/setting/:key
 (expect
- ["ABCDEFG"
-  nil
+ ["ABCDEFG" ; env var value
+  nil       ; API endpoint shouldn't return env var values
   false]
  (do ((user->client :crowberto) :delete 204 "setting/test-setting-1")
      [(test-setting-1)
       (fetch-setting :test-setting-1)
-      (setting-exists? :test-setting-1)]))
+      (setting-exists-in-db? :test-setting-1)]))

--- a/test/metabase/models/setting_test.clj
+++ b/test/metabase/models/setting_test.clj
@@ -2,7 +2,7 @@
   (:require [expectations :refer :all]
             [medley.core :as m]
             [metabase.db :as db]
-            [metabase.models.setting :refer [defsetting Setting] :as setting]
+            [metabase.models.setting :refer [defsetting Setting], :as setting]
             (metabase.test [data :refer :all]
                            [util :refer :all])))
 
@@ -11,9 +11,12 @@
 ;; so if you run unit tests while `lein ring server` is running (i.e., no Jetty server is started)
 ;; these tests will fail. FIXME
 
-(defsetting test-setting-1 "Test setting - this only shows up in dev (1)")
-(defsetting test-setting-2 "Test setting - this only shows up in dev (2)"
-  "[Default Value]")
+(defsetting test-setting-1
+  "Test setting - this only shows up in dev (1)")
+
+(defsetting test-setting-2
+  "Test setting - this only shows up in dev (2)"
+  :default "[Default Value]")
 
 
 ;; ## HELPER FUNCTIONS
@@ -26,7 +29,7 @@
 (defn setting-exists? [setting-name]
   (boolean (Setting :key (name setting-name))))
 
-(defn set-settings [setting-1-value setting-2-value]
+(defn set-settings! [setting-1-value setting-2-value]
   (test-setting-1 setting-1-value)
   (test-setting-2 setting-2-value))
 
@@ -34,61 +37,51 @@
 ;; ## GETTERS
 ;; Test defsetting getter fn. Should return the value from env var MB_TEST_SETTING_1
 (expect "ABCDEFG"
-  (do (set-settings nil nil)
+  (do (set-settings! nil nil)
       (test-setting-1)))
-
-;; Test `get` function. Shouldn't return env var value
-(expect nil
-  (do (set-settings nil nil)
-      (setting/get :test-setting-1)))
 
 ;; Test getting a default value
 (expect "[Default Value]"
-  (do (set-settings nil nil)
+  (do (set-settings! nil nil)
       (test-setting-2)))
-
-;; `get` shouldn't return default value
-(expect nil
-  (do (set-settings nil nil)
-      (setting/get :test-setting-2)))
 
 
 ;; ## SETTERS
 ;; Test defsetting setter fn
-(expect-eval-actual-first
-    ["FANCY NEW VALUE <3"
-     "FANCY NEW VALUE <3"]
+(expect
+  ["FANCY NEW VALUE <3"
+   "FANCY NEW VALUE <3"]
   [(do (test-setting-2 "FANCY NEW VALUE <3")
        (test-setting-2))
    (db-fetch-setting :test-setting-2)])
 
-;; Test `set` function
-(expect-eval-actual-first
+;; Test `set!` function
+(expect
     ["WHAT A NICE VALUE <3"
      "WHAT A NICE VALUE <3"]
-  [(do (setting/set :test-setting-2 "WHAT A NICE VALUE <3")
+  [(do (setting/set! :test-setting-2 "WHAT A NICE VALUE <3")
        (test-setting-2))
    (db-fetch-setting :test-setting-2)])
 
 ;; Set multiple at one time
-(expect-eval-actual-first
+(expect
   ["I win!"
    "For realz"]
   (do
-    (setting/set-all {:test-setting-1 "I win!"
-                      :test-setting-2 "For realz"})
+    (setting/set-many! {:test-setting-1 "I win!"
+                        :test-setting-2 "For realz"})
     [(db-fetch-setting :test-setting-1)
      (db-fetch-setting :test-setting-2)]))
 
 
 ;; ## DELETE
 ;; Test defsetting delete w/o default value
-(expect-eval-actual-first
-    ["COOL"
-     true
-     "ABCDEFG"
-     nil
-     false]
+(expect
+  ["COOL"
+   true
+   nil
+   nil
+   false]
   [(do (test-setting-1 "COOL")
        (test-setting-1))
    (setting-exists? :test-setting-1)
@@ -98,11 +91,11 @@
    (setting-exists? :test-setting-1)])
 
 ;; Test defsetting delete w/ default value
-(expect-eval-actual-first
-    ["COOL"
-     true
-     "[Default Value]"                  ; default value should get returned if none is set
-     false]                             ; setting still shouldn't exist in the DB
+(expect
+  ["COOL"
+   true
+   "[Default Value]" ; default value should get returned if none is set
+   false]            ; setting still shouldn't exist in the DB
   [(do (test-setting-2 "COOL")
        (test-setting-2))
    (setting-exists? :test-setting-2)
@@ -110,35 +103,21 @@
        (test-setting-2))
    (setting-exists? :test-setting-2)])
 
-;; Test `delete`
-(expect-eval-actual-first
-    ["VERY NICE!"
-     true
-     "ABCDEFG"
-     nil
-     false]
-  [(do (test-setting-1 "VERY NICE!")
-       (test-setting-1))
-   (setting-exists? :test-setting-1)
-   (do (test-setting-1 nil)
-       (test-setting-1))
-   (setting/get :test-setting-1)
-   (setting-exists? :test-setting-1)])
 
 ;; ## ALL SETTINGS FUNCTIONS
 
 ;; all
-(expect-eval-actual-first
-    {:test-setting-2 "TOUCANS"}
-  (do (set-settings nil "TOUCANS")
+(expect
+  {:test-setting-2 "TOUCANS"}
+  (do (set-settings! nil "TOUCANS")
       (m/filter-keys #(re-find #"^test-setting-\d$" (name %)) ; filter out any non-test settings
                      (setting/all))))
 
-;; all-with-descriptions
-(expect-eval-actual-first
-    [{:key :test-setting-1, :value nil,  :description "Test setting - this only shows up in dev (1)", :default "Using $MB_TEST_SETTING_1"}
-     {:key :test-setting-2, :value "S2", :description "Test setting - this only shows up in dev (2)", :default "[Default Value]"}]
-  (do (set-settings nil "S2")
+;; all
+(expect
+  [{:key :test-setting-1, :value nil,  :description "Test setting - this only shows up in dev (1)", :default "Using $MB_TEST_SETTING_1"}
+   {:key :test-setting-2, :value "S2", :description "Test setting - this only shows up in dev (2)", :default "[Default Value]"}]
+  (do (set-settings! nil "S2")
       (filter (fn [{k :key}]
                 (re-find #"^test-setting-\d$" (name k)))
-              (setting/all-with-descriptions))))
+              (setting/all))))

--- a/test/metabase/query_processor/qp_middleware_test.clj
+++ b/test/metabase/query_processor/qp_middleware_test.clj
@@ -45,14 +45,12 @@
   (let [original-tz (setting/get :report-timezone)
         response1   ((pre-add-settings identity) {:driver (TestDriver.)})]
     ;; make sure that if the timezone is an empty string we skip it in settings
-    (setting/set :report-timezone "")
+    (setting/set! :report-timezone "")
     (let [response2 ((pre-add-settings identity) {:driver (TestDriver.)})]
       ;; if the timezone is something valid it should show up in the query settings
-      (setting/set :report-timezone "US/Mountain")
+      (setting/set! :report-timezone "US/Mountain")
       (let [response3 ((pre-add-settings identity) {:driver (TestDriver.)})]
-        (if original-tz
-          (setting/set :report-timezone original-tz)
-          (setting/delete :report-timezone))
+        (setting/set! :report-timezone original-tz)
         [(dissoc response1 :driver)
          (dissoc response2 :driver)
          (dissoc response3 :driver)]))))

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -331,10 +331,10 @@
   [setting-k value f]
   (let [original-value (setting/get setting-k)]
     (try
-      (setting/set* setting-k value)
+      (setting/set! setting-k value)
       (f)
       (finally
-        (setting/set* setting-k original-value)))))
+        (setting/set! setting-k original-value)))))
 
 (defmacro with-temporary-setting-values
   "Temporarily bind the values of one or more `Settings`, execute body, and re-establish the original values. This works much the same way as `binding`.

--- a/test/metabase/test_setup.clj
+++ b/test/metabase/test_setup.clj
@@ -84,7 +84,7 @@
     (try
       (log/info "Setting up test DB and running migrations...")
       (db/setup-db :auto-migrate true)
-      (setting/set :site-name "Metabase Test")
+      (setting/set! :site-name "Metabase Test")
       (core/initialization-complete!)
 
       ;; make sure the driver test extensions are loaded before running the tests. :reload them because otherwise we get wacky 'method in protocol not implemented' errors


### PR DESCRIPTION
Simplified and more powerful implementation of the `defsetting` framework:
-  simplify it a bit
-  introduce a type system so we don't have to run around checking if string settings are `= "true"` everywhere 😒 
-  make it easier to define magic getters / setters so we can do better error-checking / enforce invariants / when someone changes the value of a setting we can do something magical like re-humanize the names of shizz in the DB 🙀  💻  (#2660)

Implements #2954 🎉 
