### PR TITLE
Update bin/heroku/deploy to use node buildpack branch with yarn support

### DIFF
--- a/bin/heroku/deploy
+++ b/bin/heroku/deploy
@@ -47,7 +47,7 @@ git_remote_ref="refs/heads/master"
 if ! heroku ps -a "$heroku_app_name" > /dev/null; then
     heroku apps:create -n --addons "heroku-postgresql:hobby-dev" "$heroku_app_name"
     heroku buildpacks:clear -a "$heroku_app_name"
-    heroku buildpacks:add "https://github.com/heroku/heroku-buildpack-nodejs" -a "$heroku_app_name"
+    heroku buildpacks:add "https://github.com/heroku/heroku-buildpack-nodejs#yarn" -a "$heroku_app_name"
     heroku buildpacks:add "https://github.com/heroku/heroku-buildpack-clojure" -a "$heroku_app_name"
 fi
 


### PR DESCRIPTION
Resolves #3639 but if Heroku merges the yarn branch we won't need this.
