### PR TITLE
Fix GET /api/database/:id/idfields if DB has no tables :wrench:

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -1,6 +1,7 @@
 (ns metabase.api.database
   "/api/database endpoints."
-  (:require [clojure.tools.logging :as log]
+  (:require [clojure.string :as s]
+            [clojure.tools.logging :as log]
             [compojure.core :refer [GET POST PUT DELETE]]
             [metabase.api.common :refer :all]
             (metabase [config :as config]
@@ -10,7 +11,7 @@
                       [sample-data :as sample-data]
                       [util :as u])
             (metabase.models common
-                             [database :refer [Database protected-password]]
+                             [database :refer [Database protected-password], :as database]
                              [field :refer [Field]]
                              [hydrate :refer [hydrate]]
                              [table :refer [Table]])))
@@ -200,9 +201,7 @@
   "Get a list of all primary key `Fields` for `Database`."
   [id]
   (read-check Database id)
-  (let [table_ids (db/select-ids Table, :db_id id, :active true)]
-    (sort-by #(:name (:table %)) (-> (db/select Field, :table_id [:in table_ids], :special_type "id")
-                                     (hydrate :table)))))
+  (sort-by (comp s/lower-case :name :table) (hydrate (database/pk-fields {:id id}) :table)))
 
 (defendpoint POST "/:id/sync"
   "Update the metadata for this `Database`."

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -29,6 +29,14 @@
   [{:keys [id]}]
   (db/select 'Table, :db_id id, :active true, {:order-by [[:display_name :asc]]}))
 
+(defn pk-fields
+  "Return all the primary key `Fields` associated with this DATABASE."
+  [{:keys [id]}]
+  (let [table-ids (db/select-ids 'Table, :db_id id, :active true)]
+    (when (seq table-ids)
+      (db/select 'Field, :table_id [:in table-ids], :special_type "id"))))
+
+
 (u/strict-extend (class Database)
   i/IEntity
   (merge i/IEntityDefaults


### PR DESCRIPTION
Make sure we check that `table-ids` is no-empty before trying to use it in a SQL `IN` clause.

Fixes #3248 
