### PR TITLE
Fix load-from-h2 command :wrench:

### DIFF
--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -214,7 +214,8 @@
    (load-from-h2 nil))
   ([h2-connection-string]
    (require 'metabase.cmd.load-from-h2)
-   ((resolve 'metabase.cmd.load-from-h2/load-from-h2!) h2-connection-string)))
+   (binding [db/*disable-data-migrations* true]
+     ((resolve 'metabase.cmd.load-from-h2/load-from-h2!) h2-connection-string))))
 
 (defn ^:command profile
   "Start Metabase the usual way and exit. Useful for profiling Metabase launch time."

--- a/src/metabase/db/migrations.clj
+++ b/src/metabase/db/migrations.clj
@@ -218,6 +218,10 @@
                                (swap! processed-fields conj column-name)))))))))))))))))
 
 
+;;; +------------------------------------------------------------------------------------------------------------------------+
+;;; |                                                     PERMISSIONS v1                                                     |
+;;; +------------------------------------------------------------------------------------------------------------------------+
+
 ;; Add users to default permissions groups. This will cause the groups to be created if needed as well.
 (defmigration add-users-to-default-permissions-groups
   (let [{all-users-group-id :id} (perm-group/all-users)


### PR DESCRIPTION
It turns out the data migrations that create the "magic" permissions groups and add users and databases to the default group was running before the code to load data from an H2 database. This was causing `load-from-h2` to fail because it tried to transfer the original magic permissions groups into the new DB which failed because of duplicate entries.

Fix this by adding some logic to disable the offending data migrations when Metabase is started via `load-from-h2`

Fixes #3592 
