### PR TITLE
Downgrade SQLite library version because new version breaks on Docker

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -59,14 +59,14 @@
                                com.sun.jmx/jmxri]]
                  [medley "0.8.3"]                                     ; lightweight lib of useful functions
                  [metabase/throttle "1.0.1"]                          ; Tools for throttling access to API endpoints and other code pathways
-                 [mysql/mysql-connector-java "5.1.39"]                ; MySQL JDBC driver (don't upgrade to 6.0+ yet -- that's Java 8 only)
+                 [mysql/mysql-connector-java "5.1.39"]                ; MySQL JDBC driver !!! Don't upgrade to 6.0+ yet -- that's Java 8 only !!!
                  [net.sf.cssbox/cssbox "4.12"                         ; HTML / CSS rendering
                   :exclusions [org.slf4j/slf4j-api]]
                  [net.sourceforge.jtds/jtds "1.3.1"]                  ; Open Source SQL Server driver
                  [org.liquibase/liquibase-core "3.5.2"]               ; migration management (Java lib)
                  [org.slf4j/slf4j-log4j12 "1.7.21"]                   ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
                  [org.yaml/snakeyaml "1.17"]                          ; YAML parser (required by liquibase)
-                 [org.xerial/sqlite-jdbc "3.14.2.1"]                  ; SQLite driver
+                 [org.xerial/sqlite-jdbc "3.8.11.2"]                  ; SQLite driver. !!! DO NOT UPGRADE THIS UNTIL UPSTREAM BUG IS FIXED -- SEE https://github.com/metabase/metabase/issues/3753 !!!
                  [postgresql "9.3-1102.jdbc41"]                       ; Postgres driver
                  [io.crate/crate-jdbc "1.13.1"]                       ; Crate JDBC driver
                  [io.crate/crate-client "0.56.0"]                     ; Crate Java client (used by Crate JDBC)


### PR DESCRIPTION
As @salsakran has confirmed the new version of the SQLite library we're using doesn't work on Docker, but the previous version does. Reasons unknown.

Revert for the time being until this issue is addressed upstream.

Fixed #3753