### PR TITLE
Let user create a new dashboard when adding a question to a dashboard

### DIFF
--- a/frontend/src/metabase/components/AddToDashSelectDashModal.jsx
+++ b/frontend/src/metabase/components/AddToDashSelectDashModal.jsx
@@ -65,7 +65,10 @@ export default class AddToDashSelectDashModal extends Component {
                         className="link flex-align-right px4 cursor-pointer"
                         onClick={() => this.setState({ shouldCreateDashboard: true })}
                     >
-                        <div className="flex align-center">
+                        <div
+                            className="flex align-center absolute"
+                            style={ { right: 40 } }
+                        >
                             <Icon name="add" size={16} />
                             <h3 className="ml1">Add to new dashboard</h3>
                         </div>

--- a/frontend/src/metabase/components/AddToDashSelectDashModal.jsx
+++ b/frontend/src/metabase/components/AddToDashSelectDashModal.jsx
@@ -62,7 +62,7 @@ export default class AddToDashSelectDashModal extends Component {
                 >
                 <div className="flex flex-column">
                     <div
-                        className="text-brand-hover flex-align-right px4 cursor-pointer"
+                        className="link flex-align-right px4 cursor-pointer"
                         onClick={() => this.setState({ shouldCreateDashboard: true })}
                     >
                         <div className="flex align-center">

--- a/frontend/src/metabase/components/AddToDashSelectDashModal.jsx
+++ b/frontend/src/metabase/components/AddToDashSelectDashModal.jsx
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from "react";
 
 import CreateDashboardModal from 'metabase/components/CreateDashboardModal.jsx';
+import Icon from 'metabase/components/Icon.jsx';
 import ModalContent from "metabase/components/ModalContent.jsx";
 import SortableItemList from 'metabase/components/SortableItemList.jsx';
 
@@ -59,17 +60,21 @@ export default class AddToDashSelectDashModal extends Component {
                     title="Add Question to Dashboard"
                     closeFn={this.props.closeFn}
                 >
+                <div className="flex flex-column">
+                    <div
+                        className="text-brand-hover flex-align-right px2 cursor-pointer"
+                        onClick={() => this.setState({ shouldCreateDashboard: true })}
+                    >
+                        <div className="flex align-center">
+                            <Icon name="add" size={16} />
+                            <h3 className="ml1">Add to new dashboard</h3>
+                        </div>
+                    </div>
                     <SortableItemList
                         items={this.state.dashboards}
                         onClickItemFn={this.addToDashboard}
                     />
-                    <button
-                        className="Button Button--primary"
-                        onClick={() => this.setState({shouldCreateDashboard: true})}
-                    >
-                        Or Create A New Dashboard
-                    </button>
-
+                </div>
                 </ModalContent>
             );
         }

--- a/frontend/src/metabase/components/AddToDashSelectDashModal.jsx
+++ b/frontend/src/metabase/components/AddToDashSelectDashModal.jsx
@@ -62,7 +62,7 @@ export default class AddToDashSelectDashModal extends Component {
                 >
                 <div className="flex flex-column">
                     <div
-                        className="text-brand-hover flex-align-right px2 cursor-pointer"
+                        className="text-brand-hover flex-align-right px4 cursor-pointer"
                         onClick={() => this.setState({ shouldCreateDashboard: true })}
                     >
                         <div className="flex align-center">

--- a/frontend/src/metabase/components/AddToDashSelectDashModal.jsx
+++ b/frontend/src/metabase/components/AddToDashSelectDashModal.jsx
@@ -16,7 +16,8 @@ export default class AddToDashSelectDashModal extends Component {
         this.loadDashboardList();
 
         this.state = {
-            dashboards: null
+            dashboards: null,
+            shouldCreateDashboard: false
         };
     }
 
@@ -49,7 +50,7 @@ export default class AddToDashSelectDashModal extends Component {
     render() {
         if (!this.state.dashboards) {
             return null;
-        } else if (this.state.dashboards.length === 0) {
+        } else if (this.state.dashboards.length === 0 || this.state.shouldCreateDashboard === true) {
             return <CreateDashboardModal createDashboardFn={this.createDashboard} closeFn={this.props.closeFn} />
         } else {
             return (
@@ -62,6 +63,13 @@ export default class AddToDashSelectDashModal extends Component {
                         items={this.state.dashboards}
                         onClickItemFn={this.addToDashboard}
                     />
+                    <button
+                        className="Button Button--primary"
+                        onClick={() => this.setState({shouldCreateDashboard: true})}
+                    >
+                        Or Create A New Dashboard
+                    </button>
+
                 </ModalContent>
             );
         }


### PR DESCRIPTION
Possible implementation for #1017

Up until recently I was working at Spot, and created enough dashboards that not having this might be my biggest pain point with Metabase. Wanted to scratch that itch and use it as an opportunity to learn more about React. If there is a better (or more idiomatic) way to approach this i'd love feedback.

It seems to work as I would expect it to when creating a new question, adding an existing question, or after pressing the back button in the browser.

(This obviously still needs design / UX improvements)

![add-question-to-dashboard](https://cloud.githubusercontent.com/assets/631171/19413347/48dfae92-92df-11e6-9512-90260b279a98.png)

Clicking on the button transitions the modal to this

![create-dashboard](https://cloud.githubusercontent.com/assets/631171/19413398/93879882-92e0-11e6-9fad-478637ba5321.png)
###### TODO
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
  (unless it's a tiny documentation change).
