### PR TITLE
Add support for new MBQL "named" clause :unamused: [ci drivers]

### DIFF
--- a/src/metabase/driver/druid/query_processor.clj
+++ b/src/metabase/driver/druid/query_processor.clj
@@ -218,7 +218,7 @@
                                     (ag:count output-name))))
 
 
-(defn- handle-aggregation [query-type {ag-type :aggregation-type, ag-field :field, output-name :output-name, custom-name :name, :as ag} druid-query]
+(defn- handle-aggregation [query-type {ag-type :aggregation-type, ag-field :field, output-name :output-name, custom-name :custom-name, :as ag} druid-query]
   (let [output-name (or custom-name output-name)]
     (when (isa? query-type ::ag-query)
       (merge-with concat

--- a/src/metabase/driver/druid/query_processor.clj
+++ b/src/metabase/driver/druid/query_processor.clj
@@ -218,34 +218,35 @@
                                     (ag:count output-name))))
 
 
-(defn- handle-aggregation [query-type {ag-type :aggregation-type, ag-field :field, output-name :output-name, :as ag} druid-query]
-  (when (isa? query-type ::ag-query)
-    (merge-with concat
-      druid-query
-      (let [ag-type (when-not (= ag-type :rows) ag-type)]
-        (match [ag-type ag-field]
-          ;; For 'distinct values' queries (queries with a breakout by no aggregation) just aggregate by count, but name it :___count so it gets discarded automatically
-          [nil     nil] {:aggregations [(ag:count (or output-name :___count))]}
+(defn- handle-aggregation [query-type {ag-type :aggregation-type, ag-field :field, output-name :output-name, custom-name :name, :as ag} druid-query]
+  (let [output-name (or custom-name output-name)]
+    (when (isa? query-type ::ag-query)
+      (merge-with concat
+        druid-query
+        (let [ag-type (when-not (= ag-type :rows) ag-type)]
+          (match [ag-type ag-field]
+            ;; For 'distinct values' queries (queries with a breakout by no aggregation) just aggregate by count, but name it :___count so it gets discarded automatically
+            [nil     nil] {:aggregations [(ag:count (or output-name :___count))]}
 
-          [:count  nil] {:aggregations [(ag:count (or output-name :count))]}
+            [:count  nil] {:aggregations [(ag:count (or output-name :count))]}
 
-          [:count    _] {:aggregations [(ag:count ag-field (or output-name :count))]}
+            [:count    _] {:aggregations [(ag:count ag-field (or output-name :count))]}
 
-          [:avg      _] (let [count-name (name (gensym "___count_"))
-                              sum-name   (name (gensym "___sum_"))]
-                          {:aggregations     [(ag:count ag-field count-name)
-                                              (ag:doubleSum ag-field sum-name)]
-                           :postAggregations [{:type   :arithmetic
-                                               :name   (or output-name :avg)
-                                               :fn     :/
-                                               :fields [{:type :fieldAccess, :fieldName sum-name}
-                                                        {:type :fieldAccess, :fieldName count-name}]}]})
-          [:distinct _] {:aggregations [{:type       :cardinality
-                                         :name       (or output-name :distinct___count)
-                                         :fieldNames [(->rvalue ag-field)]}]}
-          [:sum      _] {:aggregations [(ag:doubleSum ag-field (or output-name :sum))]}
-          [:min      _] {:aggregations [(ag:doubleMin ag-field (or output-name :min))]}
-          [:max      _] {:aggregations [(ag:doubleMax ag-field (or output-name :max))]})))))
+            [:avg      _] (let [count-name (name (gensym "___count_"))
+                                sum-name   (name (gensym "___sum_"))]
+                            {:aggregations     [(ag:count ag-field count-name)
+                                                (ag:doubleSum ag-field sum-name)]
+                             :postAggregations [{:type   :arithmetic
+                                                 :name   (or output-name :avg)
+                                                 :fn     :/
+                                                 :fields [{:type :fieldAccess, :fieldName sum-name}
+                                                          {:type :fieldAccess, :fieldName count-name}]}]})
+            [:distinct _] {:aggregations [{:type       :cardinality
+                                           :name       (or output-name :distinct___count)
+                                           :fieldNames [(->rvalue ag-field)]}]}
+            [:sum      _] {:aggregations [(ag:doubleSum ag-field (or output-name :sum))]}
+            [:min      _] {:aggregations [(ag:doubleMin ag-field (or output-name :min))]}
+            [:max      _] {:aggregations [(ag:doubleMax ag-field (or output-name :max))]}))))))
 
 (defn- add-expression-aggregation-output-names [args]
   (for [arg args]

--- a/src/metabase/query_processor/annotate.clj
+++ b/src/metabase/query_processor/annotate.clj
@@ -94,18 +94,24 @@
     :count
     ag-type))
 
+;; TODO - rename to `aggregation-name` now that this handles any sort of aggregation
 (defn expression-aggregation-name
-  "Return an appropriate name for an expression aggregation, e.g. `sum + count`."
-  ^String [ag]
+  "Return an appropriate name for an AGGREGATION, e.g. `sum + count`."
+  ^String [{custom-name :name, aggregation-type :aggregation-type, :as ag}]
   (cond
+    ;; if a custom name was provided use it
+    custom-name               custom-name
+    ;; for unnamed expressions, just compute a name like "sum + count"
     (instance? Expression ag) (let [{:keys [operator args]} ag]
                                 (str/join (str " " (name operator) " ")
                                           (for [arg args]
                                             (if (instance? Expression arg)
                                               (str "(" (expression-aggregation-name arg) ")")
                                               (expression-aggregation-name arg)))))
-    (:aggregation-type ag)    (name (:aggregation-type ag))
-    :else                     ag))
+    ;; for unnamed normal aggregations, the column alias is always the same as the ag type except for `:distinct` with is called `:count` (WHY?)
+    aggregation-type          (if (= (keyword aggregation-type) :distinct)
+                                "count"
+                                (name aggregation-type))))
 
 (defn- expression-aggregate-field-info [expression]
   (let [ag-name (expression-aggregation-name expression)]

--- a/src/metabase/query_processor/annotate.clj
+++ b/src/metabase/query_processor/annotate.clj
@@ -94,10 +94,10 @@
     :count
     ag-type))
 
