### PR TITLE
Make Editing Segments Great Again :wrench:

### DIFF
--- a/src/metabase/api/common/internal.clj
+++ b/src/metabase/api/common/internal.clj
@@ -1,9 +1,11 @@
 (ns metabase.api.common.internal
   "Internal functions used by `metabase.api.common`."
-  (:require [clojure.tools.logging :as log]
+  (:require [clojure.java.jdbc :as jdbc]
+            [clojure.string :as s]
             [medley.core :as m]
             [swiss.arrows :refer :all]
-            [metabase.util :as u]))
+            [metabase.util :as u])
+  (:import java.sql.SQLException))
 
 ;;; # DEFENDPOINT HELPER FUNCTIONS + MACROS
 
@@ -232,10 +234,12 @@
                       status-code            message
                       ;; Otherwise it's a 500. Return a body that includes exception & filtered stacktrace for debugging purposes
                       :else                  (let [stacktrace (u/filtered-stacktrace e)]
-                                               (log/debug message "\n" (u/pprint-to-str stacktrace))
-                                               (assoc other-info
-                                                      :message message
-                                                      :stacktrace stacktrace)))}))))
+                                               (merge (assoc other-info
+                                                        :message    message
+                                                        :stacktrace stacktrace)
+                                                      (when (instance? SQLException e)
+                                                        {:sql-exception-chain (s/split (with-out-str (jdbc/print-sql-exception-chain e))
+                                                                                       #"\s*\n\s*")}))))}))))
 
 (defmacro catch-api-exceptions
   "Execute BODY, and if an exception is thrown, return the appropriate HTTP response."

--- a/src/metabase/models/segment.clj
+++ b/src/metabase/models/segment.clj
@@ -112,7 +112,7 @@
          (integer? user-id)
          (string? revision_message)]}
   ;; update the segment itself
-  (db/update! Segment id
+  (db/update-non-nil-keys! Segment id
     :name                    name
     :description             description
     :caveats                 caveats

--- a/src/metabase/models/segment.clj
+++ b/src/metabase/models/segment.clj
@@ -112,13 +112,16 @@
          (integer? user-id)
          (string? revision_message)]}
   ;; update the segment itself
-  (db/update-non-nil-keys! Segment id
-    :name                    name
-    :description             description
-    :caveats                 caveats
-    :points_of_interest      points_of_interest
-    :show_in_getting_started show_in_getting_started
-    :definition              definition)
+  (db/update! Segment id
+    (merge
+     {:name        name
+      :description description
+      :caveats     caveats
+      :definition  definition}
+     (when (seq points_of_interest)
+       {:points_of_interest points_of_interest})
+     (when (not (nil? show_in_getting_started))
+       {:show_in_getting_started show_in_getting_started})))
   (u/prog1 (retrieve-segment id)
     (events/publish-event :segment-update (assoc <> :actor_id user-id, :revision_message revision_message))))
 

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -16,7 +16,7 @@
            (java.net Socket
                      InetSocketAddress
                      InetAddress)
-           java.sql.Timestamp
+           (java.sql SQLException Timestamp)
            (java.util Calendar TimeZone)
            javax.xml.bind.DatatypeConverter
            org.joda.time.format.DateTimeFormatter))
@@ -560,7 +560,7 @@
      (fn [& args]
        (try
          (apply f args)
-         (catch java.sql.SQLException e
+         (catch SQLException e
            (log/error (format-color 'red "%s\n%s\n%s"
                                     exception-message
                                     (with-out-str (jdbc/print-sql-exception-chain e))

--- a/test/metabase/api/segment_test.clj
+++ b/test/metabase/api/segment_test.clj
@@ -10,7 +10,8 @@
                              [table :refer [Table]])
             [metabase.test.data.users :refer :all]
             [metabase.test.data :refer :all]
-            [metabase.test.util :as tu]))
+            [metabase.test.util :as tu]
+            [metabase.util :as u]))
 
 ;; ## Helper Fns
 
@@ -358,10 +359,19 @@
 
 
 ;;; GET /api/segement/
-
 (tu/expect-with-temp [Segment [segment-1]
                       Segment [segment-2]
                       Segment [_          {:is_active false}]] ; inactive segments shouldn't show up
   (tu/mappify (hydrate [segment-1
                         segment-2] :creator))
   ((user->client :rasta) :get 200 "segment/"))
+
+
+;;; PUT /api/segment/id. Can I update a segment's name without specifying `:points_of_interest` and `:show_in_getting_started`?
+(tu/expect-with-temp [Segment [segment]]
+  :ok
+  (do ((user->client :crowberto) :put 200 (str "segment/" (u/get-id segment))
+       {:name             "Cool name"
+        :revision_message "WOW HOW COOL"
+        :definition       {}})
+      :ok))


### PR DESCRIPTION
Segment saving logic was barfing on edit segments page if you tried to make updates without passing a value for `show_in_getting_started`. 

Fixes #3570
