### PR TITLE
Fix ClassNotFoundException when building uberjar :wrench:

### DIFF
--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -10,7 +10,8 @@
                       [coerce :as coerce]
                       [format :as time])
             colorize.core
-            [metabase.config :as config])
+            [metabase.config :as config]
+            metabase.logger)             ; make sure this is loaded since we use clojure.tools.logging here
   (:import clojure.lang.Keyword
            (java.net Socket
                      InetSocketAddress


### PR DESCRIPTION
Make sure to load `metabase.logger` before calling `log`. 

Fixes #2624
