### PR TITLE
Fix setting settings

### DIFF
--- a/frontend/interfaces/webdriver.js
+++ b/frontend/interfaces/webdriver.js
@@ -2,14 +2,23 @@
 declare module "selenium-webdriver" {
 
     declare class WebDriver {
-        wait(condition: Condition|Function, timeout: ?number): Promise<WebElement>;
-        findElement(selector: By): WebElement;
+        get(url: string): Promise<void>;
+        wait(condition: Condition|Function, timeout: ?number): WebElementPromise;
+        findElement(selector: By): WebElementPromise;
+        deleteAllCookies(): Promise<void>;
+        getCurrentUrl(): Promise<string>;
     }
 
     declare class WebElement {
+        findElement(selector: By): WebElementPromise;
         click(): Promise<void>;
-        findElement(selector: By): WebElement;
+        sendKeys(keys: string): Promise<void>;
+        clear(): Promise<void>;
         getText(): Promise<string>;
+        getAttribute(attribute: string): Promise<string>;
+    }
+
+    declare class WebElementPromise extends WebElement {
     }
 
     declare class Condition {

--- a/frontend/src/metabase/admin/settings/settings.js
+++ b/frontend/src/metabase/admin/settings/settings.js
@@ -34,7 +34,7 @@ export const initializeSettings = createThunkAction("INITIALIZE_SETTINGS", funct
 export const updateSetting = createThunkAction("UPDATE_SETTING", function(setting) {
     return async function(dispatch, getState) {
         try {
-            await SettingsApi.put({ key: setting.key }, setting);
+            await SettingsApi.put(setting);
             await dispatch(refreshSiteSettings());
             return await loadSettings();
         } catch(error) {

--- a/frontend/test/e2e/.eslintrc
+++ b/frontend/test/e2e/.eslintrc
@@ -4,6 +4,7 @@
         "node": true
     },
     "globals": {
+        "d": true,
         "driver": true,
         "server": true
     }

--- a/frontend/test/e2e/admin/settings.spec.js
+++ b/frontend/test/e2e/admin/settings.spec.js
@@ -1,0 +1,30 @@
+
+import {
+    ensureLoggedIn,
+    describeE2E
+} from "../support/utils";
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 600000;
+
+describeE2E("admin/settings", () => {
+    beforeEach(() =>
+        ensureLoggedIn(server, driver, "bob@metabase.com", "12341234")
+    );
+
+    describe("admin settings", () => {
+        fit("should persist a setting", async () => {
+            const siteName = "Metabase" + Math.random();
+
+            await d.get(`${server.host}/admin/settings/general`);
+
+            expect(await d.select(".SettingsInput").wait().attribute("value")).not.toBe(siteName);
+
+            await d.select(".SettingsInput").wait().clear().sendKeys(siteName).blur();
+            await d.select(".SaveStatus.text-success").wait();
+
+            await d.get(`${server.host}/admin/settings/general`);
+
+            expect(await d.select(".SettingsInput").wait().attribute("value")).toBe(siteName);
+        });
+    });
+});

--- a/frontend/test/e2e/support/utils.js
+++ b/frontend/test/e2e/support/utils.js
@@ -3,6 +3,8 @@ import path from "path";
 
 import { By, until } from "selenium-webdriver";
 
+import { Driver } from "webchauffeur";
+
 const DEFAULT_TIMEOUT = 50000;
 
 const delay = (timeout = 0) => new Promise((resolve) => setTimeout(resolve, timeout));
@@ -189,6 +191,7 @@ export const describeE2E = (name, options, describeCallback) => {
             ]);
 
             global.driver = webdriver.driver;
+            global.d = new Driver(webdriver.driver);
             global.server = server;
 
             await driver.get(`${server.host}/`);

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "selenium-webdriver": "^2.53.3",
     "style-loader": "^0.13.0",
     "unused-files-webpack-plugin": "^2.0.2",
+    "webchauffeur": "^1.0.1",
     "webpack": "^1.12.14",
     "webpack-dev-server": "^1.14.0",
     "webpack-hot-middleware": "^2.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5377,6 +5377,10 @@ progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
 
+promise-chain-decorator@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/promise-chain-decorator/-/promise-chain-decorator-1.2.0.tgz#3ed952bd37f6351b3989468d1aff40e7d740b451"
+
 promise@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
@@ -6901,6 +6905,12 @@ watchpack@^0.2.1:
     async "^0.9.0"
     chokidar "^1.0.0"
     graceful-fs "^4.1.2"
+
+webchauffeur:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/webchauffeur/-/webchauffeur-1.0.1.tgz#ed9d4ae28bb3a2e87d755b2d470c535e39cf30e4"
+  dependencies:
+    promise-chain-decorator "^1.2.0"
 
 webpack-core@~0.6.0:
   version "0.6.8"


### PR DESCRIPTION
Broken when we replaced Angular Resource with our own and missed this form of calling a resource API.

Passing the URL params in separately is redundant since they're already included in the resource. None of our other calls to the resource APIs appear to use that syntax.

Not sure what a good way to test this would be.