### PR TITLE
Fix wrong dates in revision history :wrench:

### DIFF
--- a/src/metabase/models/revision.clj
+++ b/src/metabase/models/revision.clj
@@ -60,11 +60,14 @@
 
 (i/defentity Revision :revision)
 
+(defn- pre-insert [revision]
+  (assoc revision :timestamp (u/new-sql-timestamp)))
+
 (u/strict-extend (class Revision)
   i/IEntity
   (merge i/IEntityDefaults
          {:types      (constantly {:object :json, :message :clob})
-          :pre-insert (u/rpartial assoc :timestamp (u/new-sql-timestamp))
+          :pre-insert pre-insert
           :pre-update (fn [& _] (throw (Exception. "You cannot update a Revision!")))}))
 
 


### PR DESCRIPTION
We were incorrectly using `partial`/`rpartial` here which defined the value of `:timestamp` once when the function was created as opposed to creating a new value every time it's called.

Fixes #3643
