### PR TITLE
Code cleanup :shower:

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -324,7 +324,10 @@
 
 ;;; ------------------------------------------------------------ Running a Query ------------------------------------------------------------
 
-(defn- run-query-for-card [card-id parameters constraints]
+(defn run-query-for-card
+  "Run the query for Card with PARAMETERS and CONSTRAINTS, and return results in the usual format."
+  [card-id & {:keys [parameters constraints]
+              :or   {constraints dataset-api/default-query-constraints}}]
   {:pre [(u/maybe? sequential? parameters)]}
   (let [card    (read-check Card card-id)
         query   (assoc (:dataset_query card)
@@ -337,19 +340,19 @@
 (defendpoint POST "/:card-id/query"
   "Run the query associated with a Card."
   [card-id :as {{:keys [parameters]} :body}]
-  (run-query-for-card card-id parameters dataset-api/query-constraints))
+  (run-query-for-card card-id, :parameters parameters))
 
 (defendpoint POST "/:card-id/query/csv"
   "Run the query associated with a Card, and return its results as CSV. Note that this expects the parameters as serialized JSON in the 'parameters' parameter"
   [card-id parameters]
   {parameters (s/maybe su/JSONString)}
-  (dataset-api/as-csv (run-query-for-card card-id (json/parse-string parameters keyword) nil)))
+  (dataset-api/as-csv (run-query-for-card card-id, :parameters (json/parse-string parameters keyword), :constraints nil)))
 
 (defendpoint POST "/:card-id/query/json"
   "Run the query associated with a Card, and return its results as JSON. Note that this expects the parameters as serialized JSON in the 'parameters' parameter"
   [card-id parameters]
   {parameters (s/maybe su/JSONString)}
-  (dataset-api/as-json (run-query-for-card card-id (json/parse-string parameters keyword) nil)))
+  (dataset-api/as-json (run-query-for-card card-id, :parameters (json/parse-string parameters keyword), :constraints nil)))
 
 
 (define-routes)

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -64,9 +64,11 @@
          (recur (first rest-args) (second rest-args) (drop 2 rest-args))))))
 
 (defn check-exists?
-  "Check that object with ID exists in the DB, or throw a 404."
-  [entity id]
-  (check-404 (db/exists? entity, :id id)))
+  "Check that object with ID (or other key/values) exists in the DB, or throw a 404."
+  ([entity id]
+   (check-exists? entity :id id))
+  ([entity k v & more]
+   (check-404 (apply db/exists? entity k v more))))
 
 (defn check-superuser
   "Check that `*current-user*` is a superuser or throw a 403. This doesn't require a DB call."
@@ -210,6 +212,7 @@
 
 ;;; ------------------------------------------------------------ DEFENDPOINT AND RELATED FUNCTIONS ------------------------------------------------------------
 
+;; TODO - several of the things `defendpoint` does could and should just be done by custom Ring middleware instead
 (defmacro defendpoint
   "Define an API function.
    This automatically does several things:

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -21,7 +21,7 @@
   "General maximum number of rows to return from an API query."
   10000)
 
-(def ^:const query-constraints
+(def ^:const default-query-constraints
   "Default map of constraints that we apply on dataset queries executed by the api."
   {:max-results           max-results
    :max-results-bare-rows max-results-bare-rows})
@@ -31,7 +31,7 @@
   [:as {{:keys [database] :as body} :body}]
   (read-check Database database)
   ;; add sensible constraints for results limits on our query
-  (let [query (assoc body :constraints query-constraints)]
+  (let [query (assoc body :constraints default-query-constraints)]
     (qp/dataset-query query {:executed-by *current-user-id*})))
 
 (defendpoint POST "/duration"
@@ -39,7 +39,7 @@
   [:as {{:keys [database] :as query} :body}]
   (read-check Database database)
   ;; add sensible constraints for results limits on our query
-  (let [query         (assoc query :constraints query-constraints)
+  (let [query         (assoc query :constraints default-query-constraints)
         running-times (db/select-field :running_time QueryExecution
                         :query_hash (hash query)
                         {:order-by [[:started_at :desc]]

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -68,20 +68,20 @@
 (defn public-settings
   "Return a simple map of key/value pairs which represent the public settings (`MetabaseBootstrap`) for the front-end application."
   []
-  {:ga_code               "UA-60817802-1"
-   :password_complexity   password/active-password-complexity
-   :timezones             common/timezones
-   :version               config/mb-version-info
-   :engines               ((resolve 'metabase.driver/available-drivers))
-   :setup_token           ((resolve 'metabase.setup/token-value))
+  {:admin_email           (admin-email)
    :anon_tracking_enabled (anon-tracking-enabled)
-   :site_name             (site-name)
-   :email_configured      ((resolve 'metabase.email/email-configured?))
-   :admin_email           (admin-email)
-   :report_timezone       (setting/get :report-timezone)
-   :timezone_short        (short-timezone-name (setting/get :report-timezone))
-   :has_sample_dataset    (db/exists? 'Database, :is_sample true)
-   :google_auth_client_id (setting/get :google-auth-client-id)
-   :map_tile_server_url   (map-tile-server-url)
    :custom_geojson        (setting/get :custom-geojson)
-   :types                 (types/types->parents)})
+   :email_configured      ((resolve 'metabase.email/email-configured?))
+   :engines               ((resolve 'metabase.driver/available-drivers))
+   :ga_code               "UA-60817802-1"
+   :google_auth_client_id (setting/get :google-auth-client-id)
+   :has_sample_dataset    (db/exists? 'Database, :is_sample true)
+   :map_tile_server_url   (map-tile-server-url)
+   :password_complexity   password/active-password-complexity
+   :report_timezone       (setting/get :report-timezone)
+   :setup_token           ((resolve 'metabase.setup/token-value))
+   :site_name             (site-name)
+   :timezone_short        (short-timezone-name (setting/get :report-timezone))
+   :timezones             common/timezones
+   :types                 (types/types->parents)
+   :version               config/mb-version-info})

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -2,7 +2,7 @@
   "Unit tests for /api/dataset endpoints."
   (:require [clojure.string :as s]
             [expectations :refer :all]
-            [metabase.api.dataset :refer [query-constraints]]
+            [metabase.api.dataset :refer [default-query-constraints]]
             [metabase.db :as db]
             (metabase.models [card :refer [Card]]
                              [query-execution :refer [QueryExecution]])
@@ -65,7 +65,7 @@
                                (ql/aggregation (ql/count))))
                       (assoc :type "query")
                       (assoc-in [:query :aggregation] [{:aggregation-type "count", :custom-name nil}])
-                      (assoc :constraints query-constraints))
+                      (assoc :constraints default-query-constraints))
     :started_at   true
     :finished_at  true
     :running_time true}
@@ -81,7 +81,7 @@
                                (ql/aggregation (ql/count))))
                       (assoc :type "query")
                       (assoc-in [:query :aggregation] [{:aggregation-type "count", :custom-name nil}])
-                      (assoc :constraints query-constraints))
+                      (assoc :constraints default-query-constraints))
     :started_at   true
     :finished_at  true
     :running_time true
@@ -108,7 +108,7 @@
                 :json_query   {:database    (id)
                                :type        "native"
                                :native      {:query "foobar"}
-                               :constraints query-constraints}
+                               :constraints default-query-constraints}
                 :started_at   true
                 :finished_at  true
                 :running_time true}]


### PR DESCRIPTION
Improved documentation, variable names, code organization, etc. backported from the `public-cards-and-dashboards` branch. Separating this out to make sure it gets merged before too many merge conflicts can arise in case the public Cards & Dashboard PR goes a while without merging, and to keep the scope of that PR focused.

I'll squash and rebase that PR off of master once this is merged