### PR TITLE
Lint frontend tests, including checking for accidental fdescribe/fit

### DIFF
--- a/frontend/test/.eslintrc
+++ b/frontend/test/.eslintrc
@@ -1,0 +1,13 @@
+{
+    "rules": {
+        "jasmine/no-focused-tests": 2,
+        "jasmine/no-suite-dupes": [2, "branch"]
+    },
+    "env": {
+        "jasmine": true,
+        "node": true
+    },
+    "plugins": [
+        "jasmine"
+    ]
+}

--- a/frontend/test/e2e/admin/datamodel.spec.js
+++ b/frontend/test/e2e/admin/datamodel.spec.js
@@ -1,16 +1,9 @@
-
-import { By, until } from "selenium-webdriver";
-
 import {
-    waitForElement,
     waitForElementText,
-    waitForElementRemoved,
     findElement,
     waitForElementAndClick,
     waitForElementAndSendKeys,
-    waitForUrl,
     screenshot,
-    loginMetabase,
     ensureLoggedIn,
     describeE2E
 } from "../support/utils";

--- a/frontend/test/e2e/admin/people.spec.js
+++ b/frontend/test/e2e/admin/people.spec.js
@@ -1,10 +1,6 @@
-
-import { By, until } from "selenium-webdriver";
-
 import {
     waitForElement,
     waitForElementText,
-    waitForElementRemoved,
     findElement,
     waitForElementAndClick,
     waitForElementAndSendKeys,

--- a/frontend/test/e2e/auth/login.spec.js
+++ b/frontend/test/e2e/auth/login.spec.js
@@ -1,13 +1,6 @@
 
-import { By, until } from "selenium-webdriver";
-
+import { By } from "selenium-webdriver";
 import {
-    waitForElement,
-    waitForElementText,
-    waitForElementRemoved,
-    findElement,
-    waitForElementAndClick,
-    waitForElementAndSendKeys,
     waitForUrl,
     screenshot,
     loginMetabase,

--- a/frontend/test/e2e/query_builder/query_builder.spec.js
+++ b/frontend/test/e2e/query_builder/query_builder.spec.js
@@ -1,16 +1,9 @@
 
-import { By, until } from "selenium-webdriver";
-
 import {
-    waitForElement,
-    waitForElementText,
     waitForElementRemoved,
-    findElement,
     waitForElementAndClick,
     waitForElementAndSendKeys,
-    waitForUrl,
     screenshot,
-    loginMetabase,
     describeE2E,
     ensureLoggedIn
 } from "../support/utils";

--- a/frontend/test/e2e/query_builder/tutorial.spec.js
+++ b/frontend/test/e2e/query_builder/tutorial.spec.js
@@ -1,15 +1,10 @@
-import { By, until } from "selenium-webdriver";
-
 import {
     waitForElement,
-    waitForElementText,
     waitForElementRemoved,
-    findElement,
     waitForElementAndClick,
     waitForElementAndSendKeys,
     waitForUrl,
     screenshot,
-    loginMetabase,
     describeE2E,
     ensureLoggedIn
 } from "../support/utils";

--- a/frontend/test/e2e/setup/signup.spec.js
+++ b/frontend/test/e2e/setup/signup.spec.js
@@ -1,17 +1,12 @@
 import path from "path";
 
-import { By, until } from "selenium-webdriver";
-
 import {
     waitForElement,
-    waitForElementText,
-    waitForElementRemoved,
     findElement,
     waitForElementAndClick,
     waitForElementAndSendKeys,
     waitForUrl,
     screenshot,
-    loginMetabase,
     describeE2E
 } from "../support/utils";
 

--- a/frontend/test/e2e/support/shared-resource.js
+++ b/frontend/test/e2e/support/shared-resource.js
@@ -22,7 +22,7 @@ export default function createSharedResource(resourceName, {
         return Promise.all(exitPromises);
     })
 
-    async function kill(entry) {
+    function kill(entry) {
         if (entriesByKey.has(entry.key)) {
             entriesByKey.delete(entry.key);
             entriesByResource.delete(entry.resource);

--- a/frontend/test/e2e/support/utils.js
+++ b/frontend/test/e2e/support/utils.js
@@ -7,8 +7,6 @@ import { Driver } from "webchauffeur";
 
 const DEFAULT_TIMEOUT = 50000;
 
-const delay = (timeout = 0) => new Promise((resolve) => setTimeout(resolve, timeout));
-
 const log = (message) => {
     console.log(message);
 };

--- a/frontend/test/karma.conf.js
+++ b/frontend/test/karma.conf.js
@@ -36,9 +36,6 @@ module.exports = function(config) {
         webpackMiddleware: {
             stats: "errors-only"
         },
-        webpackMiddleware: {
-            stats: "errors-only",
-        },
         coverageReporter: {
             dir: '../coverage/',
             subdir: function(browser) {

--- a/frontend/test/unit/lib/expressions.spec.js
+++ b/frontend/test/unit/lib/expressions.spec.js
@@ -1,5 +1,5 @@
 import _ from "underscore";
-import { formatExpression, parseExpressionString, tokenAtPosition, tokensToExpression } from "metabase/lib/expressions";
+import { formatExpression, parseExpressionString } from "metabase/lib/expressions";
 
 const mockFields = [
     {id: 1, display_name: "A"},
@@ -10,12 +10,12 @@ const mockFields = [
 
 const mathOperators = new Set(['+', '-', '*', '/']);
 
-const parsedMathOperators = {
-    "+": { value: '+', start: 2, end: 3, parsedValue: '+' },
-    "-": { value: '-', start: 2, end: 3, parsedValue: '-' },
-    "*": { value: '*', start: 2, end: 3, parsedValue: '*' },
-    "/": { value: '/', start: 2, end: 3, parsedValue: '/' }
-}
+// const parsedMathOperators = {
+//     "+": { value: '+', start: 2, end: 3, parsedValue: '+' },
+//     "-": { value: '-', start: 2, end: 3, parsedValue: '-' },
+//     "*": { value: '*', start: 2, end: 3, parsedValue: '*' },
+//     "/": { value: '/', start: 2, end: 3, parsedValue: '/' }
+// }
 
 function stripStartEnd(list) {
     return list.map(i => {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "eslint": "^3.5.0",
     "eslint-loader": "^1.6.0",
     "eslint-plugin-flowtype": "^2.22.0",
+    "eslint-plugin-jasmine": "^2.2.0",
     "eslint-plugin-react": "^6.3.0",
     "exports-loader": "^0.6.3",
     "extract-text-webpack-plugin": "^1.0.1",
@@ -123,7 +124,7 @@
   },
   "scripts": {
     "dev": "yarn && concurrently --kill-others -p name -n 'backend,frontend' -c 'blue,green' 'lein ring server' 'yarn run build-hot'",
-    "lint": "eslint --ext .js --ext .jsx --max-warnings 0 frontend/src",
+    "lint": "eslint --ext .js --ext .jsx --max-warnings 0 frontend/src frontend/test",
     "flow": "flow check",
     "test": "karma start frontend/test/karma.conf.js --single-run",
     "test-watch": "karma start frontend/test/karma.conf.js --auto-watch --reporters nyan",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2368,6 +2368,10 @@ eslint-plugin-flowtype:
   dependencies:
     lodash "^4.15.0"
 
+eslint-plugin-jasmine@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jasmine/-/eslint-plugin-jasmine-2.2.0.tgz#7135879383c39a667c721d302b9f20f0389543de"
+
 eslint-plugin-react@^6.3.0:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-6.4.1.tgz#7d1aade747db15892f71eee1fea4addf97bcfa2b"


### PR DESCRIPTION
I accidentally committed a focused test (`fdescribe`/`fit`) which prevents most of the tests from running in CI, which is obviously very bad. This prevents that.