### PR TITLE
clean up pulse empty state modals

### DIFF
--- a/frontend/src/metabase/components/ModalContent.jsx
+++ b/frontend/src/metabase/components/ModalContent.jsx
@@ -58,7 +58,7 @@ const FORM_WIDTH = 500 + 32 * 2; // includes padding
 
 export const ModalHeader = ({ children }, { fullPageModal, formModal }) =>
     <div className={cx("ModalHeader flex-no-shrink px4 py4 full")}>
-        <h2 className={cx("text-bold", { "text-centered": fullPageModal })}>{children}</h2>
+        <h2 className={cx("text-bold mr4", { "text-centered": fullPageModal })}>{children}</h2>
     </div>
 
 ModalHeader.contextTypes = MODAL_CHILD_CONTEXT_TYPES;

--- a/frontend/src/metabase/components/ModalContent.jsx
+++ b/frontend/src/metabase/components/ModalContent.jsx
@@ -58,7 +58,7 @@ const FORM_WIDTH = 500 + 32 * 2; // includes padding
 
 export const ModalHeader = ({ children }, { fullPageModal, formModal }) =>
     <div className={cx("ModalHeader flex-no-shrink px4 py4 full")}>
-        <h2 className={cx("text-bold mr4", { "text-centered": fullPageModal })}>{children}</h2>
+        <h2 className={cx("text-bold", { "text-centered": fullPageModal }, { "mr4": !fullPageModal})}>{children}</h2>
     </div>
 
 ModalHeader.contextTypes = MODAL_CHILD_CONTEXT_TYPES;

--- a/frontend/src/metabase/pulse/components/SetupMessage.jsx
+++ b/frontend/src/metabase/pulse/components/SetupMessage.jsx
@@ -2,8 +2,6 @@
 import React, { Component, PropTypes } from "react";
 import { Link } from "react-router";
 
-import Icon from "metabase/components/Icon.jsx";
-
 import Settings from "metabase/lib/settings";
 
 export default class SetupMessage extends Component {
@@ -18,19 +16,11 @@ export default class SetupMessage extends Component {
 
     render() {
         let { user, channels } = this.props;
-        let heading, content;
+        let content;
         if (user.is_superuser) {
-            heading = (
-                <span className="flex align-center">
-                    <span className="ml1 h5 text-uppercase text-bold">Great News</span>
-                </span>
-            );
             content = (
-                <div className="m4 h4 text-bold">
-                    <div className="h4 text-bold text-green">
-                        You're an admin, so you can set up integrations
-                    </div>
-                    <div className="mt2">
+                <div className="flex flex-column">
+                    <div className="ml-auto">
                         {channels.map(c =>
                             <Link to={"/admin/settings/"+c.toLowerCase()} key={c.toLowerCase()} className="Button Button--primary mr1" target={window.OSX ? null : "_blank"}>Configure {c}</Link>
                         )}
@@ -40,25 +30,15 @@ export default class SetupMessage extends Component {
 
         } else {
             let adminEmail = Settings.get("admin_email");
-            heading = (
-                <span className="flex align-center relative" style={{top: "-10px"}}>
-                    <Icon name="mail" size={20} />
-                    <span className="ml1 h5 text-uppercase text-bold">Admin Email</span>
-                </span>
-            );
             content = (
-                <div className="m4 h4 text-bold">
-                    <a className="no-decoration" href={"mailto:"+adminEmail}>{adminEmail}</a>
+                <div className="mb1">
+                    <h4 className="text-grey-4">Your admin's email address:</h4>
+                    <a className="h2 link no-decoration" href={"mailto:"+adminEmail}>{adminEmail}</a>
                 </div>
             );
         }
         return (
-            <div className="mt4 rounded bordered relative">
-                <div className="absolute left right flex align-center layout-centered" style={{ top: "-8px" }}>
-                    <span className="bg-white text-grey-3 px2">
-                        {heading}
-                    </span>
-                </div>
+            <div className="mx4 mb4">
                 {content}
             </div>
         );

--- a/frontend/src/metabase/pulse/components/SetupModal.jsx
+++ b/frontend/src/metabase/pulse/components/SetupModal.jsx
@@ -2,7 +2,6 @@
 import React, { Component, PropTypes } from "react";
 
 import SetupMessage from "./SetupMessage.jsx";
-
 import ModalContent from "metabase/components/ModalContent.jsx";
 
 export default class SetupModal extends Component {
@@ -15,11 +14,9 @@ export default class SetupModal extends Component {
         return (
             <ModalContent
                 onClose={this.props.onClose}
+                title={`To send pulses, ${ this.props.user.is_superuser ? "you'll need" : "an admin needs"} to set up email or Slack integration.`}
             >
-                <div className="mx4 px4 pb4 text-centered">
-                    <h2>To send pulses, an admin needs to set up email or Slack integration.</h2>
-                    <SetupMessage user={this.props.user} />
-                </div>
+                <SetupMessage user={this.props.user} />
             </ModalContent>
         );
     }

--- a/frontend/src/metabase/pulse/components/WhatsAPulse.jsx
+++ b/frontend/src/metabase/pulse/components/WhatsAPulse.jsx
@@ -10,9 +10,9 @@ export default class WhatsAPulse extends Component {
     render() {
         return (
             <div className="flex flex-column align-center px4">
-                <div className="h2 mb4 text-centered text-brand text-bold">
+                <h2 className="my4 text-centered text-brand text-bold">
                     Help everyone on your team stay in sync with your data.
-                </div>
+                </h2>
                 <div className="mx4">
                     <RetinaImage
                         width={574}

--- a/frontend/src/metabase/pulse/components/WhatsAPulse.jsx
+++ b/frontend/src/metabase/pulse/components/WhatsAPulse.jsx
@@ -10,7 +10,7 @@ export default class WhatsAPulse extends Component {
     render() {
         return (
             <div className="flex flex-column align-center px4">
-                <h2 className="my4 text-centered text-brand text-bold">
+                <h2 className="my4 text-brand">
                     Help everyone on your team stay in sync with your data.
                 </h2>
                 <div className="mx4">
@@ -20,7 +20,7 @@ export default class WhatsAPulse extends Component {
                         forceOriginalDimensions={false}
                     />
                 </div>
-                <div className="h3 my3 text-centered  text-grey-2 text-bold" style={{maxWidth: "500px"}}>
+                <div className="h3 my3 text-centered text-grey-2 text-bold" style={{maxWidth: "500px"}}>
                     Pulses let you send data from Metabase to email or Slack on the schedule of your choice.
                 </div>
                 {this.props.button}


### PR DESCRIPTION
fixes #4420 

I also took this opportunity to do a bit of cleanup on the pulse modals and start moving them toward the spec @mazameli made in #3701. The main change is a clearer CTA in the setup modal header itself which allows for simpler user role specific content that tries to follow the spec in #3701.

![screen shot 2017-02-21 at 12 55 27 pm](https://cloud.githubusercontent.com/assets/5248953/23184810/14ff1e98-f836-11e6-8575-b6fe4300a386.png)
![screen shot 2017-02-21 at 12 55 24 pm](https://cloud.githubusercontent.com/assets/5248953/23184811/14ff1aec-f836-11e6-946c-138420a776af.png)
