### PR TITLE
Remove unused :make-pool? option [ci drivers]

### DIFF
--- a/sample_dataset/metabase/sample_dataset/generate.clj
+++ b/sample_dataset/metabase/sample_dataset/generate.clj
@@ -370,9 +370,8 @@
    (io/delete-file (str filename ".mv.db") :silently)
    (io/delete-file (str filename ".trace.db") :silently)
    (println "Creating db...")
-   (let [db (dbspec/h2 {:db         (format "file:%s;UNDO_LOG=0;CACHE_SIZE=131072;QUERY_CACHE_SIZE=128;COMPRESS=TRUE;MULTI_THREADED=TRUE;MVCC=TRUE;DEFRAG_ALWAYS=TRUE;MAX_COMPACT_TIME=5000;ANALYZE_AUTO=100"
-                                            filename)
-                        :make-pool? false})]
+   (let [db (dbspec/h2 {:db (format "file:%s;UNDO_LOG=0;CACHE_SIZE=131072;QUERY_CACHE_SIZE=128;COMPRESS=TRUE;MULTI_THREADED=TRUE;MVCC=TRUE;DEFRAG_ALWAYS=TRUE;MAX_COMPACT_TIME=5000;ANALYZE_AUTO=100"
+                                    filename)})]
      (doseq [[table-name field->type] (seq tables)]
        (jdbc/execute! db [(create-table-sql table-name field->type)]))
 

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -265,7 +265,7 @@
                  (.setTestConnectionOnCheckout     false)
                  (.setPreferredTestQuery           nil)
                  (.setProperties                   (u/prog1 (java.util.Properties.)
-                                                     (doseq [[k v] (dissoc spec :make-pool? :classname :subprotocol :subname :naming :delimiters :alias-delimiter
+                                                     (doseq [[k v] (dissoc spec :classname :subprotocol :subname :naming :delimiters :alias-delimiter
                                                                                 :excess-timeout :minimum-pool-size :idle-connection-test-period)]
                                                        (.setProperty <> (name k) (str v))))))})
 

--- a/src/metabase/db/spec.clj
+++ b/src/metabase/db/spec.clj
@@ -4,40 +4,37 @@
 (defn h2
   "Create a database specification for a h2 database. Opts should include a key
   for :db which is the path to the database file."
-  [{:keys [db make-pool?]
-    :or {db "h2.db", make-pool? true}
+  [{:keys [db]
+    :or {db "h2.db"}
     :as opts}]
   (merge {:classname "org.h2.Driver" ; must be in classpath
           :subprotocol "h2"
-          :subname db
-          :make-pool? make-pool?}
+          :subname db}
          (dissoc opts :db)))
 
 (defn postgres
   "Create a database specification for a postgres database. Opts should include
   keys for :db, :user, and :password. You can also optionally set host and
   port."
-  [{:keys [host port db make-pool?]
-    :or {host "localhost", port 5432, db "", make-pool? true}
+  [{:keys [host port db]
+    :or {host "localhost", port 5432, db ""}
     :as opts}]
   (merge {:classname "org.postgresql.Driver" ; must be in classpath
           :subprotocol "postgresql"
-          :subname (str "//" host ":" port "/" db)
-          :make-pool? make-pool?}
+          :subname (str "//" host ":" port "/" db)}
          (dissoc opts :host :port :db)))
 
 (defn mysql
   "Create a database specification for a mysql database. Opts should include keys
   for :db, :user, and :password. You can also optionally set host and port.
   Delimiters are automatically set to \"`\"."
-  [{:keys [host port db make-pool?]
-    :or {host "localhost", port 3306, db "", make-pool? true}
+  [{:keys [host port db]
+    :or {host "localhost", port 3306, db ""}
     :as opts}]
   (merge {:classname "com.mysql.jdbc.Driver" ; must be in classpath
           :subprotocol "mysql"
           :subname (str "//" host ":" port "/" db)
-          :delimiters "`"
-          :make-pool? make-pool?}
+          :delimiters "`"}
          (dissoc opts :host :port :db)))
 
 
@@ -46,25 +43,23 @@
 (defn mssql
   "Create a database specification for a mssql database. Opts should include keys
   for :db, :user, and :password. You can also optionally set host and port."
-  [{:keys [user password db host port make-pool?]
-    :or {user "dbuser", password "dbpassword", db "", host "localhost", port 1433, make-pool? true}
+  [{:keys [user password db host port]
+    :or {user "dbuser", password "dbpassword", db "", host "localhost", port 1433}
     :as opts}]
   (merge {:classname "com.microsoft.sqlserver.jdbc.SQLServerDriver" ; must be in classpath
           :subprotocol "sqlserver"
-          :subname (str "//" host ":" port ";database=" db ";user=" user ";password=" password)
-          :make-pool? make-pool?}
+          :subname (str "//" host ":" port ";database=" db ";user=" user ";password=" password)}
          (dissoc opts :host :port :db)))
 
 (defn sqlite3
   "Create a database specification for a SQLite3 database. Opts should include a
   key for :db which is the path to the database file."
-  [{:keys [db make-pool?]
-    :or {db "sqlite.db", make-pool? true}
+  [{:keys [db]
+    :or {db "sqlite.db"}
     :as opts}]
   (merge {:classname "org.sqlite.JDBC" ; must be in classpath
           :subprotocol "sqlite"
-          :subname db
-          :make-pool? make-pool?}
+          :subname db}
          (dissoc opts :db)))
 
 (defn oracle

--- a/src/metabase/driver/vertica.clj
+++ b/src/metabase/driver/vertica.clj
@@ -32,7 +32,7 @@
    (keyword "Long Varchar")   :type/Text
    (keyword "Long Varbinary") :type/*})
 
-(defn- vertica-spec [{:keys [host port db make-pool?]
+(defn- vertica-spec [{:keys [host port db]
                       :or   {host "localhost", port 5433, db ""}
                       :as   opts}]
   (merge {:classname   "com.vertica.jdbc.Driver"

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -25,7 +25,6 @@
    :classname   "org.postgresql.Driver"
    :subprotocol "postgresql"
    :subname     "//localhost:5432/bird_sightings"
-   :make-pool?  true
    :sslmode     "disable"}
   (sql/connection-details->spec pg-driver {:ssl    false
                                            :host   "localhost"
@@ -36,7 +35,6 @@
 ;; ## ssl - check that expected params get added
 (expect
   {:ssl         true
-   :make-pool?  true
    :sslmode     "require"
    :classname   "org.postgresql.Driver"
    :subprotocol "postgresql"

--- a/test/metabase/test/data/generic_sql.clj
+++ b/test/metabase/test/data/generic_sql.clj
@@ -152,8 +152,7 @@
    (quote+combine-names driver (qualified-name-components driver db-name table-name field-name))))
 
 (defn- default-database->spec [driver context dbdef]
-  (let [spec (sql/connection-details->spec driver (i/database->connection-details driver context dbdef))]
-    (assoc spec :make-pool? true)))
+  (sql/connection-details->spec driver (i/database->connection-details driver context dbdef)))
 
 
 ;;; Loading Table Data


### PR DESCRIPTION
Remove the internal `:make-pool?` option from the few places where we still specify it.

This was a Korma option but since we switched over to HoneySQL in 0.18/0.19 it's no longer used for anything.
