### PR TITLE
Don't log API calls to /health or /util/logs :pencil:

### DIFF
--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -66,7 +66,7 @@
   (check-404 (db/exists? entity, :id id)))
 
 (defn check-superuser
-  "Check that `*current-user*` is a superuser or throw a 403."
+  "Check that `*current-user*` is a superuser or throw a 403. This doesn't require a DB call."
   []
   (check-403 *is-superuser?*))
 

--- a/src/metabase/middleware.clj
+++ b/src/metabase/middleware.clj
@@ -262,8 +262,10 @@
 (defn log-api-call
   "Middleware to log `:request` and/or `:response` by passing corresponding OPTIONS."
   [handler & options]
-  (fn [request]
-    (if-not (api-call? request)
+  (fn [{:keys [uri], :as request}]
+    (if (or (not (api-call? request))
+            (= uri "/api/health")     ; don't log calls to /health or /util/logs because they clutter up
+            (= uri "/api/util/logs")) ; the logs (especially the window in admin) with useless lines
       (handler request)
       (let [start-time (System/nanoTime)]
         (db/with-call-counting [call-count]


### PR DESCRIPTION
They clutter up the logs (especially when looking at them in the admin panel) which is super-annoying

Fixes #3114 
