### PR TITLE
Sort segments by name in GET /api/segment

### DIFF
--- a/src/metabase/api/segment.clj
+++ b/src/metabase/api/segment.clj
@@ -33,7 +33,7 @@
 (defendpoint GET "/"
   "Fetch *all* `Segments`."
   []
-  (filter models/can-read? (-> (db/select Segment, :is_active true)
+  (filter models/can-read? (-> (db/select Segment, :is_active true, {:order-by [[:%lower.name :asc]]})
                                (hydrate :creator))))
 
 


### PR DESCRIPTION
Make sure to specify order Segments should be returned in by the endpoint. Fixes some of the random test failures in #4054 

Merging this into `release-0.22.0` since it seems most of our work will be happening here over the next few days