### PR TITLE
Fix double escaping of dashboard query parameters

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard.jsx
@@ -139,7 +139,7 @@ export default class Dashboard extends Component {
                 .map((value, id) => ([_.findWhere(parameters, { id }), value]))
                 .filter(([param, value]) => (param && value))
                 .reduce((params, [param, value]) => ({ ...params,
-                    [encodeURIComponent(param.slug)]: encodeURIComponent(value)
+                    [param.slug]: value
                 }), {})
                 .value();
 


### PR DESCRIPTION
Demo: https://metabase-url-escape.herokuapp.com/

Resolves #3213 

Looks like we were escaping with `encodeURIComponent` and then calling `querystring.stringify`, which escapes again, turning the `/` into `%2F` and then into `%252F`.
