### PR TITLE
Don't barf if ./bin/version doesn't work during dev (fix dev on Windows)

### DIFF
--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -60,8 +60,12 @@
 ;; Metabase version is of the format `GIT-TAG (GIT-SHORT-HASH GIT-BRANCH)`
 
 (defn- version-info-from-shell-script []
-  (let [[tag hash branch date] (-> (shell/sh "./bin/version") :out s/trim (s/split #" "))]
-    {:tag tag, :hash hash, :branch branch, :date date}))
+  (try
+    (let [[tag hash branch date] (-> (shell/sh "./bin/version") :out s/trim (s/split #" "))]
+      {:tag tag, :hash hash, :branch branch, :date date})
+    ;; if ./bin/version fails (e.g., if we are developing on Windows) just return something so the whole thing doesn't barf
+    (catch Throwable _
+      {:tag "?", :hash "?", :branch "?", :date "?"})))
 
 (defn- version-info-from-properties-file []
   (when-let [props-file (io/resource "version.properties")]


### PR DESCRIPTION
I've had this fix locally on my computer for a while now but I keep accidentally overwriting it when I do hard resets