### PR TITLE
Remove uses of expect-let in tests; bump deps

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -38,9 +38,9 @@
                                org.apache.httpcomponents/httpclient
                                net.sourceforge.nekohtml/nekohtml
                                ring/ring-core]]
-                 [com.draines/postal "2.0.0"]                         ; SMTP library
+                 [com.draines/postal "2.0.1"]                         ; SMTP library
                  [com.google.apis/google-api-services-bigquery        ; Google BigQuery Java Client Library
-                  "v2-rev310-1.22.0"]
+                  "v2-rev313-1.22.0"]
                  [com.h2database/h2 "1.4.192"]                        ; embedded SQL database
                  [com.mattbertolini/liquibase-slf4j "2.0.0"]          ; Java Migrations lib
                  [com.mchange/c3p0 "0.9.5.2"]                         ; connection pooling library
@@ -57,7 +57,7 @@
                  [medley "0.8.2"]                                     ; lightweight lib of useful functions
                  [metabase/throttle "1.0.1"]                          ; Tools for throttling access to API endpoints and other code pathways
                  [mysql/mysql-connector-java "5.1.39"]                ; MySQL JDBC driver (don't upgrade to 6.0+ yet -- that's Java 8 only)
-                 [net.sf.cssbox/cssbox "4.11"                         ; HTML / CSS rendering
+                 [net.sf.cssbox/cssbox "4.12"                         ; HTML / CSS rendering
                   :exclusions [org.slf4j/slf4j-api]]
                  [net.sourceforge.jtds/jtds "1.3.1"]                  ; Open Source SQL Server driver
                  [org.liquibase/liquibase-core "3.5.1"]               ; migration management (Java lib)
@@ -67,7 +67,7 @@
                  [postgresql "9.3-1102.jdbc41"]                       ; Postgres driver
                  [io.crate/crate-jdbc "1.13.0"]                       ; Crate JDBC driver
                  [io.crate/crate-client "0.55.2"]                     ; Crate Java client (used by Crate JDBC)
-                 [prismatic/schema "1.1.2"]                           ; Data schema declaration and validation library
+                 [prismatic/schema "1.1.3"]                           ; Data schema declaration and validation library
                  [ring/ring-jetty-adapter "1.5.0"]                    ; Ring adapter using Jetty webserver (used to run a Ring server for unit tests)
                  [ring/ring-json "0.4.0"]                             ; Ring middleware for reading/writing JSON automatically
                  [stencil "0.5.0"]                                    ; Mustache templates for Clojure
@@ -100,8 +100,8 @@
                       :exclude [#"test"
                                 #"^metabase\.http-client$"]}
   :profiles {:dev {:dependencies [[org.clojure/tools.nrepl "0.2.12"]  ; REPL <3
-                                  [expectations "2.1.3"]              ; unit tests *** DON'T UPDATE THIS UNTIL WE REMOVE USES OF DEPRECATED EXPECT-LET IN THE CODEBASE ***
-                                  [ring/ring-mock "0.3.0"]]
+                                  [expectations "2.1.9"]              ; unit tests
+                                  [ring/ring-mock "0.3.0"]]           ; Library to create mock Ring requests for unit tests
                    :plugins [[docstring-checker "1.0.0"]              ; Check that all public vars have docstrings. Run with 'lein docstring-checker'
                              [jonase/eastwood "0.2.3"
                               :exclusions [org.clojure/clojure]]      ; Linting

--- a/test/metabase/api/activity_test.clj
+++ b/test/metabase/api/activity_test.clj
@@ -2,7 +2,6 @@
   "Tests for /api/activity endpoints."
   (:require [expectations :refer :all]
             [metabase.db :as db]
-            [metabase.http-client :refer :all]
             (metabase.models [activity :refer [Activity]]
                              [card :refer [Card]]
                              [dashboard :refer [Dashboard]]
@@ -14,11 +13,11 @@
 
 ;; GET /
 
-; Things we are testing for:
-;  1. ordered by timestamp DESC
-;  2. :user and :model_exists are hydrated
+;; Things we are testing for:
+;;  1. ordered by timestamp DESC
+;;  2. :user and :model_exists are hydrated
 
-; NOTE: timestamp matching was being a real PITA so I cheated a bit.  ideally we'd fix that
+;; NOTE: timestamp matching was being a real PITA so I cheated a bit.  ideally we'd fix that
 (expect-let [_         (db/cascade-delete! Activity)
              activity1 (db/insert! Activity
                          :topic     "install"

--- a/test/metabase/api/activity_test.clj
+++ b/test/metabase/api/activity_test.clj
@@ -8,7 +8,7 @@
                              [view-log :refer [ViewLog]])
             [metabase.test.data :refer :all]
             [metabase.test.data.users :refer :all]
-            [metabase.test.util :refer [match-$ expect-with-temp resolve-private-fns]]
+            [metabase.test.util :refer [match-$ expect-with-temp resolve-private-fns], :as tu]
             [metabase.util :as u]))
 
 ;; GET /
@@ -18,26 +18,22 @@
 ;;  2. :user and :model_exists are hydrated
 
 ;; NOTE: timestamp matching was being a real PITA so I cheated a bit.  ideally we'd fix that
-(expect-let [_         (db/cascade-delete! Activity)
-             activity1 (db/insert! Activity
-                         :topic     "install"
-                         :details   {}
-                         :timestamp (u/->Timestamp "2015-09-09T12:13:14.888Z"))
-             activity2 (db/insert! Activity
-                         :topic     "dashboard-create"
-                         :user_id   (user->id :crowberto)
-                         :model     "dashboard"
-                         :model_id  1234
-                         :details   {:description  "Because I can!"
-                                     :name         "Bwahahaha"
-                                     :public_perms 2}
-                         :timestamp (u/->Timestamp "2015-09-10T18:53:01.632Z"))
-             activity3 (db/insert! Activity
-                         :topic     "user-joined"
-                         :user_id   (user->id :rasta)
-                         :model     "user"
-                         :details   {}
-                         :timestamp (u/->Timestamp "2015-09-10T05:33:43.641Z"))]
+(tu/expect-with-temp [Activity [activity1 {:topic     "install"
+                                           :details   {}
+                                           :timestamp (u/->Timestamp "2015-09-09T12:13:14.888Z")}]
+                      Activity [activity2 {:topic     "dashboard-create"
+                                           :user_id   (user->id :crowberto)
+                                           :model     "dashboard"
+                                           :model_id  1234
+                                           :details   {:description  "Because I can!"
+                                                       :name         "Bwahahaha"
+                                                       :public_perms 2}
+                                           :timestamp (u/->Timestamp "2015-09-10T18:53:01.632Z")}]
+                      Activity [activity3 {:topic     "user-joined"
+                                           :user_id   (user->id :rasta)
+                                           :model     "user"
+                                           :details   {}
+                                           :timestamp (u/->Timestamp "2015-09-10T05:33:43.641Z")}]]
   [(match-$ (Activity (:id activity2))
      {:id           $
       :topic        "dashboard-create"
@@ -98,8 +94,12 @@
       :table        nil
       :custom_id    nil
       :details      $})]
-  (for [activity ((user->client :crowberto) :get 200 "activity")]
-    (dissoc activity :timestamp)))
+  ;; clear any other activities from the DB just in case; not sure this step is needed any more
+  (do (db/cascade-delete! Activity :id [:not-in #{(:id activity1)
+                                                  (:id activity2)
+                                                  (:id activity3)}])
+      (for [activity ((user->client :crowberto) :get 200 "activity")]
+        (dissoc activity :timestamp))))
 
 
 ;;; GET /recent_views

--- a/test/metabase/api/field_test.clj
+++ b/test/metabase/api/field_test.clj
@@ -176,21 +176,21 @@
 ;; ## GET /api/field/:id/values
 ;; Should return something useful for a field that has special_type :category
 (tu/expect-eval-actual-first
-    (tu/match-$ (field->field-values :venues :price)
-      {:field_id              (id :venues :price)
-       :human_readable_values {}
-       :values                [1 2 3 4]
-       :updated_at            $
-       :created_at            $
-       :id                    $})
+  (tu/match-$ (field->field-values :venues :price)
+    {:field_id              (id :venues :price)
+     :human_readable_values {}
+     :values                [1 2 3 4]
+     :updated_at            $
+     :created_at            $
+     :id                    $})
   (do (db/update! FieldValues (:id (field->field-values :venues :price))
         :human_readable_values nil) ; clear out existing human_readable_values in case they're set
       ((user->client :rasta) :get 200 (format "field/%d/values" (id :venues :price)))))
 
 ;; Should return nothing for a field whose special_type is *not* :category
 (expect
-    {:values                {}
-     :human_readable_values {}}
+  {:values                {}
+   :human_readable_values {}}
   ((user->client :rasta) :get 200 (format "field/%d/values" (id :venues :id))))
 
 
@@ -198,21 +198,21 @@
 
 ;; Check that we can set values
 (tu/expect-eval-actual-first
-    [{:status "success"}
-     (tu/match-$ (FieldValues :field_id (id :venues :price))
-       {:field_id              (id :venues :price)
-        :human_readable_values {:1 "$"
-                                :2 "$$"
-                                :3 "$$$"
-                                :4 "$$$$"}
-        :values                [1 2 3 4]
-        :updated_at            $
-        :created_at            $
-        :id                    $})]
+  [{:status "success"}
+   (tu/match-$ (FieldValues :field_id (id :venues :price))
+     {:field_id              (id :venues :price)
+      :human_readable_values {:1 "$"
+                              :2 "$$"
+                              :3 "$$$"
+                              :4 "$$$$"}
+      :values                [1 2 3 4]
+      :updated_at            $
+      :created_at            $
+      :id                    $})]
   [((user->client :crowberto) :post 200 (format "field/%d/value_map_update" (id :venues :price)) {:values_map {:1 "$"
-                                                                                                                    :2 "$$"
-                                                                                                                    :3 "$$$"
-                                                                                                                    :4 "$$$$"}})
+                                                                                                               :2 "$$"
+                                                                                                               :3 "$$$"
+                                                                                                               :4 "$$$$"}})
    ((user->client :rasta) :get 200 (format "field/%d/values" (id :venues :price)))])
 
 ;; Check that we can unset values

--- a/test/metabase/middleware_test.clj
+++ b/test/metabase/middleware_test.clj
@@ -3,8 +3,8 @@
             [expectations :refer :all]
             [ring.mock.request :as mock]
             [metabase.api.common :refer [*current-user-id* *current-user*]]
-            [metabase.db :as db]
-            [metabase.middleware :refer :all]
+            (metabase [db :as db]
+                      [middleware :refer :all])
             [metabase.models.session :refer [Session]]
             [metabase.test.data :refer :all]
             [metabase.test.data.users :refer :all]

--- a/test/metabase/test_setup.clj
+++ b/test/metabase/test_setup.clj
@@ -22,11 +22,6 @@
 ;; Don't run unit tests whenever JVM shuts down
 (expectations/disable-run-on-shutdown)
 
-;; For good editors (i.e. Emacs) mark `expect-let` as `^:deprecated` so it will show up as such when editing code, discouraging future use
-;; TODO - this can be removed once we upgrade to a newer version of expectations that removes this
-(u/ignore-exceptions
-  (alter-meta! (resolve 'expectations/expect-let) assoc :deprecated true))
-
 
 ;; ## EXPECTATIONS FORMATTING OVERRIDES
 


### PR DESCRIPTION
Rewrite the final few tests that use `expect-let` so we can upgrade `expectations`. Bump a few other dependencies while we're at it 

Resolves #1664 
