### PR TITLE
Email type [WIP]

### DIFF
--- a/frontend/src/metabase/components/ExternalLink.jsx
+++ b/frontend/src/metabase/components/ExternalLink.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+const ExternalLink = ({ href, children }) =>
+    <a
+        href={href}
+        className="link"
+        // open in a new tab
+        target="_blank"
+        // prevent malicious pages from navigating us away
+        rel="noopener"
+        // disables quickfilter in tables
+        onClickCapture={(e) => e.stopPropagation()}
+    >
+        {children}
+    </a>
+
+export default ExternalLink;

--- a/frontend/src/metabase/lib/core.js
+++ b/frontend/src/metabase/lib/core.js
@@ -36,6 +36,10 @@ export const field_special_types = [{
     'name': 'Description',
     'section': 'Common'
 }, {
+    'id': TYPE.Email,
+    'name': 'Email',
+    'section': 'Common'
+}, {
     'id': TYPE.ImageURL,
     'name': 'Image URL',
     'section': 'Common'

--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -4,6 +4,8 @@ import moment from "moment";
 import Humanize from "humanize";
 import React from "react";
 
+import ExternalLink from "metabase/components/ExternalLink.jsx";
+
 import { isDate, isNumber, isCoordinate } from "metabase/lib/schema_metadata";
 import { isa, TYPE } from "metabase/lib/types";
 import { parseTimestamp } from "metabase/lib/time";
@@ -99,25 +101,22 @@ function formatTimeWithUnit(value, unit, options = {}) {
     }
 }
 
+const EMAIL_WHITELIST_REGEX = /.+@.+/;
+
+export function formatEmail(value, { jsx } = {}) {
+    if (jsx && EMAIL_WHITELIST_REGEX.test(value)) {
+        return <ExternalLink href={"mailto:" + value}>{value}</ExternalLink>;
+    } else {
+        value;
+    }
+}
+
 // prevent `javascript:` etc URLs
 const URL_WHITELIST_REGEX = /^(https?|mailto):/;
 
 export function formatUrl(value, { jsx } = {}) {
     if (jsx && URL_WHITELIST_REGEX.test(value)) {
-        return (
-            <a
-                href={value}
-                className="link"
-                // open in a new tab
-                target="_blank"
-                // prevent malicious pages from navigating us away
-                rel="noopener"
-                // disables quickfilter in tables
-                onClickCapture={(e) => e.stopPropagation()}
-            >
-                {value}
-            </a>
-        );
+        return <ExternalLink href={value}>{value}</ExternalLink>;
     } else {
         return value;
     }
@@ -134,6 +133,8 @@ export function formatValue(value, options = {}) {
         return null;
     } else if (column && isa(column.special_type, TYPE.URL)) {
         return formatUrl(value, options);
+    } else if (column && isa(column.special_type, TYPE.Email)) {
+        return formatEmail(value, options);
     } else if (column && column.unit != null) {
         return formatTimeWithUnit(value, column.unit, options);
     } else if (isDate(column) || moment.isDate(value) || moment.isMoment(value) || moment(value, ["YYYY-MM-DD'T'HH:mm:ss.SSSZ"], true).isValid()) {

--- a/frontend/src/metabase/query_builder/components/QueryVisualizationObjectDetailTable.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualizationObjectDetailTable.jsx
@@ -7,6 +7,7 @@ import LoadingSpinner from 'metabase/components/LoadingSpinner.jsx';
 import { foreignKeyCountsByOriginTable } from 'metabase/lib/schema_metadata';
 import { TYPE, isa, isPK } from "metabase/lib/types";
 import { singularize, inflect } from 'inflection';
+import { formatValue } from "metabase/lib/formatting";
 
 import cx from "classnames";
 
@@ -74,8 +75,10 @@ export default class QueryVisualizationObjectDetailTable extends Component {
                 let formattedJson = JSON.stringify(row[1], null, 2);
                 cellValue = (<pre className="ObjectJSON">{formattedJson}</pre>);
             } else {
-                // TODO: should we be casting all values toString()?
-                cellValue = (<ExpandableString str={row[1].toString()} length={140}></ExpandableString>);
+                cellValue = formatValue(row[1], { column: row[0], jsx: true });
+                if (typeof cellValue === "string") {
+                    cellValue = (<ExpandableString str={cellValue} length={140}></ExpandableString>);
+                }
             }
 
             // NOTE: that the values to our function call look off, but that's because we are un-pivoting them

--- a/frontend/test/unit/lib/formatting.spec.js
+++ b/frontend/test/unit/lib/formatting.spec.js
@@ -1,4 +1,7 @@
-import { formatNumber, formatValue } from 'metabase/lib/formatting';
+
+import { isElementOfType } from "react-addons-test-utils";
+
+import { formatNumber, formatValue, formatUrl } from 'metabase/lib/formatting';
 import { TYPE } from "metabase/lib/types";
 
 describe('formatting', () => {
@@ -54,4 +57,19 @@ describe('formatting', () => {
             expect(formatValue(-122.4194, { column: { base_type: TYPE.Number, special_type: TYPE.Longitude }})).toEqual("-122.41940000");
         });
     });
+
+    describe("formatUrl", () => {
+        it("should return a string when not in jsx mode", () => {
+            expect(formatUrl("http://metabase.com/")).toEqual("http://metabase.com/")
+        });
+        it("should return a component for http:, https:, and mailto: links in jsx mode", () => {
+            expect(isElementOfType(formatUrl("http://metabase.com/", { jsx: true }), "a")).toEqual(true);
+            expect(isElementOfType(formatUrl("https://metabase.com/", { jsx: true }), "a")).toEqual(true);
+            expect(isElementOfType(formatUrl("mailto:tom@metabase.com", { jsx: true }), "a")).toEqual(true);
+        });
+        it("should return a string for javascript:, data:, and other links in jsx mode", () => {
+            expect(formatUrl("javascript:alert('pwnd')", { jsx: true })).toEqual("javascript:alert('pwnd')");
+            expect(formatUrl("data:text/plain;charset=utf-8,hello%20world", { jsx: true })).toEqual("data:text/plain;charset=utf-8,hello%20world");
+        });
+    })
 });

--- a/frontend/test/unit/lib/formatting.spec.js
+++ b/frontend/test/unit/lib/formatting.spec.js
@@ -2,6 +2,7 @@
 import { isElementOfType } from "react-addons-test-utils";
 
 import { formatNumber, formatValue, formatUrl } from 'metabase/lib/formatting';
+import ExternalLink from "metabase/components/ExternalLink.jsx";
 import { TYPE } from "metabase/lib/types";
 
 describe('formatting', () => {
@@ -63,9 +64,9 @@ describe('formatting', () => {
             expect(formatUrl("http://metabase.com/")).toEqual("http://metabase.com/")
         });
         it("should return a component for http:, https:, and mailto: links in jsx mode", () => {
-            expect(isElementOfType(formatUrl("http://metabase.com/", { jsx: true }), "a")).toEqual(true);
-            expect(isElementOfType(formatUrl("https://metabase.com/", { jsx: true }), "a")).toEqual(true);
-            expect(isElementOfType(formatUrl("mailto:tom@metabase.com", { jsx: true }), "a")).toEqual(true);
+            expect(isElementOfType(formatUrl("http://metabase.com/", { jsx: true }), ExternalLink)).toEqual(true);
+            expect(isElementOfType(formatUrl("https://metabase.com/", { jsx: true }), ExternalLink)).toEqual(true);
+            expect(isElementOfType(formatUrl("mailto:tom@metabase.com", { jsx: true }), ExternalLink)).toEqual(true);
         });
         it("should return a string for javascript:, data:, and other links in jsx mode", () => {
             expect(formatUrl("javascript:alert('pwnd')", { jsx: true })).toEqual("javascript:alert('pwnd')");

--- a/src/metabase/sync_database/analyze.clj
+++ b/src/metabase/sync_database/analyze.clj
@@ -123,8 +123,8 @@
   "Mark FIELD as `:json` if it's textual, doesn't already have a special type, the majority of it's values are non-nil, and all of its non-nil values
    are valid serialized JSON dictionaries or arrays."
   [driver field field-stats]
-  (if-not (and (not (:special_type field))
-               (not (isa? (:base_type field) :type/Text)))
+  (if (or (:special_type field)
+          (not (isa? (:base_type field) :type/Text)))
     ;; this field isn't suited for this test
     field-stats
     ;; check for json values
@@ -134,14 +134,8 @@
         (log/debug (u/format-color 'green "Field '%s' looks like it contains valid JSON objects. Setting special_type to :type/JSON." (field/qualified-name field)))
         (assoc field-stats :special-type :type/JSON, :preview-display false)))))
 
-(defn valid-email?
-  [email]
-  (let [pattern #"[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?"]
-    (and (string? email) (re-matches pattern email))))
-
-
 (defn- values-are-valid-emails?
-  "`true` if at every item in VALUES is `nil` or a valid string-encoded JSON dictionary or array, and at least one of those is non-nil."
+  "`true` if at every item in VALUES is `nil` or a valid email, and at least one of those is non-nil."
   [values]
   (try
     (loop [at-least-one-non-nil-value? false, [val & more] values]
@@ -151,25 +145,25 @@
         (s/blank? val)         (recur at-least-one-non-nil-value? more)
         ;; If val is non-nil, check that it's a JSON dictionary or array. We don't want to mark Fields containing other
         ;; types of valid JSON values as :json (e.g. a string representation of a number or boolean)
-        :else                  (do (assert (valid-email? val))
+        :else                  (do (assert (u/is-email? val))
                                    (recur true more))))
     (catch Throwable _
       false)))
 
 (defn- test:email-special-type
-  "Mark FIELD as `:json` if it's textual, doesn't already have a special type, the majority of it's values are non-nil, and all of its non-nil values
-   are valid serialized JSON dictionaries or arrays."
+  "Mark FIELD as `:email` if it's textual, doesn't already have a special type, the majority of it's values are non-nil, and all of its non-nil values
+   are valid emails."
   [driver field field-stats]
-  (if-not (and (not (:special_type field))
-               (not (isa? (:base_type field) :type/Text)))
+  (if (or (:special_type field)
+          (not (isa? (:base_type field) :type/Text)))
     ;; this field isn't suited for this test
     field-stats
-    ;; check for json values
+    ;; check for emails
     (if-not (values-are-valid-emails? (take driver/max-sync-lazy-seq-results (driver/field-values-lazy-seq driver field)))
       field-stats
       (do
         (log/debug (u/format-color 'green "Field '%s' looks like it contains valid email addresses. Setting special_type to :type/Email." (field/qualified-name field)))
-        (assoc field-stats :special-type :type/Email, :preview-display false)))))
+        (assoc field-stats :special-type :type/Email, :preview-display true)))))
 
 
 
@@ -180,7 +174,8 @@
   (->> field-stats
        (test:no-preview-display driver field)
        (test:url-special-type   driver field)
-       (test:json-special-type  driver field)))
+       (test:json-special-type  driver field)
+       (test:email-special-type  driver field)))
 
 (defn make-analyze-table
   "Make a generic implementation of `analyze-table`."

--- a/src/metabase/sync_database/analyze.clj
+++ b/src/metabase/sync_database/analyze.clj
@@ -175,7 +175,7 @@
        (test:no-preview-display driver field)
        (test:url-special-type   driver field)
        (test:json-special-type  driver field)
-       (test:email-special-type  driver field)))
+       (test:email-special-type driver field)))
 
 (defn make-analyze-table
   "Make a generic implementation of `analyze-table`."

--- a/src/metabase/sync_database/analyze.clj
+++ b/src/metabase/sync_database/analyze.clj
@@ -165,8 +165,6 @@
         (log/debug (u/format-color 'green "Field '%s' looks like it contains valid email addresses. Setting special_type to :type/Email." (field/qualified-name field)))
         (assoc field-stats :special-type :type/Email, :preview-display true)))))
 
