### PR TITLE
Avoid leaving temp files in hidden docker layers

### DIFF
--- a/bin/docker/Dockerfile
+++ b/bin/docker/Dockerfile
@@ -9,17 +9,14 @@ RUN apk add --update bash ttf-dejavu fontconfig
 # fix broken cacerts
 RUN apk add --update java-cacerts && \
     rm -f /usr/lib/jvm/default-jvm/jre/lib/security/cacerts && \
-    ln -s /etc/ssl/certs/java/cacerts /usr/lib/jvm/default-jvm/jre/lib/security/cacerts
+    ln -s /etc/ssl/certs/java/cacerts /usr/lib/jvm/default-jvm/jre/lib/security/cacerts && \
+    rm -rf /tmp/* /var/cache/apk/*
 
 # add Metabase jar
 COPY ./metabase.jar /app/
 
 # add our run script to the image
 COPY ./run_metabase.sh /app/
-RUN chmod 755 /app/run_metabase.sh
-
-# tidy up
-RUN rm -rf /tmp/* /var/cache/apk/*
 
 # expose our default runtime port
 EXPOSE 3000


### PR DESCRIPTION
temp files that exist across docker RUN commands live forever in hidden layers.
