### PR TITLE
Fix expression aggregations for aggregation w/o field :wrench: [ci dr…

### DIFF
--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -18,6 +18,7 @@
             [metabase.util.honeysql-extensions :as hx])
   (:import java.sql.Timestamp
            java.util.Date
+           clojure.lang.Keyword
            (metabase.query_processor.interface AgFieldRef
                                                DateTimeField
                                                DateTimeValue
@@ -65,7 +66,8 @@
   nil                    (formatted [_] nil)
   Number                 (formatted [this] this)
   String                 (formatted [this] this)
-  honeysql.types.SqlCall (formatted [this] this)
+  Keyword                (formatted [this] this) ; HoneySQL fn calls and keywords (e.g. `:%count.*`) are
+  honeysql.types.SqlCall (formatted [this] this) ; already converted to HoneySQL so just return them as-is
 
   Expression
   (formatted [{:keys [operator args]}]

--- a/test/metabase/driver/druid_test.clj
+++ b/test/metabase/driver/druid_test.clj
@@ -182,3 +182,13 @@
     (ql/aggregation (ql/+ (ql/max $venue_price)
                           (ql/min (ql/- $venue_price $id))))
     (ql/breakout $venue_price)))
+
+;; aggregation w/o field
+(expect-with-engine :druid
+  [["1" 222.0]
+   ["2" 616.0]
+   ["3" 116.0]
+   ["4"  50.0]]
+  (druid-query-returning-rows
+    (ql/aggregation (ql/+ 1 (ql/count)))
+    (ql/breakout $venue_price)))

--- a/test/metabase/query_processor_test/expression_aggregations_test.clj
+++ b/test/metabase/query_processor_test/expression_aggregations_test.clj
@@ -134,3 +134,14 @@
             (ql/aggregation (ql/+ (ql/max $price)
                                   (ql/min (ql/- $price $id))))
             (ql/breakout $price)))))
+
+;; aggregation w/o field
+(datasets/expect-with-engines (engines-that-support :expression-aggregations)
+  [[1 23]
+   [2 60]
+   [3 14]
+   [4  7]]
+  (format-rows-by [int int]
+    (rows (data/run-query venues
+            (ql/aggregation (ql/+ 1 (ql/count)))
+            (ql/breakout $price)))))


### PR DESCRIPTION
@tlrobinson just caught this one. Expression aggregations were missing a mapping for handling `:count` aggregations. The fix itself was a one-liner but I added a few new tests for it as well.