### PR TITLE
Remove deprecated expect-eval-actual-first macro from tests :new:

### DIFF
--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -105,7 +105,7 @@
 (defendpoint POST "/reset_password"
   "Reset password with a reset token."
   [:as {{:keys [token password]} :body}]
-  {token    Required
+  {token    [Required NonEmptyString]
    password [Required ComplexPassword]}
   (or (when-let [{user-id :id, :as user} (valid-reset-token->user token)]
         (set-user-password! user-id password)

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -13,16 +13,12 @@
             [metabase.util :as u]
             [metabase.test.util :refer [random-name resolve-private-fns with-temporary-setting-values with-temp], :as tu]))
 
-(defn- is-uuid-string? [s]
-  (boolean (when (string? s)
-             (re-matches #"^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$" s))))
-
 ;; ## POST /api/session
 ;; Test that we can login
 (expect
   ;; delete all other sessions for the bird first, otherwise test doesn't seem to work (TODO - why?)
   (do (db/delete! Session, :user_id (user->id :rasta))
-      (is-uuid-string? (:id (client :post 200 "session" (user->credentials :rasta))))))
+      (tu/is-uuid-string? (:id (client :post 200 "session" (user->credentials :rasta))))))
 
 ;; Test for required params
 (expect {:errors {:email "field is a required param."}}
@@ -126,7 +122,7 @@
                   (db/update! User id, :reset_token <>))]
       (-> (client :post 200 "session/reset_password" {:token    token
                                                       :password "whateverUP12!!"})
-          (update :session_id is-uuid-string?)))))
+          (update :session_id tu/is-uuid-string?)))))
 
 ;; Test that token and password are required
 (expect {:errors {:token "field is a required param."}}
@@ -230,7 +226,7 @@
 
 (defn- is-session? [session]
   (u/ignore-exceptions
-    (is-uuid-string? (:id session))))
+    (tu/is-uuid-string? (:id session))))
 
 ;; test that an existing user can log in with Google auth even if the auto-create accounts domain is different from their account
 ;; should return a Session

--- a/test/metabase/api/setup_test.clj
+++ b/test/metabase/api/setup_test.clj
@@ -8,13 +8,13 @@
                              [user :refer [User]])
             [metabase.setup :as setup]
             (metabase.test [data :refer :all]
-                           [util :refer [match-$ random-name expect-eval-actual-first]])))
+                           [util :refer [match-$ random-name], :as tu])))
 
 
 ;; ## POST /api/setup/user
 ;; Check that we can create a new superuser via setup-token
 (let [user-name (random-name)]
-  (expect-eval-actual-first
+  (tu/expect-eval-actual-first
     [(match-$ (Session :user_id (db/select-one-id User, :email (str user-name "@metabase.com")))
       {:id $id})
      (str user-name "@metabase.com")]

--- a/test/metabase/api/setup_test.clj
+++ b/test/metabase/api/setup_test.clj
@@ -8,26 +8,27 @@
                              [user :refer [User]])
             [metabase.setup :as setup]
             (metabase.test [data :refer :all]
-                           [util :refer [match-$ random-name], :as tu])))
+                           [util :refer [match-$ random-name], :as tu])
+            [metabase.util :as u]))
 
 
 ;; ## POST /api/setup/user
 ;; Check that we can create a new superuser via setup-token
-(let [user-name (random-name)]
-  (tu/expect-eval-actual-first
-    [(match-$ (Session :user_id (db/select-one-id User, :email (str user-name "@metabase.com")))
-      {:id $id})
-     (str user-name "@metabase.com")]
-    (let [resp (http/client :post 200 "setup" {:token (setup/token-create)
-                                               :prefs {:site_name "Metabase Test"}
-                                               :user  {:first_name user-name
-                                                       :last_name  user-name
-                                                       :email      (str user-name "@metabase.com")
-                                                       :password   "anythingUP12!!"}})]
-      ;; reset our setup token
-      (setup/token-create)
-      ;; return api response
-      [resp (setting/get :admin-email)])))
+(let [user-name (random-name)
+      email     (str user-name "@metbase.com")]
+  (expect
+    [true
+     email]
+    [(tu/is-uuid-string? (:id (http/client :post 200 "setup" {:token (setup/token-create)
+                                                              :prefs {:site_name "Metabase Test"}
+                                                              :user  {:first_name user-name
+                                                                      :last_name  user-name
+                                                                      :email      email
+                                                                      :password   "anythingUP12!!"}})))
+     (do
+       ;; reset our setup token
+       (setup/token-create)
+       (setting/get :admin-email))]))
 
 
 ;; Test input validations

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -11,8 +11,9 @@
             (metabase.test.data [dataset-definitions :as defs]
                                 [datasets :as datasets]
                                 [users :refer :all])
