### PR TITLE
Fix "Cannot read property 'attrs' of undefined" when icon is missing

### DIFF
--- a/frontend/src/metabase/components/Icon.jsx
+++ b/frontend/src/metabase/components/Icon.jsx
@@ -20,6 +20,9 @@ export default class Icon extends Component {
 
     render() {
         const icon = loadIcon(this.props.name);
+        if (!icon) {
+            return null;
+        }
 
         const props = { ...icon.attrs, ...this.props };
         if (props.size != null) {
@@ -31,9 +34,7 @@ export default class Icon extends Component {
             props.height *= props.scale;
         }
 
-        if (!icon) {
-            return <span className="hide" />;
-        } else if (icon.img) {
+        if (icon.img) {
             return (<RetinaImage forceOriginalDimensions={false} {...props} src={icon.img} />);
         } else if (icon.svg) {
             return (<svg {...props} dangerouslySetInnerHTML={{__html: icon.svg}}></svg>);


### PR DESCRIPTION
@mazameli I haven't reproduced #3065 but I'm fairly sure this will fix it. Can you give it a try?
