### PR TITLE
Remove unused public_perms columns :closed_lock_with_key:

### DIFF
--- a/resources/migrations/044_remove_public_perms_columns.yaml
+++ b/resources/migrations/044_remove_public_perms_columns.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - changeSet:
+      id: 44
+      author: camsaul
+      changes:
+        - dropColumn:
+            tableName: report_card
+            columnName: public_perms
+        - dropColumn:
+            tableName: report_dashboard
+            columnName: public_perms
+        - dropColumn:
+            tableName: pulse
+            columnName: public_perms

--- a/src/metabase/db/migrations.clj
+++ b/src/metabase/db/migrations.clj
@@ -252,17 +252,6 @@
           :object   (perms/object-path database-id)
           :group_id group-id)))))
 
-;; this is purely for development convenience. Partway through development of Permissions the magic group names were changed.
-;; TODO - this can be removed once permissions is finished and ready to ship. NOCOMMIT
-(defmigration fix-legacy-magic-group-names
-  (let [change-name (fn [old new]
-                      (when (and (db/exists? 'PermissionsGroup :name old)
-                                 (not (db/exists? 'PermissionsGroup :name new)))
-                        (db/update-where! 'PermissionsGroup {:name old}
-                          :name new)))]
-    (change-name "Admin" "Administrators")
-    (change-name "Default" "All Users")))
-
 
 ;;; +------------------------------------------------------------------------------------------------------------------------+
 ;;; |                                                    NEW TYPE SYSTEM                                                     |

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -5,7 +5,6 @@
             [metabase.api.common :refer [*current-user-id* *current-user-permissions-set*]]
             [metabase.db :as db]
             (metabase.models [card-label :refer [CardLabel]]
-                             [common :as common]
                              [dependency :as dependency]
                              [interface :as i]
                              [label :refer [Label]]
@@ -113,7 +112,7 @@
 
 
 (defn- pre-insert [{:keys [dataset_query], :as card}]
-  (u/prog1 (assoc card :public_perms common/perms-readwrite)
+  (u/prog1 card
     ;; for native queries we need to make sure the user saving the card has native query permissions for the DB
     ;; because users can always see native Cards and we don't want someone getting around their lack of permissions that way
     (when (and *current-user-id*
@@ -135,7 +134,6 @@
   (merge i/IEntityDefaults
          {:hydration-keys     (constantly [:card])
           :types              (constantly {:display :keyword, :query_type :keyword, :dataset_query :json, :visualization_settings :json, :description :clob})
-          :default-fields     (constantly [:archived :created_at :creator_id :database_id :dataset_query :description :display :id :name :query_type :table_id :updated_at :visualization_settings]) ; everything except :public_perms
           :timestamped?       (constantly true)
           :can-read?          (partial i/current-user-has-full-permissions? :read)
           :can-write?         (partial i/current-user-has-full-permissions? :write)

--- a/src/metabase/models/common.clj
+++ b/src/metabase/models/common.clj
@@ -88,9 +88,3 @@
    "US/Pacific"
    "GMT"
    "UTC"])
-
-(def ^:const ^:deprecated ^Integer perms-readwrite
-  "Integer used to signify public read/write permissions.
-   This was part of the old permissions system, and hasn't been used in a long time.
-   Issue to remove it is here: https://github.com/metabase/metabase/issues/3408"
-  2)

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -3,7 +3,6 @@
             (metabase [db :as db]
                       [events :as events])
             (metabase.models [card :as card]
-                             [common :as common]
                              [dashboard-card :refer [DashboardCard], :as dashboard-card]
                              [hydrate :refer [hydrate]]
                              [interface :as i]
@@ -37,8 +36,7 @@
   (db/cascade-delete! DashboardCard :dashboard_id (u/get-id dashboard)))
 
 (defn- pre-insert [dashboard]
-  (let [defaults {:parameters   []
-                  :public_perms common/perms-readwrite}]
+  (let [defaults {:parameters   []}]
     (merge defaults dashboard)))
 
 
@@ -49,7 +47,6 @@
   (merge i/IEntityDefaults
          {:timestamped?       (constantly true)
           :types              (constantly {:description :clob, :parameters :json})
-          :default-fields     (constantly [:caveats :created_at :creator_id :description :id :name :parameters :points_of_interest :show_in_getting_started :updated_at]) ; everything except :public_perms
           :can-read?          can-read?
           :can-write?         can-read?
           :pre-cascade-delete pre-cascade-delete

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -5,7 +5,6 @@
             [metabase.db :as db]
             [metabase.events :as events]
             (metabase.models [card :refer [Card]]
-                             [common :refer [perms-readwrite]]
                              [hydrate :refer :all]
                              [interface :as i]
                              [pulse-card :refer [PulseCard]]
@@ -43,10 +42,6 @@
 
 (i/defentity Pulse :pulse)
 
-(defn- pre-insert [pulse]
-  (let [defaults {:public_perms perms-readwrite}]
-    (merge defaults pulse)))
-
 (defn- pre-cascade-delete [{:keys [id]}]
   (db/cascade-delete! PulseCard :pulse_id id)
   (db/cascade-delete! PulseChannel :pulse_id id))
@@ -55,13 +50,11 @@
   i/IEntity
   (merge i/IEntityDefaults
          {:hydration-keys     (constantly [:pulse])
-          :default-fields     (constantly [:created_at :creator_id :id :name :updated_at]) ; everything except :public_perms
           :timestamped?       (constantly true)
           :perms-objects-set  perms-objects-set
           ;; I'm not 100% sure this covers everything. If a user is subscribed to a pulse they're still allowed to know it exists, right?
           :can-read?          can-read?
           :can-write?         (partial i/current-user-has-full-permissions? :write)
-          :pre-insert         pre-insert
           :pre-cascade-delete pre-cascade-delete}))
 
 


### PR DESCRIPTION
Remove the last remnants of the old public permissions system. 

Implements #3408 
