### PR TITLE
Remove migrate down command :arrow_down:

### DIFF
--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -196,7 +196,6 @@
 
    *  `:up`            - Migrate up
    *  `:force`         - Force migrate up, ignoring locks and any DDL statements that fail.
-   *  `:down`          - Rollback *all* migrations
    *  `:down-one`      - Rollback a single migration
    *  `:print`         - Just print the SQL for running the migrations, don't actually run them.
    *  `:release-locks` - Manually release migration locks left by an earlier failed migration.
@@ -217,7 +216,6 @@
          (case direction
            :up            (migrate-up-if-needed conn liquibase)
            :force         (force-migrate-up-if-needed conn liquibase)
-           :down          (.rollback liquibase 10000 "")
            :down-one      (.rollback liquibase 1 "")
            :print         (println (migrations-sql liquibase))
            :release-locks (.forceReleaseLocks liquibase)))


### PR DESCRIPTION
As mentioned in #1081 the `migrate down` (reverse _all_ migrations) command doesn't work because some of our migrations aren't reversible. Luckily this is not something one would probably ever want to; `migrate down-one` still works fine and is actually useful in the real world.

Fixes #1081
