### PR TITLE
Make preinstall work with busybox (fixes docker build)

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "build-hot": "NODE_ENV=hot webpack --bail && NODE_ENV=hot webpack-dev-server --progress",
     "start": "yarn run build && lein ring server",
     "storybook": "start-storybook -p 9001",
-    "preinstall": "ps -fp $PPID | grep -q yarn || echo '\\033[0;33mSorry, npm is not supported. Please use Yarn (https://yarnpkg.com/).\\033[0m'",
+    "preinstall": "ps -o ppid,comm | grep -q \"^\\\\s*$PPID\\ yarn\" || echo '\\033[0;33mSorry, npm is not supported. Please use Yarn (https://yarnpkg.com/).\\033[0m'",
     "test-jest": "jest"
   },
   "jest": {


### PR DESCRIPTION
When building a docker image, it failed because `ps` didn't accept the options in the _preinstall_ step.
This change allows it to work there too.

(a [failed](https://hub.docker.com/r/questionmark/metabase/builds/bcvesdvqq5xqqxpgtgvrx4/) and [succeeded](https://hub.docker.com/r/questionmark/metabase/builds/btmqtah37ywrdenmasvdvdd/) build)