### PR TITLE
Add Google auth doc page to Admin Guide TOC

### DIFF
--- a/docs/administration-guide/start.md
+++ b/docs/administration-guide/start.md
@@ -2,15 +2,16 @@
 
 Are you in charge of managing Metabase for your organization? Then you're in the right spot. You are the chosen one.
 
-**This guide will teach you how to:**
+**This guide will teach you about:**
 
-* [Connect Metabase to databases in your organization](01-managing-databases.md)
-* [Enable features that send email (SMTP)](02-setting-up-email.md)
-* [Edit your database metadata](03-metadata-editing.md)
-* [Manage user accounts](04-managing-users.md)
+* [Connecting Metabase to databases in your organization](01-managing-databases.md)
+* [Enabling features that send email (SMTP)](02-setting-up-email.md)
+* [Editing your database metadata](03-metadata-editing.md)
+* [Managing user accounts](04-managing-users.md)
 * [Creating segments and metrics](05-segments-and-metrics.md)
-* [Configure settings](06-configuration-settings.md)
-* [Setting up Slack Integration](07-setting-up-slack.md)
+* [Configuring settings](06-configuration-settings.md)
+* [Setting up Slack integration](07-setting-up-slack.md)
+* [Enabling single sign-on with Google](08-single-sign-on.md)
 
 First things first, you'll need to install Metabase. If you haven’t done that yet, our [Installation Guide](../operations-guide/start.md#installing-and-running-metabase) will help you through the process.
 


### PR DESCRIPTION
This was overlooked in 0.19.0
