### PR TITLE
Fix region chart legend

### DIFF
--- a/frontend/src/metabase/visualizations/components/LegendVertical.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendVertical.jsx
@@ -69,7 +69,9 @@ export default class LegendVertical extends Component {
                             isMuted={hovered && hovered.index != null && index !== hovered.index}
                             showTooltip={false}
                         />
-                      <span className={cx("LegendItem","flex-align-right pl1", { muted: hovered && hovered.index != null && index !== hovered.index })}>{title[1]}</span>
+                        { Array.isArray(title) &&
+                            <span className={cx("LegendItem","flex-align-right pl1", { muted: hovered && hovered.index != null && index !== hovered.index })}>{title[1]}</span>
+                        }
                     </li>
                 )}
                 {overflowCount > 0 ?

--- a/frontend/test/unit/visualizations/components/LegendVertical.spec.js
+++ b/frontend/test/unit/visualizations/components/LegendVertical.spec.js
@@ -1,0 +1,17 @@
+
+import React from "react";
+import ReactDOM from "react-dom";
+import { renderIntoDocument } from "react-addons-test-utils";
+
+import LegendVertical from "metabase/visualizations/components/LegendVertical.jsx";
+
+describe("LegendVertical", () => {
+    fit ("should render string titles correctly", () => {
+        let legend = renderIntoDocument(<LegendVertical titles={["Hello"]} colors={["red"]} />);
+        expect(ReactDOM.findDOMNode(legend).textContent).toEqual("Hello");
+    });
+    fit ("should render array titles correctly", () => {
+        let legend = renderIntoDocument(<LegendVertical titles={[["Hello", "world"]]} colors={["red"]} />);
+        expect(ReactDOM.findDOMNode(legend).textContent).toEqual("Helloworld");
+    });
+});


### PR DESCRIPTION
It was displaying the second character of the first part of each legend. Because JavaScript.
