### PR TITLE
use a valid sans-serif font

### DIFF
--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -299,6 +299,12 @@
 .dc-chart .axis {
   z-index: -1;
 }
+
+/* TODO (@kdoh) remove this if dc-js/dc.js#1260 is merged */
+.dc-chart .axis text {
+  font-family: sans-serif;
+}
+
 .dc-chart .axis .domain,
 .dc-chart .axis .tick line {
   stroke: #EDEDED;

--- a/frontend/src/metabase/css/index.css
+++ b/frontend/src/metabase/css/index.css
@@ -1,3 +1,5 @@
+@import './vendor.css';
+
 @import './core/index.css';
 
 @import './components/buttons.css';
@@ -21,4 +23,3 @@
 @import './setup.css';
 @import './tutorial.css';
 
-@import './vendor.css';


### PR DESCRIPTION
fixes #4115 

@mazameli This resolves the serif issue you noted in #4115. I went ahead and just set things back to what we had before. Lato in very small sizes is somewhat hard to read so while I agree we should use that or another more custom solution for our axis ticks eventually, I'm inclined to do that in a subsequent fix with a bit more testing.