### PR TITLE
Make sure encrypted DB details are de-CLOBbed before decrypting

### DIFF
--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -37,7 +37,7 @@
 
 (models/add-type! :encrypted-json
   :in  encrypted-json-in
-  :out cached-encrypted-json-out)
+  :out (comp cached-encrypted-json-out u/jdbc-clob->str))
 
 
 (defn- add-created-at-timestamp [obj & _]

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -305,7 +305,7 @@
 
 (defprotocol ^:private IClobToStr
   (jdbc-clob->str ^String [this]
-   "Convert a Postgres/H2/SQLServer JDBC Clob to a string."))
+   "Convert a Postgres/H2/SQLServer JDBC Clob to a string. (If object isn't a Clob, this function returns it as-is.)"))
 
 (extend-protocol IClobToStr
   nil     (jdbc-clob->str [_]    nil)


### PR DESCRIPTION
If the H2 JDBC driver decides to return a CLOB instead of a normal `String` because the encrypted text is large make sure we we convert it to a string first