### PR TITLE
Remove unreadable cards and series from dashcards :eyes:

### DIFF
--- a/frontend/src/metabase/dashboard/dashboard.js
+++ b/frontend/src/metabase/dashboard/dashboard.js
@@ -137,6 +137,16 @@ export const fetchCardData = createThunkAction(FETCH_CARD_DATA, function(card, d
             dispatch(clearCardData(card.id, dashcard.id));
         }
 
+        // If the dataset_query was filtered then we don't have permisison to view this card, so
+        // shortcircuit and return a fake 403
+        if (!card.dataset_query) {
+            return {
+                dashcard_id: dashcard.id,
+                card_id: card.id,
+                result: { error: { status: 403 }}
+            };
+        }
+
         let result = null;
 
         // if we have a parameter, apply it to the card query before we execute
@@ -196,7 +206,8 @@ export const fetchDashboard = createThunkAction(FETCH_DASHBOARD, function(dashId
         _.chain(result.ordered_cards)
             .map((dc) => [dc.card].concat(dc.series))
             .flatten()
-            .map(card => card.dataset_query && card.dataset_query.database)
+            .filter(card => card && card.dataset_query && card.dataset_query.database)
+            .map(card => card.dataset_query.database)
             .uniq()
             .each((dbId) => dispatch(fetchDatabaseMetadata(dbId)));
 

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -38,20 +38,19 @@
   (dashboard/create-dashboard! dashboard *current-user-id*))
 
 (defn- hide-unreadable-card
-  "Replace unreadable card with object containing only the id"
+  "If CARD is unreadable, replace it with an object containing only its `:id`."
   [card]
   (if (models/can-read? card)
     card
-    {:id (:id card)}))
+    (select-keys card [:id])))
 
 (defn- hide-unreadable-cards
-  "Replace the `:card` and `:series` entries from dashcards that they user isn't allowed to read with empty object."
+  "Replace the `:card` and `:series` entries from dashcards that they user isn't allowed to read with empty objects."
   [dashboard]
-  (update dashboard :ordered_cards (fn [dashcards]
-                                     (vec (for [dashcard dashcards]
-                                            (assoc dashcard :card (hide-unreadable-card (:card dashcard))
-                                                            :series (for [card (:series dashcard)]
-                                                                      (hide-unreadable-card card))))))))
+  (update dashboard :ordered_cards (partial mapv (fn [dashcard]
+                                                   (-> dashcard
+                                                       (update :card hide-unreadable-card)
+                                                       (update :series (partial mapv hide-unreadable-card)))))))
 
 (defendpoint GET "/:id"
   "Get `Dashboard` with ID."

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -37,15 +37,21 @@
    parameters [ArrayOfMaps]}
   (dashboard/create-dashboard! dashboard *current-user-id*))
 
+(defn- hide-unreadable-card
+  "Replace unreadable card with object containing only the id"
+  [card]
+  (if (models/can-read? card)
+    card
+    {:id (:id card)}))
 
 (defn- hide-unreadable-cards
-  "Remove the `:card` and `:series` entries from dashcards that they user isn't allowed to read."
+  "Replace the `:card` and `:series` entries from dashcards that they user isn't allowed to read with empty object."
   [dashboard]
   (update dashboard :ordered_cards (fn [dashcards]
                                      (vec (for [dashcard dashcards]
-                                            (if (models/can-read? dashcard)
-                                              dashcard
-                                              (dissoc dashcard :card :series)))))))
+                                            (assoc dashcard :card (hide-unreadable-card (:card dashcard))
+                                                            :series (for [card (:series dashcard)]
+                                                                      (hide-unreadable-card card))))))))
 
 (defendpoint GET "/:id"
   "Get `Dashboard` with ID."


### PR DESCRIPTION
Part of #3435.

@tlrobinson I think it makes sense to do the frontend stuff in this branch because as it stands now the dashboards won't render once these changes are merged, instead they just show this error:

> Cannot read property 'dataset_query' of undefined

Should be an easy fix.
