### PR TITLE
Faster mac app launch time :racing_car:

### DIFF
--- a/OSX/Metabase/Backend/MetabaseTask.m
+++ b/OSX/Metabase/Backend/MetabaseTask.m
@@ -95,7 +95,9 @@
 		self.task.environment	= @{@"MB_DB_FILE": DBPath(),
 									@"MB_PLUGINS_DIR": PluginsDirPath(),
 									@"MB_JETTY_PORT": @(self.port)};
-		self.task.arguments		= @[@"-Djava.awt.headless=true",
+		self.task.arguments		= @[@"-Djava.awt.headless=true", // this prevents the extra java icon from popping up in the dock when running
+                                    @"-client",                  // make sure we're running in -client mode, which has a faster lanuch time
+                                    @"-Xverify:none",            // disable bytecode verification for faster launch speed, not really needed here since JAR is packaged as part of signed .app
 									@"-jar", UberjarPath()];
 				
 		__weak MetabaseTask *weakSelf = self;

--- a/project.clj
+++ b/project.clj
@@ -79,7 +79,8 @@
   :main ^:skip-aot metabase.core
   :manifest {"Liquibase-Package" "liquibase.change,liquibase.changelog,liquibase.database,liquibase.parser,liquibase.precondition,liquibase.datatype,liquibase.serializer,liquibase.sqlgenerator,liquibase.executor,liquibase.snapshot,liquibase.logging,liquibase.diff,liquibase.structure,liquibase.structurecompare,liquibase.lockservice,liquibase.sdk,liquibase.ext"}
   :target-path "target/%s"
-  :jvm-opts ["-Djava.awt.headless=true"]                              ; prevent Java icon from randomly popping up in dock when running `lein ring server`
+  :jvm-opts ["-server"                                                ; Run JVM in server mode as opposed to client -- see http://stackoverflow.com/questions/198577/real-differences-between-java-server-and-java-client for a good explanation of this
+             "-Djava.awt.headless=true"]                              ; prevent Java icon from randomly popping up in dock when running `lein ring server`
   :javac-options ["-target" "1.7", "-source" "1.7"]
   :uberjar-name "metabase.jar"
   :ring {:handler metabase.core/app
@@ -114,7 +115,7 @@
                    :jvm-opts ["-Dlogfile.path=target/log"
                               "-Xms1024m"                             ; give JVM a decent heap size to start with
                               "-Xmx2048m"                             ; hard limit of 2GB so we stop hitting the 4GB container limit on CircleCI
-                              "-server"                               ; Run JVM in server mode as opposed to client -- see http://stackoverflow.com/questions/198577/real-differences-between-java-server-and-java-client for a good explanation of this
+                              "-Xverify:none"                         ; disable bytecode verification when running in dev so it starts slightly faster
                               "-XX:+CMSClassUnloadingEnabled"         ; let Clojure's dynamically generated temporary classes be GC'ed from PermGen
                               "-XX:+UseConcMarkSweepGC"]              ; Concurrent Mark Sweep GC needs to be used for Class Unloading (above)
                    :aot [metabase.logger]}                            ; Log appender class needs to be compiled for log4j to use it
@@ -127,12 +128,11 @@
                                        "-Dmb.db.in.memory=true"
                                        "-Dmb.jetty.join=false"
                                        "-Dmb.jetty.port=3010"
-                                       "-Dmb.api.key=test-api-key"
-                                       "-Xverify:none"]}              ; disable bytecode verification when running tests so they start slightly faster
+                                       "-Dmb.api.key=test-api-key"]}
              :uberjar {:aot :all
                        :jvm-opts ["-Dclojure.compiler.elide-meta=[:doc :added :file :line]" ; strip out metadata for faster load / smaller uberjar size
                                   "-Dmanifold.disable-jvm8-primitives=true"]}               ; disable Manifold Java 8 primitives (see https://github.com/ztellman/manifold#java-8-extensions)
-             :generate-sample-dataset {:dependencies [[faker "0.2.2"]                   ; Fake data generator -- port of Perl/Ruby
+             :generate-sample-dataset {:dependencies [[faker "0.2.2"]                   ; Fake data generator -- port of Perl/Ruby library
                                                       [incanter/incanter-core "1.9.1"]] ; Satistical functions like normal distibutions}})
                                        :source-paths ["sample_dataset"]
                                        :main ^:skip-aot metabase.sample-dataset.generate}

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -246,11 +246,11 @@
 
 (defn- run-cmd [cmd & args]
   (try (apply (cmd->fn cmd) args)
-       (System/exit 0)
        (catch Throwable e
          (.printStackTrace e)
          (println (u/format-color 'red "Command failed with exception: %s" (.getMessage e)))
-         (System/exit 1))))
+         (System/exit 1)))
+  (System/exit 0))
 
 
 ;;; ---------------------------------------- App Entry Point ----------------------------------------

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -26,8 +26,7 @@
                       [setup :as setup]
                       [task :as task]
                       [util :as u])
