### PR TITLE
Option for watching webpack-dev-server work progress

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "test-e2e-sauce": "USE_SAUCE=true yarn run test-e2e",
     "build": "webpack --bail",
     "build-watch": "webpack --watch",
-    "build-hot": "NODE_ENV=hot webpack --bail && NODE_ENV=hot webpack-dev-server",
+    "build-hot": "NODE_ENV=hot webpack --bail && NODE_ENV=hot webpack-dev-server --progress",
     "start": "yarn run build && lein ring server",
     "storybook": "start-storybook -p 9001",
     "preinstall": "ps -fp $PPID | grep -q yarn || echo '\\033[0;33mSorry, npm is not supported. Please use Yarn (https://yarnpkg.com/).\\033[0m'"


### PR DESCRIPTION
Allow to see some progress info during compiling in console instead of hanging for some time.
Please merge it if it's usefull also for you.

###### TODO 
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
