### PR TITLE
Respect METABASE_PASSWORD_LENGTH and METABASE_PASSWORD_COMPLEXITY

### DIFF
--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -65,7 +65,7 @@
 
 
 (defn public-settings
-  "Return a simple map of key/value pairs which represent the public settings for the front-end application."
+  "Return a simple map of key/value pairs which represent the public settings (`MetabaseBootstrap`) for the front-end application."
   []
   {:ga_code               "UA-60817802-1"
    :password_complexity   password/active-password-complexity

--- a/src/metabase/util/password.clj
+++ b/src/metabase/util/password.clj
@@ -46,7 +46,7 @@
                  (when (>= (occurances char-type) min-count)
                    (recur more)))))))
 
-(def ^:const active-password-complexity
+(def active-password-complexity
   "The currently configured description of the password complexity rules being enforced"
   (merge (complexity->char-type->min (config/config-kw :mb-password-complexity))
          ;; Setting MB_PASSWORD_LENGTH overrides the default :total for a given password complexity class


### PR DESCRIPTION
Sometimes these setting would get ignored because the `active-password-complexity` was marked `^:const`. 

Fixes #3283
