### PR TITLE
Update FAQ. Fix typo of MariaSQL to MariaDB

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -43,7 +43,7 @@ Metabase currently supports:
 * Druid
 * H2
 * MongoDB (version 3.0 or higher)
-* MySQL (and MariaSQL)
+* MySQL (and MariaDB)
 * PostgreSQL
 * SQL Server
 * SQLite 


### PR DESCRIPTION
Tiny documentation change in the FAQ. Fixing typo of "MariaSQL" to the proper database name: "MariaDB"
