### PR TITLE
CrateDB: display nested object as columns

### DIFF
--- a/docs/administration-guide/databases/cratedb.md
+++ b/docs/administration-guide/databases/cratedb.md
@@ -16,3 +16,7 @@ Starting in v0.18.0 Metabase provides a driver for connecting to CrateDB directl
 3. Click the `Save` button. Done.
 
 Metabase will now begin inspecting your CrateDB Dataset and finding any tables and fields to build up a sense for the schema. Give it a little bit of time to do its work and then you're all set to start querying.
+
+### Known limitations
+
+* Columns/Fields of type `object_array` are deactivated and not exposed. However, their nested fields are listed and also supported for queries.

--- a/src/metabase/driver/crate.clj
+++ b/src/metabase/driver/crate.clj
@@ -6,7 +6,7 @@
             [metabase.driver.generic-sql :as sql]
             [metabase.util :as u]
             [clojure.tools.logging :as log])
-  (:import (java.sql.DatabaseMetaData)))
+  (:import java.sql.DatabaseMetaData))
 
 (def ^:private ^:const column->base-type
   "Map of Crate column types -> Field base types
@@ -88,9 +88,6 @@
       ;; find PKs and mark them
       (add-table-pks metadata))))
 
-(defn- field->alias [field]
-  (str \" (name field) \"))
-
 (defrecord CrateDriver []
   clojure.lang.Named
   (getName [_] "Crate"))
@@ -111,8 +108,8 @@
           :column->base-type         (u/drop-first-arg column->base-type)
           :string-length-fn          (u/drop-first-arg string-length-fn)
           :date                      crate-util/date
-          :quote-style               :ansi
-          :field->alias              (u/drop-first-arg field->alias)
+          :quote-style               (constantly :crate)
+          :field->alias              (constantly nil)
           :unix-timestamp->timestamp crate-util/unix-timestamp->timestamp
           :current-datetime-fn       (constantly now)}))
 

--- a/src/metabase/util/honeysql_extensions.clj
+++ b/src/metabase/util/honeysql_extensions.clj
@@ -30,13 +30,13 @@
   [^CharSequence s]
   (let [idx (s/index-of s "[")]
     (if (nil? idx)
-    (str \" s \")
-    (str-insert s "\"" idx))))
+      (str \" s \")
+      (str-insert s "\"" idx))))
 
 ;; `:crate` quote style that correctly quotes nested column identifiers
 (let [quote-fns     @(resolve 'honeysql.format/quote-fns)]
-  (intern 'honeysql.format 'quote-fns
-    (assoc quote-fns :crate crate-column-identifier)))
+  (->> (assoc quote-fns :crate crate-column-identifier)
+       (intern 'honeysql.format 'quote-fns)))
 
 ;; register the `extract` function with HoneySQL
 ;; (hsql/format (hsql/call :extract :a :b)) -> "extract(a from b)"

--- a/src/metabase/util/honeysql_extensions.clj
+++ b/src/metabase/util/honeysql_extensions.clj
@@ -21,6 +21,23 @@
   (intern 'honeysql.format 'quote-fns
           (assoc quote-fns :h2 (comp s/upper-case ansi-quote-fn))))
 
