### PR TITLE
handle display of 0 in the number picker

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/pickers/NumberPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/NumberPicker.jsx
@@ -24,11 +24,12 @@ export default class NumberPicker extends Component<*, Props, State> {
         super(props);
         this.state = {
             stringValues: props.values.map(v => {
-                if(v === 0) {
+                if(typeof v === 'number') {
                     return String(v)
+                } else {
+                    return String(v || "")
                 }
-                return String(v || "")}
-            ),
+            }),
             validations: this._validate(props.values)
         }
     }

--- a/frontend/src/metabase/query_builder/components/filters/pickers/NumberPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/NumberPicker.jsx
@@ -23,7 +23,12 @@ export default class NumberPicker extends Component<*, Props, State> {
     constructor(props: Props) {
         super(props);
         this.state = {
-            stringValues: props.values.map(v => String(v || "")),
+            stringValues: props.values.map(v => {
+                if(v === 0) {
+                    return String(v)
+                }
+                return String(v || "")}
+            ),
             validations: this._validate(props.values)
         }
     }


### PR DESCRIPTION
fixes #4373 

Turns out `String(0 || "")`(which is what we were passing to the textfield to display the selected value) will always return an empty string which is why even though a value was selected it was showing up blank. This is due to javascript being `neat and cool`. This is a "dumb" fix. Dunno if @attekei or @tlrobinson have a more elegant way to handle the checking here.