### PR TITLE
Fix running migrations from JAR :wrench:

### DIFF
--- a/resources/liquibase.yaml
+++ b/resources/liquibase.yaml
@@ -1,4 +1,3 @@
 databaseChangeLog:
   - includeAll:
       path: "migrations/"
-      relativeToChangelogFile: true


### PR DESCRIPTION
Don't use the `relativeToChangelogFile` option because it breaks migrations when running from a JAR. Turns out it's unnecessary anyway. 
