### PR TITLE
use tooltip for descriptions on entity pages

### DIFF
--- a/frontend/src/metabase/components/Header.jsx
+++ b/frontend/src/metabase/components/Header.jsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom";
 
 import Input from "metabase/components/Input.jsx";
 import HeaderModal from "metabase/components/HeaderModal.jsx";
+import TitleAndDescription from "metabase/components/TitleAndDescription.jsx";
 
 export default class Header extends Component {
     static defaultProps = {
@@ -76,16 +77,17 @@ export default class Header extends Component {
         } else {
             if (this.props.item && this.props.item.id != null) {
                 titleAndDescription = (
-                    <div className="Header-title my1 py2">
-                        <h2 className="Header-title-name">{this.props.item.name}</h2>
-                        <h4 className="Header-title-description text-grey-3">{this.props.item.description || "No description yet"}</h4>
-                    </div>
+                    <TitleAndDescription
+                        title={this.props.item.name} 
+                        description={this.props.item.description}
+                    />
                 );
             } else {
                 titleAndDescription = (
-                    <div className="Header-title flex align-center">
-                        <h1 className="Header-title-name my1">{"New " + this.props.objectType}</h1>
-                    </div>
+                    <TitleAndDescription
+                        title={`New ${this.props.objectType}`}
+                        description={this.props.item.description}
+                    />
                 );
             }
         }
@@ -116,7 +118,7 @@ export default class Header extends Component {
                 {this.renderEditHeader()}
                 {this.renderHeaderModal()}
                 <div className={"QueryBuilder-section flex align-center " + this.props.headerClassName} ref="header">
-                    <div className="Entity">
+                    <div className="Entity py3">
                         {titleAndDescription}
                         {attribution}
                     </div>

--- a/frontend/src/metabase/components/HeaderBar.jsx
+++ b/frontend/src/metabase/components/HeaderBar.jsx
@@ -24,11 +24,11 @@ export default class Header extends Component {
                 </div>
             );
         } else {
-            if(name && description) {
+            if (name && description) {
                 titleAndDescription = (
                     <TitleAndDescription
-                        title={ name } 
-                        description={ description }
+                        title={name} 
+                        description={description}
                     />
                 );
             } else {

--- a/frontend/src/metabase/components/HeaderBar.jsx
+++ b/frontend/src/metabase/components/HeaderBar.jsx
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from "react";
 
 import Input from "metabase/components/Input.jsx";
+import TitleAndDescription from "metabase/components/TitleAndDescription.jsx";
 
 
 export default class Header extends Component {
@@ -23,12 +24,12 @@ export default class Header extends Component {
                 </div>
             );
         } else {
-            if (name && description) {
+            if(name && description) {
                 titleAndDescription = (
-                    <div className="Header-title my1 py2">
-                        <h2>{name}</h2>
-                        <h4 className="Header-title-name text-grey-3">{description || "No description yet"}</h4>
-                    </div>
+                    <TitleAndDescription
+                        title={ name } 
+                        description={ description }
+                    />
                 );
             } else {
                 titleAndDescription = (
@@ -41,7 +42,7 @@ export default class Header extends Component {
 
         return (
             <div className={"QueryBuilder-section flex align-center " + className}>
-                <div className="Entity">
+                <div className="Entity py3">
                     {titleAndDescription}
                 </div>
 

--- a/frontend/src/metabase/components/HeaderBar.jsx
+++ b/frontend/src/metabase/components/HeaderBar.jsx
@@ -42,7 +42,7 @@ export default class Header extends Component {
 
         return (
             <div className={"QueryBuilder-section flex align-center " + className}>
-                <div className="Entity py3">
+                <div className="Entity py1">
                     {titleAndDescription}
                 </div>
 

--- a/frontend/src/metabase/components/TitleAndDescription.jsx
+++ b/frontend/src/metabase/components/TitleAndDescription.jsx
@@ -1,24 +1,25 @@
 import React, { PropTypes } from 'react';
+import pure from "recompose/pure";
 
+import Icon from "metabase/components/Icon.jsx";
 import IconBorder from "metabase/components/IconBorder.jsx";
 import Tooltip from "metabase/components/Tooltip.jsx";
-import Icon from "metabase/components/Icon.jsx";
 
 const TitleAndDescription = ({ title, description }) =>
     <div className="flex align-center">
-        <h2 className="mr1">{ title }</h2>
+        <h2 className="mr1">{title}</h2>
         { description &&
-            <Tooltip tooltip={ description }>
+            <Tooltip tooltip={description}>
                 <IconBorder>
                     <Icon name='info'/>
                 </IconBorder>
             </Tooltip>
         }
-    </div>
+    </div>;
 
 TitleAndDescription.propTypes = {
     title: PropTypes.string.isRequired,
     description: PropTypes.string
-}
+};
 
-export default TitleAndDescription
+export default pure(TitleAndDescription);

--- a/frontend/src/metabase/components/TitleAndDescription.jsx
+++ b/frontend/src/metabase/components/TitleAndDescription.jsx
@@ -9,7 +9,7 @@ const TitleAndDescription = ({ title, description }) =>
     <div className="flex align-center">
         <h2 className="mr1">{title}</h2>
         { description &&
-            <Tooltip tooltip={description}>
+            <Tooltip tooltip={description} maxWidth={'22em'}>
                 <IconBorder>
                     <Icon name='info'/>
                 </IconBorder>

--- a/frontend/src/metabase/components/TitleAndDescription.jsx
+++ b/frontend/src/metabase/components/TitleAndDescription.jsx
@@ -1,0 +1,24 @@
+import React, { PropTypes } from 'react';
+
+import IconBorder from "metabase/components/IconBorder.jsx";
+import Tooltip from "metabase/components/Tooltip.jsx";
+import Icon from "metabase/components/Icon.jsx";
+
+const TitleAndDescription = ({ title, description }) =>
+    <div className="flex align-center">
+        <h2 className="mr1">{ title }</h2>
+        { description &&
+            <Tooltip tooltip={ description }>
+                <IconBorder>
+                    <Icon name='info'/>
+                </IconBorder>
+            </Tooltip>
+        }
+    </div>
+
+TitleAndDescription.propTypes = {
+    title: PropTypes.string.isRequired,
+    description: PropTypes.string
+}
+
+export default TitleAndDescription

--- a/frontend/src/metabase/components/TooltipPopover.jsx
+++ b/frontend/src/metabase/components/TooltipPopover.jsx
@@ -1,20 +1,44 @@
 import React, { Component, PropTypes } from "react";
+import cx from "classnames";
+import pure from "recompose/pure";
 
 import Popover from "./Popover.jsx";
 
-const TooltipPopover = (props) =>
-    <Popover
-        className="PopoverBody--tooltip"
-        targetOffsetY={10}
-        {...props}
-    >
-        { typeof props.children === "string" ?
-            <div className="py1 px2" style={{maxWidth: props.maxWidth || "12em"}}>
-                {props.children}
-            </div>
-        :
-            props.children
-        }
-    </Popover>
+// if the tooltip is passed a long description we'll want to conditionally
+// format it to make it easier to read.
+// we use the number of words as an approximation
+const CONDITIONAL_WORD_COUNT = 10;
 
-export default TooltipPopover;
+const wordCount = (string) => string.split(' ').length;
+
+const TooltipPopover = ({ children, maxWidth, ...props }) => {
+
+    const needsSpace = wordCount(children) > CONDITIONAL_WORD_COUNT
+
+    return (
+        <Popover
+            className="PopoverBody--tooltip"
+            targetOffsetY={10}
+            {...props}
+        >
+            { typeof children === "string" ?
+                <div
+                    className={cx(
+                        { 'py1 px2': !needsSpace },
+                        { 'py2 px3': needsSpace }
+                    )}
+                    style={{
+                        maxWidth: maxWidth || "12em",
+                        lineHeight: needsSpace ? 1.54 : 1
+                    }}
+                >
+                    {children}
+                </div>
+            :
+               children
+            }
+        </Popover>
+    )
+}
+
+export default pure(TooltipPopover);


### PR DESCRIPTION
implements #2755

Per @mazameli's solution, If a dashboard or question has a description and you're on the main "detail" page for it, you'll see a little info button, if not then you'll just see the title as before.

<img width="897" alt="screen shot 2016-09-06 at 1 28 26 pm" src="https://cloud.githubusercontent.com/assets/5248953/18289814/d8acc014-7435-11e6-9429-bd9ec54d40da.png">
