### PR TITLE
Increase Mac App health check timeout, do health checks on higher-priority GCD queue

### DIFF
--- a/OSX/Metabase/Backend/TaskHealthChecker.m
+++ b/OSX/Metabase/Backend/TaskHealthChecker.m
@@ -9,10 +9,10 @@
 #import "TaskHealthChecker.h"
 
 /// Check out health every this many seconds
-static const CGFloat HealthCheckIntervalSeconds = 1.2f;
+static const CGFloat HealthCheckIntervalSeconds = 2.0f;
 
 /// This number should be lower than HealthCheckIntervalSeconds so requests don't end up piling up
-static const CGFloat HealthCheckRequestTimeout = 0.25f;
+static const CGFloat HealthCheckRequestTimeout = 1.75f;
 
 /// After this many seconds of being unhealthy, consider the task timed out so it can be killed
 static const CFTimeInterval TimeoutIntervalSeconds = 60.0f;

--- a/OSX/Metabase/Backend/TaskHealthChecker.m
+++ b/OSX/Metabase/Backend/TaskHealthChecker.m
@@ -50,7 +50,7 @@ static const CFTimeInterval TimeoutIntervalSeconds = 60.0f;
 	
 	[self resetTimeout];
 	
-	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
 		self.healthCheckTimer = [NSTimer timerWithTimeInterval:HealthCheckIntervalSeconds target:self selector:@selector(checkHealth) userInfo:nil repeats:YES];
 		self.healthCheckTimer.tolerance = HealthCheckIntervalSeconds / 2.0f;
 		[[NSRunLoop mainRunLoop] addTimer:self.healthCheckTimer forMode:NSRunLoopCommonModes];
@@ -91,8 +91,9 @@ static const CFTimeInterval TimeoutIntervalSeconds = 60.0f;
 }
 
 - (void)checkHealth {
+	// run the health check on the high-priorty GCD queue because it's imperative that it complete so we can get an accurate picture of Mac App health
 	__weak TaskHealthChecker *weakSelf = self;
-	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
+	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
 		[weakSelf checkHealth:^(BOOL healthy) {
 			if (!healthy) NSLog(@"😷");
 			if (healthy && !weakSelf.healthy) NSLog(@"✅");


### PR DESCRIPTION
Deal with heavy load on the Mac App server a little better by increasing the timeout for the health check

(Hopefully) resolves #3950