### PR TITLE
Fix CSV Download for SQL queries without write permissions

### DIFF
--- a/frontend/src/metabase/query_builder/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/NativeQueryEditor.jsx
@@ -217,7 +217,7 @@ export default class NativeQueryEditor extends Component {
         let dataSelectors = [];
         if (this.state.showEditor && this.props.nativeDatabases) {
             // we only render a db selector if there are actually multiple to choose from
-            if (this.props.nativeDatabases.length > 1) {
+            if (this.props.nativeDatabases.length > 1 && (this.props.query.database === null || _.any(this.props.nativeDatabases, (db) => db.id === this.props.query.database))) {
                 dataSelectors.push(
                     <div key="db_selector" className="GuiBuilder-section GuiBuilder-data flex align-center">
                         <span className="GuiBuilder-section-label Query-label">Database</span>

--- a/frontend/src/metabase/query_builder/QueryVisualization.jsx
+++ b/frontend/src/metabase/query_builder/QueryVisualization.jsx
@@ -149,6 +149,8 @@ export default class QueryVisualization extends Component {
     renderDownloadButton() {
         const { card, result } = this.props;
 
+        const csvUrl = card.id != null ? `/api/card/${card.id}/query/csv`: "/api/dataset/csv";
+
         if (result && !result.error) {
             if (result && result.data && result.data.rows_truncated) {
                 // this is a "large" dataset, so show a modal to inform users about this and make them click again to d/l
@@ -160,7 +162,7 @@ export default class QueryVisualization extends Component {
                         }}>Download CSV</button>);
                 } else {
                     downloadButton = (
-                        <form ref={(c) => this._downloadCsvForm = c} method="POST" action="/api/dataset/csv">
+                        <form ref={(c) => this._downloadCsvForm = c} method="POST" action={csvUrl}>
                             <input type="hidden" name="query" value="" />
                             <a className="Button Button--primary" onClick={() => {this.onDownloadCSV(); this.refs.downloadModal.toggle();}}>
                                 Download CSV
@@ -200,7 +202,7 @@ export default class QueryVisualization extends Component {
                     );
                 } else {
                     return (
-                        <form ref={(c) => this._downloadCsvForm = c} method="POST" action="/api/dataset/csv">
+                        <form ref={(c) => this._downloadCsvForm = c} method="POST" action={csvUrl}>
                             <input type="hidden" name="query" value="" />
                             <a className="mx1" title="Download this data" onClick={() => this.onDownloadCSV()}>
                                 <Icon name='download' size={16} />

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -262,17 +262,24 @@
 
 ;;; ------------------------------------------------------------ Running a Query ------------------------------------------------------------
 
+(defn- run-query-for-card [card-id parameters]
+  (let [card    (read-check Card card-id)
+        query   (assoc (:dataset_query card)
+                  :parameters  parameters
+                  :constraints dataset-api/query-constraints)
+        options {:executed-by *current-user-id*
+                 :card-id     card-id}]
+    (qp/dataset-query query options)))
+
 (defendpoint POST "/:card-id/query"
   "Run the query associated with a Card."
-  [card-id :as {{:keys [parameters timeout]} :body}]
-  (let [card  (read-check Card card-id)
-        query (assoc (:dataset_query card)
-                :parameters  parameters
-                :constraints dataset-api/query-constraints)]
-    ;; Now run the query!
-    (let [options {:executed-by *current-user-id*
-                   :card-id     card-id}]
-      (qp/dataset-query query options))))
+  [card-id :as {{:keys [parameters]} :body}]
+  (run-query-for-card card-id parameters))
+
+(defendpoint POST "/:card-id/query/csv"
+  "Run the query associated with a Card, and return its results as CSV."
+  [card-id :as {{:keys [parameters]} :body}]
+  (dataset-api/as-csv (run-query-for-card card-id parameters)))
 
 
 (define-routes)

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -292,6 +292,7 @@
 
 ;;; ---------------------------------------- Helper Fns ----------------------------------------
 
+;; TODO - why does this take a PATH when everything else takes PATH-COMPONENTS or IDs?
 (defn delete-related-permissions!
   "Delete all permissions for GROUP-OR-ID for ancestors or descendant objects of object with PATH.
    You can optionally include OTHER-CONDITIONS, which are anded into the filter clause, to further restrict what is deleted."

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -33,7 +33,7 @@
                Card     [{card-2-id :id} {:database_id db-id}]]
     (let [card-returned? (fn [database-id card-id]
                            (contains? (set (for [card ((user->client :rasta) :get 200 "card", :f :database, :model_id database-id)]
-                                             (:id card)))
+                                             (u/get-id card)))
                                       card-id))]
       [(card-returned? (id) card-1-id)
        (card-returned? db-id card-1-id)
@@ -60,7 +60,7 @@
                Card     [{card-2-id :id}   {:table_id table-2-id}]]
     (let [card-returned? (fn [table-id card-id]
                            (contains? (set (for [card ((user->client :rasta) :get 200 "card", :f :table, :model_id table-id)]
-                                             (:id card)))
+                                             (u/get-id card)))
                                       card-id))]
       [(card-returned? table-1-id card-1-id)
        (card-returned? table-2-id card-1-id)
@@ -188,7 +188,7 @@
      :query_type             "query"
      :archived               false
      :labels                 []})
-  ((user->client :rasta) :get 200 (str "card/" (:id card))))
+  ((user->client :rasta) :get 200 (str "card/" (u/get-id card))))
 
 ;; Check that a user without permissions isn't allowed to fetch the card
 (expect-with-temp [Database  [{database-id :id}]
@@ -201,7 +201,7 @@
     ;; revoke permissions for default group to this database
     (perms/delete-related-permissions! (perms-group/all-users) (perms/object-path database-id))
     ;; now a non-admin user shouldn't be able to fetch this card
-    ((user->client :rasta) :get 403 (str "card/" (:id card)))))
+    ((user->client :rasta) :get 403 (str "card/" (u/get-id card)))))
 
 ;; ## PUT /api/card/:id
 
@@ -252,13 +252,13 @@
 
 ;; Helper Functions
 (defn- fave? [card]
-  ((user->client :rasta) :get 200 (format "card/%d/favorite" (:id card))))
+  ((user->client :rasta) :get 200 (format "card/%d/favorite" (u/get-id card))))
 
 (defn- fave! [card]
-  ((user->client :rasta) :post 200 (format "card/%d/favorite" (:id card))))
+  ((user->client :rasta) :post 200 (format "card/%d/favorite" (u/get-id card))))
 
 (defn- unfave! [card]
-  ((user->client :rasta) :delete 204 (format "card/%d/favorite" (:id card))))
+  ((user->client :rasta) :delete 204 (format "card/%d/favorite" (u/get-id card))))
 
 ;; ## GET /api/card/:id/favorite
 ;; Can we see if a Card is a favorite ?
