### PR TITLE
Improvements to edit questions modal

### DIFF
--- a/frontend/src/metabase/components/SaveQuestionModal.css
+++ b/frontend/src/metabase/components/SaveQuestionModal.css
@@ -1,7 +1,3 @@
-:local(.saveQuestionModalFields) {
-    overflow: hidden;
-}
-
 .saveQuestionModalFields {
     overflow: hidden;
 }

--- a/frontend/src/metabase/components/SaveQuestionModal.css
+++ b/frontend/src/metabase/components/SaveQuestionModal.css
@@ -1,0 +1,23 @@
+:local(.saveQuestionModalFields) {
+    overflow: hidden;
+}
+
+.saveQuestionModalFields {
+    overflow: hidden;
+}
+
+.saveQuestionModalFields-enter {
+    max-height: 0px;
+}
+.saveQuestionModalFields-enter.saveQuestionModalFields-enter-active {
+    /* using 100% max-height breaks the transition */
+    max-height: 300px;
+    transition: max-height 500ms ease-out;
+}
+.saveQuestionModalFields-leave {
+    max-height: 300px;
+}
+.saveQuestionModalFields-leave.saveQuestionModalFields-leave-active {
+    max-height: 0px;
+    transition: max-height 500ms ease-out;
+}

--- a/frontend/src/metabase/components/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/components/SaveQuestionModal.jsx
@@ -1,5 +1,7 @@
 import React, { Component, PropTypes } from "react";
 
+import ReactCSSTransitionGroup from "react-addons-css-transition-group";
+
 import FormField from "metabase/components/FormField.jsx";
 import ModalContent from "metabase/components/ModalContent.jsx";
 
@@ -7,6 +9,8 @@ import Query from "metabase/lib/query";
 import { cancelable } from "metabase/lib/promise";
 
 import cx from "classnames";
