### PR TITLE
Remove special char in slack channel name

### DIFF
--- a/src/metabase/integrations/slack.clj
+++ b/src/metabase/integrations/slack.clj
@@ -10,7 +10,7 @@
 (defsetting slack-token "Slack API bearer token obtained from https://api.slack.com/web#authentication")
 
 (def ^:private ^:const ^String slack-api-base-url "https://slack.com/api")
-(def ^:private ^:const ^String files-channel-name "metabase_files")
+(def ^:private ^:const ^String files-channel-name "metabasefiles")
 
 (defn slack-configured?
   "Is Slack integration configured?"


### PR DESCRIPTION
###### TODO 
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).

Special char are not allowed in channel name (at least in certain team)