### PR TITLE
Fix metric creation

### DIFF
--- a/frontend/src/metabase/query_builder/components/AggregationWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/AggregationWidget.jsx
@@ -48,7 +48,6 @@ export default class AggregationWidget extends Component {
         const fieldId = AggregationClause.getField(aggregation);
 
         let selectedAggregation = getAggregator(AggregationClause.getOperator(aggregation));
-        console.log("Selected Aggregation", selectedAggregation)
         if (selectedAggregation && !_.findWhere(tableMetadata.aggregation_options, { short: selectedAggregation.short })) {
             // if this table doesn't support the selected aggregation, prompt the user to select a different one
             selectedAggregation = null;

--- a/frontend/src/metabase/query_builder/components/AggregationWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/AggregationWidget.jsx
@@ -48,7 +48,8 @@ export default class AggregationWidget extends Component {
         const fieldId = AggregationClause.getField(aggregation);
 
         let selectedAggregation = getAggregator(AggregationClause.getOperator(aggregation));
-        if (!_.findWhere(tableMetadata.aggregation_options, { short: selectedAggregation.short })) {
+        console.log("Selected Aggregation", selectedAggregation)
+        if (selectedAggregation && !_.findWhere(tableMetadata.aggregation_options, { short: selectedAggregation.short })) {
             // if this table doesn't support the selected aggregation, prompt the user to select a different one
             selectedAggregation = null;
         }

--- a/frontend/src/metabase/query_builder/components/AggregationWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/AggregationWidget.jsx
@@ -25,7 +25,7 @@ export default class AggregationWidget extends Component {
     }
 
     static propTypes = {
-        aggregation: PropTypes.array.isRequired,
+        aggregation: PropTypes.array,
         tableMetadata: PropTypes.object.isRequired,
         customFields: PropTypes.object,
         updateAggregation: PropTypes.func.isRequired


### PR DESCRIPTION
fixes #3866
`selectedAggregation` is null when the aggregation widget is first loaded. Not sure if this changed recently or why this started happening in 0.20.

Thoughts @tlrobinson -- Am I applying a bandaid here? Should this be fixed upstream of this widget? Inquiring minds want to know.