### PR TITLE
Invite email overhaul :e-mail:

### DIFF
--- a/reset_password/metabase/reset_password/core.clj
+++ b/reset_password/metabase/reset_password/core.clj
@@ -9,7 +9,7 @@
   [email-address]
   (let [user-id (or (db/select-one-id 'User, :email email-address)
                     (throw (Exception. (format "No user found with email address '%s'. Please check the spelling and try again." email-address))))]
-    (user/set-user-password-reset-token! user-id)))
+    (user/set-password-reset-token! user-id)))
 
 (defn -main
   [email-address]

--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -12,7 +12,7 @@
             (metabase.models [database :refer [Database]]
                              [session :refer [Session]]
                              [setting :as setting]
-                             [user :refer [User set-user-password!]])
+                             [user :refer [User], :as user])
             [metabase.public-settings :as public-settings]
             [metabase.setup :as setup]
             [metabase.util :as u]
@@ -43,7 +43,7 @@
                      :password     (str (java.util.UUID/randomUUID))
                      :is_superuser true)]
     ;; this results in a second db call, but it avoids redundant password code so figure it's worth it
-    (set-user-password! (:id new-user) password)
+    (user/set-password! (:id new-user) password)
     ;; set a couple preferences
     (public-settings/site-name site_name)
     (public-settings/admin-email email)

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -47,7 +47,7 @@
     ;; this user already exists but is inactive, so simply reactivate the account
     (reactivate-user! existing-user first_name last_name)
     ;; new user account, so create it
-    (user/create-user! first_name last_name email, :password password, :send-welcome true, :invitor @*current-user*)))
+    (user/invite-user! first_name last_name email password @*current-user*)))
 
 
 (defendpoint GET "/current"
@@ -91,13 +91,14 @@
     ;; regular users have to know their password, however
     (when-not (:is_superuser @*current-user*)
       (checkp (creds/bcrypt-verify (str (:password_salt user) old_password) (:password user)) "old_password" "Invalid password")))
-  (user/set-user-password! id password)
+  (user/set-password! id password)
   ;; return the updated User
   (User id))
 
 
