### PR TITLE
Add a touch of letter-spacing to uppercase text

### DIFF
--- a/frontend/src/metabase/css/core/text.css
+++ b/frontend/src/metabase/css/core/text.css
@@ -61,7 +61,10 @@
     .xl-text-right { text-align: right; }
 }
 
-.text-uppercase, :local(.text-uppercase) { text-transform: uppercase; letter-spacing: 0.8px;}
+.text-uppercase, :local(.text-uppercase) {
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
 .text-lowercase { text-transform: lowercase; }
 
 /* text weight */

--- a/frontend/src/metabase/css/core/text.css
+++ b/frontend/src/metabase/css/core/text.css
@@ -61,7 +61,7 @@
     .xl-text-right { text-align: right; }
 }
 
-.text-uppercase, :local(.text-uppercase) { text-transform: uppercase; }
+.text-uppercase, :local(.text-uppercase) { text-transform: uppercase; letter-spacing: 0.8px;}
 .text-lowercase { text-transform: lowercase; }
 
 /* text weight */


### PR DESCRIPTION
Paging @kdoh. This is the world's tiniest change, but it's been bugging me for ages.

Demonstration:

![screen shot 2016-10-28 at 11 21 30 am](https://cloud.githubusercontent.com/assets/2223916/19817729/b01dce8c-9d01-11e6-895c-5659a54c8593.png)

Further elaboration: I've always been taught and also believe that all-caps text needs a little extra letter spacing / kerning to let the larger letterforms breathe.
