### PR TITLE
Fix Postgres filtering by nil UUID values :wrench:

### DIFF
--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -167,7 +167,8 @@
     message))
 
 (defn- prepare-value [{value :value, {:keys [base-type]} :field}]
-  (if (= base-type :UUIDField)
+  (if (and (= base-type :UUIDField)
+           value)
     (java.util.UUID/fromString value)
     value))
 


### PR DESCRIPTION
make sure to check for `nil` before trying to convert string -> UUID. Includes test.

Fixes #2152 
