### PR TITLE
Druid Expression Aggregations

### DIFF
--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -135,7 +135,8 @@
   *  `:standard-deviation-aggregations` - Does this driver support [standard deviation aggregations](https://github.com/metabase/metabase/wiki/Query-Language-'98#stddev-aggregation)?
   *  `:expressions` - Does this driver support [expressions](https://github.com/metabase/metabase/wiki/Query-Language-'98#expressions) (e.g. adding the values of 2 columns together)?
   *  `:dynamic-schema` -  Does this Database have no fixed definitions of schemas? (e.g. Mongo)
-  *  `:native-parameters` - Does the driver support parameter substitution on native queries?")
+  *  `:native-parameters` - Does the driver support parameter substitution on native queries?
+  *  `:expression-aggregations` - Does the driver support using expressions inside aggregations? e.g. something like \"sum(x) + count(y)\" or \"avg(x + y)\"")
 
   (field-values-lazy-seq ^clojure.lang.Sequential [this, ^FieldInstance field]
     "Return a lazy sequence of all values of FIELD.

--- a/src/metabase/driver/druid.clj
+++ b/src/metabase/driver/druid.clj
@@ -158,7 +158,7 @@
                                                :type         :integer
                                                :default      8082}])
           :execute-query         (fn [_ query] (qp/execute-query do-query query))
-          :features              (constantly #{:basic-aggregations :set-timezone})
+          :features              (constantly #{:basic-aggregations :set-timezone :expression-aggregations})
           :field-values-lazy-seq (u/drop-first-arg field-values-lazy-seq)
           :mbql->native          (u/drop-first-arg qp/mbql->native)}))
 

--- a/src/metabase/driver/druid/js.clj
+++ b/src/metabase/driver/druid/js.clj
@@ -37,16 +37,16 @@
        (apply str body)
        " }"))
 
