### PR TITLE
Fix double /api/user/current call on load

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "react-resizable": "^1.0.1",
     "react-retina-image": "^2.0.0",
     "react-router": "^3.0.0",
-    "react-router-redux": "^4.0.5",
+    "react-router-redux": "4.0.6",
     "react-sortable": "^1.2.0",
     "react-virtualized": "^8.6.0",
     "recompose": "^0.21.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5721,9 +5721,9 @@ react-retina-image@^2.0.0:
     is-retina "^1.0.3"
     object-assign "^4.1.0"
 
-react-router-redux@^4.0.5:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/react-router-redux/-/react-router-redux-4.0.7.tgz#9b1fde4e70106c50f47214e12bdd888cfb96e2a6"
+react-router-redux@4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/react-router-redux/-/react-router-redux-4.0.6.tgz#10cf98dce911d7dd912a05bdb07fee4d3c563dee"
 
 react-router@^3.0.0:
   version "3.0.0"
@@ -6049,10 +6049,6 @@ requires-port@1.0.x, requires-port@1.x.x:
 reselect@^2.0.1:
   version "2.5.4"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-2.5.4.tgz#b7d23fdf00b83fa7ad0279546f8dbbbd765c7047"
-
-resize-observer-polyfill@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.3.2.tgz#f467efc15a86d9ee5096fd6d7f628c8a54bb805a"
 
 resize-observer-polyfill@^1.3.2:
   version "1.3.2"


### PR DESCRIPTION
Due to https://github.com/reactjs/react-router-redux/issues/481 This bug actually present in 4.0.7 and 4.0.5 but not 4.0.6. It should be fixed in 4.0.8 when that's released.

¯\\_(ツ)_/¯

Resolves #4291