-
-
 (defn- test:new-field
   "Do the various tests that should only be done for a new `Field`.
    We only run most of the field analysis work when the field is NEW in order to favor performance of the sync process."

--- a/src/metabase/types.clj
+++ b/src/metabase/types.clj
@@ -32,6 +32,8 @@
 (derive :type/AvatarURL :type/URL)
 (derive :type/ImageURL :type/URL)
 
+(derive :type/Email :type/Text)
+
 (derive :type/City :type/Text)
 (derive :type/State :type/Text)
 (derive :type/Country :type/Text)

--- a/test/metabase/sync_database/analyze_test.clj
+++ b/test/metabase/sync_database/analyze_test.clj
@@ -60,3 +60,12 @@
 (expect false (values-are-valid-json? ["100"]))
 (expect false (values-are-valid-json? ["true"]))
 (expect false (values-are-valid-json? ["false"]))
+
+;; Check that things that are valid emails are marked as Emails
+(expect true (values-are-valid-email? ["helper@metabase.com"]))
+(expect true (values-are-valid-email? ["helper@metabase.com", "someone@here.com", "help@nope.com"]))
+
+(expect false (values-are-valid-email? ["\"A string should not cause a Field to be marked as email\""]))
+(expect false (values-are-valid-email? [100]))
+(expect false (values-are-valid-email? ["true"]))
+(expect false (values-are-valid-email? ["false"]))

--- a/test/metabase/sync_database/analyze_test.clj
+++ b/test/metabase/sync_database/analyze_test.clj
@@ -23,6 +23,7 @@
 ;;; ## mark-json-field!
 
 (tu/resolve-private-vars metabase.sync-database.analyze values-are-valid-json?)
+(tu/resolve-private-vars metabase.sync-database.analyze values-are-valid-emails?)
 
 (def ^:const ^:private fake-values-seq-json
   "A sequence of values that should be marked is valid JSON.")
@@ -62,10 +63,12 @@
 (expect false (values-are-valid-json? ["false"]))
 
 ;; Check that things that are valid emails are marked as Emails
-(expect true (values-are-valid-email? ["helper@metabase.com"]))
-(expect true (values-are-valid-email? ["helper@metabase.com", "someone@here.com", "help@nope.com"]))
+(expect true (values-are-valid-emails? ["helper@metabase.com"]))
+(expect true (values-are-valid-emails? ["helper@metabase.com", "someone@here.com", "help@nope.com"]))
+(expect true (values-are-valid-emails? ["helper@metabase.com", nil, "help@nope.com"]))
 
-(expect false (values-are-valid-email? ["\"A string should not cause a Field to be marked as email\""]))
-(expect false (values-are-valid-email? [100]))
-(expect false (values-are-valid-email? ["true"]))
-(expect false (values-are-valid-email? ["false"]))
+(expect false (values-are-valid-emails? ["helper@metabase.com", "1111IsNot!An....email", "help@nope.com"]))
+(expect false (values-are-valid-emails? ["\"A string should not cause a Field to be marked as email\""]))
+(expect false (values-are-valid-emails? [100]))
+(expect false (values-are-valid-emails? ["true"]))
+(expect false (values-are-valid-emails? ["false"]))


### PR DESCRIPTION
Adds an "Email" type which we format with "mailto:" links on the frontend.

We should also attempt to detect the Email type when syncing, like we do for URL.

(this builds on #3711)