### PR TITLE
Grammar fix for Metabase invitation accepted email

### DIFF
--- a/src/metabase/email/user_joined_notification.mustache
+++ b/src/metabase/email/user_joined_notification.mustache
@@ -4,7 +4,7 @@
       <h2 style="font-weight: normal; color: #4C545B;line-height: 1.65rem;">
         {{joinedUserName}}
         {{#joinedViaSSO}}created a Metabase account.{{/joinedViaSSO}}
-        {{^joinedViaSSO}}accepted your Metabase invitation.{{/joinedViaSSO}}
+        {{^joinedViaSSO}}accepted their Metabase invitation.{{/joinedViaSSO}}
       </h2>
       <h4 style="font-weight: normal;">
         <a style="color: #4A90E2; text-decoration: none;" href="mailto:{{adminEmail}}">


### PR DESCRIPTION
When someone accepts a Metabase invitation all the admins of that instance get an email that looks like:

![screen shot 2017-04-21 at 10 59 19 am](https://cloud.githubusercontent.com/assets/1455846/25290181/99595dec-2681-11e7-8cee-4821d94c9aae.png)

However, the email *subject* reads like

```
<user> accepted their Metabase invite
```

The subject makes more sense because only one of those admins invited that user. I changed the template body to match the subject, so the body now reads:

```
<user> accepted their Metabase invitation.
```