### PR TITLE
A tiny bit of cleanup :shower:

### DIFF
--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -35,6 +35,7 @@
   "Retrieve value for a single configuration key.  Accepts either a keyword or a string.
 
    We resolve properties from these places:
+
    1.  environment variables (ex: MB_DB_TYPE -> :mb-db-type)
    2.  jvm options (ex: -Dmb.db.type -> :mb-db-type)
    3.  hard coded `app-defaults`"

--- a/src/metabase/middleware.clj
+++ b/src/metabase/middleware.clj
@@ -104,10 +104,10 @@
   "Middleware that sets the `:metabase-api-key` keyword on the request if a valid API Key can be found.
    We check the request headers for `X-METABASE-APIKEY` and if it's not found then then no keyword is bound to the request."
   [handler]
-  (fn [{:keys [headers] :as request}]
-    (handler (if-let [api-key (headers metabase-api-key-header)]
-               (assoc request :metabase-api-key api-key)
-               request))))
+  (comp handler (fn [{:keys [headers] :as request}]
+                  (if-let [api-key (headers metabase-api-key-header)]
+                    (assoc request :metabase-api-key api-key)
+                    request))))
 
 
 (defn enforce-api-key
@@ -178,21 +178,20 @@
   "Base-64 encoded public key for this site's SSL certificate. Specify this to enable HTTP Public Key Pinning.
    See http://mzl.la/1EnfqBf for more information.") ; TODO - it would be nice if we could make this a proper link in the UI; consider enabling markdown parsing
 
-;(defn- public-key-pins-header []
-;  (when-let [k (ssl-certificate-public-key)]
-;    {"Public-Key-Pins" (format "pin-sha256=\"base64==%s\"; max-age=31536000" k)}))
+#_(defn- public-key-pins-header []
+  (when-let [k (ssl-certificate-public-key)]
+    {"Public-Key-Pins" (format "pin-sha256=\"base64==%s\"; max-age=31536000" k)}))
 
 (defn- api-security-headers [] ; don't need to include all the nonsense we include with index.html
   (merge (cache-prevention-headers)
          strict-transport-security-header
-         ;(public-key-pins-header)
-         ))
+         #_(public-key-pins-header)))
 
 (defn- index-page-security-headers []
   (merge (cache-prevention-headers)
          strict-transport-security-header
          content-security-policy-header
-         ;(public-key-pins-header)
+         #_(public-key-pins-header)
          {"X-Frame-Options"                   "DENY"          ; Tell browsers not to render our site as an iframe (prevent clickjacking)
           "X-XSS-Protection"                  "1; mode=block" ; Tell browser to block suspected XSS attacks
           "X-Permitted-Cross-Domain-Policies" "none"          ; Prevent Flash / PDF files from including content from site.

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -127,57 +127,56 @@
            (fail query e)))))
 
 