-;; TODO - rename to `aggregation-name` now that this handles any sort of aggregation
+;; TODO - rename to something like `aggregation-name` or `aggregation-subclause-name` now that this handles any sort of aggregation
 (defn expression-aggregation-name
-  "Return an appropriate name for an AGGREGATION, e.g. `sum + count`."
-  ^String [{custom-name :name, aggregation-type :aggregation-type, :as ag}]
+  "Return an appropriate name for an `:aggregation` subclause (an aggregation or expression)."
+  ^String [{custom-name :custom-name, aggregation-type :aggregation-type, :as ag}]
   (cond
     ;; if a custom name was provided use it
     custom-name               custom-name

--- a/src/metabase/query_processor/expand.clj
+++ b/src/metabase/query_processor/expand.clj
@@ -64,7 +64,7 @@
    (This will probably be extended to support Fields in the future, but for now, only the `:aggregation` clause is supported.)"
   {:added "0.22.0"}
   [aggregation-or-expression :- i/Aggregation, custom-name :- su/NonBlankString]
-  (assoc aggregation-or-expression :name custom-name))
+  (assoc aggregation-or-expression :custom-name custom-name))
 
 (s/defn ^:ql ^:always-validate datetime-field :- FieldPlaceholder
   "Reference to a `DateTimeField`. This is just a `Field` reference with an associated datetime UNIT."

--- a/src/metabase/query_processor/expand.clj
+++ b/src/metabase/query_processor/expand.clj
@@ -59,6 +59,13 @@
         (field-id f))
     f))
 