+
+import S from "./SaveQuestionModal.css";
 
 
 export default class SaveQuestionModal extends Component {
@@ -161,23 +165,30 @@ export default class SaveQuestionModal extends Component {
                 <form className="flex flex-column flex-full" onSubmit={(e) => this.formSubmitted(e)}>
                     <div className="Form-inputs">
                         {saveOrUpdate}
-
-                        { details.saveType === "create" && [
-                            <FormField
-                                key="name"
-                                displayName="Name"
-                                fieldName="name"
-                                errors={this.state.errors}>
-                                <input className="Form-input full" name="name" placeholder="What is the name of your card?" value={this.state.details.name} onChange={(e) => this.onChange("name", e.target.value)} autoFocus/>
-                            </FormField>,
-                            <FormField
-                                key="description"
-                                displayName="Description"
-                                fieldName="description"
-                                errors={this.state.errors}>
-                                <textarea className="Form-input full" name="description" placeholder="It's optional but oh, so helpful" value={this.state.details.description} onChange={(e) => this.onChange("description", e.target.value)} />
-                            </FormField>
-                        ]}
+                        <ReactCSSTransitionGroup
+                            transitionName="saveQuestionModalFields"
+                            transitionEnterTimeout={500}
+                            transitionLeaveTimeout={500}
+                        >
+                            { details.saveType === "create" && 
+                                <div key="saveQuestionModalFields" className={S.saveQuestionModalFields}>
+                                    <FormField
+                                        key="name"
+                                        displayName="Name"
+                                        fieldName="name"
+                                        errors={this.state.errors}>
+                                        <input className="Form-input full" name="name" placeholder="What is the name of your card?" value={this.state.details.name} onChange={(e) => this.onChange("name", e.target.value)} autoFocus/>
+                                    </FormField>
+                                    <FormField
+                                        key="description"
+                                        displayName="Description"
+                                        fieldName="description"
+                                        errors={this.state.errors}>
+                                        <textarea className="Form-input full" name="description" placeholder="It's optional but oh, so helpful" value={this.state.details.description} onChange={(e) => this.onChange("description", e.target.value)} />
+                                    </FormField>
+                                </div>
+                            }
+                        </ReactCSSTransitionGroup>
                     </div>
 
                     <div className="Form-actions">

--- a/frontend/src/metabase/components/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/components/SaveQuestionModal.jsx
@@ -135,9 +135,17 @@ export default class SaveQuestionModal extends Component {
                     displayName="Replace or save as new?"
                     fieldName="saveType"
                     errors={this.state.errors}>
-                    <ul>
-                        <li onClick={(e) => this.onChange("saveType", "overwrite")}><input type="radio" name="saveType" value="overwrite" checked={this.state.details.saveType === "overwrite"} /> Replace original question, "{this.props.originalCard.name}"</li>
-                        <li onClick={(e) => this.onChange("saveType", "create")}><input type="radio" name="saveType" value="create" checked={this.state.details.saveType === "create"} /> Save as new question</li>
+                    <ul className="ml1">
+                        <li className="flex align-center cursor-pointer mt2 mb1" onClick={(e) => this.onChange("saveType", "overwrite")}>
+                            <input className="Form-radio" type="radio" name="saveType" id="saveType-overwrite" value="overwrite" checked={this.state.details.saveType === "overwrite"} /> 
+                            <label htmlFor="saveType-overwrite"></label>
+                            <span className={details.saveType === 'overwrite' ? 'text-brand' : 'text-default'}>Replace original question, "{this.props.originalCard.name}"</span>
+                        </li>
+                        <li className="flex align-center cursor-pointer" onClick={(e) => this.onChange("saveType", "create")}>
+                            <input className="Form-radio" type="radio" name="saveType" id="saveType-create" value="create" checked={this.state.details.saveType === "create"} />
+                            <label htmlFor="saveType-replace"></label>
+                            <span className={details.saveType === 'create' ? 'text-brand' : 'text-default'}>Save as new question</span>
+                        </li>
                     </ul>
                 </FormField>
             );

--- a/frontend/src/metabase/components/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/components/SaveQuestionModal.jsx
@@ -10,7 +10,7 @@ import { cancelable } from "metabase/lib/promise";
 
 import cx from "classnames";
 
-import S from "./SaveQuestionModal.css";
+import "./SaveQuestionModal.css";
 
 
 export default class SaveQuestionModal extends Component {
@@ -171,7 +171,7 @@ export default class SaveQuestionModal extends Component {
                             transitionLeaveTimeout={500}
                         >
                             { details.saveType === "create" && 
-                                <div key="saveQuestionModalFields" className={S.saveQuestionModalFields}>
+                                <div key="saveQuestionModalFields" className="saveQuestionModalFields">
                                     <FormField
                                         key="name"
                                         displayName="Name"

--- a/frontend/src/metabase/components/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/components/SaveQuestionModal.jsx
@@ -132,12 +132,12 @@ export default class SaveQuestionModal extends Component {
         if (!this.props.card.id && this.props.originalCard) {
             saveOrUpdate = (
                 <FormField
-                    displayName="Save or Replace?"
+                    displayName="Replace or save as new?"
                     fieldName="saveType"
                     errors={this.state.errors}>
                     <ul>
-                        <li onClick={(e) => this.onChange("saveType", "create")}><input type="radio" name="saveType" value="create" checked={this.state.details.saveType === "create"} /> Save as a new question?</li>
                         <li onClick={(e) => this.onChange("saveType", "overwrite")}><input type="radio" name="saveType" value="overwrite" checked={this.state.details.saveType === "overwrite"} /> Replace original question, "{this.props.originalCard.name}"</li>
+                        <li onClick={(e) => this.onChange("saveType", "create")}><input type="radio" name="saveType" value="create" checked={this.state.details.saveType === "create"} /> Save as new question</li>
                     </ul>
                 </FormField>
             );
@@ -164,7 +164,7 @@ export default class SaveQuestionModal extends Component {
                             </FormField>,
                             <FormField
                                 key="description"
-                                displayName="Description (optional)"
+                                displayName="Description"
                                 fieldName="description"
                                 errors={this.state.errors}>
                                 <textarea className="Form-input full" name="description" placeholder="It's optional but oh, so helpful" value={this.state.details.description} onChange={(e) => this.onChange("description", e.target.value)} />

--- a/frontend/src/metabase/css/components/form.css
+++ b/frontend/src/metabase/css/components/form.css
@@ -126,6 +126,25 @@
     transition: background .3s linear;
 }
 
+.Form-field .Form-radio {
+    display: none;
+}
+
+.Form-field .Form-radio + label {
+    display: inline-block;
+    position: relative;
+    margin-right: var(--margin-1); 
+    width: 8px;
+    height: 8px;
+    border: 2px solid white;
+    box-shadow: 0 0 0 2px var(--default-font-color);
+    border-radius: 8px;
+}
+
+.Form-field .Form-radio:checked + label {
+    box-shadow: 0 0 0 2px var(--brand-color);
+    background-color: var(--brand-color);
+}
 
 /* TODO: replace instances of Form-group with Form-field */
 .Form-group {

--- a/frontend/src/metabase/css/components/form.css
+++ b/frontend/src/metabase/css/components/form.css
@@ -131,6 +131,7 @@
 }
 
 .Form-field .Form-radio + label {
+    cursor: pointer;
     display: inline-block;
     position: relative;
     margin-right: var(--margin-1); 

--- a/frontend/src/metabase/css/components/form.css
+++ b/frontend/src/metabase/css/components/form.css
@@ -133,6 +133,7 @@
 .Form-field .Form-radio + label {
     cursor: pointer;
     display: inline-block;
+    flex: 0 0 auto;
     position: relative;
     margin-right: var(--margin-1); 
     width: 8px;

--- a/frontend/src/metabase/css/components/form.css
+++ b/frontend/src/metabase/css/components/form.css
@@ -138,7 +138,7 @@
     width: 8px;
     height: 8px;
     border: 2px solid white;
-    box-shadow: 0 0 0 2px var(--default-font-color);
+    box-shadow: 0 0 0 2px var(--grey-3);
     border-radius: 8px;
 }
 

--- a/frontend/src/metabase/reference/components/Formula.css
+++ b/frontend/src/metabase/reference/components/Formula.css
@@ -19,9 +19,6 @@
     font-size: 16px;
 }
 
-:local(.formulaDefinition) {
-    overflow: hidden;
-}
 :local(.formulaDefinitionInner) {
     composes: p2 from "style";
 }

--- a/frontend/src/metabase/reference/components/Formula.jsx
+++ b/frontend/src/metabase/reference/components/Formula.jsx
@@ -32,7 +32,7 @@ const Formula = ({
             transitionLeaveTimeout={300}
         >
             { isExpanded &&
-                <div key="formulaDefinition" className={S.formulaDefinition}>
+                <div key="formulaDefinition" className="formulaDefinition">
                     <QueryDefinition
                         className={S.formulaDefinitionInner}
                         object={entity}


### PR DESCRIPTION
Demo: https://metabase-edit-questions.herokuapp.com/

Resolves #2992 

TODOs:
- [x] Change default save mode to overwrite instead of create
- [x] Hide name and description fields when in overwrite mode
- [x] Prevent custom changes from being overwritten when switching save modes
- [x] Apply custom styling to radio buttons
- [x] Use cursor-pointer for click targets
- [x] Add height transition on fields removal
- [x] Fix radio button stretching when input overflows to more than 1 line
