### PR TITLE
Add a histogram for latitude/longitude type fields [WIP]

### DIFF
--- a/resources/migrations/052_add_min_max_to_fields.yaml
+++ b/resources/migrations/052_add_min_max_to_fields.yaml
@@ -1,0 +1,21 @@
+databaseChangeLog:
+  - changeSet:
+      id: 52
+      author: senior
+      changes:
+        - addColumn:
+            tableName: metabase_field
+            columns:
+              - column:
+                  name: min_value
+                  type: float
+                  constraints:
+                    nullable: true
+        - addColumn:
+            tableName: metabase_field
+            columns:
+              - column:
+                  name: max_value
+                  type: float
+                  constraints:
+                    nullable: true

--- a/src/metabase/db/metadata_queries.clj
+++ b/src/metabase/db/metadata_queries.clj
@@ -53,3 +53,11 @@
   [{field-id :id :as field}]
   (-> (field-query field (ql/aggregation {} (ql/count (ql/field-id field-id))))
       first first int))
+
+(defn field-max-min
+  "Returns a pair [max min] for the given `field`"
+  [{field-id :id :as field}]
+  (->> (field-query field (ql/aggregation {} [(ql/min (ql/field-id field-id))
+                                              (ql/max (ql/field-id field-id))]))
+       first
+       (map int)))

--- a/src/metabase/query_processor/interface.clj
+++ b/src/metabase/query_processor/interface.clj
@@ -88,7 +88,9 @@
                     description        :- (s/maybe su/NonBlankString)
                     parent-id          :- (s/maybe su/IntGreaterThanZero)
                     ;; Field once its resolved; FieldPlaceholder before that
-                    parent             :- s/Any]
+                    parent             :- s/Any
+                    min-value          :- (s/maybe s/Num)
+                    max-value          :- (s/maybe s/Num)]
   clojure.lang.Named
   (getName [_] field-name) ; (name <field>) returns the *unqualified* name of the field, #obvi
 

--- a/src/metabase/query_processor/resolve.clj
+++ b/src/metabase/query_processor/resolve.clj
@@ -33,7 +33,9 @@
                                     :visibility_type :visibility-type
                                     :base_type       :base-type
                                     :table_id        :table-id
-                                    :parent_id       :parent-id}))
+                                    :parent_id       :parent-id
+                                    :min_value       :min-value
+                                    :max_value       :max-value}))
 
 ;;; # ------------------------------------------------------------ IRESOLVE PROTOCOL ------------------------------------------------------------
 
@@ -197,7 +199,7 @@
         ;; If there are no more Field IDs to resolve we're done.
         expanded-query-dict
         ;; Otherwise fetch + resolve the Fields in question
-        (let [fields (->> (u/key-by :id (db/select [field/Field :name :display_name :base_type :special_type :visibility_type :table_id :parent_id :description :id]
+        (let [fields (->> (u/key-by :id (db/select [field/Field :name :display_name :base_type :special_type :visibility_type :table_id :parent_id :description :id :max_value :min_value]
                                           :visibility_type [:not= "sensitive"]
                                           :id [:in field-ids]))
                           (m/map-vals rename-mb-field-keys)

--- a/src/metabase/sync_database/interface.clj
+++ b/src/metabase/sync_database/interface.clj
@@ -11,7 +11,9 @@
    (s/optional-key :fields)    [{:id                               su/IntGreaterThanZero
                                  (s/optional-key :special-type)    su/FieldType
                                  (s/optional-key :preview-display) s/Bool
-                                 (s/optional-key :values)          [s/Any]}]})
+                                 (s/optional-key :values)          [s/Any]
+                                 (s/optional-key :min-value)       s/Num
+                                 (s/optional-key :max-value)       s/Num}]})
 
 (def DescribeDatabase
   "Schema for the expected output of `describe-database`."

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -274,7 +274,9 @@
                                                        :visibility_type    "normal"
                                                        :fk_target_field_id $
                                                        :parent_id          nil
-                                                       :values             $})
+                                                       :values             $
+                                                       :min_value          nil
+                                                       :max_value          nil})
                                                     (match-$ (hydrate/hydrate (Field (id :categories :name)) :values)
                                                       {:description        nil
                                                        :table_id           (id :categories)
@@ -296,7 +298,9 @@
                                                        :visibility_type    "normal"
                                                        :fk_target_field_id $
                                                        :parent_id          nil
-                                                       :values             $})]
+                                                       :values             $
+                                                       :min_value          nil
+                                                       :max_value          nil})]
                           :segments                []
                           :metrics                 []
                           :rows                    75