-            [metabase.test.util :refer [match-$ expect-eval-actual-first resolve-private-fns]]
-            [metabase.util :as u]))
+            [metabase.test.util :refer [match-$ resolve-private-fns]]
+            [metabase.util :as u]
+            [metabase.test.util :as tu]))
 
 (resolve-private-fns metabase.models.table pk-field-id)
 
@@ -220,259 +221,259 @@
 ;;; GET api/table/:id/query_metadata?include_sensitive_fields
 ;;; Make sure that getting the User table *does* include info about the password field, but not actual values themselves
 (expect
-    (match-$ (Table (id :users))
-      {:description     nil
-       :entity_type     nil
-       :visibility_type nil
-       :db              (db-details)
-       :schema          "PUBLIC"
-       :name            "USERS"
-       :display_name    "Users"
-       :fields          [(match-$ (Field (id :users :id))
-                           {:description     nil
-                            :table_id        (id :users)
-                            :special_type    "id"
-                            :name            "ID"
-                            :display_name    "ID"
-                            :updated_at      $
-                            :active          true
-                            :id              $
-                            :field_type      "info"
-                            :position        0
-                            :target          nil
-                            :preview_display true
-                            :created_at      $
-                            :base_type       "BigIntegerField"
-                            :visibility_type "normal"
-                            :fk_target_field_id $
-                            :parent_id       nil
-                            :raw_column_id   $
-                            :last_analyzed   $})
-                         (match-$ (Field (id :users :last_login))
-                           {:description     nil
-                            :table_id        (id :users)
-                            :special_type    nil
-                            :name            "LAST_LOGIN"
-                            :display_name    "Last Login"
-                            :updated_at      $
-                            :active          true
-                            :id              $
-                            :field_type      "info"
-                            :position        0
-                            :target          nil
-                            :preview_display true
-                            :created_at      $
-                            :base_type       "DateTimeField"
-                            :visibility_type "normal"
-                            :fk_target_field_id $
-                            :parent_id       nil
-                            :raw_column_id   $
-                            :last_analyzed   $})
-                         (match-$ (Field (id :users :name))
-                           {:description     nil
-                            :table_id        (id :users)
-                            :special_type    "name"
-                            :name            "NAME"
-                            :display_name    "Name"
-                            :updated_at      $
-                            :active          true
-                            :id              $
-                            :field_type      "info"
-                            :position        0
-                            :target          nil
-                            :preview_display true
-                            :created_at      $
-                            :base_type       "TextField"
-                            :visibility_type "normal"
-                            :fk_target_field_id $
-                            :parent_id       nil
-                            :raw_column_id   $
-                            :last_analyzed   $})
-                         (match-$ (Field :table_id (id :users), :name "PASSWORD")
-                           {:description     nil
-                            :table_id        (id :users)
-                            :special_type    "category"
-                            :name            "PASSWORD"
-                            :display_name    "Password"
-                            :updated_at      $
-                            :active          true
-                            :id              $
-                            :field_type      "info"
-                            :position        0
-                            :target          nil
-                            :preview_display true
-                            :created_at      $
-                            :base_type       "TextField"
-                            :visibility_type "sensitive"
-                            :fk_target_field_id $
-                            :parent_id       nil
-                            :raw_column_id   $
-                            :last_analyzed   $})]
-       :rows            15
-       :updated_at      $
-       :entity_name     nil
-       :active          true
-       :id              (id :users)
-       :db_id           (id)
-       :raw_table_id    $
-       :field_values    {(keyword (str (id :users :name)))
-                         ["Broen Olujimi"
-                          "Conchúr Tihomir"
-                          "Dwight Gresham"
-                          "Felipinho Asklepios"
-                          "Frans Hevel"
-                          "Kaneonuskatew Eiran"
-                          "Kfir Caj"
-                          "Nils Gotam"
-                          "Plato Yeshua"
-                          "Quentin Sören"
-                          "Rüstem Hebel"
-                          "Shad Ferdynand"
-                          "Simcha Yan"
-                          "Spiros Teofil"
-                          "Szymon Theutrich"]}
-       :segments        []
-       :metrics         []
-       :created_at      $})
-    ((user->client :rasta) :get 200 (format "table/%d/query_metadata?include_sensitive_fields=true" (id :users))))
+  (match-$ (Table (id :users))
+    {:description     nil
+     :entity_type     nil
+     :visibility_type nil
+     :db              (db-details)
+     :schema          "PUBLIC"
+     :name            "USERS"
+     :display_name    "Users"
+     :fields          [(match-$ (Field (id :users :id))
+                         {:description     nil
+                          :table_id        (id :users)
+                          :special_type    "id"
+                          :name            "ID"
+                          :display_name    "ID"
+                          :updated_at      $
+                          :active          true
+                          :id              $
+                          :field_type      "info"
+                          :position        0
+                          :target          nil
+                          :preview_display true
+                          :created_at      $
+                          :base_type       "BigIntegerField"
+                          :visibility_type "normal"
+                          :fk_target_field_id $
+                          :parent_id       nil
+                          :raw_column_id   $
+                          :last_analyzed   $})
+                       (match-$ (Field (id :users :last_login))
+                         {:description     nil
+                          :table_id        (id :users)
+                          :special_type    nil
+                          :name            "LAST_LOGIN"
+                          :display_name    "Last Login"
+                          :updated_at      $
+                          :active          true
+                          :id              $
+                          :field_type      "info"
+                          :position        0
+                          :target          nil
+                          :preview_display true
+                          :created_at      $
+                          :base_type       "DateTimeField"
+                          :visibility_type "normal"
+                          :fk_target_field_id $
+                          :parent_id       nil
+                          :raw_column_id   $
+                          :last_analyzed   $})
+                       (match-$ (Field (id :users :name))
+                         {:description     nil
+                          :table_id        (id :users)
+                          :special_type    "name"
+                          :name            "NAME"
+                          :display_name    "Name"
+                          :updated_at      $
+                          :active          true
+                          :id              $
+                          :field_type      "info"
+                          :position        0
+                          :target          nil
+                          :preview_display true
+                          :created_at      $
+                          :base_type       "TextField"
+                          :visibility_type "normal"
+                          :fk_target_field_id $
+                          :parent_id       nil
+                          :raw_column_id   $
+                          :last_analyzed   $})
+                       (match-$ (Field :table_id (id :users), :name "PASSWORD")
+                         {:description     nil
+                          :table_id        (id :users)
+                          :special_type    "category"
+                          :name            "PASSWORD"
+                          :display_name    "Password"
+                          :updated_at      $
+                          :active          true
+                          :id              $
+                          :field_type      "info"
+                          :position        0
+                          :target          nil
+                          :preview_display true
+                          :created_at      $
+                          :base_type       "TextField"
+                          :visibility_type "sensitive"
+                          :fk_target_field_id $
+                          :parent_id       nil
+                          :raw_column_id   $
+                          :last_analyzed   $})]
+     :rows            15
+     :updated_at      $
+     :entity_name     nil
+     :active          true
+     :id              (id :users)
+     :db_id           (id)
+     :raw_table_id    $
+     :field_values    {(keyword (str (id :users :name)))
+                       ["Broen Olujimi"
+                        "Conchúr Tihomir"
+                        "Dwight Gresham"
+                        "Felipinho Asklepios"
+                        "Frans Hevel"
+                        "Kaneonuskatew Eiran"
+                        "Kfir Caj"
+                        "Nils Gotam"
+                        "Plato Yeshua"
+                        "Quentin Sören"
+                        "Rüstem Hebel"
+                        "Shad Ferdynand"
+                        "Simcha Yan"
+                        "Spiros Teofil"
+                        "Szymon Theutrich"]}
+     :segments        []
+     :metrics         []
+     :created_at      $})
+  ((user->client :rasta) :get 200 (format "table/%d/query_metadata?include_sensitive_fields=true" (id :users))))
 
 ;;; GET api/table/:id/query_metadata
 ;;; Make sure that getting the User table does *not* include password info
 (expect
-    (match-$ (Table (id :users))
-      {:description     nil
-       :entity_type     nil
-       :visibility_type nil
-       :db              (db-details)
-       :schema          "PUBLIC"
-       :name            "USERS"
-       :display_name    "Users"
-       :fields          [(match-$ (Field (id :users :id))
-                           {:description     nil
-                            :table_id        (id :users)
-                            :special_type    "id"
-                            :name            "ID"
-                            :display_name    "ID"
-                            :updated_at      $
-                            :active          true
-                            :id              $
-                            :field_type      "info"
-                            :position        0
-                            :target          nil
-                            :preview_display true
-                            :created_at      $
-                            :base_type       "BigIntegerField"
-                            :visibility_type "normal"
-                            :fk_target_field_id $
-                            :parent_id       nil
-                            :raw_column_id   $
-                            :last_analyzed   $})
-                         (match-$ (Field (id :users :last_login))
-                           {:description     nil
-                            :table_id        (id :users)
-                            :special_type    nil
-                            :name            "LAST_LOGIN"
-                            :display_name    "Last Login"
-                            :updated_at      $
-                            :active          true
-                            :id              $
-                            :field_type      "info"
-                            :position        0
-                            :target          nil
-                            :preview_display true
-                            :created_at      $
-                            :base_type       "DateTimeField"
-                            :visibility_type "normal"
-                            :fk_target_field_id $
-                            :parent_id       nil
-                            :raw_column_id   $
-                            :last_analyzed   $})
-                         (match-$ (Field (id :users :name))
-                           {:description     nil
-                            :table_id        (id :users)
-                            :special_type    "name"
-                            :name            "NAME"
-                            :display_name    "Name"
-                            :updated_at      $
-                            :active          true
-                            :id              $
-                            :field_type      "info"
-                            :position        0
-                            :target          nil
-                            :preview_display true
-                            :created_at      $
-                            :base_type       "TextField"
-                            :visibility_type "normal"
-                            :fk_target_field_id $
-                            :parent_id       nil
-                            :raw_column_id   $
-                            :last_analyzed   $})]
-       :rows            15
-       :updated_at      $
-       :entity_name     nil
-       :active          true
-       :id              (id :users)
-       :db_id           (id)
-       :raw_table_id    $
-       :field_values    {(keyword (str (id :users :name)))
-                         ["Broen Olujimi"
-                          "Conchúr Tihomir"
-                          "Dwight Gresham"
-                          "Felipinho Asklepios"
-                          "Frans Hevel"
-                          "Kaneonuskatew Eiran"
-                          "Kfir Caj"
-                          "Nils Gotam"
-                          "Plato Yeshua"
-                          "Quentin Sören"
-                          "Rüstem Hebel"
-                          "Shad Ferdynand"
-                          "Simcha Yan"
-                          "Spiros Teofil"
-                          "Szymon Theutrich"]}
-       :segments        []
-       :metrics         []
-       :created_at      $})
-    ((user->client :rasta) :get 200 (format "table/%d/query_metadata" (id :users))))
+  (match-$ (Table (id :users))
+    {:description     nil
+     :entity_type     nil
+     :visibility_type nil
+     :db              (db-details)
+     :schema          "PUBLIC"
+     :name            "USERS"
+     :display_name    "Users"
+     :fields          [(match-$ (Field (id :users :id))
+                         {:description     nil
+                          :table_id        (id :users)
+                          :special_type    "id"
+                          :name            "ID"
+                          :display_name    "ID"
+                          :updated_at      $
+                          :active          true
+                          :id              $
+                          :field_type      "info"
+                          :position        0
+                          :target          nil
+                          :preview_display true
+                          :created_at      $
+                          :base_type       "BigIntegerField"
+                          :visibility_type "normal"
+                          :fk_target_field_id $
+                          :parent_id       nil
+                          :raw_column_id   $
+                          :last_analyzed   $})
+                       (match-$ (Field (id :users :last_login))
+                         {:description     nil
+                          :table_id        (id :users)
+                          :special_type    nil
+                          :name            "LAST_LOGIN"
+                          :display_name    "Last Login"
+                          :updated_at      $
+                          :active          true
+                          :id              $
+                          :field_type      "info"
+                          :position        0
+                          :target          nil
+                          :preview_display true
+                          :created_at      $
+                          :base_type       "DateTimeField"
+                          :visibility_type "normal"
+                          :fk_target_field_id $
+                          :parent_id       nil
+                          :raw_column_id   $
+                          :last_analyzed   $})
+                       (match-$ (Field (id :users :name))
+                         {:description     nil
+                          :table_id        (id :users)
+                          :special_type    "name"
+                          :name            "NAME"
+                          :display_name    "Name"
+                          :updated_at      $
+                          :active          true
+                          :id              $
+                          :field_type      "info"
+                          :position        0
+                          :target          nil
+                          :preview_display true
+                          :created_at      $
+                          :base_type       "TextField"
+                          :visibility_type "normal"
+                          :fk_target_field_id $
+                          :parent_id       nil
+                          :raw_column_id   $
+                          :last_analyzed   $})]
+     :rows            15
+     :updated_at      $
+     :entity_name     nil
+     :active          true
+     :id              (id :users)
+     :db_id           (id)
+     :raw_table_id    $
+     :field_values    {(keyword (str (id :users :name)))
+                       ["Broen Olujimi"
+                        "Conchúr Tihomir"
+                        "Dwight Gresham"
+                        "Felipinho Asklepios"
+                        "Frans Hevel"
+                        "Kaneonuskatew Eiran"
+                        "Kfir Caj"
+                        "Nils Gotam"
+                        "Plato Yeshua"
+                        "Quentin Sören"
+                        "Rüstem Hebel"
+                        "Shad Ferdynand"
+                        "Simcha Yan"
+                        "Spiros Teofil"
+                        "Szymon Theutrich"]}
+     :segments        []
+     :metrics         []
+     :created_at      $})
+  ((user->client :rasta) :get 200 (format "table/%d/query_metadata" (id :users))))
 
 
 ;; ## PUT /api/table/:id
