### PR TITLE
Fix display of MinRowsError on dashboards

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,12 @@
 {
-  "plugins": ["transform-flow-strip-types", "add-react-displayname", "transform-decorators-legacy"],
+  "plugins": [
+    "transform-flow-strip-types",
+    "add-react-displayname",
+    "transform-decorators-legacy",
+    ["babel-plugin-transform-builtin-extend", {
+        "globals": ["Error", "Array"]
+    }]
+  ],
   "presets": ["es2015", "stage-0", "react"],
   "env": {
     "development": {

--- a/frontend/test/unit/visualizations/lib/errors.spec.js
+++ b/frontend/test/unit/visualizations/lib/errors.spec.js
@@ -1,0 +1,10 @@
+import { MinRowsError } from 'metabase/visualizations/lib/errors';
+
+describe('MinRowsError', () => {
+    it("should be an instanceof Error", () => {
+        expect(new MinRowsError(1, 0) instanceof Error).toBe(true);
+    });
+    it("should be an instanceof MinRowsError", () => {
+        expect(new MinRowsError(1, 0) instanceof MinRowsError).toBe(true);
+    });
+});

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "babel-eslint": "^7.1.1",
     "babel-loader": "^6.2.4",
     "babel-plugin-add-react-displayname": "^0.0.4",
+    "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-flow-strip-types": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -739,6 +739,13 @@ babel-plugin-transform-async-to-generator@^6.16.0, babel-plugin-transform-async-
     babel-plugin-syntax-async-functions "^6.8.0"
     babel-runtime "^6.0.0"
 
+babel-plugin-transform-builtin-extend@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-builtin-extend/-/babel-plugin-transform-builtin-extend-1.1.2.tgz#5e96fecf58b8fa1ed74efcad88475b2af3c9116e"
+  dependencies:
+    babel-runtime "^6.2.0"
+    babel-template "^6.3.0"
+
 babel-plugin-transform-class-constructor-call@^6.3.13:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.18.0.tgz#80855e38a1ab47b8c6c647f8ea1bcd2c00ca3aae"
@@ -6049,10 +6056,6 @@ requires-port@1.0.x, requires-port@1.x.x:
 reselect@^2.0.1:
   version "2.5.4"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-2.5.4.tgz#b7d23fdf00b83fa7ad0279546f8dbbbd765c7047"
-
-resize-observer-polyfill@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.3.2.tgz#f467efc15a86d9ee5096fd6d7f628c8a54bb805a"
 
 resize-observer-polyfill@^1.3.2:
   version "1.3.2"


### PR DESCRIPTION
And possibly other bugs due to difference in Babel 6.

Resolves #4209 