### PR TITLE
Don't hide widget filter if filtered result is empty

### DIFF
--- a/frontend/src/metabase/questions/containers/EntityList.jsx
+++ b/frontend/src/metabase/questions/containers/EntityList.jsx
@@ -175,7 +175,7 @@ export default class EntityList extends Component {
 
         const section = this.getSection();
 
-        const hasEntitiesInPlainState = !(section.section === "all" && entityIds.length === 0);
+        const hasEntitiesInPlainState = entityIds.length > 0 || section.section !== "all";
 
         const showActionHeader = (editable && selectedCount > 0);
         const showSearchHeader = (hasEntitiesInPlainState && showSearchWidget);

--- a/frontend/src/metabase/questions/containers/EntityList.jsx
+++ b/frontend/src/metabase/questions/containers/EntityList.jsx
@@ -175,8 +175,10 @@ export default class EntityList extends Component {
 
         const section = this.getSection();
 
+        const hasEntitiesInPlainState = !(section.section === "all" && entityIds.length === 0);
+
         const showActionHeader = (editable && selectedCount > 0);
-        const showSearchHeader = (entityIds.length > 0 && showSearchWidget);
+        const showSearchHeader = (hasEntitiesInPlainState && showSearchWidget);
         const showEntityFilterWidget = onChangeSection;
         return (
             <div style={style}>
@@ -200,7 +202,7 @@ export default class EntityList extends Component {
                         :
                             null
                       }
-                      { showEntityFilterWidget && entityIds.length > 0 &&
+                      { showEntityFilterWidget && hasEntitiesInPlainState &&
                           <EntityFilterWidget
                             section={section}
                             onChange={onChangeSection}


### PR DESCRIPTION
After entering Questions tab and choosing "Favourites" filter under "Everything Else" section, I couldn't change the filter value anymore. I had no favourites and as a consequence the filter widget was hidden. In this PR, I changed the logic so that the filter widget will be hidden only if there are no questions and no filters are active. Same applies also to "Filter this list..." input for visual consistency.

How it looks after my changes if you have no favorites:

<img width="949" alt="screen shot 2017-04-06 at 12 29 25" src="https://cloud.githubusercontent.com/assets/6034928/24772160/13fbd12e-1ac5-11e7-8b98-fc647b89d0ff.png">
