### PR TITLE
Cleanup in preparation for new hierarchical field types :shower:

### DIFF
--- a/frontend/src/metabase/lib/core.js
+++ b/frontend/src/metabase/lib/core.js
@@ -88,20 +88,6 @@ export const field_special_types = [{
 export const field_special_types_map = field_special_types
     .reduce((map, type) => Object.assign({}, map, {[type.id]: type}), {});
 
-export const field_field_types = [{
-    'id': 'info',
-    'name': 'Information',
-    'description': 'Non-numerical value that is not meant to be used.'
-}, {
-    'id': 'metric',
-    'name': 'Metric',
-    'description': 'A number that can be added, graphed, etc.'
-}, {
-    'id': 'dimension',
-    'name': 'Dimension',
-    'description': 'A high or low-cardinality numerical string value that is meant to be used as a grouping.'
-}];
-
 export const field_visibility_types = [{
     'id': 'normal',
     'name': 'Everywhere',

--- a/frontend/src/metabase/lib/query.js
+++ b/frontend/src/metabase/lib/query.js
@@ -521,7 +521,6 @@ var Query = {
                 operators_lookup: {},
                 valid_operators: [],
                 active: true,
-                field_type: "info",
                 fk_target_field_id: null,
                 parent_id: null,
                 preview_display: true,

--- a/resources/migrations/041_drop_field_field_type.yaml
+++ b/resources/migrations/041_drop_field_field_type.yaml
@@ -1,0 +1,24 @@
+databaseChangeLog:
+  - changeSet:
+      id: 41
+      author: camsaul
+      changes:
+        - dropColumn:
+            tableName: metabase_field
+            columnName: field_type
+        - addDefaultValue:
+            tableName: metabase_field
+            columnName: active
+            defaultValueBoolean: true
+        - addDefaultValue:
+            tableName: metabase_field
+            columnName: preview_display
+            defaultValueBoolean: true
+        - addDefaultValue:
+            tableName: metabase_field
+            columnName: position
+            defaultValueNumeric: 0
+        - addDefaultValue:
+            tableName: metabase_field
+            columnName: visibility_type
+            defaultValue: "normal"

--- a/resources/migrations/liquibase.json
+++ b/resources/migrations/liquibase.json
@@ -37,6 +37,7 @@
       {"include": {"file": "migrations/036_add_dashboard_filters_columns.yaml"}},
       {"include": {"file": "migrations/037_add_query_hash_and_indexes.yaml"}},
       {"include": {"file": "migrations/038_getting_started_guide.yaml"}},
-      {"include": {"file": "migrations/039_add_user_google_auth_column.yaml"}}
+      {"include": {"file": "migrations/039_add_user_google_auth_column.yaml"}},
+      {"include": {"file": "migrations/041_drop_field_field_type.yaml"}}
   ]
 }

--- a/sample_dataset/metabase/sample_dataset/generate.clj
+++ b/sample_dataset/metabase/sample_dataset/generate.clj
@@ -337,8 +337,7 @@
                           :latitude   {:description "This is the latitude of the user on sign-up. It might be updated in the future to the last seen location."}
                           :longitude  {:description "This is the longitude of the user on sign-up. It might be updated in the future to the last seen location."}
                           :name       {:description "The name of the user who owns an account"}
-                          :password   {:description "This is the salted password of the user. It should not be visible"
-                                       :field_type  :sensitive}
+                          :password   {:description "This is the salted password of the user. It should not be visible"}
                           :source     {:description "The channel through which we acquired this user. Valid values include: Affiliate, Facebook, Google, Organic and Twitter"}
                           :state      {:description "The state or province of the account’s billing address"}
                           :zip        {:description  "The postal code of the account’s billing address"

--- a/src/metabase/db/migrations.clj
+++ b/src/metabase/db/migrations.clj
@@ -135,11 +135,6 @@
     (db/update-where! Field {:visibility_type "unset"
                              :active          false}
       :visibility_type "retired")
-    ;; anything that is active with field_type = :sensitive gets visibility_type :sensitive
-    (db/update-where! Field {:visibility_type "unset"
-                             :active          true
-                             :field_type      "sensitive"}
-      :visibility_type "sensitive")
     ;; if field is active but preview_display = false then it becomes :details-only
     (db/update-where! Field {:visibility_type "unset"
                              :active          true

--- a/src/metabase/driver/druid.clj
+++ b/src/metabase/driver/druid.clj
@@ -65,12 +65,12 @@
 ;;; ### Sync
 
 (defn- describe-table-field [druid-field-type field-name]
-  (merge {:name field-name}
-         ;; all dimensions are Strings, and all metrics as JS Numbers, I think (?)
-         ;; string-encoded booleans + dates are treated as strings (!)
-         (if (= :metric druid-field-type)
-           {:field-type :metric,    :base-type :FloatField}
-           {:field-type :dimension, :base-type :TextField})))
+  ;; all dimensions are Strings, and all metrics as JS Numbers, I think (?)
+  ;; string-encoded booleans + dates are treated as strings (!)
+  {:name      field-name
+   :base-type (if (= :metric druid-field-type)
+                :FloatField
+                :TextField)})
 
 (defn- describe-table [database table]
   (let [details                      (:details database)
@@ -81,7 +81,6 @@
                     ;; every Druid table is an event stream w/ a timestamp field
                     [{:name       "timestamp"
                       :base-type  :DateTimeField
-                      :field-type :dimension
                       :pk?        true}]
                     (map (partial describe-table-field :dimension) dimensions)
                     (map (partial describe-table-field :metric) metrics)))}))

--- a/src/metabase/query_processor/expand.clj
+++ b/src/metabase/query_processor/expand.clj
@@ -9,8 +9,8 @@
             [metabase.db :as db]
             [metabase.models.table :refer [Table]]
             [metabase.query-processor.interface :refer [*driver*], :as i]
-            [metabase.util :as u])
-
+            [metabase.util :as u]
+            [metabase.util.schema :as su])
   (:import (metabase.query_processor.interface AgFieldRef
                                                BetweenFilter
                                                ComparisonFilter
@@ -29,7 +29,7 @@
 
 (s/defn ^:private ^:always-validate normalize-token :- s/Keyword
   "Convert a string or keyword in various cases (`lisp-case`, `snake_case`, or `SCREAMING_SNAKE_CASE`) to a lisp-cased keyword."
-  [token :- (s/named (s/cond-pre s/Keyword s/Str) "Valid token (keyword or string)")]
+  [token :- su/KeywordOrString]
   (-> (name token)
       str/lower-case
       (str/replace #"_" "-")
@@ -48,7 +48,7 @@
 
 (s/defn ^:ql ^:always-validate field-id :- FieldPlaceholder
   "Create a generic reference to a `Field` with ID."
-  [id :- i/IntGreaterThanZero]
+  [id :- su/IntGreaterThanZero]
   (i/map->FieldPlaceholder {:field-id id}))
 
 (s/defn ^:private ^:always-validate field :- i/AnyField
@@ -108,7 +108,7 @@
 
 (s/defn ^:ql ^:always-validate expression :- ExpressionRef
   {:added "0.17.0"}
-  [expression-name :- (s/cond-pre s/Str s/Keyword)]
+  [expression-name :- su/KeywordOrString]
   (i/strict-map->ExpressionRef {:expression-name (name expression-name)}))
 
 

--- a/src/metabase/query_processor/interface.clj
+++ b/src/metabase/query_processor/interface.clj
@@ -4,7 +4,8 @@
    should go in `metabase.query-processor.expand`."
   (:require [schema.core :as s]
             [metabase.models.field :as field]
-            [metabase.util :as u])
+            [metabase.util :as u]
+            [metabase.util.schema :as su])
   (:import clojure.lang.Keyword
            java.sql.Timestamp))
 
@@ -34,21 +35,15 @@
 
 ;; These are just used by the QueryExpander to record information about how joins should occur.
 
-(def IntGreaterThanZero
-  "Schema representing an `s/Int` than must also be greater than zero."
-  (s/constrained s/Int
-                 (partial < 0)
-                 "Integer greater than zero"))
-
-(s/defrecord JoinTableField [field-id   :- IntGreaterThanZero
-                             field-name :- s/Str])
+(s/defrecord JoinTableField [field-id   :- su/IntGreaterThanZero
+                             field-name :- su/NonBlankString])
 
 (s/defrecord JoinTable [source-field :- JoinTableField
                         pk-field     :- JoinTableField
-                        table-id     :- IntGreaterThanZero
-                        table-name   :- s/Str
-                        schema       :- (s/maybe s/Str)
-                        join-alias   :- s/Str])
+                        table-id     :- su/IntGreaterThanZero
+                        table-name   :- su/NonBlankString
+                        schema       :- (s/maybe su/NonBlankString)
+                        join-alias   :- su/NonBlankString])
 
 ;;; # ------------------------------------------------------------ PROTOCOLS ------------------------------------------------------------
 
@@ -61,19 +56,19 @@
 ;;; # ------------------------------------------------------------ "RESOLVED" TYPES: FIELD + VALUE ------------------------------------------------------------
 
 ;; Field is the expansion of a Field ID in the standard QL
-(s/defrecord Field [field-id           :- IntGreaterThanZero
-                    field-name         :- s/Str
-                    field-display-name :- s/Str
+(s/defrecord Field [field-id           :- su/IntGreaterThanZero
+                    field-name         :- su/NonBlankString
+                    field-display-name :- su/NonBlankString
                     base-type          :- (apply s/enum field/base-types)
                     special-type       :- (s/maybe (apply s/enum field/special-types))
                     visibility-type    :- (apply s/enum field/visibility-types)
-                    table-id           :- IntGreaterThanZero
-                    schema-name        :- (s/maybe s/Str)
-                    table-name         :- (s/maybe s/Str) ; TODO - Why is this `maybe` ?
-                    position           :- (s/maybe s/Int) ; TODO - int >= 0
+                    table-id           :- su/IntGreaterThanZero
+                    schema-name        :- (s/maybe su/NonBlankString)
+                    table-name         :- (s/maybe su/NonBlankString) ; TODO - Why is this `maybe` ?
+                    position           :- (s/maybe su/IntGreaterThanZero)
                     fk-field-id        :- (s/maybe s/Int)
-                    description        :- (s/maybe s/Str)
-                    parent-id          :- (s/maybe IntGreaterThanZero)
+                    description        :- (s/maybe su/NonBlankString)
+                    parent-id          :- (s/maybe su/IntGreaterThanZero)
                     ;; Field once its resolved; FieldPlaceholder before that
                     parent             :- s/Any]
   clojure.lang.Named
@@ -116,11 +111,7 @@
   clojure.lang.Named
   (getName [_] (name field)))
 
-(def NonEmptyString
-  "Schema for a non-empty string."
-  (s/constrained s/Str seq "non-empty string")) ; TODO - should this be used elsewhere as well, for things like `Field`?
-
-(s/defrecord ExpressionRef [expression-name :- NonEmptyString]
+(s/defrecord ExpressionRef [expression-name :- su/NonBlankString]
   clojure.lang.Named
   (getName [_] expression-name)
   IField
@@ -130,7 +121,7 @@
 
 ;; Value is the expansion of a value within a QL clause
 ;; Information about the associated Field is included for convenience
-(s/defrecord Value [value   :- (s/maybe (s/cond-pre s/Bool s/Num s/Str))
+(s/defrecord Value [value   :- (s/maybe (s/cond-pre s/Bool s/Num su/NonBlankString))
                     field   :- (s/named (s/cond-pre Field ExpressionRef)   ; TODO - Value doesn't need the whole field, just the relevant type info / units
                                         "field or expression reference")])
 
@@ -162,8 +153,8 @@
 ;;; # ------------------------------------------------------------ PLACEHOLDER TYPES: FIELDPLACEHOLDER + VALUEPLACEHOLDER ------------------------------------------------------------
 
 ;; Replace Field IDs with these during first pass
-(s/defrecord FieldPlaceholder [field-id      :- IntGreaterThanZero
-                               fk-field-id   :- (s/maybe (s/constrained IntGreaterThanZero
+(s/defrecord FieldPlaceholder [field-id      :- su/IntGreaterThanZero
+                               fk-field-id   :- (s/maybe (s/constrained su/IntGreaterThanZero
                                                                         (fn [_] (or (assert-driver-supports :foreign-keys) true))
                                                                         "foreign-keys is not supported by this driver."))
                                datetime-unit :- (s/maybe (apply s/enum datetime-field-units))])
@@ -203,7 +194,7 @@
 
 (def LiteralDatetimeString
   "Schema for an MBQL datetime string literal, in ISO-8601 format."
-  (s/constrained s/Str u/date-string? "Valid ISO-8601 datetime string literal"))
+  (s/constrained su/NonBlankString u/date-string? "Valid ISO-8601 datetime string literal"))
 
 (def LiteralDatetime
   "Schema for an MBQL literal datetime value: and ISO-8601 string or `java.sql.Date`."
@@ -219,7 +210,7 @@
 
 (def AnyValue
   "Schema for anything that is a considered a valid value in MBQL - `nil`, a `Boolean`, `Number`, `String`, or relative datetime form."
-  (s/named (s/maybe (s/cond-pre s/Bool s/Str OrderableValue)) "Valid value (must be nil, boolean, number, string, or a relative-datetime form)"))
+  (s/named (s/maybe (s/cond-pre s/Bool su/NonBlankString OrderableValue)) "Valid value (must be nil, boolean, number, string, or a relative-datetime form)"))
 
 ;; Replace values with these during first pass over Query.
 ;; Include associated Field ID so appropriate the info can be found during Field resolution
@@ -316,8 +307,8 @@
 
 (def Page
   "Schema for the top-level `page` clause in a MBQL query."
-  (s/named {:page  IntGreaterThanZero
-            :items IntGreaterThanZero}
+  (s/named {:page  su/IntGreaterThanZero
+            :items su/IntGreaterThanZero}
            "Valid page clause"))
 
 (def Query
@@ -326,8 +317,8 @@
    (s/optional-key :breakout)    [FieldPlaceholderOrExpressionRef]
    (s/optional-key :fields)      [AnyField]
    (s/optional-key :filter)      Filter
-   (s/optional-key :limit)       IntGreaterThanZero
+   (s/optional-key :limit)       su/IntGreaterThanZero
    (s/optional-key :order-by)    [OrderBy]
    (s/optional-key :page)        Page
    (s/optional-key :expressions) {s/Keyword Expression}
-   :source-table                 IntGreaterThanZero})
+   :source-table                 su/IntGreaterThanZero})

--- a/src/metabase/sync_database/interface.clj
+++ b/src/metabase/sync_database/interface.clj
@@ -20,7 +20,6 @@
   "Schema for a given Field as provided in `describe-table` or `analyze-table`."
   {:name                                  schema/Str
    :base-type                             (apply schema/enum field/base-types)
-   (schema/optional-key :field-type)      (apply schema/enum field/field-types)
    (schema/optional-key :special-type)    (apply schema/enum field/special-types)
    (schema/optional-key :pk?)             schema/Bool
    (schema/optional-key :nested-fields)   #{(schema/recursive #'DescribeTableField)}

--- a/src/metabase/util/schema.clj
+++ b/src/metabase/util/schema.clj
@@ -1,0 +1,16 @@
+(ns metabase.util.schema
+  "Various schemas that are useful throughout the app."
+  (:require [clojure.string :as str]
+            [schema.core :as s]))
+
+(def NonBlankString
+  "Schema for a string that cannot be blank."
+  (s/constrained s/Str (complement str/blank?) "Non-blank string"))
+
+(def IntGreaterThanZero
+  "Schema representing an integer than must also be greater than zero."
+  (s/constrained s/Int (partial < 0) "Integer greater than zero"))
+
+(def KeywordOrString
+  "Schema for something that can be either a `Keyword` or a `String`."
+  (s/named (s/cond-pre s/Keyword s/Str) "Keyword or string"))

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -266,7 +266,6 @@
                                                        :active             true
                                                        :id                 $
                                                        :raw_column_id      $
-                                                       :field_type         "info"
                                                        :position           0
                                                        :target             nil
                                                        :preview_display    true
@@ -289,7 +288,6 @@
                                                        :active             true
                                                        :id                 $
                                                        :raw_column_id      $
-                                                       :field_type         "info"
                                                        :position           0
                                                        :target             nil
                                                        :preview_display    true

--- a/test/metabase/api/field_test.clj
+++ b/test/metabase/api/field_test.clj
@@ -62,7 +62,6 @@
      :last_analyzed      $
      :active             true
      :id                 (id :users :name)
-     :field_type         "info"
      :visibility_type    "normal"
      :position           0
      :preview_display    true
@@ -143,13 +142,6 @@
   (tu/with-temp* [Field [{field-id :id} {:base_type :IntegerField}]]
     ((user->client :crowberto) :put 200 (str "field/" field-id) {:special_type :timestamp_seconds})
     (db/select-one-field :special_type Field, :id field-id)))
-
-;; check that a Field with a :base_type of :sensitive can still be modified as normal.
-;; This was a bug introduced when :visibility-type was added -- see issue #2678
-(expect
-  (tu/with-temp* [Field [{field-id :id} {:field_type "sensitive"}]]
-    (boolean ((user->client :crowberto) :put 200 (str "field/" field-id) {:special_type :avatar}))))
-
 
 
 (defn- field->field-values

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -122,7 +122,6 @@
       :updated_at         $
       :active             true
       :id                 (id :categories :id)
-      :field_type         "info"
       :position           0
       :preview_display    true
       :created_at         $
@@ -145,7 +144,6 @@
       :updated_at         $
       :active             true
       :id                 (id :categories :name)
-      :field_type         "info"
       :position           0
       :preview_display    true
       :created_at         $
@@ -181,7 +179,6 @@
                                   :updated_at         $
                                   :active             true
                                   :id                 $
-                                  :field_type         "info"
                                   :position           0
                                   :target             nil
                                   :preview_display    true
@@ -203,7 +200,6 @@
                                   :updated_at         $
                                   :active             true
                                   :id                 $
-                                  :field_type         "info"
                                   :position           0
                                   :target             nil
                                   :preview_display    true
@@ -269,7 +265,6 @@
                                   :updated_at         $
                                   :active             true
                                   :id                 $
-                                  :field_type         "info"
                                   :position           0
                                   :target             nil
                                   :preview_display    true
@@ -291,7 +286,6 @@
                                   :updated_at         $
                                   :active             true
                                   :id                 $
-                                  :field_type         "info"
                                   :position           0
                                   :target             nil
                                   :preview_display    true
@@ -313,7 +307,6 @@
                                   :updated_at         $
                                   :active             true
                                   :id                 $
-                                  :field_type         "info"
                                   :position           0
                                   :target             nil
                                   :preview_display    true
@@ -335,7 +328,6 @@
                                   :updated_at         $
                                   :active             true
                                   :id                 $
-                                  :field_type         "info"
                                   :position           0
                                   :target             nil
                                   :preview_display    true
@@ -399,7 +391,6 @@
                                   :updated_at         $
                                   :active             true
                                   :id                 $
-                                  :field_type         "info"
                                   :position           0
                                   :target             nil
                                   :preview_display    true
@@ -421,7 +412,6 @@
                                   :updated_at         $
                                   :active             true
                                   :id                 $
-                                  :field_type         "info"
                                   :position           0
                                   :target             nil
                                   :preview_display    true
@@ -443,7 +433,6 @@
                                   :updated_at         $
                                   :active             true
                                   :id                 $
-                                  :field_type         "info"
                                   :position           0
                                   :target             nil
                                   :preview_display    true
@@ -547,7 +536,6 @@
                          :visibility_type    "normal"
                          :preview_display    $
                          :position           $
-                         :field_type         "info"
                          :active             true
                          :special_type       "fk"
                          :fk_target_field_id $
@@ -587,7 +575,6 @@
                          :visibility_type    "normal"
                          :preview_display    $
                          :position           $
-                         :field_type         "info"
                          :active             true
                          :special_type       "id"
                          :fk_target_field_id $

--- a/test/metabase/models/field_test.clj
+++ b/test/metabase/models/field_test.clj
@@ -2,7 +2,8 @@
   (:require [expectations :refer :all]
             (metabase.models [field :refer :all]
                              [field-values :refer :all])
-            [metabase.test.data :refer :all]))
+            [metabase.test.data :refer :all]
+            [metabase.test.util :as tu]))
 
 
 ;; valid-special-type-for-base-type?
@@ -80,7 +81,10 @@
                                                :visibility_type :normal}))
 
 
-;; infer-field-special-type
+;;; infer-field-special-type
+
+(tu/resolve-private-fns metabase.models.field infer-field-special-type)
+
 (expect nil (infer-field-special-type nil nil))
 (expect nil (infer-field-special-type "id" nil))
 (expect nil (infer-field-special-type nil :IntegerField))

--- a/test/metabase/sync_database/sync_dynamic_test.clj
+++ b/test/metabase/sync_database/sync_dynamic_test.clj
@@ -287,7 +287,7 @@
     (let [get-fields (fn []
                        (for [field (db/select Field, :table_id table-id, {:order-by [:id]})]
                          (dissoc (tu/boolean-ids-and-timestamps field)
-                                 :active :field_type :position :preview_display)))]
+                                 :active :position :preview_display)))]
       ;; start with no fields
       [(get-fields)
        ;; first sync will add all the fields

--- a/test/metabase/sync_database/sync_test.clj
+++ b/test/metabase/sync_database/sync_test.clj
@@ -289,7 +289,7 @@
     (let [get-fields #(->> (db/select Field, :table_id table-id, {:order-by [:id]})
                            (mapv tu/boolean-ids-and-timestamps)
                            (mapv (fn [m]
-                                   (dissoc m :active :field_type :position :preview_display))))
+                                   (dissoc m :active :position :preview_display))))
           initial-fields (get-fields)
           first-sync     (do
                            (save-table-fields! tbl)

--- a/test/metabase/sync_database_test.clj
+++ b/test/metabase/sync_database_test.clj
@@ -91,7 +91,6 @@
                                :name               "id"
                                :active             true
                                :parent_id          false
-                               :field_type         :info
                                :position           0
                                :preview_display    true
                                :display_name       "ID"
@@ -111,7 +110,6 @@
                                :name               "studio"
                                :active             true
                                :parent_id          false
-                               :field_type         :info
                                :position           0
                                :preview_display    true
                                :display_name       "Studio"
@@ -131,7 +129,6 @@
                                :name               "title"
                                :active             true
                                :parent_id          false
-                               :field_type         :info
                                :position           0
                                :preview_display    true
                                :display_name       "Title"
@@ -168,7 +165,6 @@
                                :name               "name"
                                :active             true
                                :parent_id          false
-                               :field_type         :info
                                :position           0
                                :preview_display    true
                                :display_name       "Name"
@@ -188,7 +184,6 @@
                                :name               "studio"
                                :active             true
                                :parent_id          false
-                               :field_type         :info
                                :position           0
                                :preview_display    true
                                :display_name       "Studio"
@@ -236,7 +231,6 @@
                               :name               "id"
                               :active             true
                               :parent_id          false
-                              :field_type         :info
                               :position           0
                               :preview_display    true
                               :display_name       "ID"
@@ -256,7 +250,6 @@
                               :name               "studio"
                               :active             true
                               :parent_id          false
-                              :field_type         :info
                               :position           0
                               :preview_display    true
                               :display_name       "Studio"
@@ -276,7 +269,6 @@
                               :name               "title"
                               :active             true
                               :parent_id          false
-                              :field_type         :info
                               :position           0
                               :preview_display    true
                               :display_name       "Title"

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -188,7 +188,7 @@
              ;; Sync the database
              (sync-database/sync-database! db)
 
-             ;; Add extra metadata like Field field-type, base-type, etc.
+             ;; Add extra metadata like Field base-type, etc.
              (doseq [^TableDefinition table-definition (:table-definitions database-definition)]
                (let [table-name (:table-name table-definition)
                      table      (delay (or  (i/metabase-instance table-definition db)

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -196,14 +196,11 @@
                                                                        table-name
                                                                        (u/pprint-to-str (dissoc table-definition :rows))
                                                                        (u/pprint-to-str (db/select [Table :schema :name], :db_id (:id db))))))))]
-                 (doseq [{:keys [field-name field-type visibility-type special-type], :as field-definition} (:field-definitions table-definition)]
+                 (doseq [{:keys [field-name visibility-type special-type], :as field-definition} (:field-definitions table-definition)]
                    (let [field (delay (or (i/metabase-instance field-definition @table)
                                           (throw (Exception. (format "Field '%s' not loaded from definition:\n"
                                                                      field-name
                                                                      (u/pprint-to-str field-definition))))))]
-                     (when field-type
-                       (log/debug (format "SET FIELD TYPE %s.%s -> %s" table-name field-name field-type))
-                       (db/update! Field (:id @field) :field_type (name field-type)))
                      (when visibility-type
                        (log/debug (format "SET VISIBILITY TYPE %s.%s -> %s" table-name field-name visibility-type))
                        (db/update! Field (:id @field) :visibility_type (name visibility-type)))

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -131,7 +131,7 @@
 
 (defn create-field-definition
   "Create a new `FieldDefinition`; verify its values."
-  ^FieldDefinition [{:keys [field-name base-type field-type special-type visibility-type fk], :as field-definition-map}]
+  ^FieldDefinition [field-definition-map]
   (s/validate FieldDefinition (map->FieldDefinition field-definition-map)))
 
 (defn create-table-definition

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -3,36 +3,39 @@
 
    Objects that implement `IDatasetLoader` know how to load a `DatabaseDefinition` into an
    actual physical RDMS database. This functionality allows us to easily test with multiple datasets."
-  (:require [clojure.string :as s]
+  (:require [clojure.string :as str]
+            [schema.core :as s]
             (metabase [db :as db]
                       [driver :as driver])
             (metabase.models [database :refer [Database]]
                              [field :refer [Field] :as field]
                              [table :refer [Table]])
-            [metabase.util :as u])
+            [metabase.util :as u]
+            [metabase.util.schema :as su])
   (:import clojure.lang.Keyword))
 
-(defrecord FieldDefinition [^String  field-name
-                            ^Keyword base-type
-                            ^Keyword field-type
-                            ^Keyword special-type
-                            ^Keyword visibility-type
-                            ^Keyword fk])
+(s/defrecord FieldDefinition [field-name      :- su/NonBlankString
+                              base-type       :- (s/cond-pre {:native su/NonBlankString}
+                                                             (apply s/enum field/base-types))
+                              special-type    :- (s/maybe (apply s/enum field/special-types))
+                              visibility-type :- (s/maybe (apply s/enum field/visibility-types))
+                              fk              :- (s/maybe s/Keyword)])
 
-(defrecord TableDefinition [^String table-name
-                            field-definitions
-                            rows])
+(s/defrecord TableDefinition [table-name        :- su/NonBlankString
+                              field-definitions :- [FieldDefinition]
+                              rows              :- [[s/Any]]])
 
-(defrecord DatabaseDefinition [^String database-name
-                               table-definitions
-                               ;; Optional. Set this to non-nil to let dataset loaders know that we don't intend to keep it
-                               ;; for long -- they can adjust connection behavior, e.g. choosing simple connections instead of creating pools.
-                               ^Boolean short-lived?])
+(s/defrecord DatabaseDefinition [database-name     :- su/NonBlankString
+                                 table-definitions :- [TableDefinition]
+                                 ;; Optional. Set this to non-nil to let dataset loaders know that we don't intend to keep it
+                                 ;; for long -- they can adjust connection behavior, e.g. choosing simple connections instead of creating pools.
+                                 ;; TODO - not sure this is still used now that we create connection pools directly via C3P0; we might be able to remove it
+                                 short-lived?      :- (s/maybe s/Bool)])
 
 (defn escaped-name
   "Return escaped version of database name suitable for use as a filename / database name / etc."
   ^String [^DatabaseDefinition database-definition]
-  (s/replace (:database-name database-definition) #"\s+" "_"))
+  (str/replace (:database-name database-definition) #"\s+" "_"))
 
 (defn db-qualified-table-name
   "Return a combined table name qualified with the name of its database, suitable for use as an identifier.
@@ -41,7 +44,7 @@
   ^String [^String database-name, ^String table-name]
   {:pre [(string? database-name) (string? table-name)]}
   ;; take up to last 30 characters because databases like Oracle have limits on the lengths of identifiers
-  (apply str (take-last 30 (s/replace (s/lower-case (str database-name \_ table-name)) #"-" "_"))))
+  (apply str (take-last 30 (str/replace (str/lower-case (str database-name \_ table-name)) #"-" "_"))))
 
 
 (defprotocol IMetabaseInstance
@@ -53,19 +56,19 @@
 (extend-protocol IMetabaseInstance
   FieldDefinition
   (metabase-instance [this table]
-    (Field :table_id (:id table), :%lower.name (s/lower-case (:field-name this))))
+    (Field :table_id (:id table), :%lower.name (str/lower-case (:field-name this))))
 
   TableDefinition
   (metabase-instance [this database]
     ;; Look first for an exact table-name match; otherwise allow DB-qualified table names for drivers that need them like Oracle
-    (or (Table :db_id (:id database), :%lower.name (s/lower-case (:table-name this)))
+    (or (Table :db_id (:id database), :%lower.name (str/lower-case (:table-name this)))
         (Table :db_id (:id database), :%lower.name (db-qualified-table-name (:name database) (:table-name this)))))
 
   DatabaseDefinition
   (metabase-instance [{:keys [database-name]} engine-kw]
     (assert (string? database-name))
     (assert (keyword? engine-kw))
-    (db/setup-db-if-needed :auto-migrate true)
+    (db/setup-db-if-needed, :auto-migrate true)
     (Database :name database-name, :engine (name engine-kw))))
 
 
@@ -129,34 +132,21 @@
 (defn create-field-definition
   "Create a new `FieldDefinition`; verify its values."
   ^FieldDefinition [{:keys [field-name base-type field-type special-type visibility-type fk], :as field-definition-map}]
-  (assert (or (contains? field/base-types base-type)
-              (and (map? base-type)
-                   (string? (:native base-type))))
-    (str (format "Invalid field base type: '%s'\n" base-type)
-         "Field base-type should be either a valid base type like :TextField or be some native type wrapped in a map, like {:native \"JSON\"}."))
-  (when field-type
-    (assert (contains? field/field-types field-type)))
-  (when visibility-type
-    (assert (contains? field/visibility-types visibility-type)))
-  (when special-type
-    (assert (contains? field/special-types special-type)))
-  (map->FieldDefinition field-definition-map))
+  (s/validate FieldDefinition (map->FieldDefinition field-definition-map)))
 
 (defn create-table-definition
   "Convenience for creating a `TableDefinition`."
-  ^TableDefinition [^String table-name field-definition-maps rows]
-  (map->TableDefinition {:table-name          table-name
-                         :rows                rows
-                         :field-definitions   (mapv create-field-definition field-definition-maps)}))
+  ^TableDefinition [^String table-name, field-definition-maps rows]
+  (s/validate TableDefinition (map->TableDefinition {:table-name        table-name
+                                                     :rows              rows
+                                                     :field-definitions (mapv create-field-definition field-definition-maps)})))
 
 (defn create-database-definition
   "Convenience for creating a new `DatabaseDefinition`."
   ^DatabaseDefinition [^String database-name & table-name+field-definition-maps+rows]
-  {:pre [(string? database-name)
-         (not (s/blank? database-name))]}
-  (map->DatabaseDefinition {:database-name     database-name
-                            :table-definitions (mapv (partial apply create-table-definition)
-                                                     table-name+field-definition-maps+rows)}))
+  (s/validate DatabaseDefinition (map->DatabaseDefinition {:database-name     database-name
+                                                           :table-definitions (mapv (partial apply create-table-definition)
+                                                                                    table-name+field-definition-maps+rows)})))
 
 (defmacro def-database-definition
   "Convenience for creating a new `DatabaseDefinition` named by the symbol DATASET-NAME."
@@ -221,8 +211,8 @@
     field-name
     (let [[_ fk-table fk-dest-name] field-name]
       (-> fk-table
-          (s/replace #"ies$" "y")
-          (s/replace #"s$" "")
+          (str/replace #"ies$" "y")
+          (str/replace #"s$" "")
           (str  \_ (flatten-field-name fk-dest-name))))))
 
 (defn flatten-dbdef

--- a/test/metabase/test/mock/moviedb.clj
+++ b/test/metabase/test/mock/moviedb.clj
@@ -266,7 +266,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -286,7 +285,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -323,7 +321,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -343,7 +340,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -363,7 +359,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -400,7 +395,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -420,7 +414,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -440,7 +433,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -477,7 +469,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -497,7 +488,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -517,7 +507,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -537,7 +526,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -557,7 +545,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true

--- a/test/metabase/test/mock/schema_per_customer.clj
+++ b/test/metabase/test/mock/schema_per_customer.clj
@@ -483,7 +483,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -503,7 +502,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -540,7 +538,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -560,7 +557,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -597,7 +593,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -617,7 +612,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -638,7 +632,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -658,7 +651,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -696,7 +688,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -717,7 +708,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -737,7 +727,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -774,7 +763,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -794,7 +782,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -831,7 +818,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -851,7 +837,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -872,7 +857,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -892,7 +876,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -930,7 +913,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -951,7 +933,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -971,7 +952,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -1008,7 +988,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -1028,7 +1007,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -1065,7 +1043,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -1085,7 +1062,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -1106,7 +1082,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -1126,7 +1101,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -1164,7 +1138,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -1185,7 +1158,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -1205,7 +1177,6 @@
                                :id                 true
                                :raw_column_id      true
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true

--- a/test/metabase/test/mock/toucanery.clj
+++ b/test/metabase/test/mock/toucanery.clj
@@ -103,7 +103,6 @@
                                :id                 true
                                :raw_column_id      false
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -123,7 +122,6 @@
                                :id                 true
                                :raw_column_id      false
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -160,7 +158,6 @@
                                :id                 true
                                :raw_column_id      false
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -180,7 +177,6 @@
                                :id                 true
                                :raw_column_id      false
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -200,7 +196,6 @@
                                :id                 true
                                :raw_column_id      false
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -220,7 +215,6 @@
                                :id                 true
                                :raw_column_id      false
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -240,7 +234,6 @@
                                :id                 true
                                :raw_column_id      false
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -260,7 +253,6 @@
                                :id                 true
                                :raw_column_id      false
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -280,7 +272,6 @@
                                :id                 true
                                :raw_column_id      false
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -300,7 +291,6 @@
                                :id                 true
                                :raw_column_id      false
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -320,7 +310,6 @@
                                :id                 true
                                :raw_column_id      false
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true
@@ -340,7 +329,6 @@
                                :id                 true
                                :raw_column_id      false
                                :last_analyzed      false
-                               :field_type         :info
                                :position           0
                                :visibility_type    :normal
                                :preview_display    true

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -123,13 +123,10 @@
 
 (u/strict-extend (class Field)
   WithTempDefaults
-  {:with-temp-defaults (fn [_] {:active          true
-                                :base_type       :TextField
-                                :field_type      :info
-                                :name            (random-name)
-                                :position        1
-                                :preview_display true
-                                :table_id        (data/id :venues)})})
+  {:with-temp-defaults (fn [_] {:base_type :TextField
+                                :name      (random-name)
+                                :position  1
+                                :table_id  (data/id :venues)})})
 
 (u/strict-extend (class Metric)
   WithTempDefaults


### PR DESCRIPTION
While working on #2663 I've realized that we'll need to clean up a few pieces of cruft in order to do it. I'll break those out into separate PRs as much as possible to keep the scope of the PR that introduces the new type system reasonably small.

This PR:
-  Removes the `metabase_field.field_type` (`info`/`dimension`) column, which hasn't been used for a while (#2454)
-  Adds some DB-level default values to `metabase_field` columns; we were setting default values in Clojure-land, which is silly when we can have the DB do it
-  Organize the `metabase.models.field` namespace (group it into sections)
-  Use `schema` to validate our temporary database definitions in the unit test code, which is clearer and better-checked than using tons of `assert` statements
###### TL;DR

Nothing particularly interesting here. Fixes #2454
