### PR TITLE
Dont run as root in containers

### DIFF
--- a/bin/docker/run_metabase.sh
+++ b/bin/docker/run_metabase.sh
@@ -32,31 +32,82 @@ MGID=${MGID:-2000}
 MUID=${MUID:-2000}
 
 # create the group if it does not exist
+# TODO: edit an existing group if MGID has changed
 getent group metabase > /dev/null 2>&1
 group_exists=$?
-if [ $group_exists ]; then
+if [ $group_exists -ne 0 ]; then
     addgroup -g $MGID -S metabase
 fi
 
 # create the user if it does not exist
+# TODO: edit an existing user if MGID has changed
 id -u metabase > /dev/null 2>&1
 user_exists=$?
 if [[ $user_exists -ne 0 ]]; then
     adduser -D -u $MUID -G metabase metabase
 fi
 
-# this is to avoid running creating non-root DB files at the root of the filesystem
-# while still making them easy to find for DB export when migrating from H2 to other application DBs
+db_file=${MB_DB_FILE:-/metabase.db}
 
-db_file=${MB_DB_FILE:-/app/metabase.db}
-db_alias=/metabase.db
-export MB_DB_FILE=$db_file
-chown metabase:metabase /app
-touch $db_file
-chown metabase:metabase $db_file
-if [[ ! -f $db_alias ]]; then
-    ln -s $db_file $db_alias
+# In order to run metabase as a non-root user in docker, we need to handle various
+# cases where we where previously ran as root and have an existing database that
+# consists of a bunch of files, that are owned by root, sitting in a directory that
+# may only be writable by root. It's not safe to simply change the ownership or
+# permissions of an unknown directory that may be a volume mounted on the host, so
+# we will need to detect this and make a place that is going to be safe to set
+# permissions on.
+
+# So first some preliminary checks:
+
+# 1. Does this container have an existing H2 database file?
+# 2. or an existing H2 database in it's own directory,
+# 3. or neither?
+
+
+# is there a pre-existing files only database without a metabase specific directory?
+if ls $db_file\.* > /dev/null 2>&1; then
+    db_exists=true
+else
+    db_exists=false
 fi