--- a/test/metabase/api/field_test.clj
+++ b/test/metabase/api/field_test.clj
@@ -68,7 +68,9 @@
      :created_at         $
      :base_type          "type/Text"
      :fk_target_field_id nil
-     :parent_id          nil})
+     :parent_id          nil
+     :min_value          nil
+     :max_value          nil})
   ((user->client :rasta) :get 200 (format "field/%d" (id :users :name))))
 
 

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -70,7 +70,9 @@
    :visibility_type    "normal"
    :caveats            nil
    :points_of_interest nil
-   :parent_id          nil})
+   :parent_id          nil
+   :min_value          nil
+   :max_value          nil})
 
 
 ;; ## GET /api/table

--- a/test/metabase/driver/generic_sql_test.clj
+++ b/test/metabase/driver/generic_sql_test.clj
@@ -73,8 +73,12 @@
   {:row_count 100,
    :fields    [{:id (id :venues :category_id)}
                {:id (id :venues :id)}
-               {:id (id :venues :latitude)}
-               {:id (id :venues :longitude)}
+               {:id (id :venues :latitude)
+                :min-value 10, :max-value 40
+                :special-type :type/Latitude}
+               {:id (id :venues :longitude)
+                :min-value -165, :max-value -73
+                :special-type :type/Longitude}
                {:id (id :venues :name), :values (db/select-one-field :values 'FieldValues, :field_id (id :venues :name))}
                {:id (id :venues :price), :values [1 2 3 4]}]}
   (driver/analyze-table (H2Driver.) @venues-table (set (mapv :id (table/fields @venues-table)))))

--- a/test/metabase/query_processor/expand_resolve_test.clj
+++ b/test/metabase/query_processor/expand_resolve_test.clj
@@ -54,7 +54,9 @@
                                                 :position           nil
                                                 :description        nil
                                                 :parent-id          nil
-                                                :parent             nil}
+                                                :parent             nil
+                                                :min-value          nil
+                                                :max-value          nil}
                                   :value       {:value 1
                                                 :field {:field-id           (id :venues :price)
                                                         :fk-field-id        nil
@@ -69,12 +71,14 @@
                                                         :position           nil
                                                         :description        nil
                                                         :parent-id          nil
-                                                        :parent             nil}}}
+                                                        :parent             nil
+                                                        :min-value          nil
+                                                        :max-value          nil}}}
                    :join-tables  nil}
     :fk-field-ids #{}
     :table-ids    #{(id :venues)}}]
   (let [expanded-form (ql/expand (wrap-inner-query (query venues
-                                                        (ql/filter (ql/and (ql/> $price 1))))))]
+                                                          (ql/filter (ql/and (ql/> $price 1))))))]
     (mapv obj->map [expanded-form
                     (resolve/resolve expanded-form)])))
 
@@ -113,7 +117,9 @@
                                                 :position           nil
                                                 :description        nil
                                                 :parent-id          nil
-                                                :parent             nil}
+                                                :parent             nil
+                                                :min-value          nil
+                                                :max-value          nil}
                                   :value       {:value "abc"
                                                 :field {:field-id           (id :categories :name)
                                                         :fk-field-id        (id :venues :category_id)
@@ -128,7 +134,9 @@
                                                         :position           nil
                                                         :description        nil
                                                         :parent-id          nil
-                                                        :parent             nil}}}
+                                                        :parent             nil
+                                                        :min-value          nil
+                                                        :max-value          nil}}}
                    :join-tables  [{:source-field {:field-id   (id :venues :category_id)
                                                   :field-name "CATEGORY_ID"}
                                    :pk-field     {:field-id   (id :categories :id)
@@ -140,8 +148,8 @@
     :fk-field-ids #{(id :venues :category_id)}
     :table-ids    #{(id :categories)}}]
   (let [expanded-form (ql/expand (wrap-inner-query (query venues
-                                                        (ql/filter (ql/= $category_id->categories.name
-                                                                         "abc")))))]
+                                                          (ql/filter (ql/= $category_id->categories.name
+                                                                           "abc")))))]
     (mapv obj->map [expanded-form
                     (resolve/resolve expanded-form)])))
 
