### PR TITLE
Fix getting started guide endpoint if no metrics are defined :wrench:

### DIFF
--- a/src/metabase/api/getting_started.clj
+++ b/src/metabase/api/getting_started.clj
@@ -33,7 +33,8 @@
      :important_segments       segment-ids
      ;; A map of metric_id -> sequence of important field_ids
      :metric_important_fields  (m/map-vals (partial map :field_id)
-                                           (group-by :metric_id (db/select ['MetricImportantField :field_id :metric_id]
-                                                                 :metric_id [:in metric-ids])))}))
+                                           (group-by :metric_id (when (seq metric-ids)
+                                                                  (db/select ['MetricImportantField :field_id :metric_id]
+                                                                    :metric_id [:in metric-ids]))))}))
 
 (define-routes)

--- a/test/metabase/api/getting_started_guide_test.clj
+++ b/test/metabase/api/getting_started_guide_test.clj
@@ -1,0 +1,8 @@
+(ns metabase.api.getting-started-guide-test
+  (:require [expectations :refer :all]
+            [metabase.test.data.users :refer [user->client]]))
+
+;; just make sure the getting started guide endpoint works and returns the correct keys
+(expect
+  #{:metric_important_fields :most_important_dashboard :things_to_know :important_metrics :important_segments :important_tables :contact}
+  (set (keys ((user->client :rasta) :get 200 "getting_started"))))

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -1,5 +1,6 @@
 (ns metabase.test.data.users
   "Code related to creating / managing fake `Users` for testing purposes."
+  ;; TODO - maybe this namespace should just be `metabase.test.users`.
   (:require [medley.core :as m]
             (metabase [db :as db]
                       [http-client :as http])


### PR DESCRIPTION
There was a bug in this endpoint if the user hadn't defined any metrics yet

Includes test

fixes #3571
