### PR TITLE
custom dashboard refresh interval [WIP]

### DIFF
--- a/frontend/src/metabase/dashboard/components/RefreshWidget.jsx
+++ b/frontend/src/metabase/dashboard/components/RefreshWidget.jsx
@@ -44,8 +44,36 @@ export default class RefreshWidget extends Component {
                             <RefreshOption key={option.period} name={option.name} period={option.period} selected={option.period === period} onClick={() => { this.refs.popover.close(); onChangePeriod(option.period) }} />
                         ) }
                     </RefreshOptionList>
+                    <CustomRefreshInterval
+                        onChangePeriod={onChangePeriod}
+                        selected={OPTIONS.filter(option => option.period !== period)}
+                    />
                 </div>
             </PopoverWithTrigger>
+        );
+    }
+}
+
+class CustomRefreshInterval extends Component {
+    constructor () {
+        super();
+        this.state = {};
+    }
+    render () {
+        const { onChangePeriod, selected } = this.props;
+        return (
+            <div className="border-top ml3">
+                <input
+                    className="input input--small mt1"
+                    type="text"
+                    value={this.state.period}
+                    placeholder="Custom (seconds)"
+                    onChange={(ev) => {
+                        onChangePeriod(ev.target.value)
+                        this.setState({ period: ev.target.value })
+                    }}
+                />
+            </div>
         );
     }
 }


### PR DESCRIPTION
Playing with this as a more extensible alternative to #4299. Rather than adding more options to the refresh intervals as people make us aware of their needs, it seems like it makes sense to provide a small set of defaults and then allow for any custom interval a user might need. Here's what it looks like so far.

<img width="320" alt="screen shot 2017-02-14 at 10 18 09 am" src="https://cloud.githubusercontent.com/assets/5248953/22942869/24721812-f2a0-11e6-8da2-b8e0f5ec001f.png">

Since we already support custom refresh intervals via the URL this just provides an interface to that.

One potential downside is that this could open up a way to hammer the metabase backend. It's also not a true replacement for realtime dashboards even if you set the interval to 1 second, which is what I think the request in #4299 is really getting at.

@shargon @alirezastack would a solution like this solve your needs? @metabase/core-developers what do we think about this alternative approach?
