### PR TITLE
Fade out dashboard cards that don't have all active filters applied

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -84,7 +84,7 @@ export default class DashCard extends Component {
 
         const hasUnmappedParameters = _.any(series, (s) => s.json_query && _.any(s.json_query.parameters, (p) => p.target == null));
         const hasParameterMappings = dashcard.parameter_mappings && dashcard.parameter_mappings
-            .some(mapping => parameterValues[mapping.parameter_id]);
+            .some(mapping => parameterValues[mapping.parameter_id] !== undefined);
         const hasParameters = Object.values(parameterValues).length > 0;
 
         const errors = series.map(s => s.error).filter(e => e);

--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -83,9 +83,11 @@ export default class DashCard extends Component {
         const isSlow = loading && _.some(series, (s) => s.duration) && (usuallyFast ? "usually-fast" : "usually-slow");
 
         const hasUnmappedParameters = _.any(series, (s) => s.json_query && _.any(s.json_query.parameters, (p) => p.target == null));
-        const hasParameterMappings = dashcard.parameter_mappings && dashcard.parameter_mappings
-            .some(mapping => parameterValues[mapping.parameter_id] !== undefined);
-        const hasParameters = Object.values(parameterValues).length > 0;
+        const hasParameterMappings = dashcard && dashcard.parameter_mappings && dashcard.parameter_mappings
+            .some(mapping => parameterValues[mapping.parameter_id]);
+        const hasParameters = parameterValues && Object.values(parameterValues)
+            .filter(parameterValue => parameterValue !== null)
+            .length > 0;
 
         const errors = series.map(s => s.error).filter(e => e);
         const error = errors[0] || this.state.error;

--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -29,7 +29,7 @@ export default class DashCard extends Component {
     static propTypes = {
         dashcard: PropTypes.object.isRequired,
         dashcardData: PropTypes.object.isRequired,
-
+        parameterValues: PropTypes.object.isRequired,
         markNewCardSeen: PropTypes.func.isRequired,
         fetchCardData: PropTypes.func.isRequired,
     };
@@ -67,7 +67,7 @@ export default class DashCard extends Component {
     }
 
     render() {
-        const { dashcard, dashcardData, cardDurations, isEditing, isEditingParameter, onAddSeries, onRemove } = this.props;
+        const { dashcard, dashcardData, cardDurations, parameterValues, isEditing, isEditingParameter, onAddSeries, onRemove } = this.props;
 
         const cards = [dashcard.card].concat(dashcard.series || []);
         const series = cards
@@ -83,7 +83,9 @@ export default class DashCard extends Component {
         const isSlow = loading && _.some(series, (s) => s.duration) && (usuallyFast ? "usually-fast" : "usually-slow");
 
         const hasUnmappedParameters = _.any(series, (s) => s.json_query && _.any(s.json_query.parameters, (p) => p.target == null));
-        const hasParameterMappings = dashcard.parameter_mappings && dashcard.parameter_mappings.length > 0;
+        const hasParameterMappings = dashcard.parameter_mappings && dashcard.parameter_mappings
+            .some(mapping => parameterValues[mapping.parameter_id]);
+        const hasParameters = Object.values(parameterValues).length > 0;
 
         const errors = series.map(s => s.error).filter(e => e);
         const error = errors[0] || this.state.error;
@@ -106,7 +108,7 @@ export default class DashCard extends Component {
             <div
                 className={"Card bordered rounded flex flex-column " + cx({
                     "Card--recent": dashcard.isAdded,
-                    "Card--unmapped": (hasUnmappedParameters || !hasParameterMappings) && !isEditing,
+                    "Card--unmapped": (hasUnmappedParameters || (hasParameters && !hasParameterMappings)) && !isEditing,
                     "Card--slow": isSlow === "usually-slow"
                 })}
             >

--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -82,12 +82,9 @@ export default class DashCard extends Component {
         const usuallyFast = _.every(series, (s) => s.duration && s.duration.average < s.duration.fast_threshold);
         const isSlow = loading && _.some(series, (s) => s.duration) && (usuallyFast ? "usually-fast" : "usually-slow");
 
-        const hasUnmappedParameters = _.any(series, (s) => s.json_query && _.any(s.json_query.parameters, (p) => p.target == null));
         const parameterMap = dashcard && dashcard.parameter_mappings && dashcard.parameter_mappings
             .reduce((map, mapping) => ({...map, [mapping.parameter_id]: mapping}), {});
-        // not quite sure if hasUnmappedParameters is still needed?
-        // seems like they have the same purpose judging from the naming, but the current 
-        // implementation of hasUnmappedParameters doesn't seem to work? 
+
         const isMappedToAllParameters = !parameterValues || Object.keys(parameterValues)
             .filter(parameterId => parameterValues[parameterId] !== null)
             .every(parameterId => parameterMap[parameterId]);
@@ -113,7 +110,7 @@ export default class DashCard extends Component {
             <div
                 className={"Card bordered rounded flex flex-column " + cx({
                     "Card--recent": dashcard.isAdded,
-                    "Card--unmapped": (hasUnmappedParameters || !isMappedToAllParameters) && !isEditing,
+                    "Card--unmapped": !isMappedToAllParameters && !isEditing,
                     "Card--slow": isSlow === "usually-slow"
                 })}
             >

--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -83,6 +83,7 @@ export default class DashCard extends Component {
         const isSlow = loading && _.some(series, (s) => s.duration) && (usuallyFast ? "usually-fast" : "usually-slow");
 
         const hasUnmappedParameters = _.any(series, (s) => s.json_query && _.any(s.json_query.parameters, (p) => p.target == null));
+        const hasParameterMappings = dashcard.parameter_mappings && dashcard.parameter_mappings.length > 0;
 
         const errors = series.map(s => s.error).filter(e => e);
         const error = errors[0] || this.state.error;
@@ -105,7 +106,7 @@ export default class DashCard extends Component {
             <div
                 className={"Card bordered rounded flex flex-column " + cx({
                     "Card--recent": dashcard.isAdded,
-                    "Card--unmapped": hasUnmappedParameters && !isEditing,
+                    "Card--unmapped": (hasUnmappedParameters || !hasParameterMappings) && !isEditing,
                     "Card--slow": isSlow === "usually-slow"
                 })}
             >

--- a/frontend/src/metabase/dashboard/components/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard.jsx
@@ -237,6 +237,7 @@ export default class Dashboard extends Component {
         let parameters = this.props.dashboard && this.props.dashboard.parameters || [];
         parameters = _.reject(parameters, (p) => p.id === parameter.id);
         this.setDashboardAttribute("parameters", parameters);
+        this.props.removeParameter(parameter.id);
     }
 
     // TODO: move to action

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -43,6 +43,7 @@ export default class DashboardGrid extends Component {
         isEditing: PropTypes.bool.isRequired,
         isEditingParameter: PropTypes.bool.isRequired,
         dashboard: PropTypes.object.isRequired,
+        parameterValues: PropTypes.object.isRequired,
         cards: PropTypes.array,
 
         setDashCardAttributes: PropTypes.func.isRequired,
@@ -203,6 +204,7 @@ export default class DashboardGrid extends Component {
             <DashCard
                 dashcard={dc}
                 dashcardData={this.props.dashcardData}
+                parameterValues={this.props.parameterValues}
                 cardDurations={this.props.cardDurations}
                 fetchCardData={this.props.fetchCardData}
                 markNewCardSeen={this.props.markNewCardSeen}

--- a/frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx
@@ -101,14 +101,18 @@ export default class DashCardCardParameterMapper extends Component {
                     triggerClasses={cx({ "disabled": disabled })}
                     triggerElement={
                         <Tooltip tooltip={tooltipText} verticalAttachments={["bottom", "top"]}>
-                            <button
+                            {/* using div instead of button due to
+                                https://bugzilla.mozilla.org/show_bug.cgi?id=984869
+                                and click event on close button not propagating in FF
+                            */}
+                            <div
                                 className={cx(S.button, {
                                     [S.mapped]: !!selected,
                                     [S.warn]: noOverlap,
                                     [S.disabled]: disabled
                                 })}
                             >
-                                <span className="mr1">
+                                <span className="text-centered mr1">
                                 { disabled ?
                                     "No valid fields"
                                 : selected ?
@@ -118,11 +122,11 @@ export default class DashCardCardParameterMapper extends Component {
                                 }
                                 </span>
                                 { selected ?
-                                    <Icon className="flex-align-right" name="close" size={16} onClick={(e) => { this.onChange(null); e.stopPropagation(); }}/>
+                                    <Icon className="flex-align-right" name="close" size={16} onClick={(e) => { console.log('detected');this.onChange(null); e.stopPropagation(); }}/>
                                 : !disabled ?
                                     <Icon className="flex-align-right" name="chevrondown" size={16} />
                                 : null }
-                            </button>
+                            </div>
                         </Tooltip>
                     }
                 >

--- a/frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx
@@ -122,7 +122,7 @@ export default class DashCardCardParameterMapper extends Component {
                                 }
                                 </span>
                                 { selected ?
-                                    <Icon className="flex-align-right" name="close" size={16} onClick={(e) => { console.log('detected');this.onChange(null); e.stopPropagation(); }}/>
+                                    <Icon className="flex-align-right" name="close" size={16} onClick={(e) => { this.onChange(null); e.stopPropagation(); }}/>
                                 : !disabled ?
                                     <Icon className="flex-align-right" name="chevrondown" size={16} />
                                 : null }

--- a/frontend/src/metabase/dashboard/dashboard.js
+++ b/frontend/src/metabase/dashboard/dashboard.js
@@ -318,9 +318,7 @@ export const setParameterValue = createThunkAction(SET_PARAMETER_VALUE, (paramet
 )
 
 export const removeParameter = createThunkAction(REMOVE_PARAMETER, (parameterId) =>
-    (dispatch, getState) => {
-        return { id: parameterId };
-    }
+    (dispatch, getState) => ({ id: parameterId })
 );
 
 

--- a/frontend/src/metabase/dashboard/dashboard.js
+++ b/frontend/src/metabase/dashboard/dashboard.js
@@ -57,6 +57,7 @@ export const FETCH_DATABASE_METADATA = "metabase/dashboard/FETCH_DATABASE_METADA
 
 export const SET_EDITING_PARAMETER_ID = "metabase/dashboard/SET_EDITING_PARAMETER_ID";
 export const ADD_PARAMETER = "metabase/dashboard/ADD_PARAMETER";
+export const REMOVE_PARAMETER = "metabase/dashboard/REMOVE_PARAMETER";
 export const SET_PARAMETER_MAPPING = "metabase/dashboard/SET_PARAMETER_MAPPING";
 export const SET_PARAMETER_NAME = "metabase/dashboard/SET_PARAMETER_NAME";
 export const SET_PARAMETER_VALUE = "metabase/dashboard/SET_PARAMETER_VALUE";
@@ -316,6 +317,13 @@ export const setParameterValue = createThunkAction(SET_PARAMETER_VALUE, (paramet
     }
 )
 
+export const removeParameter = createThunkAction(REMOVE_PARAMETER, (parameterId) =>
+    (dispatch, getState) => {
+        return { id: parameterId };
+    }
+);
+
+
 // reducers
 
 const dashboardId = handleActions({
@@ -405,7 +413,8 @@ const cardDurations = handleActions({
 }, {});
 
 const parameterValues = handleActions({
-    [SET_PARAMETER_VALUE]: { next: (state, { payload: { id, value }}) => i.assoc(state, id, value) }
+    [SET_PARAMETER_VALUE]: { next: (state, { payload: { id, value }}) => i.assoc(state, id, value) },
+    [REMOVE_PARAMETER]: { next: (state, { payload: { id }}) => i.dissoc(state, id) }
 }, {});
 
 const dashboardListing = handleActions({


### PR DESCRIPTION
Demo: https://metabase-fade-dashcards.herokuapp.com/

Resolves #3196

TODO:
- [x] Fade out dashboard cards that don't have ~~an active filter applied~~ all active filters applied
- [x] Fix not being able to clear filter on dashboard cards. Only reproducible in FF. Could be caused by the "x" overflowing to a second line? See screenshot below. 

UPDATE: These are separate issues. Buttons ignoring flex layout is known: https://bugzilla.mozilla.org/show_bug.cgi?id=984869. Click event not propagating to "x" button was fixed with the same workaround (switching from button to div element).

![firefox-card-filter-overflow](https://cloud.githubusercontent.com/assets/6934200/17746385/aacaac32-6464-11e6-8c5d-489ba57f57f6.png)
