### PR TITLE
Popover sizeToFit option

### DIFF
--- a/frontend/src/metabase/components/Popover.jsx
+++ b/frontend/src/metabase/components/Popover.jsx
@@ -24,7 +24,8 @@ export default class Popover extends Component {
         isOpen: PropTypes.bool,
         hasArrow: PropTypes.bool,
         // target: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
-        tetherOptions: PropTypes.object
+        tetherOptions: PropTypes.object,
+        sizeToFit: PropTypes.bool,
     };
 
     static defaultProps = {
@@ -33,7 +34,8 @@ export default class Popover extends Component {
         verticalAttachments: ["top", "bottom"],
         horizontalAttachments: ["center", "left", "right"],
         targetOffsetX: 24,
-        targetOffsetY: 5
+        targetOffsetY: 5,
+        sizeToFit: false,
     };
 
     _getPopoverElement() {
@@ -234,6 +236,28 @@ export default class Popover extends Component {
 
                 // finally set the best options
                 this._setTetherOptions(tetherOptions, best);
+            }
+
+            if (this.props.sizeToFit) {
+                const verticalMargin = 5;
+                const body = tetherOptions.element.querySelector(".PopoverBody");
+                if (this._tether.attachment.top === "top") {
+                    let screenBottom = window.innerHeight + window.scrollY;
+                    let overflowY = body.getBoundingClientRect().bottom - screenBottom;
+                    if (overflowY + verticalMargin > 0) {
+                        body.style.maxHeight = (body.getBoundingClientRect().height - overflowY - verticalMargin) + "px";
+                        body.classList.add("scroll-y");
+                        body.classList.add("scroll-show");
+                    }
+                } else {
+                    let screenTop = window.scrollY;
+                    let overflowY = screenTop - body.getBoundingClientRect().top;
+                    if (overflowY + verticalMargin > 0) {
+                        body.style.maxHeight = (body.getBoundingClientRect().height - overflowY - verticalMargin) + "px";
+                        body.classList.add("scroll-y");
+                        body.classList.add("scroll-show");
+                    }
+                }
             }
         } else {
             // if the popover isn't open then actively unmount our popover

--- a/frontend/src/metabase/query_builder/components/VisualizationSettings.jsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationSettings.jsx
@@ -60,6 +60,7 @@ export default class VisualizationSettings extends React.Component {
                     triggerId="VisualizationTrigger"
                     triggerElement={triggerElement}
                     triggerClasses="flex align-center"
+                    sizeToFit
                 >
                     <ul className="pt1 pb1">
                         { Array.from(visualizations).map(([vizType, viz], index) =>


### PR DESCRIPTION
Adds an option to automatically size popovers to fit on screen, so that the entire page doesn't need to scroll to view long popovers.

<img width="295" alt="screenshot 2017-02-07 01 03 18" src="https://cloud.githubusercontent.com/assets/18193/22684483/672ffad6-ecd1-11e6-8903-37fb5625b1f3.png">

We probably can't enable this by default since a lot of popovers have their own scrolling and this will result in double scrolling.

I've only enabled it on the visualization display type popover so far.