### PR TITLE
Usable table column enable/disabling with default disabled for "detail-only"

### DIFF
--- a/frontend/src/metabase/lib/data_grid.js
+++ b/frontend/src/metabase/lib/data_grid.js
@@ -7,31 +7,6 @@ function compareNumbers(a, b) {
     return a - b;
 }
 
-export function filterOnPreviewDisplay(data) {
-    // find any columns where visibility_type = details-only
-    var hiddenColumnIdxs = _.map(data.cols, function(col, idx) { if(col.visibility_type === "details-only") return idx; });
-    hiddenColumnIdxs = _.filter(hiddenColumnIdxs, function(val) { return val !== undefined; });
-
-    // filter out our data grid using the indexes of the hidden columns
-    var filteredRows = data.rows.map(function(row, rowIdx) {
-        return row.filter(function(cell, cellIdx) {
-            if (_.contains(hiddenColumnIdxs, cellIdx)) {
-                return false;
-            } else {
-                return true;
-            }
-        });
-    });
-
-    return {
-        cols: _.filter(data.cols, function(col) { return col.visibility_type !== "details-only"; }),
-        columns: _.map(data.cols, function(col) { return col.display_name; }),
-        rows: filteredRows,
-        rows_truncated: data.rows_truncated,
-        native_form: data.native_form
-    };
-}
-
 export function pivot(data) {
     // find the lowest cardinality dimension and make it our "pivoted" column
     // TODO: we assume dimensions are in the first 2 columns, which is less than ideal

--- a/frontend/src/metabase/lib/visualization_settings.js
+++ b/frontend/src/metabase/lib/visualization_settings.js
@@ -530,7 +530,7 @@ const SETTINGS = {
             columnsAreValid(card.visualization_settings["table.columns"].map(x => x.name), data),
         getDefault: ([{ data: { cols }}]) => cols.map(col => ({
             name: col.name,
-            enabled: true
+            enabled: col.visibility_type !== "details-only"
         })),
         getProps: ([{ data: { cols }}]) => ({
             columnNames: cols.reduce((o, col) => ({ ...o, [col.name]: getFriendlyName(col)}), {})

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -5,8 +5,6 @@ import _ from "underscore";
 import { getTemplateTags } from "metabase/meta/Card";
 
 import { isCardDirty, isCardRunnable } from "metabase/lib/card";
-import * as DataGrid from "metabase/lib/data_grid";
-import Query from "metabase/lib/query";
 import { parseFieldTarget } from "metabase/lib/query_time";
 import { isPK } from "metabase/lib/types";
 import { applyParameters } from "metabase/meta/Card";
@@ -132,18 +130,8 @@ export const isObjectDetail = createSelector(
 );
 
 export const queryResult = createSelector(
-	[state => state.qb.queryResult, isObjectDetail],
-	(queryResult, isObjectDetail) => {
-		// if we are display bare rows, filter out columns with visibility_type = details-only
-        if (queryResult && queryResult.json_query && !isObjectDetail &&
-        		Query.isStructured(queryResult.json_query) &&
-                Query.isBareRowsAggregation(queryResult.json_query.query)) {
-        	// TODO: mutability?
-            queryResult.data = DataGrid.filterOnPreviewDisplay(queryResult.data);
-        }
-
-        return queryResult;
-	}
+	[state => state.qb.queryResult],
+	(queryResult) => queryResult
 );
 
 export const getImplicitParameters = createSelector(


### PR DESCRIPTION
Previously we filtered "detail-only" columns at a higher level, but not that we have settings to disable/enable columns in table view we should just use that, with columns marked as "detail-only" disabled by default.

![screen shot 2016-11-02 at 11 24 56 am](https://cloud.githubusercontent.com/assets/18193/19942260/59aa8f8e-a0f0-11e6-81d5-7facf41b26c9.png)
![screen shot 2016-11-02 at 11 25 01 am](https://cloud.githubusercontent.com/assets/18193/19942261/59ab278c-a0f0-11e6-8ba3-db5aa07967fa.png)

