### PR TITLE
Fix running JAR on Java 7 [ci skip]

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
                  [amalloy/ring-gzip-middleware "0.1.3"]               ; Ring middleware to GZIP responses if client can handle it
                  [aleph "0.4.1"]                                      ; Async HTTP library; WebSockets
                  [buddy/buddy-core "1.2.0"]                           ; various cryptograhpic functions
-                 [buddy/buddy-sign "1.1.0"]                           ; JSON Web Tokens; High-Level message signing library
+                 [buddy/buddy-sign "1.5.0"]                           ; JSON Web Tokens; High-Level message signing library
                  [cheshire "5.7.0"]                                   ; fast JSON encoding (used by Ring JSON middleware)
                  [clj-http "3.4.1"                                    ; HTTP client
                   :exclusions [commons-codec


### PR DESCRIPTION
Fixed by upgrading to new version of `buddy-sign` incorporating fix I submitted yesterday.
Confirmed that JAR built with JDK 8 now runs on JRE 7 as expected.

Fixes #4586