### PR TITLE
shortened sql remarks for consistency with MySQL 5.1

### DIFF
--- a/resources/migrations/043_add_permissions_revision_table.yaml
+++ b/resources/migrations/043_add_permissions_revision_table.yaml
@@ -5,7 +5,7 @@ databaseChangeLog:
       changes:
         - createTable:
             tableName: permissions_revision
-            remarks: 'This is used to keep track of changes made to permissions via the admin panel, primarily for auditing purposes. Changes are batched, and a new entry is added for every batch.'
+            remarks: 'Used to keep track of changes made to permissions.'
             columns:
               - column:
                   name: id
@@ -17,13 +17,13 @@ databaseChangeLog:
               - column:
                   name: before
                   type: text
-                  remarks: 'Serialized JSON of relvant sections of the permissions graph changed as part of this revision, with their values *before* the changes.'
+                  remarks: 'Serialized JSON of the permissions before the changes.'
                   constraints:
                     nullable: false
               - column:
                   name: after
                   type: text
-                  remarks: 'Serialized JSON of relvant sections of the permissions graph changed as part of this revision, with their values *after* the changes.'
+                  remarks: 'Serialized JSON of the permissions after the changes.'
                   constraints:
                     nullable: false
               - column:


### PR DESCRIPTION
This PR fixes the #3502 by shortening the remarks in migration description, reducing them to be below 60 characters and allowing for smooth MySQL migration between Metabase v0.19 and v0.20.

Had I skipped something (eg. in previous migration scripts), please let me know.
