### PR TITLE
Fix OS X build scripts :wrench: [ci skip]

### DIFF
--- a/bin/osx-release
+++ b/bin/osx-release
@@ -1,4 +1,4 @@
-#! /usr/bin/perl -I./bin
+#! /usr/bin/env perl -I./bin
 
 use strict;
 use warnings;

--- a/bin/osx-setup
+++ b/bin/osx-setup
@@ -1,4 +1,4 @@
-#! /usr/bin/perl -I./bin
+#! /usr/bin/env perl -I./bin
 
 use strict;
 use warnings;


### PR DESCRIPTION
Use `/usr/bin/env perl` instead of `/usr/bin/perl` so we are using correct version of perl
