### PR TITLE
Add 0.5rem padding to ColumnarSelector row Icon-check (fix for issue …

### DIFF
--- a/frontend/src/metabase/components/ColumnarSelector.css
+++ b/frontend/src/metabase/components/ColumnarSelector.css
@@ -67,6 +67,7 @@
 
 .ColumnarSelector-row .Icon-check {
     visibility: hidden;
+    padding-right: 0.5rem;
 }
 
 .ColumnarSelector-row.ColumnarSelector-row--selected .Icon-check {


### PR DESCRIPTION
Fix for issue #4244 ; set padding-right in the ColumnarSelector's CSS file for the check-mark icon



