### PR TITLE
fix typo in error message

### DIFF
--- a/frontend/src/metabase/query_builder/VisualizationError.jsx
+++ b/frontend/src/metabase/query_builder/VisualizationError.jsx
@@ -45,7 +45,7 @@ class VisualizationError extends Component {
           } else {
               return <VisualizationErrorMessage
                         type="serverError"
-                        title="We\'re experiencing server issues"
+                        title="We're experiencing server issues"
                         message="Try refreshing the page after waiting a minute or two. If the problem persists we'd recommend you contact an admin."
                         action={<EmailAdmin />}
                     />


### PR DESCRIPTION
Fixes this (`We\'re`). I don't believe escaping the apostrophe is necessary here, correct?

![screen shot 2016-09-28 at 11 20 55 am](https://cloud.githubusercontent.com/assets/2223916/18976427/92c4722a-8666-11e6-88c2-7eadc504a37f.png)
