### PR TITLE
Make site-url a normal setting and set automatically via middleware

### DIFF
--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -21,7 +21,7 @@ const SECTIONS = [
                 type: "string"
             },
             {
-                key: "-site-url",
+                key: "site-url",
                 display_name: "Site URL",
                 type: "string"
             },

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -75,14 +75,14 @@
 
 (defendpoint POST "/forgot_password"
   "Send a reset email when user has forgotten their password."
-  [:as {:keys [server-name] {:keys [email]} :body, remote-address :remote-addr, :as request}]
+  [:as {:keys [server-name] {:keys [email]} :body, remote-address :remote-addr}]
   {email su/Email}
   (throttle/check (forgot-password-throttlers :ip-address) remote-address)
   (throttle/check (forgot-password-throttlers :email)      email)
   ;; Don't leak whether the account doesn't exist, just pretend everything is ok
   (when-let [{user-id :id, google-auth? :google_auth} (db/select-one ['User :id :google_auth] :email email, :is_active true)]
     (let [reset-token        (set-user-password-reset-token! user-id)
-          password-reset-url (str (public-settings/site-url request) "/auth/reset_password/" reset-token)]
+          password-reset-url (str (public-settings/site-url) "/auth/reset_password/" reset-token)]
       (email/send-password-reset-email! email google-auth? server-name password-reset-url)
       (log/info password-reset-url))))
 

--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -27,15 +27,13 @@
 (defendpoint POST "/"
   "Special endpoint for creating the first user during setup.
    This endpoint both creates the user AND logs them in and returns a session ID."
-  [:as {{:keys [token] {:keys [name engine details is_full_sync]} :database, {:keys [first_name last_name email password]} :user, {:keys [allow_tracking site_name]} :prefs} :body, :as request}]
+  [:as {{:keys [token] {:keys [name engine details is_full_sync]} :database, {:keys [first_name last_name email password]} :user, {:keys [allow_tracking site_name]} :prefs} :body}]
   {token      SetupToken
    site_name  su/NonBlankString
    first_name su/NonBlankString
    last_name  su/NonBlankString
    email      su/Email
    password   su/ComplexPassword}
-  ;; Call (public-settings/site-url request) to set the Site URL setting if it's not already set
-  (public-settings/site-url request)
   ;; Now create the user
   (let [session-id (str (java.util.UUID/randomUUID))
         new-user   (db/insert! User

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -46,6 +46,7 @@
       mb-middleware/wrap-current-user-id ; looks for :metabase-session-id and sets :metabase-user-id if Session ID is valid
       mb-middleware/wrap-api-key         ; looks for a Metabase API Key on the request and assocs as :metabase-api-key
       mb-middleware/wrap-session-id      ; looks for a Metabase Session ID and assoc as :metabase-session-id
+      mb-middleware/maybe-set-site-url   ; set the value of `site-url` if it hasn't been set yet
       wrap-cookies                       ; Parses cookies in the request map and assocs as :cookies
       wrap-session                       ; reads in current HTTP session and sets :session/key
       wrap-gzip))                        ; GZIP response if client can handle it

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -9,7 +9,7 @@
             [toucan.db :as db]
             (metabase [config :as config]
                       [email :as email])
-            [metabase.models.setting :as setting]
+            [metabase.public-settings :as public-settings]
             [metabase.pulse.render :as render]
             [metabase.util :as u]
             (metabase.util [quotation :as quotation]
@@ -49,7 +49,7 @@
 (defn send-new-user-email!
   "Send an email to INVITIED letting them know INVITOR has invited them to join Metabase."
   [invited invitor join-url]
-  (let [company      (or (setting/get :site-name) "Unknown")
+  (let [company      (or (public-settings/site-name) "Unknown")
         message-body (stencil/render-file "metabase/email/new_user_invite"
                        (merge {:emailType    "new_user_invite"
                                :invitedName  (:first_name invited)
@@ -70,7 +70,7 @@
   "Return a `:recipients` vector for all Admin users."
   []
   (concat (db/select-field :email 'User, :is_superuser true, :is_active true)
-          (when-let [admin-email (setting/get :admin-email)]
+          (when-let [admin-email (public-settings/admin-email)]
             [admin-email])))
 
 (defn send-user-joined-admin-notification-email!
@@ -96,7 +96,7 @@
                             :joinedUserEmail   (:email new-user)
                             :joinedDate        (u/format-date "EEEE, MMMM d") ; e.g. "Wednesday, July 13". TODO - is this what we want?
                             :invitorEmail      invitor-email
-                            :joinedUserEditUrl (str (setting/get :-site-url) "/admin/people")}
+                            :joinedUserEditUrl (str (public-settings/site-url) "/admin/people")}
                            (random-quote-context)))))
 
 

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -6,11 +6,10 @@
                     [models :as models])
             [metabase.email.messages :as email]
             (metabase.models [permissions :as perms]
-                             [permissions-group :as perm-group]
-                             [permissions-group-membership :refer [PermissionsGroupMembership], :as perm-membership]
-                             [setting :as setting])
-            [metabase.util :as u]
-            [metabase.models.permissions-group :as group])
+                             [permissions-group :as group]
+                             [permissions-group-membership :refer [PermissionsGroupMembership], :as perm-membership])
+            [metabase.public-settings :as public-settings]
+            [metabase.util :as u])
   (:import java.util.UUID))
 
 ;;; ------------------------------------------------------------ Entity & Lifecycle ------------------------------------------------------------
@@ -44,12 +43,12 @@
       #_(log/info (format "Adding user %d to All Users permissions group..." user-id))
       (db/insert! PermissionsGroupMembership
         :user_id  user-id
-        :group_id (:id (perm-group/all-users))))
+        :group_id (:id (group/all-users))))
     (when superuser?
       #_(log/info (format "Adding user %d to Admin permissions group..." user-id))
       (db/insert! PermissionsGroupMembership
         :user_id  user-id
-        :group_id (:id (perm-group/admin))))))
+        :group_id (:id (group/admin))))))
 
 (defn- pre-update [{:keys [email reset_token is_superuser id] :as user}]
   ;; when `:is_superuser` is toggled add or remove the user from the 'Admin' group as appropriate
@@ -163,7 +162,7 @@
   "Generate a properly formed password reset url given a password reset token."
   [reset-token]
   {:pre [(string? reset-token)]}
-  (str (setting/get :-site-url) "/auth/reset_password/" reset-token))
+  (str (public-settings/site-url) "/auth/reset_password/" reset-token))
 
 
 ;;; ------------------------------------------------------------ Permissions ------------------------------------------------------------

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -22,12 +22,12 @@
   "The name used for this instance of Metabase."
   :default "Metabase")
 