@@ -308,3 +308,35 @@
     [(get-labels)                            ; (1)
      (update-labels [label-1-id label-2-id]) ; (2)
      (update-labels [])]))                   ; (3)
+
+
+;;; POST /api/:card-id/query/csv
+
+(defn- do-with-temp-native-card {:style/indent 0} [f]
+  (with-temp* [Database  [{database-id :id} {:details (:details (Database (id))), :engine :h2}]
+               Table     [{table-id :id}    {:db_id database-id, :name "CATEGORIES"}]
+               Card      [card              {:dataset_query {:database database-id
+                                                             :type     :native
+                                                             :native   {:query "SELECT COUNT(*) FROM CATEGORIES;"}
+                                                             :query    {:source-table table-id, :aggregation {:aggregation-type :count}}}}]]
+    ;; delete all permissions for this DB
+    (perms/delete-related-permissions! (perms-group/all-users) (perms/object-path database-id))
+    (f database-id card)))
+
+;; can someone with native query *read* permissions see a CSV card? (Issue #3648)
+(expect
+  (str "COUNT(*)\n"
+       "75\n")
+  (do-with-temp-native-card
+    (fn [database-id card]
+      ;; insert new permissions for native read access
+      (perms/grant-native-read-permissions! (perms-group/all-users) database-id)
+      ;; now run the query
+      ((user->client :rasta) :post 200 (format "card/%d/query/csv" (u/get-id card))))))
+
+;; does someone without *read* permissions get DENIED?
+(expect
+  "You don't have permissions to do that."
+  (do-with-temp-native-card
+    (fn [database-id card]
+      ((user->client :rasta) :post 403 (format "card/%d/query/csv" (u/get-id card))))))


### PR DESCRIPTION
Partial fix for #3641

This adds a new endpoint, `POST /api/card/:id/query/csv`, that we should use for fetching the CSV results of a Card. (Right now we're fetching CSV results by just passing in the raw query, which means we have know way to know if it's from an existing Card or not.)

We still need to switch the frontend over to use this and add a few tests.