-(expect-eval-actual-first
-    (match-$ (u/prog1 (Table (id :users))
-               ;; reset Table back to its original state
-               (db/update! Table (id :users), :display_name "Users", :entity_type nil, :visibility_type nil, :description nil))
-      {:description     "What a nice table!"
-       :entity_type     "person"
-       :visibility_type "hidden"
-       :db              (match-$ (db)
-                          {:description     nil
-                           :organization_id $
-                           :name            "test-data"
-                           :is_sample       false
-                           :is_full_sync    true
-                           :updated_at      $
-                           :details         $
-                           :id              $
-                           :engine          "h2"
-                           :created_at      $
-                           :features        (mapv name (driver/features (driver/engine->driver :h2)))})
-       :schema          "PUBLIC"
-       :name            "USERS"
-       :rows            15
-       :updated_at      $
-       :entity_name     nil
-       :display_name    "Userz"
-       :active          true
-       :pk_field        (pk-field-id $$)
-       :id              $
-       :db_id           (id)
-       :raw_table_id    $
-       :created_at      $})
-    (do ((user->client :crowberto) :put 200 (format "table/%d" (id :users)) {:display_name "Userz"
-                                                                             :entity_type "person"
-                                                                             :visibility_type "hidden"
-                                                                             :description "What a nice table!"})
-        ((user->client :crowberto) :get 200 (format "table/%d" (id :users)))))
+(tu/expect-eval-actual-first
+  (match-$ (u/prog1 (Table (id :users))
+             ;; reset Table back to its original state
+             (db/update! Table (id :users), :display_name "Users", :entity_type nil, :visibility_type nil, :description nil))
+    {:description     "What a nice table!"
+     :entity_type     "person"
+     :visibility_type "hidden"
+     :db              (match-$ (db)
+                        {:description     nil
+                         :organization_id $
+                         :name            "test-data"
+                         :is_sample       false
+                         :is_full_sync    true
+                         :updated_at      $
+                         :details         $
+                         :id              $
+                         :engine          "h2"
+                         :created_at      $
+                         :features        (mapv name (driver/features (driver/engine->driver :h2)))})
+     :schema          "PUBLIC"
+     :name            "USERS"
+     :rows            15
+     :updated_at      $
+     :entity_name     nil
+     :display_name    "Userz"
+     :active          true
+     :pk_field        (pk-field-id $$)
+     :id              $
+     :db_id           (id)
+     :raw_table_id    $
+     :created_at      $})
+  (do ((user->client :crowberto) :put 200 (format "table/%d" (id :users)) {:display_name "Userz"
+                                                                           :entity_type "person"
+                                                                           :visibility_type "hidden"
+                                                                           :description "What a nice table!"})
+      ((user->client :crowberto) :get 200 (format "table/%d" (id :users)))))
 
 
 ;; ## GET /api/table/:id/fks
