### PR TITLE
Support MB_EMOJI_IN_LOGS env var for disabling emoji

### DIFF
--- a/docs/operations-guide/start.md
+++ b/docs/operations-guide/start.md
@@ -11,6 +11,7 @@
 *  [Customizing the Metabase Jetty Webserver](#customizing-the-metabase-jetty-webserver)
 *  [Changing password complexity](#changing-metabase-password-complexity)
 *  [Handling Timezones](#handling-timezones-in-metabase)
+*  [Configuring Emoji Logging](#configuring-emoji-logging)
 
 # Installing and Running Metabase
 
@@ -290,3 +291,11 @@ To ensure proper reporting it's important that timezones be set consistently in 
 Common Pitfalls:
 1. Your database is using date/time columns without any timezone information.  Typically when this happens your database will assume all the data is from whatever timezone the database is configured in or possible just default to UTC (check your database vendor to be sure).
 2. Your JVM timezone is not the same as your Metabase `Report Timezone` choice.  This is a very common issue and can be corrected by launching java with the `-Duser.timezone=<timezone>` option properly set to match your Metabase report timezone.
+
+
+# Configuring Emoji Logging
+
+By default Metabase will include emoji characters in logs. You can disable this by using the following environment variable:
+
+    export MB_EMOJI_IN_LOGS="false"
+    java -jar metabase.jar

--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -28,7 +28,8 @@
    ;:mb-password-length "8"
    :mb-version-info-url "http://static.metabase.com/version-info.json"
    :max-session-age "20160"                     ; session length in minutes (14 days)
-   :mb-colorize-logs "true"})
+   :mb-colorize-logs "true"
+   :mb-emoji-in-logs "true"})
 
 
 (defn config-str

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -340,7 +340,7 @@
             (require 'metabase.driver)
             ((resolve 'metabase.driver/can-connect-with-details?) engine details))
     (format "Unable to connect to Metabase %s DB." (name engine)))
-  (log/info "Verify Database Connection ... ✅"))
+  (log/info "Verify Database Connection ... " (u/emoji "✅")))
 
 
 (def ^:dynamic ^Boolean *disable-data-migrations*
@@ -373,7 +373,7 @@
                      "\n\n"
                      "Once your database is updated try running the application again.\n"))
       (throw (java.lang.Exception. "Database requires manual upgrade."))))
-  (log/info "Database Migrations Current ... ✅")
+  (log/info "Database Migrations Current ... " (u/emoji "✅"))
 
   ;; Establish our 'default' DB Connection
   (create-connection-pool! (jdbc-details db-details))

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -256,7 +256,7 @@
   [^Keyword engine, driver-instance]
   {:pre [(keyword? engine) (map? driver-instance)]}
   (swap! registered-drivers assoc engine driver-instance)