+(defn- str-insert
+  "Insert c in string s at index i."
+  [s c i]
+  (str c (subs s 0 i) c (subs s i)))
+
+(defn- crate-column-identifier
+  [^CharSequence s]
+  (let [idx (s/index-of s "[")]
+    (if (nil? idx)
+    (str \" s \")
+    (str-insert s "\"" idx))))
+
+;; `:crate` quote style that correctly quotes nested column identifiers
+(let [quote-fns     @(resolve 'honeysql.format/quote-fns)]
+  (intern 'honeysql.format 'quote-fns
+    (assoc quote-fns :crate crate-column-identifier)))
+
 ;; register the `extract` function with HoneySQL
 ;; (hsql/format (hsql/call :extract :a :b)) -> "extract(a from b)"
 (defmethod hformat/fn-handler "extract" [_ unit expr]


### PR DESCRIPTION
We at Crate.io are currently trying to improve the functionality of our Crate Driver in Metabase. Crate is able to store fields of type „object“ which is basically a JSON object. However, those nested fields are not exposed in the JDBC metadata function „.getColumns“ (issue https://github.com/metabase/metabase/issues/2962). It is possible to query those nested object fields by a custom SQL query on the „Information_schema.columns“ table in CrateDB.
So far so good – I’m now trying to implement this in Metabase and I think I am on a good way when I’m overriding the „describe-table“ function. However, I'm not getting the results that would expect.
Note: I have deactivated the quoting of the column identifier since this is necessary in CrateDB for querying a nested column. The field alias needs to be quoted instead.

When I do a db "sync" I see that the query gets executed successfully and the metadata gets returned sequentially in `column_name` and `type_name` field. However, I also see those log results and it seems that each column is set as "inactive". I have checked the "Data Model" after that and there are no column entries available (see screen).
Is it possible to help me with this issue?

![metabase-data-model](https://cloud.githubusercontent.com/assets/6863216/20861950/f9c35e9a-b99d-11e6-800a-3c013b41df81.PNG)

```
12-03 21:11:34 INFO metabase.sync-database :: Syncing Crate database 'Crate Localhost'...
12-03 21:11:34 INFO sync-database.introspect :: Introspecting schema on Crate database 'Crate Localhost' ...
12-03 21:11:34 DEBUG driver.generic-sql :: Creating new connection pool for database 2 ...
12-03 21:11:34 DEBUG sync-database.introspect :: Marked column constraint_name as inactive.
12-03 21:11:34 DEBUG sync-database.introspect :: Marked column constraint_type as inactive.
12-03 21:11:34 DEBUG sync-database.introspect :: Marked column table_name as inactive.
12-03 21:11:34 DEBUG sync-database.introspect :: Marked column table_schema as inactive.
12-03 21:11:34 INFO sync-database.introspect :: [**················································] ?    5% Synced table 'information_schema.table_constraints'.
12-03 21:11:34 DEBUG sync-database.introspect :: Marked column id as inactive.
12-03 21:11:34 DEBUG sync-database.introspect :: Marked column started as inactive.
12-03 21:11:34 DEBUG sync-database.introspect :: Marked column stmt as inactive.
12-03 21:11:34 INFO sync-database.introspect :: [*****·············································] ?   10% Synced table 'sys.jobs'.
12-03 21:11:34 DEBUG sync-database.introspect :: Marked column fs as inactive.
12-03 21:11:34 DEBUG sync-database.introspect :: Marked column heap as inactive.
12-03 21:11:34 DEBUG sync-database.introspect :: Marked column hostname as inactive.
12-03 21:11:34 DEBUG sync-database.introspect :: Marked column id as inactive.
12-03 21:11:34 DEBUG sync-database.introspect :: Marked column load as inactive.
12-03 21:11:34 DEBUG sync-database.introspect :: Marked column mem as inactive.
12-03 21:11:34 DEBUG sync-database.introspect :: Marked column name as inactive.
12-03 21:11:34 DEBUG sync-database.introspect :: Marked column network as inactive.
12-03 21:11:34 DEBUG sync-database.introspect :: Marked column os as inactive.
12-03 21:11:34 DEBUG sync-database.introspect :: Marked column os_info as inactive.
12-03 21:11:34 DEBUG sync-database.introspect :: Marked column port as inactive.
12-03 21:11:34 DEBUG sync-database.introspect :: Marked column process as inactive.
12-03 21:11:34 DEBUG sync-database.introspect :: Marked column rest_url as inactive.
12-03 21:11:34 DEBUG sync-database.introspect :: Marked column thread_pools as inactive.
12-03 21:11:34 DEBUG sync-database.introspect :: Marked column version as inactive.
12-03 21:11:34 INFO sync-database.introspect :: [*******···········································] ?   15% Synced table 'sys.nodes'.
12-03 21:11:34 DEBUG sync-database.introspect :: Marked column id as inactive.
12-03 21:11:34 DEBUG sync-database.introspect :: Marked column master_node as inactive.
...

12-03 21:11:34 INFO sync-database.introspect :: Introspection completed on Crate database 'Crate Localhost' (890 ms)
12-03 21:11:35 INFO sync-database.analyze :: Analyzing data in Crate database 'Crate Localhost' (this may take a while) ...
12-03 21:11:35 INFO sync-database.analyze :: [**················································] ?    5% Analyzed table 'columns'.
12-03 21:11:35 INFO sync-database.analyze :: [*****·············································] ?   10% Analyzed table 'routines'.
12-03 21:11:35 INFO sync-database.analyze :: [*******···········································] ?   15% Analyzed table 'schemata'.
12-03 21:11:35 INFO sync-database.analyze :: [**********········································] ?   20% Analyzed table 'sql_features'.
12-03 21:11:35 INFO sync-database.analyze :: [************······································] ?   25% Analyzed table 'table_constraints'.
12-03 21:11:35 INFO sync-database.analyze :: [***************···································] ?   30% Analyzed table 'table_partitions'.
12-03 21:11:35 INFO sync-database.analyze :: [*****************·································] ?   35% Analyzed table 'tables'.
12-03 21:11:35 INFO sync-database.analyze :: [********************······························] ?   40% Analyzed table 'pg_type'.
12-03 21:11:35 INFO sync-database.analyze :: [**********************····························] ?   45% Analyzed table 'checks'.
12-03 21:11:35 INFO sync-database.analyze :: [*************************·························] ?   50% Analyzed table 'cluster'.
12-03 21:11:35 INFO sync-database.analyze :: [***************************·······················] ?   55% Analyzed table 'jobs'.
12-03 21:11:35 INFO sync-database.analyze :: [******************************····················] ?   60% Analyzed table 'jobs_log'.
12-03 21:11:35 INFO sync-database.analyze :: [********************************··················] ?   65% Analyzed table 'node_checks'.
12-03 21:11:35 INFO sync-database.analyze :: [**********************************················] ?   70% Analyzed table 'nodes'.
12-03 21:11:35 INFO sync-database.analyze :: [*************************************·············] ?   75% Analyzed table 'operations'.
12-03 21:11:35 INFO sync-database.analyze :: [****************************************··········] ?   80% Analyzed table 'operations_log'.
12-03 21:11:35 INFO sync-database.analyze :: [******************************************········] ?   85% Analyzed table 'repositories'.
12-03 21:11:35 INFO sync-database.analyze :: [********************************************······] ?   90% Analyzed table 'shards'.
12-03 21:11:35 INFO sync-database.analyze :: [***********************************************···] ?   95% Analyzed table 'snapshots'.
12-03 21:11:35 INFO sync-database.analyze :: [**************************************************] ?  100% Analyzed table 'summits'.
12-03 21:11:35 INFO sync-database.analyze :: Analysis of Crate database 'Crate Localhost' completed (770 ms).
12-03 21:11:35 INFO metabase.sync-database :: Finished syncing Crate database 'Crate Localhost'. (2 s)
```
