### PR TITLE
Change Variables button tooltip to 'Variables'

### DIFF
--- a/frontend/src/metabase/query_builder/QueryHeader.jsx
+++ b/frontend/src/metabase/query_builder/QueryHeader.jsx
@@ -264,7 +264,7 @@ export default class QueryHeader extends Component {
                 'text-brand-hover': !this.props.uiControls.isShowingTemplateTagsEditor
             });
             buttonSections.push([
-                <Tooltip key="parameterEdititor" tooltip="Parameters">
+                <Tooltip key="parameterEdititor" tooltip="Variables">
                     <a className={parametersButtonClasses}>
                         <Icon name="variable" size={16} onClick={this.props.toggleTemplateTagsEditor}></Icon>
                     </a>


### PR DESCRIPTION
Tiny little change that was bugging me.
