### PR TITLE
Make admin header and edit bar prettier

### DIFF
--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx
@@ -23,7 +23,7 @@ const PermissionsEditor = ({ grid, onUpdatePermission, onSave, onCancel, isDirty
                             action={onCancel}
                             content="No changes to permissions will be made."
                         >
-                            <button className="Button Button--borderless Button--small">
+                            <button className="Button Button--borderless Button--small text-white text-white-hover">
                                 Cancel
                             </button>
                         </Confirm>,
@@ -33,7 +33,7 @@ const PermissionsEditor = ({ grid, onUpdatePermission, onSave, onCancel, isDirty
                             content={<PermissionsConfirm diff={diff} />}
                             triggerClasses={cx({ disabled: !isDirty })}
                         >
-                            <button className={cx("Button Button--primary Button--small")}>Save Changes</button>
+                            <button className={cx("Button Button--primary Button--small text-bold text-white-hover")}>Save Changes</button>
                         </Confirm>
                     ]}
                 />

--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx
@@ -23,7 +23,7 @@ const PermissionsEditor = ({ grid, onUpdatePermission, onSave, onCancel, isDirty
                             action={onCancel}
                             content="No changes to permissions will be made."
                         >
-                            <button className="Button Button--borderless">
+                            <button className="Button Button--borderless Button--small">
                                 Cancel
                             </button>
                         </Confirm>,
@@ -33,7 +33,7 @@ const PermissionsEditor = ({ grid, onUpdatePermission, onSave, onCancel, isDirty
                             content={<PermissionsConfirm diff={diff} />}
                             triggerClasses={cx({ disabled: !isDirty })}
                         >
-                            <button className={cx("Button")}>Save Changes</button>
+                            <button className={cx("Button Button--primary Button--small")}>Save Changes</button>
                         </Confirm>
                     ]}
                 />

--- a/frontend/src/metabase/css/admin.css
+++ b/frontend/src/metabase/css/admin.css
@@ -1,5 +1,6 @@
 :root {
     --admin-nav-bg-color: #8091AB;
+    --admin-nav-bg-color-tint: #9AA7BC;
     --admin-nav-item-text-color: rgba(255, 255, 255, 0.63);
     --admin-nav-item-text-active-color: #fff;
     --page-header-padding: 2.375rem;
@@ -36,11 +37,11 @@
 
 .AdminNav .NavDropdown.open .NavDropdown-button,
 .AdminNav .NavDropdown .NavDropdown-content-layer {
-    background-color: #8993A1;
+    background-color: var(--admin-nav-bg-color-tint);
 }
 
 .AdminNav .Dropdown-item:hover {
-    background-color: #6F7A8B;
+    background-color: var(--admin-nav-bg-color);
 }
 
 /* utility to get a simple common hover state for admin items */

--- a/frontend/src/metabase/css/admin.css
+++ b/frontend/src/metabase/css/admin.css
@@ -1,5 +1,5 @@
 :root {
-    --admin-nav-bg-color: #6F7A8B;
+    --admin-nav-bg-color: #8091AB;
     --admin-nav-item-text-color: rgba(255, 255, 255, 0.63);
     --admin-nav-item-text-active-color: #fff;
     --page-header-padding: 2.375rem;

--- a/frontend/src/metabase/css/components/buttons.css
+++ b/frontend/src/metabase/css/components/buttons.css
@@ -45,7 +45,7 @@
 }
 
 .Button--small {
-    padding: 0.4rem 0.75rem;
+    padding: 0.45rem 1rem;
     font-size: 0.6rem;
 }
 

--- a/frontend/src/metabase/css/components/header.css
+++ b/frontend/src/metabase/css/components/header.css
@@ -39,7 +39,7 @@
 }
 
 .EditHeader.EditHeader--admin {
-    background-color: #8C95A2;
+    background-color: rgba(128, 145, 171, 0.8);
 }
 
 .EditHeader-title {
@@ -54,15 +54,15 @@
 .EditHeader .Button {
     color: var(--brand-color);
     border: none;
-    text-transform: uppercase;
-    font-size: 0.75rem;
-    background-color: rgba(255,255,255,0.5);
-    font-weight: normal;
+    font-size: 0.875rem;
+    background-color: rgba(255,255,255,0.1);
+    font-weight: 700;
     margin-left: 0.75em;
 }
 
 .EditHeader .Button--primary {
     background-color: white;
+    color: #444444;
 }
 
 .EditHeader .Button:hover {
@@ -70,10 +70,18 @@
     background-color: var(--brand-color);
 }
 
+.EditHeader.EditHeader--admin .Button:hover {
+  background-color: var(--admin-nav-bg-color);
+}
+
+.EditHeader.EditHeader--admin .Button.Button--primary:hover {
+  color: white;
+}
+
 .EditHeader.EditHeader--admin .Button {
     color: white;
 }
 
 .EditHeader.EditHeader--admin .Button.Button--primary {
-    color: var(--brand-color);
+    color: #444;
 }

--- a/frontend/src/metabase/css/components/header.css
+++ b/frontend/src/metabase/css/components/header.css
@@ -39,7 +39,7 @@
 }
 
 .EditHeader.EditHeader--admin {
-    background-color: rgba(128, 145, 171, 0.8);
+    background-color: var(--admin-nav-bg-color-tint);
 }
 
 .EditHeader-title {

--- a/frontend/src/metabase/css/components/header.css
+++ b/frontend/src/metabase/css/components/header.css
@@ -52,17 +52,22 @@
 }
 
 .EditHeader .Button {
-    color: var(--brand-color);
+    color: white;
     border: none;
-    font-size: 0.875rem;
+    font-size: 1em;
+    text-transform: capitalize;
     background-color: rgba(255,255,255,0.1);
-    font-weight: 700;
     margin-left: 0.75em;
 }
 
 .EditHeader .Button--primary {
     background-color: white;
-    color: #444444;
+    color: var(--brand-color);
+}
+
+.EditHeader.EditHeader--admin .Button--primary {
+  background-color: white;
+  color: var(--70-percent-black);
 }
 
 .EditHeader .Button:hover {
@@ -72,16 +77,4 @@
 
 .EditHeader.EditHeader--admin .Button:hover {
   background-color: var(--admin-nav-bg-color);
-}
-
-.EditHeader.EditHeader--admin .Button.Button--primary:hover {
-  color: white;
-}
-
-.EditHeader.EditHeader--admin .Button {
-    color: white;
-}
-
-.EditHeader.EditHeader--admin .Button.Button--primary {
-    color: #444;
 }

--- a/frontend/src/metabase/css/core/text.css
+++ b/frontend/src/metabase/css/core/text.css
@@ -1,5 +1,6 @@
 :root {
   --body-text-color: #8E9BA9;
+  --70-percent-black: #444444;
 }
 
 /* center */

--- a/frontend/src/metabase/dashboard/components/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader.jsx
@@ -97,22 +97,13 @@ export default class DashboardHeader extends Component {
 
     getEditingButtons() {
         return [
-            <ActionButton
-                key="save"
-                actionFn={() => this.onSave()}
-                className="Button Button--small Button--primary text-uppercase"
-                normalText="Save"
-                activeText="Saving…"
-                failedText="Save failed"
-                successText="Saved"
-            />,
-            <a data-metabase-event="Dashboard;Cancel Edits" key="cancel" className="Button Button--small text-uppercase" onClick={() => this.onCancel()}>
+            <a data-metabase-event="Dashboard;Cancel Edits" key="cancel" className="Button Button--small" onClick={() => this.onCancel()}>
                 Cancel
             </a>,
             <ModalWithTrigger
                 key="delete"
                 ref="deleteDashboardModal"
-                triggerClasses="Button Button--small text-uppercase"
+                triggerClasses="Button Button--small"
                 triggerElement="Delete"
             >
                 <DeleteDashboardModal
@@ -120,7 +111,16 @@ export default class DashboardHeader extends Component {
                     onClose={() => this.refs.deleteDashboardModal.toggle()}
                     onDelete={() => this.onDelete()}
                 />
-            </ModalWithTrigger>
+            </ModalWithTrigger>,
+            <ActionButton
+                key="save"
+                actionFn={() => this.onSave()}
+                className="Button Button--small Button--primary"
+                normalText="Save"
+                activeText="Saving…"
+                failedText="Save failed"
+                successText="Saved"
+            />
         ];
     }
 

--- a/frontend/src/metabase/nav/containers/Navbar.jsx
+++ b/frontend/src/metabase/nav/containers/Navbar.jsx
@@ -73,10 +73,10 @@ export default class Navbar extends Component {
                 <div className="wrapper flex align-center">
                     <div className="NavTitle flex align-center">
                         <Icon name={'gear'} className="AdminGear" size={22}></Icon>
-                        <span className="NavItem-text ml1 hide sm-show">Site Administration</span>
+                        <span className="NavItem-text ml1 hide sm-show text-bold">Metabase Admin Panel</span>
                     </div>
 
-                    <ul className="sm-ml4 flex flex-full">
+                    <ul className="sm-ml4 flex flex-full text-strong">
                         <AdminNavItem name="Settings"    path="/admin/settings"     currentPath={this.props.path} />
                         <AdminNavItem name="People"      path="/admin/people"       currentPath={this.props.path} />
                         <AdminNavItem name="Data Model"  path="/admin/datamodel"    currentPath={this.props.path} />


### PR DESCRIPTION
**To-do**
- [x] Fix the top-right dropdown menu bg color
- [x] Fix the way this PR messes with the user-land edit bar

**Current:**

![screen shot 2016-12-20 at 12 32 41 pm](https://cloud.githubusercontent.com/assets/2223916/21366884/a053daae-c6b0-11e6-80b7-ca7d9e6988e3.png)

<img width="1264" alt="26fa11ac-5fe8-11e6-9577-f16654bd02aa" src="https://cloud.githubusercontent.com/assets/2223916/21401841/ac4231f2-c76a-11e6-944f-2859f7119771.png">


**Proposed:**

![screen shot 2016-12-20 at 12 32 08 pm](https://cloud.githubusercontent.com/assets/2223916/21366888/a806b5a0-c6b0-11e6-8585-0b01285754de.png)

<img width="1265" alt="348ce948-5fe8-11e6-94b3-a80da8cc1b22" src="https://cloud.githubusercontent.com/assets/2223916/21401843/afc32a3e-c76a-11e6-9e62-42a33f1dc6b8.png">



**Summary of changes:**
- Change title of admin panel header
- Change bg color of header (slight blue tint)
- Change bg color of edit bar (tint of the new header color)
- Change style of edit bar buttons (Sentence case, bolder, and better color harmony)
- Change style of userland edit bar buttons
- Reorder userland edit bar buttons
