### PR TITLE
Fix GeoJSON validation for local resources :wrench:

### DIFF
--- a/src/metabase/api/geojson.clj
+++ b/src/metabase/api/geojson.clj
@@ -1,26 +1,45 @@
 (ns metabase.api.geojson
-  (:require [cheshire.core :as json]
+  (:require [clojure.java.io :as io]
+            [cheshire.core :as json]
             [compojure.core :refer [defroutes GET]]
             [schema.core :as s]
             [metabase.api.common :refer :all]
             [metabase.models.setting :refer [defsetting], :as setting]
             [metabase.util :as u]))
 
+(defn- valid-json?
+  "Does this URL-OR-RESOURCE point to valid JSON?
+   URL-OR-RESOURCE should be something that can be passed to `slurp`, like an HTTP URL or a `java.net.URL` (which is what `io/resource` returns below)."
+  [url-or-resource]
+  (u/with-timeout 5000
+    (json/parse-string (slurp url-or-resource)))
+  true)
 
-(def ^:private valid-json-url?
+(defn- valid-json-resource?
+  "Does this RELATIVE-PATH point to a valid local JSON resource? (RELATIVE-PATH is something like \"app/charts/us-states.json\".)"
+  [relative-path]
+  (when-let [^java.net.URI uri (u/ignore-exceptions (java.net.URI. relative-path))]
+    (when-not (.isAbsolute uri)
+      (valid-json? (io/resource (str "frontend_client" uri))))))
+
+(defn- valid-json-url?
+  "Is URL a valid HTTP URL and does it point to valid JSON?"
+  [url]
+  (when (u/is-url? url)
+    (valid-json? url)))
+
+(def ^:private valid-json-url-or-resource?
   "Check that remote URL points to a valid JSON file, or throw an exception.
    Since the remote file isn't likely to change, this check isn't repeated for URLs that have already succeded;
    if the check fails, an exception is thrown (thereby preventing memoization)."
-  (memoize (fn [url]
-             (assert (u/is-url? url)
-               (str "Invalid URL: " url))
-             (u/with-timeout 5000
-               (json/parse-string (slurp url)))
-             true)))
+  (memoize (fn [url-or-resource-path]
+             (or (valid-json-url? url-or-resource-path)
+                 (valid-json-resource? url-or-resource-path)
+                 (throw (Exception. (str "Invalid JSON URL or resource: " url-or-resource-path)))))))
 
 (def ^:private CustomGeoJSON
   {s/Keyword {:name        s/Str
-              :url         (s/constrained s/Str valid-json-url? "URL must point to a valid JSON file.")
+              :url         (s/constrained s/Str valid-json-url-or-resource? "URL must point to a valid JSON file.")
               :region_key  (s/maybe s/Str)
               :region_name (s/maybe s/Str)}})
 


### PR DESCRIPTION
The GeoJSON code has heavy validation logic to make sure people don't set it to something that's invalid. When I originally wrote this it only allowed external HTTP URLs; tweak it so it allows local resources as well.
