### PR TITLE
Copy list of already-ran data migrations when loading from H2 :wrench:

### DIFF
--- a/src/metabase/cmd/load_from_h2.clj
+++ b/src/metabase/cmd/load_from_h2.clj
@@ -20,6 +20,7 @@
             [medley.core :as m]
             [metabase.config :as config]
             [metabase.db :as db]
+            [metabase.db.migrations :refer [DataMigrations]]
             (metabase.models [activity :refer [Activity]]
                              [card :refer [Card]]
                              [card-favorite :refer [CardFavorite]]
@@ -95,7 +96,8 @@
    PermissionsGroup
    PermissionsGroupMembership
    Permissions
-   PermissionsRevision])
+   PermissionsRevision
+   DataMigrations])
 
 
 (defn- h2-details [h2-connection-string-or-nil]
@@ -177,7 +179,7 @@
 
 (def ^:private entities-without-autoinc-ids
   "Entities that do NOT use an auto incrementing ID column."
-  #{Setting Session})
+  #{Setting Session DataMigrations})
 
 (defn- set-postgres-sequence-values-if-needed!
   "When loading data into a Postgres DB, update the sequence nextvals."

--- a/src/metabase/db/migrations.clj
+++ b/src/metabase/db/migrations.clj
@@ -31,7 +31,7 @@
 
 ;;; # Migration Helpers
 
-(defentity ^:private DataMigrations :data_migrations)
+(defentity DataMigrations :data_migrations)
 
 (defn- run-migration-if-needed!
   "Run migration defined by MIGRATION-VAR if needed.

--- a/test/metabase/cmd/load_from_h2_test.clj
+++ b/test/metabase/cmd/load_from_h2_test.clj
@@ -13,7 +13,8 @@
 
 (defn- all-entity-names []
   (set (for [ns       (ns-find/find-namespaces (classpath/classpath))
-             :when    (re-find #"^metabase\.models\." (name ns))
+             :when    (or (re-find #"^metabase\.models\." (name ns))
+                          (= (name ns) "metabase.db.migrations"))
              :when    (not (re-find #"test" (name ns)))
              [_ varr] (do (require ns)
                           (ns-interns ns))
@@ -22,5 +23,5 @@
          (:name entity))))
 
 (expect
-  (migrated-entity-names)
-  (all-entity-names))
+  (all-entity-names)
+  (migrated-entity-names))


### PR DESCRIPTION
Copy the list of data migrations that have already been ran when copying data from H2 to Postgres or MySQL. This will prevent them from getting ran on first launch with the new DB, which breaks things.

Fixes #3677
