### PR TITLE
Prepared statements for sql params

### DIFF
--- a/src/metabase/driver/bigquery.clj
+++ b/src/metabase/driver/bigquery.clj
@@ -11,6 +11,7 @@
             [metabase.driver.google :as google]
             [metabase.driver.generic-sql :as sql]
             [metabase.driver.generic-sql.query-processor :as sqlqp]
+            [metabase.driver.generic-sql.util.unprepare :as unprepare]
             (metabase.models [database :refer [Database]]
                              [field :as field]
                              [table :as table])
@@ -294,8 +295,10 @@
        :table-name table-name
        :mbql?      true})))
 
-(defn- execute-query [{{{:keys [dataset-id]} :details, :as database} :database, {sql :query, :keys [table-name mbql?]} :native, :as outer-query}]
-  (let [sql     (str "-- " (qp/query->remark outer-query) "\n" sql)
+(defn- execute-query [{{{:keys [dataset-id]} :details, :as database} :database, {sql :query, params :params, :keys [table-name mbql?]} :native, :as outer-query}]
+  (let [sql     (str "-- " (qp/query->remark outer-query) "\n" (if (seq params)
+                                                                 (unprepare/unprepare (cons sql params))
+                                                                 sql))
         results (process-native* database sql)
         results (if mbql?
                   (post-process-mbql dataset-id table-name results)

--- a/src/metabase/driver/bigquery.clj
+++ b/src/metabase/driver/bigquery.clj
@@ -242,9 +242,6 @@
     :quarter-of-year (hx/quarter expr)
     :year            (hx/year expr)))
 
-(defn- date-string->literal [^String date-string]
-  (hx/->timestamp (hx/literal (u/format-date "yyyy-MM-dd 00:00" (u/->Date date-string)))))
-
 (defn- unix-timestamp->timestamp [expr seconds-or-milliseconds]
   (case seconds-or-milliseconds
     :seconds      (hsql/call :sec_to_timestamp  expr)
@@ -396,7 +393,6 @@
           :connection-details->spec  (constantly nil)                           ; since we don't use JDBC
           :current-datetime-fn       (constantly :%current_timestamp)
           :date                      (u/drop-first-arg date)
-          :date-string->literal      (u/drop-first-arg date-string->literal)
           :field->alias              (u/drop-first-arg field->alias)
           :field->identifier         (u/drop-first-arg field->identifier)
           :prepare-value             (u/drop-first-arg prepare-value)

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -79,6 +79,17 @@
 
      Return `nil` to prevent FIELD from being aliased.")
 
+  (prepare-sql-param [this obj]
+    "*OPTIONAL*. Do any neccesary type conversions, etc. to an object being passed as a prepared statment argument in a parameterized raw SQL query.
+     For example, a raw SQL query with a date param, `x`, e.g. `WHERE date > {{x}}`, is converted to SQL like `WHERE date > ?`, and the value of
+     `x` is passed as a `java.sql.Timestamp`. Some databases, notably SQLite, don't work with `Timestamps`, and dates must be passed as string literals
+     instead; the SQLite driver overrides this method to convert dates as needed.
+
+  The default implementation is `identity`.
+
+  NOTE - This method is only used for parameters in raw SQL queries. It's not needed for MBQL queries because other functions like `prepare-value` are
+  used for similar purposes; at some point in the future, we might be able to combine them into a single method used in both places.")
+
   (prepare-value [this, ^Value value]
     "*OPTIONAL*. Prepare a value (e.g. a `String` or `Integer`) that will be used in a HoneySQL form. By default, this returns VALUE's `:value` as-is, which
      is eventually passed as a parameter in a prepared statement. Drivers such as BigQuery that don't support prepared statements can skip this
@@ -424,6 +435,7 @@
    :field->identifier    (u/drop-first-arg (comp (partial apply hsql/qualify) field/qualified-name-components))
    :field->alias         (u/drop-first-arg name)
    :field-percent-urls   fast-field-percent-urls
+   :prepare-sql-param    (u/drop-first-arg identity)
    :prepare-value        (u/drop-first-arg :value)
    :quote-style          (constantly :ansi)
    :set-timezone-sql     (constantly nil)

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -59,11 +59,6 @@
   (date [this, ^Keyword unit, field-or-value]
     "Return a HoneySQL form for truncating a date or timestamp field or value to a given resolution, or extracting a date component.")
 
-  (date-string->literal [this, ^String date-string]
-    "*OPTIONAL*. Return an appropriate HoneySQL form to represent a DATE-STRING literal.
-     The default implementation is just `hx/literal`; in other words, it just single-quotes DATE-STRING. Some drivers like BigQuery or Oracle need to do something more advanced.
-     (This is used for the implementation of SQL parameters).")
-
   (excluded-schemas ^java.util.Set [this]
     "*OPTIONAL*. Set of string names of schemas to skip syncing tables from.")
 
@@ -425,7 +420,6 @@
    :apply-page           (resolve 'metabase.driver.generic-sql.query-processor/apply-page)
    :column->special-type (constantly nil)
    :current-datetime-fn  (constantly :%now)
-   :date-string->literal (u/drop-first-arg hx/literal)
    :excluded-schemas     (constantly nil)
    :field->identifier    (u/drop-first-arg (comp (partial apply hsql/qualify) field/qualified-name-components))
    :field->alias         (u/drop-first-arg name)

--- a/src/metabase/driver/generic_sql/util/unprepare.clj
+++ b/src/metabase/driver/generic_sql/util/unprepare.clj
@@ -1,0 +1,26 @@
+(ns metabase.driver.generic-sql.util.unprepare
+  "Utility functions for converting a prepared statement with `?` into a plain SQL query."
+  (:require [clojure.string :as str]
+            [honeysql.core :as hsql]
+            [metabase.util :as u]
+            [metabase.util.honeysql-extensions :as hx])
+  (:import java.util.Date))
+
+(defprotocol ^:private IUnprepare
+  (^:private unprepare-arg ^String [this]))
+
+(extend-protocol IUnprepare
+  nil     (unprepare-arg [this] "NULL")
+  String  (unprepare-arg [this] (str \' (str/replace this "'" "\\\\'") \')) ; escape single-quotes
+  Boolean (unprepare-arg [this] (if this "TRUE" "FALSE"))
+  Number  (unprepare-arg [this] (str this))
+  Date    (unprepare-arg [this] (first (hsql/format (hsql/call :timestamp (hx/literal (u/date->iso-8601 this))))))) ; TODO - this probably doesn't work for every DB!
+
+(defn unprepare
+  "Convert a normal SQL `[statement & prepared-statement-args]` vector into a flat, non-prepared statement."
+  ^String [[sql & args]]
+  (loop [sql sql, [arg & more-args, :as args] args]
+    (if-not (seq args)
+      sql
+      (recur (str/replace-first sql #"(?<!\?)\?(?!\?)" (unprepare-arg arg))
+             more-args))))

--- a/src/metabase/driver/oracle.clj
+++ b/src/metabase/driver/oracle.clj
@@ -86,11 +86,6 @@
                            3)
     :year            (hsql/call :extract :year v)))
 
-(defn- date-string->literal [^String date-string]
-  (hsql/call :to_timestamp
-    (hx/literal (u/format-date "yyyy-MM-dd" (u/->Date date-string)))
-    (hx/literal "YYYY-MM-DD")))
-
 (def ^:private ^:const now             (hsql/raw "SYSDATE"))
 (def ^:private ^:const date-1970-01-01 (hsql/call :to_timestamp (hx/literal :1970-01-01) (hx/literal :YYYY-MM-DD)))
 
@@ -223,7 +218,6 @@
           :connection-details->spec  (u/drop-first-arg connection-details->spec)
           :current-datetime-fn       (constantly now)
           :date                      (u/drop-first-arg date)
-          :date-string->literal      (u/drop-first-arg date-string->literal)
           :excluded-schemas          (fn [& _]
                                        (set/union
                                         #{"ANONYMOUS"

--- a/src/metabase/driver/sqlite.clj
+++ b/src/metabase/driver/sqlite.clj
@@ -97,10 +97,13 @@
                                    :quarter [3 "months"]
                                    :year    [1 "years"])]
     ;; Make a string like DATETIME(DATE('now', 'start of month'), '-1 month')
-    ;; The date bucketing will end up being done twice since `date` is called on the results of `date-interval` automatically. This shouldn't be a big deal because it's used for relative dates and only needs to be done once.
-    ;; It's important to call `date` on 'now' to apply bucketing *before* adding/subtracting dates to handle certain edge cases as discussed in issue #2275 (https://github.com/metabase/metabase/issues/2275).
+    ;; The date bucketing will end up being done twice since `date` is called on the results of `date-interval` automatically.
+    ;; This shouldn't be a big deal because it's used for relative dates and only needs to be done once.
+    ;; It's important to call `date` on 'now' to apply bucketing *before* adding/subtracting dates to handle certain edge cases as discussed in
+    ;; issue #2275 (https://github.com/metabase/metabase/issues/2275).
     ;; Basically, March 30th minus one month becomes Feb 30th in SQLite, which becomes March 2nd. DATE(DATETIME('2016-03-30', '-1 month'), 'start of month') is thus March 1st.
-    ;; The SQL we produce instead (for "last month") ends up looking something like: DATE(DATETIME(DATE('2015-03-30', 'start of month'), '-1 month'), 'start of month'). It's a little verbose, but gives us the correct answer (Feb 1st).
+    ;; The SQL we produce instead (for "last month") ends up looking something like: DATE(DATETIME(DATE('2015-03-30', 'start of month'), '-1 month'), 'start of month').
+    ;; It's a little verbose, but gives us the correct answer (Feb 1st).
     (->datetime (date unit (hx/literal "now"))
                 (hx/literal (format "%+d %s" (* amount multiplier) sqlite-unit)))))
 
@@ -108,6 +111,17 @@
   (case seconds-or-milliseconds
     :seconds      (->datetime expr (hx/literal "unixepoch"))
     :milliseconds (recur (hx// expr 1000) :seconds)))
+
+
+;; SQLite doesn't like things like Timestamps getting passed in as prepared statement args, so we need to convert them to date literal strings instead to get things to work
+;; TODO - not sure why this doesn't need to be done in `prepare-value` as well? I think it's because the MBQL date values are funneled through the `date` family of functions above
+(defn- prepare-sql-param [obj]
+  (if (instance? java.util.Date obj)
+    ;; for anything that's a Date (usually a java.sql.Timestamp) convert it to a yyyy-MM-dd formatted date literal string
+    ;; For whatever reason the SQL generated from parameters ends up looking like `WHERE date(some_field) = ?` sometimes so we need to use just the date rather than a full ISO-8601 string
+    (u/format-date "yyyy-MM-dd" obj)
+    ;; every other prepared statement arg can be returned as-is
+    obj))
 
 ;; SQLite doesn't support `TRUE`/`FALSE`; it uses `1`/`0`, respectively; convert these booleans to numbers.
 (defn- prepare-value [{value :value}]
@@ -145,8 +159,9 @@
          {:active-tables             sql/post-filtered-active-tables
           :column->base-type         (sql/pattern-based-column->base-type pattern->type)
           :connection-details->spec  (u/drop-first-arg dbspec/sqlite3)
-          :current-datetime-fn       (constantly (hsql/raw "datetime('now')"))
+          :current-datetime-fn       (constantly (hsql/call :datetime (hx/literal :now)))
           :date                      (u/drop-first-arg date)
+          :prepare-sql-param         (u/drop-first-arg prepare-sql-param)
           :prepare-value             (u/drop-first-arg prepare-value)
           :string-length-fn          (u/drop-first-arg string-length-fn)
           :unix-timestamp->timestamp (u/drop-first-arg unix-timestamp->timestamp)}))

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -1,6 +1,7 @@
 (ns metabase.query-processor
   "Preprocessor that does simple transformations to all incoming queries, simplifing the driver-specific implementations."
-  (:require [clojure.walk :as walk]
+  (:require (clojure [data :as data]
+                     [walk :as walk])
             [clojure.tools.logging :as log]
             [medley.core :as m]
             (schema [core :as s]
@@ -163,7 +164,7 @@
   (u/prog1 (params/expand-parameters query)
     (when (and (not *disable-qp-logging*)
                (not= <> query))
-      (log/debug (u/format-color 'cyan "\n\nPARAMS/SUBSTITUTED: %s\n%s" (u/emoji "😻") (u/pprint-to-str <>))))))
+      (log/debug (u/format-color 'cyan "\n\nPARAMS/SUBSTITUTED: %s\n%s" (u/emoji "😻") (u/pprint-to-str (second (data/diff query <>))))))))
 
 (defn- pre-substitute-parameters [qp] (comp qp substitute-parameters))
 

--- a/src/metabase/query_processor/sql_parameters.clj
+++ b/src/metabase/query_processor/sql_parameters.clj
@@ -289,10 +289,10 @@
 ;;
 ;; The details maps returned have the format:
 ;;
-;;    {:param-key               :timestamp                           ; name of the param being replaced
-;;     :original-snippet        "[[AND timestamp < {{timestamp}}]]"  ; full text of the snippet to be replaced
-;;     :optional-snippet        "AND timestamp < {{timestamp}}"      ; portion of the snippet inside [[optional]] brackets, or `nil` if the snippet isn't optional
-;;     :variable-snippet        "{{timestamp}}"}                     ; portion of the snippet referencing the variable itself, e.g. {{x}}
+;;    {:param-key        :timestamp                           ; name of the param being replaced
+;;     :original-snippet "[[AND timestamp < {{timestamp}}]]"  ; full text of the snippet to be replaced
+;;     :optional-snippet "AND timestamp < {{timestamp}}"      ; portion of the snippet inside [[optional]] brackets, or `nil` if the snippet isn't optional
+;;     :variable-snippet "{{timestamp}}"}                     ; portion of the snippet referencing the variable itself, e.g. {{x}}
 
 (s/defn ^:private ^:always-validate param-snippet->param-name :- s/Keyword
   "Return the keyword name of the param being referenced inside PARAM-SNIPPET.

--- a/src/metabase/query_processor/sql_parameters.clj
+++ b/src/metabase/query_processor/sql_parameters.clj
@@ -377,7 +377,8 @@
   (log/debug (format "PARAM INFO: %s\n%s" (u/emoji "🔥") (u/pprint-to-str 'yellow param-snippets-info)))
   (loop [sql sql, prepared-statement-args [], [snippet-info & more] param-snippets-info]
     (if-not snippet-info
-      {:query (str/trim sql), :params prepared-statement-args}
+      {:query (str/trim sql), :params (for [arg prepared-statement-args]
+                                        ((resolve 'metabase.driver.generic-sql/prepare-sql-param) *driver* arg))}
       (recur (substitute-one sql snippet-info)
              (concat prepared-statement-args (:prepared-statement-args snippet-info))
              more))))

--- a/src/metabase/query_processor/sql_parameters.clj
+++ b/src/metabase/query_processor/sql_parameters.clj
@@ -1,140 +1,113 @@
 (ns metabase.query-processor.sql-parameters
-  "Param substitution for *SQL* queries."
-  (:require [clojure.string :as s]
+  "Param substitution for *SQL* queries.
+   This is a new implementation, fondly referred to as 'SQL parameters 2.0', written for v0.23.0.
+   The new implementation uses prepared statement args instead of substituting them directly into the query,
+   and is much better-organized and better-documented."
+  (:require [clojure.tools.logging :as log]
+            [clojure.string :as str]
             [honeysql.core :as hsql]
+            [schema.core :as s]
             [toucan.db :as db]
             [metabase.models.field :refer [Field], :as field]
             [metabase.query-processor.expand :as ql]
-            [metabase.util :as u])
-  (:import clojure.lang.Keyword
+            [metabase.util :as u]
+            [metabase.util.schema :as su])
+  (:import java.text.NumberFormat
+           clojure.lang.Keyword
            honeysql.types.SqlCall
            metabase.models.field.FieldInstance))
+
+;; The Basics:
+;;
+;; *  Things like `{{x}}` (required params) get subsituted with the value of `:x`, which can be a literal used in a clause (e.g. in a clause like `value = {{x}}`) or a
+;;    "field filter" that handles adding the clause itself  (e.g. `{{timestamp}}` might become `timestamp BETWEEN ? AND ?`).
+;; *  Things like `[[AND {{x}]]` are optional param. If the param (`:x`) isn't specified, the *entire* clause inside `[[...]]` is replaced with an empty string;
+;;    If it is specified, the value inside the curly brackets `{{x}}` is replaced as usual and the rest of the clause (`AND ...`) is included in the query as-is
+;;
+;; See the various parts of this namespace below to see how it's done.
+
+
+;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+;;; |                                                                              ETC                                                                               |
+;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+;; Dynamic variables and record types used by the other parts of this namespace.
 
 ;; TODO - we have dynamic *driver* variables like this in several places; it probably makes more sense to see if we can share one used somewhere else instead
 (def ^:private ^:dynamic *driver* nil)
 
 (def ^:private ^:dynamic *timezone* nil)
 
-;;; ------------------------------------------------------------ String Substituion ------------------------------------------------------------
 
-(defprotocol ^:private ISQLParamSubstituion
-  (^:private ->sql ^String [this]))
+;; various record types below are used as a convenience for differentiating the different param types.
 
-(defrecord ^:private Dimension [^FieldInstance field, param]) ;; param is either a single param or a vector of params
+;; "Dimension" here means a "FIELD FILTER", e.g. something that expands to a clause like "some_field BETWEEN 1 AND 100"
+(s/defrecord ^:private Dimension [field :- FieldInstance, param]) ;; param is either a single param or a vector of params
 
-(defrecord ^:private Date [s])
+;; as in a literal date, defined by date-string S
+(s/defrecord ^:private Date [s :- s/Str])
 
 (defrecord ^:private DateRange [start end])
 
-(defrecord ^:private NumberValue [value])
-
-(defn- dimension-value->sql
-  "Return an appropriate operator and rhs of a SQL `WHERE` clause, e.g. \"= 100\"."
-  ^String [dimension-type value]
-  (cond
-    ;; for relative dates convert the param to a `DateRange` record type and call `->sql` on it
-    (contains? #{"date/range" "date/month-year" "date/quarter-year" "date/relative"} dimension-type)
-    (->sql (map->DateRange ((resolve 'metabase.query-processor.parameters/date->range) value *timezone*))) ; TODO - get timezone from query dict
-    ;; for other date types convert the param to a date
-    (s/starts-with? dimension-type "date/")
-    (str "= " (->sql (map->Date {:s value})))
-    ;; for everything else just call `->sql` on it directly
-    :else
-    (str "= " (->sql value))))
-
-(defn- honeysql->sql ^String [x]
-  (first (hsql/format x
-           :quoting ((resolve 'metabase.driver.generic-sql/quote-style) *driver*))))
-
-(defn- format-date-string
-  "Format DATE-STRING as an appropriate literal using the driver's definition of `date-string->literal`."
-  ^String [^String date-string]
-  (honeysql->sql ((resolve 'metabase.driver.generic-sql/date-string->literal) *driver* date-string)))
-
-(extend-protocol ISQLParamSubstituion
-  nil         (->sql [_]    "NULL")
-  Object      (->sql [this] (str this))
-  Boolean     (->sql [this] (honeysql->sql this))
-  NumberValue (->sql [this] (:value this))
-  String      (->sql [this] (str \' (s/replace this #"'" "\\\\'") \')) ; quote single quotes inside the string
-  Keyword     (->sql [this] (honeysql->sql this))
-  SqlCall     (->sql [this] (honeysql->sql this))
-
-  FieldInstance
-  (->sql [this]
-    (->sql (let [identifier ((resolve 'metabase.driver.generic-sql/field->identifier) *driver* this)]
-             (if (re-find #"^date/" (:type this))
-               ((resolve 'metabase.driver.generic-sql/date) *driver* :day identifier)
-               identifier))))
-
-  Date
-  (->sql [{:keys [s]}]
-    (format-date-string s))
-
-  DateRange
-  (->sql [{:keys [start end]}]
-    (if (= start end)
-      (format "= %s" (format-date-string start))
-      (format "BETWEEN %s AND %s" (format-date-string start) (format-date-string end))))
-
-  Dimension
-  (->sql [{:keys [field param], :as dimension}]
-    (cond
-      ;; if the param is `nil` just put in something that will always be true, such as `1` (e.g. `WHERE 1 = 1`)
-      (nil? param) "1 = 1"
-      ;; if we have a vector of multiple params recursively convert them to SQL and combine into an `AND` clause
-      (vector? param)
-      (format "(%s)" (s/join " AND " (for [p param]
-                                       (->sql (assoc dimension :param p)))))
-      ;; otherwise convert single param to SQL
-      :else
-      (let [param-type (:type param)]
-        (format "%s %s" (->sql (assoc field :type param-type)) (dimension-value->sql param-type (:value param)))))))
+;; convenience for representing an *optional* parameter present in a query but whose value is unspecified in the param values.
+(defrecord ^:private NoValue [])
 
 
-(defn- replace-param [s params match param]
-  (let [k (keyword param)
-        _ (assert (contains? params k)
-            (format "Unable to substitute '%s': param not specified.\nFound: %s" param (keys params)))
-        v (->sql (k params))]
-    (s/replace-first s match v)))
+;; various schemas are used to check that various functions return things in expected formats
 
-(defn- handle-simple
-  "Replace a 'simple' SQL parameter (curly brackets only, i.e. `{{...}}`)."
-  [s params]
-  (loop [s s, [[match param] & more] (re-seq #"\{\{\s*(\w+)\s*\}\}" s)]
-    (if-not match
-      s
-      (recur (replace-param s params match param) more))))
+;; TAGS in this case are simple params like {{x}} that get replaced with a single value ("ABC" or 1) as opposed to a "FieldFilter" clause like Dimensions
+(def ^:private TagParam
+  "Schema for values passed in as part of the `:template_tags` list."
+  {(s/optional-key :id)        su/NonBlankString ; this is used internally by the frontend
+   :name                       su/NonBlankString
+   :display_name               su/NonBlankString
+   :type                       (s/enum "number" "dimension" "text" "date")
+   (s/optional-key :dimension) [s/Any]
+   (s/optional-key :required)  s/Bool
+   (s/optional-key :default)   s/Any})
 
-(defn- handle-optional
-  "Replace an 'optional' parameter."
-  [s params]
-  (try (handle-simple s params)
-       (catch Throwable _
-         "")))
+(def ^:private DimensionValue
+  {:type                   su/NonBlankString
+   :target                 s/Any
+   (s/optional-key :value) s/Any}) ; not specified if the param has no value. TODO - make this stricter
 
-(defn- substitute
-  "Replace PARAMS in SQL string. See parameterized SQL guide for more details. (TODO - Add link once we have the guide)
+(def ^:private ParamValue
+  (s/named (s/maybe (s/cond-pre NoValue
+                                Dimension
+                                Date
+                                s/Num
+                                s/Str
+                                s/Bool))
+           "Valid param value"))
 
-     (substitute \"SELECT * FROM bird_facts WHERE toucans_are_cool = {{toucans_are_cool}}\"
-       {:toucans_are_cool true})
-     ; -> \"SELECT * FROM bird_facts WHERE toucans_are_cool = TRUE\""
-  {:style/indent 1}
-  ^String [sql params]
-  {:pre [(string? sql) (seq sql) (u/maybe? map? params)]}
-  (loop [s sql, [[match optional] & more] (re-seq #"\[\[(.+?)\]\]" sql)]
-    (if-not match
-      (s/trim (handle-simple s params))
-      (let [s (s/replace-first s match (handle-optional optional params))]
-        (recur s more)))))
+(def ^:private ParamValues
+  {s/Keyword ParamValue})
+
+(def ^:private ParamSnippetInfo
+  {(s/optional-key :param-key)               s/Keyword
+   (s/optional-key :original-snippet)        su/NonBlankString
+   (s/optional-key :variable-snippet)        su/NonBlankString
+   (s/optional-key :optional-snippet)        (s/maybe su/NonBlankString)
+   (s/optional-key :replacement-snippet)     s/Str                       ; allowed to be blank if this is an optional param
+   (s/optional-key :prepared-statement-args) [s/Any]})
 
 
-;;; ------------------------------------------------------------ Param Resolution ------------------------------------------------------------
+;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+;;; |                                                                     PARAM INFO RESOLUTION                                                                      |
+;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
-(defn- param-with-target
+;; These functions build a map of information about the types and values of the params used in a query.
+;; (These functions don't pare the query itself, but instead look atthe values of `:template_tags` and `:parameters` passed along with the query.)
+;;
+;;     (query->params-map some-query)
+;;     ;; -> {:checkin_date {:field {:name "\date"\, :parent_id nil, :table_id 1375}
+;;                           :param {:type   "\date/range"\
+;;                                   :target ["\dimension"\ ["\template-tag"\ "\checkin_date"\]]
+;;                                   :value  "\2015-01-01~2016-09-01"\}}}
+
+(s/defn ^:private ^:always-validate param-with-target
   "Return the param in PARAMS with a matching TARGET."
-  [params target]
+  [params :- (s/maybe [DimensionValue]), target]
   (when-let [matching-params (seq (for [param params
                                         :when (= (:target param) target)]
                                     param))]
@@ -143,42 +116,54 @@
        first
        vec) matching-params)))
 
-(defn- param-value-for-tag [tag params]
+(s/defn ^:private ^:always-validate param-value-for-tag [tag :- TagParam, params :- (s/maybe [DimensionValue])]
   (when (not= (:type tag) "dimension")
     (:value (param-with-target params ["variable" ["template-tag" (:name tag)]]))))
 
-(defn- dimension->field-id [dimension]
+(s/defn ^:private ^:always-validate dimension->field-id :- su/IntGreaterThanZero
+  [dimension]
   (:field-id (ql/expand-ql-sexpr dimension)))
 
-(defn- dimension-value-for-tag [tag params]
+(s/defn ^:private ^:always-validate dimension-value-for-tag :- (s/maybe Dimension)
+  [tag :- TagParam, params :- (s/maybe [DimensionValue])]
   (when-let [dimension (:dimension tag)]
-    (let [field-id (or (dimension->field-id dimension)
-                       (throw (Exception. (str "Don't know how to handle dimension: " dimension))))]
-      (map->Dimension {:field (db/select-one [Field :name :parent_id :table_id], :id field-id)
-                       :param (param-with-target params ["dimension" ["template-tag" (:name tag)]])}))))
+    (map->Dimension {:field (or (db/select-one [Field :name :parent_id :table_id], :id (dimension->field-id dimension))
+                                (throw (Exception. (str "Can't find field with ID: " (dimension->field-id dimension)))))
+                     :param (param-with-target params ["dimension" ["template-tag" (:name tag)]])})))
 
-(defn- default-value-for-tag [{:keys [default display_name required]}]
+(s/defn ^:private ^:always-validate default-value-for-tag [{:keys [default display_name required]} :- TagParam]
   (or default
       (when required
         (throw (Exception. (format "'%s' is a required param." display_name))))))
 
-(defn- parse-value-for-type [param-type value]
+(s/defn ^:private ^:always-validate value->number :- s/Num
+  [value]
+  (if (string? value)
+    (.parse (NumberFormat/getInstance) ^String value)
+    value))
+
+;; TODO - this should probably be converting strings to numbers (issue #3816)
+(s/defn ^:private ^:always-validate parse-value-for-type :- ParamValue
+  [param-type value]
   (cond
-    (= param-type "number")                          (->NumberValue value)
+    (instance? NoValue value)                        value
+    (= param-type "number")                          (value->number value)
+    (= param-type "date")                            (map->Date {:s value})
     (and (= param-type "dimension")
-         (= (get-in value [:param :type]) "number")) (update-in value [:param :value] ->NumberValue)
+         (= (get-in value [:param :type]) "number")) (update-in value [:param :value] value->number)
     :else                                            value))
 
-(defn- value-for-tag
+(s/defn ^:private ^:always-validate value-for-tag :- ParamValue
   "Given a map TAG (a value in the `:template_tags` dictionary) return the corresponding value from the PARAMS sequence.
-   The VALUE is something that can be compiled to SQL via `->sql`."
-  [tag params]
-  {:pre [(map? tag) (u/maybe? sequential? params)]}
+   The VALUE is something that can be compiled to SQL via `->replacement-snippet-info`."
+  [tag :- TagParam, params :- (s/maybe [DimensionValue])]
   (parse-value-for-type (:type tag) (or (param-value-for-tag tag params)
                                         (dimension-value-for-tag tag params)
-                                        (default-value-for-tag tag))))
+                                        (default-value-for-tag tag)
+                                        ;; TODO - what if value is specified but is `nil`?
+                                        (NoValue.))))
 
-(defn- query->params-map
+(s/defn ^:private ^:always-validate query->params-map :- ParamValues
   "Extract parameters info from QUERY. Return a map of parameter name -> value.
 
      (query->params-map some-query)
@@ -195,11 +180,221 @@
              {k v})))
 
 
-;;; ------------------------------------------------------------ Public API ------------------------------------------------------------
+;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+;;; |                                                                    PARAM->SQL SUBSTITUTION                                                                     |
+;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+;; These functions take the info for a param fetched by the functions above and add additional info about how that param should be represented as SQL.
+;; (Specifically, they return information in this format:
+;;
+;;    {:replacement-snippet     "= ?"                  ; appropriate SQL that should be used to replace the param snippet, e.g. {{x}}
+;;     :prepared-statement-args [#inst "2017-01-01"]}  ; any prepared statement args (values for `?` placeholders) needed for the replacement snippet
+
+(defprotocol ^:private ISQLParamSubstituion
+  "Protocol for specifying what SQL should be generated for parameters of various types."
+  (^:private ->replacement-snippet-info [this]
+   "Return information about how THIS should be converted to SQL, as a map with keys `:replacement-snippet` and `:prepared-statement-args`.
+
+      (->replacement-snippet-info \"ABC\") -> {:replacement-snippet \"?\", :prepared-statement-args \"ABC\"}"))
+
+
+(defn- relative-date-param-type? [param-type] (contains? #{"date/range" "date/month-year" "date/quarter-year" "date/relative"} param-type))
+(defn- date-param-type?          [param-type] (str/starts-with? param-type "date/"))
+
+;; for relative dates convert the param to a `DateRange` record type and call `->replacement-snippet-info` on it
+(s/defn ^:private ^:always-validate relative-date-dimension-value->replacement-snippet-info :- ParamSnippetInfo
+  [value]
+  (->replacement-snippet-info (map->DateRange ((resolve 'metabase.query-processor.parameters/date->range) value *timezone*)))) ; TODO - get timezone from query dict
+
+(s/defn ^:private ^:always-validate dimension-value->equals-clause-sql :- ParamSnippetInfo
+  [value]
+  (update (->replacement-snippet-info value) :replacement-snippet (partial str "= ")))
+
+(s/defn ^:private ^:always-validate dimension->replacement-snippet-info :- ParamSnippetInfo
+  "Return `[replacement-snippet & prepared-statement-args]` appropriate for a DIMENSION parameter."
+  [{param-type :type, value :value} :- DimensionValue]
+  (cond
+    (relative-date-param-type? param-type) (relative-date-dimension-value->replacement-snippet-info value) ; convert relative dates to approprate date range representations
+    (date-param-type? param-type)          (dimension-value->equals-clause-sql (map->Date {:s value}))     ; convert all other dates to `= <date>`
+    :else                                  (dimension-value->equals-clause-sql value)))                    ; convert everything else to `= <value>`
+
+(s/defn ^:private ^:always-validate honeysql->replacement-snippet-info :- ParamSnippetInfo
+  "Convert X to a replacement snippet info map by passing it to HoneySQL's `format` function."
+  [x]
+  (let [[snippet & args] (hsql/format x, :quoting ((resolve 'metabase.driver.generic-sql/quote-style) *driver*))]
+    {:replacement-snippet     snippet
+     :prepared-statement-args args}))
+
+(s/defn ^:private ^:always-validate field->identifier :- su/NonBlankString
+  "Return an approprate snippet to represent this FIELD in SQL given its param type.
+   For non-date Fields, this is just a quoted identifier; for dates, the SQL includes appropriately bucketing based on the PARAM-TYPE."
+  [field param-type]
+  (-> (honeysql->replacement-snippet-info (let [identifier ((resolve 'metabase.driver.generic-sql/field->identifier) *driver* field)]
+                                            (if (date-param-type? param-type)
+                                              ((resolve 'metabase.driver.generic-sql/date) *driver* :day identifier)
+                                              identifier)))
+      :replacement-snippet))
+
+(s/defn ^:private ^:always-validate combine-replacement-snippet-maps :- ParamSnippetInfo
+  "Combine multiple REPLACEMENT-SNIPPET-MAPS into a single map using a SQL `AND` clause."
+  [replacement-snippet-maps :- [ParamSnippetInfo]]
+  {:replacement-snippet     (str \( (str/join " AND " (map :replacement-snippet replacement-snippet-maps)) \))
+   :prepared-statement-args (reduce concat (map :prepared-statement-args replacement-snippet-maps))})
+
+(extend-protocol ISQLParamSubstituion
+  nil         (->replacement-snippet-info [this] (honeysql->replacement-snippet-info this))
+  Object      (->replacement-snippet-info [this] (honeysql->replacement-snippet-info (str this)))
+  Number      (->replacement-snippet-info [this] (honeysql->replacement-snippet-info this))
+  Boolean     (->replacement-snippet-info [this] (honeysql->replacement-snippet-info this))
+  Keyword     (->replacement-snippet-info [this] (honeysql->replacement-snippet-info this))
+  SqlCall     (->replacement-snippet-info [this] (honeysql->replacement-snippet-info this))
+  NoValue     (->replacement-snippet-info [_]    {:replacement-snippet ""})
+
+  Date
+  (->replacement-snippet-info [{:keys [s]}]
+    (honeysql->replacement-snippet-info (u/->Timestamp s)))
+
+  DateRange
+  (->replacement-snippet-info [{:keys [start end]}]
+    (if (= start end)
+      {:replacement-snippet "= ?",             :prepared-statement-args [(u/->Timestamp start)]}
+      {:replacement-snippet "BETWEEN ? AND ?", :prepared-statement-args [(u/->Timestamp start) (u/->Timestamp end)]}))
+
+  ;; TODO - clean this up if possible!
+  Dimension
+  (->replacement-snippet-info [{:keys [field param], :as dimension}]
+    (cond
+      ;; if the param is `nil` just put in something that will always be true, such as `1` (e.g. `WHERE 1 = 1`)
+      (nil? param) {:replacement-snippet "1 = 1"}
+      ;; if we have a vector of multiple params recursively convert them to SQL and combine into an `AND` clause
+      (vector? param)
+      (combine-replacement-snippet-maps (for [p param]
+                                          (->replacement-snippet-info (assoc dimension :param p))))
+      ;; otherwise convert single param to SQL.
+      ;; Convert the value to a replacement snippet info map and then tack on the field identifier to the front
+      :else
+      (update (dimension->replacement-snippet-info param) :replacement-snippet (partial str (field->identifier field (:type param)) " ")))))
+
+
+;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+;;; |                                                                 QUERY PARSING / PARAM SNIPPETS                                                                 |
+;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+;; These functions parse a query and look for param snippets, which look like:
+;;
+;; * {{...}} (required)
+;; * [[...{{...}}...]] (optional)
+;;
+;; and creates a list of these snippets, keeping the original order.
+;;
+;; The details maps returned have the format:
+;;
+;;    {:param-key               :timestamp                           ; name of the param being replaced
+;;     :original-snippet        "[[AND timestamp < {{timestamp}}]]"  ; full text of the snippet to be replaced
+;;     :optional-snippet        "AND timestamp < {{timestamp}}"      ; portion of the snippet inside [[optional]] brackets, or `nil` if the snippet isn't optional
+;;     :variable-snippet        "{{timestamp}}"}                     ; portion of the snippet referencing the variable itself, e.g. {{x}}
+
+(s/defn ^:private ^:always-validate param-snippet->param-name :- s/Keyword
+  "Return the keyword name of the param being referenced inside PARAM-SNIPPET.
+
+     (param-snippet->param-name \"{{x}}\") -> :x"
+  [param-snippet :- su/NonBlankString]
+  (keyword (second (re-find #"\{\{\s*(\w+)\s*\}\}" param-snippet))))
+
+(s/defn ^:private ^:always-validate sql->params-snippets-info :- [ParamSnippetInfo]
+  "Return a sequence of maps containing information about the param snippets found by paring SQL."
+  [sql :- su/NonBlankString]
+  (for [[param-snippet optional-replacement-snippet] (re-seq #"(?:\[\[(.+?)\]\])|(?:\{\{\s*\w+\s*\}\})" sql)]
+    {:param-key        (param-snippet->param-name param-snippet)
+     :original-snippet  param-snippet
+     :variable-snippet (re-find #"\{\{\s*\w+\s*\}\}" param-snippet)
+     :optional-snippet optional-replacement-snippet}))
+
+
+;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+;;; |                                                                     PARAMS DETAILS LIST                                                                        |
+;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+;; These functions combine the info from the other 3 stages (Param Info Resolution, Param->SQL Substitution, and Query Parsing) and create a sequence of maps
+;; containing param details that has all the information needed to do SQL substituion. This sequence is returned in the same order as params encountered in the
+;; original query, making passing prepared statement args simple
+;;
+;; The details maps returned have the format:
+;;
+;;    {:original-snippet        "[[AND timestamp < {{timestamp}}]]"  ; full text of the snippet to be replaced
+;;     :replacement-snippet     "AND timestamp < ?"                  ; full text that the snippet should be replaced with
+;;     :prepared-statement-args [#inst "2016-01-01"]}                ; prepared statement args needed by the replacement snippet
+;;
+;; (Basically these functions take `:param-key`, `:optional-snippet`, and `:variable-snippet` from the Query Parsing stage and the info from the other stages
+;; to add the appropriate info for `:replacement-snippet` and `:prepared-statement-args`.)
+
+(s/defn ^:private ^:always-validate snippet-value :- ParamValue
+  "Fetch the value from PARAM-KEY->VALUE for SNIPPET-INFO.
+   If no value is specified, return `NoValue` if the snippet is optional; otherwise throw an Exception."
+  [{:keys [param-key optional-snippet]} :- ParamSnippetInfo, param-key->value :- ParamValues]
+  (u/prog1 (get param-key->value param-key (NoValue.))
+    ;; if ::no-value was specified an the param is not [[optional]], throw an exception
+    (when (and (instance? NoValue <>)
+               (not optional-snippet))
+      (throw (ex-info (format "Unable to substitute '%s': param not specified.\nFound: %s" param-key (keys param-key->value))
+               {:status-code 400})))))
+
+(s/defn ^:private ^:always-validate handle-optional-snippet :- ParamSnippetInfo
+  "Create the approprate `:replacement-snippet` for PARAM, combining the value of REPLACEMENT-SNIPPET from the Param->SQL Substitution phase
+   with the OPTIONAL-SNIPPET, if any."
+  [{:keys [variable-snippet optional-snippet replacement-snippet], :as snippet-info} :- ParamSnippetInfo]
+  (assoc snippet-info
+    :replacement-snippet (cond
+                           (not optional-snippet)    replacement-snippet                                                 ; if there is no optional-snippet return replacement as-is
+                           (seq replacement-snippet) (str/replace optional-snippet variable-snippet replacement-snippet) ; if replacement-snippet is non blank splice into optional-snippet
+                           :else                     "")))                                                               ; otherwise return blank replacement (i.e. for NoValue)
+
+(s/defn ^:private ^:always-validate add-replacement-snippet-info :- [ParamSnippetInfo]
+  "Add `:replacement-snippet` and `:prepared-statement-args` info to the maps in PARAMS-SNIPPETS-INFO by looking at PARAM-KEY->VALUE
+   and using the Param->SQL substituion functions."
+  [params-snippets-info :- [ParamSnippetInfo], param-key->value :- ParamValues]
+  (for [snippet-info params-snippets-info]
+    (handle-optional-snippet (merge snippet-info (s/validate ParamSnippetInfo (->replacement-snippet-info (snippet-value snippet-info param-key->value)))))))
+
+
+
+;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+;;; |                                                                          SUBSTITUION                                                                           |
+;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+;; These functions take the information about parameters from the Params Details List functions and then convert the original SQL Query into a SQL query with
+;; appropriate subtitutions and a sequence of prepared statement args
+
+(s/defn ^:private ^:always-validate substitute-one
+  [sql :- su/NonBlankString, {:keys [original-snippet replacement-snippet]} :- ParamSnippetInfo]
+  (str/replace-first sql original-snippet replacement-snippet))
+
+
+(s/defn ^:private ^:always-validate substitute :- {:query su/NonBlankString, :params [s/Any]}
+  "Using the PARAM-SNIPPET-INFO built from the stages above, replace the snippets in SQL and return a vector of `[sql & prepared-statement-params]`."
+  {:style/indent 1}
+  [sql :- su/NonBlankString, param-snippets-info :- [ParamSnippetInfo]]
+  (log/debug (format "PARAM INFO: %s\n%s" (u/emoji "🔥") (u/pprint-to-str 'yellow param-snippets-info)))
+  (loop [sql sql, prepared-statement-args [], [snippet-info & more] param-snippets-info]
+    (if-not snippet-info
+      {:query (str/trim sql), :params prepared-statement-args}
+      (recur (substitute-one sql snippet-info)
+             (concat prepared-statement-args (:prepared-statement-args snippet-info))
+             more))))
+
+
+;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+;;; |                                                                    PUTTING IT ALL TOGETHER                                                                     |
+;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+(s/defn ^:private ^:always-validate expand-query-params
+  [{sql :query, :as native}, param-key->value :- ParamValues]
+  (merge native (when-let [param-snippets-info (seq (add-replacement-snippet-info (sql->params-snippets-info sql) param-key->value))]
+                  (substitute sql param-snippets-info))))
 
 (defn expand-params
   "Expand parameters inside a *native* QUERY."
   [query]
   (binding [*driver*   (:driver query)
             *timezone* (get-in query [:settings :report-timezone])]
-    (update-in query [:native :query] (u/rpartial substitute (query->params-map query)))))
+    (update query :native expand-query-params (query->params-map query))))

--- a/test/metabase/driver/generic_sql/util/unprepare_test.clj
+++ b/test/metabase/driver/generic_sql/util/unprepare_test.clj
@@ -1,0 +1,10 @@
+(ns metabase.driver.generic-sql.util.unprepare-test
+  (:require [expectations :refer :all]
+            [metabase.driver.generic-sql.util.unprepare :as unprepare]))
+
+(expect
+  "SELECT 'Cam\\'s Cool Toucan' FROM TRUE WHERE x ?? y AND z = timestamp('2017-01-01T00:00:00.000Z')"
+  (unprepare/unprepare ["SELECT ? FROM ? WHERE x ?? y AND z = ?"
+                        "Cam's Cool Toucan"
+                        true
+                        #inst "2017-01-01T00:00:00.000Z"]))

--- a/test/metabase/query_processor/sql_parameters_test.clj
+++ b/test/metabase/query_processor/sql_parameters_test.clj
@@ -19,21 +19,28 @@
 
 (defn- substitute {:style/indent 1} [sql params]
   (binding [metabase.query-processor.sql-parameters/*driver* (driver/engine->driver :h2)] ; apparently you can still bind private dynamic vars
-    ((resolve 'metabase.query-processor.sql-parameters/substitute) sql params)))
+    ((resolve 'metabase.query-processor.sql-parameters/expand-query-params)
+     {:query sql}
+     (into {} (for [[k v] params]
+                {k v})))))
 
-(expect "SELECT * FROM bird_facts WHERE toucans_are_cool = TRUE"
+(expect
+  {:query  "SELECT * FROM bird_facts WHERE toucans_are_cool = TRUE"
+   :params []}
   (substitute "SELECT * FROM bird_facts WHERE toucans_are_cool = {{toucans_are_cool}}"
     {:toucans_are_cool true}))
 
-(expect AssertionError
+(expect Exception
   (substitute "SELECT * FROM bird_facts WHERE toucans_are_cool = {{toucans_are_cool}}"
     nil))
 
-(expect "SELECT * FROM bird_facts WHERE toucans_are_cool = TRUE AND bird_type = 'toucan'"
+(expect
+  {:query  "SELECT * FROM bird_facts WHERE toucans_are_cool = TRUE AND bird_type = ?"
+   :params ["toucan"]}
   (substitute "SELECT * FROM bird_facts WHERE toucans_are_cool = {{toucans_are_cool}} AND bird_type = {{bird_type}}"
     {:toucans_are_cool true, :bird_type "toucan"}))
 
-(expect AssertionError
+(expect Exception
   (substitute "SELECT * FROM bird_facts WHERE toucans_are_cool = {{toucans_are_cool}} AND bird_type = {{bird_type}}"
     {:toucans_are_cool true}))
 
@@ -41,116 +48,137 @@
 ;;; ------------------------------------------------------------ optional substitution -- [[ ... {{x}} ... ]] ------------------------------------------------------------
 
 (expect
-  "SELECT * FROM bird_facts WHERE toucans_are_cool = TRUE"
+  {:query  "SELECT * FROM bird_facts WHERE toucans_are_cool = TRUE"
+   :params []}
   (substitute "SELECT * FROM bird_facts [[WHERE toucans_are_cool = {{toucans_are_cool}}]]"
     {:toucans_are_cool true}))
 
 (expect
-  "SELECT * FROM bird_facts WHERE toucans_are_cool = TRUE"
+  {:query  "SELECT * FROM bird_facts WHERE toucans_are_cool = TRUE"
+   :params []}
   (substitute "SELECT * FROM bird_facts [[WHERE toucans_are_cool = {{ toucans_are_cool }}]]"
     {:toucans_are_cool true}))
 
 (expect
-  "SELECT * FROM bird_facts WHERE toucans_are_cool = TRUE"
+  {:query  "SELECT * FROM bird_facts WHERE toucans_are_cool = TRUE"
+   :params []}
   (substitute "SELECT * FROM bird_facts [[WHERE toucans_are_cool = {{toucans_are_cool }}]]"
     {:toucans_are_cool true}))
 
 (expect
-  "SELECT * FROM bird_facts WHERE toucans_are_cool = TRUE"
+  {:query  "SELECT * FROM bird_facts WHERE toucans_are_cool = TRUE"
+   :params []}
   (substitute "SELECT * FROM bird_facts [[WHERE toucans_are_cool = {{ toucans_are_cool}}]]"
     {:toucans_are_cool true}))
 
 (expect
-  "SELECT * FROM bird_facts WHERE toucans_are_cool = TRUE"
+  {:query  "SELECT * FROM bird_facts WHERE toucans_are_cool = TRUE"
+   :params []}
   (substitute "SELECT * FROM bird_facts [[WHERE toucans_are_cool = {{toucans_are_cool_2}}]]"
     {:toucans_are_cool_2 true}))
 
 (expect
-  "SELECT * FROM bird_facts WHERE toucans_are_cool = TRUE AND bird_type = 'toucan'"
+  {:query  "SELECT * FROM bird_facts WHERE toucans_are_cool = TRUE AND bird_type = 'toucan'"
+   :params []}
   (substitute "SELECT * FROM bird_facts [[WHERE toucans_are_cool = {{toucans_are_cool}} AND bird_type = 'toucan']]"
     {:toucans_are_cool true}))
 
 (expect
-  "SELECT * FROM bird_facts"
+  {:query  "SELECT * FROM bird_facts"
+   :params []}
   (substitute "SELECT * FROM bird_facts [[WHERE toucans_are_cool = {{toucans_are_cool}}]]"
     nil))
 
 (expect
-  "SELECT * FROM toucanneries WHERE TRUE AND num_toucans > 5"
+  {:query  "SELECT * FROM toucanneries WHERE TRUE AND num_toucans > 5"
+   :params []}
   (substitute "SELECT * FROM toucanneries WHERE TRUE [[AND num_toucans > {{num_toucans}}]]"
     {:num_toucans 5}))
 
+;; make sure nil gets substituted in as `NULL`
 (expect
-  "SELECT * FROM toucanneries WHERE TRUE AND num_toucans > NULL"
+  {:query  "SELECT * FROM toucanneries WHERE TRUE AND num_toucans > NULL"
+   :params []}
   (substitute "SELECT * FROM toucanneries WHERE TRUE [[AND num_toucans > {{num_toucans}}]]"
     {:num_toucans nil}))
 
 (expect
-  "SELECT * FROM toucanneries WHERE TRUE AND num_toucans > TRUE"
+  {:query  "SELECT * FROM toucanneries WHERE TRUE AND num_toucans > TRUE"
+   :params []}
   (substitute "SELECT * FROM toucanneries WHERE TRUE [[AND num_toucans > {{num_toucans}}]]"
     {:num_toucans true}))
 
 (expect
-  "SELECT * FROM toucanneries WHERE TRUE AND num_toucans > FALSE"
+  {:query  "SELECT * FROM toucanneries WHERE TRUE AND num_toucans > FALSE"
+   :params []}
   (substitute "SELECT * FROM toucanneries WHERE TRUE [[AND num_toucans > {{num_toucans}}]]"
     {:num_toucans false}))
 
 (expect
-  "SELECT * FROM toucanneries WHERE TRUE AND num_toucans > 'abc'"
+  {:query  "SELECT * FROM toucanneries WHERE TRUE AND num_toucans > ?"
+   :params ["abc"]}
   (substitute "SELECT * FROM toucanneries WHERE TRUE [[AND num_toucans > {{num_toucans}}]]"
     {:num_toucans "abc"}))
 
 (expect
-  "SELECT * FROM toucanneries WHERE TRUE AND num_toucans > 'yo\\' mama'"
+  {:query  "SELECT * FROM toucanneries WHERE TRUE AND num_toucans > ?"
+   :params ["yo' mama"]}
   (substitute "SELECT * FROM toucanneries WHERE TRUE [[AND num_toucans > {{num_toucans}}]]"
     {:num_toucans "yo' mama"}))
 
 (expect
-  "SELECT * FROM toucanneries WHERE TRUE"
+  {:query  "SELECT * FROM toucanneries WHERE TRUE"
+   :params []}
   (substitute "SELECT * FROM toucanneries WHERE TRUE [[AND num_toucans > {{num_toucans}}]]"
     nil))
 
 (expect
-  "SELECT * FROM toucanneries WHERE TRUE AND num_toucans > 2 AND total_birds > 5"
+  {:query  "SELECT * FROM toucanneries WHERE TRUE AND num_toucans > 2 AND total_birds > 5"
+   :params []}
   (substitute "SELECT * FROM toucanneries WHERE TRUE [[AND num_toucans > {{num_toucans}}]] [[AND total_birds > {{total_birds}}]]"
     {:num_toucans 2, :total_birds 5}))
 
 (expect
-  "SELECT * FROM toucanneries WHERE TRUE  AND total_birds > 5"
+  {:query  "SELECT * FROM toucanneries WHERE TRUE  AND total_birds > 5"
+   :params []}
   (substitute "SELECT * FROM toucanneries WHERE TRUE [[AND num_toucans > {{num_toucans}}]] [[AND total_birds > {{total_birds}}]]"
     {:total_birds 5}))
 
 (expect
-  "SELECT * FROM toucanneries WHERE TRUE AND num_toucans > 3"
+  {:query  "SELECT * FROM toucanneries WHERE TRUE AND num_toucans > 3"
+   :params []}
   (substitute "SELECT * FROM toucanneries WHERE TRUE [[AND num_toucans > {{num_toucans}}]] [[AND total_birds > {{total_birds}}]]"
     {:num_toucans 3}))
 
 (expect
-  "SELECT * FROM toucanneries WHERE TRUE"
+  {:query  "SELECT * FROM toucanneries WHERE TRUE"
+   :params []}
   (substitute "SELECT * FROM toucanneries WHERE TRUE [[AND num_toucans > {{num_toucans}}]] [[AND total_birds > {{total_birds}}]]"
     nil))
 
 (expect
-  "SELECT * FROM toucanneries WHERE bird_type = 'toucan' AND num_toucans > 2 AND total_birds > 5"
+  {:query  "SELECT * FROM toucanneries WHERE bird_type = ? AND num_toucans > 2 AND total_birds > 5"
+   :params ["toucan"]}
   (substitute "SELECT * FROM toucanneries WHERE bird_type = {{bird_type}} [[AND num_toucans > {{num_toucans}}]] [[AND total_birds > {{total_birds}}]]"
     {:bird_type "toucan", :num_toucans 2, :total_birds 5}))
 
 (expect
-  AssertionError
+  Exception
   (substitute "SELECT * FROM toucanneries WHERE bird_type = {{bird_type}} [[AND num_toucans > {{num_toucans}}]] [[AND total_birds > {{total_birds}}]]"
     {:num_toucans 2, :total_birds 5}))
 
 (expect
-  "SELECT * FROM toucanneries WHERE TRUE AND num_toucans > 5 AND num_toucans < 5"
+  {:query  "SELECT * FROM toucanneries WHERE TRUE AND num_toucans > 5 AND num_toucans < 5"
+   :params []}
   (substitute "SELECT * FROM toucanneries WHERE TRUE [[AND num_toucans > {{num_toucans}}]] [[AND num_toucans < {{num_toucans}}]]"
     {:num_toucans 5}))
 
 ;; Make sure that substiutions still work if the subsitution contains brackets inside it (#3657)
 (expect
-  "select * from foobars  where foobars.id in (string_to_array(100, ',')::integer[])"
-  ((resolve 'metabase.query-processor.sql-parameters/substitute)
-   "select * from foobars [[ where foobars.id in (string_to_array({{foobar_id}}, ',')::integer[]) ]]"
-   {:foobar_id 100}))
+  {:query  "select * from foobars  where foobars.id in (string_to_array(100, ',')::integer[])"
+   :params []}
+  (substitute "select * from foobars [[ where foobars.id in (string_to_array({{foobar_id}}, ',')::integer[]) ]]"
+    {:foobar_id 100}))
 
 
 ;;; ------------------------------------------------------------ tests for value-for-tag ------------------------------------------------------------
@@ -165,7 +193,7 @@
 
 ;; variable -- unspecified
 (expect
-  nil
+  #metabase.query_processor.sql_parameters.NoValue{}
   (value-for-tag {:name "id", :display_name "ID", :type "text"} nil))
 
 ;; variable -- default
@@ -211,13 +239,18 @@
 
 ;;; ------------------------------------------------------------ expansion tests: variables ------------------------------------------------------------
 
+(defn- expand-params* [query]
+  (-> (expand-params (assoc query :driver     (driver/engine->driver :h2)))
+      :native
+      (select-keys [:query :params])))
+
 ;; unspecified optional param
 (expect
-  "SELECT * FROM orders ;"
-  (-> (expand-params {:native     {:query "SELECT * FROM orders [[WHERE id = {{id}}]];"
-                                   :template_tags {:id {:name "id", :display_name "ID", :type "number"}}}
-                      :parameters []})
-      :native :query))
+  {:query  "SELECT * FROM orders ;"
+   :params []}
+  (expand-params* {:native     {:query "SELECT * FROM orders [[WHERE id = {{id}}]];"
+                                :template_tags {:id {:name "id", :display_name "ID", :type "number"}}}
+                   :parameters []}))
 
 ;; unspecified *required* param
 (expect
@@ -228,128 +261,153 @@
 
 ;; default value
 (expect
-  "SELECT * FROM orders WHERE id = 100;"
-  (-> (expand-params {:native     {:query "SELECT * FROM orders WHERE id = {{id}};"
-                                   :template_tags {:id {:name "id", :display_name "ID", :type "number", :required true, :default "100"}}}
-                      :parameters []})
-      :native :query))
+  {:query  "SELECT * FROM orders WHERE id = 100;"
+   :params []}
+  (expand-params* {:native     {:query "SELECT * FROM orders WHERE id = {{id}};"
+                                :template_tags {:id {:name "id", :display_name "ID", :type "number", :required true, :default "100"}}}
+                   :parameters []}))
 
 ;; specified param (numbers)
 (expect
-  "SELECT * FROM orders WHERE id = 2;"
-  (-> (expand-params {:native     {:query "SELECT * FROM orders WHERE id = {{id}};"
-                                   :template_tags {:id {:name "id", :display_name "ID", :type "number", :required true, :default "100"}}}
-                      :parameters [{:type "category", :target ["variable" ["template-tag" "id"]], :value "2"}]})
-      :native :query))
+  {:query  "SELECT * FROM orders WHERE id = 2;"
+   :params []}
+  (expand-params* {:native     {:query "SELECT * FROM orders WHERE id = {{id}};"
+                                :template_tags {:id {:name "id", :display_name "ID", :type "number", :required true, :default "100"}}}
+                   :parameters [{:type "category", :target ["variable" ["template-tag" "id"]], :value "2"}]}))
 
 ;; specified param (date/single)
 (expect
-  "SELECT * FROM orders WHERE created_at > '2016-07-19';"
-  (-> (expand-params {:native     {:query "SELECT * FROM orders WHERE created_at > {{created_at}};"
-                                   :template_tags {:created_at {:name "created_at", :display_name "Created At", :type "date"}}}
-                      :parameters [{:type "date/single", :target ["variable" ["template-tag" "created_at"]], :value "2016-07-19"}]})
-      :native :query))
+  {:query  "SELECT * FROM orders WHERE created_at > ?;"
+   :params [#inst "2016-07-19T00:00:00.000000000-00:00"]}
+  (expand-params* {:native     {:query "SELECT * FROM orders WHERE created_at > {{created_at}};"
+                                :template_tags {:created_at {:name "created_at", :display_name "Created At", :type "date"}}}
+                   :parameters [{:type "date/single", :target ["variable" ["template-tag" "created_at"]], :value "2016-07-19"}]}))
 
 ;; specified param (text)
 (expect
-  "SELECT * FROM products WHERE category = 'Gizmo';"
-  (-> (expand-params {:native     {:query "SELECT * FROM products WHERE category = {{category}};"
-                                   :template_tags {:category {:name "category", :display_name "Category", :type "text"}}}
-                      :parameters [{:type "category", :target ["variable" ["template-tag" "category"]], :value "Gizmo"}]})
-      :native :query))
+  {:query  "SELECT * FROM products WHERE category = ?;"
+   :params ["Gizmo"]}
+  (expand-params* {:native     {:query "SELECT * FROM products WHERE category = {{category}};"
+                                :template_tags {:category {:name "category", :display_name "Category", :type "text"}}}
+                   :parameters [{:type "category", :target ["variable" ["template-tag" "category"]], :value "Gizmo"}]}))
 
 
 ;;; ------------------------------------------------------------ expansion tests: dimensions ------------------------------------------------------------
 
 (defn- expand-with-dimension-param [dimension-param]
   (with-redefs [t/now (fn [] (t/date-time 2016 06 07 12 0 0))]
-    (-> (expand-params {:driver        (driver/engine->driver :h2)
-                        :native     {:query "SELECT * FROM checkins WHERE {{date}};"
-                                     :template_tags {:date {:name "date", :display_name "Checkin Date", :type "dimension", :dimension ["field-id" (data/id :checkins :date)]}}}
-                        :parameters [(when dimension-param
-                                       (merge {:target ["dimension" ["template-tag" "date"]]}
-                                              dimension-param))]})
-        :native :query)))
+    (expand-params* {:native     {:query "SELECT * FROM checkins WHERE {{date}};"
+                                  :template_tags {:date {:name "date", :display_name "Checkin Date", :type "dimension", :dimension ["field-id" (data/id :checkins :date)]}}}
+                     :parameters (when dimension-param
+                                   [(merge {:target ["dimension" ["template-tag" "date"]]}
+                                            dimension-param)])})))
 
 ;; dimension (date/single)
 (expect
-  "SELECT * FROM checkins WHERE CAST(\"PUBLIC\".\"CHECKINS\".\"DATE\" AS date) = '2016-07-01';"
+  {:query  "SELECT * FROM checkins WHERE CAST(\"PUBLIC\".\"CHECKINS\".\"DATE\" AS date) = ?;"
+   :params [#inst "2016-07-01T00:00:00.000000000-00:00"]}
   (expand-with-dimension-param {:type "date/single", :value "2016-07-01"}))
 
 ;; dimension (date/range)
 (expect
-  "SELECT * FROM checkins WHERE CAST(\"PUBLIC\".\"CHECKINS\".\"DATE\" AS date) BETWEEN '2016-07-01' AND '2016-08-01';"
+  {:query  "SELECT * FROM checkins WHERE CAST(\"PUBLIC\".\"CHECKINS\".\"DATE\" AS date) BETWEEN ? AND ?;"
+   :params [#inst "2016-07-01T00:00:00.000000000-00:00"
+            #inst "2016-08-01T00:00:00.000000000-00:00"]}
   (expand-with-dimension-param {:type "date/range", :value "2016-07-01~2016-08-01"}))
 
 
 ;; dimension (date/month-year)
 (expect
-  "SELECT * FROM checkins WHERE CAST(\"PUBLIC\".\"CHECKINS\".\"DATE\" AS date) BETWEEN '2016-07-01' AND '2016-07-31';"
+  {:query  "SELECT * FROM checkins WHERE CAST(\"PUBLIC\".\"CHECKINS\".\"DATE\" AS date) BETWEEN ? AND ?;"
+   :params [#inst "2016-07-01T00:00:00.000000000-00:00"
+            #inst "2016-07-31T00:00:00.000000000-00:00"]}
   (expand-with-dimension-param {:type "date/month-year", :value "2016-07"}))
 
 ;; dimension (date/quarter-year)
 (expect
-  "SELECT * FROM checkins WHERE CAST(\"PUBLIC\".\"CHECKINS\".\"DATE\" AS date) BETWEEN '2016-01-01' AND '2016-03-31';"
+  {:query  "SELECT * FROM checkins WHERE CAST(\"PUBLIC\".\"CHECKINS\".\"DATE\" AS date) BETWEEN ? AND ?;"
+   :params [#inst "2016-01-01T00:00:00.000000000-00:00"
+            #inst "2016-03-31T00:00:00.000000000-00:00"]}
   (expand-with-dimension-param {:type "date/quarter-year", :value "Q1-2016"}))
 
 ;; relative date -- "yesterday"
 (expect
-  "SELECT * FROM checkins WHERE CAST(\"PUBLIC\".\"CHECKINS\".\"DATE\" AS date) = '2016-06-06';"
+  {:query  "SELECT * FROM checkins WHERE CAST(\"PUBLIC\".\"CHECKINS\".\"DATE\" AS date) = ?;"
+   :params [#inst "2016-06-06T00:00:00.000000000-00:00"]}
   (expand-with-dimension-param {:type "date/range", :value "yesterday"}))
 
 ;; relative date -- "past7days"
 (expect
-  "SELECT * FROM checkins WHERE CAST(\"PUBLIC\".\"CHECKINS\".\"DATE\" AS date) BETWEEN '2016-05-31' AND '2016-06-06';"
+  {:query  "SELECT * FROM checkins WHERE CAST(\"PUBLIC\".\"CHECKINS\".\"DATE\" AS date) BETWEEN ? AND ?;"
+   :params [#inst "2016-05-31T00:00:00.000000000-00:00"
+            #inst "2016-06-06T00:00:00.000000000-00:00"]}
   (expand-with-dimension-param {:type "date/range", :value "past7days"}))
 
 ;; relative date -- "past30days"
 (expect
-  "SELECT * FROM checkins WHERE CAST(\"PUBLIC\".\"CHECKINS\".\"DATE\" AS date) BETWEEN '2016-05-08' AND '2016-06-06';"
+  {:query  "SELECT * FROM checkins WHERE CAST(\"PUBLIC\".\"CHECKINS\".\"DATE\" AS date) BETWEEN ? AND ?;"
+   :params [#inst "2016-05-08T00:00:00.000000000-00:00"
+            #inst "2016-06-06T00:00:00.000000000-00:00"]}
   (expand-with-dimension-param {:type "date/range", :value "past30days"}))
 
 ;; relative date -- "thisweek"
 (expect
-  "SELECT * FROM checkins WHERE CAST(\"PUBLIC\".\"CHECKINS\".\"DATE\" AS date) BETWEEN '2016-06-05' AND '2016-06-11';"
+  {:query  "SELECT * FROM checkins WHERE CAST(\"PUBLIC\".\"CHECKINS\".\"DATE\" AS date) BETWEEN ? AND ?;"
+   :params [#inst "2016-06-05T00:00:00.000000000-00:00"
+            #inst "2016-06-11T00:00:00.000000000-00:00"]}
   (expand-with-dimension-param {:type "date/range", :value "thisweek"}))
 
 ;; relative date -- "thismonth"
 (expect
-  "SELECT * FROM checkins WHERE CAST(\"PUBLIC\".\"CHECKINS\".\"DATE\" AS date) BETWEEN '2016-06-01' AND '2016-06-30';"
+  {:query  "SELECT * FROM checkins WHERE CAST(\"PUBLIC\".\"CHECKINS\".\"DATE\" AS date) BETWEEN ? AND ?;"
+   :params [#inst "2016-06-01T00:00:00.000000000-00:00"
+            #inst "2016-06-30T00:00:00.000000000-00:00"]}
   (expand-with-dimension-param {:type "date/range", :value "thismonth"}))
 
 ;; relative date -- "thisyear"
 (expect
-  "SELECT * FROM checkins WHERE CAST(\"PUBLIC\".\"CHECKINS\".\"DATE\" AS date) BETWEEN '2016-01-01' AND '2016-12-31';"
+  {:query  "SELECT * FROM checkins WHERE CAST(\"PUBLIC\".\"CHECKINS\".\"DATE\" AS date) BETWEEN ? AND ?;"
+   :params [#inst "2016-01-01T00:00:00.000000000-00:00"
+            #inst "2016-12-31T00:00:00.000000000-00:00"]}
   (expand-with-dimension-param {:type "date/range", :value "thisyear"}))
 
 ;; relative date -- "lastweek"
 (expect
-  "SELECT * FROM checkins WHERE CAST(\"PUBLIC\".\"CHECKINS\".\"DATE\" AS date) BETWEEN '2016-05-29' AND '2016-06-04';"
+  {:query  "SELECT * FROM checkins WHERE CAST(\"PUBLIC\".\"CHECKINS\".\"DATE\" AS date) BETWEEN ? AND ?;"
+   :params [#inst "2016-05-29T00:00:00.000000000-00:00"
+            #inst "2016-06-04T00:00:00.000000000-00:00"]}
   (expand-with-dimension-param {:type "date/range", :value "lastweek"}))
 
 ;; relative date -- "lastmonth"
 (expect
-  "SELECT * FROM checkins WHERE CAST(\"PUBLIC\".\"CHECKINS\".\"DATE\" AS date) BETWEEN '2016-05-01' AND '2016-05-31';"
+  {:query  "SELECT * FROM checkins WHERE CAST(\"PUBLIC\".\"CHECKINS\".\"DATE\" AS date) BETWEEN ? AND ?;"
+   :params [#inst "2016-05-01T00:00:00.000000000-00:00"
+            #inst "2016-05-31T00:00:00.000000000-00:00"]}
   (expand-with-dimension-param {:type "date/range", :value "lastmonth"}))
 
 ;; relative date -- "lastyear"
 (expect
-  "SELECT * FROM checkins WHERE CAST(\"PUBLIC\".\"CHECKINS\".\"DATE\" AS date) BETWEEN '2015-01-01' AND '2015-12-31';"
+  {:query  "SELECT * FROM checkins WHERE CAST(\"PUBLIC\".\"CHECKINS\".\"DATE\" AS date) BETWEEN ? AND ?;"
+   :params [#inst "2015-01-01T00:00:00.000000000-00:00"
+            #inst "2015-12-31T00:00:00.000000000-00:00"]}
   (expand-with-dimension-param {:type "date/range", :value "lastyear"}))
 
 ;; dimension with no value -- just replace with an always true clause (e.g. "WHERE 1 = 1")
 (expect
-  "SELECT * FROM checkins WHERE 1 = 1;"
+  {:query  "SELECT * FROM checkins WHERE 1 = 1;"
+   :params []}
   (expand-with-dimension-param nil))
 
 ;; dimension -- number
 (expect
-  "SELECT * FROM checkins WHERE \"PUBLIC\".\"CHECKINS\".\"DATE\" = 100;"
+  {:query  "SELECT * FROM checkins WHERE \"PUBLIC\".\"CHECKINS\".\"DATE\" = 100;"
+   :params []}
   (expand-with-dimension-param {:type "number", :value "100"}))
 
 ;; dimension -- text
 (expect
-  "SELECT * FROM checkins WHERE \"PUBLIC\".\"CHECKINS\".\"DATE\" = '100';"
+  {:query  "SELECT * FROM checkins WHERE \"PUBLIC\".\"CHECKINS\".\"DATE\" = ?;"
+   :params ["100"]}
   (expand-with-dimension-param {:type "text", :value "100"}))
 
 
@@ -416,3 +474,45 @@
                     :template_tags {:checkin_date {:name "checkin_date", :display_name "Checkin Date", :type "dimension", :dimension ["field-id" (data/id :checkins :date)]}}}
        :parameters [{:type "date/range",  :target ["dimension" ["template-tag" "checkin_date"]], :value "2015-01-01~2016-09-01"}
                     {:type "date/single", :target ["dimension" ["template-tag" "checkin_date"]], :value "2015-07-01"}]))))
+
+
+;;; ------------------------------------------------------------ SQL PARAMETERS 2.0 TESTS ------------------------------------------------------------
+
+;; Some random end-to-end param expansion tests added as part of the SQL Parameters 2.0 rewrite
+
+(expect
+  {:query         "SELECT count(*) FROM CHECKINS WHERE CAST(\"PUBLIC\".\"CHECKINS\".\"DATE\" AS date) BETWEEN ? AND ?"
+   :template_tags {:created_at {:name "created_at", :display_name "Created At", :type "dimension", :dimension ["field-id" (data/id :checkins :date)]}},
+   :params        [#inst "2017-03-01T00:00:00.000000000-00:00"
+                   #inst "2017-03-31T00:00:00.000000000-00:00"]}
+  (:native (expand-params {:driver     (driver/engine->driver :h2)
+                           :native     {:query         "SELECT count(*) FROM CHECKINS WHERE {{created_at}}"
+                                        :template_tags {:created_at {:name "created_at", :display_name "Created At", :type "dimension", :dimension ["field-id" (data/id :checkins :date)]}}}
+                           :parameters [{:type "date/month-year", :target ["dimension" ["template-tag" "created_at"]], :value "2017-03"}]})))
+
+(expect
+  {:query         "SELECT count(*) FROM ORDERS"
+   :template_tags {:price {:name "price", :display_name "Price", :type "number", :required false}}
+   :params        []}
+  (:native (expand-params {:driver     (driver/engine->driver :h2)
+                           :native     {:query         "SELECT count(*) FROM ORDERS [[WHERE price > {{price}}]]"
+                                        :template_tags {:price {:name "price", :display_name "Price", :type "number", :required false}}}
+                           :parameters []})))
+
+(expect
+  {:query         "SELECT count(*) FROM ORDERS WHERE price > 100"
+   :template_tags {:price {:name "price", :display_name "Price", :type "number", :required false}}
+   :params        []}
+  (:native (expand-params {:driver     (driver/engine->driver :h2)
+                           :native     {:query         "SELECT count(*) FROM ORDERS [[WHERE price > {{price}}]]"
+                                        :template_tags {:price {:name "price", :display_name "Price", :type "number", :required false}}}
+                           :parameters [{:type "category", :target ["variable" ["template-tag" "price"]], :value "100"}]})))
+
+(expect
+  {:query         "SELECT count(*) FROM PRODUCTS WHERE TITLE LIKE ?"
+   :template_tags {:x {:name "x", :display_name "X", :type "text", :required true, :default "%Toucan%"}}
+   :params        ["%Toucan%"]}
+  (:native (expand-params {:driver     (driver/engine->driver :h2)
+                           :native     {:query         "SELECT count(*) FROM PRODUCTS WHERE TITLE LIKE {{x}}",
+                                        :template_tags {:x {:name "x", :display_name "X", :type "text", :required true, :default "%Toucan%"}}},
+                           :parameters [{:type "category", :target ["variable" ["template-tag" "x"]]}]})))


### PR DESCRIPTION
Complete rewrite of the hairy SQL param code; SQL params are now passed as prepared statement args instead of being included as part of the query itself, except for BigQuery, which now uses special logic to un-prepare things.

Fixes #3816 and #4313 