### PR TITLE
Add new version command :1234:

### DIFF
--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -230,7 +230,26 @@
   (doseq [[symb varr] (sort (ns-interns 'metabase.core))
           :when       (:command (meta varr))]
     (println symb (s/join " " (:arglists (meta varr))))
-    (println "\t" (:doc (meta varr)))))
+    (println "\t" (:doc (meta varr))))
+  (println "\nSome other commands you might find useful:\n")
+  (println "java -cp metabase.jar org.h2.tools.Shell -url jdbc:h2:/path/to/metabase.db")
+  (println "\tOpen an SQL shell for the Metabase H2 DB"))
+
+(defn ^:command version
+  "Print version information about Metabase and the current system."
+  []
+  (println "Metabase version:" config/mb-version-info)
+  (println "\nOS:"
+           (System/getProperty "os.name")
+           (System/getProperty "os.version")
+           (System/getProperty "os.arch"))
+  (println "\nJava version:"
+           (System/getProperty "java.vm.name")
+           (System/getProperty "java.version"))
+  (println "\nCountry:" (System/getProperty "user.country"))
+  (println "System timezone:" (System/getProperty "user.timezone"))
+  (println "Language:" (System/getProperty "user.language"))
+  (println "File encoding:" (System/getProperty "file.encoding")))
 
 (defn- cmd->fn [command-name]
   (or (when (seq command-name)


### PR DESCRIPTION
Add a new `java -jar metabase.jar version` command that should help when debugging things. Sample output:

``` bash
$ lein run version
10-13 14:03:06 INFO metabase.util :: Loading Metabase...
Metabase version: {:tag v0.20.0, :hash 156d971, :branch release-0.20.1, :date 2016-10-12}

OS: Mac OS X 10.12 x86_64

Java version: Java HotSpot(TM) 64-Bit Server VM 1.8.0_45

Country: US
System timezone: America/Los_Angeles
Language: en
File encoding: UTF-8
```

I've also added info about how to run the H2 shell to the new `java -jar metabase.jar help` command:

``` bash
$ lein run help
10-13 14:05:06 INFO metabase.util :: Loading Metabase...
Valid commands are:
help []
     Show this help message listing valid Metabase commands.
load-from-h2 [] [h2-connection-string]
     Transfer data from existing H2 database to the newly created MySQL or Postgres DB specified by env vars.
migrate [direction]
     Run database migrations. Valid options for DIRECTION are `up`, `force`, `down-one`, `print`, or `release-locks`.
profile []
     Start Metabase the usual way and exit. Useful for profiling Metabase launch time.
version []
     Print version information about Metabase and the current system.

Some other commands you might find useful:

java -cp metabase.jar org.h2.tools.Shell -url jdbc:h2:/path/to/metabase.db
    Open an SQL shell for the Metabase H2 DB
```
