### PR TITLE
Fix running native :timeseries query on Druid :wrench:

### DIFF
--- a/src/metabase/driver/druid/query_processor.clj
+++ b/src/metabase/driver/druid/query_processor.clj
@@ -554,12 +554,12 @@
 
 (defmulti ^:private post-process query-type-dispatch-fn)
 
-(defmethod post-process ::select     [_ results] (->> results first :result :events (map :event)))
-(defmethod post-process ::total      [_ results] (map :result results))
-(defmethod post-process ::topN       [_ results] (-> results first :result))
-(defmethod post-process ::groupBy    [_ results] (map :event results))
+(defmethod post-process ::select  [_ results] (->> results first :result :events (map :event)))
+(defmethod post-process ::total   [_ results] (map :result results))
+(defmethod post-process ::topN    [_ results] (-> results first :result))
+(defmethod post-process ::groupBy [_ results] (map :event results))
 
-(defmethod post-process ::grouped-timeseries [_ results]
+(defmethod post-process ::timeseries [_ results]
   (for [event results]
     (conj {:timestamp (:timestamp event)} (:result event))))
 

--- a/test/metabase/driver/druid_test.clj
+++ b/test/metabase/driver/druid_test.clj
@@ -3,10 +3,10 @@
             [expectations :refer :all]
             [metabase.query-processor :as qp]
             [metabase.test.data :as data]
-            [metabase.test.data.datasets :refer [expect-with-engine]]
+            [metabase.test.data.datasets :as datasets, :refer [expect-with-engine]]
             [metabase.timeseries-query-processor-test :as timeseries-qp-test]))
 
-(def ^:const ^:private native-query
+(def ^:const ^:private ^String native-query-1
   (json/generate-string
     {:intervals   ["1900-01-01/2100-01-01"]
      :granularity :all
@@ -18,6 +18,13 @@
                    :user_name
                    :id]
      :metrics     [:count]}))
+
+(defn- process-native-query [query]
+  (datasets/with-engine :druid
+    (timeseries-qp-test/with-flattened-dbdef
+      (qp/process-query {:native   {:query query}
+                         :type     :native
+                         :database (data/id)}))))
 
 ;; test druid native queries
 (expect-with-engine :druid
@@ -33,9 +40,22 @@
                              {:name "venue_price", :base_type :type/Text}
                              {:name "venue_name",  :base_type :type/Text}
                              {:name "count",       :base_type :type/Integer}]
-               :native_form {:query native-query}}}
-  (metabase.test.data.datasets/with-engine :druid
-    (timeseries-qp-test/with-flattened-dbdef
-      (qp/process-query {:native   {:query native-query}
-                         :type     :native
-                         :database (data/id)}))))
+               :native_form {:query native-query-1}}}
+  (process-native-query native-query-1))
+
+
+;; make sure we can run a native :timeseries query. This was throwing an Exception -- see #3409
+(def ^:const ^:private ^String native-query-2
+  (json/generate-string
+    {:intervals    ["1900-01-01/2100-01-01"]
+     :granularity  {:type     :period
+                    :period   :P1M
+                    :timeZone :UTC}
+     :queryType    :timeseries
+     :dataSource   :checkins
+     :aggregations [{:type :count
+                     :name :count}]}))
+
+(expect-with-engine :druid
+  :completed
+  (:status (process-native-query native-query-2)))


### PR DESCRIPTION
Fix a recent bug that broke running native `:timeseries` queries for Druid. Add a test for this

Fixes #3409
