### PR TITLE
Change H2 filename suffix in documentation

### DIFF
--- a/docs/operations-guide/running-the-metabase-mac-app.md
+++ b/docs/operations-guide/running-the-metabase-mac-app.md
@@ -28,6 +28,6 @@ Now that you’ve installed Metabase, it’s time to [set it up and connect it t
 ### The application database
 
 The application database lives on your filesystem, at 
-`~/Library/Application Support/Metabase/metabase.db.h2.db`
+`~/Library/Application Support/Metabase/metabase.db.mv.db`
 
 If you want to delete it, back it up, or replace it with an old backup, shut down the application and then delete, copy or replace the file.

--- a/docs/operations-guide/running-the-metabase-mac-app.md
+++ b/docs/operations-guide/running-the-metabase-mac-app.md
@@ -28,6 +28,9 @@ Now that you’ve installed Metabase, it’s time to [set it up and connect it t
 ### The application database
 
 The application database lives on your filesystem, at 
-`~/Library/Application Support/Metabase/metabase.db.mv.db`
+`~/Library/Application Support/Metabase/metabase.db.h2.db`
 
 If you want to delete it, back it up, or replace it with an old backup, shut down the application and then delete, copy or replace the file.
+
+Note: depending on when you first started using Metabase the file may be called
+`~/Library/Application Support/Metabase/metabase.db.mv.db`

--- a/docs/operations-guide/start.md
+++ b/docs/operations-guide/start.md
@@ -96,7 +96,7 @@ You can see these database files from the terminal:
 
 You should see the following files:
 
-    metabase.db.h2.db
+    metabase.db.mv.db
     metabase.db.trace.db
 
 If for any reason you want to use an H2 database file in a separate location from where you launch Metabase you can do so using an environment variable.  For example:
@@ -206,7 +206,7 @@ If you are using Metabase in a production environment or simply want to make sur
 Metabase uses a single SQL database for all of its runtime application data, so all you need to do is backup that database and you're good to go.  From a database back-up you can restore any Metabase installation.
 
 ### H2 Embedded Database (default)
-If you launched Metabase on a laptop or PC the application will create an embedded H2 database in the directory it is being run in.  Navigate to the directory where you started Metabase from and find the file named `metabase.db.h2.db`.  Simply copy that file somewhere safe and you are all backed up!
+If you launched Metabase on a laptop or PC the application will create an embedded H2 database in the directory it is being run in.  Navigate to the directory where you started Metabase from and find the file named `metabase.db.mv.db`.  Simply copy that file somewhere safe and you are all backed up!
 
 NOTE: If your Metabase is currently running it's best to shut down the Metabase process before making a backup copy of the file.  Then, restart the application.
 

--- a/docs/operations-guide/start.md
+++ b/docs/operations-guide/start.md
@@ -96,7 +96,7 @@ You can see these database files from the terminal:
 
 You should see the following files:
 
-    metabase.db.mv.db
+    metabase.db.h2.db  # Or metabase.db.mv.db depending on when you first started using Metabase.
     metabase.db.trace.db
 
 If for any reason you want to use an H2 database file in a separate location from where you launch Metabase you can do so using an environment variable.  For example:
@@ -206,7 +206,7 @@ If you are using Metabase in a production environment or simply want to make sur
 Metabase uses a single SQL database for all of its runtime application data, so all you need to do is backup that database and you're good to go.  From a database back-up you can restore any Metabase installation.
 
 ### H2 Embedded Database (default)
-If you launched Metabase on a laptop or PC the application will create an embedded H2 database in the directory it is being run in.  Navigate to the directory where you started Metabase from and find the file named `metabase.db.mv.db`.  Simply copy that file somewhere safe and you are all backed up!
+If you launched Metabase on a laptop or PC the application will create an embedded H2 database in the directory it is being run in.  Navigate to the directory where you started Metabase from and find the file named `metabase.db.h2.db` or `metabase.db.mv.db` (you will see one of the two depending on when you first started using Metabase).  Simply copy that file somewhere safe and you are all backed up!
 
 NOTE: If your Metabase is currently running it's best to shut down the Metabase process before making a backup copy of the file.  Then, restart the application.
 


### PR DESCRIPTION
On Ubuntu 16.04 when running Metabase `0.20.1` and starting with `java -jar metabase.jar` the filename of the local H2 database is now `metabase.db.mv.db`

And when I ran the Mac app it was `~/Library/Application Support/Metabase/metabase.db.mv.db`

Looking at the [H2 changelog](http://www.h2database.com/html/changelog.html) I think the file suffix potentially changed in `1.4.177` when MVStore storage appears to have become the default.
###### TODO
-  [X] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
  (unless it's a tiny documentation change).
