### PR TITLE
Optional symmetric encryption for DB details (AES256 CBC + HMAC SHA512)

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -23,7 +23,7 @@ node-2() {
     if is_engine_enabled "crate"; then
         run_step install-crate
     fi
-    MB_DB_TYPE=mysql MB_DB_DBNAME=circle_test MB_DB_PORT=3306 MB_DB_USER=ubuntu MB_DB_HOST=localhost \
+    MB_ENCRYPTION_SECRET_KEY='Orw0AAyzkO/kPTLJRxiyKoBHXa/d6ZcO+p+gpZO/wSQ=' MB_DB_TYPE=mysql MB_DB_DBNAME=circle_test MB_DB_PORT=3306 MB_DB_USER=ubuntu MB_DB_HOST=localhost \
         run_step lein-test
 }
 node-3() {

--- a/project.clj
+++ b/project.clj
@@ -26,6 +26,7 @@
                                org.clojure/clojurescript]]            ; fixed length queue implementation, used in log buffering
                  [amalloy/ring-gzip-middleware "0.1.3"]               ; Ring middleware to GZIP responses if client can handle it
                  [aleph "0.4.1"]                                      ; Async HTTP library; WebSockets
+                 [buddy/buddy-core "1.2.0"]                           ; various cryptograhpic functions
                  [cheshire "5.7.0"]                                   ; fast JSON encoding (used by Ring JSON middleware)
                  [clj-http "3.4.1"                                    ; HTTP client
                   :exclusions [commons-codec

--- a/src/metabase/logger.clj
+++ b/src/metabase/logger.clj
@@ -10,15 +10,16 @@
 
 (def ^:private ^:const max-log-entries 2500)
 
-(def ^:private messages (atom (ring-buffer max-log-entries)))
+(defonce ^:private messages (atom (ring-buffer max-log-entries)))
 
+;; TODO - rename to `messages`
 (defn get-messages
-  "Get the list of currently buffered log entries"
+  "Get the list of currently buffered log entries, from most-recent to oldest."
   []
   (reverse (seq @messages)))
 
 
-(def ^:private formatter (time/formatter "MMM dd HH:mm:ss" (t/default-time-zone)))
+(defonce ^:private formatter (time/formatter "MMM dd HH:mm:ss" (t/default-time-zone)))
 
 (defn -append
   "Append a new EVENT to the `messages` atom.

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -42,7 +42,7 @@
   models/IModel
   (merge models/IModelDefaults
          {:hydration-keys (constantly [:database :db])
-          :types          (constantly {:details :json, :engine :keyword})
+          :types          (constantly {:details :encrypted-json, :engine :keyword})
           :properties     (constantly {:timestamped? true})
           :post-insert    post-insert
           :post-select    post-select

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -811,3 +811,9 @@
              {k (if-not (seq nested-keys)
                   v
                   (select-nested-keys v nested-keys))})))
+
+(defn base-64-string?
+  "Is S a Base-64 encoded string?"
+  ^Boolean [s]
+  (boolean (when (string? s)
+             (re-find #"^[0-9A-Za-z/+]+=*$" s))))

--- a/src/metabase/util/encryption.clj
+++ b/src/metabase/util/encryption.clj
@@ -1,0 +1,75 @@
+(ns metabase.util.encryption
+  "Utility functions for encrypting and decrypting strings using AES256 CBC + HMAC SHA512 and the `MB_ENCRYPTION_SECRET_KEY` env var."
+  (:require (buddy.core [codecs :as codecs]
+                        [crypto :as crypto]
+                        [kdf :as kdf]
+                        [nonce :as nonce])
+            [clojure.tools.logging :as log]
+            [environ.core :as env]
+            [ring.util.codec :as codec]
+            [metabase.util :as u]))
+
+(defn secret-key->hash
+  "Generate a 64-byte byte array hash of SECRET-KEY using 100,000 iterations of PBKDF2+SHA512."
+  [^String secret-key]
+  (kdf/get-bytes (kdf/engine {:alg        :pbkdf2+sha512
+                              :key        secret-key
+                              :iterations 100000}) ; 100,000 iterations takes about ~160ms on my laptop
+                 64))
+
+(defonce ^:private default-secret-key
+  (when-let [secret-key (env/env :mb-encryption-secret-key)]
+    (when (seq secret-key)
+      (assert (>= (count secret-key) 16)
+        "MB_ENCRYPTION_SECRET_KEY must be at least 16 characters.")
+      (secret-key->hash secret-key))))
+
+;; log a nice message letting people know whether DB details encryption is enabled
+(log/info (format "DB details encryption is %s for this Metabase instance. %s"
+                  (if default-secret-key "ENABLED" "DISABLED")
+                  (u/emoji (if default-secret-key "🔐" "🔓"))))
+
+(defn encrypt
+  "Encrypt string S as hex bytes using a SECRET-KEY (a 64-byte byte array), by default the hashed value of `MB_ENCRYPTION_SECRET_KEY`."
+  (^String [^String s]
+   (encrypt default-secret-key s))
+  (^String [^String secret-key, ^String s]
+   (let [iv (nonce/random-bytes 16)]
+     (codec/base64-encode (byte-array (concat iv
+                                              (crypto/encrypt (codecs/to-bytes s) secret-key iv {:algorithm :aes256-cbc-hmac-sha512})))))))
+
+(defn decrypt
+  "Decrypt string S  using a SECRET-KEY (a 64-byte byte array), by default the hashed value of `MB_ENCRYPTION_SECRET_KEY`."
+  (^String [^String s]
+   (decrypt default-secret-key s))
+  (^String [secret-key, ^String s]
+   (let [bytes        (codec/base64-decode s)
+         [iv message] (split-at 16 bytes)]
+     (codecs/bytes->str (crypto/decrypt (byte-array message) secret-key (byte-array iv) {:algorithm :aes256-cbc-hmac-sha512})))))
+
+
+(defn maybe-encrypt
+  "If `MB_ENCRYPTION_SECRET_KEY` is set, return an encrypted version of S; otherwise return S as-is."
+  (^String [^String s]
+   (maybe-encrypt default-secret-key s))
+  (^String [secret-key, ^String s]
+   (if secret-key
+     (when (seq s)
+       (encrypt secret-key s))
+     s)))
+
+(defn maybe-decrypt
+  "If `MB_ENCRYPTION_SECRET_KEY` is set and S is encrypted, decrypt S; otherwise return S as-is."
+  (^String [^String s]
+   (maybe-decrypt default-secret-key s))
+  (^String [secret-key, ^String s]
+   (if (and secret-key (seq s))
+     (try
+       (decrypt secret-key s)
+       (catch Throwable e
+         (if (u/base-64-string? s)
+           ;; if we can't decrypt `s`, but it *is* encrypted, log an error message and return `nil`
+           (log/error "Cannot decrypt encrypted details. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?" (.getMessage e))
+           ;; otherwise return S without decrypting. It's probably not decrypted in the first place
+           s)))
+     s)))

--- a/test/metabase/util/encryption_test.clj
+++ b/test/metabase/util/encryption_test.clj
@@ -1,0 +1,53 @@
+(ns metabase.util.encryption-test
+  (:require [clojure.string :as str]
+            [expectations :refer :all]
+            [metabase.test.util :as tu]
+            [metabase.util.encryption :as encryption]))
+
+(def ^:private secret   (encryption/secret-key->hash "Orw0AAyzkO/kPTLJRxiyKoBHXa/d6ZcO+p+gpZO/wSQ="))
+(def ^:private secret-2 (encryption/secret-key->hash "0B9cD6++AME+A7/oR7Y2xvPRHX3cHA2z7w+LbObd/9Y="))
+
+;; test that hashing a secret key twice gives you the same results
+(expect
+  (= (vec (encryption/secret-key->hash "Toucans"))
+     (vec (encryption/secret-key->hash "Toucans"))))
+
+;; two different secret keys should have different results
+(expect (not= (vec secret)
+              (vec secret-2)))
+
+;; test that we can encrypt a message. Should be base-64
+(expect
+  #"^[0-9A-Za-z/+]+=*$"
+  (encryption/encrypt secret "Hello!"))
+
+;; test that encrypting something twice gives you two different ciphertexts
+(expect
+  (not= (encryption/encrypt secret "Hello!")
+        (encryption/encrypt secret "Hello!")))
+
+;; test that we can decrypt something
+(expect
+  "Hello!"
+  (encryption/decrypt secret (encryption/encrypt secret "Hello!")))
+
+;; trying to decrypt something with the wrong key with `decrypt` should throw an Exception
+(expect
+  Exception
+  (encryption/decrypt secret-2 (encryption/encrypt secret "WOW")))
+
+;; trying to `maybe-decrypt` something that's not encrypted should return it as-is
+(expect
+  "{\"a\":100}"
+  (encryption/maybe-decrypt secret "{\"a\":100}"))
+
+;; trying to decrypt something that is encrypted with the wrong key with `maybe-decrypt` should return `nil`...
+(expect
+  nil
+  (encryption/maybe-decrypt secret-2 (encryption/encrypt secret "WOW")))
+
+(expect
+  (some (fn [[_ _ message]]
+          (str/includes? message "Cannot decrypt encrypted details. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY? Message seems corrupt or manipulated."))
+        (tu/with-log-messages
+          (encryption/maybe-decrypt secret-2 (encryption/encrypt secret "WOW")))))

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -202,3 +202,11 @@
 (expect
   {}
   (select-nested-keys {} [:c]))
+
+
+;; tests for base-64-string?
+(expect (base-64-string? "ABc"))
+(expect (base-64-string? "ABc/+asdasd=="))
+(expect false (base-64-string? 100))
+(expect false (base-64-string? "<<>>"))
+(expect false (base-64-string? "{\"a\": 10}"))

--- a/test_resources/log4j.properties
+++ b/test_resources/log4j.properties
@@ -19,3 +19,4 @@ log4j.logger.com.mchange=ERROR
 log4j.logger.metabase=ERROR
 log4j.logger.metabase.test.data.datasets=INFO
 log4j.logger.metabase.test-setup=INFO
+log4j.logger.metabase.util.encryption=INFO


### PR DESCRIPTION
This was easy to implement so I don't know why I waited so long to do it. Implements #865

Here's the basic idea:

### Part 1: Huh?

Pass `MB_ENCRYPTION_SECRET_KEY` env var to Metabase. This secret key can be whatever you want! 😻 

```bash
MB_ENCRYPTION_SECRET_KEY='WowILoveToucans' lein ring server
```

Then Metabase will log a sweet message letting you know encryption is g2g when you launch:

![screen shot 2017-02-08 at 7 12 09 pm](https://cloud.githubusercontent.com/assets/1455846/22767797/98892348-ee32-11e6-9e8f-5353413c3e2e.png)


And that's *all you have to do*. Wow.

DB details are completely transparent to application:

```clojure
(toucan.db/select-one-field :details 'Database :engine "postgres")
;; -> {:host "localhost", :port 5432, :dbname "test-data", :user "camsaul", :password nil, :ssl false}
```

But they're encrypted in the database:

```clojure
(jdbc/query (toucan.db/connection) 
  "SELECT details FROM metabase_database WHERE engine = 'postgres' LIMIT 1;")
;; -> ({:details "ae98856ee4b0e6210d8833678f931b4fa88dbef585b6d81266947f7eaff8440d0331d28dfbc542195c7bcdcace3cf18748cd871568f04c85e7c9df6abc96b11a8216dc04049c2c1cb16676200d680e9ad74804f6fb63d3fb354dd4980a4dc7a9a43b4ed3af920231f3fd5ea3180e7e099f1579e5f3421b092b628c78215655bda391141827795e22153870ebf9b3652189263d8b81a48f3f3969e04fea2b22c8"})
```

So if someone ever steals your Metabase DB, they won't know what's Gucci. #WOW 🙀 

### Part 2: How it all works?

1.  When Metabase launches, the secret key is hashed using ~~SHA-512~~ 100,000 iterations of PBKDF2+SHA-512

Using [Toucan](https://github.com/metabase/metabase/)'s powerful type system, whenever DB details are saved, we:

1.  generate an initialization vector (IV) of 16 cryptographically-secure random bytes
1.  serialize the DB details as a JSON string
1.  encrypt the string using IV + hashed secret key
1.  calculate a SHA-512 HMAC tag using IV, hashed secret key, and encrypted string
1.  encode (IV + encrypted string + tag) bytes as ~~hex~~ Base-64
1.  store in DB
1.  profit 💰 

When something is fetched from the DB:

1.  decode ~~hex~~ Base-64 -> bytes
1.  split into IV, encrypted message, and tag
1.  verify the tag using HMAC, secret key
1.  decrypt message w/ IV and secret key
1.  parse as JSON
1.  profit 💰 

This is backwards-compatible with unencrypted DB details, and includes some light TTL caching to prevent your computer from exploding by decrypting DB details (somewhat expensive) every time a query is ran. Nice 😎 

### Part 3: Next Steps

If we like this approach, we should do the following:

*  Add a few tests for this (should be pretty simple, we can have one of the test nodes use encryption)
*  Write some documentation about how to use this