### PR TITLE
update crate-jdbc to 2.1.2 which fixes a critical bug

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -68,7 +68,7 @@
                  [org.yaml/snakeyaml "1.17"]                          ; YAML parser (required by liquibase)
                  [org.xerial/sqlite-jdbc "3.8.11.2"]                  ; SQLite driver !!! DO NOT UPGRADE THIS UNTIL UPSTREAM BUG IS FIXED -- SEE https://github.com/metabase/metabase/issues/3753 !!!
                  [postgresql "9.3-1102.jdbc41"]                       ; Postgres driver
-                 [io.crate/crate-jdbc "2.1.1"]                        ; Crate JDBC driver
+                 [io.crate/crate-jdbc "2.1.2"]                        ; Crate JDBC driver
                  [prismatic/schema "1.1.3"]                           ; Data schema declaration and validation library
                  [ring/ring-jetty-adapter "1.5.0"]                    ; Ring adapter using Jetty webserver (used to run a Ring server for unit tests)
                  [ring/ring-json "0.4.0"]                             ; Ring middleware for reading/writing JSON automatically


### PR DESCRIPTION
that broke the postgresql implementation due to overriding jdbc connection string
see https://github.com/crate/crate-jdbc/commit/d25e2ca02efe212452288ff84004ee6bdc1b8d5d

###### TODO 
-  [ ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).

