### PR TITLE
Filter out Field targets if you don't have read perms for their table

### DIFF
--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -106,7 +106,7 @@
                                                (:fk_target_field_id field))]
                                 (:fk_target_field_id field)))
         id->target-field (u/key-by :id (when (seq target-field-ids)
-                                         (db/select Field :id [:in target-field-ids])))]
+                                         (filter i/can-read? (db/select Field :id [:in target-field-ids]))))]
     (for [field fields
           :let  [target-id (:fk_target_field_id field)]]
       (assoc field :target (id->target-field target-id)))))


### PR DESCRIPTION
Basically a one-line fix here since all Field `:target`s are hydrated by the same function. Includes test.

Fixes #3867