-  (log/debug (format "Registered driver %s 🚚" (u/format-color 'blue engine))))
+  (log/debug (format "Registered driver %s %s" (u/format-color 'blue engine) (u/emoji "🚚"))))
 
 (defn available-drivers
   "Info about available drivers."

--- a/src/metabase/events.clj
+++ b/src/metabase/events.clj
@@ -30,7 +30,7 @@
       (require ns-symb)
       ;; look for `events-init` function in the namespace and call it if it exists
       (when-let [init-fn (ns-resolve ns-symb 'events-init)]
-        (log/info "Starting events listener:" (u/format-color 'blue ns-symb) "👂")
+        (log/info "Starting events listener:" (u/format-color 'blue ns-symb) (u/emoji "👂"))
         (init-fn)))))
 
 (defn initialize-events!

--- a/src/metabase/plugins.clj
+++ b/src/metabase/plugins.clj
@@ -34,5 +34,5 @@
             :when (and (.isFile file)
                        (.canRead file)
                        (re-find #"\.jar$" (.getPath file)))]
-      (log/info (u/format-color 'magenta "Loading plugin %s... 🔌" file))
+      (log/info (u/format-color 'magenta "Loading plugin %s... %s" file (u/emoji "🔌")))
       (add-jar-to-classpath! file))))

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -152,7 +152,7 @@
     (u/prog1 (macros/expand-macros query)
       (when (and (not *disable-qp-logging*)
                  (not= <> query))
-        (log/debug (u/format-color 'cyan "\n\nMACRO/SUBSTITUTED: 😻\n%s" (u/pprint-to-str <>)))))))
+        (log/debug (u/format-color 'cyan "\n\nMACRO/SUBSTITUTED: %s\n%s" (u/emoji "😻") (u/pprint-to-str <>)))))))
 
 (defn- pre-expand-macros [qp] (comp qp expand-macros))
 
@@ -163,7 +163,7 @@
   (u/prog1 (params/expand-parameters query)
     (when (and (not *disable-qp-logging*)
                (not= <> query))
-      (log/debug (u/format-color 'cyan "\n\nPARAMS/SUBSTITUTED: 😻\n%s" (u/pprint-to-str <>))))))
+      (log/debug (u/format-color 'cyan "\n\nPARAMS/SUBSTITUTED: %s\n%s" (u/emoji "😻") (u/pprint-to-str <>))))))
 
 (defn- pre-substitute-parameters [qp] (comp qp substitute-parameters))
 
@@ -347,7 +347,8 @@
   (u/prog1 query
     (when (and (mbql-query? query)
                (not *disable-qp-logging*))
-      (log/debug (u/format-color 'magenta "\nPREPROCESSED/EXPANDED: 😻\n%s"
+      (log/debug (u/format-color 'magenta "\nPREPROCESSED/EXPANDED: %s\n%s"
+                   (u/emoji "😻")
                    (u/pprint-to-str
                     ;; Remove empty kv pairs because otherwise expanded query is HUGE
                     (walk/prewalk
@@ -356,7 +357,7 @@
                                (m/filter-vals identity (into {} f))))
                      ;; obscure DB details when logging. Just log the name of driver because we don't care about its properties
                      (-> query
-                         (assoc-in [:database :details] "😋 ") ; :yum:
+                         (assoc-in [:database :details] (u/emoji "😋 ")) ; :yum:
                          (update :driver name)))))))))
 
 (defn- pre-log-query [qp] (comp qp log-query))
@@ -423,7 +424,7 @@
                                 (:native query)
                                 (driver/mbql->native (:driver query) query))
                        (when-not *disable-qp-logging*
-                         (log/debug (u/format-color 'green "NATIVE FORM: 😳\n%s\n" (u/pprint-to-str <>)))))
+                         (log/debug (u/format-color 'green "NATIVE FORM: %s\n%s\n" (u/emoji "😳") (u/pprint-to-str <>)))))
         native-query (if-not (mbql-query? query)
                        query
                        (assoc query :native native-form))
@@ -471,7 +472,7 @@
   {:style/indent 0}
   [query]
   (when-not *disable-qp-logging*
-    (log/debug (u/format-color 'blue "\nQUERY: 😎\n%s"  (u/pprint-to-str query))))
+    (log/debug (u/format-color 'blue "\nQUERY: %s\n%s"  (u/emoji "😎") (u/pprint-to-str query))))
   ;; TODO: it probably makes sense to throw an error or return a failure response here if we can't get a driver
   (let [driver (driver/database-id->driver (:database query))]
     (binding [*driver* driver]

--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -20,7 +20,7 @@
   []
   (doseq [ns-symb @u/metabase-namespace-symbols
           :when   (.startsWith (name ns-symb) "metabase.task.")]
-    (log/info "Loading tasks namespace:" (u/format-color 'blue ns-symb) "📆")
+    (log/info "Loading tasks namespace:" (u/format-color 'blue ns-symb) (u/emoji "📆"))
     (require ns-symb)
     ;; look for `task-init` function in the namespace and call it if it exists
     (when-let [init-fn (ns-resolve ns-symb 'task-init)]

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -495,6 +495,12 @@
      ~@body
      ~'<>))
 
+(def ^String ^{:arglists '([emoji-string])} emoji
+  "Returns the EMOJI-STRING passed in if emoji in logs are enabled, otherwise always returns an empty string."
+  (if (config/config-bool :mb-emoji-in-logs)
+    identity
+    (constantly "")))
+
 (def ^String ^{:style/indent 2, :arglists '([color-symb x] [color-symb format-str & args])}
   format-color
   "Like `format`, but uses a function in `colorize.core` to colorize the output.
@@ -554,7 +560,7 @@
         (str "["
              (s/join (repeat filleds "*"))
              (s/join (repeat blanks "·"))
-             (format "] %s  %3.0f%%" (percent-done->emoji percent-done) (* percent-done 100.0)))))))
+             (format "] %s  %3.0f%%" (emoji (percent-done->emoji percent-done)) (* percent-done 100.0)))))))
 
 (defn filtered-stacktrace
   "Get the stack trace associated with E and return it as a vector with non-metabase frames filtered out."


### PR DESCRIPTION
Add support for env var `MB_EMOJI_IN_LOGS` which can be used to disable emoji in logs.

Supersedes #3587 
Fixes #3358