### PR TITLE
Fix Slack settings bugs

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsSetting.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsSetting.jsx
@@ -12,7 +12,8 @@ export default class SettingsSetting extends Component {
         setting: PropTypes.object.isRequired,
         updateSetting: PropTypes.func.isRequired,
         handleChangeEvent: PropTypes.func.isRequired,
-        autoFocus: PropTypes.bool
+        autoFocus: PropTypes.bool,
+        disabled: PropTypes.bool,
     };
 
     renderStringInput(setting, type="text") {

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -125,7 +125,7 @@ const SECTIONS = [
                 description: "",
                 placeholder: "Enter the token you received from Slack",
                 type: "string",
-                required: true,
+                required: false,
                 autoFocus: true
             },
             {

--- a/frontend/src/metabase/lib/utils.js
+++ b/frontend/src/metabase/lib/utils.js
@@ -37,7 +37,7 @@ var MetabaseUtils = {
     },
 
     isEmpty: function(str) {
-        return (!str || 0 === str.length);
+        return (str == null || 0 === str.length);
     },
 
     // pretty limited.  just does 0-9 for right now.

--- a/src/metabase/api/slack.clj
+++ b/src/metabase/api/slack.clj
@@ -9,10 +9,11 @@
 (defendpoint PUT "/settings"
   "Update Slack related settings. You must be a superuser to do this."
   [:as {{slack-token :slack-token, metabot-enabled :metabot-enabled, :as slack-settings} :body}]
-  {metabot-enabled [Required]}
+  {slack-token     [NonEmptyString]
+   metabot-enabled [Required]}
   (check-superuser)
-  (if (not slack-token)
-    (setting/set-many! { :slack-token nil, :metabot-enabled false })
+  (if-not slack-token
+    (setting/set-many! {:slack-token nil, :metabot-enabled false})
     (try
       ;; just check that channels.list doesn't throw an exception (a.k.a. that the token works)
       (when-not config/is-test?
@@ -20,7 +21,6 @@
       (setting/set-many! slack-settings)
       {:ok true}
       (catch clojure.lang.ExceptionInfo info
-        {:status 400, :body (ex-data info)})))
-  )
+        {:status 400, :body (ex-data info)}))))
 
 (define-routes)

--- a/src/metabase/api/slack.clj
+++ b/src/metabase/api/slack.clj
@@ -9,16 +9,18 @@
 (defendpoint PUT "/settings"
   "Update Slack related settings. You must be a superuser to do this."
   [:as {{slack-token :slack-token, metabot-enabled :metabot-enabled, :as slack-settings} :body}]
-  {slack-token     [Required NonEmptyString]
-   metabot-enabled [Required]}
+  {metabot-enabled [Required]}
   (check-superuser)
-  (try
-    ;; just check that channels.list doesn't throw an exception (a.k.a. that the token works)
-    (when-not config/is-test?
-      (slack/GET :channels.list, :exclude_archived 1, :token slack-token))
-    (setting/set-many! slack-settings)
-    {:ok true}
-    (catch clojure.lang.ExceptionInfo info
-      {:status 400, :body (ex-data info)})))
+  (if (not slack-token)
+    (setting/set-many! { :slack-token nil, :metabot-enabled false })
+    (try
+      ;; just check that channels.list doesn't throw an exception (a.k.a. that the token works)
+      (when-not config/is-test?
+        (slack/GET :channels.list, :exclude_archived 1, :token slack-token))
+      (setting/set-many! slack-settings)
+      {:ok true}
+      (catch clojure.lang.ExceptionInfo info
+        {:status 400, :body (ex-data info)})))
+  )
 
 (define-routes)


### PR DESCRIPTION
Fixes:
- slack-token marked as required on front and backend
- validation interpreting 'false' as empty.

Resolves #3518
