### PR TITLE
Fix running GA queries as a non-admin user :wrench: [ci drivers]

### DIFF
--- a/src/metabase/query_processor/expand.clj
+++ b/src/metabase/query_processor/expand.clj
@@ -421,7 +421,15 @@
 (def ^:ql ^{:arglists '([rvalue1 rvalue2 & more]), :added "0.17.0"} * "Arithmetic multiplication function." (partial expression-fn :*))
 (def ^:ql ^{:arglists '([rvalue1 rvalue2 & more]), :added "0.17.0"} / "Arithmetic division function."       (partial expression-fn :/))
 
-;;; EXPRESSION PARSING
+;;; Metric & Segment handlers
+
+;; These *do not* expand the normal Metric and Segment macros used in normal queries; that's handled in `metabase.query-processor.macros` before
+;; this namespace ever even sees the query. But since the GA driver's queries consist of custom `metric` and `segment` clauses we need to at least
+;; accept them without barfing so we can expand a query in order to check what permissions it requires.
+;; TODO - in the future, we should just make these functions expand Metric and Segment macros for consistency with the rest of the MBQL clauses
+(defn- ^:ql metric  [& _])
+(defn- ^:ql segment [& _])
+
 
 ;;; # ------------------------------------------------------------ Expansion ------------------------------------------------------------
 

--- a/src/metabase/query_processor/expand.clj
+++ b/src/metabase/query_processor/expand.clj
@@ -427,8 +427,8 @@
 ;; this namespace ever even sees the query. But since the GA driver's queries consist of custom `metric` and `segment` clauses we need to at least
 ;; accept them without barfing so we can expand a query in order to check what permissions it requires.
 ;; TODO - in the future, we should just make these functions expand Metric and Segment macros for consistency with the rest of the MBQL clauses
-(defn- ^:ql metric  [& _])
-(defn- ^:ql segment [& _])
+(defn ^:ql metric  "Placeholder expansion function for GA metric clauses. (This does not expand normal Metric macros; that is done in `metabase.query-processor.macros`.)"   [& _])
+(defn ^:ql segment "Placeholder expansion function for GA segment clauses. (This does not expand normal Segment macros; that is done in `metabase.query-processor.macros`.)" [& _])
 
 
 ;;; # ------------------------------------------------------------ Expansion ------------------------------------------------------------

--- a/src/metabase/query_processor/macros.clj
+++ b/src/metabase/query_processor/macros.clj
@@ -21,7 +21,7 @@
       subclause                                subclause
       form                                     (throw (java.lang.Exception. (format "segment-parse-filter-subclause failed: invalid clause: %s" form))))))
 
-(defn segment-parse-filter [form]
+(defn- segment-parse-filter [form]
   (when (non-empty-clause? form)
     (match form
       ["AND" & subclauses] (into ["AND"] (mapv segment-parse-filter subclauses))

--- a/src/metabase/query_processor/macros.clj
+++ b/src/metabase/query_processor/macros.clj
@@ -12,26 +12,22 @@
            (and (seq clause)
                 (not (every? nil? clause))))))
 
-(defmacro defparser
-  "Convenience for writing a parser function, i.e. one that pattern-matches against a lone argument."
-  [fn-name & match-forms]
-  `(defn ~(vary-meta fn-name assoc :private true) [form#]
-     (when (non-empty-clause? form#)
-       (match form#
-         ~@match-forms
-         form# (throw (Exception. (format ~(format "%s failed: invalid clause: %%s" fn-name) form#)))))))
-
-
 ;;; ------------------------------------------------------------ Segments ------------------------------------------------------------
 
-(defparser segment-parse-filter-subclause
-  ["SEGMENT" (segment-id :guard integer?)] (:filter (db/select-one-field :definition 'Segment, :id segment-id))
-  subclause  subclause)
+(defn- segment-parse-filter-subclause [form]
+  (when (non-empty-clause? form)
+    (match form
+      ["SEGMENT" (segment-id :guard integer?)] (:filter (db/select-one-field :definition 'Segment :id segment-id))
+      subclause                                subclause
+      form                                     (throw (java.lang.Exception. (format "segment-parse-filter-subclause failed: invalid clause: %s" form))))))
 
-(defparser segment-parse-filter
-  ["AND" & subclauses] (into ["AND"] (mapv segment-parse-filter subclauses))
-  ["OR" & subclauses]  (into ["OR"] (mapv segment-parse-filter subclauses))
-  subclause            (segment-parse-filter-subclause subclause))
+(defn segment-parse-filter [form]
+  (when (non-empty-clause? form)
+    (match form
+      ["AND" & subclauses] (into ["AND"] (mapv segment-parse-filter subclauses))
+      ["OR"  & subclauses] (into ["OR"]  (mapv segment-parse-filter subclauses))
+      subclause            (segment-parse-filter-subclause subclause)
+      form                 (throw (java.lang.Exception. (format "segment-parse-filter failed: invalid clause: %s" form))))))
 
 (defn- macroexpand-segment [query-dict]
   (if (non-empty-clause? (get-in query-dict [:query :filter]))


### PR DESCRIPTION
GA queries contain custom non-MBQL clauses (custom metrics and segments) which caused the query parser to fail which meant non-admins weren't allowed to see saved GA questions.

Add some placeholder functions in the Query eXpander code to handle those clauses so things work as expected

Fixes #4156