### PR TITLE
Catch and surface Pulse channel errors

### DIFF
--- a/frontend/src/metabase/pulse/components/PulseEditChannels.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEditChannels.jsx
@@ -160,6 +160,9 @@ export default class PulseEditChannels extends Component {
         let isValid = this.props.pulseIsValid && channelIsValid(channel, channelSpec);
         return (
             <li key={index} className="py2">
+                { channelSpec.error &&
+                    <div className="pb2 text-bold text-error">{channelSpec.error}</div>
+                }
                 { channelSpec.recipients &&
                     <div>
                         <div className="h4 text-bold mb1">To:</div>

--- a/src/metabase/api/pulse.clj
+++ b/src/metabase/api/pulse.clj
@@ -86,12 +86,14 @@
                  ;; no Slack integration, so we are g2g
                  chan-types
                  ;; if we have Slack enabled build a dynamic list of channels/users
-                 (let [slack-channels (for [channel (slack/channels-list)]
-                                        (str \# (:name channel)))
-                       slack-users    (for [user (slack/users-list)]
-                                        (str \@ (:name user)))]
-                   (assoc-in chan-types [:slack :fields 0 :options] (concat slack-channels slack-users))))}))
-
+                 (try
+                   (let [slack-channels (for [channel (slack/channels-list)]
+                                          (str \# (:name channel)))
+                         slack-users    (for [user (slack/users-list)]
+                                          (str \@ (:name user)))]
+                     (assoc-in chan-types [:slack :fields 0 :options] (concat slack-channels slack-users)))
+                   (catch Throwable e
+                     (assoc-in chan-types [:slack :error] (.getMessage e)))))}))
 
 (defendpoint GET "/preview_card/:id"
   "Get HTML rendering of a `Card` with ID."


### PR DESCRIPTION
Resolves #3016

This catches errors when hitting the Slack API to get the channel/user listing, which fixes the referenced issue, and also surfaces the error in the UI.

I did the simplest treatment possible but open to suggestions:

![screenshot 2017-03-21 17 44 28](https://cloud.githubusercontent.com/assets/18193/24177194/0f63f2e0-0e5e-11e7-9f09-53b3e298bdc6.png)
