### PR TITLE
Use schema for API validation. Add api-documentation command

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -22,7 +22,6 @@
                               (execute-query 1)
                               (execute-sql! 2)
                               (expect 0)
-                              (expect-expansion 0)
                               (expect-when-testing-engine 1)
                               (expect-with-all-engines 0)
                               (expect-with-engine 1)

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -1,0 +1,1468 @@
+# API Documentation for Metabase v0.21.0-snapshot
+
+## `GET /api/activity/`
+
+Get recent activity.
+
+
+## `GET /api/activity/recent_views`
+
+Get the list of 10 things the current user has been viewing most recently.
+
+
+## `DELETE /api/card/:card-id/favorite`
+
+Unfavorite a Card.
+
+##### PARAMS:
+
+*  **`card-id`** 
+
+
+## `DELETE /api/card/:id`
+
+Delete a `Card`.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `GET /api/card/`
+
+Get all the `Cards`. Option filter param `f` can be used to change the set of Cards that are returned; default is `all`,
+   but other options include `mine`, `fav`, `database`, `table`, `recent`, `popular`, and `archived`. See corresponding implementation
+   functions above for the specific behavior of each filter option. :card_index:
+
+   Optionally filter cards by LABEL slug.
+
+##### PARAMS:
+
+*  **`f`** value may be nil, or if non-nil, value must be one of: `all`, `archived`, `database`, `fav`, `mine`, `popular`, `recent`, `table`.
+
+*  **`model_id`** value may be nil, or if non-nil, value must be an integer greater than zero.
+
+*  **`label`** value may be nil, or if non-nil, value must be a non-blank string.
+
+
+## `GET /api/card/:card-id/favorite`
+
+Has current user favorited this `Card`?
+
+##### PARAMS:
+
+*  **`card-id`** 
+
+
+## `GET /api/card/:id`
+
+Get `Card` with ID.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `POST /api/card/`
+
+Create a new `Card`.
+
+##### PARAMS:
+
+*  **`dataset_query`** 
+
+*  **`description`** 
+
+*  **`display`** value must be a non-blank string.
+
+*  **`name`** value must be a non-blank string.
+
+*  **`visualization_settings`** value must be a map.
+
+
+## `POST /api/card/:card-id/favorite`
+
+Favorite a Card.
+
+##### PARAMS:
+
+*  **`card-id`** 
+
+
+## `POST /api/card/:card-id/labels`
+
+Update the set of `Labels` that apply to a `Card`.
+
+##### PARAMS:
+
+*  **`card-id`** 
+
+*  **`label_ids`** value must be an array. Each value must be an integer greater than zero.
+
+
+## `POST /api/card/:card-id/query`
+
+Run the query associated with a Card.
+
+##### PARAMS:
+
+*  **`card-id`** 
+
+*  **`parameters`** 
+
+
+## `PUT /api/card/:id`
+
+Update a `Card`.
+
+##### PARAMS:
+
+*  **`id`** 
+
+*  **`dataset_query`** 
+
+*  **`description`** 
+
+*  **`display`** value may be nil, or if non-nil, value must be a non-blank string.
+
+*  **`name`** value may be nil, or if non-nil, value must be a non-blank string.
+
+*  **`visualization_settings`** value may be nil, or if non-nil, value must be a map.
+
+*  **`archived`** value may be nil, or if non-nil, value must be a boolean.
+
+*  **`body`** 
+
+
+## `DELETE /api/dashboard/:id`
+
+Delete a `Dashboard`.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `DELETE /api/dashboard/:id/cards`
+
+Remove a `DashboardCard` from a `Dashboard`.
+
+##### PARAMS:
+
+*  **`id`** 
+
+*  **`dashcardId`** value must be a valid integer greater than zero.
+
+
+## `GET /api/dashboard/`
+
+Get `Dashboards`. With filter option `f` (default `all`), restrict results as follows:
+
+  *  `all` - Return all `Dashboards`.
+  *  `mine` - Return `Dashboards` created by the current user.
+
+##### PARAMS:
+
+*  **`f`** value may be nil, or if non-nil, value must be one of: `all`, `mine`.
+
+
+## `GET /api/dashboard/:id`
+
+Get `Dashboard` with ID.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `GET /api/dashboard/:id/revisions`
+
+Fetch `Revisions` for `Dashboard` with ID.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `POST /api/dashboard/`
+
+Create a new `Dashboard`.
+
+##### PARAMS:
+
+*  **`name`** value must be a non-blank string.
+
+*  **`parameters`** value must be an array. Each value must be a map.
+
+*  **`dashboard`** 
+
+
+## `POST /api/dashboard/:id/cards`
+
+Add a `Card` to a `Dashboard`.
+
+##### PARAMS:
+
+*  **`id`** 
+
+*  **`cardId`** value must be an integer greater than zero.
+
+*  **`parameter_mappings`** value must be an array. Each value must be a map.
+
+*  **`series`** 
+
+*  **`dashboard-card`** 
+
+
+## `POST /api/dashboard/:id/revert`
+
+Revert a `Dashboard` to a prior `Revision`.
+
+##### PARAMS:
+
+*  **`id`** 
+
+*  **`revision_id`** value must be an integer greater than zero.
+
+
+## `PUT /api/dashboard/:id`
+
+Update a `Dashboard`.
+
+##### PARAMS:
+
+*  **`id`** 
+
+*  **`description`** 
+
+*  **`name`** value must be a non-blank string.
+
+*  **`parameters`** value must be an array. Each value must be a map.
+
+*  **`caveats`** 
+
+*  **`points_of_interest`** 
+
+*  **`show_in_getting_started`** 
+
+*  **`dashboard`** 
+
+
+## `PUT /api/dashboard/:id/cards`
+
+Update `Cards` on a `Dashboard`. Request body should have the form:
+
+    {:cards [{:id ...
+              :sizeX ...
+              :sizeY ...
+              :row ...
+              :col ...
+              :series [{:id 123
+                        ...}]} ...]}
+
+##### PARAMS:
+
+*  **`id`** 
+
+*  **`cards`** 
+
+
+## `DELETE /api/database/:id`
+
+Delete a `Database`.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `GET /api/database/`
+
+Fetch all `Databases`.
+
+##### PARAMS:
+
+*  **`include_tables`** 
+
+
+## `GET /api/database/:id`
+
+Get `Database` with ID.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `GET /api/database/:id/autocomplete_suggestions`
+
+Return a list of autocomplete suggestions for a given PREFIX.
+   This is intened for use with the ACE Editor when the User is typing raw SQL.
+   Suggestions include matching `Tables` and `Fields` in this `Database`.
+
+   Tables are returned in the format `[table_name "Table"]`;
+   Fields are returned in the format `[field_name "table_name base_type special_type"]`
+
+##### PARAMS:
+
+*  **`id`** 
+
+*  **`prefix`** value must be a non-blank string.
+
+
+## `GET /api/database/:id/fields`
+
+Get a list of all `Fields` in `Database`.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `GET /api/database/:id/idfields`
+
+Get a list of all primary key `Fields` for `Database`.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `GET /api/database/:id/metadata`
+
+Get metadata about a `Database`, including all of its `Tables` and `Fields`.
+   Returns DB, fields, and field values.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `GET /api/database/:id/tables`
+
+Get a list of all `Tables` in `Database`.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `POST /api/database/`
+
+Add a new `Database`.
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`name`** value must be a non-blank string.
+
+*  **`engine`** value must be a valid database engine.
+
+*  **`details`** value must be a map.
+
+*  **`is_full_sync`** 
+
+
+## `POST /api/database/:id/sync`
+
+Update the metadata for this `Database`.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `POST /api/database/sample_dataset`
+
+Add the sample dataset as a new `Database`.
+
+You must be a superuser to do this.
+
+
+## `PUT /api/database/:id`
+
+Update a `Database`.
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`id`** 
+
+*  **`name`** value must be a non-blank string.
+
+*  **`engine`** value must be a valid database engine.
+
+*  **`details`** value must be a map.
+
+*  **`is_full_sync`** 
+
+*  **`description`** 
+
+*  **`caveats`** 
+
+*  **`points_of_interest`** 
+
+
+## `GET /api/dataset/card/:id`
+
+Execute the MQL query for a given `Card` and retrieve both the `Card` and the execution results as JSON.
+   This is a convenience endpoint which simplifies the normal 2 api calls to fetch the `Card` then execute its query.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `POST /api/dataset/`
+
+Execute an MQL query and retrieve the results as JSON.
+
+##### PARAMS:
+
+*  **`database`** 
+
+*  **`body`** 
+
+
+## `POST /api/dataset/csv`
+
+Execute an MQL query and download the result data as a CSV file.
+
+##### PARAMS:
+
+*  **`query`** value must be a valid JSON string.
+
+
+## `POST /api/dataset/duration`
+
+Get historical query execution duration.
+
+##### PARAMS:
+
+*  **`database`** 
+
+*  **`query`** 
+
+
+## `POST /api/email/test`
+
+Send a test email. You must be a superuser to do this.
+
+You must be a superuser to do this.
+
+
+## `PUT /api/email/`
+
+Update multiple `Settings` values.  You must be a superuser to do this.
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`settings`** value must be a map.
+
+
+## `GET /api/field/:id`
+
+Get `Field` with ID.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `GET /api/field/:id/summary`
+
+Get the count and distinct count of `Field` with ID.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `GET /api/field/:id/values`
+
+If `Field`'s special type derives from `type/Category`, or its base type is `type/Boolean`, return
+   all distinct values of the field, and a map of human-readable values defined by the user.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `POST /api/field/:id/value_map_update`
+
+Update the human-readable values for a `Field` whose special type is `category`/`city`/`state`/`country`
+   or whose base type is `type/Boolean`.
+
+##### PARAMS:
+
+*  **`id`** 
+
+*  **`values_map`** value must be a map.
+
+
+## `PUT /api/field/:id`
+
+Update `Field` with ID.
+
+##### PARAMS:
+
+*  **`visibility_type`** value may be nil, or if non-nil, value must be one of: `details-only`, `hidden`, `normal`, `retired`, `sensitive`.
+
+*  **`display_name`** value may be nil, or if non-nil, value must be a non-blank string.
+
+*  **`body`** 
+
+*  **`points_of_interest`** value may be nil, or if non-nil, value must be a non-blank string.
+
+*  **`description`** value may be nil, or if non-nil, value must be a non-blank string.
+
+*  **`special_type`** value may be nil, or if non-nil, value must be a valid field type.
+
+*  **`caveats`** value may be nil, or if non-nil, value must be a non-blank string.
+
+*  **`fk_target_field_id`** value may be nil, or if non-nil, value must be an integer.
+
+*  **`id`** 
+
+
+## `GET /api/geojson/:key`
+
+Fetch a custom GeoJSON file as defined in the `custom-geojson` setting. (This just acts as a simple proxy for the file specified for KEY).
+
+##### PARAMS:
+
+*  **`key`** value must be a non-blank string.
+
+
+## `GET /api/getting-started/`
+
+Fetch basic info for the Getting Started guide.
+
+
+## `DELETE /api/label/:id`
+
+Delete a `Label`. :label:
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `GET /api/label/`
+
+List all `Labels`. :label:
+
+
+## `POST /api/label/`
+
+Create a new `Label`. :label: 
+
+##### PARAMS:
+
+*  **`name`** value must be a non-blank string.
+
+*  **`icon`** value may be nil, or if non-nil, value must be a non-blank string.
+
+
+## `PUT /api/label/:id`
+
+Update a `Label`. :label:
+
+##### PARAMS:
+
+*  **`id`** 
+
+*  **`name`** value may be nil, or if non-nil, value must be a non-blank string.
+
+*  **`icon`** value may be nil, or if non-nil, value must be a non-blank string.
+
+*  **`body`** 
+
+
+## `DELETE /api/metric/:id`
+
+Delete a `Metric`.
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`id`** 
+
+*  **`revision_message`** value must be a non-blank string.
+
+
+## `GET /api/metric/`
+
+Fetch *all* `Metrics`.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `GET /api/metric/:id`
+
+Fetch `Metric` with ID.
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `GET /api/metric/:id/revisions`
+
+Fetch `Revisions` for `Metric` with ID.
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `POST /api/metric/`
+
+Create a new `Metric`.
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`name`** value must be a non-blank string.
+
+*  **`description`** 
+
+*  **`table_id`** value must be an integer greater than zero.
+
+*  **`definition`** value must be a map.
+
+
+## `POST /api/metric/:id/revert`
+
+Revert a `Metric` to a prior `Revision`.
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`id`** 
+
+*  **`revision_id`** value must be an integer greater than zero.
+
+
+## `PUT /api/metric/:id`
+
+Update a `Metric` with ID.
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`points_of_interest`** 
+
+*  **`description`** 
+
+*  **`definition`** value must be a map.
+
+*  **`revision_message`** value must be a non-blank string.
+
+*  **`show_in_getting_started`** 
+
+*  **`name`** value must be a non-blank string.
+
+*  **`caveats`** 
+
+*  **`id`** 
+
+*  **`how_is_this_calculated`** 
+
+
+## `PUT /api/metric/:id/important_fields`
+
+Update the important `Fields` for a `Metric` with ID.
+   (This is used for the Getting Started guide).
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`id`** 
+
+*  **`important_field_ids`** value must be an array. Each value must be an integer greater than zero.
+
+
+## `POST /api/notify/db/:id`
+
+Notification about a potential schema change to one of our `Databases`.
+  Caller can optionally specify a `:table_id` or `:table_name` in the body to limit updates to a single `Table`.
+
+##### PARAMS:
+
+*  **`id`** 
+
+*  **`table_id`** 
+
+*  **`table_name`** 
+
+
+## `DELETE /api/permissions/group/:group-id`
+
+Delete a specific `PermissionsGroup`.
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`group-id`** 
+
+
+## `DELETE /api/permissions/membership/:id`
+
+Remove a User from a PermissionsGroup (delete their membership).
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `GET /api/permissions/graph`
+
+Fetch a graph of all Permissions.
+
+You must be a superuser to do this.
+
+
+## `GET /api/permissions/group`
+
+Fetch all `PermissionsGroups`.
+
+You must be a superuser to do this.
+
+
+## `GET /api/permissions/group/:id`
+
+Fetch the details for a certain permissions group.
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `GET /api/permissions/membership`
+
+Fetch a map describing the group memberships of various users.
+   This map's format is:
+
+    {<user-id> [{:membership_id <id>
+                 :group_id      <id>}]}
+
+You must be a superuser to do this.
+
+
+## `POST /api/permissions/group`
+
+Create a new `PermissionsGroup`.
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`name`** value must be a non-blank string.
+
+
+## `POST /api/permissions/membership`
+
+Add a `User` to a `PermissionsGroup`. Returns updated list of members belonging to the group.
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`group_id`** value must be an integer greater than zero.
+
+*  **`user_id`** value must be an integer greater than zero.
+
+
+## `PUT /api/permissions/graph`
+
+Do a batch update of Permissions by passing in a modified graph. This should return the same graph,
+   in the same format, that you got from `GET /api/permissions/graph`, with any changes made in the wherever neccesary.
+   This modified graph must correspond to the `PermissionsGraph` schema.
+   If successful, this endpoint returns the updated permissions graph; use this as a base for any further modifications.
+
+   Revisions to the permissions graph are tracked. If you fetch the permissions graph and some other third-party modifies it before you can submit
+   you revisions, the endpoint will instead make no changes andr eturn a 409 (Conflict) response. In this case, you should fetch the updated graph
+   and make desired changes to that.
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`body`** value must be a map.
+
+
+## `PUT /api/permissions/group/:group-id`
+
+Update the name of a `PermissionsGroup`.
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`group-id`** 
+
+*  **`name`** value must be a non-blank string.
+
+
+## `DELETE /api/pulse/:id`
+
+Delete a `Pulse`.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `GET /api/pulse/`
+
+Fetch all `Pulses`
+
+
+## `GET /api/pulse/:id`
+
+Fetch `Pulse` with ID.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `GET /api/pulse/form_input`
+
+Provides relevant configuration information and user choices for creating/updating `Pulses`.
+
+
+## `GET /api/pulse/preview_card/:id`
+
+Get HTML rendering of a `Card` with ID.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `GET /api/pulse/preview_card_info/:id`
+
+Get JSON object containing HTML rendering of a `Card` with ID and other information.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `GET /api/pulse/preview_card_png/:id`
+
+Get PNG rendering of a `Card` with ID.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `POST /api/pulse/`
+
+Create a new `Pulse`.
+
+##### PARAMS:
+
+*  **`name`** value must be a non-blank string.
+
+*  **`cards`** value must be an array. Each value must be a map. The array cannot be empty.
+
+*  **`channels`** value must be an array. Each value must be a map. The array cannot be empty.
+
+
+## `POST /api/pulse/test`
+
+Test send an unsaved pulse.
+
+##### PARAMS:
+
+*  **`name`** value must be a non-blank string.
+
+*  **`cards`** value must be an array. Each value must be a map. The array cannot be empty.
+
+*  **`channels`** value must be an array. Each value must be a map. The array cannot be empty.
+
+*  **`body`** 
+
+
+## `PUT /api/pulse/:id`
+
+Update a `Pulse` with ID.
+
+##### PARAMS:
+
+*  **`id`** 
+
+*  **`name`** value must be a non-blank string.
+
+*  **`cards`** value must be an array. Each value must be a map. The array cannot be empty.
+
+*  **`channels`** value must be an array. Each value must be a map. The array cannot be empty.
+
+
+## `GET /api/revision/`
+
+Get revisions of an object.
+
+##### PARAMS:
+
+*  **`entity`** value must be one of: `card`, `dashboard`.
+
+*  **`id`** value must be an integer.
+
+
+## `POST /api/revision/revert`
+
+Revert an object to a prior revision.
+
+##### PARAMS:
+
+*  **`entity`** value must be one of: `card`, `dashboard`.
+
+*  **`id`** value must be an integer.
+
+*  **`revision_id`** value must be an integer.
+
+
+## `DELETE /api/segment/:id`
+
+Delete a `Segment`.
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`id`** 
+
+*  **`revision_message`** value must be a non-blank string.
+
+
+## `GET /api/segment/`
+
+Fetch *all* `Segments`.
+
+
+## `GET /api/segment/:id`
+
+Fetch `Segment` with ID.
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `GET /api/segment/:id/revisions`
+
+Fetch `Revisions` for `Segment` with ID.
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `POST /api/segment/`
+
+Create a new `Segment`.
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`name`** value must be a non-blank string.
+
+*  **`description`** 
+
+*  **`table_id`** value must be an integer greater than zero.
+
+*  **`definition`** value must be a map.
+
+
+## `POST /api/segment/:id/revert`
+
+Revert a `Segement` to a prior `Revision`.
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`id`** 
+
+*  **`revision_id`** value must be an integer greater than zero.
+
+
+## `PUT /api/segment/:id`
+
+Update a `Segment` with ID.
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`id`** 
+
+*  **`name`** value must be a non-blank string.
+
+*  **`description`** 
+
+*  **`caveats`** 
+
+*  **`points_of_interest`** 
+
+*  **`show_in_getting_started`** 
+
+*  **`definition`** value must be a map.
+
+*  **`revision_message`** value must be a non-blank string.
+
+
+## `DELETE /api/session/`
+
+Logout.
+
+##### PARAMS:
+
+*  **`session_id`** value must be a non-blank string.
+
+
+## `GET /api/session/password_reset_token_valid`
+
+Check is a password reset token is valid and isn't expired.
+
+##### PARAMS:
+
+*  **`token`** value must be a string.
+
+
+## `GET /api/session/properties`
+
+Get all global properties and their values. These are the specific `Settings` which are meant to be public.
+
+
+## `POST /api/session/`
+
+Login.
+
+##### PARAMS:
+
+*  **`email`** value must be a valid email address.
+
+*  **`password`** value must be a non-blank string.
+
+*  **`remote-address`** 
+
+
+## `POST /api/session/forgot_password`
+
+Send a reset email when user has forgotten their password.
+
+##### PARAMS:
+
+*  **`server-name`** 
+
+*  **`email`** value must be a valid email address.
+
+*  **`remote-address`** 
+
+*  **`request`** 
+
+
+## `POST /api/session/google_auth`
+
+Login with Google Auth.
+
+##### PARAMS:
+
+*  **`token`** value must be a non-blank string.
+
+*  **`remote-address`** 
+
+
+## `POST /api/session/reset_password`
+
+Reset password with a reset token.
+
+##### PARAMS:
+
+*  **`token`** value must be a non-blank string.
+
+*  **`password`** Insufficient password strength
+
+
+## `DELETE /api/setting/:key`
+
+Delete a `Setting`. You must be a superuser to do this.
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`key`** value must be a non-blank string.
+
+
+## `GET /api/setting/`
+
+Get all `Settings` and their values. You must be a superuser to do this.
+
+You must be a superuser to do this.
+
+
+## `GET /api/setting/:key`
+
+Fetch a single `Setting`. You must be a superuser to do this.
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`key`** value must be a non-blank string.
+
+
+## `PUT /api/setting/`
+
+Update multiple `Settings` values.  You must be a superuser to do this.
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`settings`** value must be a map.
+
+
+## `PUT /api/setting/:key`
+
+Create/update a `Setting`. You must be a superuser to do this.
+   This endpoint can also be used to delete Settings by passing `nil` for `:value`.
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`key`** value must be a non-blank string.
+
+*  **`value`** 
+
+
+## `GET /api/setup/admin_checklist`
+
+Return various "admin checklist" steps and whether they've been completed. You must be a superuser to see this!
+
+You must be a superuser to do this.
+
+
+## `POST /api/setup/`
+
+Special endpoint for creating the first user during setup.
+   This endpoint both creates the user AND logs them in and returns a session ID.
+
+##### PARAMS:
+
+*  **`engine`** 
+
+*  **`allow_tracking`** 
+
+*  **`email`** value must be a valid email address.
+
+*  **`first_name`** value must be a non-blank string.
+
+*  **`request`** 
+
+*  **`password`** Insufficient password strength
+
+*  **`name`** 
+
+*  **`is_full_sync`** 
+
+*  **`site_name`** value must be a non-blank string.
+
+*  **`token`** Token does not match the setup token.
+
+*  **`details`** 
+
+*  **`last_name`** value must be a non-blank string.
+
+
+## `POST /api/setup/validate`
+
+Validate that we can connect to a database given a set of details.
+
+##### PARAMS:
+
+*  **`engine`** value must be a valid database engine.
+
+*  **`host`** 
+
+*  **`port`** 
+
+*  **`details`** 
+
+*  **`token`** Token does not match the setup token.
+
+
+## `PUT /api/slack/settings`
+
+Update Slack related settings. You must be a superuser to do this.
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`slack-token`** value may be nil, or if non-nil, value must be a non-blank string.
+
+*  **`metabot-enabled`** value must be a boolean.
+
+*  **`slack-settings`** 
+
+
+## `GET /api/table/`
+
+Get all `Tables`.
+
+
+## `GET /api/table/:id`
+
+Get `Table` with ID.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `GET /api/table/:id/fields`
+
+Get all `Fields` for `Table` with ID.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `GET /api/table/:id/fks`
+
+Get all foreign keys whose destination is a `Field` that belongs to this `Table`.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `GET /api/table/:id/query_metadata`
+
+Get metadata about a `Table` useful for running queries.
+   Returns DB, fields, field FKs, and field values.
+
+  By passing `include_sensitive_fields=true`, information *about* sensitive `Fields` will be returned; in no case
+  will any of its corresponding values be returned. (This option is provided for use in the Admin Edit Metadata page).
+
+##### PARAMS:
+
+*  **`id`** 
+
+*  **`include_sensitive_fields`** value may be nil, or if non-nil, value must be a valid boolean (true or false).
+
+
+## `POST /api/table/:id/reorder`
+
+Re-order the `Fields` belonging to this `Table`.
+
+##### PARAMS:
+
+*  **`id`** 
+
+*  **`new_order`** value must be an array.
+
+
+## `POST /api/table/:id/sync`
+
+Re-sync the metadata for this `Table`. This is ran asynchronously; the endpoint returns right away.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `PUT /api/table/:id`
+
+Update `Table` with ID.
+
+##### PARAMS:
+
+*  **`id`** 
+
+*  **`display_name`** value may be nil, or if non-nil, value must be a non-blank string.
+
+*  **`entity_type`** value may be nil, or if non-nil, value must be one of: `event`, `person`, `photo`, `place`.
+
+*  **`visibility_type`** value may be nil, or if non-nil, value must be one of: `cruft`, `hidden`, `technical`.
+
+*  **`description`** 
+
+*  **`caveats`** 
+
+*  **`points_of_interest`** 
+
+*  **`show_in_getting_started`** 
+
+
+## `GET /api/tiles/:zoom/:x/:y/:lat-field-id/:lon-field-id/:lat-col-idx/:lon-col-idx/`
+
+This endpoints provides an image with the appropriate pins rendered given a json query.
+   We evaluate the query and find the set of lat/lon pairs which are relevant and then render the appropriate ones.
+   It's expected that to render a full map view several calls will be made to this endpoint in parallel.
+
+##### PARAMS:
+
+*  **`zoom`** value must be a valid integer.
+
+*  **`x`** value must be a valid integer.
+
+*  **`y`** value must be a valid integer.
+
+*  **`lat-field-id`** value must be a valid integer greater than zero.
+
+*  **`lon-field-id`** value must be a valid integer greater than zero.
+
+*  **`lat-col-idx`** value must be a valid integer.
+
+*  **`lon-col-idx`** value must be a valid integer.
+
+*  **`query`** value must be a valid JSON string.
+
+
+## `DELETE /api/user/:id`
+
+Disable a `User`.  This does not remove the `User` from the db and instead disables their account.
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `GET /api/user/`
+
+Fetch a list of all active `Users` for the admin People page.
+
+
+## `GET /api/user/:id`
+
+Fetch a `User`. You must be fetching yourself *or* be a superuser.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `GET /api/user/current`
+
+Fetch the current `User`.
+
+
+## `POST /api/user/`
+
+Create a new `User`, or or reäctivate an existing one.
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`first_name`** value must be a non-blank string.
+
+*  **`last_name`** value must be a non-blank string.
+
+*  **`email`** value must be a valid email address.
+
+*  **`password`** 
+
+
+## `POST /api/user/:id/send_invite`
+
+Resend the user invite email for a given user.
+
+You must be a superuser to do this.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `PUT /api/user/:id`
+
+Update a `User`.
+
+##### PARAMS:
+
+*  **`id`** 
+
+*  **`email`** value must be a valid email address.
+
+*  **`first_name`** value may be nil, or if non-nil, value must be a non-blank string.
+
+*  **`last_name`** value may be nil, or if non-nil, value must be a non-blank string.
+
+*  **`is_superuser`** 
+
+
+## `PUT /api/user/:id/password`
+
+Update a user's password.
+
+##### PARAMS:
+
+*  **`id`** 
+
+*  **`password`** Insufficient password strength
+
+*  **`old_password`** 
+
+
+## `PUT /api/user/:id/qbnewb`
+
+Indicate that a user has been informed about the vast intricacies of 'the' QueryBuilder.
+
+##### PARAMS:
+
+*  **`id`** 
+
+
+## `GET /api/util/logs`
+
+Logs.
+
+You must be a superuser to do this.
+
+
+## `POST /api/util/password_check`
+
+Endpoint that checks if the supplied password meets the currently configured password complexity rules.
+
+##### PARAMS:
+
+*  **`password`** Insufficient password strength

