### PR TITLE
Support postgresql:// in MB_DB_CONNECTION_URI

### DIFF
--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -49,7 +49,10 @@
   "Parse a DB connection URI like `postgres://cam@localhost.com:5432/cams_cool_db?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory` and return a broken-out map."
   [uri]
   (when-let [[_ protocol user pass host port db query] (re-matches #"^([^:/@]+)://(?:([^:/@]+)(?::([^:@]+))?@)?([^:@]+)(?::(\d+))?/([^/?]+)(?:\?(.*))?$" uri)]
-    (merge {:type     (keyword protocol)
+    (merge {:type     (case (keyword protocol)
+                        :postgres   :postgres
+                        :postgresql :postgres
+                        :mysql      :mysql)
             :user     user
             :password pass
             :host     host

--- a/test/metabase/db_test.clj
+++ b/test/metabase/db_test.clj
@@ -6,11 +6,18 @@
 (tu/resolve-private-vars metabase.db parse-connection-string)
 
 ;; parse minimal connection string
-(expect {:type :postgres :user nil :password nil :host "localhost" :port nil :dbname "toms_cool_db" }
+(expect
+  {:type :postgres, :user nil, :password nil, :host "localhost", :port nil, :dbname "toms_cool_db" }
   (parse-connection-string "postgres://localhost/toms_cool_db"))
 
+;; parse connection string using alternate `postgreql` URI schema
+(expect
+  {:type :postgres, :user nil, :password nil, :host "localhost", :port nil, :dbname "toms_cool_db" }
+  (parse-connection-string "postgresql://localhost/toms_cool_db"))
+
 ;; parse all fields and query string arguments
-(expect {:type :postgres :user "tom" :password "1234" :host "localhost" :port "5432" :dbname "toms_cool_db" :ssl "true" :sslfactory "org.postgresql.ssl.NonValidatingFactory"}
+(expect
+  {:type :postgres, :user "tom", :password "1234", :host "localhost", :port "5432", :dbname "toms_cool_db", :ssl "true", :sslfactory "org.postgresql.ssl.NonValidatingFactory"}
   (parse-connection-string "postgres://tom:1234@localhost:5432/toms_cool_db?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory"))
 
 


### PR DESCRIPTION
Apparently a Postgres DB connection URL can have either `postgres://` or `postgresql://`.

Tweak things so we allow either option. Includes test.

Fixes #3726