### PR TITLE
Save template tag parameter input field value immediately when typing it

### DIFF
--- a/frontend/src/metabase/dashboard/containers/ParameterWidget.jsx
+++ b/frontend/src/metabase/dashboard/containers/ParameterWidget.jsx
@@ -35,11 +35,13 @@ export default class ParameterWidget extends Component {
     }
 
     static propTypes = {
-        parameter: PropTypes.object
+        parameter: PropTypes.object,
+        commitImmediately: PropTypes.object
     };
 
     static defaultProps = {
         parameter: null,
+        commitImmediately: false
     }
 
     getValues() {
@@ -55,7 +57,7 @@ export default class ParameterWidget extends Component {
     }
 
     renderPopover(value, setValue, placeholder, isFullscreen) {
-        const {parameter, editingParameter} = this.props;
+        const {parameter, editingParameter, commitImmediately} = this.props;
         const isEditingParameter = !!(editingParameter && editingParameter.id === parameter.id);
         const values = this.getValues();
         return (
@@ -69,6 +71,7 @@ export default class ParameterWidget extends Component {
                 placeholder={placeholder}
                 focusChanged={this.focusChanged}
                 isFullscreen={isFullscreen}
+                commitImmediately={commitImmediately}
             />
         );
     }

--- a/frontend/src/metabase/dashboard/containers/Parameters.jsx
+++ b/frontend/src/metabase/dashboard/containers/Parameters.jsx
@@ -11,6 +11,7 @@ export default class Parameters extends Component {
     defaultProps = {
         syncQueryString: false,
         vertical: false,
+        commitImmediately: false
     }
 
     componentWillMount() {
@@ -62,7 +63,8 @@ export default class Parameters extends Component {
             editingParameter, setEditingParameter,
             isEditing, isFullscreen, isNightMode, isQB,
             setParameterName, setParameterValue, setParameterDefaultValue, removeParameter,
-            vertical
+            vertical,
+            commitImmediately
         } = this.props;
 
         const parameters = this._parametersWithValues();
@@ -88,6 +90,8 @@ export default class Parameters extends Component {
                         setValue={(value) => setParameterValue(parameter.id, value)}
                         setDefaultValue={(value) => setParameterDefaultValue(parameter.id, value)}
                         remove={() => removeParameter(parameter.id)}
+
+                        commitImmediately={commitImmediately}
                     />
                 ) }
             </div>

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -347,6 +347,7 @@ export default class NativeQueryEditor extends Component {
                             setParameterValue={setParameterValue}
                             syncQueryString
                             isQB
+                            commitImmediately
                         />
                         <a className="Query-label no-decoration flex-align-right flex align-center px2" onClick={this.toggleEditor}>
                             <span className="mx2">{toggleEditorText}</span>


### PR DESCRIPTION
When you are editing template tag values in query builder:

<img width="705" alt="screen shot 2017-04-07 at 16 13 25" src="https://cloud.githubusercontent.com/assets/6034928/24822824/2b5c1d0e-1bad-11e7-820b-0ab4854162a7.png">

When you are typing value for "Name", you expect that clicking "Get Answer" applies the field value. This didn't work because clicking Enter/Return was required to save the value. This PR fixes the behavior exclusively for this context (in dashboards clicking Enter/Return is still required).