@@ -180,7 +188,9 @@
                                                         :position           nil
                                                         :description        nil
                                                         :parent-id          nil
-                                                        :parent             nil}
+                                                        :parent             nil
+                                                        :min-value          nil
+                                                        :max-value          nil}
                                                 :unit  :year}
                                   :value       {:value (u/->Timestamp "1980-01-01")
                                                 :field {:field {:field-id           (id :users :last_login)
@@ -196,7 +206,9 @@
                                                                 :position           nil
                                                                 :description        nil
                                                                 :parent-id          nil
-                                                                :parent             nil}
+                                                                :parent             nil
+                                                                :min-value          nil
+                                                                :max-value          nil}
                                                         :unit  :year}}}
                    :join-tables  [{:source-field {:field-id   (id :checkins :user_id)
                                                   :field-name "USER_ID"}
@@ -250,7 +262,9 @@
                                                       :field-id           (id :venues :price)
                                                       :fk-field-id        (id :checkins :venue_id)
                                                       :table-name         "VENUES__via__VENUE_ID"
-                                                      :schema-name        nil}}]
+                                                      :schema-name        nil
+                                                      :min-value          nil
+                                                      :max-value          nil}}]
                    :breakout     [{:field {:description        nil
                                            :base-type          :type/Date
                                            :parent             nil
@@ -264,7 +278,9 @@
                                            :field-id           (id :checkins :date)
                                            :fk-field-id        nil
                                            :table-name         "CHECKINS"
-                                           :schema-name        "PUBLIC"}
+                                           :schema-name        "PUBLIC"
+                                           :min-value          nil
+                                           :max-value          nil}
                                    :unit  :day-of-week}]
                    :join-tables  [{:source-field {:field-id   (id :checkins :venue_id)
                                                   :field-name "VENUE_ID"}

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -91,11 +91,13 @@
    :visibility_type :normal
    :schema_name     (data/default-schema)
    :source          :fields
-   :fk_field_id     nil})
+   :fk_field_id     nil
+   :min-value       nil
+   :max-value       nil})
 
 (defn- target-field [field]
   (when (data/fks-supported?)
-    (dissoc field :target :extra_info :schema_name :source :fk_field_id)))
+    (dissoc field :target :extra_info :schema_name :source :fk_field_id :min-value :max-value)))
 
 (defn categories-col
   "Return column information for the `categories` column named by keyword COL."
@@ -154,7 +156,9 @@
      :id          {:special_type :type/PK
                    :base_type    (data/id-field-type)
                    :name         (data/format-name "id")
-                   :display_name "ID"}
+                   :display_name "ID"
+                   :min-value    nil
+                   :max-value    nil}
      :category_id {:extra_info   (if (data/fks-supported?)
                                    {:target_table_id (data/id :categories)}
                                    {})
@@ -164,23 +168,33 @@
                                    :type/Category)
                    :base_type    (data/expected-base-type->actual :type/Integer)
                    :name         (data/format-name "category_id")
-                   :display_name "Category ID"}
+                   :display_name "Category ID"
+                   :min-value    nil
+                   :max-value    nil}
      :price       {:special_type :type/Category
                    :base_type    (data/expected-base-type->actual :type/Integer)
                    :name         (data/format-name "price")
-                   :display_name "Price"}
+                   :display_name "Price"
+                   :min-value    nil
+                   :max-value    nil}
      :longitude   {:special_type :type/Longitude
                    :base_type    (data/expected-base-type->actual :type/Float)
                    :name         (data/format-name "longitude")
-                   :display_name "Longitude"}
+                   :display_name "Longitude"
+                   :min-value    nil
+                   :max-value    nil}
      :latitude    {:special_type :type/Latitude
                    :base_type    (data/expected-base-type->actual :type/Float)
                    :name         (data/format-name "latitude")
-                   :display_name "Latitude"}
+                   :display_name "Latitude"
+                   :min-value    nil
+                   :max-value    nil}
      :name        {:special_type :type/Name
                    :base_type    (data/expected-base-type->actual :type/Text)
                    :name         (data/format-name "name")
-                   :display_name "Name"})))
+                   :display_name "Name"
+                   :min-value    nil
+                   :max-value    nil})))
 
 (defn venues-cols
   "`cols` information for all the columns in `venues`."

--- a/test/metabase/query_processor_test/breakout_test.clj
+++ b/test/metabase/query_processor_test/breakout_test.clj
@@ -71,3 +71,10 @@
          (ql/limit 10))
        booleanize-native-form
        (format-rows-by [int int int])))
