### PR TITLE
Setting to make emojis in logs optional

### DIFF
--- a/docs/operations-guide/start.md
+++ b/docs/operations-guide/start.md
@@ -11,6 +11,7 @@
 *  [Customizing the Metabase Jetty Webserver](#customizing-the-metabase-jetty-webserver)
 *  [Changing password complexity](#changing-metabase-password-complexity)
 *  [Handling Timezones](#handling-timezones-in-metabase)
+*  [Configuring Emoji Logging](#configuring-emoji-logging)
 
 # Installing and Running Metabase
 
@@ -289,3 +290,11 @@ To ensure proper reporting it's important that timezones be set consistently in 
 Common Pitfalls:
 1. Your database is using date/time columns without any timezone information.  Typically when this happens your database will assume all the data is from whatever timezone the database is configured in or possible just default to UTC (check your database vendor to be sure).
 2. Your JVM timezone is not the same as your Metabase `Report Timezone` choice.  This is a very common issue and can be corrected by launching java with the `-Duser.timezone=<timezone>` option properly set to match your Metabase report timezone.
+
+
+# Configuring Emoji Logging
+
+By default Metabase will include emoji characters in logs. You can disable this by using the following environment variable:
+
+    export MB_EMOJI_IN_LOGS="false"
+    java -jar metabase.jar

--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -28,7 +28,8 @@
    ;:mb-password-length "8"
    :mb-version-info-url "http://static.metabase.com/version-info.json"
    :max-session-age "20160"                     ; session length in minutes (14 days)
-   :mb-colorize-logs "true"})
+   :mb-colorize-logs "true"
+   :mb-emoji-in-logs "true"})
 
 
 (defn config-str

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -333,7 +333,7 @@
             (require 'metabase.driver)
             ((resolve 'metabase.driver/can-connect-with-details?) engine details))
     (format "Unable to connect to Metabase %s DB." (name engine)))
-  (log/info "Verify Database Connection ... ✅"))
+  (log/info "Verify Database Connection ... " (u/format-emoji "✅")))
 
 (defn setup-db!
   "Do general preparation of database by validating that we can connect.
@@ -359,7 +359,7 @@
                      "\n\n"
                      "Once your database is updated try running the application again.\n"))
       (throw (java.lang.Exception. "Database requires manual upgrade."))))
-  (log/info "Database Migrations Current ... ✅")
+  (log/info "Database Migrations Current ... " (u/format-emoji "✅"))
 
   ;; Establish our 'default' DB Connection
   (create-connection-pool! (jdbc-details db-details))

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -333,7 +333,7 @@
             (require 'metabase.driver)
             ((resolve 'metabase.driver/can-connect-with-details?) engine details))
     (format "Unable to connect to Metabase %s DB." (name engine)))
-  (log/info "Verify Database Connection ... " (u/format-emoji "✅")))
+  (log/info "Verify Database Connection ... " (u/emoji "✅")))
 
 (defn setup-db!
   "Do general preparation of database by validating that we can connect.
@@ -359,7 +359,7 @@
                      "\n\n"
                      "Once your database is updated try running the application again.\n"))
       (throw (java.lang.Exception. "Database requires manual upgrade."))))
-  (log/info "Database Migrations Current ... " (u/format-emoji "✅"))
+  (log/info "Database Migrations Current ... " (u/emoji "✅"))
 
   ;; Establish our 'default' DB Connection
   (create-connection-pool! (jdbc-details db-details))

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -257,7 +257,7 @@
   [^Keyword engine, driver-instance]
   {:pre [(keyword? engine) (map? driver-instance)]}
   (swap! registered-drivers assoc engine driver-instance)
