### PR TITLE
bump h2 version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -44,7 +44,7 @@
                   "v3-rev135-1.22.0"]
                  [com.google.apis/google-api-services-bigquery        ; Google BigQuery Java Client Library
                   "v2-rev324-1.22.0"]
-                 [com.h2database/h2 "1.4.192"]                        ; embedded SQL database
+                 [com.h2database/h2 "1.4.193"]                        ; embedded SQL database
                  [com.mattbertolini/liquibase-slf4j "2.0.0"]          ; Java Migrations lib
                  [com.mchange/c3p0 "0.9.5.2"]                         ; connection pooling library
                  [com.novemberain/monger "3.1.0"]                     ; MongoDB Driver


### PR DESCRIPTION
bumping from `1.4.192` to `1.4.193` seems  to solve some local connection issues in dev