### PR TITLE
Remove bad data migration :wrench:

### DIFF
--- a/resources/migrations/046_add_not_null_constraints_for_dashboard_card_row_col.yaml
+++ b/resources/migrations/046_add_not_null_constraints_for_dashboard_card_row_col.yaml
@@ -1,0 +1,23 @@
+databaseChangeLog:
+  - changeSet:
+      id: 46
+      author: camsaul
+      changes:
+        - addNotNullConstraint:
+            tableName: report_dashboardcard
+            columnName: row
+            columnDataType: integer
+            defaultNullValue: 0
+        - addNotNullConstraint:
+            tableName: report_dashboardcard
+            columnName: col
+            columnDataType: integer
+            defaultNullValue: 0
+        - addDefaultValue:
+            tableName: report_dashboardcard
+            columnName: row
+            defaultValueNumeric: 0
+        - addDefaultValue:
+            tableName: report_dashboardcard
+            columnName: col
+            defaultValueNumeric: 0

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -110,8 +110,8 @@
    :parameters              []
    :ordered_cards           [{:sizeX                  2
                               :sizeY                  2
-                              :col                    nil
-                              :row                    nil
+                              :col                    0
+                              :row                    0
                               :updated_at             true
                               :created_at             true
                               :parameter_mappings     []
@@ -267,8 +267,8 @@
 (expect
   [[{:sizeX                  2
      :sizeY                  2
-     :col                    nil
-     :row                    nil
+     :col                    0
+     :row                    0
      :series                 []
      :parameter_mappings     []
      :visualization_settings {}
@@ -276,8 +276,8 @@
      :updated_at             true}
     {:sizeX                  2
      :sizeY                  2
-     :col                    nil
-     :row                    nil
+     :col                    0
+     :row                    0
      :parameter_mappings     []
      :visualization_settings {}
      :series                 []
@@ -340,10 +340,10 @@
                       (dissoc :email :date_joined :last_login :is_superuser :is_qbnewb))
     :diff         {:before {:name        "b"
                             :description nil
-                            :cards       [{:series nil, :col nil, :row nil, :sizeY 2, :sizeX 2}]}
+                            :cards       [{:series nil, :sizeY 2, :sizeX 2}]}
                    :after  {:name        "c"
                             :description "something"
-                            :cards       [{:series [8 9], :col 0, :row 0, :sizeY 3, :sizeX 4}]}}
+                            :cards       [{:series [8 9], :sizeY 3, :sizeX 4}]}}
     :description  "renamed it from \"b\" to \"c\", added a description, rearranged the cards and added some series to card 123."}
    {:is_reversion false
     :is_creation  true
@@ -359,8 +359,8 @@
                                                :description  nil
                                                :cards        [{:sizeX   2
                                                                :sizeY   2
-                                                               :row     nil
-                                                               :col     nil
+                                                               :row     0
+                                                               :col     0
                                                                :card_id 123
                                                                :series  []}]}
                                 :is_creation  true}]

--- a/test/metabase/api/revision_test.clj
+++ b/test/metabase/api/revision_test.clj
@@ -108,13 +108,13 @@
     :message      nil
     :user         @rasta-revision-info
     :diff         {:before {:cards nil}
-                   :after  {:cards [{:sizeX 2, :sizeY 2, :row nil, :col nil, :card_id card-id, :series []}]}}
+                   :after  {:cards [{:sizeX 2, :sizeY 2, :row 0, :col 0, :card_id card-id, :series []}]}}
     :description  "added a card."}
    {:is_reversion false
     :is_creation  false
     :message      nil
     :user         @rasta-revision-info
-    :diff         {:before {:cards [{:sizeX 2, :sizeY 2, :row nil, :col nil, :card_id card-id, :series []}]}
+    :diff         {:before {:cards [{:sizeX 2, :sizeY 2, :row 0, :col 0, :card_id card-id, :series []}]}
                    :after  {:cards nil}}
     :description "removed a card."}
    {:is_reversion false
@@ -122,7 +122,7 @@
     :message      nil
     :user         @rasta-revision-info
     :diff         {:before {:cards nil}
-                   :after  {:cards [{:sizeX 2, :sizeY 2, :row nil, :col nil, :card_id card-id, :series []}]}}
+                   :after  {:cards [{:sizeX 2, :sizeY 2, :row 0, :col 0, :card_id card-id, :series []}]}}
     :description "added a card."}
    {:is_reversion false
     :is_creation  true

--- a/test/metabase/events/revision_test.clj
+++ b/test/metabase/events/revision_test.clj
@@ -160,8 +160,8 @@
                                                                         :card_id card-id
                                                                         :sizeX   4
                                                                         :sizeY   2
-                                                                        :row     nil
-                                                                        :col     nil
+                                                                        :row     0
+                                                                        :col     0
                                                                         :series  []}])
    :is_reversion false
    :is_creation  false}