-  (log/debug (format "Registered driver %s 🚚" (u/format-color 'blue engine))))
+  (log/debug (format "Registered driver %s %s" (u/format-color 'blue engine) (u/format-emoji "🚚"))))
 
 (defn available-drivers
   "Info about available drivers."

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -257,7 +257,7 @@
   [^Keyword engine, driver-instance]
   {:pre [(keyword? engine) (map? driver-instance)]}
   (swap! registered-drivers assoc engine driver-instance)
-  (log/debug (format "Registered driver %s %s" (u/format-color 'blue engine) (u/format-emoji "🚚"))))
+  (log/debug (format "Registered driver %s %s" (u/format-color 'blue engine) (u/emoji "🚚"))))
 
 (defn available-drivers
   "Info about available drivers."

--- a/src/metabase/events.clj
+++ b/src/metabase/events.clj
@@ -32,7 +32,7 @@
       (require ns-symb)
       ;; look for `events-init` function in the namespace and call it if it exists
       (when-let [init-fn (ns-resolve ns-symb 'events-init)]
-        (log/info "Starting events listener:" (u/format-color 'blue ns-symb) "👂")
+        (log/info "Starting events listener:" (u/format-color 'blue ns-symb) (u/format-emoji "👂"))
         (init-fn)))))
 
 (defn initialize-events!

--- a/src/metabase/events.clj
+++ b/src/metabase/events.clj
@@ -32,7 +32,7 @@
       (require ns-symb)
       ;; look for `events-init` function in the namespace and call it if it exists
       (when-let [init-fn (ns-resolve ns-symb 'events-init)]
-        (log/info "Starting events listener:" (u/format-color 'blue ns-symb) (u/format-emoji "👂"))
+        (log/info "Starting events listener:" (u/format-color 'blue ns-symb) (u/emoji "👂"))
         (init-fn)))))
 
 (defn initialize-events!

--- a/src/metabase/plugins.clj
+++ b/src/metabase/plugins.clj
@@ -34,5 +34,5 @@
             :when (and (.isFile file)
                        (.canRead file)
                        (re-find #"\.jar$" (.getPath file)))]
-      (log/info (u/format-color 'magenta "Loading plugin %s... %s" file (u/format-emoji "🔌")))
+      (log/info (u/format-color 'magenta "Loading plugin %s... %s" file (u/emoji "🔌")))
       (add-jar-to-classpath! file))))

--- a/src/metabase/plugins.clj
+++ b/src/metabase/plugins.clj
@@ -34,5 +34,5 @@
             :when (and (.isFile file)
                        (.canRead file)
                        (re-find #"\.jar$" (.getPath file)))]
-      (log/info (u/format-color 'magenta "Loading plugin %s... 🔌" file))
+      (log/info (u/format-color 'magenta "Loading plugin %s... %s" file (u/format-emoji "🔌")))
       (add-jar-to-classpath! file))))

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -152,7 +152,7 @@
     (u/prog1 (macros/expand-macros query)
       (when (and (not *disable-qp-logging*)
                  (not= <> query))
-        (log/debug (u/format-color 'cyan "\n\nMACRO/SUBSTITUTED: 😻\n%s" (u/pprint-to-str <>)))))))
+        (log/debug (u/format-color 'cyan "\n\nMACRO/SUBSTITUTED: %s\n%s" (u/emoji "😻") (u/pprint-to-str <>)))))))
 
 (defn- pre-expand-macros [qp] (comp qp expand-macros))
 
@@ -163,7 +163,7 @@
   (u/prog1 (params/expand-parameters query)
     (when (and (not *disable-qp-logging*)
                (not= <> query))
-      (log/debug (u/format-color 'cyan "\n\nPARAMS/SUBSTITUTED: 😻\n%s" (u/pprint-to-str <>))))))
+      (log/debug (u/format-color 'cyan "\n\nPARAMS/SUBSTITUTED: %s\n%s" (u/emoji "😻") (u/pprint-to-str <>))))))
 
 (defn- pre-substitute-parameters [qp] (comp qp substitute-parameters))
 
@@ -407,7 +407,8 @@
   (u/prog1 query
     (when (and (mbql-query? query)
                (not *disable-qp-logging*))
-      (log/debug (u/format-color 'magenta "\nPREPROCESSED/EXPANDED: 😻\n%s"
+      (log/debug (u/format-color 'magenta "\nPREPROCESSED/EXPANDED: %s\n%s"
+                   (u/emoji "😻")
                    (u/pprint-to-str
                     ;; Remove empty kv pairs because otherwise expanded query is HUGE
                     (walk/prewalk
@@ -416,7 +417,7 @@
                                (m/filter-vals identity (into {} f))))
                      ;; obscure DB details when logging. Just log the name of driver because we don't care about its properties
                      (-> query
-                         (assoc-in [:database :details] "😋 ") ; :yum:
+                         (assoc-in [:database :details] (u/emoji "😋 ")) ; :yum:
                          (update :driver name)))))))))
 
 (defn- pre-log-query [qp] (comp qp log-query))
@@ -483,7 +484,7 @@
                                 (:native query)
                                 (driver/mbql->native (:driver query) query))
                        (when-not *disable-qp-logging*
-                         (log/debug (u/format-color 'green "NATIVE FORM: 😳\n%s\n" (u/pprint-to-str <>)))))
+                         (log/debug (u/format-color 'green "NATIVE FORM: %s\n%s\n" (u/emoji "😳") (u/pprint-to-str <>)))))
         native-query (if-not (mbql-query? query)
                        query
                        (assoc query :native native-form))
@@ -531,7 +532,7 @@
   {:style/indent 0}
   [query]
   (when-not *disable-qp-logging*
-    (log/debug (u/format-color 'blue "\nQUERY: 😎\n%s"  (u/pprint-to-str query))))
+    (log/debug (u/format-color 'blue "\nQUERY: %s\n%s"  (u/emoji "😎") (u/pprint-to-str query))))
   ;; TODO: it probably makes sense to throw an error or return a failure response here if we can't get a driver
   (let [driver (driver/database-id->driver (:database query))]
     (binding [*driver* driver]

--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -22,7 +22,7 @@
   []
   (doseq [ns-symb (ns-find/find-namespaces (classpath/classpath))
           :when   (re-find #"^metabase\.task\." (name ns-symb))]
-    (log/info "Loading tasks namespace:" (u/format-color 'blue ns-symb) (u/format-emoji "📆"))
+    (log/info "Loading tasks namespace:" (u/format-color 'blue ns-symb) (u/emoji "📆"))
     (require ns-symb)
     ;; look for `task-init` function in the namespace and call it if it exists
     (when-let [init-fn (ns-resolve ns-symb 'task-init)]

--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -22,7 +22,7 @@
   []
   (doseq [ns-symb (ns-find/find-namespaces (classpath/classpath))
           :when   (re-find #"^metabase\.task\." (name ns-symb))]
-    (log/info "Loading tasks namespace:" (u/format-color 'blue ns-symb) "📆")
+    (log/info "Loading tasks namespace:" (u/format-color 'blue ns-symb) (u/format-emoji "📆"))
     (require ns-symb)
     ;; look for `task-init` function in the namespace and call it if it exists
     (when-let [init-fn (ns-resolve ns-symb 'task-init)]

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -472,12 +472,11 @@
      ~@body
      ~'<>))
 
-(defn format-emoji
-  "Returns the string passed in if emojis in logs are enabled, an empty string otherwise."
-  [format-string]
+(def ^String ^{:arglists '([emoji-string])} format-emoji
+  "Returns the EMOJI-STRING passed in if emoji in logs are enabled, otherwise always returns an empty string."
   (if (config/config-bool :mb-emoji-in-logs)
-      format-string
-      ""))
+    identity
+    (constantly "")))
 
 (def ^String ^{:style/indent 2} format-color
   "Like `format`, but uses a function in `colorize.core` to colorize the output.

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -472,6 +472,13 @@
      ~@body
      ~'<>))
 
+(defn format-emoji
+  "Returns the string passed in if emojis in logs are enabled, an empty string otherwise."
+  [format-string]
+  (if (config/config-bool :mb-emoji-in-logs)
+      format-string
+      ""))
+
 (def ^String ^{:style/indent 2} format-color
   "Like `format`, but uses a function in `colorize.core` to colorize the output.
    COLOR-SYMB should be a quoted symbol like `green`, `red`, `yellow`, `blue`,
@@ -530,7 +537,7 @@
         (str "["
              (s/join (repeat filleds "*"))
              (s/join (repeat blanks "·"))
-             (format "] %s  %3.0f%%" (percent-done->emoji percent-done) (* percent-done 100.0)))))))
+             (format "] %s  %3.0f%%" (format-emoji (percent-done->emoji percent-done)) (* percent-done 100.0)))))))
 
 (defn filtered-stacktrace
   "Get the stack trace associated with E and return it as a vector with non-metabase frames filtered out."

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -472,7 +472,7 @@
      ~@body
      ~'<>))
 
-(def ^String ^{:arglists '([emoji-string])} format-emoji
+(def ^String ^{:arglists '([emoji-string])} emoji
   "Returns the EMOJI-STRING passed in if emoji in logs are enabled, otherwise always returns an empty string."
   (if (config/config-bool :mb-emoji-in-logs)
     identity
@@ -536,7 +536,7 @@
         (str "["
              (s/join (repeat filleds "*"))
              (s/join (repeat blanks "·"))
-             (format "] %s  %3.0f%%" (format-emoji (percent-done->emoji percent-done)) (* percent-done 100.0)))))))
+             (format "] %s  %3.0f%%" (emoji (percent-done->emoji percent-done)) (* percent-done 100.0)))))))
 
 (defn filtered-stacktrace
   "Get the stack trace associated with E and return it as a vector with non-metabase frames filtered out."

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -134,6 +134,3 @@
    2 {:id 2, :name "Lucky"}}
   (key-by :id [{:id 1, :name "Rasta"}
                {:id 2, :name "Lucky"}]))
-
-;;; ## tests for EMOJI
-(expect "🔌" (emoji "🔌"))

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -134,3 +134,6 @@
    2 {:id 2, :name "Lucky"}}
   (key-by :id [{:id 1, :name "Rasta"}
                {:id 2, :name "Lucky"}]))
+
+;;; ## tests for EMOJI
+(expect "🔌" (emoji "🔌"))


### PR DESCRIPTION
Took a stab at #3358 
There may be a better way to do this (feedback appreciated), and I'm not sure the naming of format-emoji is appropriate since it differs from Clojure's format and the existing format-color function in src/metabase/util.clj 
## Running normally

![with-emoji](https://cloud.githubusercontent.com/assets/631171/19404012/abd7a434-921f-11e6-8530-3fc7cea07308.png)
## Running with `MB_EMOJI_IN_LOGS=false`

![without-emojis](https://cloud.githubusercontent.com/assets/631171/19404052/f9414c84-921f-11e6-9e63-16954c6cd236.png)
###### TODO
-  [ X ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
  (unless it's a tiny documentation change).
