### PR TITLE
wip: introspection tidy

### DIFF
--- a/resources/migrations/50_add_raw_column_position.yaml
+++ b/resources/migrations/50_add_raw_column_position.yaml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: 50
+      author: lstevens
+      changes:
+        - addColumn:
+            tableName: raw_column
+            columns:
+              - column:
+                  name: ordinal_position
+                  type: int
+                  remarks: 'Column position within a table, as reported by JDBC driver.'

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -213,7 +213,7 @@
 (defn update-field-from-field-def!
   "Update an EXISTING-FIELD from the given FIELD-DEF."
   {:arglists '([existing-field field-def])}
-  [{:keys [id], :as existing-field} {field-name :name, :keys [base-type special-type pk? parent-id]}]
+  [{:keys [id], :as existing-field} {field-name :name, :keys [base-type special-type pk? parent-id ordinal_position]}]
   (u/prog1 (assoc existing-field
              :base_type    base-type
              :display_name (or (:display_name existing-field)
@@ -223,20 +223,21 @@
                                (when pk?
                                  :type/PK)
                                (infer-field-special-type field-name base-type))
-
-             :parent_id    parent-id)
+             :parent_id    parent-id
+             :position     (or ordinal_position 0))
     ;; if we have a different base-type or special-type, then update
     (when (first (d/diff <> existing-field))
       (db/update! Field id
         :display_name (:display_name <>)
         :base_type    base-type
         :special_type (:special_type <>)
-        :parent_id    parent-id))))
+        :parent_id    parent-id
+        :position     (:position <>)))))
 
 (defn create-field-from-field-def!
   "Create a new `Field` from the given FIELD-DEF."
   {:arglists '([table-id field-def])}
-  [table-id {field-name :name, :keys [base-type special-type pk? parent-id raw-column-id]}]
+  [table-id {field-name :name, :keys [base-type special-type pk? parent-id raw-column-id ordinal_position]}]
   {:pre [(integer? table-id) (string? field-name) (isa? base-type :type/*)]}
   (let [special-type (or special-type
                        (when pk? :type/PK)
@@ -248,4 +249,5 @@
       :display_name  (humanization/name->human-readable-name field-name)
       :base_type     base-type
       :special_type  special-type
-      :parent_id     parent-id)))
+      :parent_id     parent-id
+      :position      (or ordinal_position 0))))

--- a/src/metabase/sync_database/interface.clj
+++ b/src/metabase/sync_database/interface.clj
@@ -25,6 +25,7 @@
    (s/optional-key :special-type)  su/FieldType
    (s/optional-key :pk?)           s/Bool
    (s/optional-key :nested-fields) #{(s/recursive #'DescribeTableField)}
+   (s/optional-key :position)      s/Int
    (s/optional-key :custom)        {s/Any s/Any}})
 
 (def DescribeTable

--- a/src/metabase/sync_database/introspect.clj
+++ b/src/metabase/sync_database/introspect.clj
@@ -50,7 +50,7 @@
           (db/update! RawColumn column-id, :active false)))
 
       ;; insert or update the remaining columns
-      (doseq [{column-name :name, :keys [base-type pk? special-type details]} (sort-by :name columns)]
+      (doseq [{column-name :name, :keys [base-type pk? special-type details position]} (sort-by (or :position :name) columns)]
         (let [details (merge (or details {})
                              {:base-type base-type}
                              (when special-type {:special-type special-type}))
@@ -61,14 +61,16 @@
               :name    column-name
               :is_pk   is_pk
               :details details
-              :active  true)
+              :active  true
+              :ordinal_position position)
             ;; must be a new column, insert it
             (db/insert! RawColumn
               :raw_table_id id
               :name         column-name
               :is_pk        is_pk
               :details      details
-              :active       true)))))))
+              :active       true
+              :ordinal_position position)))))))
 
 (defn- create-raw-table!
   "Create a new `RawTable`, includes saving all specified `:columns`."

--- a/src/metabase/sync_database/sync.clj
+++ b/src/metabase/sync_database/sync.clj
@@ -86,7 +86,7 @@
                            :set   {:visibility_type "retired"}})))
 
     ;; create/update the active columns
-    (doseq [{raw-column-id :id, :keys [details], :as column} active-raw-columns]
+    (doseq [{raw-column-id :id, :keys [details ordinal_position], :as column} (sort-by :ordinal_position active-raw-columns)]
       ;; do a little bit of key renaming to match what's expected for a call to update/create-field
       (let [column (-> (set/rename-keys column {:id    :raw-column-id
                                                 :is_pk :pk?})


### PR DESCRIPTION
PR is incomplete (see below) but I wanted to get feedback on whether these changes are things that are generally agreeable in terms of the design and content, and/or what should be changed.

The changes follow on from my comment on #4329, where I noticed that the order of columns is different between the UI areas: Data Model, Data Reference, and Query Builder. This PR updates the introspection workflow to keep the original column order the same in all places. 

While I was working on the above, I also addressed another introspection issue (for me, anyway) where all objects would be catalogued and considered "queryable", without checking whether the database connection provided permissions for querying the object. I think if an object exists but can't be queried then it should be completely ignored. Sadly, the JDBC function for this kind of thing called  `getTablePermissions` strictly only considers tables (not views, matviews, foreign tables, etc), so to check this I'm doing a `try count(*) / catch` and filtering out `nil` (empty objects return `count(*)` = zero). It's a raw query since I couldn't see how to use the existing `table-row-count` function, which expects a table-id from an already-catalogued object, and I didn't understand the underlying query processor pipeline calls to use them instead.

Lastly, while doing the above, I noticed that the Postgres driver has a custom implementation of `describe-database` in order to discover Materialized Views. The need for this can be avoided by adding the table type to the getMetadata call in the generic implementation.

To state all this in other words, as described in the commit message:
- add ordinal_position column to raw_column model, because otherwise this info is lost (metabase_field is generated from raw_column)
- add insertion of ordinal_position to existing metabase_field.position field (instead of default zero)
- add sorting of rows by (ordinal_)position pre-insertion to both raw_column and metabase_field, so that data reference UI displays them in correct order (actually sorted by ID)
- add materialized views to the TableType filter list in getTables metadata call, which avoids need for custom matview lookup in postgres driver
- add filtering of database relations found via getTables that aren't queryable (select count(*) is nil, e.g. due to no SELECT permission)

**Incomplete?**
By "PR is incomplete", I mean that these changes broke a few tests, and it's missing tests for the introduced functionality. The broken tests are of the type where a specific tuple is expected but now the tuple content doesn't match, e.g. `metabase_field` tests expecting `position` to always be zero, but now it may be non-zero; or `raw_column` tests not expecting a tuple that doesn't include the new `ordinal_position` field key or value.


###### TODO 
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
