### PR TITLE
Fix metabot toggle :robot_face:

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsSetting.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsSetting.jsx
@@ -56,7 +56,8 @@ export default class SettingsSetting extends Component {
     }
 
     renderToggleInput(setting) {
-        const on = (setting.value == null ? setting.default : setting.value) === true;
+        const value = setting.value == null ? setting.default : setting.value,
+              on    = value === true || value === "true";
         return (
             <div className="flex align-center pt1">
                 <Toggle value={on} onChange={!this.props.disabled ? this.props.updateSetting.bind(null, setting, on ? "false" : "true") : null}/>


### PR DESCRIPTION
It was only rendering the toggle switch as "On" if the value for the setting in question was `true`, but the code actually set the new value was setting it to `"true"`. 

The simplest fix here seemed to be to just tweak it to accept either representation of truthiness.

Fixes #3112 