+
+(expect-with-non-timeseries-dbs
+  [[1 10.0] [4 33.0] [57 34.0] [29 37.0] [9 40.0]]
+  (format-rows-by [int (partial u/round-to-decimals 4)]
+    (rows (data/run-query venues
+            (ql/aggregation (ql/count))
+            (ql/breakout $latitude)))))

--- a/test/metabase/sync_database/sync_dynamic_test.clj
+++ b/test/metabase/sync_database/sync_dynamic_test.clj
@@ -32,7 +32,9 @@
    :fk_target_field_id false
    :last_analyzed      false
    :created_at         true
-   :updated_at         true})
+   :updated_at         true
+   :min_value          nil
+   :max_value          nil})
 
 ;; save-table-fields!  (also covers save-nested-fields!)
 (expect

--- a/test/metabase/sync_database/sync_test.clj
+++ b/test/metabase/sync_database/sync_test.clj
@@ -111,7 +111,9 @@
    :fk_target_field_id false
    :last_analyzed      false
    :created_at         true
-   :updated_at         true})
+   :updated_at         true
+   :min_value          nil
+   :max_value          nil})
 
 ;; save-table-fields!
 ;; this test also covers create-field-from-field-def! and update-field-from-field-def!

--- a/test/metabase/sync_database_test.clj
+++ b/test/metabase/sync_database_test.clj
@@ -96,7 +96,9 @@
    :fk_target_field_id false
    :created_at         true
    :updated_at         true
-   :last_analyzed      true})
+   :last_analyzed      true
+   :min_value          nil
+   :max_value          nil})
 
 
 ;; ## SYNC DATABASE
@@ -317,3 +319,13 @@
      ;; 3. Now re-sync the table and make sure the value is back
      (do (sync-table! @venues-table)
          (get-field-values))]))
+
+(expect
+  [-165.0 -73.0 10.0 40.0]
+  (tt/with-temp* [Database [database {:details (:details (Database (id))), :engine :h2}]
+                  Table    [table    {:db_id (u/get-id database), :name "VENUES"}]]
+    (sync-table! table)
+    [(db/select-one-field :min_value Field, :id (id :venues :longitude))
+     (db/select-one-field :max_value Field, :id (id :venues :longitude))
+     (db/select-one-field :min_value Field, :id (id :venues :latitude))
+     (db/select-one-field :max_value Field, :id (id :venues :latitude))]))

--- a/test/metabase/test/mock/moviedb.clj
+++ b/test/metabase/test/mock/moviedb.clj
@@ -184,7 +184,9 @@
    :position           0
    :visibility_type    :normal
    :preview_display    true
-   :created_at         true})
+   :created_at         true
+   :min_value          nil
+   :max_value          nil})
 
 (def ^:const moviedb-tables-and-fields
   [(merge table-defaults

--- a/test/metabase/test/mock/schema_per_customer.clj
+++ b/test/metabase/test/mock/schema_per_customer.clj
@@ -282,7 +282,9 @@
    :position           0
    :visibility_type    :normal
    :preview_display    true
-   :created_at         true})
+   :created_at         true
+   :min_value          nil
+   :max_value          nil})
 
 (def ^:const schema-per-customer-tables-and-fields
   [(merge table-defaults

--- a/test/metabase/test/mock/toucanery.clj
+++ b/test/metabase/test/mock/toucanery.clj
@@ -109,7 +109,9 @@
    :position           0
    :visibility_type    :normal
    :preview_display    true
-   :created_at         true})
+   :created_at         true
+   :min_value          nil
+   :max_value          nil})
 
 (def ^:const toucanery-tables-and-fields
   [(merge table-defaults


### PR DESCRIPTION
This is a step toward #798 which is aimed at continuous variables. This PR specifically targets latitude and longitude fields and is intended to start the conversation on what an implementation would look like and to see if I'm on the right track. This PR is just tested against H2 but the changes were made in the generic SQL driver so it should work in many of the other variants.

[This](https://www.wagonhq.com/sql-tutorial/creating-a-histogram-sql) was useful for some basic info on creating histograms generically in SQL. One difference is named vs. positional group by and order by fields. Databases like MySQL and PostgreSQL support this but H2 does not. This PR instead adds a projected column aliased as `bin` that will work more broadly.