+;; TODO - This could be handled by PUT /api/user/:id, we don't need a separate endpoint
 (defendpoint PUT "/:id/qbnewb"
-  "Indicate that a user has been informed about the vast intricacies of 'the' QueryBuilder."
+  "Indicate that a user has been informed about the vast intricacies of 'the' Query Builder."
   [id]
   (check-self-or-superuser id)
   (check-500 (db/update! User id, :is_qbnewb false))
@@ -109,7 +110,7 @@
   [id]
   (check-superuser)
   (when-let [user (User :id id, :is_active true)]
-    (let [reset-token (user/set-user-password-reset-token! id)
+    (let [reset-token (user/set-password-reset-token! id)
           ;; NOTE: the new user join url is just a password reset with an indicator that this is a first time user
           join-url    (str (user/form-password-reset-url reset-token) "#new")]
       (email/send-new-user-email! user @*current-user* join-url))))
@@ -119,8 +120,7 @@
   "Disable a `User`.  This does not remove the `User` from the DB, but instead disables their account."
   [id]
   (check-superuser)
-  (check-500 (db/update! User id
-               :is_active false))
+  (check-500 (db/update! User id, :is_active false))
   {:success true})
 
 

--- a/src/metabase/email.clj
+++ b/src/metabase/email.clj
@@ -23,8 +23,7 @@
 
 ;; ## PUBLIC INTERFACE
 
-;; TODO - just use `with-redefs` for tests ?
-(def ^:dynamic *send-email-fn*
+(def ^{:arglists '([smtp-credentials email-details]), :style/indent 1} send-email!
   "Internal function used to send messages. Should take 2 args - a map of SMTP credentials, and a map of email details.
    Provided so you can swap this out with an \"inbox\" for test purposes."
   postal/send-message)
@@ -68,19 +67,18 @@
          (contains? #{:text :html :attachments} message-type)
          (if (= message-type :attachments) (sequential? message) (string? message))]}
   (try
-    ;; Check to make sure all valid settings are set!
     (when-not (email-smtp-host)
       (throw (Exception. "SMTP host is not set.")))
     ;; Now send the email
-    (*send-email-fn* (smtp-settings)
-                     {:from    (email-from-address)
-                      :to      recipients
-                      :subject subject
-                      :body    (case message-type
-                                 :attachments message
-                                 :text        message
-                                 :html        [{:type    "text/html; charset=utf-8"
-                                                :content message}])})
+    (send-email! (smtp-settings)
+      {:from    (email-from-address)
+       :to      recipients
+       :subject subject
+       :body    (case message-type
+                  :attachments message
+                  :text        message
+                  :html        [{:type    "text/html; charset=utf-8"
+                                 :content message}])})
     (catch Throwable e
       (log/warn "Failed to send email: " (.getMessage e))
       {:error   :ERROR

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -67,37 +67,35 @@
       :message      message-body)))
 
 (defn- all-admin-recipients
-  "Return a `:recipients` vector for all Admin users."
+  "Return a sequence of email addresses for all Admin users.
+   The first recipient will be the site admin (or oldest admin if unset), which is the address that should be used in `mailto` links
+   (e.g., for the new user to email with any questions)."
   []
-  (concat (db/select-field :email 'User, :is_superuser true, :is_active true)
-          (when-let [admin-email (public-settings/admin-email)]
-            [admin-email])))
+  (concat (when-let [admin-email (public-settings/admin-email)]
+            [admin-email])
+          (db/select-field :email 'User, :is_superuser true, :is_active true, {:order-by [[:id :asc]]})))
 
 (defn send-user-joined-admin-notification-email!
   "Send an email to the INVITOR (the Admin who invited NEW-USER) letting them know NEW-USER has joined."
-  [new-user {invitor-email :email} google-auth?]
-  {:pre [(map? new-user)
-         (m/boolean? google-auth?)
-         (or google-auth?
-             (u/is-email? invitor-email))]}
-  (email/send-message!
-    :subject      (format (if google-auth?
-                            "%s created a Metabase account"
-                            "%s accepted your Metabase invite")
-                          (:common_name new-user))
-    :recipients   (if google-auth?
-                    (all-admin-recipients)
-                    [invitor-email])
-    :message-type :html
-    :message      (stencil/render-file "metabase/email/user_joined_notification"
-                    (merge {:logoHeader        true
-                            :joinedUserName    (:first_name new-user)
-                            :joinedViaSSO      google-auth?
-                            :joinedUserEmail   (:email new-user)
-                            :joinedDate        (u/format-date "EEEE, MMMM d") ; e.g. "Wednesday, July 13". TODO - is this what we want?
-                            :invitorEmail      invitor-email
-                            :joinedUserEditUrl (str (public-settings/site-url) "/admin/people")}
-                           (random-quote-context)))))
+  [new-user & {:keys [google-auth?]}]
+  {:pre [(map? new-user)]}
+  (let [recipients (all-admin-recipients)]
+    (email/send-message!
+      :subject      (format (if google-auth?
+                              "%s created a Metabase account"
+                              "%s accepted their Metabase invite")
+                            (:common_name new-user))
+      :recipients   recipients
+      :message-type :html
+      :message      (stencil/render-file "metabase/email/user_joined_notification"
+                      (merge {:logoHeader        true
+                              :joinedUserName    (:first_name new-user)
+                              :joinedViaSSO      google-auth?
+                              :joinedUserEmail   (:email new-user)
+                              :joinedDate        (u/format-date "EEEE, MMMM d") ; e.g. "Wednesday, July 13". TODO - is this what we want?
+                              :adminEmail        (first recipients)
+                              :joinedUserEditUrl (str (public-settings/site-url) "/admin/people")}
+                             (random-quote-context))))))
 
 
 (defn send-password-reset-email!

--- a/src/metabase/email/user_joined_notification.mustache
+++ b/src/metabase/email/user_joined_notification.mustache
@@ -7,7 +7,7 @@
         {{^joinedViaSSO}}accepted your Metabase invitation.{{/joinedViaSSO}}
       </h2>
       <h4 style="font-weight: normal;">
-        <a style="color: #4A90E2; text-decoration: none;" href="mailto:{{invitorEmail}}">
+        <a style="color: #4A90E2; text-decoration: none;" href="mailto:{{adminEmail}}">
           {{joinedUserEmail}}
         </a>
         joined {{#joinedViaSSO}}via Google Auth{{/joinedViaSSO}} on {{joinedDate}}

--- a/test/metabase/models/user_test.clj
+++ b/test/metabase/models/user_test.clj
@@ -1,8 +1,10 @@
 (ns metabase.models.user-test
-  (:require [expectations :refer :all]
+  (:require [clojure.string :as str]
+            [expectations :refer :all]
             [toucan.db :as db]
             [toucan.util.test :as tt]
             [metabase.email-test :as email-test]
+            [metabase.http-client :as http]
             (metabase.models [permissions :as perms]
                              [permissions-group :refer [PermissionsGroup]]
                              [permissions-group-membership :refer [PermissionsGroupMembership]]
@@ -27,54 +29,107 @@
           (perms/is-permissions-set? (user/permissions-set (user->id :rasta)))))
 
 
-;;; Tests for create-user!
+;;; Tests for invite-user and create-new-google-auth-user!
 
-(defn- create-user-and-check-inbox!
-  "Create user by passing CREATE-USER-ARGS to `create-user!`, and return a set of addresses emails were sent to."
-  [& create-user-args]
-  (email-test/with-fake-inbox
-    (let [email (tu/random-email)]
-      (try
-        (apply user/create-user! (tu/random-name) (tu/random-name) email create-user-args)
-        (set (keys @email-test/inbox))
-        (finally
-          (db/delete! User :email email)))))) ; Clean up after ourselves
+(defn- maybe-accept-invite!
+  "Accept an invite if applicable. Look in the body of the content of the invite email for the reset token
+   since this is the only place to get it (the token stored in the DB is an encrypted hash)."
+  [new-user-email-address]
+  (when-let [[{[{invite-email :content}] :body}] (get @email-test/inbox new-user-email-address)]
+    (let [[_ reset-token] (re-find #"/auth/reset_password/(\d+_[\w_-]+)#new" invite-email)]
+      (http/client :post 200 "session/reset_password" {:token    reset-token
+                                                       :password "ABC123"}))))
+
+(defn sent-emails
+  "Fetch the emails that have been sent in the form of a map of email address -> sequence of email subjects.
+   For test-writing convenience the random email and names assigned to the new user are replaced with `<New User>`."
+  [new-user-email-address new-user-first-name new-user-last-name]
+  (into {} (for [[address emails] @email-test/inbox
+                 :let             [address (if (= address new-user-email-address)
+                                             "<New User>"
+                                             address)]]
+             {address (for [{subject :subject} emails]
+                        (str/replace subject (str new-user-first-name " " new-user-last-name) "<New User>"))})))
+
+
+(defn- invite-user-accept-and-check-inboxes!
+  "Create user by passing INVITE-USER-ARGS to `invite-user!` or `create-new-google-auth-user!`,
+   and return a map of addresses emails were sent to to the email subjects."
+  [& {:keys [google-auth? accept-invite? password invitor]
+      :or   {accept-invite? true}}]
+  (tu/with-temporary-setting-values [site-name "Metabase"]
+    (email-test/with-fake-inbox
+      (let [new-user-email      (tu/random-email)
+            new-user-first-name (tu/random-name)
+            new-user-last-name  (tu/random-name)]
+        (try
+          (if google-auth?
+            (user/create-new-google-auth-user! new-user-first-name new-user-last-name new-user-email)
+            (user/invite-user!                 new-user-first-name new-user-last-name new-user-email password invitor))
+          (when accept-invite?
+            (maybe-accept-invite! new-user-email))
+          (sent-emails new-user-email new-user-first-name new-user-last-name)
+          ;; Clean up after ourselves
+          (finally
+            (db/delete! User :email new-user-email)))))))
+
+
+;; admin shouldn't get email saying user joined until they accept the invite (i.e., reset their password)
+(expect
+  {"<New User>"             ["You're invited to join Metabase's Metabase"]}
+  (do
+    (test-users/delete-temp-users!)
+    (invite-user-accept-and-check-inboxes! :invitor {:email "crowberto@metabase.com", :is_active true}, :accept-invite? false)))
 
 ;; admin should get an email when a new user joins...
 (expect
-  #{"crowberto@metabase.com"}
+  {"<New User>"             ["You're invited to join Metabase's Metabase"]
+   "crowberto@metabase.com" ["<New User> accepted their Metabase invite"]}
   (do
     (test-users/delete-temp-users!)
-    (create-user-and-check-inbox! :invitor {:email "crowberto@metabase.com", :is_active true})))
-
-;; ... but if that admin is inactive they shouldn't get an email
-(expect
-  #{}
-  (do
-    (test-users/delete-temp-users!)
-    (tt/with-temp User [inactive-admin {:is_superuser true, :is_active false}]
-      (create-user-and-check-inbox! :invitor (assoc inactive-admin :is_active false)))))
-
-;; for google auth, all admins should get an email...
-(expect
-  #{"crowberto@metabase.com" "some_other_admin@metabase.com"}
-  (do
-    (test-users/delete-temp-users!)
-    (tt/with-temp User [_ {:is_superuser true, :email "some_other_admin@metabase.com"}]
-      (create-user-and-check-inbox! :google-auth? true))))
+    (invite-user-accept-and-check-inboxes! :invitor {:email "crowberto@metabase.com", :is_active true})))
 
 ;; ...including the site admin if it is set...
 (expect
-  #{"crowberto@metabase.com" "some_other_admin@metabase.com" "cam@metabase.com"}
+  {"<New User>"             ["You're invited to join Metabase's Metabase"]
+   "crowberto@metabase.com" ["<New User> accepted their Metabase invite"]
+   "cam@metabase.com"       ["<New User> accepted their Metabase invite"]}
+  (tu/with-temporary-setting-values [admin-email "cam@metabase.com"]
+    (test-users/delete-temp-users!)
+    (invite-user-accept-and-check-inboxes! :invitor {:email "crowberto@metabase.com", :is_active true})))
+
+;; ... but if that admin is inactive they shouldn't get an email
+(expect
+  {"<New User>"             ["You're invited to join Metabase's Metabase"]
+   "crowberto@metabase.com" ["<New User> accepted their Metabase invite"]}
+  (do
+    (test-users/delete-temp-users!)
+    (tt/with-temp User [inactive-admin {:is_superuser true, :is_active false}]
+      (invite-user-accept-and-check-inboxes! :invitor (assoc inactive-admin :is_active false)))))
+
+;; for google auth, all admins should get an email...
+(expect
+  {"crowberto@metabase.com"        ["<New User> created a Metabase account"]
+   "some_other_admin@metabase.com" ["<New User> created a Metabase account"]}
+  (do
+    (test-users/delete-temp-users!)
+    (tt/with-temp User [_ {:is_superuser true, :email "some_other_admin@metabase.com"}]
+      (invite-user-accept-and-check-inboxes! :google-auth? true))))
+
+;; ...including the site admin if it is set...
+(expect
+  {"crowberto@metabase.com"        ["<New User> created a Metabase account"]
+   "some_other_admin@metabase.com" ["<New User> created a Metabase account"]
+   "cam@metabase.com"              ["<New User> created a Metabase account"]}
   (tu/with-temporary-setting-values [admin-email "cam@metabase.com"]
     (test-users/delete-temp-users!)
     (tt/with-temp User [_ {:is_superuser true, :email "some_other_admin@metabase.com"}]
-      (create-user-and-check-inbox! :google-auth? true))))
+      (invite-user-accept-and-check-inboxes! :google-auth? true))))
 
 ;; ...unless they are inactive
 (expect
-  #{"crowberto@metabase.com"}
+  {"crowberto@metabase.com" ["<New User> created a Metabase account"]}
   (do
     (test-users/delete-temp-users!)
     (tt/with-temp User [_ {:is_superuser true, :is_active false}]
-      (create-user-and-check-inbox! :google-auth? true))))
+      (invite-user-accept-and-check-inboxes! :google-auth? true))))


### PR DESCRIPTION
A rework of the invite email code that fixes some embarrassing problems like admins getting "[New User] has accepted your invitation" emails as soon as they are invited. Add lots of additional tests, including ones that make sure you can use the `reset_password` link you get in an email (the tests actually parse the email to get the link and test it)

Fixes #3356