### PR TITLE
Add default values for row and col to create-dashboard-card! :wrench:

### DIFF
--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -133,8 +133,8 @@
                                               :card_id                card_id
                                               :sizeX                  sizeX
                                               :sizeY                  sizeY
-                                              :row                    row
-                                              :col                    col
+                                              :row                    (or row 0)
+                                              :col                    (or col 0)
                                               :parameter_mappings     (or parameter_mappings [])
                                               :visualization_settings (or visualization_settings {}))]
         ;; add series to the DashboardCard


### PR DESCRIPTION
Previously we had a broken data migration to "fix" DashboardCards with empty values for `row` and `col` (#2213). This was a bad approach, IMO; if we didn't want to allow update `NULL` values, we should have added a DB-level constraint. #3596 removed the data migration and added `NOT NULL` constraints and default values for `DashboardCard` `row` and `col`. 

It turns out `nil` was coming in to the API for `row` and `col`. On Postgres default values still apply if you try to `INSERT` a row with `NULL` values; apparently on H2 they don't.

Simple fix: when `row` or `col` are `nil` just give them a non-`nil` value before saving them.

Fixes #3620
