### PR TITLE
Send anonymous usage information from the server

### DIFF
--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -15,6 +15,7 @@
             [metabase.db.spec :as dbspec]
             [metabase.models.interface :as models]
             [metabase.util :as u]
+            [metabase.util.tracking :as tracking]
             metabase.util.honeysql-extensions) ; this needs to be loaded so the `:h2` quoting style gets added
   (:import java.io.StringWriter
            java.sql.Connection
@@ -176,6 +177,7 @@
    that were made. (If a single statement in a transaction fails you can't do anything futher until you clear the error state by doing something like calling `.rollback`.)"
   [conn, ^Liquibase liquibase]
   (when (has-unran-migrations? liquibase)
+    (tracking/track-event! "server-info" "migration" "forced" "started")
     (doseq [line (migrations-lines liquibase)]
       (log/info line)
       (jdbc/with-db-transaction [nested-transaction-connection conn]
@@ -183,6 +185,7 @@
              (log/info (u/format-color 'green "[SUCCESS]"))
              (catch Throwable e
                (.rollback (jdbc/get-connection nested-transaction-connection))
+               (tracking/track-event! "server-error" "migration" "forced" "nested-error")
                (log/error (u/format-color 'red "[ERROR] %s" (.getMessage e)))))))))
 
 (def ^{:arglists '([])} ^DatabaseFactory database-factory
@@ -236,6 +239,7 @@
        :done
        ;; If for any reason any part of the migrations fail then rollback all changes
        (catch Throwable e
+         (tracking/track-event! "server-error" "migration" "error" "top-level")
          ;; This should already be happening as a result of `db-set-rollback-only!` but running it twice won't hurt so better safe than sorry
          (.rollback (jdbc/get-connection conn))
          (throw e))))))

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -177,7 +177,7 @@
    that were made. (If a single statement in a transaction fails you can't do anything futher until you clear the error state by doing something like calling `.rollback`.)"
   [conn, ^Liquibase liquibase]
   (when (has-unran-migrations? liquibase)
-    (tracking/track-event! "server-info" "migration" "forced" "started")
+    (tracking/track-info! :action "migration" :label "forced" :value "started")
     (doseq [line (migrations-lines liquibase)]
       (log/info line)
       (jdbc/with-db-transaction [nested-transaction-connection conn]
@@ -185,7 +185,7 @@
              (log/info (u/format-color 'green "[SUCCESS]"))
              (catch Throwable e
                (.rollback (jdbc/get-connection nested-transaction-connection))
-               (tracking/track-event! "server-error" "migration" "forced" "nested-error")
+               (tracking/track-error! :action "migration" :label "forced" :value "nested-error")
                (log/error (u/format-color 'red "[ERROR] %s" (.getMessage e)))))))))
 
 (def ^{:arglists '([])} ^DatabaseFactory database-factory
@@ -239,7 +239,7 @@
        :done
        ;; If for any reason any part of the migrations fail then rollback all changes
        (catch Throwable e
-         (tracking/track-event! "server-error" "migration" "error" "top-level")
+         (tracking/track-error! :action "migration" :label "error" :value "top-level")
          ;; This should already be happening as a result of `db-set-rollback-only!` but running it twice won't hurt so better safe than sorry
          (.rollback (jdbc/get-connection conn))
          (throw e))))))

--- a/src/metabase/util/tracking.clj
+++ b/src/metabase/util/tracking.clj
@@ -1,16 +1,14 @@
 (ns metabase.util.tracking
   (:require [metabase.models.setting :as setting]
-            [clj-http.client :as client]
-            [ring.util.codec/form-encode :as form-encode]))
+            [clj-http.client :as client]))
 
 (def ^:private ^:const ^String google-analytics-collect-url "http://www.google-analytics.com/collect")
 ;; This is also in public_settings.clj. Should I access it from there?
 (def ^:private ^:const ^String metabase-google-analytics-id "UA-60817802-1")
 
-(defn- generate-anonymous-id
+(def ^:private ^Integer anonymous-id
   "Generate an anonymous id. Don't worry too much about hash collisions or localhost cases, etc.
    The goal is to be able to get a rough sense for how many different hosts are throwing a specific error/event." 
-  []
   (hash (str (java.net.InetAddress/getLocalHost)))
   )
 
@@ -23,13 +21,13 @@
   ([event-category event-action event-label]
    (track-event! event-category event-action event-label ""))
   ([event-category event-action event-label event-value]
-  	(when (setting/get :anon-tracking-enabled)
+    (when (setting/get :anon-tracking-enabled)
       (let [form-params {:v 1
-    		             :tid metabase-google-analytics-id 
-             		     :cid (generate-anonymous-id)
-                		 :t "event"
-                		 :ec event-category
-                		 :ea event-action
-                	     :el event-label
-                		 :ev event-value } ]
-  		(client/post google-analytics-collect-url {:form-params form-params})))))
+                         :tid metabase-google-analytics-id 
+                         :cid anonymous-id
+                         :t "event"
+                         :ec event-category
+                         :ea event-action
+                         :el event-label
+                         :ev event-value } ]
+        (client/post google-analytics-collect-url {:form-params form-params})))))

--- a/src/metabase/util/tracking.clj
+++ b/src/metabase/util/tracking.clj
@@ -1,0 +1,35 @@
+(ns metabase.util.tracking
+  (:require [metabase.models.setting :as setting]
+            [clj-http.client :as client]
+            [ring.util.codec/form-encode :as form-encode]))
+
+(def ^:private ^:const ^String google-analytics-collect-url "http://www.google-analytics.com/collect")
+;; This is also in public_settings.clj. Should I access it from there?
+(def ^:private ^:const ^String metabase-google-analytics-id "UA-60817802-1")
+
+(defn- generate-anonymous-id
+  "Generate an anonymous id. Don't worry too much about hash collisions or localhost cases, etc.
+   The goal is to be able to get a rough sense for how many different hosts are throwing a specific error/event." 
+  []
+  (hash (str (java.net.InetAddress/getLocalHost)))
+  )
+
+(defn track-event!
+  "Send anonymous usage information via Google Analytics
+   For server errors, the use event-category `server-error`
+   For others use `server-event`"
+  [event-category event-action]
+  (track-event! event-category event-action "" "")
+  [event-category event-action event-label]
+  (track-event! event-category event-action event-label "")
+  [event-category event-action event-label event-value]
+  (if (setting/get :anon-tracking-enabled)
+      (let [form-params {:v 1
+                :tid metabase-google-analytics-id 
+                :cid (generate-anonymous-id)
+                :t "event"
+                :ec event-category
+                :ea event-action
+                :el event-label
+                :ev event-value } ]
+  		(client/post google-analytics-collect-url {:form-params form-params}))))

--- a/src/metabase/util/tracking.clj
+++ b/src/metabase/util/tracking.clj
@@ -18,18 +18,18 @@
   "Send anonymous usage information via Google Analytics
    For server errors, the use event-category `server-error`
    For others use `server-event`"
-  [event-category event-action]
-  (track-event! event-category event-action "" "")
-  [event-category event-action event-label]
-  (track-event! event-category event-action event-label "")
-  [event-category event-action event-label event-value]
-  (if (setting/get :anon-tracking-enabled)
+  ([event-category event-action]
+   (track-event! event-category event-action "" ""))
+  ([event-category event-action event-label]
+   (track-event! event-category event-action event-label ""))
+  ([event-category event-action event-label event-value]
+  	(when (setting/get :anon-tracking-enabled)
       (let [form-params {:v 1
-                :tid metabase-google-analytics-id 
-                :cid (generate-anonymous-id)
-                :t "event"
-                :ec event-category
-                :ea event-action
-                :el event-label
-                :ev event-value } ]
-  		(client/post google-analytics-collect-url {:form-params form-params}))))
+    		             :tid metabase-google-analytics-id 
+             		     :cid (generate-anonymous-id)
+                		 :t "event"
+                		 :ec event-category
+                		 :ea event-action
+                	     :el event-label
+                		 :ev event-value } ]
+  		(client/post google-analytics-collect-url {:form-params form-params})))))

--- a/src/metabase/util/tracking.clj
+++ b/src/metabase/util/tracking.clj
@@ -12,13 +12,13 @@
   "Get the GA id for the main metabase application"
   []
   (require 'metabase.public-settings)
-  ((resolve 'metabase.public-settings/ga_code)))
+  ((resolve 'metabase.public-settings) :ga_code))
 
 (defn- anon-tracking-enabled? 
   "To avoid a circular reference"
   []
   (require 'metabase.public-settings)
-  ((resolve 'metabase.public-settings/anon-tracking-enabled)))
+  ((resolve 'metabase.public-settings) :anon-tracking-enabled))
 
 (defn track-event!
   "Send anonymous usage information via Google Analytics
@@ -43,16 +43,12 @@
 
 (defn track-error! 
   "Simpler way to track errors that keeps our event labels tidy"
-  [& {:keys [action label value]
-      :or {label "" 
-           value ""}}]
-  (track-event! :category "server-error" :action action :label label :value value)
+  [& args]
+  (track-event! :category "server-error" args)
   )
 
-((defn track-info! 
+(defn track-info! 
   "Simpler way to track server events that keeps our event labels tidy"
-  [& {:keys [action label value]
-      :or {label "" 
-           value ""}}]
-  (track-event! :category "server-info" :action action :label label :value value)
-  ))
+  [& args]
+  (track-event! :category "server-info" args)
+  )

--- a/src/metabase/util/tracking.clj
+++ b/src/metabase/util/tracking.clj
@@ -1,33 +1,58 @@
 (ns metabase.util.tracking
-  (:require [metabase.models.setting :as setting]
-            [clj-http.client :as client]))
+  (:require [clj-http.client :as client]))
 
 (def ^:private ^:const ^String google-analytics-collect-url "http://www.google-analytics.com/collect")
-;; This is also in public_settings.clj. Should I access it from there?
-(def ^:private ^:const ^String metabase-google-analytics-id "UA-60817802-1")
 
 (def ^:private ^Integer anonymous-id
   "Generate an anonymous id. Don't worry too much about hash collisions or localhost cases, etc.
    The goal is to be able to get a rough sense for how many different hosts are throwing a specific error/event." 
-  (hash (str (java.net.InetAddress/getLocalHost)))
-  )
+  (hash (str (java.net.InetAddress/getLocalHost))))
+
+(defn- google-analytics-tracking-code
+  "Get the GA id for the main metabase application"
+  []
+  (require 'metabase.public-settings)
+  ((resolve 'metabase.public-settings/ga_code)))
+
+(defn- anon-tracking-enabled? 
+  "To avoid a circular reference"
+  []
+  (require 'metabase.public-settings)
+  ((resolve 'metabase.public-settings/anon-tracking-enabled)))
 
 (defn track-event!
   "Send anonymous usage information via Google Analytics
    For server errors, the use event-category `server-error`
    For others use `server-event`"
-  ([event-category event-action]
-   (track-event! event-category event-action "" ""))
-  ([event-category event-action event-label]
-   (track-event! event-category event-action event-label ""))
-  ([event-category event-action event-label event-value]
-    (when (setting/get :anon-tracking-enabled)
-      (let [form-params {:v 1
-                         :tid metabase-google-analytics-id 
-                         :cid anonymous-id
-                         :t "event"
-                         :ec event-category
-                         :ea event-action
-                         :el event-label
-                         :ev event-value } ]
-        (client/post google-analytics-collect-url {:form-params form-params})))))
+  [& {:keys [category action label value]
+      :or {label "" 
+           value ""}}]
+  {:pre [(string? category) (string? action)]}
+  (when (anon-tracking-enabled?)
+    (let [form-params {:v 1
+                      :tid (google-analytics-tracking-code)
+                      :cid anonymous-id
+                      :t "event"
+                      :ec category
+                      :ea action
+                      :el label
+                      :ev value } ]
+        (future (client/post google-analytics-collect-url {:form-params form-params})))))
+  
+
+
+(defn track-error! 
+  "Simpler way to track errors that keeps our event labels tidy"
+  [& {:keys [action label value]
+      :or {label "" 
+           value ""}}]
+  (track-event! :category "server-error" :action action :label label :value value)
+  )
+
+((defn track-info! 
+  "Simpler way to track server events that keeps our event labels tidy"
+  [& {:keys [action label value]
+      :or {label "" 
+           value ""}}]
+  (track-event! :category "server-info" :action action :label label :value value)
+  ))


### PR DESCRIPTION
In trying to debug eg migrations, it'd be useful to get a sense for how common people are forcing migrations, getting errors, etc. 

@camsaul how should I deal with the circular dependency that's produced by requiring metabase.util.tracking in db.clj ? Tracking needs to get at the settings to see if the anonymous collection setting is true. 

Other comments welcome as well. 