-            (metabase.models [setting :refer [defsetting]]
-                             [user :refer [User]])))
+            [metabase.models.user :refer [User]]))
 
 ;;; CONFIG
 

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -222,9 +222,7 @@
   []
   ;; override env var that would normally make Jetty block forever
   (intern 'environ.core 'env (assoc environ.core/env :mb-jetty-join "false"))
-  (let [start-ns (System/nanoTime)]
-    (start-normally)
-    (println (u/format-color 'green "start-normally took %s." (u/format-nanoseconds (- (System/nanoTime) start-ns))))))
+  (u/profile "start-normally" (start-normally)))
 
 (defn ^:command help
   "Show this help message listing valid Metabase commands."

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -204,12 +204,12 @@
 
 ;;; ---------------------------------------- Special Commands ----------------------------------------
 
-(defn- ^:command migrate
+(defn ^:command migrate
   "Run database migrations. Valid options for DIRECTION are `up`, `force`, `down-one`, `print`, or `release-locks`."
   [direction]
   (db/migrate! @db/db-connection-details (keyword direction)))
 
-(defn- ^:command load-from-h2
+(defn ^:command load-from-h2
   "Transfer data from existing H2 database to the newly created MySQL or Postgres DB specified by env vars."
   ([]
    (load-from-h2 nil))
@@ -217,7 +217,7 @@
    (require 'metabase.cmd.load-from-h2)
    ((resolve 'metabase.cmd.load-from-h2/load-from-h2!) h2-connection-string)))
 
-(defn- ^:command profile
+(defn ^:command profile
   "Start Metabase the usual way and exit. Useful for profiling Metabase launch time."
   []
   ;; override env var that would normally make Jetty block forever
@@ -226,7 +226,7 @@
     (start-normally)
     (println (u/format-color 'green "start-normally took %s." (u/format-nanoseconds (- (System/nanoTime) start-ns))))))
 
-(defn- ^:command help
+(defn ^:command help
   "Show this help message listing valid Metabase commands."
   []
   (println "Valid commands are:")

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -21,6 +21,11 @@
            javax.xml.bind.DatatypeConverter
            org.joda.time.format.DateTimeFormatter))
 
+;; This is the very first log message that will get printed.
+;; It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
+;; It shows up a solid 10-15 seconds before the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
+(log/info "Loading Metabase...")
+
 ;; Set the default width for pprinting to 200 instead of 72. The default width is too narrow and wastes a lot of space for pprinting huge things like expanded queries
 (intern 'clojure.pprint '*print-right-margin* 200)
 

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -712,3 +712,11 @@
     (map? object-or-id)     (recur (:id object-or-id))
     (integer? object-or-id) object-or-id
     :else                   (throw (Exception. (str "Not something with an ID: " object-or-id)))))
+
+(defmacro profile
+  "Like `clojure.core/time`, but lets you specify a message that gets printed with the total time, and formats the time nicely using `format-nanoseconds`."
+  {:style/indent 1}
+  [message & body]
+  `(let [start-time# (System/nanoTime)]
+     (prog1 (do ~@body)
+       (println (format-color '~'green "%s took %s" ~message (format-nanoseconds (- (System/nanoTime) start-time#)))))))


### PR DESCRIPTION
Skip Java's bytecode verification when launching the Mac App because the JAR is already known to be good and the app is signed preventing shady kittens from modifying the JAR. Shaves off a second or so of launch time.
