### PR TITLE
Use ResizeObserver ponyfill for ExplicitSize HOC (release-0.22.1)

### DIFF
--- a/frontend/src/metabase/components/ExplicitSize.jsx
+++ b/frontend/src/metabase/components/ExplicitSize.jsx
@@ -1,6 +1,8 @@
 import React, { Component, PropTypes } from "react";
 import ReactDOM from "react-dom";
 
+import ResizeObserver from "resize-observer-polyfill";
+
 export default ComposedComponent => class extends Component {
     static displayName = "ExplicitSize["+(ComposedComponent.displayName || ComposedComponent.name)+"]";
 
@@ -12,23 +14,33 @@ export default ComposedComponent => class extends Component {
         };
     }
 
-    componentWillMount() {
-        window.addEventListener("resize", this._updateSize);
+    componentDidMount() {
+        // media query listener, ensure re-layout when printing
         this._mql = window.matchMedia("print");
         this._mql.addListener(this._updateSize);
-    }
 
-    componentWillUnmount() {
-        window.removeEventListener("resize", this._updateSize);
-        this._mql.removeListener(this._updateSize);
-    }
+        // resize observer, ensure re-layout when container element changes size
+        this._ro = new ResizeObserver((entries, observer) => {
+            const element = ReactDOM.findDOMNode(this);
+            for (const entry of entries) {
+                if (entry.target === element) {
+                    this._updateSize();
+                    break;
+                }
+            }
+        });
+        this._ro.observe(ReactDOM.findDOMNode(this));
 
-    componentDidMount() {
         this._updateSize();
     }
 
     componentDidUpdate() {
         this._updateSize();
+    }
+
+    componentWillUnmount() {
+        this._ro.disconnect();
+        this._mql.removeListener(this._updateSize);
     }
 
     _updateSize = () => {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "redux-router": "^2.1.2",
     "redux-thunk": "^2.0.1",
     "reselect": "^2.0.1",
+    "resize-observer-polyfill": "^1.3.2",
     "screenfull": "^3.0.0",
     "stack-source-map": "^1.0.4",
     "tether": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6024,6 +6024,10 @@ resolve-dir@^0.1.0:
     expand-tilde "^1.2.2"
     global-modules "^0.2.3"
 
+resize-observer-polyfill@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.3.2.tgz#f467efc15a86d9ee5096fd6d7f628c8a54bb805a"
+
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"


### PR DESCRIPTION
#4185 should have been merged to release-0.22.1