### PR TITLE
Tweak editing bar [WIP]

### DIFF
--- a/frontend/src/metabase/css/components/buttons.css
+++ b/frontend/src/metabase/css/components/buttons.css
@@ -45,7 +45,7 @@
 }
 
 .Button--small {
-    padding: 0.4rem 0.75rem;
+    padding: 0.45rem 1rem;
     font-size: 0.6rem;
 }
 

--- a/frontend/src/metabase/css/components/header.css
+++ b/frontend/src/metabase/css/components/header.css
@@ -40,6 +40,7 @@
 
 .EditHeader-title {
     color: white;
+    font-weight: bold;
 }
 
 .EditHeader-subtitle {
@@ -47,17 +48,18 @@
 }
 
 .EditHeader .Button {
-    color: var(--brand-color);
+    color: white;
     border: none;
-    text-transform: uppercase;
-    font-size: 0.75rem;
-    background-color: rgba(255,255,255,0.5);
-    font-weight: normal;
-    margin-left: 0.75em;
+    font-size: 0.875rem;
+    text-transform: capitalize;
+    background-color: rgba(255,255,255,0.1);
+    font-weight: bold;
+    margin-left: 0.75em
 }
 
 .EditHeader .Button--primary {
     background-color: white;
+    color: var(--brand-color);
 }
 
 .EditHeader .Button:hover {

--- a/frontend/src/metabase/dashboard/components/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader.jsx
@@ -97,22 +97,13 @@ export default class DashboardHeader extends Component {
 
     getEditingButtons() {
         return [
-            <ActionButton
-                key="save"
-                actionFn={() => this.onSave()}
-                className="Button Button--small Button--primary text-uppercase"
-                normalText="Save"
-                activeText="Saving…"
-                failedText="Save failed"
-                successText="Saved"
-            />,
-            <a data-metabase-event="Dashboard;Cancel Edits" key="cancel" className="Button Button--small text-uppercase" onClick={() => this.onCancel()}>
+            <a data-metabase-event="Dashboard;Cancel Edits" key="cancel" className="Button Button--small" onClick={() => this.onCancel()}>
                 Cancel
             </a>,
             <ModalWithTrigger
                 key="delete"
                 ref="deleteDashboardModal"
-                triggerClasses="Button Button--small text-uppercase"
+                triggerClasses="Button Button--small"
                 triggerElement="Delete"
             >
                 <DeleteDashboardModal
@@ -120,7 +111,16 @@ export default class DashboardHeader extends Component {
                     onClose={() => this.refs.deleteDashboardModal.toggle()}
                     onDelete={() => this.onDelete()}
                 />
-            </ModalWithTrigger>
+            </ModalWithTrigger>,
+            <ActionButton
+                key="save"
+                actionFn={() => this.onSave()}
+                className="Button Button--small Button--primary"
+                normalText="Save"
+                activeText="Saving…"
+                failedText="Save failed"
+                successText="Saved"
+            />
         ];
     }
 


### PR DESCRIPTION
Playing around with an updated style, and with the idea of rearranging the order of the items to: Cancel, Delete/Archive, Save. Currently only affects the dashboard edit bar. 

Current:
<img width="1264" alt="screen shot 2016-08-11 at 5 18 19 pm" src="https://cloud.githubusercontent.com/assets/2223916/17609271/26fa11ac-5fe8-11e6-9577-f16654bd02aa.png">

Proposed:
<img width="1265" alt="screen shot 2016-08-11 at 5 18 29 pm" src="https://cloud.githubusercontent.com/assets/2223916/17609276/348ce948-5fe8-11e6-94b3-a80da8cc1b22.png">

To-do:
- [ ] implement this new order for all instances where this bar is used
- [ ] switch question editing over to this style of edit mode
- [ ] ideally we'd want to implement dashboard organizing so we could implement dashboard archiving, so we could change `delete` to `archive` ??
