### PR TITLE
use helmet for page titles [POC]

### DIFF
--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from "react";
+import Helmet from "react-helmet";
 
 import Navbar from "metabase/nav/containers/Navbar.jsx";
 
@@ -7,6 +8,10 @@ export default class App extends Component {
         const { children, location } = this.props;
         return (
             <div className="spread flex flex-column">
+                <Helmet
+                    defaultTitle="Metabase"
+                    titleTemplate="Metabase - %s"
+                />
                 <Navbar location={location} className="flex-no-shrink" />
                 {children}
             </div>

--- a/frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx
+++ b/frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from "react";
 
 import _ from "underscore";
 import cx from "classnames";
+import Helmet from "react-helmet";
 
 import AuthScene from "../components/AuthScene.jsx";
 import BackToLogin from "../components/BackToLogin.jsx"
@@ -48,6 +49,7 @@ export default class ForgotPasswordApp extends Component {
 
         return (
             <div className="full-height bg-white flex flex-column flex-full md-layout-centered">
+                <Helmet title="Forgot password?" />
                 <div className="Login-wrapper wrapper Grid Grid--full md-Grid--1of2">
                       <div className="Grid-cell flex layout-centered text-brand">
                           <LogoIcon className="Logo my4 sm-my0" width={66} height={85} />

--- a/frontend/src/metabase/auth/containers/LoginApp.jsx
+++ b/frontend/src/metabase/auth/containers/LoginApp.jsx
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from "react";
 import { findDOMNode } from "react-dom";
 import { Link } from "react-router";
 import { connect } from "react-redux";
+import Helmet from "react-helmet";
 
 import cx from "classnames";
 
@@ -108,6 +109,7 @@ export default class LoginApp extends Component {
 
         return (
             <div className="full-height full bg-white flex flex-column flex-full md-layout-centered">
+                <Helmet title="Login" />
                 <div className="Login-wrapper wrapper Grid Grid--full md-Grid--1of2 relative z2">
                     <div className="Grid-cell flex layout-centered text-brand">
                         <LogoIcon className="Logo my4 sm-my0" width={66} height={85} />

--- a/frontend/src/metabase/dashboard/components/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard.jsx
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from "react";
 import ReactDOM from "react-dom";
+import Helmet from "react-helmet";
 
 import DashboardHeader from "../components/DashboardHeader.jsx";
 import DashboardGrid from "../components/DashboardGrid.jsx";
@@ -330,6 +331,7 @@ export default class Dashboard extends Component {
             <LoadingAndErrorWrapper style={{ minHeight: "100%" }} className={cx("Dashboard flex-full", { "Dashboard--fullscreen": isFullscreen, "Dashboard--night": isNightMode})} loading={!dashboard} error={error}>
             {() =>
                 <div className="full" style={{ overflowX: "hidden" }}>
+                    <Helmet title={dashboard.name} />
                     <header className="DashboardHeader relative z2">
                         <DashboardHeader
                             {...this.props}

--- a/frontend/src/metabase/home/containers/HomepageApp.jsx
+++ b/frontend/src/metabase/home/containers/HomepageApp.jsx
@@ -1,6 +1,7 @@
 
 import React, { Component, PropTypes } from "react";
 import { connect } from "react-redux";
+import Helmet from "react-helmet";
 
 import Greeting from "metabase/lib/greeting";
 import Modal from "metabase/components/Modal.jsx";
@@ -75,6 +76,8 @@ export default class HomepageApp extends Component {
                         />
                     </Modal>
                 : null }
+
+                <Helmet title="Home" />
 
                 <div className="CheckBg bg-brand text-white md-pl4">
                     <div style={{marginRight: 346}}>

--- a/frontend/src/metabase/pulse/components/PulseList.jsx
+++ b/frontend/src/metabase/pulse/components/PulseList.jsx
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from "react";
+import Helmet from "react-helmet";
 
 import PulseListItem from "./PulseListItem.jsx";
 import WhatsAPulse from "./WhatsAPulse.jsx";
@@ -41,6 +42,7 @@ export default class PulseList extends Component {
         let { pulses, user } = this.props;
         return (
             <div className="PulseList pt3">
+                <Helmet title="Pulses" />
                 <div className="border-bottom mb2">
                     <div className="wrapper wrapper--trim flex align-center mb2">
                         <h1>Pulses</h1>

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom";
 import { connect } from "react-redux";
 import cx from "classnames";
 import _ from "underscore";
+import Helmet from "react-helmet";
 
 import { loadTableAndForeignKeys } from "metabase/lib/table";
 import { isPK, isFK } from "metabase/lib/types";
@@ -201,6 +202,7 @@ export default class QueryBuilder extends Component {
         const showDrawer = uiControls.isShowingDataReference || uiControls.isShowingTemplateTagsEditor;
         return (
             <div className="flex-full relative">
+                <Helmet title={card.name ? card.name : 'New question'} />
                 <div className={cx("QueryBuilder flex flex-column bg-white spread", {"QueryBuilder--showSideDrawer": showDrawer})}>
                     <div id="react_qb_header">
                         <QueryHeader {...this.props}/>

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-ansi-style": "^1.0.0",
     "react-dom": "^15.2.1",
     "react-draggable": "^1.1.3",
+    "react-helmet": "^3.2.2",
     "react-redux": "^4.4.5",
     "react-resizable": "^1.0.1",
     "react-retina-image": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1908,7 +1908,7 @@ deep-diff@0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.4.tgz#aac5c39952236abe5f037a2349060ba01b00ae48"
 
-deep-equal@^1.0.0, deep-equal@^1.0.1:
+deep-equal@^1.0.0, deep-equal@^1.0.1, deep-equal@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
@@ -2590,6 +2590,14 @@ fbjs@^0.8.1, fbjs@^0.8.4:
     object-assign "^4.1.0"
     promise "^7.1.1"
     ua-parser-js "^0.7.9"
+
+fbjs@0.1.0-alpha.10:
+  version "0.1.0-alpha.10"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.1.0-alpha.10.tgz#46e457c09cbefb51fc752a3e030e7b67fcc384c8"
+  dependencies:
+    core-js "^1.0.0"
+    promise "^7.0.3"
+    whatwg-fetch "^0.9.0"
 
 figures@^1.3.5:
   version "1.7.0"
@@ -5385,7 +5393,7 @@ promise-loader:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/promise-loader/-/promise-loader-1.0.0.tgz#6fc7c8529c1fdfc497bef5fe7448bb61af9546cc"
 
-promise@^7.1.1:
+promise@^7.0.3, promise@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
   dependencies:
@@ -5538,6 +5546,16 @@ react-fuzzy@^0.2.3:
     classnames "^2.2.3"
     fuse.js "^2.2.0"
 
+react-helmet:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-3.2.2.tgz#1fc4646cbc5d26246ab45d5a84b504ed639810e6"
+  dependencies:
+    deep-equal "1.0.1"
+    object-assign "^4.0.1"
+    react-side-effect "1.0.2"
+    shallowequal "0.2.2"
+    warning "3.0.0"
+
 react-hot-api@^0.4.5:
   version "0.4.7"
   resolved "https://registry.yarnpkg.com/react-hot-api/-/react-hot-api-0.4.7.tgz#a7e22a56d252e11abd9366b61264cf4492c58171"
@@ -5616,6 +5634,12 @@ react-router@^2.6.0:
     invariant "^2.2.1"
     loose-envify "^1.2.0"
     warning "^3.0.0"
+
+react-side-effect@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-1.0.2.tgz#98e354decdbf0281e4223d87852d33e345eda561"
+  dependencies:
+    fbjs "0.1.0-alpha.10"
 
 react-simple-di@^1.2.0:
   version "1.2.0"
@@ -6158,7 +6182,7 @@ sha.js@2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.2.6.tgz#17ddeddc5f722fb66501658895461977867315ba"
 
-shallowequal@0.2.x:
+shallowequal@0.2.2, shallowequal@0.2.x:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-0.2.2.tgz#1e32fd5bcab6ad688a4812cb0cc04efc75c7014e"
   dependencies:
@@ -6892,7 +6916,7 @@ warning@^2.0.0:
   dependencies:
     loose-envify "^1.0.0"
 
-warning@^3.0.0:
+warning@^3.0.0, warning@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
   dependencies:
@@ -7003,6 +7027,10 @@ websocket-driver@>=0.5.1:
 websocket-extensions@>=0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.1.tgz#76899499c184b6ef754377c2dbb0cd6cb55d29e7"
+
+whatwg-fetch@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz#0e3684c6cb9995b43efc9df03e4c365d95fd9cc0"
 
 whatwg-fetch@>=0.10.0:
   version "1.0.0"


### PR DESCRIPTION
quick stab at using [helmet](https://github.com/nfl/react-helmet) for page titles.

This approach seems fairly reasonable but seems like it could be a bit susceptible to forgetting to add the component.

My ideal approach would involve just setting a title attribute on the route handler itself but from the little bit of digging I found it seemed like most folks are opting towards the `helmet` route (forgive the pun).

Seems like we could also do this via some sort route middleware. Anyhoo, a quick attempt in order to start a conversation to ease @tlrobinson's pain.

addresses #1484 