### PR TITLE
send-message -> send-message!

### DIFF
--- a/src/metabase/api/email.clj
+++ b/src/metabase/api/email.clj
@@ -75,7 +75,7 @@
   "Send a test email. You must be a superuser to do this."
   []
   (check-superuser)
-  (let [response (email/send-message
+  (let [response (email/send-message!
                    :subject      "Metabase Test Email"
                    :recipients   [(:email @*current-user*)]
                    :message-type :text

--- a/src/metabase/email.clj
+++ b/src/metabase/email.clj
@@ -35,11 +35,11 @@
   []
   (not (s/blank? (setting/get :email-smtp-host))))
 
-(defn send-message
+(defn send-message!
   "Send an email to one or more RECIPIENTS.
    RECIPIENTS is a sequence of email addresses; MESSAGE-TYPE must be either `:text` or `:html`.
 
-     (email/send-message
+     (email/send-message!
        :subject      \"[Metabase] Password Reset Request\"
        :recipients   [\"cam@metabase.com\"]
        :message-type :text
@@ -95,8 +95,8 @@
   {:pre [(string? host)
          (integer? port)]}
   (try
-    (let [ssl     (= security "ssl")
-          proto   (if ssl "smtps" "smtp")
+    (let [ssl?    (= security "ssl")
+          proto   (if ssl? "smtps" "smtp")
           details (-> details
                       (assoc :proto proto
                              :connectiontimeout "1000"
@@ -112,6 +112,6 @@
     {:error   :SUCCESS
      :message nil}
     (catch Throwable e
-      (println "err" (.getMessage e))
+      (log/error "Error testing SMTP connection:" (.getMessage e))
       {:error   :ERROR
        :message (.getMessage e)})))

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -38,7 +38,7 @@
                         :quotationAuthor (:author data-quote)
                         :today           (u/format-date "MMM'&nbsp;'dd,'&nbsp;'yyyy")
                         :logoHeader      true})]
-    (email/send-message
+    (email/send-message!
       :subject      (str "You're invited to join " company "'s Metabase")
       :recipients   [(:email invited)]
       :message-type :html
@@ -54,7 +54,7 @@
              (and (map? invitor)
                   (u/is-email? (:email invitor))))]}
   (let [data-quote (quotation/random-quote)]
-    (email/send-message
+    (email/send-message!
       :subject      (format (if google-auth?
                               "%s created a Metabase account"
                               "%s accepted your Metabase invite")
@@ -90,7 +90,7 @@
                         :sso              google-auth?
                         :passwordResetUrl password-reset-url
                         :logoHeader       true})]
-    (email/send-message
+    (email/send-message!
       :subject      "[Metabase] Password Reset Request"
       :recipients   [email]
       :message-type :html
@@ -124,7 +124,7 @@
                                  :quotation (:quote data-quote)
                                  :quotationAuthor (:author data-quote)))
         message-body  (stencil/render-file "metabase/email/notification" context)]
-    (email/send-message
+    (email/send-message!
       :subject      "[Metabase] Notification"
       :recipients   [email]
       :message-type :html
@@ -153,7 +153,7 @@
                                 :callToAction "Would you mind taking a fast 6 question survey to tell us how it’s going?"
                                 :link         "http://www.metabase.com/feedback/active"}))
         message-body  (stencil/render-file "metabase/email/follow_up_email" context)]
-    (email/send-message
+    (email/send-message!
       :subject      subject
       :recipients   [email]
       :message-type :html

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -35,7 +35,7 @@
   (log/debug (format "Sending Pulse (%d: %s) via Channel :email" id name))
   (let [email-subject    (str "Pulse: " name)
         email-recipients (filterv u/is-email? (map :email recipients))]
-    (email/send-message
+    (email/send-message!
       :subject      email-subject
       :recipients   email-recipients
       :message-type :attachments

--- a/test/metabase/api/email_test.clj
+++ b/test/metabase/api/email_test.clj
@@ -32,16 +32,3 @@
         new-settings  (email-settings)
         _             (setting/set-many! orig-settings)]
     new-settings))
-
-
-;; with-fake-inbox doesn't work in this case because of the api call
-;; /api/email/test - sends a test email to the given user
-;(expect
-;  [{:from "notifications@metabase.com",
-;    :to [(-> (fetch-user :crowberto) :email)],
-;    :subject "Metabase Test Email",
-;    :body [{:type    "text/plain; charset=utf-8"
-;            :content "Your Metabase emails are working — hooray!"}]}]
-;  (with-fake-inbox
-;    ((user->client :crowberto) :post 200 "email/test")
-;    (@inbox (-> (fetch-user :crowberto) :email))))

--- a/test/metabase/email_test.clj
+++ b/test/metabase/email_test.clj
@@ -42,7 +42,7 @@
     :body [{:type    "text/html; charset=utf-8"
             :content "101. Metabase will make you a better person"}]}]
   (with-fake-inbox
-    (email/send-message
+    (email/send-message!
       :subject      "101 Reasons to use Metabase"
       :recipients   ["test@test.com"]
       :message-type :html


### PR DESCRIPTION
Some minor cleanup I made while poking around code trying to figure out how to fix #3356

*  `send-message!` instead of `send-message` because the function has side-effects
*   Use `log/error` to log errors, not `println`