### PR TITLE
Parse BigQuery ints as longs [ci drivers] (Credit: @felipegasparini)

### DIFF
--- a/src/metabase/driver/bigquery.clj
+++ b/src/metabase/driver/bigquery.clj
@@ -139,7 +139,7 @@
   "Functions that should be used to coerce string values in responses to the appropriate type for their column."
   {"BOOLEAN"   #(Boolean/parseBoolean %)
    "FLOAT"     #(Double/parseDouble %)
-   "INTEGER"   #(Integer/parseInt %)
+   "INTEGER"   #(Long/parseLong %)
    "RECORD"    identity
    "STRING"    identity
    "TIMESTAMP" parse-timestamp-str})


### PR DESCRIPTION
As @felipegasparini pointed out in #3789 BigQuery `INTEGER`s are 64-bit so we should be treating them as Java `Long`s instead of `Integer`s. 

Fixes #3789