--- a/src/metabase/api/activity.clj
+++ b/src/metabase/api/activity.clj
@@ -81,4 +81,5 @@
                       (models/can-read? model-object))]
     (assoc view-log :model_object (dissoc model-object :dataset_query))))
 
+
 (define-routes)

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -1,6 +1,7 @@
 (ns metabase.api.card
   (:require [clojure.data :as data]
             [compojure.core :refer [GET POST DELETE PUT]]
+            [schema.core :as s]
             (metabase.api [common :refer :all]
                           [dataset :as dataset-api])
             (metabase [db :as db]
@@ -17,7 +18,8 @@
                              [table :refer [Table]]
                              [view-log :refer [ViewLog]])
             (metabase [query-processor :as qp]
-                      [util :as u])))
+                      [util :as u])
+            [metabase.util.schema :as su]))
 
 
 ;;; ------------------------------------------------------------ Hydration ------------------------------------------------------------
@@ -135,10 +137,9 @@
 
 ;;; ------------------------------------------------------------ /api/card & /api/card/:id endpoints ------------------------------------------------------------
 
-(defannotation CardFilterOption
-  "Option must be a valid card filter option."
-  [symb value :nillable]
-  (checkp-contains? (set (keys filter-option->fn)) symb (keyword value)))
+(def ^:private CardFilterOption
+  "Schema for a valid card filter option."
+  (apply s/enum (map name (keys filter-option->fn))))
 
 (defendpoint GET "/"
   "Get all the `Cards`. Option filter param `f` can be used to change the set of Cards that are returned; default is `all`,
@@ -147,22 +148,23 @@
 
    Optionally filter cards by LABEL slug."
   [f model_id label]
-  {f CardFilterOption, model_id Integer, label NonEmptyString}
-  (when (contains? #{:database :table} f)
-    (checkp (integer? model_id) "id" (format "id is required parameter when filter mode is '%s'" (name f)))
-    (case f
-      :database (read-check Database model_id)
-      :table    (read-check Database (db/select-one-field :db_id Table, :id model_id))))
-  (->> (cards-for-filter-option f model_id label)
-       (filterv models/can-read?))) ; filterv because we want make sure all the filtering is done while current user perms set is still bound
+  {f (s/maybe CardFilterOption), model_id (s/maybe su/IntGreaterThanZero), label (s/maybe su/NonBlankString)}
+  (let [f (keyword f)]
+    (when (contains? #{:database :table} f)
+      (checkp (integer? model_id) "id" (format "id is required parameter when filter mode is '%s'" (name f)))
+      (case f
+        :database (read-check Database model_id)
+        :table    (read-check Database (db/select-one-field :db_id Table, :id model_id))))
+    (->> (cards-for-filter-option f model_id label)
+         (filterv models/can-read?)))) ; filterv because we want make sure all the filtering is done while current user perms set is still bound
 
 
 (defendpoint POST "/"
   "Create a new `Card`."
   [:as {{:keys [dataset_query description display name visualization_settings]} :body}]
-  {name                   [Required NonEmptyString]
-   display                [Required NonEmptyString]
-   visualization_settings [Required Dict]}
+  {name                   su/NonBlankString
+   display                su/NonBlankString
+   visualization_settings su/Map}
   (check-403 (perms/set-has-full-permissions-for-set? @*current-user-permissions-set* (card/query-perms-set dataset_query :write)))
   (->> (db/insert! Card
          :creator_id             *current-user-id*
@@ -187,10 +189,10 @@
 (defendpoint PUT "/:id"
   "Update a `Card`."
   [id :as {{:keys [dataset_query description display name visualization_settings archived], :as body} :body}]
-  {name                   NonEmptyString
-   display                NonEmptyString
-   visualization_settings Dict
-   archived               Boolean}
+  {name                   (s/maybe su/NonBlankString)
+   display                (s/maybe su/NonBlankString)
+   visualization_settings (s/maybe su/Map)
+   archived               (s/maybe s/Bool)}
   (let [card (write-check Card id)]
     (db/update-non-nil-keys! Card id
       :dataset_query          dataset_query
@@ -249,7 +251,7 @@
 (defendpoint POST "/:card-id/labels"
   "Update the set of `Labels` that apply to a `Card`."
   [card-id :as {{:keys [label_ids]} :body}]
-  {label_ids [Required ArrayOfIntegers]}
+  {label_ids [su/IntGreaterThanZero]}
   (write-check Card card-id)
   (let [[labels-to-remove labels-to-add] (data/diff (set (db/select-field :label_id CardLabel :card_id card-id))
                                                     (set label_ids))]
@@ -264,7 +266,7 @@
 
 (defendpoint POST "/:card-id/query"
   "Run the query associated with a Card."
-  [card-id :as {{:keys [parameters timeout]} :body}]
+  [card-id :as {{:keys [parameters]} :body}]
   (let [card  (read-check Card card-id)
         query (assoc (:dataset_query card)
                 :parameters  parameters

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -9,12 +9,11 @@
             [metabase.api.common.internal :refer :all]
             [metabase.db :as db]
             [metabase.models.interface :as models]
-            [metabase.util :as u]
-            [metabase.util.password :as password]))
+            [metabase.util :as u]))
 
 (declare check-403 check-404)
 
-;;; ## DYNAMIC VARIABLES
+;;; ------------------------------------------------------------ DYNAMIC VARIABLES ------------------------------------------------------------
 ;; These get bound by middleware for each HTTP request.
 
 (def ^:dynamic ^Integer *current-user-id*
@@ -35,7 +34,7 @@
   (atom #{}))
 
 
-;;; ## CONDITIONAL RESPONSE FUNCTIONS / MACROS
+;;; ------------------------------------------------------------ Precondition checking helper fns  ------------------------------------------------------------
 
 (defn check
   "Assertion mechanism for use inside API functions.
@@ -131,7 +130,7 @@
   (checkp-with (partial contains? valid-values-set) symb value (str "must be one of: " valid-values-set)))
 
 
-;;; #### api-let, api->, etc.
+;;; ------------------------------------------------------------ api-let, api->, etc. ------------------------------------------------------------
 
 ;; The following all work exactly like the corresponding Clojure versions
 ;; but take an additional arg at the beginning called RESPONSE-PAIR.
@@ -209,187 +208,7 @@
 (defmacro ->>500    "If form is `nil` or `false`, throw a 500; otherwise thread it through BODY via `->>`." [& body] `(api->>    ~generic-500 ~@body))
 
 
-;;; ## DEFENDPOINT AND RELATED FUNCTIONS
-
-
-;;; ### Arg annotation fns
-
-(defmulti ^{:doc "*Internal* - don't use this directly.
-
-                  Multimethod used internally to dispatch arg annotation functions.
-                  Dispatches on the arg annotation as a keyword.
-
-                   {id Required}
-                   -> ((-arg-annotation-fn :Required) 'id id)
-                   -> (annotation:Required 'id id)"} -arg-annotation-fn ; for some reason supplying a docstr the normal way doesn't assoc it with the metadata like we'd expect
-  (fn [annotation-kw]
-    {:pre [(keyword? annotation-kw)]}
-    annotation-kw))
-
-;; By default, throw an exception if we see an arg annotation we don't understand
-(defmethod -arg-annotation-fn :default [annotation-kw]
-  (throw (Exception. (format "Don't know what to do with arg annotation '%s'!" (name annotation-kw)))))
-
-;; ### defannotation
-
-(defmacro defannotation
-  "Convenience for defining a new `defendpoint` arg annotation.
-
-    (defannotation Required
-      \"Param must be non-nil.\"
-      [symb value]
-      (when-not value
-        (throw (ex-info (format \"'%s' is a required param.\" symb) {:status-code 400})))
-      value)
-
-   SYMBOL-BINDING is bound to the *symbol* of the annotated API arg (e.g., `'org`).
-   This is useful for returning relevant error messages to the user (see example above).
-
-   VALUE-BINDING is bound to the *value* of the annotated API arg (e.g., `1`).
-
-   You may optionally specify that the param is `:nillable`.
-   This means BODY will only be evaluated if VALUE is non-nil.
-
-    (defannotation CardFilterOption [symb value :nillable]
-      (checkp-contains? #{:all :mine :fav} symb (keyword value)))
-
-   Internally, `defannotation` creates a function with the name of the annotation prefixed by `annotation:`.
-   This can be used to test the annotation:
-
-    (annotation:Required org 100) -> 100
-    (annotation:Required org nil) -> exception: 'org' is a required param.
-
-   You can also use it inside the body of another annotation:
-
-    (defannotation PublicPerm [symb value :nillable]
-      (annotation:Integer symb value]
-      (checkp-contains? #{0 1 2} symb value))
-
-   Try to add a docstr for all annotations. When they exist, they'll be included in the API documentation for
-   all parameters that use them. A good annotation docstr should explain what the valid values for the param are."
-  {:arglists '([annotation-name docstr? [symbol-binding value-binding nillable?] & body])}
-  [annotation-name & args]
-  {:pre [(symbol? annotation-name)]}
-  (let [[docstr [[symbol-binding value-binding & [nillable?]] & body]] (u/optional string? args)]
-    (assert (symbol? symbol-binding))
-    (assert (symbol? value-binding))
-    (assert (or (nil? nillable?)
-                (= nillable? :nillable)))
-    (when-not docstr
-      (log/warn (format "Warning: annotation %s/%s does not have a docstring." (.getName *ns*) annotation-name)))
-    (let [fn-name (symbol (str "annotation:" annotation-name))]
-      `(do
-         (defn ~fn-name ~@(when docstr [docstr]) [~symbol-binding ~value-binding]
-           {:pre [(symbol? ~symbol-binding)]}
-           ~(if nillable?
-              `(when-not (nil? ~value-binding)
-                 ~@body)
-              `(do
-                 ~@body)))
-         (defmethod -arg-annotation-fn ~(keyword annotation-name) [~'_]
-           ~fn-name)))))
-
-;; ### common annotation definitions
-
-(defannotation Required
-  "Param may not be `nil`."
-  [symb value]
-  (u/prog1 value
-    (when (nil? value)
-      (throw-invalid-param-exception (name symb) "field is a required param."))))
-
-(defannotation Date
-  "Parse param string as an [ISO 8601 date](http://en.wikipedia.org/wiki/ISO_8601), e.g.
-   `2015-03-24T06:57:23+00:00`"
-  [symb value :nillable]
-  (try (u/->Timestamp value)
-       (catch Throwable _
-         (throw-invalid-param-exception (name symb) (format "'%s' is not a valid date." value)))))
-
-(defannotation String->Integer
-  "Param is converted from a string to an integer."
-  [symb value :nillable]
-  (try (Integer/parseInt value)
-       (catch java.lang.NumberFormatException _
-         (format "Invalid value '%s' for '%s': cannot parse as an integer." value symb)))) ; TODO - why aren't we re-throwing these exceptions ?
-
-(defannotation String->Dict
-  "Param is converted from a JSON string to a dictionary."
-  [symb value :nillable]
-  (try (walk/keywordize-keys (json/parse-string value))
-       (catch java.lang.Exception _
-         (format "Invalid value '%s' for '%s': cannot parse as json." value symb))))
-
-(defannotation String->Boolean
-  "Param is converted from `\"true\"` or `\"false\"` to the corresponding boolean."
-  [symb value :nillable]
-  (cond
-    (= value "true")  true
-    (= value "false") false
-    (nil? value)      nil
-    :else             (throw-invalid-param-exception (name symb) (format "'%s' is not a valid boolean." value))))
-
-(defannotation Integer
-  "Param must be an integer (this does *not* cast the param)."
-  [symb value :nillable]
-  (checkp-with integer? symb value "value must be an integer."))
-
-(defannotation Boolean
-  "Param must be a boolean (this does *not* cast the param)."
-  [symb value :nillable]
-  (checkp-with m/boolean? symb value "value must be a boolean."))
-
-(defannotation Dict
-  "Param must be a dictionary (this does *not* cast the param)."
-  [symb value :nillable]
-  (checkp-with map? symb value "value must be a dictionary."))
-
-(defannotation ArrayOfIntegers
-  "Param must be an array of integers (this does *not* cast the param)."
-  [symb value :nillable]
-  (checkp-with vector? symb value "value must be an array.")
-  (mapv #(checkp-with integer? symb % "array value must be a integer.") value))
-
-(defannotation ArrayOfStrings
-  "Param must be an array of strings (this does *not* cast the param)."
-  [symb value :nillable]
-  (checkp-with vector? symb value "value must be an array.")
-  (mapv #(checkp-with string? symb % "array value must be a string.") value))
-
-(defannotation ArrayOfMaps
-  "Param must be an array of maps (this does *not* cast the param)."
-  [symb value :nillable]
-  (checkp-with vector? symb value "value must be an array.")
-  (mapv #(checkp-with map? symb % "array value must be a map.") value))
-
-(defannotation NonEmptyString
-  "Param must be a non-empty string (strings that only contain whitespace are considered empty)."
-  [symb value :nillable]
-  (checkp-with (complement s/blank?) symb value "value must be a non-empty string."))
-
-(defannotation ^:deprecated PublicPerms
-  "Param must be an integer and either `0` (no public permissions), `1` (public may read), or `2` (public may read and write)."
-  [symb value :nillable]
-  (annotation:Integer symb value)
-  (checkp-contains? #{0 1 2} symb value))
-
-(defannotation Email
-  "Param must be a valid email address."
-  [symb value :nillable]
-  (checkp-with u/is-email? symb value "Not a valid email address."))
-
-(defannotation ComplexPassword
-  "Param must be a complex password (*what does this mean?*)"
-  [symb value]
-  (checkp (password/is-complex? value) symb "Insufficient password strength")
-  value)
-
-(defannotation FilterOptionAllOrMine
-  "Param must be either `all` or `mine`."
-  [symb value :nillable]
-  (checkp-contains? #{:all :mine} symb (keyword value)))
-
-;;; ### defendpoint
+;;; ------------------------------------------------------------ DEFENDPOINT AND RELATED FUNCTIONS ------------------------------------------------------------
 
 (defmacro defendpoint
   "Define an API function.
@@ -397,32 +216,34 @@
 
    -  calls `auto-parse` to automatically parse certain args. e.g. `id` is converted from `String` to `Integer` via `Integer/parseInt`
    -  converts ROUTE from a simple form like `\"/:id\"` to a typed one like `[\"/:id\" :id #\"[0-9]+\"]`
-   -  sequentially applies specified annotation functions on args to validate or cast them.
+   -  sequentially applies specified annotation functions on args to validate them.
    -  executes BODY inside a `try-catch` block that handles exceptions; if exception is an instance of `ExceptionInfo` and includes a `:status-code`,
       that code will be returned
    -  automatically calls `wrap-response-if-needed` on the result of BODY
    -  tags function's metadata in a way that subsequent calls to `define-routes` (see below)
       will automatically include the function in the generated `defroutes` form.
    -  Generates a super-sophisticated Markdown-formatted docstring"
-  {:arglists '([method route docstr? args annotations-map? & body])}
+  {:arglists '([method route docstr? args schemas-map? & body])}
   [method route & more]
   {:pre [(or (string? route)
              (vector? route))]}
-  (let [fn-name               (route-fn-name method route)
+  (let [fn-name                (route-fn-name method route)
         route                  (typify-route route)
         [docstr [args & more]] (u/optional string? more)
-        _                      (when-not docstr
-                                 (log/warn (format "Warning: endpoint %s/%s does not have a docstring." (ns-name *ns*) fn-name)))
-        [arg-annotations body] (u/optional #(and (map? %) (every? symbol? (keys %))) more)]
+        [arg->schema body]     (u/optional #(and (map? %) (every? symbol? (keys %))) more)
+        validate-param-calls   (validate-params arg->schema)]
+    (when-not docstr
+      (log/warn (format "Warning: endpoint %s/%s does not have a docstring." (ns-name *ns*) fn-name)))
     `(def ~(vary-meta fn-name assoc
-                      :doc (route-dox method route docstr args arg-annotations)
+                      ;; eval the vals in arg->schema to make sure the actual schemas are resolved so we can document their API error messages
+                      :doc (route-dox method route docstr args (m/map-vals eval arg->schema) body)
                       :is-endpoint? true)
        (~method ~route ~args
-                (catch-api-exceptions
-                  (auto-parse ~args
-                    (let-annotated-args ~arg-annotations
-                                        (-> (do ~@body)
-                                            wrap-response-if-needed))))))))
+        (catch-api-exceptions
+          (auto-parse ~args
+            ~@validate-param-calls
+            (wrap-response-if-needed (do ~@body))))))))
+
 
 (defmacro define-routes
   "Create a `(defroutes routes ...)` form that automatically includes all functions created with
@@ -437,6 +258,9 @@
                                                            (s/replace #"\." "/"))
                                                        (u/pprint-to-str (concat api-routes additional-routes))))
        ~@api-routes ~@additional-routes)))
+
+
+;;; ------------------------------------------------------------ PERMISSIONS CHECKING HELPER FNS ------------------------------------------------------------
 
 (defn read-check
   "Check whether we can read an existing OBJ, or ENTITY with ID.

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -10,7 +10,8 @@
                              [hydrate :refer [hydrate]]
                              [query-execution :refer [QueryExecution]])
             (metabase [query-processor :as qp]
-                      [util :as u])))
+                      [util :as u])
+            [metabase.util.schema :as su]))
 
 (def ^:private ^:const max-results-bare-rows
   "Maximum number of rows to return specifically on :rows type queries via the API."
@@ -51,9 +52,9 @@
 (defendpoint POST "/csv"
   "Execute an MQL query and download the result data as a CSV file."
   [query]
-  {query [Required String->Dict]}
+  {query su/JSONString}
   (read-check Database (:database query))
-  (let [{{:keys [columns rows]} :data :keys [status] :as response} (qp/dataset-query query {:executed-by *current-user-id*})
+  (let [{{:keys [columns rows]} :data :keys [status] :as response} (qp/dataset-query (json/parse-string query keyword) {:executed-by *current-user-id*})
         columns (map name columns)] ; turn keywords into strings, otherwise we get colons in our output
     (if (= status :completed)
       ;; successful query, send CSV file

--- a/src/metabase/api/email.clj
+++ b/src/metabase/api/email.clj
@@ -6,7 +6,8 @@
             [metabase.api.common :refer :all]
             [metabase.config :as config]
             [metabase.email :as email]
-            [metabase.models.setting :as setting]))
+            [metabase.models.setting :as setting]
+            [metabase.util.schema :as su]))
 
 (def ^:private ^:const mb-to-smtp-settings
   {:email-smtp-host     :host
@@ -53,7 +54,7 @@
 (defendpoint PUT "/"
   "Update multiple `Settings` values.  You must be a superuser to do this."
   [:as {settings :body}]
-  {settings [Required Dict]}
+  {settings su/Map}
   (check-superuser)
   (let [email-settings (select-keys settings (keys mb-to-smtp-settings))
         smtp-settings  (-> (set/rename-keys email-settings mb-to-smtp-settings)

--- a/src/metabase/api/geojson.clj
+++ b/src/metabase/api/geojson.clj
@@ -5,7 +5,8 @@
             [schema.core :as s]
             [metabase.api.common :refer :all]
             [metabase.models.setting :refer [defsetting], :as setting]
-            [metabase.util :as u]))
+            [metabase.util :as u]
+            [metabase.util.schema :as su]))
 
 (defn- valid-json?
   "Does this URL-OR-RESOURCE point to valid JSON?
@@ -70,6 +71,7 @@
 (defendpoint GET "/:key"
   "Fetch a custom GeoJSON file as defined in the `custom-geojson` setting. (This just acts as a simple proxy for the file specified for KEY)."
   [key]
+  {key su/NonBlankString}
   (let [url (or (get-in (custom-geojson) [(keyword key) :url])
                 (throw (ex-info (str "Invalid custom GeoJSON key: " key)
                          {:status-code 400})))]

--- a/src/metabase/api/label.clj
+++ b/src/metabase/api/label.clj
@@ -1,9 +1,11 @@
 (ns metabase.api.label
   "`/api/label` endpoints."
   (:require [compojure.core :refer [GET POST DELETE PUT]]
+            [schema.core :as s]
             [metabase.api.common :refer [defendpoint define-routes write-check]]
             [metabase.db :as db]
-            [metabase.models.label :refer [Label]]))
+            [metabase.models.label :refer [Label]]
+            [metabase.util.schema :as su]))
 
 (defendpoint GET "/"
   "List all `Labels`. :label:"
@@ -13,15 +15,15 @@
 (defendpoint POST "/"
   "Create a new `Label`. :label: "
   [:as {{:keys [name icon]} :body}]
-  {name [Required NonEmptyString]
-   icon NonEmptyString}
+  {name su/NonBlankString
+   icon (s/maybe su/NonBlankString)}
   (db/insert! Label, :name name, :icon icon))
 
 (defendpoint PUT "/:id"
   "Update a `Label`. :label:"
   [id :as {{:keys [name icon], :as body} :body}]
-  {name NonEmptyString
-   icon NonEmptyString}
+  {name (s/maybe su/NonBlankString)
+   icon (s/maybe su/NonBlankString)}
   (write-check Label id)
   (db/update! Label id body)
   (Label id)) ; return the updated Label

--- a/src/metabase/api/metric.clj
+++ b/src/metabase/api/metric.clj
@@ -3,21 +3,23 @@
   (:require [clojure.data :as data]
             [clojure.tools.logging :as log]
             [compojure.core :refer [defroutes GET PUT POST DELETE]]
+            [schema.core :as s]
             [metabase.api.common :refer :all]
             [metabase.db :as db]
             (metabase.models [hydrate :refer [hydrate]]
                              [interface :as models]
                              [metric :refer [Metric], :as metric]
                              [revision :as revision]
-                             [table :refer [Table]])))
+                             [table :refer [Table]])
+            [metabase.util.schema :as su]))
 
 
 (defendpoint POST "/"
   "Create a new `Metric`."
   [:as {{:keys [name description table_id definition]} :body}]
-  {name       [Required NonEmptyString]
-   table_id   [Required Integer]
-   definition [Required Dict]}
+  {name       su/NonBlankString
+   table_id   su/IntGreaterThanZero
+   definition su/Map}
   (check-superuser)
   (write-check Table table_id)
   (check-500 (metric/create-metric! table_id name description *current-user-id* definition)))
@@ -40,9 +42,9 @@
 (defendpoint PUT "/:id"
   "Update a `Metric` with ID."
   [id :as {{:keys [name description caveats points_of_interest how_is_this_calculated show_in_getting_started definition revision_message]} :body}]
-  {name             [Required NonEmptyString]
-   revision_message [Required NonEmptyString]
-   definition       [Required Dict]}
+  {name             su/NonBlankString
+   revision_message su/NonBlankString
+   definition       su/Map}
   (check-superuser)
   (write-check Metric id)
   (metric/update-metric!
@@ -61,7 +63,7 @@
   "Update the important `Fields` for a `Metric` with ID.
    (This is used for the Getting Started guide)."
   [id :as {{:keys [important_field_ids]} :body}]
-  {important_field_ids [Required ArrayOfIntegers]}
+  {important_field_ids [su/IntGreaterThanZero]}
   (check-superuser)
   (write-check Metric id)
   (check (<= (count important_field_ids) 3)
@@ -82,7 +84,7 @@
 (defendpoint DELETE "/:id"
   "Delete a `Metric`."
   [id revision_message]
-  {revision_message [Required NonEmptyString]}
+  {revision_message su/NonBlankString}
   (check-superuser)
   (write-check Metric id)
   (metric/delete-metric! id *current-user-id* revision_message)
@@ -100,7 +102,7 @@
 (defendpoint POST "/:id/revert"
   "Revert a `Metric` to a prior `Revision`."
   [id :as {{:keys [revision_id]} :body}]
-  {revision_id [Required Integer]}
+  {revision_id su/IntGreaterThanZero}
   (check-superuser)
   (write-check Metric id)
   (revision/revert!
@@ -111,5 +113,3 @@
 
 
 (define-routes)
-
-[]

--- a/src/metabase/api/permissions.clj
+++ b/src/metabase/api/permissions.clj
@@ -10,7 +10,8 @@
                              [permissions-group :refer [PermissionsGroup], :as group]
                              [permissions-group-membership :refer [PermissionsGroupMembership]]
                              [table :refer [Table]])
-            [metabase.util :as u]))
+            [metabase.util :as u]
+            [metabase.util.schema :as su]))
 
 ;;; +------------------------------------------------------------------------------------------------------------------------------------------------------+
 ;;; |                                                             PERMISSIONS GRAPH ENDPOINTS                                                              |
@@ -66,7 +67,7 @@
    you revisions, the endpoint will instead make no changes andr eturn a 409 (Conflict) response. In this case, you should fetch the updated graph
    and make desired changes to that."
   [:as {body :body}]
-  {body [Required Dict]}
+  {body su/Map}
   (check-superuser)
   (perms/update-graph! (dejsonify-graph body))
   (perms/graph))
@@ -100,7 +101,7 @@
 (defendpoint POST "/group"
   "Create a new `PermissionsGroup`."
   [:as {{:keys [name]} :body}]
-  {name [Required NonEmptyString]}
+  {name su/NonBlankString}
   (check-superuser)
   (db/insert! PermissionsGroup
     :name name))
@@ -108,7 +109,7 @@
 (defendpoint PUT "/group/:group-id"
   "Update the name of a `PermissionsGroup`."
   [group-id :as {{:keys [name]} :body}]
-  {name [Required NonEmptyString]}
+  {name su/NonBlankString}
   (check-superuser)
   (check-404 (db/exists? PermissionsGroup :id group-id))
   (db/update! PermissionsGroup group-id
@@ -138,8 +139,8 @@
 (defendpoint POST "/membership"
   "Add a `User` to a `PermissionsGroup`. Returns updated list of members belonging to the group."
   [:as {{:keys [group_id user_id]} :body}]
-  {group_id [Required Integer]
-   user_id  [Required Integer]}
+  {group_id su/IntGreaterThanZero
+   user_id  su/IntGreaterThanZero}
   (check-superuser)
   (db/insert! PermissionsGroupMembership
     :group_id group_id

--- a/src/metabase/api/pulse.clj
+++ b/src/metabase/api/pulse.clj
@@ -15,7 +15,8 @@
             [metabase.query-processor :as qp]
             [metabase.pulse :as p]
             [metabase.pulse.render :as render]
-            [metabase.util :as u]))
+            [metabase.util :as u]
+            [metabase.util.schema :as su]))
 
 
 (defendpoint GET "/"
@@ -30,18 +31,18 @@
 
 
 (defn- check-card-read-permissions [cards]
-  (doseq [{card-id :id} cards
-          :when         card-id] ; for some reason, without explanation, the code below makes it look as though card IDs may randomly be `nil`
+  (doseq [{card-id :id} cards]
+    (assert (integer? card-id))
     (read-check Card card-id)))
 
 (defendpoint POST "/"
   "Create a new `Pulse`."
   [:as {{:keys [name cards channels]} :body}]
-  {name     [Required NonEmptyString]
-   cards    [Required ArrayOfMaps]
-   channels [Required ArrayOfMaps]}
+  {name     su/NonBlankString
+   cards    (su/non-empty [su/Map])
+   channels (su/non-empty [su/Map])}
   (check-card-read-permissions cards)
-  (check-500 (pulse/create-pulse! name *current-user-id* (filter identity (map :id cards)) channels)))
+  (check-500 (pulse/create-pulse! name *current-user-id* (map u/get-id cards) channels)))
 
 
 (defendpoint GET "/:id"
@@ -54,14 +55,14 @@
 (defendpoint PUT "/:id"
   "Update a `Pulse` with ID."
   [id :as {{:keys [name cards channels]} :body}]
-  {name     [Required NonEmptyString]
-   cards    [Required ArrayOfMaps]
-   channels [Required ArrayOfMaps]}
+  {name     su/NonBlankString
+   cards    (su/non-empty [su/Map])
+   channels (su/non-empty [su/Map])}
   (write-check Pulse id)
   (check-card-read-permissions cards)
   (pulse/update-pulse! {:id       id
                         :name     name
-                        :cards    (filter identity (map :id cards))
+                        :cards    (map u/get-id cards)
                         :channels channels})
   (pulse/retrieve-pulse id))
 
@@ -124,11 +125,11 @@
     {:status 200, :headers {"Content-Type" "image/png"}, :body (new java.io.ByteArrayInputStream ba)}))
 
 (defendpoint POST "/test"
-  "Test send an unsaved pulse"
+  "Test send an unsaved pulse."
   [:as {{:keys [name cards channels] :as body} :body}]
-  {name     [Required NonEmptyString]
-   cards    [Required ArrayOfMaps]
-   channels [Required ArrayOfMaps]}
+  {name     su/NonBlankString
+   cards    (su/non-empty [su/Map])
+   channels (su/non-empty [su/Map])}
   (check-card-read-permissions cards)
   (p/send-pulse! body)
   {:ok true})

--- a/src/metabase/api/revision.clj
+++ b/src/metabase/api/revision.clj
@@ -1,38 +1,41 @@
 (ns metabase.api.revision
   (:require [compojure.core :refer [GET POST]]
+            [schema.core :as s]
             [metabase.api.common :refer :all]
             [metabase.db :as db]
             (metabase.models [card :refer [Card]]
                              [dashboard :refer [Dashboard]]
-                             [revision :as revision])))
+                             [revision :as revision, :refer [Revision]])))
 
-(def ^:private ^:const entity-kw->entity
-  {:card      Card
-   :dashboard Dashboard})
+(def ^:private ^:const name->entity
+  {"card"      Card
+   "dashboard" Dashboard})
 
-(defannotation Entity
-  "Option must be a valid revisionable entity name. Returns corresponding entity."
-  [symb value]
-  (let [entity (entity-kw->entity (keyword value))]
-    (checkp entity symb (format "Invalid entity: %s" value))
-    entity))
+(def ^:private Entity
+  "Schema for a valid revisionable entity name."
+  (apply s/enum (keys name->entity)))
 
 (defendpoint GET "/"
   "Get revisions of an object."
   [entity id]
-  {entity Entity, id Integer}
-  (check-404 (db/exists? entity :id id))
-  (revision/revisions+details entity id))
+  {entity Entity, id s/Int}
+  (let [entity (name->entity entity)]
+    (check-404 (db/exists? entity :id id))
+    (revision/revisions+details entity id)))
 
 (defendpoint POST "/revert"
   "Revert an object to a prior revision."
   [:as {{:keys [entity id revision_id]} :body}]
-  {entity Entity, id Integer, revision_id Integer}
-  (check-404 (db/exists? revision/Revision :model (:name entity) :model_id id :id revision_id))
-  (revision/revert!
-    :entity      entity
-    :id          id
-    :user-id     *current-user-id*
-    :revision-id revision_id))
+  {entity Entity, id s/Int, revision_id s/Int}
+  (let [entity (name->entity entity)]
+    (check-404 (db/exists? Revision
+                 :model    (:name entity)
+                 :model_id id
+                 :id       revision_id))
+    (revision/revert!
+      :entity      entity
+      :id          id
+      :user-id     *current-user-id*
+      :revision-id revision_id)))
 
 (define-routes)

--- a/src/metabase/api/segment.clj
+++ b/src/metabase/api/segment.clj
@@ -1,21 +1,23 @@
 (ns metabase.api.segment
   "/api/segment endpoints."
   (:require [compojure.core :refer [defroutes GET PUT POST DELETE]]
+            [schema.core :as s]
             [metabase.api.common :refer :all]
             [metabase.db :as db]
             (metabase.models [hydrate :refer [hydrate]]
                              [interface :as models]
                              [revision :as revision]
                              [segment :refer [Segment], :as segment]
-                             [table :refer [Table]])))
+                             [table :refer [Table]])
+            [metabase.util.schema :as su]))
 
 
 (defendpoint POST "/"
   "Create a new `Segment`."
   [:as {{:keys [name description table_id definition]} :body}]
-  {name       [Required NonEmptyString]
-   table_id   [Required Integer]
-   definition [Required Dict]}
+  {name       su/NonBlankString
+   table_id   su/IntGreaterThanZero
+   definition su/Map}
   (check-superuser)
   (write-check Table table_id)
   (check-500 (segment/create-segment! table_id name description *current-user-id* definition)))
@@ -38,9 +40,9 @@
 (defendpoint PUT "/:id"
   "Update a `Segment` with ID."
   [id :as {{:keys [name description caveats points_of_interest show_in_getting_started definition revision_message]} :body}]
-  {name             [Required NonEmptyString]
-   revision_message [Required NonEmptyString]
-   definition       [Required Dict]}
+  {name             su/NonBlankString
+   revision_message su/NonBlankString
+   definition       su/Map}
   (check-superuser)
   (write-check Segment id)
   (segment/update-segment!
@@ -58,7 +60,7 @@
 (defendpoint DELETE "/:id"
   "Delete a `Segment`."
   [id revision_message]
-  {revision_message [Required NonEmptyString]}
+  {revision_message su/NonBlankString}
   (check-superuser)
   (write-check Segment id)
   (segment/delete-segment! id *current-user-id* revision_message)
@@ -76,7 +78,7 @@
 (defendpoint POST "/:id/revert"
   "Revert a `Segement` to a prior `Revision`."
   [id :as {{:keys [revision_id]} :body}]
-  {revision_id [Required Integer]}
+  {revision_id su/IntGreaterThanZero}
   (check-superuser)
   (write-check Segment id)
   (revision/revert!

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -5,6 +5,7 @@
             [cheshire.core :as json]
             [clj-http.client :as http]
             [compojure.core :refer [defroutes GET POST DELETE]]
+            [schema.core :as s]
             [throttle.core :as throttle]
             [metabase.api.common :refer :all]
             [metabase.db :as db]
@@ -15,7 +16,8 @@
                              [setting :refer [defsetting]])
             [metabase.public-settings :as public-settings]
             [metabase.util :as u]
-            [metabase.util.password :as pass]))
+            (metabase.util [password :as pass]
+                           [schema :as su])))
 
 
 (defn- create-session!
@@ -39,8 +41,8 @@
 (defendpoint POST "/"
   "Login."
   [:as {{:keys [email password]} :body, remote-address :remote-addr}]
-  {email    [Required Email]
-   password [Required NonEmptyString]}
+  {email    su/Email
+   password su/NonBlankString}
   (throttle/check (login-throttlers :ip-address) remote-address)
   (throttle/check (login-throttlers :email)      email)
   (let [user (db/select-one [User :id :password_salt :password :last_login], :email email, :is_active true)]
@@ -55,7 +57,7 @@
 (defendpoint DELETE "/"
   "Logout."
   [session_id]
-  {session_id [Required NonEmptyString]}
+  {session_id su/NonBlankString}
   (check-exists? Session session_id)
   (db/cascade-delete! Session, :id session_id))
 
@@ -73,7 +75,7 @@
 (defendpoint POST "/forgot_password"
   "Send a reset email when user has forgotten their password."
   [:as {:keys [server-name] {:keys [email]} :body, remote-address :remote-addr, :as request}]
-  {email [Required Email]}
+  {email su/Email}
   (throttle/check (forgot-password-throttlers :ip-address) remote-address)
   (throttle/check (forgot-password-throttlers :email)      email)
   ;; Don't leak whether the account doesn't exist, just pretend everything is ok
@@ -105,8 +107,8 @@
 (defendpoint POST "/reset_password"
   "Reset password with a reset token."
   [:as {{:keys [token password]} :body}]
-  {token    [Required NonEmptyString]
-   password [Required ComplexPassword]}
+  {token    su/NonBlankString
+   password su/ComplexPassword}
   (or (when-let [{user-id :id, :as user} (valid-reset-token->user token)]
         (set-user-password! user-id password)
         ;; after a successful password update go ahead and offer the client a new session that they can use
@@ -118,7 +120,7 @@
 (defendpoint GET "/password_reset_token_valid"
   "Check is a password reset token is valid and isn't expired."
   [token]
-  {token Required}
+  {token s/Str}
   {:valid (boolean (valid-reset-token->user token))})
 
 
@@ -179,7 +181,7 @@
 (defendpoint POST "/google_auth"
   "Login with Google Auth."
   [:as {{:keys [token]} :body, remote-address :remote-addr}]
-  {token [Required NonEmptyString]}
+  {token su/NonBlankString}
   (throttle/check (login-throttlers :ip-address) remote-address) ; TODO - Should we throttle this? It might keep us from being slammed with calls that have to make outbound HTTP requests, etc.
   ;; Verify the token is valid with Google
   (let [{:keys [given_name family_name email]} (google-auth-token-info token)]

--- a/src/metabase/api/setting.clj
+++ b/src/metabase/api/setting.clj
@@ -2,7 +2,8 @@
   "/api/setting endpoints"
   (:require [compojure.core :refer [GET PUT DELETE]]
             [metabase.api.common :refer :all]
-            [metabase.models.setting :as setting]))
+            [metabase.models.setting :as setting]
+            [metabase.util.schema :as su]))
 
 (defendpoint GET "/"
   "Get all `Settings` and their values. You must be a superuser to do this."
@@ -13,7 +14,7 @@
 (defendpoint PUT "/"
   "Update multiple `Settings` values.  You must be a superuser to do this."
   [:as {settings :body}]
-  {settings [Required Dict]}
+  {settings su/Map}
   (check-superuser)
   (setting/set-many! settings)
   (setting/all))
@@ -21,7 +22,7 @@
 (defendpoint GET "/:key"
   "Fetch a single `Setting`. You must be a superuser to do this."
   [key]
-  {key Required}
+  {key su/NonBlankString}
   (check-superuser)
   (let [k (keyword key)
         v (setting/get k)]
@@ -33,7 +34,7 @@
   "Create/update a `Setting`. You must be a superuser to do this.
    This endpoint can also be used to delete Settings by passing `nil` for `:value`."
   [key :as {{:keys [value]} :body}]
-  {key Required}
+  {key su/NonBlankString}
   (check-superuser)
   (setting/set! key value))
 
@@ -41,7 +42,7 @@
 (defendpoint DELETE "/:key"
   "Delete a `Setting`. You must be a superuser to do this."
   [key]
-  {key Required}
+  {key su/NonBlankString}
   (check-superuser)
   (setting/set! key nil)
   {:status 204, :body nil})

--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -1,8 +1,9 @@
 (ns metabase.api.setup
   (:require [compojure.core :refer [GET POST]]
             [medley.core :as m]
+            [schema.core :as s]
             (metabase.api [common :refer :all]
-                          [database :refer [annotation:DBEngine]])
+                          [database :refer [DBEngine]])
             (metabase [db :as db]
                       [driver :as driver]
                       [email :as email]
@@ -14,24 +15,25 @@
                              [user :refer [User set-user-password!]])
             [metabase.public-settings :as public-settings]
             [metabase.setup :as setup]
-            [metabase.util :as u]))
+            [metabase.util :as u]
+            [metabase.util.schema :as su]))
 
-(defannotation SetupToken
-  "Check that param matches setup token or throw a 403."
-  [symb value]
-  (checkp-with setup/token-match? symb value "Token does not match the setup token."))
+(def ^:private SetupToken
+  "Schema for a string that matches the instance setup token."
+  (su/with-api-error-message (s/constrained su/NonBlankString setup/token-match?)
+    "Token does not match the setup token."))
 
 
 (defendpoint POST "/"
   "Special endpoint for creating the first user during setup.
    This endpoint both creates the user AND logs them in and returns a session ID."
   [:as {{:keys [token] {:keys [name engine details is_full_sync]} :database, {:keys [first_name last_name email password]} :user, {:keys [allow_tracking site_name]} :prefs} :body, :as request}]
-  {token      [Required SetupToken]
-   site_name  [Required NonEmptyString]
-   first_name [Required NonEmptyString]
-   last_name  [Required NonEmptyString]
-   email      [Required Email]
-   password   [Required ComplexPassword]}
+  {token      SetupToken
+   site_name  su/NonBlankString
+   first_name su/NonBlankString
+   last_name  su/NonBlankString
+   email      su/Email
+   password   su/ComplexPassword}
   ;; Call (public-settings/site-url request) to set the Site URL setting if it's not already set
   (public-settings/site-url request)
   ;; Now create the user
@@ -75,8 +77,8 @@
 (defendpoint POST "/validate"
   "Validate that we can connect to a database given a set of details."
   [:as {{{:keys [engine] {:keys [host port] :as details} :details} :details, token :token} :body}]
-  {token      [Required SetupToken]
-   engine     [Required DBEngine]}
+  {token  SetupToken
+   engine DBEngine}
   (let [engine           (keyword engine)
         details          (assoc details :engine engine)
         response-invalid (fn [field m] {:status 400 :body (if (= :general field)

--- a/src/metabase/api/slack.clj
+++ b/src/metabase/api/slack.clj
@@ -1,16 +1,18 @@
 (ns metabase.api.slack
   "/api/slack endpoints"
   (:require [compojure.core :refer [PUT]]
+            [schema.core :as s]
             [metabase.api.common :refer :all]
             [metabase.config :as config]
             [metabase.integrations.slack :as slack]
-            [metabase.models.setting :as setting]))
+            [metabase.models.setting :as setting]
+            [metabase.util.schema :as su]))
 
 (defendpoint PUT "/settings"
   "Update Slack related settings. You must be a superuser to do this."
   [:as {{slack-token :slack-token, metabot-enabled :metabot-enabled, :as slack-settings} :body}]
-  {slack-token     [NonEmptyString]
-   metabot-enabled [Required]}
+  {slack-token     (s/maybe su/NonBlankString)
+   metabot-enabled s/Bool}
   (check-superuser)
   (if-not slack-token
     (setting/set-many! {:slack-token nil, :metabot-enabled false})

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -1,12 +1,14 @@
 (ns metabase.api.user
   (:require [cemerick.friend.credentials :as creds]
             [compojure.core :refer [defroutes GET DELETE POST PUT]]
+            [schema.core :as s]
             [metabase.api.common :refer :all]
             [metabase.api.session :as session-api]
             [metabase.db :as db]
             [metabase.email.messages :as email]
             [metabase.models.user :refer [User create-user! set-user-password! set-user-password-reset-token! form-password-reset-url]]
-            [metabase.util :as u]))
+            [metabase.util :as u]
+            [metabase.util.schema :as su]))
 
 (defn- check-self-or-superuser
   "Check that USER-ID is `*current-user-id*` or that `*current-user*` is a superuser, or throw a 403."
@@ -20,7 +22,7 @@
   []
   (db/select [User :id :first_name :last_name :email :is_superuser :google_auth :last_login], :is_active true))
 
-(defn- reäctivate-user! [existing-user first-name last-name]
+(defn- reactivate-user! [existing-user first-name last-name]
   (when-not (:is_active existing-user)
     (db/update! User (u/get-id existing-user)
       :first_name    first-name
@@ -37,13 +39,13 @@
 (defendpoint POST "/"
   "Create a new `User`, or or reäctivate an existing one."
   [:as {{:keys [first_name last_name email password]} :body}]
-  {first_name [Required NonEmptyString]
-   last_name  [Required NonEmptyString]
-   email      [Required Email]}
+  {first_name su/NonBlankString
+   last_name  su/NonBlankString
+   email      su/Email}
   (check-superuser)
   (if-let [existing-user (db/select-one [User :id :is_active :google_auth], :email email)]
     ;; this user already exists but is inactive, so simply reactivate the account
-    (reäctivate-user! existing-user first_name last_name)
+    (reactivate-user! existing-user first_name last_name)
     ;; new user account, so create it
     (create-user! first_name last_name email, :password password, :send-welcome true, :invitor @*current-user*)))
 
@@ -64,9 +66,9 @@
 (defendpoint PUT "/:id"
   "Update a `User`."
   [id :as {{:keys [email first_name last_name is_superuser]} :body}]
-  {email      [Required Email]
-   first_name NonEmptyString
-   last_name  NonEmptyString}
+  {email      su/Email
+   first_name (s/maybe su/NonBlankString)
+   last_name  (s/maybe su/NonBlankString)}
   (check-self-or-superuser id)
   (check-404 (db/exists? User, :id id, :is_active true))            ; only allow updates if the specified account is active
   (check-400 (not (db/exists? User, :email email, :id [:not= id]))) ; can't change email if it's already taken BY ANOTHER ACCOUNT
@@ -82,7 +84,7 @@
 (defendpoint PUT "/:id/password"
   "Update a user's password."
   [id :as {{:keys [password old_password]} :body}]
-  {password     [Required ComplexPassword]}
+  {password su/ComplexPassword}
   (check-self-or-superuser id)
   (let-404 [user (db/select-one [User :password_salt :password], :id id, :is_active true)]
     (when (and (not (:is_superuser @*current-user*))

--- a/src/metabase/api/util.clj
+++ b/src/metabase/api/util.clj
@@ -1,14 +1,13 @@
 (ns metabase.api.util
   (:require [compojure.core :refer [defroutes GET POST]]
             [metabase.api.common :refer :all]
-            [metabase.logger :as logger]))
-
+            [metabase.logger :as logger]
+            [metabase.util.schema :as su]))
 
 (defendpoint POST "/password_check"
   "Endpoint that checks if the supplied password meets the currently configured password complexity rules."
   [:as {{:keys [password]} :body}]
-  {password [Required ComplexPassword]}
-  ;; checking happens in the
+  {password su/ComplexPassword} ;; if we pass the su/ComplexPassword test we're g2g
   {:valid true})
 
 (defendpoint GET "/logs"

--- a/src/metabase/cmd/endpoint_dox.clj
+++ b/src/metabase/cmd/endpoint_dox.clj
@@ -1,0 +1,26 @@
+(ns metabase.cmd.endpoint-dox
+  "Implementation for the `api-documentation` command, which generate"
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [metabase.config :as config]
+            [metabase.util :as u]))
+
+
+(defn- dox
+  "Generate a Markdown string containing documentation for all Metabase API endpoints."
+  []
+  (str "# API Documentation for Metabase "
+       (config/mb-version-info :tag)
+       "\n\n"
+       (str/join "\n\n\n" (for [ns-symb     @u/metabase-namespace-symbols
+                                :when       (.startsWith (name ns-symb) "metabase.api.")
+                                [symb varr] (do (require ns-symb)
+                                                (sort (ns-interns ns-symb)))
+                                :when       (:is-endpoint? (meta varr))]
+                            (:doc (meta varr))))))
+
+(defn generate-dox!
+  "Write markdown file containing documentation for all the API endpoints to `docs/api-documentation.md`."
+  []
+  (spit (io/file "docs/api-documentation.md") (dox))
+  (println "Documentation generated at docs/api-documentation.md."))

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -252,6 +252,13 @@
   (println "Language:" (System/getProperty "user.language"))
   (println "File encoding:" (System/getProperty "file.encoding")))
 
+(defn ^:command api-documentation
+  "Generate a markdown file containing documentation for all API endpoints. This is written to a file called `docs/api-documentation.md`."
+  []
+  (require 'metabase.cmd.endpoint-dox)
+  ((resolve 'metabase.cmd.endpoint-dox/generate-dox!)))
+
+
 (defn- cmd->fn [command-name]
   (or (when (seq command-name)
         (when-let [varr (ns-resolve 'metabase.core (symbol command-name))]

--- a/src/metabase/events.clj
+++ b/src/metabase/events.clj
@@ -53,6 +53,7 @@
    Expects a map as input and the map must have a `:topic` key."
   (async/pub events-channel :topic))
 
+;; TODO - this should be named `publish-event!`
 (defn publish-event
   "Publish an item into the events stream.
   Returns the published item to allow for chaining."

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -168,7 +168,7 @@
   {:pre [(string? pulse-name)
          (integer? creator-id)
          (sequential? card-ids)
-         (> (count card-ids) 0)
+         (seq card-ids)
          (every? integer? card-ids)
          (coll? channels)
          (every? map? channels)]}

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -705,11 +705,10 @@
     (s/replace (str k) #"^:" "")))
 
 (defn get-id
-  "Return the value of `:id` if OBJECT-OR-ID is a map, or otherwise return OBJECT-OR-ID as-is.
-   This is provided as a convenience to allow model-layer functions to easily accept either an object or raw ID.
-   This is guaranteed to return an integer ID; it will throw an Exception if it cannot find one."
+  "Return the value of `:id` if OBJECT-OR-ID is a map, or otherwise return OBJECT-OR-ID as-is if it is an integer.
+   This is guaranteed to return an integer ID; it will throw an Exception if it cannot find one.
+   This is provided as a convenience to allow model-layer functions to easily accept either an object or raw ID."
   ;; TODO - lots of functions can be rewritten to use this, which would make them more flexible
-  ;; TODO - should we allow a default option, or make a variation of this function that won't throw an Exception?
   ^Integer [object-or-id]
   (cond
     (map? object-or-id)     (recur (:id object-or-id))

--- a/src/metabase/util/schema.clj
+++ b/src/metabase/util/schema.clj
@@ -1,22 +1,117 @@
 (ns metabase.util.schema
   "Various schemas that are useful throughout the app."
   (:require [clojure.string :as str]
+            [cheshire.core :as json]
             [schema.core :as s]
             metabase.types
-            [metabase.util :as u]))
+            [metabase.util :as u]
+            [metabase.util.password :as password]))
+
+(defn with-api-error-message
+  "Return SCHEMA with an additional API-ERROR-MESSAGE that will be used to explain the error if a parameter fails validation."
+  {:style/indent 1}
+  [schema api-error-message]
+  {:pre [(map? schema)]}
+  (assoc schema :api-error-message api-error-message))
+
+(def ^:private existing-schema->api-error-message
+  "Error messages for various schemas already defined in `schema.core`.
+   These are used as a fallback by API param validation if no value for `:api-error-message` is present."
+  {s/Int  "value must be an integer."
+   s/Str  "value must be a string."
+   s/Bool "value must be a boolean."})
+
+(defn api-error-message
+  "Extract the API error messages attached to a schema, if any.
+   This functionality is fairly sophisticated:
+
+    (api-error-message (s/maybe (non-empty [NonBlankString])))
+    ;; -> \"value may be nil, or if non-nil, value must be an array. Each value must be a non-blank string. The array cannot be empty.\""
+  [schema]
+  (or (:api-error-message schema)
+      (existing-schema->api-error-message schema)
+      ;; for schemas wrapped by an `s/maybe` we can generate a nice error message like "value may be nil, or if non-nil, value must be ..."
+      (when (instance? schema.core.Maybe schema)
+        (when-let [message (api-error-message (:schema schema))]
+          (str "value may be nil, or if non-nil, " message)))
+      ;; we can do something similar for enum schemas which are also likely to be defined inline
+      (when (instance? schema.core.EnumSchema schema)
+        (format "value must be one of: %s." (str/join ", " (for [v (sort (:vs schema))]
+                                                             (str "`" v "`")))))
+      ;; do the same for sequences of a schema
+      (when (vector? schema)
+        (str "value must be an array." (when (= (count schema) 1)
+                                         (when-let [message (:api-error-message (first schema))]
+                                           (str " Each " message)))))))
+
+
+(defn non-empty
+  "Add an addditonal constraint to SCHEMA (presumably an array) that requires it to be non-empty (i.e., it must satisfy `seq`)."
+  [schema]
+  (with-api-error-message (s/constrained schema seq "Non-empty")
+    (str (api-error-message schema) " The array cannot be empty.")))
+
+;;; ------------------------------------------------------------ Util Schemas ------------------------------------------------------------
 
 (def NonBlankString
   "Schema for a string that cannot be blank."
-  (s/constrained s/Str (complement str/blank?) "Non-blank string"))
+  (with-api-error-message (s/constrained s/Str (complement str/blank?) "Non-blank string")
+    "value must be a non-blank string."))
 
 (def IntGreaterThanZero
   "Schema representing an integer than must also be greater than zero."
-  (s/constrained s/Int (partial < 0) "Integer greater than zero"))
+  (with-api-error-message
+      (s/constrained s/Int (partial < 0) "Integer greater than zero")
+    "value must be an integer greater than zero."))
 
 (def KeywordOrString
   "Schema for something that can be either a `Keyword` or a `String`."
   (s/named (s/cond-pre s/Keyword s/Str) "Keyword or string"))
 
 (def FieldType
-  "Is this a valid Field type (does it derive from `:type/*`?"
-  (s/pred (u/rpartial isa? :type/*) "Valid type"))
+  "Schema for a valid Field type (does it derive from `:type/*`?"
+  (with-api-error-message (s/pred (u/rpartial isa? :type/*) "Valid field type")
+    "value must be a valid field type."))
+
+(def Map
+  "Schema for a valid map."
+  (with-api-error-message (s/pred map? "Valid map")
+    "value must be a map."))
+
+(def Email
+  "Schema for a valid email string."
+  (with-api-error-message (s/constrained s/Str u/is-email? "Valid email address")
+    "value must be a valid email address."))
+
+(def ComplexPassword
+  "Schema for a valid password of sufficient complexity."
+  (with-api-error-message (s/constrained s/Str password/is-complex?)
+    "Insufficient password strength"))
+
+(def IntegerString
+  "Schema for a string that can be parsed as an integer.
+   Something that adheres to this schema is guaranteed to to work with `Integer/parseInt`."
+  (with-api-error-message (s/constrained s/Str #(u/ignore-exceptions (Integer/parseInt %)))
+    "value must be a valid integer."))
+
+(def IntegerStringGreaterThanZero
+  "Schema for a string that can be parsed as an integer, and is greater than zero.
+   Something that adheres to this schema is guaranteed to to work with `Integer/parseInt`."
+  (with-api-error-message (s/constrained s/Str #(u/ignore-exceptions (< 0 (Integer/parseInt %))))
+    "value must be a valid integer greater than zero."))
+
+(defn- boolean-string? ^Boolean [s]
+  (boolean (when (string? s)
+             (let [s (str/lower-case s)]
+               (contains? #{"true" "false"} s)))))
+
+(def BooleanString
+  "Schema for a string that is a valid representation of a boolean (either `true` or `false`).
+   Something that adheres to this schema is guaranteed to to work with `Boolean/parseBoolean`."
+  (with-api-error-message (s/constrained s/Str boolean-string?)
+    "value must be a valid boolean (true or false)."))
+
+(def JSONString
+  "Schema for a string that is valid serialized JSON."
+  (with-api-error-message (s/constrained s/Str #(u/ignore-exceptions (json/parse-string %)))
+    "value must be a valid JSON string."))

--- a/test/metabase/api/metric_test.clj
+++ b/test/metabase/api/metric_test.clj
@@ -51,21 +51,21 @@
                                              :definition {}}))
 
 ;; test validations
-(expect {:errors {:name "field is a required param."}}
+(expect {:errors {:name "value must be a non-blank string."}}
   ((user->client :crowberto) :post 400 "metric" {}))
 
-(expect {:errors {:table_id "field is a required param."}}
+(expect {:errors {:table_id "value must be an integer greater than zero."}}
   ((user->client :crowberto) :post 400 "metric" {:name "abc"}))
 
-(expect {:errors {:table_id "Invalid value 'foobar' for 'table_id': value must be an integer."}}
+(expect {:errors {:table_id "value must be an integer greater than zero."}}
   ((user->client :crowberto) :post 400 "metric" {:name     "abc"
                                                  :table_id "foobar"}))
 
-(expect {:errors {:definition "field is a required param."}}
+(expect {:errors {:definition "value must be a map."}}
   ((user->client :crowberto) :post 400 "metric" {:name     "abc"
                                                  :table_id 123}))
 
-(expect {:errors {:definition "Invalid value 'foobar' for 'definition': value must be a dictionary."}}
+(expect {:errors {:definition "value must be a map."}}
   ((user->client :crowberto) :post 400 "metric" {:name       "abc"
                                                  :table_id   123
                                                  :definition "foobar"}))
@@ -106,21 +106,21 @@
                                               :revision_message "something different"}))
 
 ;; test validations
-(expect {:errors {:name "field is a required param."}}
+(expect {:errors {:name "value must be a non-blank string."}}
   ((user->client :crowberto) :put 400 "metric/1" {}))
 
-(expect {:errors {:revision_message "field is a required param."}}
+(expect {:errors {:revision_message "value must be a non-blank string."}}
   ((user->client :crowberto) :put 400 "metric/1" {:name "abc"}))
 
-(expect {:errors {:revision_message "Invalid value '' for 'revision_message': value must be a non-empty string."}}
+(expect {:errors {:revision_message "value must be a non-blank string."}}
   ((user->client :crowberto) :put 400 "metric/1" {:name             "abc"
                                                    :revision_message ""}))
 
-(expect {:errors {:definition "field is a required param."}}
+(expect {:errors {:definition "value must be a map."}}
   ((user->client :crowberto) :put 400 "metric/1" {:name             "abc"
                                                    :revision_message "123"}))
 
-(expect {:errors {:definition "Invalid value 'foobar' for 'definition': value must be a dictionary."}}
+(expect {:errors {:definition "value must be a map."}}
   ((user->client :crowberto) :put 400 "metric/1" {:name             "abc"
                                                    :revision_message "123"
                                                    :definition       "foobar"}))
@@ -163,10 +163,10 @@
 
 
 ;; test validations
-(expect {:errors {:revision_message "field is a required param."}}
+(expect {:errors {:revision_message "value must be a non-blank string."}}
   ((user->client :crowberto) :delete 400 "metric/1" {:name "abc"}))
 
-(expect {:errors {:revision_message "Invalid value '' for 'revision_message': value must be a non-empty string."}}
+(expect {:errors {:revision_message "value must be a non-blank string."}}
   ((user->client :crowberto) :delete 400 "metric/1" :revision_message ""))
 
 (expect
@@ -274,10 +274,10 @@
   ((user->client :rasta) :post 403 "metric/1/revert" {:revision_id 56}))
 
 
-(expect {:errors {:revision_id "field is a required param."}}
+(expect {:errors {:revision_id "value must be an integer greater than zero."}}
   ((user->client :crowberto) :post 400 "metric/1/revert" {}))
 
-(expect {:errors {:revision_id "Invalid value 'foobar' for 'revision_id': value must be an integer."}}
+(expect {:errors {:revision_id "value must be an integer greater than zero."}}
   ((user->client :crowberto) :post 400 "metric/1/revert" {:revision_id "foobar"}))
 
 

--- a/test/metabase/api/pulse_test.clj
+++ b/test/metabase/api/pulse_test.clj
@@ -52,30 +52,30 @@
 
 ;; ## POST /api/pulse
 
-(expect {:errors {:name "field is a required param."}}
+(expect {:errors {:name "value must be a non-blank string."}}
   ((user->client :rasta) :post 400 "pulse" {}))
 
-(expect {:errors {:cards "field is a required param."}}
+(expect {:errors {:cards "value must be an array. Each value must be a map. The array cannot be empty."}}
   ((user->client :rasta) :post 400 "pulse" {:name "abc"}))
 
-(expect {:errors {:cards "Invalid value 'foobar' for 'cards': value must be an array."}}
+(expect {:errors {:cards "value must be an array. Each value must be a map. The array cannot be empty."}}
   ((user->client :rasta) :post 400 "pulse" {:name  "abc"
                                             :cards "foobar"}))
 
-(expect {:errors {:cards "Invalid value 'abc' for 'cards': array value must be a map."}}
+(expect {:errors {:cards "value must be an array. Each value must be a map. The array cannot be empty."}}
   ((user->client :rasta) :post 400 "pulse" {:name  "abc"
                                             :cards ["abc"]}))
 
-(expect {:errors {:channels "field is a required param."}}
+(expect {:errors {:channels "value must be an array. Each value must be a map. The array cannot be empty."}}
   ((user->client :rasta) :post 400 "pulse" {:name "abc"
                                             :cards [{:id 100} {:id 200}]}))
 
-(expect {:errors {:channels "Invalid value 'foobar' for 'channels': value must be an array."}}
+(expect {:errors {:channels "value must be an array. Each value must be a map. The array cannot be empty."}}
   ((user->client :rasta) :post 400 "pulse" {:name    "abc"
                                             :cards   [{:id 100} {:id 200}]
                                             :channels "foobar"}))
 
-(expect {:errors {:channels "Invalid value 'abc' for 'channels': array value must be a map."}}
+(expect {:errors {:channels "value must be an array. Each value must be a map. The array cannot be empty."}}
   ((user->client :rasta) :post 400 "pulse" {:name     "abc"
                                             :cards    [{:id 100} {:id 200}]
                                             :channels ["abc"]}))
@@ -112,30 +112,30 @@
 
 ;; ## PUT /api/pulse
 
-(expect {:errors {:name "field is a required param."}}
+(expect {:errors {:name "value must be a non-blank string."}}
   ((user->client :rasta) :put 400 "pulse/1" {}))
 
-(expect {:errors {:cards "field is a required param."}}
+(expect {:errors {:cards "value must be an array. Each value must be a map. The array cannot be empty."}}
   ((user->client :rasta) :put 400 "pulse/1" {:name "abc"}))
 
-(expect {:errors {:cards "Invalid value 'foobar' for 'cards': value must be an array."}}
+(expect {:errors {:cards "value must be an array. Each value must be a map. The array cannot be empty."}}
   ((user->client :rasta) :put 400 "pulse/1" {:name  "abc"
                                              :cards "foobar"}))
 
-(expect {:errors {:cards "Invalid value 'abc' for 'cards': array value must be a map."}}
+(expect {:errors {:cards "value must be an array. Each value must be a map. The array cannot be empty."}}
   ((user->client :rasta) :put 400 "pulse/1" {:name  "abc"
                                              :cards ["abc"]}))
 
-(expect {:errors {:channels "field is a required param."}}
+(expect {:errors {:channels "value must be an array. Each value must be a map. The array cannot be empty."}}
   ((user->client :rasta) :put 400 "pulse/1" {:name "abc"
                                              :cards [{:id 100} {:id 200}]}))
 
-(expect {:errors {:channels "Invalid value 'foobar' for 'channels': value must be an array."}}
+(expect {:errors {:channels "value must be an array. Each value must be a map. The array cannot be empty."}}
   ((user->client :rasta) :put 400 "pulse/1" {:name    "abc"
                                              :cards   [{:id 100} {:id 200}]
                                              :channels "foobar"}))
 
-(expect {:errors {:channels "Invalid value 'abc' for 'channels': array value must be a map."}}
+(expect {:errors {:channels "value must be an array. Each value must be a map. The array cannot be empty."}}
   ((user->client :rasta) :put 400 "pulse/1" {:name     "abc"
                                              :cards    [{:id 100} {:id 200}]
                                              :channels ["abc"]}))

--- a/test/metabase/api/segment_test.clj
+++ b/test/metabase/api/segment_test.clj
@@ -52,21 +52,21 @@
                                               :definition {}}))
 
 ;; test validations
-(expect {:errors {:name "field is a required param."}}
+(expect {:errors {:name "value must be a non-blank string."}}
   ((user->client :crowberto) :post 400 "segment" {}))
 
-(expect {:errors {:table_id "field is a required param."}}
+(expect {:errors {:table_id "value must be an integer greater than zero."}}
   ((user->client :crowberto) :post 400 "segment" {:name "abc"}))
 
-(expect {:errors {:table_id "Invalid value 'foobar' for 'table_id': value must be an integer."}}
+(expect {:errors {:table_id "value must be an integer greater than zero."}}
   ((user->client :crowberto) :post 400 "segment" {:name     "abc"
                                                   :table_id "foobar"}))
 
-(expect {:errors {:definition "field is a required param."}}
+(expect {:errors {:definition "value must be a map."}}
   ((user->client :crowberto) :post 400 "segment" {:name     "abc"
                                                   :table_id 123}))
 
-(expect {:errors {:definition "Invalid value 'foobar' for 'definition': value must be a dictionary."}}
+(expect {:errors {:definition "value must be a map."}}
   ((user->client :crowberto) :post 400 "segment" {:name       "abc"
                                                   :table_id   123
                                                   :definition "foobar"}))
@@ -105,21 +105,21 @@
                                                :revision_message "something different"}))
 
 ;; test validations
-(expect {:errors {:name "field is a required param."}}
+(expect {:errors {:name "value must be a non-blank string."}}
   ((user->client :crowberto) :put 400 "segment/1" {}))
 
-(expect {:errors {:revision_message "field is a required param."}}
+(expect {:errors {:revision_message "value must be a non-blank string."}}
   ((user->client :crowberto) :put 400 "segment/1" {:name "abc"}))
 
-(expect {:errors {:revision_message "Invalid value '' for 'revision_message': value must be a non-empty string."}}
+(expect {:errors {:revision_message "value must be a non-blank string."}}
   ((user->client :crowberto) :put 400 "segment/1" {:name             "abc"
                                                    :revision_message ""}))
 
-(expect {:errors {:definition "field is a required param."}}
+(expect {:errors {:definition "value must be a map."}}
   ((user->client :crowberto) :put 400 "segment/1" {:name             "abc"
                                                    :revision_message "123"}))
 
-(expect {:errors {:definition "Invalid value 'foobar' for 'definition': value must be a dictionary."}}
+(expect {:errors {:definition "value must be a map."}}
   ((user->client :crowberto) :put 400 "segment/1" {:name             "abc"
                                                    :revision_message "123"
                                                    :definition       "foobar"}))
@@ -160,10 +160,10 @@
 
 
 ;; test validations
-(expect {:errors {:revision_message "field is a required param."}}
+(expect {:errors {:revision_message "value must be a non-blank string."}}
   ((user->client :crowberto) :delete 400 "segment/1" {:name "abc"}))
 
-(expect {:errors {:revision_message "Invalid value '' for 'revision_message': value must be a non-empty string."}}
+(expect {:errors {:revision_message "value must be a non-blank string."}}
   ((user->client :crowberto) :delete 400 "segment/1" :revision_message ""))
 
 (expect
@@ -266,10 +266,10 @@
   ((user->client :rasta) :post 403 "segment/1/revert" {:revision_id 56}))
 
 
-(expect {:errors {:revision_id "field is a required param."}}
+(expect {:errors {:revision_id "value must be an integer greater than zero."}}
   ((user->client :crowberto) :post 400 "segment/1/revert" {}))
 
-(expect {:errors {:revision_id "Invalid value 'foobar' for 'revision_id': value must be an integer."}}
+(expect {:errors {:revision_id "value must be an integer greater than zero."}}
   ((user->client :crowberto) :post 400 "segment/1/revert" {:revision_id "foobar"}))
 
 

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -21,10 +21,10 @@
       (tu/is-uuid-string? (:id (client :post 200 "session" (user->credentials :rasta))))))
 
 ;; Test for required params
-(expect {:errors {:email "field is a required param."}}
+(expect {:errors {:email "value must be a valid email address."}}
   (client :post 400 "session" {}))
 
-(expect {:errors {:password "field is a required param."}}
+(expect {:errors {:password "value must be a non-blank string."}}
   (client :post 400 "session" {:email "anything@metabase.com"}))
 
 ;; Test for inactive user (user shouldn't be able to login if :is_active = false)
@@ -76,7 +76,7 @@
     (reset-fields-set?)))
 
 ;; Test that email is required
-(expect {:errors {:email "field is a required param."}}
+(expect {:errors {:email "value must be a valid email address."}}
   (client :post 400 "session/forgot_password" {}))
 
 ;; Test that email not found also gives 200 as to not leak existence of user
@@ -125,10 +125,10 @@
           (update :session_id tu/is-uuid-string?)))))
 
 ;; Test that token and password are required
-(expect {:errors {:token "field is a required param."}}
+(expect {:errors {:token "value must be a non-blank string."}}
   (client :post 400 "session/reset_password" {}))
 
-(expect {:errors {:password "field is a required param."}}
+(expect {:errors {:password "Insufficient password strength"}}
   (client :post 400 "session/reset_password" {:token "anything"}))
 
 ;; Test that malformed token returns 400

--- a/test/metabase/api/setup_test.clj
+++ b/test/metabase/api/setup_test.clj
@@ -33,31 +33,31 @@
 
 
 ;; Test input validations
-(expect {:errors {:token "field is a required param."}}
+(expect {:errors {:token "Token does not match the setup token."}}
   (http/client :post 400 "setup" {}))
 
-(expect {:errors {:token "Invalid value 'foobar' for 'token': Token does not match the setup token."}}
+(expect {:errors {:token "Token does not match the setup token."}}
   (http/client :post 400 "setup" {:token "foobar"}))
 
-(expect {:errors {:site_name "field is a required param."}}
+(expect {:errors {:site_name "value must be a non-blank string."}}
   (http/client :post 400 "setup" {:token (setup/token-value)}))
 
-(expect {:errors {:first_name "field is a required param."}}
+(expect {:errors {:first_name "value must be a non-blank string."}}
   (http/client :post 400 "setup" {:token (setup/token-value)
                                   :prefs {:site_name "awesomesauce"}}))
 
-(expect {:errors {:last_name "field is a required param."}}
+(expect {:errors {:last_name "value must be a non-blank string."}}
   (http/client :post 400 "setup" {:token (setup/token-value)
                                   :prefs {:site_name "awesomesauce"}
                                   :user {:first_name "anything"}}))
 
-(expect {:errors {:email "field is a required param."}}
+(expect {:errors {:email "value must be a valid email address."}}
   (http/client :post 400 "setup" {:token (setup/token-value)
                                   :prefs {:site_name "awesomesauce"}
                                   :user {:first_name "anything"
                                          :last_name "anything"}}))
 
-(expect {:errors {:password "field is a required param."}}
+(expect {:errors {:password "Insufficient password strength"}}
   (http/client :post 400 "setup" {:token (setup/token-value)
                                   :prefs {:site_name "awesomesauce"}
                                   :user {:first_name "anything"
@@ -65,7 +65,7 @@
                                          :email "anything@metabase.com"}}))
 
 ;; valid email + complex password
-(expect {:errors {:email "Invalid value 'anything' for 'email': Not a valid email address."}}
+(expect {:errors {:email "value must be a valid email address."}}
   (http/client :post 400 "setup" {:token (setup/token-value)
                                   :prefs {:site_name "awesomesauce"}
                                   :user {:token "anything"
@@ -85,11 +85,11 @@
 
 
 ;; ## POST /api/setup/validate
-(expect {:errors {:token "field is a required param."}}
+(expect {:errors {:token "Token does not match the setup token."}}
   (http/client :post 400 "setup/validate" {}))
 
-(expect {:errors {:token "Invalid value 'foobar' for 'token': Token does not match the setup token."}}
+(expect {:errors {:token "Token does not match the setup token."}}
   (http/client :post 400 "setup/validate" {:token "foobar"}))
 
-(expect {:errors {:engine "field is a required param."}}
+(expect {:errors {:engine "value must be a valid database engine."}}
   (http/client :post 400 "setup/validate" {:token (setup/token-value)}))

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -97,20 +97,20 @@
 
 ;; Test input validations
 (expect
-  {:errors {:first_name "field is a required param."}}
+  {:errors {:first_name "value must be a non-blank string."}}
   ((user->client :crowberto) :post 400 "user" {}))
 
 (expect
-  {:errors {:last_name "field is a required param."}}
+  {:errors {:last_name "value must be a non-blank string."}}
   ((user->client :crowberto) :post 400 "user" {:first_name "whatever"}))
 
 (expect
-  {:errors {:email "field is a required param."}}
+  {:errors {:email "value must be a valid email address."}}
   ((user->client :crowberto) :post 400 "user" {:first_name "whatever"
                                                :last_name  "whatever"}))
 
 (expect
-  {:errors {:email "Invalid value 'whatever' for 'email': Not a valid email address."}}
+  {:errors {:email "value must be a valid email address."}}
   ((user->client :crowberto) :post 400 "user" {:first_name "whatever"
                                                :last_name  "whatever"
                                                :email      "whatever"}))
@@ -227,7 +227,7 @@
 
 ;; Test input validations on password change
 (expect
-  {:errors {:password "field is a required param."}}
+  {:errors {:password "Insufficient password strength"}}
   ((user->client :rasta) :put 400 (format "user/%d/password" (user->id :rasta)) {}))
 
 ;; Make sure that if current password doesn't match we get a 400

--- a/test/metabase/api/util_test.clj
+++ b/test/metabase/api/util_test.clj
@@ -7,7 +7,7 @@
 ;; ## POST /api/util/password_check
 
 ;; Test for required params
-(expect {:errors {:password "field is a required param."}}
+(expect {:errors {:password "Insufficient password strength"}}
   (client :post 400 "util/password_check" {}))
 
 ;; Test complexity check


### PR DESCRIPTION
Remove the somewhat-opaque "annotation" framework I hand-rolled for validating and parsing API endpoint params and just use [schema](https://github.com/plumatic/schema) since that's what we're using everywhere else. This code was one of the first parts of Metabase I wrote (close to 2 years old at this point :scream_cat:) and something I've been wanting to clean up for a long time.

The new API param validation logic should be a bit easier to understand, which should lower the barrier to entry a bit. I've also managed to tweak it to give us better error messages when you pass an invalid param and better auto-generated documentation.

While I was testing out the new documentation I went ahead and added a command to generate documentation for all the API endpoints: 

``` bash
lein run api-documentation
# or
java -jar metabase.jar api-documentation
```

This generates a pretty cool new [`api-documentation.md`](https://github.com/metabase/metabase/blob/0b0fcb70d6dea972c92f61e327b7f5c9ad678767/docs/api-documentation.md) file:

![screen shot 2016-10-18 at 10 42 02 pm](https://cloud.githubusercontent.com/assets/1455846/19506909/20e991da-9584-11e6-811e-3fcff228b9cf.png)

Docs aren't perfect, but a lot better than what we used to have.

Fixes #2689, #3223
