### PR TITLE
Properly handle METRICs defined with nested ag syntax

### DIFF
--- a/test/metabase/query_processor/macros_test.clj
+++ b/test/metabase/query_processor/macros_test.clj
@@ -4,9 +4,15 @@
             [metabase.models.metric :refer [Metric]]
             [metabase.models.segment :refer [Segment]]
             [metabase.models.table :refer [Table]]
-            [metabase.query-processor.macros :refer :all]
-            [metabase.test.data.users :refer :all]
-            [metabase.test.util :as tu]))
+            [metabase.query-processor :as qp]
+            (metabase.query-processor [expand :as ql]
+                                      [macros :refer :all])
+            [metabase.query-processor-test :refer :all]
+            [metabase.test.data :as data]
+            (metabase.test.data [datasets :as datasets]
+                                [users :refer :all])
+            [metabase.test.util :as tu]
+            [metabase.util :as u]))
 
 ;; expand-macros
 
@@ -127,3 +133,19 @@
                                :filter      ["AND" [">" 4 1] ["SEGMENT" segment-2-id]]
                                :breakout    [17]
                                :order_by    [[1 "ASC"]]}})))
+
+;; Check that a metric w/ multiple aggregation syntax (nested vector) still works correctly
+(datasets/expect-with-engines (engines-that-support :expression-aggregations)
+  [[2 118]
+   [3  39]
+   [4  24]]
+  (tu/with-temp Metric [metric {:table_id   (data/id :venues)
+                                :definition {:aggregation [[:sum [:field-id (data/id :venues :price)]]]
+                                             :filter      [:> [:field-id (data/id :venues :price)] 1]}}]
+    (format-rows-by [int int]
+      (rows (qp/process-query
+              {:database (data/id)
+               :type     :query
+               :query    {:source-table (data/id :venues)
+                          :aggregation  [["METRIC" (u/get-id metric)]]
+                          :breakout     [(ql/breakout (ql/field-id (data/id :venues :price)))]}})))))

--- a/test/metabase/query_processor_test/expression_aggregations_test.clj
+++ b/test/metabase/query_processor_test/expression_aggregations_test.clj
@@ -219,3 +219,21 @@
                             :query    {:source-table (data/id :venues)
                                        :aggregation  [[:named ["METRIC" (u/get-id metric)] "My Cool Metric"]]
                                        :breakout     [(ql/breakout (ql/field-id (data/id :venues :price)))]}})))))
+
+;; check that METRICS (ick) with a nested aggregation still work inside a NAMED clause
+(datasets/expect-with-engines (engines-that-support :expression-aggregations)
+  {:rows    [[2 118]
+             [3  39]
+             [4  24]]
+   :columns [(data/format-name "price")
+             (if (= *engine* :redshift) "my cool metric" "My Cool Metric")]}
+  (tu/with-temp Metric [metric {:table_id   (data/id :venues)
+                                :definition {:aggregation [[:sum [:field-id (data/id :venues :price)]]]
+                                             :filter      [:> [:field-id (data/id :venues :price)] 1]}}]
+    (format-rows-by [int int]
+      (rows+column-names (qp/process-query
+                           {:database (data/id)
+                            :type     :query
+                            :query    {:source-table (data/id :venues)
+                                       :aggregation  [[:named ["METRIC" (u/get-id metric)] "My Cool Metric"]]
+                                       :breakout     [(ql/breakout (ql/field-id (data/id :venues :price)))]}})))))

--- a/test/metabase/query_processor_test/expression_aggregations_test.clj
+++ b/test/metabase/query_processor_test/expression_aggregations_test.clj
@@ -201,3 +201,21 @@
                :query    {:source-table (data/id :venues)
                           :aggregation  [:+ ["METRIC" (u/get-id metric)] 1]
                           :breakout     [(ql/breakout (ql/field-id (data/id :venues :price)))]}})))))
+
+;; check that we can handle METRICS (ick) inside a NAMED clause
+(datasets/expect-with-engines (engines-that-support :expression-aggregations)
+  {:rows    [[2 118]
+             [3  39]
+             [4  24]]
+   :columns [(data/format-name "price")
+             (if (= *engine* :redshift) "my cool metric" "My Cool Metric")]}
+  (tu/with-temp Metric [metric {:table_id   (data/id :venues)
+                                :definition {:aggregation [:sum [:field-id (data/id :venues :price)]]
+                                             :filter      [:> [:field-id (data/id :venues :price)] 1]}}]
+    (format-rows-by [int int]
+      (rows+column-names (qp/process-query
+                           {:database (data/id)
+                            :type     :query
+                            :query    {:source-table (data/id :venues)
+                                       :aggregation  [[:named ["METRIC" (u/get-id metric)] "My Cool Metric"]]
+                                       :breakout     [(ql/breakout (ql/field-id (data/id :venues :price)))]}})))))


### PR DESCRIPTION
This test is already passing but it was something that wasn't covered.

Check that we can use a MBQL `:named` clause on a pseudo-MBQL `METRIC` clause.