### PR TITLE
Fix watching files changes for webpack-dev-server

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -213,6 +213,11 @@ if (NODE_ENV === "hot") {
         hot: true,
         inline: true,
         contentBase: "frontend"
+        // if webpack doesn't reload UI after code change in development
+        // watchOptions: {
+        //     aggregateTimeout: 300,
+        //     poll: 1000
+        // }
         // if you want to reduce stats noise
         // stats: 'minimal' // values: none, errors-only, minimal, normal, verbose
     };


### PR DESCRIPTION
Reloading UI (On my vagrant machine) after code change wasn't working. Webpack-dev-server was hanging.
I fix issue.

###### TODO 
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
