### PR TITLE
Add :native_permissions to dbs in GET /api/database :heavy_plus_sign:

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -37,10 +37,11 @@
 
 (defn- add-native-perms-info [dbs]
   (for [db dbs]
-    (assoc db :native_permissions (cond
-                                    (perms/set-has-full-permissions? @*current-user-permissions-set* (perms/native-readwrite-path (u/get-id db))) :readwrite
-                                    (perms/set-has-full-permissions? @*current-user-permissions-set* (perms/native-read-path (u/get-id db)))      :read
-                                    :else                                                                                                         :none))))
+    (let [user-has-perms? (fn [f] (perms/set-has-full-permissions? @*current-user-permissions-set* (f (u/get-id db))))]
+      (assoc db :native_permissions (cond
+                                      (user-has-perms? perms/native-readwrite-path) :readwrite
+                                      (user-has-perms? perms/native-read-path)      :read
+                                      :else                                         :none)))))
 
 (defn- dbs-list [include-tables?]
   (when-let [dbs (seq (filter models/can-read? (db/select Database {:order-by [:%lower.name]})))]

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -37,6 +37,7 @@
     (db/select Label, :id [:in label-ids], {:order-by [:%lower.name]})
     []))
 
+
 ;;; ------------------------------------------------------------ Permissions Checking ------------------------------------------------------------
 
 (defn- permissions-path-set:mbql [{database-id :database, :as query}]

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -163,6 +163,7 @@
                                      :id                 $
                                      :updated_at         $
                                      :name               "test-data"
+                                     :native_permissions "readwrite"
                                      :is_sample          false
                                      :is_full_sync       true
                                      :description        nil
@@ -175,6 +176,7 @@
                                  :id                 $
                                  :updated_at         $
                                  :name               $
+                                 :native_permissions "readwrite"
                                  :is_sample          false
                                  :is_full_sync       true
                                  :description        nil
@@ -195,6 +197,7 @@
                 :id                 $
                 :updated_at         $
                 :name               $
+                :native_permissions "readwrite"
                 :is_sample          false
                 :is_full_sync       true
                 :description        nil
@@ -211,6 +214,7 @@
                                        :id                 $
                                        :updated_at         $
                                        :name               "test-data"
+                                       :native_permissions "readwrite"
                                        :is_sample          false
                                        :is_full_sync       true
                                        :description        nil


### PR DESCRIPTION
Include a `:native_permissions` column for each DB returned by `GET /api/database`. Value will be one of `:readwrite`, `:read`, or `:none`.

(Part of #3435)
