### PR TITLE
Allow to display different chart types on a single DashCard

### DIFF
--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -323,6 +323,7 @@
   fill-opacity: 1;
 }
 
+.dc-tooltip circle.dot.enable-dot,
 .enable-dots .dc-tooltip circle.dot {
   r: 3px !important;
   fill: white;
@@ -332,6 +333,8 @@
   stroke-opacity: 1 !important;
 }
 
+.dc-tooltip circle.dot.enable-dot:hover,
+.dc-tooltip circle.dot.enable-dot.hover,
 .enable-dots .dc-tooltip circle.dot:hover,
 .enable-dots .dc-tooltip circle.dot.hover {
   fill: currentColor;

--- a/frontend/src/metabase/lib/visualization_settings.js
+++ b/frontend/src/metabase/lib/visualization_settings.js
@@ -116,8 +116,7 @@ const SETTINGS = {
         isValid: ([{ card, data }], vizSettings) =>
             columnsAreValid(card.visualization_settings["graph.dimensions"], data, isDimension) &&
             columnsAreValid(card.visualization_settings["graph.metrics"], data, isMetric),
-        getDefault: (series, vizSettings) =>
-            getDefaultDimensionsAndMetrics(series).dimensions,
+        getDefault: (series, vizSettings) => getDefaultDimensionsAndMetrics(series).dimensions,
         getProps: ([{ card, data }], vizSettings) => {
             const value = vizSettings["graph.dimensions"];
             const options = data.cols.filter(isDimension).map(getOptionFromColumn);

--- a/frontend/src/metabase/visualizations/components/CardRenderer.jsx
+++ b/frontend/src/metabase/visualizations/components/CardRenderer.jsx
@@ -64,8 +64,8 @@ export default class CardRenderer extends Component {
         element = document.createElement("div");
         parent.appendChild(element);
 
-        try {
             this._chart = this.props.renderer(element, this.props);
+        try {
         } catch (err) {
             console.error(err);
             this.props.onRenderError(err.message || err);

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -85,6 +85,7 @@ export default class Visualization extends Component {
 
         // don't try to load settings unless data is loaded
         let settings = this.props.settings || {};
+        let all_series_settings = series.map((_) => {});
 
         if (!loading && !error) {
             settings = this.props.settings || getSettings(series);
@@ -103,6 +104,7 @@ export default class Visualization extends Component {
                     error = e.message || "Could not display this chart with this data.";
                 }
             }
+            all_series_settings = series.map((series_item) => getSettings([series_item]))
         }
         if (!error) {
             noResults = getIn(series, [0, "data", "rows", "length"]) === 0;
@@ -114,7 +116,6 @@ export default class Visualization extends Component {
         } else if (isSlow) {
             extra = <LoadingSpinner className={isSlow === "usually-slow" ? "text-gold" : "text-slate"} size={18} />
         }
-
         return (
             <div className={cx(className, "flex flex-column")}>
                 { isDashboard && (loading || error || !CardVisualization.noHeader) || replacementContent ?
@@ -179,6 +180,7 @@ export default class Visualization extends Component {
                         className="flex-full"
                         series={series}
                         settings={settings}
+                        all_settings={all_series_settings}
                         card={series[0].card} // convienence for single-series visualizations
                         data={series[0].data} // convienence for single-series visualizations
                         hovered={this.state.hovered}

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -116,12 +116,35 @@ export default class Visualization extends Component {
         } else if (isSlow) {
             extra = <LoadingSpinner className={isSlow === "usually-slow" ? "text-gold" : "text-slate"} size={18} />
         }
+
+
+    const sortOrder = {
+        bar: 0,
+        line: 1
+    }
+    let series_to_sort = series.map((group, index) => {
+        console.log('index', index, series[index].card.display)
+        return {'the_series': series[index], _settings: all_series_settings[index]}
+    })
+    console.log('before sort', series_to_sort);
+    series_to_sort = series_to_sort.sort((a, b) => {
+        const a_sortOrder = sortOrder[a.the_series.card.display]
+        const b_sortOrder = sortOrder[b.the_series.card.display]
+        if (a_sortOrder === b_sortOrder) {
+            return a.index - b.index; // preserve old ordering
+        } else {
+            return a_sortOrder - b_sortOrder;
+        }
+    })
+    console.log('after sort', series_to_sort);
+    const sorted_series = series_to_sort.map((the_series) => the_series.the_series)
+    const sorted_all_series_settings = series_to_sort.map((the_series) => the_series._settings)
         return (
             <div className={cx(className, "flex flex-column")}>
                 { isDashboard && (loading || error || !CardVisualization.noHeader) || replacementContent ?
                     <div className="p1 flex-no-shrink">
                         <LegendHeader
-                            series={series}
+                            series={sorted_series}
                             actionButtons={extra}
                             settings={settings}
                         />
@@ -178,9 +201,9 @@ export default class Visualization extends Component {
                     <CardVisualization
                         {...this.props}
                         className="flex-full"
-                        series={series}
+                        series={sorted_series}
                         settings={settings}
-                        all_settings={all_series_settings}
+                        all_settings={sorted_all_series_settings}
                         card={series[0].card} // convienence for single-series visualizations
                         data={series[0].data} // convienence for single-series visualizations
                         hovered={this.state.hovered}

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -287,6 +287,7 @@ function lineAndBarOnRender(chart, settings) {
             const overlapping = Object.keys(overlappedIndex).length;
             enableDots = overlapping < DOT_OVERLAP_COUNT_LIMIT || (overlapping / total) < DOT_OVERLAP_RATIO;
         }
+        console.log(chart);
         chart.svg()
             .classed("enable-dots", enableDots)
             .classed("enable-dots-onhover", !enableDots);
@@ -331,7 +332,7 @@ function lineAndBarOnRender(chart, settings) {
                 .enter().append("svg:path")
                     .filter((d) => d != undefined)
                     .attr("d", (d) => {
-console.log(d, "M" + d.join("L") + "Z");
+                        //console.log(d, "M" + d.join("L") + "Z");
 return "M" + d.join("L") + "Z"
 })
                     .attr("clip-path", (d,i) => "url(#clip-"+i+")")
@@ -439,9 +440,7 @@ return "M" + d.join("L") + "Z"
     chart.render();
 }
 
-export default function lineAreaBar(element, { series, onHoverChange, onRender, chartType, isScalarSeries, settings }) {
-    //console.log('series are!!', series);
-    //console.log('settings', settings);
+export default function lineAreaBar(element, { series, onHoverChange, onRender, chartType, isScalarSeries, settings, all_settings }) {
     const colors = settings["graph.colors"];
 
     const isTimeseries = dimensionIsTimeseries(series[0].data);
@@ -535,7 +534,7 @@ export default function lineAreaBar(element, { series, onHoverChange, onRender, 
     }
     let groups_to_sort = groups.map((group, index) => {
         console.log('index', index, series[index].card.display)
-        return {'group_series': series[index], index, group}
+        return {'group_series': series[index], _settings: all_settings[index], index, group}
     })
     //console.log('before sort', groups_to_sort);
     groups_to_sort = groups_to_sort.sort((a, b) => {
@@ -550,6 +549,7 @@ export default function lineAreaBar(element, { series, onHoverChange, onRender, 
     //console.log('after sort', groups_to_sort);
     groups = groups_to_sort.map((group_to_sort) => group_to_sort.group)
     series = groups_to_sort.map((group_to_sort) => group_to_sort.group_series)
+    all_settings = groups_to_sort.map((group_to_sort) => group_to_sort._settings)
 
     let charts = groups.map((group, index) => {
         //console.log('group', group);
@@ -579,8 +579,8 @@ export default function lineAreaBar(element, { series, onHoverChange, onRender, 
         for (var i = 1; i < group.length; i++) {
             chart.stack(group[i])
         }
-
-        applyChartLineBarSettings(chart, settings, currentChartType, isLinear, isTimeseries);
+        console.log(all_settings[index])
+        applyChartLineBarSettings(chart, all_settings[index], currentChartType, isLinear, isTimeseries);
 
         return chart;
     });

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -437,6 +437,7 @@ function lineAndBarOnRender(chart, settings) {
 }
 
 export default function lineAreaBar(element, { series, onHoverChange, onRender, chartType, isScalarSeries, settings }) {
+    console.log('series are!!', series);
     const colors = settings["graph.colors"];
 
     const isTimeseries = dimensionIsTimeseries(series[0].data);
@@ -525,7 +526,9 @@ export default function lineAreaBar(element, { series, onHoverChange, onRender, 
     }
 
     let charts = groups.map((group, index) => {
-        let chart = dc[getDcjsChartType(chartType)](parent);
+        let chartType1 = (index > 0) ? 'line' : 'bar';
+        console.log('chartType1', chartType1);
+        let chart = dc[getDcjsChartType(chartType1)](parent);
 
         chart
             .dimension(dimension)

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -456,7 +456,7 @@ export default function lineAreaBar(element, { series, onHoverChange, onRender, 
         ])
     );
 
-    let xValues = getXValues(datas, chartType);
+    let xValues = getXValues(datas, null);
 
     let dimension, groups, yAxisSplit;
 
@@ -549,11 +549,10 @@ export default function lineAreaBar(element, { series, onHoverChange, onRender, 
     series = groups_to_sort.map((group_to_sort) => group_to_sort.group_series)
 
     let charts = groups.map((group, index) => {
-        //let chartType1 = (index > 0) ? 'line' : 'bar';
-        //console.log('chartType1', chartType1);
         //console.log('group', group);
 
-        let chart = dc[getDcjsChartType(series[index].card.display)](parent);
+        const currentChartType = series[index].card.display
+        let chart = dc[getDcjsChartType(currentChartType)](parent);
 
         chart
             .dimension(dimension)
@@ -578,7 +577,7 @@ export default function lineAreaBar(element, { series, onHoverChange, onRender, 
             chart.stack(group[i])
         }
 
-        applyChartLineBarSettings(chart, settings, chartType, isLinear, isTimeseries);
+        applyChartLineBarSettings(chart, settings, currentChartType, isLinear, isTimeseries);
 
         return chart;
     });
@@ -610,7 +609,7 @@ export default function lineAreaBar(element, { series, onHoverChange, onRender, 
         }
 
         // HACK: compositeChart + ordinal X axis shenanigans
-        if (chartType === "bar") {
+        if (chartType === "bar") { // TODO
             chart._rangeBandPadding(BAR_PADDING_RATIO) // https://github.com/dc-js/dc.js/issues/678
         } else {
             chart._rangeBandPadding(1) // https://github.com/dc-js/dc.js/issues/662

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -437,8 +437,8 @@ function lineAndBarOnRender(chart, settings) {
 }
 
 export default function lineAreaBar(element, { series, onHoverChange, onRender, chartType, isScalarSeries, settings }) {
-    console.log('series are!!', series);
-    console.log('settings', settings);
+    //console.log('series are!!', series);
+    //console.log('settings', settings);
     const colors = settings["graph.colors"];
 
     const isTimeseries = dimensionIsTimeseries(series[0].data);
@@ -526,10 +526,32 @@ export default function lineAreaBar(element, { series, onHoverChange, onRender, 
         parent = element;
     }
 
+    const sortOrder = {
+        bar: 0,
+        line: 1
+    }
+    let groups_to_sort = groups.map((group, index) => {
+        console.log('index', index, series[index].card.display)
+        return {'group_series': series[index], index, group}
+    })
+    //console.log('before sort', groups_to_sort);
+    groups_to_sort = groups_to_sort.sort((a, b) => {
+        const a_sortOrder = sortOrder[a.group_series.card.display]
+        const b_sortOrder = sortOrder[b.group_series.card.display]
+        if (a_sortOrder === b_sortOrder) {
+            return a.index - b.index; // preserve old ordering
+        } else {
+            return a_sortOrder - b_sortOrder;
+        }
+    })
+    //console.log('after sort', groups_to_sort);
+    groups = groups_to_sort.map((group_to_sort) => group_to_sort.group)
+    series = groups_to_sort.map((group_to_sort) => group_to_sort.group_series)
+
     let charts = groups.map((group, index) => {
-        let chartType1 = (index > 0) ? 'line' : 'bar';
-        console.log('chartType1', chartType1);
-        console.log('group', group);
+        //let chartType1 = (index > 0) ? 'line' : 'bar';
+        //console.log('chartType1', chartType1);
+        //console.log('group', group);
 
         let chart = dc[getDcjsChartType(series[index].card.display)](parent);
 

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -438,6 +438,7 @@ function lineAndBarOnRender(chart, settings) {
 
 export default function lineAreaBar(element, { series, onHoverChange, onRender, chartType, isScalarSeries, settings }) {
     console.log('series are!!', series);
+    console.log('settings', settings);
     const colors = settings["graph.colors"];
 
     const isTimeseries = dimensionIsTimeseries(series[0].data);
@@ -528,7 +529,9 @@ export default function lineAreaBar(element, { series, onHoverChange, onRender, 
     let charts = groups.map((group, index) => {
         let chartType1 = (index > 0) ? 'line' : 'bar';
         console.log('chartType1', chartType1);
-        let chart = dc[getDcjsChartType(chartType1)](parent);
+        console.log('group', group);
+
+        let chart = dc[getDcjsChartType(series[index].card.display)](parent);
 
         chart
             .dimension(dimension)

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -238,7 +238,7 @@ function applyChartLineBarSettings(chart, settings, chartType, isLinear, isTimes
     }
 }
 
-function lineAndBarOnRender(chart, settings, all_settings) {
+function lineAndBarOnRender(chart, settings, all_settings, series) {
     // once chart has rendered and we can access the SVG, do customizations to axis labels / etc that you can't do through dc.js
 
     function removeClipPath() {
@@ -267,10 +267,15 @@ function lineAndBarOnRender(chart, settings, all_settings) {
             for (let i in all_settings) {
                 let enableDots;
                 const current_settings = all_settings[i];
+                if (series[i].card.display !== 'line') {
+                    continue;
+                }
                 if (current_settings["line.marker_enabled"]) {
                     let the_dots = chart.svg().selectAll('.chart-body').filter(function (d, j) { return j === parseInt(i, 10) + 1;}).selectAll('.dot')
                     let dots = the_dots[0]
-                    window.test3 = dots;
+                    if (typeof dots === 'undefined') {
+                        continue;
+                    }
                     if (dots.length === 0 || dots.length > 500) {
                         continue;
                     }
@@ -662,7 +667,7 @@ export default function lineAreaBar(element, { series, onHoverChange, onRender, 
     chart.render();
 
     // apply any on-rendering functions
-    lineAndBarOnRender(chart, settings, all_settings);
+    lineAndBarOnRender(chart, settings, all_settings, series);
 
     onRender && onRender({ yAxisSplit });
 

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -330,7 +330,10 @@ function lineAndBarOnRender(chart, settings) {
                 .data(voronoi(vertices), (d) => d&&d.join(","))
                 .enter().append("svg:path")
                     .filter((d) => d != undefined)
-                    .attr("d", (d) => "M" + d.join("L") + "Z")
+                    .attr("d", (d) => {
+console.log(d, "M" + d.join("L") + "Z");
+return "M" + d.join("L") + "Z"
+})
                     .attr("clip-path", (d,i) => "url(#clip-"+i+")")
                     .on("mousemove", ({ point }) => {
                         let e = point[2];


### PR DESCRIPTION
One my client suggests to have different chart types (such as bar and line charts) to be displayed on a single DashCard. An example:

![1](https://cloud.githubusercontent.com/assets/731973/19015566/b6e35c7a-880f-11e6-8de2-9a81110e77f5.png)

On a first dashcard here are blue and green line charts and red bar chart. This involves few issues which I'm solving:
- Points (dots) display (only some line charts might have points displayed) — via re-arranging the CSS classes and procedures which set that classes
- Line style (Line, Curve, Step) — via changing the procedures that define settings object
- Displaying stacked bar charts with everything else isn't implemented (it's more complicated and now it defaults to the standard Metabase behaviour)

I were forking commit 7f5072c (master branch, and I weren't create a PR starting from a branch-less commit), but as we discuss I might make my changes more up-to-date. So, I want to know if such change might be considered.
