### PR TITLE
Make sure to de-CLOB-er the error message for H2 legacy query executions

### DIFF
--- a/src/metabase/db/migrations.clj
+++ b/src/metabase/db/migrations.clj
@@ -343,7 +343,7 @@
   models/IModel
   (merge models/IModelDefaults
          {:default-fields (constantly [:executor_id :result_rows :started_at :json_query :error :running_time])
-          :types          (constantly {:json_query :json})}))
+          :types          (constantly {:json_query :json, :error :clob})}))
 
 (defn- LegacyQueryExecution->QueryExecution
   "Convert a LegacyQueryExecution to a format suitable for insertion as a new-format QueryExecution."


### PR DESCRIPTION
Fix issue discovered by @mazameli 

QueryExecution migrations weren't working for H2 since the error column was being returned as a CLOB instead of a String like Postgres and MySQL.