### PR TITLE
ensure parameters are on top of dashboard empty state

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard.jsx
@@ -269,7 +269,7 @@ export default class Dashboard extends Component {
                         />
                     </header>
                     {!isFullscreen && parameters &&
-                        <div className="wrapper flex flex-column align-start mt1">
+                        <div className="wrapper flex flex-column align-start mt1 relative z2">
                             {parameters}
                         </div>
                     }


### PR DESCRIPTION
fixes #4181 

If all cards were removed from a dashboard then the empty state view was rendered and it's z-index and absolute positioning combo ended up covering the parameter element and preventing clicks.