### PR TITLE
Replace angular mb-icon directive with icon component on password reset.

### DIFF
--- a/frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx
+++ b/frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx
@@ -10,6 +10,7 @@ import FormField from "metabase/components/form/FormField.jsx";
 import FormLabel from "metabase/components/form/FormLabel.jsx";
 import FormMessage from "metabase/components/form/FormMessage.jsx";
 import LogoIcon from "metabase/components/LogoIcon.jsx";
+import Icon from "metabase/components/Icon.jsx";
 
 import MetabaseSettings from "metabase/lib/settings";
 
@@ -85,7 +86,7 @@ export default class ForgotPasswordApp extends Component {
                           <div>
                               <div className="SuccessGroup bg-white bordered rounded shadowed">
                                   <div className="SuccessMark">
-                                      <mb-icon name="check"></mb-icon>
+                                      <Icon name="check" />
                                   </div>
                                   <p className="SuccessText">Check your email for instructions on how to reset your password.</p>
                               </div>

--- a/frontend/src/metabase/auth/containers/PasswordResetApp.jsx
+++ b/frontend/src/metabase/auth/containers/PasswordResetApp.jsx
@@ -10,6 +10,7 @@ import FormField from "metabase/components/form/FormField.jsx";
 import FormLabel from "metabase/components/form/FormLabel.jsx";
 import FormMessage from "metabase/components/form/FormMessage.jsx";
 import LogoIcon from "metabase/components/LogoIcon.jsx";
+import Icon from "metabase/components/Icon.jsx";
 
 import MetabaseSettings from "metabase/lib/settings";
 
@@ -155,7 +156,7 @@ export default class PasswordResetApp extends Component {
                           <div className="Grid-cell">
                               <div className="SuccessGroup bg-white bordered rounded shadowed">
                                   <div className="SuccessMark">
-                                      <mb-icon name="check"></mb-icon>
+                                      <Icon name="check" />
                                   </div>
                                   <p>Your password has been reset.</p>
                                   <p>


### PR DESCRIPTION
Fixes a couple instances where we'd forgotten to switch over from angular directives while refactoring.
