### PR TITLE
Improve line-height in data ref paragraphs [ci skip]

### DIFF
--- a/frontend/src/metabase/components/Detail.css
+++ b/frontend/src/metabase/components/Detail.css
@@ -28,6 +28,7 @@
 :local(.detailSubtitle) {
     composes: text-dark mt2 from "style";
     font-size: 16px;
+    line-height: 24px;
 }
 
 :local(.detailSubtitleLight) {

--- a/frontend/src/metabase/components/Detail.css
+++ b/frontend/src/metabase/components/Detail.css
@@ -26,11 +26,11 @@
 }
 
 :local(.detailSubtitle) {
-    composes: text-dark mt2 text-reading from "style";
+    composes: text-dark mt2 text-paragraph from "style";
 }
 
 :local(.detailSubtitleLight) {
-    composes: mt2 text-reading from "style";
+    composes: mt2 text-paragraph from "style";
     color: var(--subtitle-color);
 }
 

--- a/frontend/src/metabase/components/Detail.css
+++ b/frontend/src/metabase/components/Detail.css
@@ -26,9 +26,8 @@
 }
 
 :local(.detailSubtitle) {
-    composes: text-dark mt2 from "style";
+    composes: text-dark mt2 text-reading from "style";
     font-size: 16px;
-    line-height: 24px;
 }
 
 :local(.detailSubtitleLight) {

--- a/frontend/src/metabase/components/Detail.css
+++ b/frontend/src/metabase/components/Detail.css
@@ -27,13 +27,11 @@
 
 :local(.detailSubtitle) {
     composes: text-dark mt2 text-reading from "style";
-    font-size: 16px;
 }
 
 :local(.detailSubtitleLight) {
-    composes: mt2 from "style";
+    composes: mt2 text-reading from "style";
     color: var(--subtitle-color);
-    font-size: 16px;
 }
 
 :local(.detailTextArea) {

--- a/frontend/src/metabase/css/core/text.css
+++ b/frontend/src/metabase/css/core/text.css
@@ -81,7 +81,7 @@
   color: var(--body-text-color); /* TODO - is this bad? */
 }
 
-.text-reading, :local(.text-reading) {
+.text-paragraph, :local(.text-paragraph) {
   font-size: 1.143em;
   line-height: 1.5em;
 }

--- a/frontend/src/metabase/css/core/text.css
+++ b/frontend/src/metabase/css/core/text.css
@@ -81,6 +81,11 @@
   color: var(--body-text-color); /* TODO - is this bad? */
 }
 
+.text-reading, :local(.text-reading) {
+  font-size: 1em;
+  line-height: 1.5em;
+}
+
 .text-current {
     color: currentColor;
 }

--- a/frontend/src/metabase/css/core/text.css
+++ b/frontend/src/metabase/css/core/text.css
@@ -82,7 +82,7 @@
 }
 
 .text-reading, :local(.text-reading) {
-  font-size: 1em;
+  font-size: 1.143em;
   line-height: 1.5em;
 }
 

--- a/frontend/src/metabase/reference/Reference.css
+++ b/frontend/src/metabase/reference/Reference.css
@@ -13,7 +13,7 @@
 }
 
 :local(.guideEmptyMessage) {
-    composes: text-dark text-reading text-centered mt3 from "style";
+    composes: text-dark text-paragraph text-centered mt3 from "style";
 }
 
 :local(.columnHeader) {

--- a/frontend/src/metabase/reference/Reference.css
+++ b/frontend/src/metabase/reference/Reference.css
@@ -13,9 +13,7 @@
 }
 
 :local(.guideEmptyMessage) {
-    composes: text-dark text-centered mt3 from "style";
-    font-size: 1.1em;
-    line-height: 1.457em;
+    composes: text-dark text-reading text-centered mt3 from "style";
 }
 
 :local(.columnHeader) {


### PR DESCRIPTION
Another Trivial PR™. This one makes the line-height of long paragraphs be more friendly and legible. Incidentally, this whole css file uses `px` throughout, so I used that in my change, but I'm not sure if we want to switch everything in the file to `rems`. In conclusion, let's make line-height great again!

Before:
![screen shot 2016-08-15 at 3 08 45 pm](https://cloud.githubusercontent.com/assets/2223916/17681503/03b50060-62fb-11e6-8848-8b673584c235.png)

After:
![screen shot 2016-08-15 at 3 08 33 pm](https://cloud.githubusercontent.com/assets/2223916/17681504/08a7cbd4-62fb-11e6-9d19-61731dded4d5.png)
