### PR TITLE
Fixed tag in ChartTooltip table.

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
@@ -35,15 +35,15 @@ export default class ChartTooltip extends Component {
                         { Array.isArray(hovered.data)  ?
                             hovered.data.map(({ key, value }, index) =>
                                 <tr key={index}>
-                                    <th className="text-light text-right">{key}:</th>
-                                    <th className="pl1 text-bold text-left">{value}</th>
+                                    <td className="text-light text-right">{key}:</td>
+                                    <td className="pl1 text-bold text-left">{value}</td>
                                 </tr>
                             )
                         :
                             [["key", 0], ["value", 1]].map(([propName, colIndex]) =>
                                 <tr key={propName} className="">
-                                    <th className="text-light text-right">{getFriendlyName(s.data.cols[colIndex])}:</th>
-                                    <th className="pl1 text-bold text-left">{formatValue(hovered.data[propName], { column: s.data.cols[colIndex], jsx: true, majorWidth: 0 })}</th>
+                                    <td className="text-light text-right">{getFriendlyName(s.data.cols[colIndex])}:</td>
+                                    <td className="pl1 text-bold text-left">{formatValue(hovered.data[propName], { column: s.data.cols[colIndex], jsx: true, majorWidth: 0 })}</td>
                                 </tr>
                             )
                         }


### PR DESCRIPTION
The current implementation of `ChartTooltip` component use `table` > `tbody` > `tr` > `th` but the W3C specs for [`th`](https://w3c.github.io/html/tabular-data.html#the-th-element) element suppose you are in  `table` > `thead` > `tr` > `th`. Fixed by switch from `th` to `td`.

As I can see there are no impact on styling.