--- a/test/metabase/models/dashboard_card_test.clj
+++ b/test/metabase/models/dashboard_card_test.clj
@@ -30,8 +30,8 @@
 (expect
   {:sizeX                  2
    :sizeY                  2
-   :col                    nil
-   :row                    nil
+   :col                    0
+   :row                    0
    :parameter_mappings     [{:foo "bar"}]
    :visualization_settings {}
    :series                 []}
@@ -45,8 +45,8 @@
 (expect
   {:sizeX                  2
    :sizeY                  2
-   :col                    nil
-   :row                    nil
+   :col                    0
+   :row                    0
    :parameter_mappings     []
    :visualization_settings {}
    :series                 [{:name                   "Additional Series Card 1"
@@ -144,8 +144,8 @@
 (expect
   [{:sizeX                  2
     :sizeY                  2
-    :col                    nil
-    :row                    nil
+    :col                    0
+    :row                    0
     :parameter_mappings     [{:foo "bar"}]
     :visualization_settings {}
     :series                 []}

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -18,8 +18,8 @@
    :description  nil
    :cards        [{:sizeX   2
                    :sizeY   2
-                   :row     nil
-                   :col     nil
+                   :row     0
+                   :col     0
                    :id      true
                    :card_id true
                    :series  true}]}
@@ -58,8 +58,8 @@
      :description  nil
      :cards        [{:sizeX   2
                      :sizeY   2
-                     :row     nil
-                     :col     nil
+                     :row     0
+                     :col     0
                      :id      1
                      :card_id 1
                      :series  []}]}))
@@ -71,15 +71,15 @@
      :description  nil
      :cards        [{:sizeX   2
                      :sizeY   2
-                     :row     nil
-                     :col     nil
+                     :row     0
+                     :col     0
                      :id      1
                      :card_id 1
                      :series  [5 6]}
                     {:sizeX   2
                      :sizeY   2
-                     :row     nil
-                     :col     nil
+                     :row     0
+                     :col     0
                      :id      2
                      :card_id 2
                      :series  []}]}
@@ -110,8 +110,8 @@
     :description  nil
     :cards        [{:sizeX   2
                     :sizeY   2
-                    :row     nil
-                    :col     nil
+                    :row     0
+                    :col     0
                     :id      true
                     :card_id true
                     :series  true}]}
@@ -122,8 +122,8 @@
     :description  nil
     :cards        [{:sizeX   2
                     :sizeY   2
-                    :row     nil
-                    :col     nil
+                    :row     0
+                    :col     0
                     :id      false
                     :card_id true
                     :series  true}]}]


### PR DESCRIPTION
Take out the broken old data migration from #2213 and replace it with a proper Liquibase migration that adds default values and `NOT NULL` constraints for the columns. If we have a migration to "fix" `nil` columns it's a sign we should have had `NOT NULL` constraints in the first place.

Using Liquibase migrations and actual DB constraints is always safer and preferable to Clojure-based migrations. We should only use Clojure-based ones when absolutely necessary, which wasn't the case here.

I've also added some metadata to the different data migrations we have to help us keep track of when and where each one was added. Turns out almost half of them are from `0.12.0` or `0.13.0` so we can probably remove those at some point -- I don't think anybody's going to be upgrading from `0.11.0` to `0.21.0`

Fixes #3473 