+# is it an old style file
+if [[ -d "$db_file" ]]; then
+    db_directory=true
+else
+    db_directory=false
+fi
+
+# If the db exits, and it's just some files in a shared directory we could do
+# serious damage to peoples home or /tmp directories if we where to set the
+# permissions on that directory to allow metabase to create db-lock and db-part
+# file there. To keep them safe we make a new directory with the same name and
+# move the db file into the new directory. If we where passed the name of a
+# directory rather than a specific file, then we are safe to set permissions on
+# that directory so there is no need to move anything.
+
+# an example file would look like /tmp/metabase.db/metabase.db.mv.db
+new_db_dir=$(dirname $db_file)/$(basename $db_file)
+
+if [[ $db_exists = "true" && ! $db_directory = "true" ]]; then
+    mkdir $new_db_dir
+    mv $db_file\.* $new_db_dir/
+fi
+
+# and for the new install case we create the directory
+if [[ $db_exists = "false" && $db_directory = "false" ]]; then
+    mkdir $new_db_dir
+fi
+
+# the case where the DB exists and is a directory, there is nothing to do
+# so nothing happens here. This will be the normal case.
+
+# next we tell metabase use the files we just moved into the directory
+# or create the files in that directory if they don't exist.
+export MB_DB_FILE=$new_db_dir/$(basename $db_file)
+
+# TODO: print big scary warning if they are configuring an ephemeral instance
+
+chown metabase:metabase $new_db_dir $new_db_dir/* 2>/dev/null  # all that fussing makes this safe
 
 # Setup Java Options
 JAVA_OPTS="${JAVA_OPTS} -Dlogfile.path=target/log -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -server"

--- a/bin/docker/run_metabase.sh
+++ b/bin/docker/run_metabase.sh
@@ -48,7 +48,7 @@ fi
 # this is to avoid running creating non-root DB files at the root of the filesystem
 # while still making them easy to find for DB export when migrating from H2 to other application DBs
 
-db_file=/app/metabase.db
+db_file=${MB_DB_FILE:-/app/metabase.db}
 db_alias=/metabase.db
 export MB_DB_FILE=$db_file
 chown metabase:metabase /app

--- a/bin/docker/run_metabase.sh
+++ b/bin/docker/run_metabase.sh
@@ -25,12 +25,47 @@ if [ ! -z "$RDS_HOSTNAME" ]; then
 fi
 
 
+# Avoid running metabase (or any server) as root where possible
+# If you want to use specific user and group ids that matches an existing
+# account on the host pass them in $MGID and $MUID when starting metabase
+MGID=${MGID:-2000}
+MUID=${MUID:-2000}
+
+# create the group if it does not exist
+getent group metabase > /dev/null 2>&1
+group_exists=$?
+if [ $group_exists ]; then
+    addgroup -g $MGID -S metabase
+fi
+
+# create the user if it does not exist
+id -u metabase > /dev/null 2>&1
+user_exists=$?
+if [[ $user_exists -ne 0 ]]; then
+    adduser -D -u $MUID -G metabase metabase
+fi
+
+# this is to avoid running creating non-root DB files at the root of the filesystem
+# while still making them easy to find for DB export when migrating from H2 to other application DBs
+
+db_file=/app/metabase.db
+db_alias=/metabase.db
+export MB_DB_FILE=$db_file
+chown metabase:metabase /app
+touch $db_file
+chown metabase:metabase $db_file
+if [[ ! -f $db_alias ]]; then
+    ln -s $db_file $db_alias
+fi
+
 # Setup Java Options
 JAVA_OPTS="${JAVA_OPTS} -Dlogfile.path=target/log -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -server"
 
 if [ ! -z "$JAVA_TIMEZONE" ]; then
-  JAVA_OPTS="${JAVA_OPTS} -Duser.timezone=${JAVA_TIMEZONE}"
+    JAVA_OPTS="${JAVA_OPTS} -Duser.timezone=${JAVA_TIMEZONE}"
 fi
 
 # Launch the application
-exec java $JAVA_OPTS -jar /app/metabase.jar
+# exec is here twice on purpose to  ensure that metabase runs as PID 1 (the init process)
+# and thus receives signals sent to the container. This allows it to shutdown cleanly on exit
+exec su metabase -s /bin/sh -c "exec java $JAVA_OPTS -jar /app/metabase.jar"

--- a/docs/operations-guide/running-metabase-on-docker.md
+++ b/docs/operations-guide/running-metabase-on-docker.md
@@ -84,6 +84,12 @@ It's best to set your Java timezone to match the timezone you'd like all your re
 
 While running Metabase on docker you can use any of the custom settings from [Customizing the Metabase Jetty Webserver](./start.md#customizing-the-metabase-jetty-webserver) by setting environment variables on your docker run command.
 
+In addition to the standard custom settings there are two docker specific environment variables `MUID` and `MGID` which are used to set the user and group IDs used by metabase when running in a docker container. These settings make it possible to match file permissions when files, such as the application database, are shared between the host and the container.
+
+Here's how to use a database file, owned by your account, that is stored in your home directory:
+
+    docker run -d -v ~/my-metabase-db:/metabase.db --name metabase -e MB_DB_FILE=/metabase.db -e MUID=$UID -e MGID=$GID -p 3000:3000 metabase/metabase
+
 Now that you’ve installed Metabase, it’s time to [set it up and connect it to your database](../setting-up-metabase.md).
 
 


### PR DESCRIPTION
Drop superuser before exec'ing into java
Resolves #4734 

``` 
~/metabase/metabase » sudo docker exec -ti mb /bin/bash                                                                137 ↵ (dont-run-as-root-in-containers⚡) arthur@a:18:44:41
bash-4.3# ps
PID   USER     TIME   COMMAND
    1 metabase   0:21 java -Dlogfile.path=target/log -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -server -jar /app/metabase.jar
   35 root       0:00 /bin/bash
   62 root       0:00 ps
```
uses the environment variables

* MUID to set custom user id
* MGID to set custom group id