@@ -556,8 +557,8 @@
 
 
 ;; ## POST /api/table/:id/reorder
-(expect-eval-actual-first
-    {:result "success"}
+(expect
+  {:result "success"}
   (let [categories-id-field   (Field :table_id (id :categories), :name "ID")
         categories-name-field (Field :table_id (id :categories), :name "NAME")
         api-response          ((user->client :crowberto) :post 200 (format "table/%d/reorder" (id :categories))

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -96,6 +96,10 @@
         (swap! tokens assoc username <>))
       (throw (Exception. (format "Authentication failed for %s with credentials %s" username (user->credentials username))))))
 
+;; TODO - does it make sense just to make this a non-higher-order function? Or a group of functions, e.g.
+;; (GET :rasta 200 "field/10/values")
+;; vs.
+;; ((user->client :rasta) :get 200 "field/10/values")
 (defn user->client
   "Returns a `metabase.http-client/client` partially bound with the credentials for User with USERNAME.
    In addition, it forces lazy creation of the User if needed.

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -347,3 +347,10 @@
     (if (seq more)
       `(with-temporary-setting-values ~more ~body)
       body)))
+
+
+(defn is-uuid-string?
+  "Is string S a valid UUID string?"
+  ^Boolean [^String s]
+  (boolean (when (string? s)
+             (re-matches #"^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$" s))))

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -62,27 +62,7 @@
       form))
 
 
-;; By default `expect` evaluates EXPECTED first. This isn't always what we want; for example, sometime API tests affect the DB
-;; and we'd like to check the results.
-(defmacro ^:deprecated -doexpect [e a]
-  `(let [a# (try ~a (catch java.lang.Throwable t# t#))
-         e# (try ~e (catch java.lang.Throwable t# t#))]
-     (report
-      (try (compare-expr e# a# '~e '~a)
-           (catch java.lang.Throwable e2#
-             (compare-expr e2# a# '~e '~a))))))
-
-(defmacro ^:deprecated expect-eval-actual-first
-  "Identical to `expect` but evaluates `actual` first (instead of evaluating `expected` first).
-   DEPRECATED: You shouldn't need to use this when writing new tests. `expect-with-temp` should be used instead, as it handles cleaning up after itself."
-  {:style/indent 0}
-  [expected actual]
-  (let [fn-name (gensym)]
-    `(def ~(vary-meta fn-name assoc :expectation true)
-       (fn [] (-doexpect ~expected ~actual)))))
-
-
-;; ## random-name
+;;; random-name
 (let [random-uppercase-letter (partial rand-nth (mapv char (range (int \A) (inc (int \Z)))))]
   (defn random-name
     "Generate a random string of 20 uppercase letters."

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -62,10 +62,8 @@
       form))
 
 
-;; ## expect-eval-actual-first
 ;; By default `expect` evaluates EXPECTED first. This isn't always what we want; for example, sometime API tests affect the DB
 ;; and we'd like to check the results.
-
 (defmacro ^:deprecated -doexpect [e a]
   `(let [a# (try ~a (catch java.lang.Throwable t# t#))
          e# (try ~e (catch java.lang.Throwable t# t#))]


### PR DESCRIPTION
Rewrite tests that used deprecated old pattern to use new, safer patterns.

Resolves #2890 
