### PR TITLE
Alphabet sort in dashboards dropdown

### DIFF
--- a/frontend/src/metabase/nav/containers/DashboardsDropdown.jsx
+++ b/frontend/src/metabase/nav/containers/DashboardsDropdown.jsx
@@ -133,7 +133,7 @@ export default class DashboardsDropdown extends Component {
                                     </div>
                                 :
                                     <ul className="NavDropdown-content-layer">
-                                        { dashboards.map(dash =>
+                                        { dashboards.sort((dash1, dash2) => dash1.name.localeCompare(dash2.name)).map(dash =>
                                             <li key={dash.id} className="block">
                                                 <Link to={"/dash/"+dash.id} data-metabase-event={"Navbar;Dashboard Dropdown;Open Dashboard;"+dash.id} className="Dropdown-item block text-white no-decoration" onClick={this.closeDropdown}>
                                                     <div className="flex text-bold">


### PR DESCRIPTION
Hi guys! I already have 9 dashboards in dropdown menu. I use metabase with Vertica.

This pull request add alphabet sort the list of dashboards.

(also please merge to master this pull request - https://github.com/metabase/metabase/pull/3848)