### PR TITLE
Fix expression aggregations with number literals inside agg [ci drivers]

### DIFF
--- a/src/metabase/query_processor/interface.clj
+++ b/src/metabase/query_processor/interface.clj
@@ -185,10 +185,10 @@
                          args     :- [(s/cond-pre (s/recursive #'RValue)
                                                   (s/recursive #'Aggregation))]])
 
-(def AnyField
+(def AnyFieldOrExpression
   "Schema for a `FieldPlaceholder`, `AgRef`, or `Expression`."
   (s/named (s/cond-pre ExpressionRef Expression FieldPlaceholderOrAgRef)
-           "Valid field, ag field reference, or expression reference."))
+           "Valid field, ag field reference, expression, or expression reference."))
 
 
 (def LiteralDatetimeString
@@ -302,7 +302,7 @@
 
 (def OrderBy
   "Schema for top-level `order-by` clause in an MBQL query."
-  (s/named {:field     AnyField
+  (s/named {:field     AnyFieldOrExpression
             :direction OrderByDirection}
            "Valid order-by subclause"))
 
@@ -317,7 +317,7 @@
   "Schema for an MBQL query."
   {(s/optional-key :aggregation) [Aggregation]
    (s/optional-key :breakout)    [FieldPlaceholderOrExpressionRef]
-   (s/optional-key :fields)      [AnyField]
+   (s/optional-key :fields)      [AnyFieldOrExpression]
    (s/optional-key :filter)      Filter
    (s/optional-key :limit)       su/IntGreaterThanZero
    (s/optional-key :order-by)    [OrderBy]

--- a/test/metabase/driver/druid_test.clj
+++ b/test/metabase/driver/druid_test.clj
@@ -192,3 +192,13 @@
   (druid-query-returning-rows
     (ql/aggregation (ql/+ 1 (ql/count)))
     (ql/breakout $venue_price)))
+
+;; aggregation with math inside the aggregation :scream_cat:
+(expect-with-engine :druid
+  [["1"  442.0]
+   ["2" 1845.0]
+   ["3"  460.0]
+   ["4"  245.0]]
+  (druid-query-returning-rows
+    (ql/aggregation (ql/sum (ql/+ $venue_price 1)))
+    (ql/breakout $venue_price)))

--- a/test/metabase/query_processor_test/expression_aggregations_test.clj
+++ b/test/metabase/query_processor_test/expression_aggregations_test.clj
@@ -145,3 +145,14 @@
     (rows (data/run-query venues
             (ql/aggregation (ql/+ 1 (ql/count)))
             (ql/breakout $price)))))
+
+;; aggregation with math inside the aggregation :scream_cat:
+(datasets/expect-with-engines (engines-that-support :expression-aggregations)
+  [[1  44]
+   [2 177]
+   [3  52]
+   [4  30]]
+  (format-rows-by [int int]
+    (rows (data/run-query venues
+            (ql/aggregation (ql/sum (ql/+ $price 1)))
+            (ql/breakout $price)))))


### PR DESCRIPTION
As discovered by @tlrobinson expression aggregations like `[:sum [:+ [:field-id 100] 1]]` weren't working because of a small logic issue. 

Fixed & added new tests.

