### PR TITLE
Embedding usage stats

### DIFF
--- a/src/metabase/util/stats.clj
+++ b/src/metabase/util/stats.clj
@@ -161,26 +161,56 @@
   []
   {:groups (db/count PermissionsGroup)})
 
+(defn- card-has-params? [card]
+  (boolean (get-in card [:dataset_query :native :template_tags])))
+
 (defn- question-metrics
   "Get metrics based on questions
   TODO characterize by # executions and avg latency"
   []
-  {:questions (merge-count-maps (for [{query-type :query_type} (db/select [Card :query_type])]
-                                  (let [native? (= (keyword query-type) :native)]
-                                    {:total  1
-                                     :native native?
-                                     :gui    (not native?)})))})
+  (let [cards (db/select [Card :query_type :public_uuid :enable_embedding :embedding_params :dataset_query])]
+    {:questions (merge-count-maps (for [card cards]
+                                    (let [native? (= (keyword (:query_type card)) :native)]
+                                      {:total       1
+                                       :native      native?
+                                       :gui         (not native?)
+                                       :with_params (card-has-params? card)})))
+     :public    (merge-count-maps (for [card  cards
+                                        :when (:public_uuid card)]
+                                    {:total       1
+                                     :with_params (card-has-params? card)}))
+     :embedded  (merge-count-maps (for [card  cards
+                                        :when (:enable_embedding card)]
+                                    (let [embedding-params-vals (set (vals (:embedding_params card)))]
+                                      {:total                1
+                                       :with_params          (card-has-params? card)
+                                       :with_enabled_params  (contains? embedding-params-vals "enabled")
+                                       :with_locked_params   (contains? embedding-params-vals "locked")
+                                       :with_disabled_params (contains? embedding-params-vals "disabled")})))}))
 
 (defn- dashboard-metrics
   "Get metrics based on dashboards
   TODO characterize by # of revisions, and created by an admin"
   []
-  (let [dashboards (db/select [Dashboard :creator_id])
+  (let [dashboards (db/select [Dashboard :creator_id :public_uuid :parameters :enable_embedding :embedding_params])
         dashcards  (db/select [DashboardCard :card_id :dashboard_id])]
     {:dashboards         (count dashboards)
+     :with_params        (count (filter (comp seq :parameters) dashboards))
      :num_dashs_per_user (medium-histogram dashboards :creator_id)
      :num_cards_per_dash (medium-histogram dashcards :dashboard_id)
-     :num_dashs_per_card (medium-histogram dashcards :card_id)}))
+     :num_dashs_per_card (medium-histogram dashcards :card_id)
+     :public             (merge-count-maps (for [dash  dashboards
+                                                 :when (:public_uuid dash)]
+                                             {:total       1
+                                              :with_params (seq (:parameters dash))}))
+     :embedded           (merge-count-maps (for [dash  dashboards
+                                                 :when (:enable_embedding dash)]
+                                             (let [embedding-params-vals (set (vals (:embedding_params dash)))]
+                                               {:total                1
+                                                :with_params          (seq (:parameters dash))
+                                                :with_enabled_params  (contains? embedding-params-vals "enabled")
+                                                :with_locked_params   (contains? embedding-params-vals "locked")
+                                                :with_disabled_params (contains? embedding-params-vals "disabled")})))}))
 
 (defn- pulse-metrics
   "Get mes based on pulses


### PR DESCRIPTION
Implements #4521

I added a few extra things as well, like whether normal Cards & Dashboards have params

@salsakran take a look, here's the format I came up with (example results from my computer)

let me know if that works for you

```clojure
{:slack_configured false,
 :report_timezone nil,
 :running_on :unknown,
 :friendly_names true,
 :check_for_updates true,
 :site_name true,
 :has_sample_data true,
 :application_database "postgres",
 :email_configured false,
 :instance_started #inst "2016-12-07T21:31:18.466000000-00:00",
 :sso_configured false,
 :uuid 1042520891,
 :version "v0.23.0-snapshot",
 :timestamp #inst "2017-03-15T21:45:24.784-00:00",
 :stats
 {:execution
  {:executions 87, :by_status {:completed 86, :failed 1}, :num_per_user {"51-250" 1, "1-10" 1}, :num_by_latency {"1-10" 1, "< 1" 86}},
  :group {:groups 3},
  :table {:tables 12, :num_per_database {"1-5" 3}, :num_per_schema {"1-5" 1, "6-10" 1}},
  :question
  {:questions {:total 4, :native 1, :gui 3, :with_params 1},
   :public {:total 1, :with_params 0},
   :embedded {:total 1, :with_params 0, :with_enabled_params 0, :with_locked_params 0, :with_disabled_params 1}},
  :dashboard
  {:dashboards 4,
   :with_params 2,
   :num_dashs_per_user {"1-5" 1},
   :num_cards_per_dash {"1-5" 2},
   :num_dashs_per_card {"1-5" 3},
   :public {:total 1, :with_params 1},
   :embedded {:total 1, :with_params 1, :with_enabled_params 0, :with_locked_params 0, :with_disabled_params 1}},
  :field {:fields 66, :num_per_table {"1-5" 6, "6-10" 5, "11-25" 1}},
  :segment {:segments 0},
  :label {:labels 0, :num_labels_per_card {}, :num_cards_per_label {}},
  :pulse
  {:pulses 0, :pulse_types {}, :pulse_schedules {}, :num_pulses_per_user {}, :num_pulses_per_card {}, :num_cards_per_pulses {}},
  :database {:databases {:total 3, :analyzed 3}},
  :collection {:collections 0, :cards_in_collections 0, :cards_not_in_collections 4, :num_cards_per_collection {"1-5" 1}},
  :user {:users {:total 4, :active 3, :admin 1, :logged_in 2, :sso 0}},
  :metric {:metrics 0}}}
```
