### PR TITLE
Custom GeoJSON setting & endpoint :globe_with_meridians:

### DIFF
--- a/src/metabase/api/util.clj
+++ b/src/metabase/api/util.clj
@@ -26,7 +26,8 @@
         (when-let [url (public-settings/geojson-url)]
           {:status  200
            :headers {"Content-Type" "application/json"}
-           :body    (slurp (public-settings/geojson-url))}))
+           :body    (u/with-timeout 5000
+                      (slurp (public-settings/geojson-url)))}))
       ;; return a generic 204 "no content" if there's no GeoJSON to return
       {:status 204
        :body   nil}))

--- a/src/metabase/api/util.clj
+++ b/src/metabase/api/util.clj
@@ -1,7 +1,9 @@
 (ns metabase.api.util
   (:require [compojure.core :refer [defroutes GET POST]]
             [metabase.api.common :refer :all]
-            [metabase.logger :as logger]))
+            (metabase [logger :as logger]
+                      [public-settings :as public-settings]
+                      [util :as u])))
 
 
 (defendpoint POST "/password_check"
@@ -16,5 +18,18 @@
   []
   (check-superuser)
   (logger/get-messages))
+
+(defendpoint GET "/geojson"
+  "Return the custom GeoJSON file specified by the user, if any."
+  []
+  (or (u/ignore-exceptions
+        (when-let [url (public-settings/geojson-url)]
+          {:status  200
+           :headers {"Content-Type" "application/json"}
+           :body    (slurp (public-settings/geojson-url))}))
+      ;; return a generic 204 "no content" if there's no GeoJSON to return
+      {:status 204
+       :body   nil}))
+
 
 (define-routes)

--- a/src/metabase/driver/druid.clj
+++ b/src/metabase/driver/druid.clj
@@ -28,7 +28,7 @@
   [request-fn url & {:as options}]
   {:pre [(fn? request-fn) (string? url)]}
   (let [options                  (cond-> (merge {:content-type "application/json"} options)
-                                (:body options) (update :body json/generate-string))
+                                   (:body options) (update :body json/generate-string))
         {:keys [status body]} (request-fn url options)]
     (when (not= status 200)
       (throw (Exception. (format "Error [%d]: %s" status body))))

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -300,11 +300,14 @@
    You may optionally pass any of the OPTIONS below:
 
    *  `:default` - The default value of the setting. (default: `nil`)
-   *  `:type` - Either `:string` (default) or `:boolean`. Non-string settings have special default getters and setters that automatically coerce values to the correct types.
+   *  `:type` - `:string` (default), `:boolean`, or `:json`. Non-`:string` settings have special default getters and setters that automatically coerce values to the correct types.
    *  `:internal?` - This `Setting` is for internal use and shouldn't be exposed in the UI (i.e., not
                      returned by the corresponding endpoints). Default: `false`
    *  `:getter` - A custom getter fn, which takes no arguments. Overrides the default implementation.
-   *  `:setter` - A custom setter fn, which takes a single argument. Overrides the default implementation."
+                  (This can in turn call functions in this namespace like `get-string` or `get-boolean` to invoke the default getter behavior.)
+   *  `:setter` - A custom setter fn, which takes a single argument. Overrides the default implementation.
+                  (This can in turn call functions in this namespace like `set-string!` or `set-boolean!` to invoke the default setter behavior.
+                   Keep in mind that the custom setter may be passed `nil`, which should clear the values of the Setting.)"
   {:style/indent 1}
   [setting-symb description & {:as options}]
   {:pre [(symbol? setting-symb) (string? description)]}

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -4,6 +4,7 @@
                       [db :as db])
             (metabase.models [common :as common]
                              [setting :refer [defsetting], :as setting])
+            [metabase.util :as u]
             [metabase.util.password :as password])
   (:import java.util.TimeZone))
 
@@ -34,6 +35,16 @@
 
 (defsetting google-maps-api-key
   "A Google Maps API key is required to enable certain map visualizations.")
+
+(defsetting geojson-url
+  "A URL to a custom GeoJSON file that can be used in map visualizations instead of the default US State Map and World GeoJSON files."
+  ;; Custom setter below validates that the new value is a valid URL or refuses to set it
+  ;; TODO - if we have other URL settings we should consider moving this setter to `setting/` or even making `:url` an official Setting type
+  :setter (fn [url]
+            (when (seq url)
+              (assert (u/is-url? url)
+                (str "Invalid URL: " url)))
+            (setting/set-string! :geojson-url url)))
 
 (defn site-url
   "Fetch the site base URL that should be used for password reset emails, etc.
@@ -80,4 +91,5 @@
    :timezone_short        (short-timezone-name (setting/get :report-timezone))
    :has_sample_dataset    (db/exists? 'Database, :is_sample true)
    :google_auth_client_id (setting/get :google-auth-client-id)
-   :google_maps_api_key   (google-maps-api-key)})
+   :google_maps_api_key   (google-maps-api-key)
+   :geojson_url           (geojson-url)})

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -69,6 +69,7 @@
 (expect true (is-url? "http://www.cool.com"))
 (expect true (is-url? "http://localhost/"))
 (expect true (is-url? "http://localhost:3000"))
+(expect true (is-url? "https://www.mapbox.com/help/data/stations.geojson"))
 (expect true (is-url? "http://www.cool.com:3000"))
 (expect true (is-url? "http://localhost:3000/auth/reset_password/144_f98987de-53ca-4335-81da-31bb0de8ea2b#new"))
 (expect false (is-url? "google.com"))                      ; missing protocol


### PR DESCRIPTION
@tlrobinson this should do what you need.

Added new Setting `geojson-url` which can be fetched / changed the usual way. Setting `geojson-url` will check that the new value is a valid URL that points to a valid JSON file that can be fetched in under 5 seconds, or it will refuse to set the value.

The file in question can now be fetched via `GET /api/util/geojson`. This endpoint basically acts as a proxy for the file and will pass it unmodified if the URL is set and the file exists; if the value is unset or the fetch times out or otherwise fails the endpoint will return a 204 "No Content". 
