### PR TITLE
Add missing newlines in docs pages

### DIFF
--- a/docs/administration-guide/03-metadata-editing.md
+++ b/docs/administration-guide/03-metadata-editing.md
@@ -78,6 +78,7 @@ Common detailed types include:
 * Zip Code
 
 This is also where you set mark special fields in a table:
+
 * Entity Key — the field in this table that uniquely identifies each row. Could be a product ID, serial number, etc.
 * Entity Name — different from the entity key, this is the field whose heading represents what each row in the table *is*. For example, in a Users table, the User column might be the entity name.
 * Foreign Key — this is a field in this table that uniquely identifies a *row* in another table. In other words, this is a field that, almost always, points to the primary key of another table. For example, in a Products table, you might have a Customer ID field that points to a Customers table, where Customer ID is the primary key.

--- a/docs/administration-guide/10-single-sign-on.md
+++ b/docs/administration-guide/10-single-sign-on.md
@@ -28,4 +28,4 @@ Note: Metabase accounts created with Single Sign-On do not have passwords and mu
 ---
 
 ## Next: Creating a Getting Started Guide
-Learn how to easily [make a Getting Started Guide](10-getting-started-guide.md) for your team.
+Learn how to easily [make a Getting Started Guide](11-getting-started-guide.md) for your team.

--- a/docs/users-guide/09-pulses.md
+++ b/docs/users-guide/09-pulses.md
@@ -21,6 +21,7 @@ When you select a saved question, Metabase will show you a preview of how it’l
 ![Behold! The metamorphosis.](images/pulses/04-transformation.png)
 
 Currently, there are a few restrictions on what kinds of saved questions you can put into a pulse:
+
 * Raw data can’t be put in a pulse
 * Tables will be cropped to a maximum of three columns and 10 rows
 * Bar charts (and pie charts which get turned into bar charts) will be cropped to one column for the labels, one column for the values, and 10 total rows


### PR DESCRIPTION
Missing newline causes text rendered on metabase.com docs site to be in a paragraph instead of a bulleted list. It looks fine on GitHub though.  (it's a tiny documentation change)

###### TODO 
-  [] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
