### PR TITLE
Handle ISODate() calls in Mongo native queries [ci drivers]

### DIFF
--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -312,6 +312,7 @@
              [java.sql.Date                  :type/Date]
              [java.sql.Timestamp             :type/DateTime]
              [java.util.Date                 :type/DateTime]
+             [org.joda.time.DateTime         :type/DateTime]
              [java.util.UUID                 :type/Text]       ; shouldn't this be :type/UUID ?
              [clojure.lang.IPersistentMap    :type/Dictionary]
              [clojure.lang.IPersistentVector :type/Array]


### PR DESCRIPTION
Handle `ISODate()` calls in Mongo native queries, which are invalid JSON but valid in Mongo. One of our more-requested Mongo features.

Credit to @omf for originally coming up with the idea in #3741.

Includes tests. Fixes #3170