### PR TITLE
Use kmeans to automatically group map data

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "reselect": "^2.0.1",
     "resize-observer-polyfill": "^1.3.2",
     "screenfull": "^3.0.0",
+    "simple-statistics": "^2.5.0",
     "stack-source-map": "^1.0.4",
     "tether": "^1.2.0",
     "underscore": "^1.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7120,6 +7120,10 @@ signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
+simple-statistics@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/simple-statistics/-/simple-statistics-2.5.0.tgz#7cd77b04288402f17fe21fd2b63c5e1a51ef3f51"
+
 simple-swizzle@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"


### PR DESCRIPTION
See http://roadtolarissa.com/coloring-maps/ and
http://bl.ocks.org/thadk/37ff4c03358b414acd1e for some background research / example of the different implementations.

Problem I'm trying to solve:
When trying to put onto a map values that are heavily skewed, the map view's colors end up being completely useless. After doing some research, I found that a common solution to this problem is to use [Jenks Natural Breaks Optimization](https://en.wikipedia.org/wiki/Jenks_natural_breaks_optimization) or a k-means solution. I went with the library [simple-statistics](https://github.com/simple-statistics/simple-statistics) to calculate this, due to it's permissive license and efficiency.

Please note the following rendered maps for the table:

```
account_state,sum
AK,66
AL,67
AR,95
AZ,335
CA,4376
CO,71
CT,145
FL,669
GA,140
ID,356
IL,165
IN,369
KS,732
LA,330
MA,70
MD,15
ME,287
MI,182
MN,64
MS,189
MT,48
NC,23
ND,69
NE,55
NH,53
NM,31
NY,126
OH,6
OK,43
OR,610
PA,16
TN,53
TX,54
UT,37
VA,22
VT,197
WA,449
WI,221
WY,21
```

current metabase map using quantize:
![quantize](https://cloud.githubusercontent.com/assets/1134611/24224163/e0721c0a-0f16-11e7-9f01-d2e74c916d94.png)

new map using kmeans:
![kmeans-fixed-data](https://cloud.githubusercontent.com/assets/1134611/24224500/b131bfd4-0f18-11e7-9d32-2f9388a7cd9c.png)


###### TODO 
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
