### PR TITLE
Fix Firefox Content-Security-Policy warnings

### DIFF
--- a/src/metabase/middleware.clj
+++ b/src/metabase/middleware.clj
@@ -191,11 +191,9 @@
                                                                     "https://www.google-analytics.com" ; Safari requires the protocol
                                                                     "https://*.googleapis.com"
                                                                     "*.gstatic.com"
-                                                                    "js.intercomcdn.com"
-                                                                    "*.intercom.io"
                                                                     (when config/is-dev?
                                                                       "localhost:8080")]
-                                                      :frame-src   ["'self'"
+                                                      :child-src   ["'self'"
                                                                     "https://accounts.google.com"] ; TODO - double check that we actually need this for Google Auth
                                                       :style-src   ["'unsafe-inline'"
                                                                     "'self'"
@@ -206,11 +204,9 @@
                                                                     (when config/is-dev?
                                                                       "localhost:8080")]
                                                       :img-src     ["*"
-                                                                    "self data:"]
+                                                                    "'self' data:"]
                                                       :connect-src ["'self'"
                                                                     "metabase.us10.list-manage.com"
-                                                                    "*.intercom.io"
-                                                                    "wss://*.intercom.io" ; allow websockets as well
                                                                     (when config/is-dev?
                                                                       "localhost:8080 ws://localhost:8080")]}]
                                           (format "%s %s; " (name k) (apply str (interpose " " vs)))))})


### PR DESCRIPTION
Fix the warnings in Firefox from #4671. Not sure this will do anything to resolve the actual issue but it does resolve the warning messages.

Also remove Intercom exceptions from the list while I'm at it since we don't use it anymore.