### PR TITLE
Collections fixes 2

### DIFF
--- a/frontend/src/metabase/components/Modal.jsx
+++ b/frontend/src/metabase/components/Modal.jsx
@@ -116,13 +116,13 @@ export class FullPageModal extends Component {
         this._modalElement.className = "Modal--full";
         document.querySelector('body').appendChild(this._modalElement);
 
-        this.componentDidUpdate();
-
         // save the scroll position, scroll to the top left, and disable scrolling
         this._scrollX = window.scrollX;
         this._scrollY = window.scrollY;
         window.scrollTo(0,0);
         document.body.style.overflow = "hidden";
+
+        this.componentDidUpdate();
     }
 
     componentDidUpdate() {

--- a/frontend/src/metabase/questions/collections.js
+++ b/frontend/src/metabase/questions/collections.js
@@ -1,7 +1,7 @@
 
 import { createAction, createThunkAction, handleActions, combineReducers } from "metabase/lib/redux";
 import { reset } from 'redux-form';
-import { push } from "react-router-redux";
+import { replace } from "react-router-redux";
 import Urls from "metabase/lib/urls";
 
 import _ from "underscore";
@@ -37,7 +37,8 @@ export const saveCollection = createThunkAction(SAVE_COLLECTION, (collection) =>
             if (response.id != null) {
                 dispatch(reset("collection"));
             }
-            dispatch(push(Urls.collection(response)));
+            // use `replace` so form url doesn't appear in history
+            dispatch(replace(Urls.collection(response)));
             return response;
         } catch (e) {
             // redux-form expects an object with either { field: error } or { _error: error }

--- a/frontend/src/metabase/questions/containers/CollectionPage.jsx
+++ b/frontend/src/metabase/questions/containers/CollectionPage.jsx
@@ -22,7 +22,7 @@ const mapDispatchToProps = ({
     goBack,
     goToQuestions: () => push(`/questions`),
     editCollection: (id) => push(`/collections/${id}`),
-    editPermissions: (id) => push(`/collections/permissions?collection=${id}`),
+    editPermissions: (id) => push(`/collections/permissions?collectionId=${id}`),
     loadCollections,
 })
 


### PR DESCRIPTION
* [x] the move to collection modal renders the collection list unreliably depending on scroll position when triggered. Resolves #4068
* [x] Hitting back after creating a collection should return you to `questions/all`. Resolves #4055