### PR TITLE
Don't include AUTO_SERVER in H2 conn str placeholder

### DIFF
--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -210,7 +210,7 @@
          {:date-interval                     (u/drop-first-arg date-interval)
           :details-fields                    (constantly [{:name         "db"
                                                            :display-name "Connection String"
-                                                           :placeholder  "file:/Users/camsaul/bird_sightings/toucans;AUTO_SERVER=TRUE"
+                                                           :placeholder  "file:/Users/camsaul/bird_sightings/toucans"
                                                            :required     true}])
           :humanize-connection-error-message (u/drop-first-arg humanize-connection-error-message)
           :process-query-in-context          (u/drop-first-arg process-query-in-context)})


### PR DESCRIPTION
Don't include `AUTO_SERVER=TRUE` in the connection string placeholder for H2 databases because you're not allowed to use it