### PR TITLE
Fix an issue where the pie chart would throw a max call stack exceede…

### DIFF
--- a/frontend/src/metabase/visualizations/components/LegendVertical.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendVertical.jsx
@@ -21,20 +21,30 @@ export default class LegendVertical extends Component {
     static defaultProps = {};
 
     componentDidUpdate() {
+        // Get the bounding rectangle of the chart widget to determine if
+        // legend items will overflow the widget area
         let size = ReactDOM.findDOMNode(this).getBoundingClientRect();
-        if (this.state.size && (size.width !== this.state.size.width || size.height !== this.state.size.height)) {
-            this.setState({ overflowCount: 0, size });
-        } else if (this.state.overflowCount === 0) {
+
+        let widgetSizeHasChanged = this.state.size && (size.width !== this.state.size.width || size.height !== this.state.size.height);
+        let firstLoad = !this.state.size;
+
+        if (firstLoad || widgetSizeHasChanged){
+            // Determine how many legend items extend outside of the widget area and
+            // set overflow count to # of items
             let overflowCount = 0;
             for (var i = 0; i < this.props.titles.length; i++) {
+                if (!this.refs["item"+i]){
+                    // Handle the case where we are resizing the widget but have already
+                    // removed overflow.  Just exit and don't call setState() to avoid
+                    // infinite loop.
+                    return
+                }
                 let itemSize = ReactDOM.findDOMNode(this.refs["item"+i]).getBoundingClientRect();
                 if (size.top > itemSize.top || size.bottom < itemSize.bottom) {
                     overflowCount++;
                 }
             }
-            if (this.state.overflowCount !== overflowCount) {
-                this.setState({ overflowCount, size });
-            }
+            this.setState({ overflowCount, size });
         }
     }
 


### PR DESCRIPTION
This is a fix for:
https://github.com/metabase/metabase/issues/2608
https://github.com/metabase/metabase/issues/3239

The issue occurs in chrome when using the pie chart.  If you shrink the size of the pie chart so that the legend items (labels) overflow the widget, the code would throw the max call stack exceeded error in the javascript developer tools window.  To the user it just looks like the application is locking up / taking forever to refresh. 

**Root Cause**
The problem was that react was in an infinite loop.  componentDidUpdate() would call setState() and set the overflow legend items to 10 (or whatever # happened to overflow).  This would trigger a render() in react, and then another componentDidUpdate() would be triggered.  But the code would set overflow back to 0.  This would repeat in an infinite loop until the stack size was exceeded.

**Fix**
The code is a bit tricky because render() needs to render the extra legend items to the screen, immediately calculate the overflowing legend items, and then re-render the screen before the user notices.  It needs to render too many items first so that the code can then call _ReactDOM.findDOMNode(this.refs["item"+i]).getBoundingClientRect()_ to see if they labels overflow. 

The code now works as follows:

1. render() is called once in order to add the legend items to the screen
2. Once the legend items are added, componentDidUpdate() uses the DOM ( getBoundingClientRect() ) to see if the legend items would overflow the area of the widget.  It then needs to call setState() with the number of overflow items so that render() can remove the legend items from the screen. 
3.  Then, render() has to run again to remove the legend items from the screen.

I added some comments and restructured the code a bit to make it easier to follow.  Let me know if there's any changes you'd like me to make to it. 


###### TODO 
-  [ x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
