### PR TITLE
Fix SQL for :limit clause for old versions of Oracle :wrench: [ci dri…

### DIFF
--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -478,7 +478,7 @@
 
 (defn- format-sql [sql]
   (when sql
-    (loop [sql sql, [k & more] ["FROM" "WHERE" "LEFT JOIN" "INNER JOIN" "ORDER BY" "LIMIT"]]
+    (loop [sql sql, [k & more] ["FROM" "LEFT JOIN" "INNER JOIN" "WHERE" "GROUP BY" "HAVING" "ORDER BY" "OFFSET" "LIMIT"]]
       (if-not k
         sql
         (recur (s/replace sql (re-pattern (format "\\s+%s\\s+" k)) (format "\n%s " k))

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -221,42 +221,31 @@
       (h/limit items)
       (h/offset (* items (dec page)))))
 
-;; TODO - not sure "pprint" is an appropriate name for this since this function doesn't print anything
-(defn pprint-sql
-  "Add newlines to the SQL to make it more readable."
-  [sql]
-  (when sql
-    (-> sql
-        (s/replace #"\sFROM"      "\nFROM")
-        (s/replace #"\sLEFT JOIN" "\nLEFT JOIN")
-        (s/replace #"\sWHERE"     "\nWHERE")
-        (s/replace #"\sGROUP BY"  "\nGROUP BY")
-        (s/replace #"\sORDER BY"  "\nORDER BY")
-        (s/replace #"\sLIMIT"     "\nLIMIT")
-        (s/replace #"\sAND\s"     "\n   AND ")
-        (s/replace #"\sOR\s"      "\n    OR "))))
 
-
-;; TODO - make this a protocol method ?
+;; TODO - is there any reason to make this a protocol method ?
 (defn- apply-source-table [_ honeysql-form {{table-name :name, schema :schema} :source-table}]
   {:pre [table-name]}
   (h/from honeysql-form (hx/qualify-and-escape-dots schema table-name)))
 
 (def ^:private clause-handlers
-  {:aggregation  #'sql/apply-aggregation ; use the vars rather than the functions themselves because them implementation
-   :breakout     #'sql/apply-breakout    ; will get swapped around and  we'll be left with old version of the function that nobody implements
+  ;; 1) Use the vars rather than the functions themselves because them implementation
+  ;;    will get swapped around and  we'll be left with old version of the function that nobody implements
+  ;; 2) This is a vector rather than a map because the order the clauses get handled is important for some drivers.
+  ;;    For example, Oracle needs to wrap the entire query in order to apply its version of limit (`WHERE ROWNUM`).
+  [:source-table apply-source-table
+   :aggregation  #'sql/apply-aggregation
+   :breakout     #'sql/apply-breakout
    :fields       #'sql/apply-fields
    :filter       #'sql/apply-filter
    :join-tables  #'sql/apply-join-tables
-   :limit        #'sql/apply-limit
    :order-by     #'sql/apply-order-by
    :page         #'sql/apply-page
-   :source-table apply-source-table})
+   :limit        #'sql/apply-limit])
 
 (defn- apply-clauses
   "Loop through all the `clause->handler` entries; if the query contains a given clause, apply the handler fn."
   [driver honeysql-form query]
-  (loop [honeysql-form honeysql-form, [[clause f] & more] (seq clause-handlers)]
+  (loop [honeysql-form honeysql-form, [clause f & more] (seq clause-handlers)]
     (let [honeysql-form (if (clause query)
                           (f driver honeysql-form query)
                           honeysql-form)]


### PR DESCRIPTION
Oracle doesn't support `LIMIT` the way Postgres/MySQL/H2/everybody else does. In Oracle 12, you can do:

``` sql
SELECT ... FROM ... OFFSET 0 ROWS FETCH NEXT 2000 ROWS ONLY
```

That doesn't work on older versions of Oracle. Instead you have to do:

``` sql
SELECT ... FROM ... WHERE rownum <= 2000
```

Switch to the second syntax because it works for older versions as well as new ones. Fixes #3568