-(defsetting -site-url
+(defsetting site-url
   "The base URL of this Metabase instance, e.g. \"http://metabase.my-company.com\".
    This is *guaranteed* never to have a tailing slash."
   :setter (fn [new-value]
-            (setting/set-string! :-site-url (when new-value
-                                              (s/replace new-value #"/$" "")))))
+            (setting/set-string! :site-url (when new-value
+                                             (s/replace new-value #"/$" "")))))
 
 (defsetting admin-email
   "The email address users should be referred to if they encounter a problem.")
@@ -40,20 +40,6 @@
 (defsetting map-tile-server-url
   "The map tile server URL template used in map visualizations, for example from OpenStreetMaps or MapBox."
   :default "http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png")
-
-(defn site-url
-  "Fetch the site base URL that should be used for password reset emails, etc.
-   This strips off any trailing slashes that may have been added.
-
-   The first time this function is called, we'll set the value of the setting `-site-url` with the value of
-   the ORIGIN header (falling back to HOST if needed, i.e. for unit tests) of some API request.
-   Subsequently, the site URL can only be changed via the admin page."
-  {:arglists '([request])}
-  [{{:strs [origin host]} :headers}]
-  {:pre  [(or origin host)]
-   :post [(string? %)]}
-  (or (-site-url)
-      (-site-url (or origin host))))
 
 (defsetting enable-public-sharing
   "Enable admins to create publically viewable links for Cards and Dashboards?"

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -164,7 +164,8 @@
   (u/prog1 (params/expand-parameters query)
     (when (and (not *disable-qp-logging*)
                (not= <> query))
-      (log/debug (u/format-color 'cyan "\n\nPARAMS/SUBSTITUTED: %s\n%s" (u/emoji "😻") (u/pprint-to-str (second (data/diff query <>))))))))
+      (when-let [diff (second (data/diff query <>))]
+        (log/debug (u/format-color 'cyan "\n\nPARAMS/SUBSTITUTED: %s\n%s" (u/emoji "😻") (u/pprint-to-str diff)))))))
 
 (defn- pre-substitute-parameters [qp] (comp qp substitute-parameters))
 

--- a/src/metabase/util/embed.clj
+++ b/src/metabase/util/embed.clj
@@ -9,10 +9,10 @@
 
      (oembed-url \"/x\") -> \"http://localhost:3000/api/public/oembed?url=x&format=json\""
   ^String [^String relative-url]
-  (str (public-settings/-site-url)
+  (str (public-settings/site-url)
        "/api/public/oembed"
        ;; NOTE: some oEmbed consumers require `url` be the first param???
-       "?url=" (codec/url-encode (str (public-settings/-site-url) relative-url))
+       "?url=" (codec/url-encode (str (public-settings/site-url) relative-url))
        "&format=json"))
 
 (defn- oembed-link

--- a/src/metabase/util/urls.clj
+++ b/src/metabase/util/urls.clj
@@ -13,25 +13,25 @@
 
      (pulse-url 10) -> \"http://localhost:3000/pulse#10\""
   [^Integer id]
-  (format "%s/pulse#%d" (public-settings/-site-url) id))
+  (format "%s/pulse#%d" (public-settings/site-url) id))
 
 (defn dashboard-url
   "Return an appropriate URL for a `Dashboard` with ID.
 
      (dashboard-url 10) -> \"http://localhost:3000/dash/10\""
   [^Integer id]
-  (format "%s/dash/%d" (public-settings/-site-url) id))
+  (format "%s/dash/%d" (public-settings/site-url) id))
 
 (defn card-url
   "Return an appropriate URL for a `Card` with ID.
 
      (card-url 10) -> \"http://localhost:3000/card/10\""
   [^Integer id]
-  (format "%s/card/%d" (public-settings/-site-url) id))
+  (format "%s/card/%d" (public-settings/site-url) id))
 
 (defn segment-url
   "Return an appropriate URL for a `Segment` with ID.
 
      (segment-url 10) -> \"http://localhost:3000/admin/datamodel/segment/10\""
   [^Integer id]
-  (format "%s/admin/datamodel/segment/%d" (public-settings/-site-url) id))
+  (format "%s/admin/datamodel/segment/%d" (public-settings/site-url) id))

--- a/test/metabase/publc_settings_test.clj
+++ b/test/metabase/publc_settings_test.clj
@@ -3,9 +3,9 @@
             [metabase.public-settings :as public-settings]
             [metabase.test.util :as tu]))
 
-;; double-check that setting the `-site-url` setting will automatically strip off trailing slashes
+;; double-check that setting the `site-url` setting will automatically strip off trailing slashes
 (expect
   "http://localhost:3000"
-  (tu/with-temporary-setting-values [-site-url nil]
-    (public-settings/-site-url "http://localhost:3000/")
-    (public-settings/-site-url)))
+  (tu/with-temporary-setting-values [site-url nil]
+    (public-settings/site-url "http://localhost:3000/")
+    (public-settings/site-url)))

--- a/test_resources/log4j.properties
+++ b/test_resources/log4j.properties
@@ -17,6 +17,7 @@ log4j.appender.file.layout.ConversionPattern=%d [%t] %-5p%c - %m%n
 # customizations to logging by package
 log4j.logger.com.mchange=ERROR
 log4j.logger.metabase=ERROR
-log4j.logger.metabase.test.data.datasets=INFO
+log4j.logger.metabase.middleware=INFO
 log4j.logger.metabase.test-setup=INFO
+log4j.logger.metabase.test.data.datasets=INFO
 log4j.logger.metabase.util.encryption=INFO


### PR DESCRIPTION
Eliminate the somewhat confusing Code Reality(™) where we had a Setting named `-site-url` that you were (ostensibly) supposed to fetch via a function called `site-url` that would set its value if needed. Instead, `site-url` is now just a normal setting, and is set automatically via Ring middleware when unset. yay

Implements #4188 