### PR TITLE
Make preinstall work again (fixes docker build)

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "build-hot": "NODE_ENV=hot webpack --bail && NODE_ENV=hot webpack-dev-server --progress",
     "start": "yarn run build && lein ring server",
     "storybook": "start-storybook -p 9001",
-    "preinstall": "ps -fp $PPID | grep -q yarn || echo '\\033[0;33mSorry, npm is not supported. Please use Yarn (https://yarnpkg.com/).\\033[0m'",
+    "preinstall": "echo $npm_execpath | grep -q yarn || echo '\\033[0;33mSorry, npm is not supported. Please use Yarn (https://yarnpkg.com/).\\033[0m'",
     "test-jest": "jest"
   },
   "jest": {


### PR DESCRIPTION
Building the Docker image failed because Busybox doesn't support the `ps` argument used in `preinstall`.

Also, the yarn check always failed actually, because `$PPID` is the shell, not yarn. This fixed both.

(a [failed](https://hub.docker.com/r/questionmark/metabase/builds/bcvesdvqq5xqqxpgtgvrx4/) and [succeeded](https://hub.docker.com/r/questionmark/metabase/builds/bpalurhcaukfsdevgywflkk/) build)