### PR TITLE
Use proper type for Metabase Enabled Setting Comparison

### DIFF
--- a/src/metabase/events/metabot_lifecycle.clj
+++ b/src/metabase/events/metabot_lifecycle.clj
@@ -27,12 +27,19 @@
   (when-let [{topic :topic object :item} metabot-lifecycle-event]
     (try
       ;; if someone updated our slack-token, or metabot was enabled/disabled then react accordingly
-      (let [{:keys [slack-token metabot-enabled]} object]
-        (cond
-          (and (contains? object :metabot-enabled)
-               (not metabot-enabled))      (metabot/stop-metabot!)
-          (and (contains? object :slack-token)
-               (seq slack-token))                  (metabot/start-metabot!)))
+      (when (and (contains? object :metabot-enabled) (contains? object :slack-token))
+        
+        (let [{:keys [slack-token metabot-enabled]} object]
+          (cond
+            (nil? slack-token) (metabot/stop-metabot!) 
+            (not metabot-enabled)  (metabot/stop-metabot!)
+            :else (metabot/restart-metabot!))))
+      ; (let [{:keys [slack-token metabot-enabled]} object]
+      ;   (cond
+      ;     (and (contains? object :metabot-enabled)
+      ;          (not metabot-enabled))      (metabot/stop-metabot!)
+      ;     (and (contains? object :slack-token)
+      ;          (seq slack-token))                  (metabot/start-metabot!)))
       (catch Throwable e
         (log/warn (format "Failed to process driver notifications event. %s" topic) e)))))
 

--- a/src/metabase/events/metabot_lifecycle.clj
+++ b/src/metabase/events/metabot_lifecycle.clj
@@ -32,7 +32,7 @@
           (cond
             (nil? slack-token)      (metabot/stop-metabot!)
             (not metabot-enabled)   (metabot/stop-metabot!)
-             :else (metabot/restart-metabot!))))
+            :else                   (metabot/restart-metabot!))))
       (catch Throwable e
         (log/warn (format "Failed to process driver notifications event. %s" topic) e)))))
 

--- a/src/metabase/events/metabot_lifecycle.clj
+++ b/src/metabase/events/metabot_lifecycle.clj
@@ -30,7 +30,7 @@
       (let [{:keys [slack-token metabot-enabled]} object]
         (cond
           (and (contains? object :metabot-enabled)
-               (not= "true" metabot-enabled))      (metabot/stop-metabot!)
+               (not metabot-enabled))      (metabot/stop-metabot!)
           (and (contains? object :slack-token)
                (seq slack-token))                  (metabot/start-metabot!)))
       (catch Throwable e

--- a/src/metabase/events/metabot_lifecycle.clj
+++ b/src/metabase/events/metabot_lifecycle.clj
@@ -33,12 +33,6 @@
             (nil? slack-token)      (metabot/stop-metabot!)
             (not metabot-enabled)   (metabot/stop-metabot!)
             :else (metabot/restart-metabot!))))
-      ; (let [{:keys [slack-token metabot-enabled]} object]
-      ;   (cond
-      ;     (and (contains? object :metabot-enabled)
-      ;          (not metabot-enabled))      (metabot/stop-metabot!)
-      ;     (and (contains? object :slack-token)
-      ;          (seq slack-token))                  (metabot/start-metabot!)))
       (catch Throwable e
         (log/warn (format "Failed to process driver notifications event. %s" topic) e)))))
 

--- a/src/metabase/events/metabot_lifecycle.clj
+++ b/src/metabase/events/metabot_lifecycle.clj
@@ -32,7 +32,7 @@
           (cond
             (nil? slack-token)      (metabot/stop-metabot!)
             (not metabot-enabled)   (metabot/stop-metabot!)
-            :else (metabot/restart-metabot!))))
+             :else (metabot/restart-metabot!))))
       (catch Throwable e
         (log/warn (format "Failed to process driver notifications event. %s" topic) e)))))
 

--- a/src/metabase/events/metabot_lifecycle.clj
+++ b/src/metabase/events/metabot_lifecycle.clj
@@ -28,11 +28,10 @@
     (try
       ;; if someone updated our slack-token, or metabot was enabled/disabled then react accordingly
       (when (and (contains? object :metabot-enabled) (contains? object :slack-token))
-        
         (let [{:keys [slack-token metabot-enabled]} object]
           (cond
-            (nil? slack-token) (metabot/stop-metabot!) 
-            (not metabot-enabled)  (metabot/stop-metabot!)
+            (nil? slack-token)      (metabot/stop-metabot!)
+            (not metabot-enabled)   (metabot/stop-metabot!)
             :else (metabot/restart-metabot!))))
       ; (let [{:keys [slack-token metabot-enabled]} object]
       ;   (cond

--- a/src/metabase/metabot.clj
+++ b/src/metabase/metabot.clj
@@ -317,3 +317,13 @@
   (log/info "Stopping MetaBot...  🤖")
   (reset! websocket-monitor-thread-id nil)
   (disconnect-websocket!))
+
+(defn restart-metabot! 
+  "Restart the Metaot. 
+   Used on settings changed"
+  []
+  (when @websocket-monitor-thread-id
+    (log/info "Metabot already running. Killing the previous WebSocket listener first.")
+    (stop-metabot!))
+  (start-metabot!)
+  )

--- a/src/metabase/metabot.clj
+++ b/src/metabase/metabot.clj
@@ -318,12 +318,11 @@
   (reset! websocket-monitor-thread-id nil)
   (disconnect-websocket!))
 
-(defn restart-metabot! 
-  "Restart the Metaot. 
+(defn restart-metabot!
+  "Restart the Metabot listening process.
    Used on settings changed"
   []
   (when @websocket-monitor-thread-id
     (log/info "Metabot already running. Killing the previous WebSocket listener first.")
     (stop-metabot!))
-  (start-metabot!)
-  )
+  (start-metabot!))


### PR DESCRIPTION
In https://github.com/metabase/metabase/commit/0ee81b86f77bfe6db74a87042ebcc35bbff44081#diff-129f6bcce726d47c246ea8f3135256f4R21 the setting type was changed to a boolean but this was never updated. 

Might be a fix for #3965
This bug prevented Metabot from turning on unless you restarted the instance.