+(s/defn ^:ql ^:always-validate named :- i/Aggregation
+  "Specify a CUSTOM-NAME to use for a top-level AGGREGATION-OR-EXPRESSION in the results.
+   (This will probably be extended to support Fields in the future, but for now, only the `:aggregation` clause is supported.)"
+  {:added "0.22.0"}
+  [aggregation-or-expression :- i/Aggregation, custom-name :- su/NonBlankString]
+  (assoc aggregation-or-expression :name custom-name))
+
 (s/defn ^:ql ^:always-validate datetime-field :- FieldPlaceholder
   "Reference to a `DateTimeField`. This is just a `Field` reference with an associated datetime UNIT."
   ([f _ unit] (log/warn (u/format-color 'yellow (str "The syntax for datetime-field has changed in MBQL '98. [:datetime-field <field> :as <unit>] is deprecated. "
@@ -122,11 +129,11 @@
                        (if (number? arg)
                          arg
                          (field-or-expression arg))))
-    ;; otherwise if it's not an Expression it's a a
+    ;; otherwise if it's not an Expression it's a Field
     (field f)))
 
 (s/defn ^:private ^:always-validate ag-with-field :- i/Aggregation [ag-type f]
-  (i/strict-map->AggregationWithField {:aggregation-type ag-type, :field (field-or-expression f)}))
+  (i/map->AggregationWithField {:aggregation-type ag-type, :field (field-or-expression f)}))
 
 (def ^:ql ^{:arglists '([f])} avg      "Aggregation clause. Return the average value of F."                (partial ag-with-field :avg))
 (def ^:ql ^{:arglists '([f])} distinct "Aggregation clause. Return the number of distinct values of F."    (partial ag-with-field :distinct))
@@ -144,13 +151,13 @@
 
 (s/defn ^:ql ^:always-validate count :- i/Aggregation
   "Aggregation clause. Return total row count (e.g., `COUNT(*)`). If F is specified, only count rows where F is non-null (e.g. `COUNT(f)`)."
-  ([]  (i/strict-map->AggregationWithoutField {:aggregation-type :count}))
+  ([]  (i/map->AggregationWithoutField {:aggregation-type :count}))
   ([f] (ag-with-field :count f)))
 
 (s/defn ^:ql ^:always-validate cum-count :- i/Aggregation
   "Aggregation clause. Return the cumulative row count (presumably broken out in some way)."
   []
-  (i/strict-map->AggregationWithoutField {:aggregation-type :cumulative-count}))
+  (i/map->AggregationWithoutField {:aggregation-type :cumulative-count}))
 
 (defn ^:ql ^:deprecated rows
   "Bare rows aggregation. This is the default behavior, so specifying it is deprecated."
@@ -405,10 +412,10 @@
 
 (s/defn ^:private ^:always-validate expression-fn :- Expression
   [k :- s/Keyword, & args]
-  (i/strict-map->Expression {:operator k, :args (vec (for [arg args]
-                                                       (if (number? arg)
-                                                         (float arg) ; convert args to floats so things like 5 / 10 -> 0.5 instead of 0
-                                                         arg)))}))
+  (i/map->Expression {:operator k, :args (vec (for [arg args]
+                                                (if (number? arg)
+                                                  (float arg) ; convert args to floats so things like 5 / 10 -> 0.5 instead of 0
+                                                  arg)))}))
 
 (def ^:ql ^{:arglists '([rvalue1 rvalue2 & more]), :added "0.17.0"} + "Arithmetic addition function."       (partial expression-fn :+))
 (def ^:ql ^{:arglists '([rvalue1 rvalue2 & more]), :added "0.17.0"} - "Arithmetic subtraction function."    (partial expression-fn :-))

--- a/src/metabase/query_processor/interface.clj
+++ b/src/metabase/query_processor/interface.clj
@@ -183,7 +183,8 @@
 
 (s/defrecord Expression [operator :- ExpressionOperator
                          args     :- [(s/cond-pre (s/recursive #'RValue)
-                                                  (s/recursive #'Aggregation))]])
+                                                  (s/recursive #'Aggregation))]
+                         name     :- (s/maybe su/NonBlankString)])
 
 (def AnyFieldOrExpression
   "Schema for a `FieldPlaceholder`, `AgRef`, or `Expression`."
@@ -241,12 +242,14 @@
 ;;; # ------------------------------------------------------------ CLAUSE SCHEMAS ------------------------------------------------------------
 
 (s/defrecord AggregationWithoutField [aggregation-type :- (s/named (s/enum :count :cumulative-count)
-                                                                   "Valid aggregation type")])
+                                                                   "Valid aggregation type")
+                                      name             :- (s/maybe su/NonBlankString)])
 
 (s/defrecord AggregationWithField [aggregation-type :- (s/named (s/enum :avg :count :cumulative-sum :distinct :max :min :stddev :sum)
                                                                 "Valid aggregation type")
                                    field            :- (s/cond-pre FieldPlaceholderOrExpressionRef
-                                                                   Expression)])
+                                                                   Expression)
+                                   name             :- (s/maybe su/NonBlankString)])
 
 (defn- valid-aggregation-for-driver? [{:keys [aggregation-type]}]
   (when (= aggregation-type :stddev)

--- a/src/metabase/query_processor/interface.clj
+++ b/src/metabase/query_processor/interface.clj
@@ -181,10 +181,10 @@
 
 (def ^:private ExpressionOperator (s/named (s/enum :+ :- :* :/) "Valid expression operator"))
 
-(s/defrecord Expression [operator :- ExpressionOperator
-                         args     :- [(s/cond-pre (s/recursive #'RValue)
-                                                  (s/recursive #'Aggregation))]
-                         name     :- (s/maybe su/NonBlankString)])
+(s/defrecord Expression [operator   :- ExpressionOperator
+                         args       :- [(s/cond-pre (s/recursive #'RValue)
+                                                    (s/recursive #'Aggregation))]
+                         custom-name :- (s/maybe su/NonBlankString)])
 
 (def AnyFieldOrExpression
   "Schema for a `FieldPlaceholder`, `AgRef`, or `Expression`."
@@ -243,13 +243,13 @@
 
 (s/defrecord AggregationWithoutField [aggregation-type :- (s/named (s/enum :count :cumulative-count)
                                                                    "Valid aggregation type")
-                                      name             :- (s/maybe su/NonBlankString)])
+                                      custom-name      :- (s/maybe su/NonBlankString)])
 
 (s/defrecord AggregationWithField [aggregation-type :- (s/named (s/enum :avg :count :cumulative-sum :distinct :max :min :stddev :sum)
                                                                 "Valid aggregation type")
                                    field            :- (s/cond-pre FieldPlaceholderOrExpressionRef
                                                                    Expression)
-                                   name             :- (s/maybe su/NonBlankString)])
+                                   custom-name      :- (s/maybe su/NonBlankString)])
 
 (defn- valid-aggregation-for-driver? [{:keys [aggregation-type]}]
   (when (= aggregation-type :stddev)

--- a/src/metabase/query_processor/macros.clj
+++ b/src/metabase/query_processor/macros.clj
@@ -71,10 +71,15 @@
                      (expand-metric form filter-clauses-atom)))
                  query-dict))
 
+(defn- add-metrics-filter-clauses [query-dict filter-clauses]
+  (update-in query-dict [:query :filter] merge-filter-clauses (if (> (count filter-clauses) 1)
+                                                                (cons "AND" filter-clauses)
+                                                                (first filter-clauses))))
+
 (defn- expand-metrics [query-dict]
   (let [filter-clauses-atom (atom [])
         query-dict          (expand-metrics-in-ag-clause query-dict filter-clauses-atom)]
-    (update-in query-dict [:query :filter] merge-filter-clauses @filter-clauses-atom)))
+    (add-metrics-filter-clauses query-dict @filter-clauses-atom)))
 
 (defn- macroexpand-metric [{{aggregations :aggregation} :query, :as query-dict}]
   (if-not (seq aggregations)

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -64,7 +64,7 @@
                         (query checkins
                                (ql/aggregation (ql/count))))
                       (assoc :type "query")
-                      (assoc-in [:query :aggregation] [{:aggregation-type "count"}])
+                      (assoc-in [:query :aggregation] [{:aggregation-type "count", :custom-name nil}])
                       (assoc :constraints query-constraints))
     :started_at   true
     :finished_at  true
@@ -80,7 +80,7 @@
                         (query checkins
                                (ql/aggregation (ql/count))))
                       (assoc :type "query")
-                      (assoc-in [:query :aggregation] [{:aggregation-type "count"}])
+                      (assoc-in [:query :aggregation] [{:aggregation-type "count", :custom-name nil}])
                       (assoc :constraints query-constraints))
     :started_at   true
     :finished_at  true

--- a/test/metabase/events/activity_feed_test.clj
+++ b/test/metabase/events/activity_feed_test.clj
@@ -271,7 +271,7 @@
    :model       "segment"
    :model_id    (:id segment)
    :database_id (id)
-   :table_id    (id :venues)
+   :table_id    (id :checkins)
    :details     {:name        (:name segment)
                  :description (:description segment)}}
   (with-temp-activities
@@ -288,7 +288,7 @@
    :model       "segment"
    :model_id    (:id segment)
    :database_id (id)
-   :table_id    (id :venues)
+   :table_id    (id :checkins)
    :details     {:name             (:name segment)
                  :description      (:description segment)
                  :revision_message "update this mofo"}}
@@ -310,7 +310,7 @@
    :model       "segment"
    :model_id    (:id segment)
    :database_id (id)
-   :table_id    (id :venues)
+   :table_id    (id :checkins)
    :details     {:name             (:name segment)
                  :description      (:description segment)
                  :revision_message "deleted"}}

--- a/test/metabase/query_processor/expand_resolve_test.clj
+++ b/test/metabase/query_processor/expand_resolve_test.clj
@@ -222,9 +222,10 @@
     :type     :query
     :query    {:source-table (id :checkins)
                :aggregation  [{:aggregation-type :sum
-                                :field            {:field-id      (id :venues :price)
-                                                   :fk-field-id   (id :checkins :venue_id)
-                                                   :datetime-unit nil}}]
+                               :custom-name      nil
+                               :field            {:field-id      (id :venues :price)
+                                                  :fk-field-id   (id :checkins :venue_id)
+                                                  :datetime-unit nil}}]
                :breakout     [{:field-id      (id :checkins :date)
                                :fk-field-id   nil
                                :datetime-unit :day-of-week}]}}
@@ -235,20 +236,21 @@
                                   :name   "CHECKINS"
                                   :id     (id :checkins)}
                    :aggregation  [{:aggregation-type :sum
-                                    :field            {:description        nil
-                                                       :base-type          :type/Integer
-                                                       :parent             nil
-                                                       :table-id           (id :venues)
-                                                       :special-type       :type/Category
-                                                       :field-name         "PRICE"
-                                                       :field-display-name "Price"
-                                                       :parent-id          nil
-                                                       :visibility-type    :normal
-                                                       :position           nil
-                                                       :field-id           (id :venues :price)
-                                                       :fk-field-id        (id :checkins :venue_id)
-                                                       :table-name         "VENUES__via__VENUE_ID"
-                                                       :schema-name        nil}}]
+                                   :custom-name      nil
+                                   :field            {:description        nil
+                                                      :base-type          :type/Integer
+                                                      :parent             nil
+                                                      :table-id           (id :venues)
+                                                      :special-type       :type/Category
+                                                      :field-name         "PRICE"
+                                                      :field-display-name "Price"
+                                                      :parent-id          nil
+                                                      :visibility-type    :normal
+                                                      :position           nil
+                                                      :field-id           (id :venues :price)
+                                                      :fk-field-id        (id :checkins :venue_id)
+                                                      :table-name         "VENUES__via__VENUE_ID"
+                                                      :schema-name        nil}}]
                    :breakout     [{:field {:description        nil
                                            :base-type          :type/Date
                                            :parent             nil
@@ -275,7 +277,7 @@
     :fk-field-ids #{(id :checkins :venue_id)}
     :table-ids    #{(id :venues) (id :checkins)}}]
   (let [expanded-form (ql/expand (wrap-inner-query (query checkins
-                                                        (ql/aggregation (ql/sum $venue_id->venues.price))
-                                                        (ql/breakout (ql/datetime-field $checkins.date :day-of-week)))))]
+                                                     (ql/aggregation (ql/sum $venue_id->venues.price))
+                                                     (ql/breakout (ql/datetime-field $checkins.date :day-of-week)))))]
     (mapv obj->map [expanded-form
                     (resolve/resolve expanded-form)])))

