### PR TITLE
#1113 Adds MongoDB delegated authentication

### DIFF
--- a/src/metabase/driver/mongo.clj
+++ b/src/metabase/driver/mongo.clj
@@ -190,6 +190,9 @@
                                                            :display-name "Database password"
                                                            :type         :password
                                                            :placeholder  "******"}
+                                                          {:name         "authdb"
+                                                           :display-name "Authentication Database"
+                                                           :placeholder  "Optional database to use when authenticating"}
                                                           {:name         "ssl"
                                                            :display-name "Use a secure connection (SSL)?"
                                                            :type         :boolean

--- a/src/metabase/driver/mongo/util.clj
+++ b/src/metabase/driver/mongo/util.clj
@@ -43,7 +43,7 @@
   "Run F with a new connection (bound to `*mongo-connection*`) to DATABASE.
    Don't use this directly; use `with-mongo-connection`."
   [f database]
-  (let [{:keys [dbname host port user pass ssl]
+  (let [{:keys [dbname host port user pass ssl authdb]
          :or   {port 27017, pass "", ssl false}} (cond
                                                    (string? database)            {:dbname database}
                                                    (:dbname (:details database)) (:details database) ; entire Database obj
@@ -53,9 +53,12 @@
                            user)
         pass             (when (seq pass)
                            pass)
+        authdb           (if (seq authdb)
+                           authdb
+                           dbname)
         server-address   (mg/server-address host port)
         credentials      (when user
-                           (mcred/create user dbname pass))
+                           (mcred/create user authdb pass))
         connect          (partial mg/connect server-address (build-connection-options :ssl? ssl))
         conn             (if credentials
                            (connect credentials)


### PR DESCRIPTION
Based on metabase/metabase#1113, adds support for specifying an "authdb" parameter that is passed as the authentication database when connecting.