### PR TITLE
[WIP] Unify timeouts

### DIFF
--- a/bin/aws-eb-docker/.ebextensions/metabase_config/nginx/default_server
+++ b/bin/aws-eb-docker/.ebextensions/metabase_config/nginx/default_server
@@ -11,6 +11,12 @@ server {
         proxy_set_header    Host                  $host;
         proxy_set_header    X-Real-IP             $remote_addr;
         proxy_set_header    X-Forwarded-For       $proxy_add_x_forwarded_for;
+        proxy_connect_timeout 600;
+        proxy_send_timeout 600;
+        proxy_read_timeout 600;
+        send_timeout 600;
+
+
     }
 
     location / {


### PR DESCRIPTION
Right now there are a number of distinct timeouts on the query execution path of the beanstalk recipe.

1. Our own timeout clientside
2. ELB timeout
3. NGINX timeout
4. Jetty web timeout
5. Database timeout

This PR will unify them and hopefully make longer running queries less fragile.

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**