-(defn- pre-add-settings
+(defn- add-settings
   "Adds the `:settings` map to the query which can contain any fixed properties that would be useful at execution time.
    Currently supports a settings object like:
 
-       {:report-timezone \"US/Pacific\"}
-   "
-  [qp]
-  (fn [{:keys [driver] :as query}]
-    (let [settings {:report-timezone (when (driver/driver-supports? driver :set-timezone)
-                                       (let [report-tz (driver/report-timezone)]
-                                         (when-not (empty? report-tz)
-                                           report-tz)))}]
-      (qp (assoc query :settings (m/filter-vals (complement nil?) settings))))))
+       {:report-timezone \"US/Pacific\"}"
+  [{:keys [driver] :as query}]
+  (let [settings {:report-timezone (when (driver/driver-supports? driver :set-timezone)
+                                     (let [report-tz (driver/report-timezone)]
+                                       (when-not (empty? report-tz)
+                                         report-tz)))}]
+    (assoc query :settings (m/filter-vals (complement nil?) settings))))
+
+(defn- pre-add-settings [qp] (comp qp add-settings))
 
 
-(defn- pre-expand-macros
+(defn- expand-macros
   "Looks for macros in a structured (unexpanded) query and substitutes the macros for their contents."
-  [qp]
-  (fn [query]
-    ;; if necessary, handle macro substitution
-    (let [query (if-not (mbql-query? query)
-                  query
-                  ;; for MBQL queries run our macro expansion
-                  (u/prog1 (macros/expand-macros query)
-                    (when (and (not *disable-qp-logging*)
-                               (not= <> query))
-                      (log/debug (u/format-color 'cyan "\n\nMACRO/SUBSTITUTED: 😻\n%s" (u/pprint-to-str <>))))))]
-      (qp query))))
+  [query]
+  (if-not (mbql-query? query)
+    query
+    (u/prog1 (macros/expand-macros query)
+      (when (and (not *disable-qp-logging*)
+                 (not= <> query))
+        (log/debug (u/format-color 'cyan "\n\nMACRO/SUBSTITUTED: 😻\n%s" (u/pprint-to-str <>)))))))
 
-(defn- pre-substitute-parameters
+(defn- pre-expand-macros [qp] (comp qp expand-macros))
+
+
+(defn- substitute-parameters
   "If any parameters were supplied then substitute them into the query."
-  [qp]
-  (fn [query]
-    ;; if necessary, handle parameters substitution
-    (let [query (u/prog1 (params/expand-parameters query)
-                  (when (and (not *disable-qp-logging*)
-                             (not= <> query))
-                    (log/debug (u/format-color 'cyan "\n\nPARAMS/SUBSTITUTED: 😻\n%s" (u/pprint-to-str <>)))))]
-      (qp query))))
+  [query]
+  (u/prog1 (params/expand-parameters query)
+    (when (and (not *disable-qp-logging*)
+               (not= <> query))
+      (log/debug (u/format-color 'cyan "\n\nPARAMS/SUBSTITUTED: 😻\n%s" (u/pprint-to-str <>))))))
 
-(defn- pre-expand-resolve
+(defn- pre-substitute-parameters [qp] (comp qp substitute-parameters))
+
+
+(defn- expand-resolve
   "Transforms an MBQL into an expanded form with more information and structure. Also resolves references to fields, tables,
    etc, into their concrete details which are necessary for query formation by the executing driver."
-  [qp]
-  (fn [{database-id :database, :as query}]
-    (let [resolved-db (db/select-one [database/Database :name :id :engine :details], :id database-id)
-          query       (if-not (mbql-query? query)
-                        query
-                        ;; for MBQL queries we expand first, then resolve
-                        (resolve/resolve (expand/expand query)))]
-      (qp (assoc query :database resolved-db)))))
+  [{database-id :database, :as query}]
+  (let [resolved-db (db/select-one [database/Database :name :id :engine :details], :id database-id)
+        query       (if-not (mbql-query? query)
+                      query
+                      (resolve/resolve (expand/expand query)))]
+    (assoc query :database resolved-db)))
+
+(defn- pre-expand-resolve [qp] (comp qp expand-resolve))
 
 
 (defn- post-add-row-count-and-status
@@ -243,37 +242,37 @@
         (map->DateTimeField {:field field, :unit :default})
         field))))
 
-(defn- pre-add-implicit-fields
+(defn- add-implicit-fields
   "Add an implicit `fields` clause to queries with `rows` aggregations."
-  [qp]
-  (fn [{{:keys [source-table]} :query, :as query}]
-    (let [query (if-not (should-add-implicit-fields? query)
-                  query
-                  ;; this is a structured `:rows` query, so lets add a `:fields` clause with all fields from the source table + expressions
-                  (let [fields      (fields-for-source-table source-table)
-                        expressions (for [[expression-name] (get-in query [:query :expressions])]
-                                      (strict-map->ExpressionRef {:expression-name (name expression-name)}))]
-                    (when-not (seq fields)
-                      (log/warn (format "Table '%s' has no Fields associated with it." (:name source-table))))
-                    (-> query
-                        (assoc-in [:query :fields-is-implicit] true)
-                        (assoc-in [:query :fields] (concat fields expressions)))))]
-      (qp query))))
+  [{{:keys [source-table]} :query, :as query}]
+  (if-not (should-add-implicit-fields? query)
+    query
+    ;; this is a structured `:rows` query, so lets add a `:fields` clause with all fields from the source table + expressions
+    (let [fields      (fields-for-source-table source-table)
+          expressions (for [[expression-name] (get-in query [:query :expressions])]
+                        (strict-map->ExpressionRef {:expression-name (name expression-name)}))]
+      (when-not (seq fields)
+        (log/warn (format "Table '%s' has no Fields associated with it." (:name source-table))))
+      (-> query
+          (assoc-in [:query :fields-is-implicit] true)
+          (assoc-in [:query :fields] (concat fields expressions))))))
+
+(defn- pre-add-implicit-fields [qp] (comp qp add-implicit-fields))
 
 
-(defn- pre-add-implicit-breakout-order-by
+(defn- add-implicit-breakout-order-by
   "`Fields` specified in `breakout` should add an implicit ascending `order-by` subclause *unless* that field is *explicitly* referenced in `order-by`."
-  [qp]
-  (fn [{{breakout-fields :breakout, order-by :order-by} :query, :as query}]
-    (if (mbql-query? query)
-      (let [order-by-fields                   (set (map :field order-by))
-            implicit-breakout-order-by-fields (filter (partial (complement contains?) order-by-fields)
-                                                      breakout-fields)]
-        (qp (cond-> query
-              (seq implicit-breakout-order-by-fields) (update-in [:query :order-by] concat (for [field implicit-breakout-order-by-fields]
-                                                                                             {:field field, :direction :ascending})))))
-      ;; for non-MBQL queries we do nothing
-      (qp query))))
+  [{{breakout-fields :breakout, order-by :order-by} :query, :as query}]
+  (if-not (mbql-query? query)
+    query
+    (let [order-by-fields                   (set (map :field order-by))
+          implicit-breakout-order-by-fields (filter (partial (complement contains?) order-by-fields)
+                                                    breakout-fields)]
+      (cond-> query
+        (seq implicit-breakout-order-by-fields) (update-in [:query :order-by] concat (for [field implicit-breakout-order-by-fields]
+                                                                                       {:field field, :direction :ascending}))))))
+
+(defn- pre-add-implicit-breakout-order-by [qp] (comp qp add-implicit-breakout-order-by))
 
 
 (defn- pre-cumulative-sum
@@ -402,9 +401,8 @@
       (update results :rows (partial take (or max-results
                                               absolute-max-results))))))
 
-
-(defn- pre-log-query [qp]
-  (fn [query]
+(defn- log-query [query]
+  (u/prog1 query
     (when (and (mbql-query? query)
                (not *disable-qp-logging*))
       (log/debug (u/format-color 'magenta "\nPREPROCESSED/EXPANDED: 😻\n%s"
@@ -417,8 +415,9 @@
                      ;; obscure DB details when logging. Just log the name of driver because we don't care about its properties
                      (-> query
                          (assoc-in [:database :details] "😋 ") ; :yum:
-                         (update :driver name)))))))
-    (qp query)))
+                         (update :driver name)))))))))
+
+(defn- pre-log-query [qp] (comp qp log-query))
 
 ;; The following are just assertions that check the behavior of the QP. It doesn't make sense to run them on prod because at best they
 ;; just waste CPU cycles and at worst cause a query to fail when it would otherwise succeed.
@@ -431,11 +430,11 @@
   (if config/is-prod?
     identity
     (fn [qp]
-      (let [called? (atom false)]
-        (fn [query]
-          (assert (not @called?) "(QP QUERY) IS BEING CALLED MORE THAN ONCE!")
-          (reset! called? true)
-          (qp query))))))
+      (comp qp (let [called? (atom false)]
+                 (fn [query]
+                   (u/prog1 query
+                     (assert (not @called?) "(QP QUERY) IS BEING CALLED MORE THAN ONCE!")
+                     (reset! called? true))))))))
 
 
 (def ^:private post-check-results-format
@@ -445,9 +444,7 @@
   (if config/is-prod?
     identity
     (fn [qp]
-      (fn [query]
-        (u/prog1 (qp query)
-          (validate-results <>))))))
+      (comp validate-results qp))))
 
 (defn query->remark
   "Genarate an approparite REMARK to be prepended to a query to give DBAs additional information about the query being executed.


### PR DESCRIPTION
1.  fix markdown formatting in doc str
2.  Use `comp` when possible in our Ring middleware and QP middleware since it simplifies things a bit and reduces our function call depth, which should be a little more performant and makes reading stacktraces a little easier:
###### Example "Before" Stacktrace (45 Frames)

```
query_processor$run_query.invokeStatic(query_processor.clj:484)
query_processor$run_query.invoke(query_processor.clj:468)
query_processor$pre_log_query$fn__21551.invoke(query_processor.clj:421)
query_processor$limit$fn__21542.invoke(query_processor.clj:401)
query_processor$cumulative_count$fn__21537.invoke(query_processor.clj:390)
query_processor$cumulative_sum$fn__21507.invoke(query_processor.clj:338)
query_processor$pre_add_implicit_breakout_order_by$fn__21453.invoke(query_processor.clj:276)
query_processor$pre_add_implicit_fields$fn__21430.invoke(query_processor.clj:261)
query_processor$post_format_rows$fn__21396.invoke(query_processor.clj:215)
query_processor$post_add_row_count_and_status$fn__21341.invoke(query_processor.clj:191)
[...]
query_processor$pre_expand_resolve$fn__21336.invoke(query_processor.clj:180)
query_processor$pre_substitute_parameters$fn__21330.invoke(query_processor.clj:168)
query_processor$pre_expand_macros$fn__21325.invoke(query_processor.clj:157)
query_processor$pre_add_settings$fn__21321.invoke(query_processor.clj:142)
[...]
middleware$add_security_headers$fn__25065.invoke(middleware.clj:206)
middleware$bind_current_user$fn__25024.invoke(middleware.clj:100)
middleware$wrap_current_user_id$fn__25009.invoke(middleware.clj:62)
middleware$wrap_api_key$fn__25031.invoke(middleware.clj:109)
middleware$wrap_session_id$fn__25002.invoke(middleware.clj:53)
```
###### Example "After" Stacktrace (35 Frames)

```
query_processor$run_query.invokeStatic(query_processor.clj:481)
query_processor$run_query.invoke(query_processor.clj:465)
query_processor$limit$fn__80666.invoke(query_processor.clj:400)
query_processor$cumulative_count$fn__80661.invoke(query_processor.clj:389)
query_processor$cumulative_sum$fn__80631.invoke(query_processor.clj:337)
query_processor$post_format_rows$fn__80522.invoke(query_processor.clj:214)
query_processor$post_add_row_count_and_status$fn__80467.invoke(query_processor.clj:190)
[...]
middleware$add_security_headers$fn__45344.invoke(middleware.clj:204)
middleware$bind_current_user$fn__45303.invoke(middleware.clj:99)
```
