### PR TITLE
Hide expand/collapse arrow in query builder when selecting fields from a single table

### DIFF
--- a/frontend/src/metabase/components/AccordianList.jsx
+++ b/frontend/src/metabase/components/AccordianList.jsx
@@ -166,7 +166,7 @@ export default class AccordianList extends Component {
                                     <div className="List-section-header px1 py1 cursor-pointer full flex align-center" onClick={() => this.toggleSection(sectionIndex)}>
                                         { this.renderSectionIcon(section, sectionIndex) }
                                         <h3 className="List-section-title">{section.name}</h3>
-                                        { section.items.length > 0 && !alwaysExpanded &&
+                                        { section.items.length > 0 &&
                                             <span className="flex-align-right">
                                                 <Icon name={sectionIsOpen(sectionIndex) ? "chevronup" : "chevrondown"} size={12} />
                                             </span>

--- a/frontend/src/metabase/components/AccordianList.jsx
+++ b/frontend/src/metabase/components/AccordianList.jsx
@@ -166,7 +166,7 @@ export default class AccordianList extends Component {
                                     <div className="List-section-header px1 py1 cursor-pointer full flex align-center" onClick={() => this.toggleSection(sectionIndex)}>
                                         { this.renderSectionIcon(section, sectionIndex) }
                                         <h3 className="List-section-title">{section.name}</h3>
-                                        { section.items.length > 0 &&
+                                        { section.items.length > 0 && !alwaysExpanded &&
                                             <span className="flex-align-right">
                                                 <Icon name={sectionIsOpen(sectionIndex) ? "chevronup" : "chevrondown"} size={12} />
                                             </span>

--- a/frontend/src/metabase/query_builder/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/DataSelector.jsx
@@ -223,7 +223,7 @@ export default class DataSelector extends Component {
                     itemIsSelected={(item) => item.table ? item.table.id === this.getTableId() : false}
                     itemIsClickable={(item) => item.table}
                     renderItemIcon={(item) => item.table ? <Icon name="table2" size={18} /> : null}
-                    alwaysExpanded={true}
+                    hideSingleSectionTitle={true}
                 />
             );
         }

--- a/frontend/src/metabase/query_builder/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/DataSelector.jsx
@@ -223,6 +223,7 @@ export default class DataSelector extends Component {
                     itemIsSelected={(item) => item.table ? item.table.id === this.getTableId() : false}
                     itemIsClickable={(item) => item.table}
                     renderItemIcon={(item) => item.table ? <Icon name="table2" size={18} /> : null}
+                    alwaysExpanded={true}
                 />
             );
         }


### PR DESCRIPTION
Demo: https://metabase-hide-arrow.herokuapp.com/

Resolves #3172 
