### PR TITLE
Fix dashcard visualization_settings migration :wrench:

### DIFF
--- a/resources/migrations/045_add_dashcard_visualization_settings_field.yaml
+++ b/resources/migrations/045_add_dashcard_visualization_settings_field.yaml
@@ -9,8 +9,8 @@ databaseChangeLog:
               - column:
                   name: visualization_settings
                   type: text
-                  constraints:
-                    nullable: true
-                    deferrable: false
-                    initiallyDeferred: false
-                    nullable: false
+        - addNotNullConstraint:
+            tableName: report_dashboardcard
+            columnName: visualization_settings
+            columnDataType: text
+            defaultNullValue: '{}'


### PR DESCRIPTION
Add `NOT NULL` constraint separately so we can set a default value for NULL columns. Have to do this way because it doesn't work with MySQL to set a general default value
