### PR TITLE
Fix SQL param optional subsitution if SQL contain brackets

### DIFF
--- a/src/metabase/query_processor/sql_parameters.clj
+++ b/src/metabase/query_processor/sql_parameters.clj
@@ -123,7 +123,7 @@
   {:style/indent 1}
   ^String [sql params]
   {:pre [(string? sql) (seq sql) (u/maybe? map? params)]}
-  (loop [s sql, [[match optional] & more] (re-seq #"\[\[([^\]]+)\]\]" sql)]
+  (loop [s sql, [[match optional] & more] (re-seq #"\[\[(.+?)\]\]" sql)]
     (if-not match
       (s/trim (handle-simple s params))
       (let [s (s/replace-first s match (handle-optional optional params))]

--- a/test/metabase/query_processor/sql_parameters_test.clj
+++ b/test/metabase/query_processor/sql_parameters_test.clj
@@ -145,6 +145,14 @@
   (substitute "SELECT * FROM toucanneries WHERE TRUE [[AND num_toucans > {{num_toucans}}]] [[AND num_toucans < {{num_toucans}}]]"
     {:num_toucans 5}))
 
+;; Make sure that substiutions still work if the subsitution contains brackets inside it (#3657)
+(expect
+  "select * from foobars  where foobars.id in (string_to_array(100, ',')::integer[])"
+  ((resolve 'metabase.query-processor.sql-parameters/substitute)
+   "select * from foobars [[ where foobars.id in (string_to_array({{foobar_id}}, ',')::integer[]) ]]"
+   {:foobar_id 100}))
+
+
 ;;; ------------------------------------------------------------ tests for value-for-tag ------------------------------------------------------------
 
 (tu/resolve-private-vars metabase.query-processor.sql-parameters value-for-tag)


### PR DESCRIPTION
The problem was the old regex didn't match things that contained a right square bracket like 

```sql
[[ where foobars.id in (string_to_array({{foobar_id}}, ',')::integer[]) ]]
```

The old regex was

```clojure
#"\[\[([^\]]+)\]\]"
```

Instead I replaced that with 

```clojure
#"\[\[(.+?)\]\]"
```