### PR TITLE
Fix QueryExecution data migration :wrench:

### DIFF
--- a/src/metabase/db/migrations.clj
+++ b/src/metabase/db/migrations.clj
@@ -361,10 +361,11 @@
 (defmigration ^{:author "camsaul", :added "0.23.0"} migrate-query-executions
   ;; migrate the most recent 100,000 entries
   ;; make sure the DB doesn't get snippy by trying to insert too many records at once. Divide the INSERT statements into chunks of 1,000
-  (doseq [chunk (partition-all 1000 (db/select LegacyQueryExecution {:limit 100000, :order-by [[:id :desc]]}))]
-    (db/insert-many! QueryExecution
-      (for [query-execution chunk]
-        (LegacyQueryExecution->QueryExecution query-execution)))))
+  (binding [query-execution/*validate-context* false]
+    (doseq [chunk (partition-all 1000 (db/select LegacyQueryExecution {:limit 100000, :order-by [[:id :desc]]}))]
+      (db/insert-many! QueryExecution
+        (for [query-execution chunk]
+          (LegacyQueryExecution->QueryExecution query-execution))))))
 
 ;; drop the legacy QueryExecution table now that we don't need it anymore
 (defmigration ^{:author "camsaul", :added "0.23.0"} drop-old-query-execution-table

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -23,9 +23,8 @@
 
 (defn- post-select [{:keys [engine] :as database}]
   (if-not engine database
-          (assoc database :features (or (when-let [driver ((resolve 'metabase.driver/engine->driver) engine)]
-                                          (seq ((resolve 'metabase.driver/features) driver)))
-                                        []))))
+          (assoc database :features (set (when-let [driver ((resolve 'metabase.driver/engine->driver) engine)]
+                                           ((resolve 'metabase.driver/features) driver))))))
 
 (defn- pre-delete [{:keys [id]}]
   (db/delete! 'Card        :database_id id)

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -93,7 +93,7 @@
      :description        nil
      :caveats            nil
      :points_of_interest nil
-     :features           (vec (driver/features (driver/engine->driver :postgres)))})
+     :features           (driver/features (driver/engine->driver :postgres))})
   (Database (:id db)))
 
 


### PR DESCRIPTION
Add the line of code switching off validation for the value of the `:context` column back to the QueryExecution migration code (it was there originally, but I accidentally deleted it earlier)