-(defn- arthitmetic-operator
+(defn- arithmetic-operator
   "Interpose artihmetic OPERATOR between ARGS, and wrap the entire expression in parens."
   ^String [operator & args]
   (parens (s/join (str " " (name operator) " ")
                   (map ->js args))))
 
-(def ^{:arglists '([& args])} ^String + "Interpose `+` between ARGS, and wrap the entire expression in parens." (partial arthitmetic-operator :+))
-(def ^{:arglists '([& args])} ^String - "Interpose `-` between ARGS, and wrap the entire expression in parens." (partial arthitmetic-operator :-))
-(def ^{:arglists '([& args])} ^String * "Interpose `*` between ARGS, and wrap the entire expression in parens." (partial arthitmetic-operator :*))
-(def ^{:arglists '([& args])} ^String / "Interpose `/` between ARGS, and wrap the entire expression in parens." (partial arthitmetic-operator :/))
+(def ^{:arglists '([& args])} ^String + "Interpose `+` between ARGS, and wrap the entire expression in parens." (partial arithmetic-operator :+))
+(def ^{:arglists '([& args])} ^String - "Interpose `-` between ARGS, and wrap the entire expression in parens." (partial arithmetic-operator :-))
+(def ^{:arglists '([& args])} ^String * "Interpose `*` between ARGS, and wrap the entire expression in parens." (partial arithmetic-operator :*))
+(def ^{:arglists '([& args])} ^String / "Interpose `/` between ARGS, and wrap the entire expression in parens." (partial arithmetic-operator :/))
 
 (defn fn-call
   "Generate a JavaScript function call.

--- a/src/metabase/driver/druid/js.clj
+++ b/src/metabase/driver/druid/js.clj
@@ -1,0 +1,68 @@
+(ns metabase.driver.druid.js
+  "Util fns for creating Javascript functions."
+  (:refer-clojure :exclude [+ - * / or])
+  (:require [clojure.string :as s]))
+
+(defn- ->js [x]
+  {:pre [(not (coll? x))]}
+  (if (keyword? x)
+    (name x)
+    x))
+
+(defn parens
+  "Wrap S (presumably a string) in parens."
+  ^String [s]
+  (str "(" s ")"))
+
+(defn argslist
+  "Generate a list of arguments, e.g. for a function declaration or function call.
+   ARGS are separated by commas and wrapped in parens.
+
+     (argslist [:x :y]) -> \"(x, y)\""
+  ^String [args]
+  (parens (s/join ", " (map ->js args))))
+
+(defn return
+  "Generate a javascript `return` statement. STATEMENT-PARTS are combined directly into a single string.
+
+     (return :x :+ :y) -> \"return x+y;\""
+  ^String [& statement-parts]
+  (str "return " (apply str (map ->js statement-parts)) ";"))
+
+(defn function
+  "Create a JavaScript function with ARGS and BODY."
+  {:style/indent 1}
+  ^String [args & body]
+  (str "function" (argslist args) " { "
+       (apply str body)
+       " }"))
+
+(defn- arthitmetic-operator
+  "Interpose artihmetic OPERATOR between ARGS, and wrap the entire expression in parens."
+  ^String [operator & args]
+  (parens (s/join (str " " (name operator) " ")
+                  (map ->js args))))
+
+(def ^{:arglists '([& args])} ^String + "Interpose `+` between ARGS, and wrap the entire expression in parens." (partial arthitmetic-operator :+))
+(def ^{:arglists '([& args])} ^String - "Interpose `-` between ARGS, and wrap the entire expression in parens." (partial arthitmetic-operator :-))
+(def ^{:arglists '([& args])} ^String * "Interpose `*` between ARGS, and wrap the entire expression in parens." (partial arthitmetic-operator :*))
+(def ^{:arglists '([& args])} ^String / "Interpose `/` between ARGS, and wrap the entire expression in parens." (partial arthitmetic-operator :/))
+
+(defn fn-call
+  "Generate a JavaScript function call.
+
+     (fn-call :parseFloat :x :y) -> \"parseFloat(x, y)\""
+  ^String [fn-name & args]
+  (str (name fn-name) (argslist args)))
+
+(def ^{:arglists '([x])} ^String parse-float
+  "Generate a call to the JavaScript `parseFloat` function."
+  (partial fn-call :parseFloat))
+
+
+(defn or
+  "Interpose the JavaScript or operator (`||`) betwen ARGS, and wrap the entire expression in parens.
+
+     (or :x :y) -> \"(x || y)\""
+  ^String [& args]
+  (parens (s/join " || " (map ->js args))))

--- a/src/metabase/query_processor/resolve.clj
+++ b/src/metabase/query_processor/resolve.clj
@@ -39,12 +39,15 @@
 (defprotocol ^:private IResolve
   (^:private unresolved-field-id ^Integer [this]
    "Return the unresolved Field ID associated with this object, if any.")
+
   (^:private fk-field-id ^Integer [this]
    "Return a the FK Field ID (for joining) associated with this object, if any.")
+
   (^:private resolve-field [this, ^clojure.lang.IPersistentMap field-id->field]
    "This method is called when walking the Query after fetching `Fields`.
     Placeholder objects should lookup the relevant Field in FIELD-ID->FIELDS and
-    return their expanded form. Other objects should just return themselves.a")
+    return their expanded form. Other objects should just return themselves.")
+
   (resolve-table [this, ^clojure.lang.IPersistentMap fk-id+table-id->tables]
    "Called when walking the Query after `Fields` have been resolved and `Tables` have been fetched.
     Objects like `Fields` can add relevant information like the name of their `Table`."))
@@ -194,7 +197,7 @@
         expanded-query-dict
         ;; Otherwise fetch + resolve the Fields in question
         (let [fields (->> (u/key-by :id (db/select [field/Field :name :display_name :base_type :special_type :visibility_type :table_id :parent_id :description :id]
-                                          :visibility_type [:not-in ["sensitive"]]
+                                          :visibility_type [:not= "sensitive"]
                                           :id [:in field-ids]))
                           (m/map-vals rename-mb-field-keys)
                           (m/map-vals #(assoc % :parent (when-let [parent-id (:parent-id %)]
@@ -204,7 +207,7 @@
            ;; Those will be used for Table resolution in the next step.
            (update expanded-query-dict :table-ids set/union (set (map :table-id (vals fields))))
            ;; Walk the query and resolve all fields
-           (walk/postwalk #(resolve-field % fields))
+           (walk/postwalk (u/rpartial resolve-field fields))
            ;; Recurse in case any new (nested) unresolved fields were found.
            (recur (dec max-iterations))))))))
 
@@ -218,10 +221,8 @@
                            [:target-table.name   :target-table-name]
                            [:target-table.schema :target-table-schema]]
                :from      [[field/Field :source-fk]]
-               :left-join [[field/Field :target-pk]
-                           [:= :source-fk.fk_target_field_id :target-pk.id]
-                           [Table :target-table]
-                           [:= :target-pk.table_id :target-table.id]]
+               :left-join [[field/Field :target-pk] [:= :source-fk.fk_target_field_id :target-pk.id]
+                           [Table :target-table]    [:= :target-pk.table_id :target-table.id]]
                :where     [:and [:in :source-fk.id      (set fk-field-ids)]
                                 [:=  :source-fk.table_id     source-table-id]
                                 (db/isa :source-fk.special_type :type/FK)]})))

--- a/test/metabase/driver/druid_test.clj
+++ b/test/metabase/driver/druid_test.clj
@@ -2,9 +2,12 @@
   (:require [cheshire.core :as json]
             [expectations :refer :all]
             [metabase.query-processor :as qp]
+            [metabase.query-processor.expand :as ql]
+            [metabase.query-processor-test :refer [rows]]
             [metabase.test.data :as data]
             [metabase.test.data.datasets :as datasets, :refer [expect-with-engine]]
-            [metabase.timeseries-query-processor-test :as timeseries-qp-test]))
+            [metabase.timeseries-query-processor-test :as timeseries-qp-test]
+            [metabase.query :as q]))
 
 (def ^:const ^:private ^String native-query-1
   (json/generate-string
@@ -59,3 +62,123 @@
 (expect-with-engine :druid
   :completed
   (:status (process-native-query native-query-2)))
+
+
+;;; +------------------------------------------------------------------------------------------------------------------------+
+;;; |                                                   MATH AGGREGATIONS                                                    |
+;;; +------------------------------------------------------------------------------------------------------------------------+
+
+(defmacro ^:private druid-query-returning-rows {:style/indent 0} [& body]
+  `(rows (timeseries-qp-test/with-flattened-dbdef
+           (qp/process-query {:database (data/id)
+                              :type     :query
+                              :query    (data/query ~'checkins
+                                          ~@body)}))))
+
+;; sum, *
+(expect-with-engine :druid
+  [["1" 110688.0]
+   ["2" 616708.0]
+   ["3" 179661.0]
+   ["4"  86284.0]]
+  (druid-query-returning-rows
+    (ql/aggregation (ql/sum (ql/* $id $venue_price)))
+    (ql/breakout $venue_price)))
+
+;; min, +
+(expect-with-engine :druid
+  [["1"  4.0]
+   ["2"  3.0]
+   ["3"  8.0]
+   ["4" 12.0]]
+  (druid-query-returning-rows
+    (ql/aggregation (ql/min (ql/+ $id $venue_price)))
+    (ql/breakout $venue_price)))
+
+;; max, /
+(expect-with-engine :druid
+  [["1" 1000.0]
+   ["2"  499.5]
+   ["3"  332.0]
+   ["4"  248.25]]
+  (druid-query-returning-rows
+    (ql/aggregation (ql/max (ql// $id $venue_price)))
+    (ql/breakout $venue_price)))
+
+;; avg, -
+(expect-with-engine :druid
+  [["1" 500.85067873303166]
+   ["2" 1002.7772357723577]
+   ["3" 1562.2695652173913]
+   ["4" 1760.8979591836735]]
+  (druid-query-returning-rows
+    (ql/aggregation (ql/avg (ql/* $id $venue_price)))
+    (ql/breakout $venue_price)))
+
+;; post-aggregation math w/ 2 args: count + sum
+(expect-with-engine :druid
+  [["1"  442.0]
+   ["2" 1845.0]
+   ["3"  460.0]
+   ["4"  245.0]]
+  (druid-query-returning-rows
+    (ql/aggregation (ql/+ (ql/count $id)
+                          (ql/sum $venue_price)))
+    (ql/breakout $venue_price)))
+
+;; post-aggregation math w/ 3 args: count + sum + count
+(expect-with-engine :druid
+  [["1"  663.0]
+   ["2" 2460.0]
+   ["3"  575.0]
+   ["4"  294.0]]
+  (druid-query-returning-rows
+    (ql/aggregation (ql/+ (ql/count $id)
+                          (ql/sum $venue_price)
+                          (ql/count $venue_price)))
+    (ql/breakout $venue_price)))
+
+;; post-aggregation math w/ a constant: count * 10
+(expect-with-engine :druid
+  [["1" 2210.0]
+   ["2" 6150.0]
+   ["3" 1150.0]
+   ["4"  490.0]]
+  (druid-query-returning-rows
+    (ql/aggregation (ql/* (ql/count $id)
+                          10))
+    (ql/breakout $venue_price)))
+
+;; nested post-aggregation math: count + (count * sum)
+(expect-with-engine :druid
+  [["1"  49062.0]
+   ["2" 757065.0]
+   ["3"  39790.0]
+   ["4"  9653.0]]
+  (druid-query-returning-rows
+    (ql/aggregation (ql/+ (ql/count $id)
+                          (ql/* (ql/count $id)
+                                (ql/sum $venue_price))))
+    (ql/breakout $venue_price)))
+
+;; post-aggregation math w/ avg: count + avg
+(expect-with-engine :druid
+  [["1"  721.8506787330316]
+   ["2" 1116.388617886179]
+   ["3"  635.7565217391304]
+   ["4"  489.2244897959184]]
+  (druid-query-returning-rows
+    (ql/aggregation (ql/+ (ql/count $id)
+                          (ql/avg $id)))
+    (ql/breakout $venue_price)))
+
+;; post aggregation math + math inside aggregations: max(venue_price) + min(venue_price - id)
+(expect-with-engine :druid
+  [["1" -998.0]
+   ["2" -995.0]
+   ["3" -990.0]
+   ["4" -985.0]]
+  (druid-query-returning-rows
+    (ql/aggregation (ql/+ (ql/max $venue_price)
+                          (ql/min (ql/- $venue_price $id))))
+    (ql/breakout $venue_price)))


### PR DESCRIPTION
This part is ready to be merged. Support expression aggregations, e.g. MBQL

```clojure
;; expressions inside aggregations
{:aggregation [:sum [:+ [:field-id 1]
                        [:field-id 2]]]}

;; post-aggregation math
{:aggregation [:+ [:sum [:field-id 1]]
                  [:avg [:field-id 2]]]}

;; both 
{:aggregation [:+ [:sum [:field-id 1]]
                  [:avg [:- [:field-id 2]
                            [:field-id 3]]]]}
```

As with "Calculated Column" Expressions, expression aggregations may be nested arbitrarily.

Drivers that support expression aggregations declare the feature `:expression-aggregations`. Currently, only the Druid driver supports this, but SQL support is forthcoming.

Tests included