### PR TITLE
change logout to sign out

### DIFF
--- a/frontend/src/metabase/nav/components/ProfileLink.jsx
+++ b/frontend/src/metabase/nav/components/ProfileLink.jsx
@@ -124,7 +124,7 @@ export default class ProfileLink extends Component {
                                         data-metabase-event={"Navbar;Profile Dropdown;Logout"}
                                         className="Dropdown-item block text-white no-decoration"
                                     >
-                                        Logout
+                                        Sign out
                                     </Link>
                                 </li>
                             </ul>


### PR DESCRIPTION
[Nielson](http://ux.stackexchange.com/questions/1080/using-sign-in-vs-using-log-in) recommends this, it's common among large websites (see Google, Amazon, GitHub, Slack — notable exception being Facebook, but who signs out of that? ;) ), and Metabase currently uses `Sign in` on our … sign in page.

Tiny change, but just something that bugged me. If anyone feels strongly _against_ this, then we need to at least fix our grammar and change it to "Log out," since it's a verb and not a noun.