### PR TITLE
Fix tiles endpoint & add test :wrench:

### DIFF
--- a/src/metabase/util/schema.clj
+++ b/src/metabase/util/schema.clj
@@ -88,6 +88,7 @@
   (with-api-error-message (s/constrained s/Str password/is-complex?)
     "Insufficient password strength"))
 
+;; TODO - maybe rename this to `IntString` so it's consistent with `IntGreaterThanZero`
 (def IntegerString
   "Schema for a string that can be parsed as an integer.
    Something that adheres to this schema is guaranteed to to work with `Integer/parseInt`."

--- a/test/metabase/api/tiles_test.clj
+++ b/test/metabase/api/tiles_test.clj
@@ -1,0 +1,16 @@
+(ns metabase.api.tiles-test
+  "Tests for `/api/tiles` endpoints."
+  (:require [cheshire.core :as json]
+            [expectations :refer :all]
+            [metabase.query-processor.expand :as ql]
+            [metabase.test.data :refer :all]
+            [metabase.test.data.users :refer :all]))
+
+;;; GET /api/tiles/:zoom/:x/:y/:lat-field-id/:lon-field-id/:lat-col-idx/:lon-col-idx/
+(expect
+  String
+  ((user->client :rasta) :get 200 (format "tiles/1/1/1/%d/%d/1/1/" (id :venues :latitude) (id :venues :longitude))
+   :query (json/generate-string {:database (id)
+                                 :type     :query
+                                 :query    (ql/query
+                                             (ql/source-table (id :venues)))})))


### PR DESCRIPTION
Earlier today @tlrobinson pointed out to me that 

```
GET /api/:zoom/:x/:y/:lat-field-id/:lon-field-id/:lat-col-idx/:lon-col-idx/
```

(lol) stopped working since I switched the param validation to use the Schema library. Fixed this (was using the wrong validator) and added our first test for the endpoint

🎉 
