### PR TITLE
shortened sql remarks for consistency with MySQL 5.1

### DIFF
--- a/resources/migrations/043_add_permissions_revision_table.yaml
+++ b/resources/migrations/043_add_permissions_revision_table.yaml
@@ -2,6 +2,8 @@ databaseChangeLog:
   - changeSet:
       id: 43
       author: camsaul
+      validCheckSum: 7:b20750a949504e93efced32877a4488f
+      validCheckSum: 7:dbc18c8ca697fc335869f0ed0eb5f4cb
       changes:
         - createTable:
             tableName: permissions_revision

--- a/resources/migrations/043_add_permissions_revision_table.yaml
+++ b/resources/migrations/043_add_permissions_revision_table.yaml
@@ -5,7 +5,7 @@ databaseChangeLog:
       changes:
         - createTable:
             tableName: permissions_revision
-            remarks: 'This is used to keep track of changes made to permissions via the admin panel, primarily for auditing purposes. Changes are batched, and a new entry is added for every batch.'
+            remarks: 'Used to keep track of changes made to permissions.'
             columns:
               - column:
                   name: id
@@ -17,13 +17,13 @@ databaseChangeLog:
               - column:
                   name: before
                   type: text
-                  remarks: 'Serialized JSON of relvant sections of the permissions graph changed as part of this revision, with their values *before* the changes.'
+                  remarks: 'Serialized JSON of the permissions before the changes.'
                   constraints:
                     nullable: false
               - column:
                   name: after
                   type: text
-                  remarks: 'Serialized JSON of relvant sections of the permissions graph changed as part of this revision, with their values *after* the changes.'
+                  remarks: 'Serialized JSON of the permissions after the changes.'
                   constraints:
                     nullable: false
               - column:


### PR DESCRIPTION
Same as #3504 but specify that the checksum of the previous version of the migration is valid so people who've already ran it don't run into issues.

Fixes #3502 
