### PR TITLE
start in non editing mode when a new query is initialized

### DIFF
--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -104,7 +104,7 @@ export const initializeQB = createThunkAction(INITIALIZE_QB, (location, params) 
 
         const { currentUser } = getState();
 
-        let card, databases, originalCard, uiControls = {};
+        let card, databases, originalCard, uiControls = { isEditing: false };
 
         // always start the QB by loading up the databases for the application
         try {


### PR DESCRIPTION
`isEditing` in the QB `uiControls` state wasn't properly being reset if you left edit mode having not canceled or saved. To fix this, we set the initial value to false when a new query is initialized.

@tlrobinson Let me know if there's a better fix for this.

resolves #4148