--- a/test/metabase/query_processor/macros_test.clj
+++ b/test/metabase/query_processor/macros_test.clj
@@ -14,7 +14,7 @@
 (expect
   {:database 1
    :type     :query
-   :query    {:aggregation [["rows"]]
+   :query    {:aggregation ["rows"]
               :filter      ["AND" [">" 4 1]]
               :breakout    [17]}}
   (expand-macros {:database 1
@@ -27,8 +27,10 @@
 (expect
   {:database 1
    :type     :query
-   :query    {:aggregation [["rows"]]
-              :filter      ["AND" ["AND" ["=" 5 "abc"]] ["OR" ["AND" ["IS_NULL" 7]] [">" 4 1]]]
+   :query    {:aggregation ["rows"]
+              :filter      ["AND" ["AND" ["=" 5 "abc"]]
+                                  ["OR" ["AND" ["IS_NULL" 7]]
+                                        [">" 4 1]]]
               :breakout    [17]}}
   (tu/with-temp* [Database [{database-id :id}]
                   Table    [{table-id :id}     {:db_id database-id}]
@@ -46,8 +48,9 @@
 (expect
   {:database 1
    :type     :query
-   :query    {:aggregation [["count"]]
-              :filter      ["AND" ["AND" [">" 4 1]] ["AND" ["=" 5 "abc"]]]
+   :query    {:aggregation ["count"]
+              :filter      ["AND" ["AND" [">" 4 1]]
+                                  ["AND" ["=" 5 "abc"]]]
               :breakout    [17]
               :order_by    [[1 "ASC"]]}}
   (tu/with-temp* [Database [{database-id :id}]
@@ -66,7 +69,7 @@
 (expect
   {:database 1
    :type     :query
-   :query    {:aggregation [["count"]]
+   :query    {:aggregation ["count"]
               :filter      ["AND" ["=" 5 "abc"]]
               :breakout    [17]
               :order_by    [[1 "ASC"]]}}
@@ -86,7 +89,7 @@
 (expect
   {:database 1
    :type     :query
-   :query    {:aggregation [["count"]]
+   :query    {:aggregation ["count"]
               :filter      ["AND" ["=" 5 "abc"]]
               :breakout    [17]
               :order_by    [[1 "ASC"]]}}
@@ -105,7 +108,7 @@
 (expect
   {:database 1
    :type     :query
-   :query    {:aggregation [["sum" 18]]
+   :query    {:aggregation ["sum" 18]
               :filter      ["AND" ["AND" [">" 4 1] ["AND" ["IS_NULL" 7]]] ["AND" ["=" 5 "abc"] ["AND" ["BETWEEN" 9 0 25]]]]
               :breakout    [17]
               :order_by    [[1 "ASC"]]}}

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -288,15 +288,22 @@
 
 
 (defn rows
-  "Return the result rows from query results, or throw an Exception if they're missing."
+  "Return the result rows from query RESULTS, or throw an Exception if they're missing."
   {:style/indent 0}
   [results]
-  (vec (or (-> results :data :rows)
+  (vec (or (get-in results [:data :rows])
            (println (u/pprint-to-str 'red results))
            (throw (Exception. "Error!")))))
 
+(defn rows+column-names
+  "Return the result rows and column names from query RESULTS, or throw an Exception if they're missing."
+  {:style/indent 0}
+  [results]
+  {:rows    (rows results)
+   :columns (get-in results [:data :columns])})
+
 (defn first-row
-  "Return the first row in the results of a query, or throw an Exception if they're missing."
+  "Return the first row in the RESULTS of a query, or throw an Exception if they're missing."
   {:style/indent 0}
   [results]
   (first (rows results)))

--- a/test/metabase/query_processor_test/expression_aggregations_test.clj
+++ b/test/metabase/query_processor_test/expression_aggregations_test.clj
@@ -156,3 +156,29 @@
     (rows (data/run-query venues
             (ql/aggregation (ql/sum (ql/+ $price 1)))
             (ql/breakout $price)))))
+
+;; check that we can name an expression aggregation w/ aggregation at top-level
+(datasets/expect-with-engines (engines-that-support :expression-aggregations)
+  {:rows    [[1  44]
+             [2 177]
+             [3  52]
+             [4  30]]
+   :columns [(data/format-name "price")
+             "New Price"]}
+  (format-rows-by [int int]
+    (rows+column-names (data/run-query venues
+                         (ql/aggregation (ql/named (ql/sum (ql/+ $price 1)) "New Price"))
+                         (ql/breakout $price)))))
+
+;; check that we can name an expression aggregation w/ expression at top-level
+(datasets/expect-with-engines (engines-that-support :expression-aggregations)
+  {:rows    [[1 -19]
+             [2  77]
+             [3  -2]
+             [4 -17]]
+   :columns [(data/format-name "price")
+             "Sum-41"]}
+  (format-rows-by [int int]
+    (rows+column-names (data/run-query venues
+                         (ql/aggregation (ql/named (ql/- (ql/sum $price) 41) "Sum-41"))
+                         (ql/breakout $price)))))

--- a/test/metabase/query_processor_test/expression_aggregations_test.clj
+++ b/test/metabase/query_processor_test/expression_aggregations_test.clj
@@ -167,7 +167,7 @@
              [3  52]
              [4  30]]
    :columns [(data/format-name "price")
-             "New Price"]}
+             (if (= *engine* :redshift) "new price" "New Price")]} ; Redshift annoyingly always lowercases column aliases
   (format-rows-by [int int]
     (rows+column-names (data/run-query venues
                          (ql/aggregation (ql/named (ql/sum (ql/+ $price 1)) "New Price"))
@@ -180,7 +180,7 @@
              [3  -2]
              [4 -17]]
    :columns [(data/format-name "price")
-             "Sum-41"]}
+             (if (= *engine* :redshift) "sum-41" "Sum-41")]}
   (format-rows-by [int int]
     (rows+column-names (data/run-query venues
                          (ql/aggregation (ql/named (ql/- (ql/sum $price) 41) "Sum-41"))

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -105,6 +105,7 @@
   "Call `driver/process-query` on expanded inner QUERY, looking up the `Database` ID for the `source-table.`
 
      (run-query* (query (source-table 5) ...))"
+  {:style/indent 0}
   [query :- qi/Query]
   (qp/process-query (wrap-inner-query query)))
 

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -124,7 +124,7 @@
   {:with-temp-defaults (fn [_] {:base_type :type/Text
                                 :name      (random-name)
                                 :position  1
-                                :table_id  (data/id :venues)})})
+                                :table_id  (data/id :checkins)})})
 
 (u/strict-extend (class Metric)
   WithTempDefaults
@@ -132,7 +132,7 @@
                                 :definition  {}
                                 :description "Lookin' for a blueberry"
                                 :name        "Toucans in the rainforest"
-                                :table_id    (data/id :venues)})})
+                                :table_id    (data/id :checkins)})})
 
 (u/strict-extend (class PermissionsGroup)
   WithTempDefaults
@@ -172,7 +172,7 @@
                                 :definition  {}
                                 :description "Lookin' for a blueberry"
                                 :name        "Toucans in the rainforest"
-                                :table_id    (data/id :venues)})})
+                                :table_id    (data/id :checkins)})})
 
 ;; TODO - `with-temp` doesn't return `Sessions`, probably because their ID is a string?
 


### PR DESCRIPTION
Add support for giving aggregations custom names.

MBQL syntax is simple:

```
[:named <aggregation-or-expression> "Some name"]
```

e.g. just wrap whatever you want to name in the `:named` clause.

Tests included.