### PR TITLE
Simplify API logic with new select-non-nil-keys and select-keys-when fns

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -3570,14 +3570,16 @@ databaseChangeLog:
   - changeSet:
       id: 54
       author: tlrobinson
+      validCheckSum: '7:695b12a78e897c62c21d41bfb04ab44b'
+      validCheckSum: '7:0857800db71a4757e7202aad4eaed48d'
       changes:
         - addColumn:
             tableName: pulse
-            remarks: 'Skip a scheduled Pulse if none of its questions have any results'
             columns:
               - column:
                   name: skip_if_empty
                   type: boolean
+                  remarks: 'Skip a scheduled Pulse if none of its questions have any results'
                   defaultValueBoolean: false
                   constraints:
                     nullable: false

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -317,4 +317,5 @@
   "Check that the OBJECT is not `:archived`, or throw a `404`. Returns OBJECT as-is if check passes."
   [object]
   (u/prog1 object
-    (check-404 (not (:archived object)))))
+    (check (not (:archived object))
+      [404 "The object has been archived."])))

--- a/src/metabase/api/segment.clj
+++ b/src/metabase/api/segment.clj
@@ -39,22 +39,16 @@
 
 (defendpoint PUT "/:id"
   "Update a `Segment` with ID."
-  [id :as {{:keys [name description caveats points_of_interest show_in_getting_started definition revision_message]} :body}]
+  [id :as {{:keys [name definition revision_message], :as body} :body}]
   {name             su/NonBlankString
    revision_message su/NonBlankString
    definition       su/Map}
   (check-superuser)
   (write-check Segment id)
   (segment/update-segment!
-    {:id                      id
-     :name                    name
-     :description             description
-     :caveats                 caveats
-     :points_of_interest      points_of_interest
-     :show_in_getting_started show_in_getting_started
-     :definition              definition
-     :revision_message        revision_message}
-    *current-user-id*))
+   (assoc (select-keys body #{:name :description :caveats :points_of_interest :show_in_getting_started :definition :revision_message})
+     :id id)
+   *current-user-id*))
 
 
 (defendpoint DELETE "/:id"

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -89,26 +89,6 @@
        (events/publish-event! :dashboard-create)))
 
 
-
-(defn update-dashboard!
-  "Update a `Dashboard`"
-  [dashboard user-id]
-  {:pre [(map? dashboard)
-         (u/maybe? u/sequence-of-maps? (:parameters dashboard))
-         (integer? user-id)]}
-  (db/update! Dashboard (u/get-id dashboard)
-    (merge
-     ;; description is allowed to be `nil`
-     (when (contains? dashboard :description)
-       {:description (:description dashboard)})
-     ;; only set everything else if its non-nil
-     (into {} (for [k     [:name :parameters :caveats :points_of_interest :show_in_getting_started :enable_embedding :embedding_params]
-                    :when (k dashboard)]
-                {k (k dashboard)}))))
-  (u/prog1 (Dashboard (u/get-id dashboard))
-    (events/publish-event! :dashboard-update (assoc <> :actor_id user-id))))
-
-
 ;;; ## ---------------------------------------- REVISIONS ----------------------------------------
 
 (defn serialize-dashboard

--- a/src/metabase/models/metric.clj
+++ b/src/metabase/models/metric.clj
@@ -49,8 +49,8 @@
                                                (select-keys metric1 [:name :description :definition])
                                                (select-keys metric2 [:name :description :definition]))]
       (cond-> (merge-with merge
-                          (m/map-vals (fn [v] {:after v}) (:after base-diff))
-                          (m/map-vals (fn [v] {:before v}) (:before base-diff)))
+                (m/map-vals (fn [v] {:after v}) (:after base-diff))
+                (m/map-vals (fn [v] {:before v}) (:before base-diff)))
         (or (get-in base-diff [:after :definition])
             (get-in base-diff [:before :definition])) (assoc :definition {:before (get-in metric1 [:definition])
                                                                           :after  (get-in metric2 [:definition])})))))
@@ -117,16 +117,20 @@
    (retrieve-metrics table-id :active))
   ([table-id state]
    {:pre [(integer? table-id) (keyword? state)]}
-   (-> (if (= :all state)
-         (db/select Metric, :table_id table-id, {:order-by [[:name :asc]]})
-         (db/select Metric, :table_id table-id, :is_active (= :active state), {:order-by [[:name :asc]]}))
+   (-> (db/select Metric
+         {:where    [:and [:= :table_id table-id]
+                          (case state
+                            :all     true
+                            :active  [:= :is_active true]
+                            :deleted [:= :is_active false])]
+          :order-by [[:name :asc]]})
        (hydrate :creator))))
 
 (defn update-metric!
   "Update an existing `Metric`.
 
    Returns the updated `Metric` or throws an Exception."
-  [{:keys [id name description caveats points_of_interest how_is_this_calculated show_in_getting_started definition revision_message]} user-id]
+  [{:keys [id name definition revision_message], :as body} user-id]
   {:pre [(integer? id)
          (string? name)
          (map? definition)
@@ -134,13 +138,7 @@
          (string? revision_message)]}
   ;; update the metric itself
   (db/update! Metric id
-    :name                    name
-    :description             description
-    :caveats                 caveats
-    :points_of_interest      points_of_interest
-    :how_is_this_calculated  how_is_this_calculated
-    :show_in_getting_started show_in_getting_started
-    :definition              definition)
+    (select-keys body #{:caveats :definition :description :how_is_this_calculated :name :points_of_interest :show_in_getting_started}))
   (u/prog1 (retrieve-metric id)
     (events/publish-event! :metric-update (assoc <> :actor_id user-id, :revision_message revision_message))))
 

--- a/src/metabase/models/segment.clj
+++ b/src/metabase/models/segment.clj
@@ -107,8 +107,7 @@
 (defn update-segment!
   "Update an existing `Segment`.
    Returns the updated `Segment` or throws an Exception."
-  {:style/indent 0}
-  [{:keys [id name description caveats points_of_interest show_in_getting_started definition revision_message]} user-id]
+  [{:keys [id name description caveats points_of_interest show_in_getting_started definition revision_message], :as body} user-id]
   {:pre [(integer? id)
          (string? name)
          (map? definition)
@@ -116,15 +115,9 @@
          (string? revision_message)]}
   ;; update the segment itself
   (db/update! Segment id
-    (merge
-     {:name        name
-      :description description
-      :caveats     caveats
-      :definition  definition}
-     (when (seq points_of_interest)
-       {:points_of_interest points_of_interest})
-     (when (not (nil? show_in_getting_started))
-       {:show_in_getting_started show_in_getting_started})))
+    (u/select-keys-when body
+      :present #{:name :description :caveats :definition}
+      :non-nil #{:points_of_interest :show_in_getting_started}))
   (u/prog1 (retrieve-segment id)
     (events/publish-event! :segment-update (assoc <> :actor_id user-id, :revision_message revision_message))))
 

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -831,3 +831,28 @@
       (if-let [new-index (s/index-of s substr index)]
         (recur (inc new-index) (inc cnt))
         cnt))))
+
+(defn select-non-nil-keys
+  "Like `select-keys`, but returns a map only containing keys in KS that are present *and non-nil* in M.
+
+     (select-non-nil-keys {:a 100, :b nil} #{:a :b :c})
+     ;; -> {:a 100}"
+  [m ks]
+  (into {} (for [k     ks
+                 :when (not (nil? (get m k)))]
+             {k (get m k)})))
+
+(defn select-keys-when
+  "Returns a map that only contains keys that are either `:present` or `:non-nil`.
+   Combines behavior of `select-keys` and `select-non-nil-keys`.
+   This is useful for API endpoints that update a model, which often have complex rules about what gets updated
+   (some keys are updated if `nil`, others only if non-nil).
+
+     (select-keys-when {:a 100, :b nil, :d 200, :e nil}
+       :present #{:a :b :c}
+       :non-nil #{:d :e :f})
+     ;; -> {:a 100, :b nil, :d 200}"
+  {:style/indent 1}
+  [m & {:keys [present non-nil]}]
+  (merge (select-keys m present)
+         (select-non-nil-keys m non-nil)))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -649,7 +649,7 @@
 
 ;; Test that we *cannot* share a Card if the Card has been archived
 (expect
-  "Not found."
+  "The object has been archived."
   (tu/with-temporary-setting-values [enable-public-sharing true]
     (tt/with-temp Card [card {:archived true}]
       ((user->client :crowberto) :post 404 (format "card/%d/public_link" (u/get-id card))))))

--- a/test/metabase/api/metric_test.clj
+++ b/test/metabase/api/metric_test.clj
@@ -15,6 +15,17 @@
 
 ;; ## Helper Fns
 
+(def ^:private ^:const metric-defaults
+  {:description             nil
+   :show_in_getting_started false
+   :caveats                 nil
+   :points_of_interest      nil
+   :how_is_this_calculated  nil
+   :created_at              true
+   :updated_at              true
+   :is_active               true
+   :definition              {}})
+
 (defn- user-details [user]
   (tu/match-$ user
     {:id           $
@@ -72,19 +83,13 @@
                                                  :definition "foobar"}))
 
 (expect
-  {:name                    "A Metric"
-   :description             "I did it!"
-   :show_in_getting_started false
-   :caveats                 nil
-   :points_of_interest      nil
-   :how_is_this_calculated  nil
-   :creator_id              (user->id :crowberto)
-   :creator                 (user-details (fetch-user :crowberto))
-   :created_at              true
-   :updated_at              true
-   :is_active               true
-   :definition              {:database 21
-                             :query    {:filter ["abc"]}}}
+  (merge metric-defaults
+         {:name        "A Metric"
+          :description "I did it!"
+          :creator_id  (user->id :crowberto)
+          :creator     (user-details (fetch-user :crowberto))
+          :definition  {:database 21
+                        :query    {:filter ["abc"]}}})
   (tt/with-temp* [Database [{database-id :id}]
                   Table    [{:keys [id]} {:db_id database-id}]]
     (metric-response ((user->client :crowberto) :post 200 "metric" {:name                    "A Metric"
@@ -107,39 +112,37 @@
                                               :revision_message "something different"}))
 
 ;; test validations
-(expect {:errors {:name "value must be a non-blank string."}}
+(expect
+  {:errors {:name "value must be a non-blank string."}}
   ((user->client :crowberto) :put 400 "metric/1" {}))
 
-(expect {:errors {:revision_message "value must be a non-blank string."}}
+(expect
+  {:errors {:revision_message "value must be a non-blank string."}}
   ((user->client :crowberto) :put 400 "metric/1" {:name "abc"}))
 
-(expect {:errors {:revision_message "value must be a non-blank string."}}
+(expect
+  {:errors {:revision_message "value must be a non-blank string."}}
   ((user->client :crowberto) :put 400 "metric/1" {:name             "abc"
-                                                   :revision_message ""}))
-
-(expect {:errors {:definition "value must be a map."}}
-  ((user->client :crowberto) :put 400 "metric/1" {:name             "abc"
-                                                   :revision_message "123"}))
-
-(expect {:errors {:definition "value must be a map."}}
-  ((user->client :crowberto) :put 400 "metric/1" {:name             "abc"
-                                                   :revision_message "123"
-                                                   :definition       "foobar"}))
+                                                  :revision_message ""}))
 
 (expect
-  {:name                    "Costa Rica"
-   :description             nil
-   :show_in_getting_started false
-   :caveats                 nil
-   :points_of_interest      nil
-   :how_is_this_calculated  nil
-   :creator_id              (user->id :rasta)
-   :creator                 (user-details (fetch-user :rasta))
-   :created_at              true
-   :updated_at              true
-   :is_active               true
-   :definition              {:database 2
-                             :query    {:filter ["not" "the toucans you're looking for"]}}}
+  {:errors {:definition "value must be a map."}}
+  ((user->client :crowberto) :put 400 "metric/1" {:name             "abc"
+                                                  :revision_message "123"}))
+
+(expect
+  {:errors {:definition "value must be a map."}}
+  ((user->client :crowberto) :put 400 "metric/1" {:name             "abc"
+                                                  :revision_message "123"
+                                                  :definition       "foobar"}))
+
+(expect
+  (merge metric-defaults
+         {:name       "Costa Rica"
+          :creator_id (user->id :rasta)
+          :creator    (user-details (fetch-user :rasta))
+          :definition {:database 2
+                       :query    {:filter ["not" "the toucans you're looking for"]}}})
   (tt/with-temp* [Database [{database-id :id}]
                   Table    [{table-id :id} {:db_id database-id}]
                   Metric   [{:keys [id]} {:table_id table-id}]]
@@ -172,18 +175,12 @@
 
 (expect
   [{:success true}
-   {:name                    "Toucans in the rainforest"
-    :description             "Lookin' for a blueberry"
-    :show_in_getting_started false
-    :caveats                 nil
-    :points_of_interest      nil
-    :how_is_this_calculated  nil
-    :creator_id              (user->id :rasta)
-    :creator                 (user-details (fetch-user :rasta))
-    :created_at              true
-    :updated_at              true
-    :is_active               false
-    :definition              {}}]
+   (merge metric-defaults
+          {:name        "Toucans in the rainforest"
+           :description "Lookin' for a blueberry"
+           :creator_id  (user->id :rasta)
+           :creator     (user-details (fetch-user :rasta))
+           :is_active   false})]
   (tt/with-temp* [Database [{database-id :id}]
                   Table    [{table-id :id} {:db_id database-id}]
                   Metric   [{:keys [id]}   {:table_id table-id}]]
@@ -199,18 +196,11 @@
 
 
 (expect
-  {:name                    "Toucans in the rainforest"
-   :description             "Lookin' for a blueberry"
-   :show_in_getting_started false
-   :caveats                 nil
-   :points_of_interest      nil
-   :how_is_this_calculated  nil
-   :creator_id              (user->id :crowberto)
-   :creator                 (user-details (fetch-user :crowberto))
-   :created_at              true
-   :updated_at              true
-   :is_active               true
-   :definition              {}}
+  (merge metric-defaults
+         {:name        "Toucans in the rainforest"
+          :description "Lookin' for a blueberry"
+          :creator_id  (user->id :crowberto)
+          :creator     (user-details (fetch-user :crowberto))})
   (tt/with-temp* [Database [{database-id :id}]
                   Table    [{table-id :id} {:db_id database-id}]
                   Metric   [{:keys [id]}   {:creator_id  (user->id :crowberto)

--- a/test/metabase/models/metric_test.clj
+++ b/test/metabase/models/metric_test.clj
@@ -10,6 +10,15 @@
             [metabase.test.util :as tu]
             [metabase.util :as u]))
 
+(def ^:private ^:const metric-defaults
+  {:description             nil
+   :how_is_this_calculated  nil
+   :show_in_getting_started false
+   :caveats                 nil
+   :points_of_interest      nil
+   :is_active               true
+   :definition              {}})
+
 (defn- user-details
   [username]
   (dissoc (fetch-user username) :date_joined :last_login))
@@ -30,16 +39,11 @@
 
 ;; create-metric!
 (expect
-  {:creator_id              (user->id :rasta)
-   :creator                 (user-details :rasta)
-   :name                    "I only want *these* things"
-   :description             nil
-   :how_is_this_calculated  nil
-   :show_in_getting_started false
-   :caveats                 nil
-   :points_of_interest      nil
-   :is_active               true
-   :definition              {:clause ["a" "b"]}}
+  (merge metric-defaults
+         {:creator_id (user->id :rasta)
+          :creator    (user-details :rasta)
+          :name       "I only want *these* things"
+          :definition {:clause ["a" "b"]}})
   (tt/with-temp* [Database [{database-id :id}]
                   Table    [{:keys [id]}      {:db_id database-id}]]
     (create-metric-then-select! id "I only want *these* things" nil (user->id :rasta) {:clause ["a" "b"]})))
@@ -60,17 +64,13 @@
 
 ;; retrieve-metric
 (expect
-  {:creator_id              (user->id :rasta)
-   :creator                 (user-details :rasta)
-   :name                    "Toucans in the rainforest"
-   :description             "Lookin' for a blueberry"
-   :how_is_this_calculated  nil
-   :show_in_getting_started false
-   :caveats                 nil
-   :points_of_interest      nil
-   :is_active               true
-   :definition              {:database 45
-                             :query    {:filter ["yay"]}}}
+  (merge metric-defaults
+         {:creator_id  (user->id :rasta)
+          :creator     (user-details :rasta)
+          :name        "Toucans in the rainforest"
+          :description "Lookin' for a blueberry"
+          :definition  {:database 45
+                        :query    {:filter ["yay"]}}})
   (tt/with-temp* [Database [{database-id :id}]
                   Table    [{table-id :id}    {:db_id database-id}]
                   Metric   [{metric-id :id}   {:table_id    table-id
@@ -81,18 +81,12 @@
               :creator (u/rpartial dissoc :date_joined :last_login)))))
 
 
-;; retrieve-segements
+;; retrieve-metrics
 (expect
-  [{:creator_id              (user->id :rasta)
-    :creator                 (user-details :rasta)
-    :name                    "Metric 1"
-    :description             nil
-    :how_is_this_calculated  nil
-    :show_in_getting_started false
-    :caveats                 nil
-    :points_of_interest      nil
-    :is_active               true
-    :definition              {}}]
+  [(merge metric-defaults
+          {:creator_id (user->id :rasta)
+           :creator    (user-details :rasta)
+           :name       "Metric 1"})]
   (tt/with-temp* [Database [{database-id :id}]
                   Table    [{table-id-1 :id}    {:db_id database-id}]
                   Table    [{table-id-2 :id}    {:db_id database-id}]
@@ -113,17 +107,12 @@
 ;;  4. ability to modify the definition json
 ;;  5. revision is captured along with our commit message
 (expect
-  {:creator_id              (user->id :rasta)
-   :creator                 (user-details :rasta)
-   :name                    "Costa Rica"
-   :description             nil
-   :how_is_this_calculated  nil
-   :show_in_getting_started false
-   :caveats                 nil
-   :points_of_interest      nil
-   :is_active               true
-   :definition              {:database 2
-                             :query    {:filter ["not" "the toucans you're looking for"]}}}
+  (merge metric-defaults
+         {:creator_id (user->id :rasta)
+          :creator    (user-details :rasta)
+          :name       "Costa Rica"
+          :definition {:database 2
+                       :query    {:filter ["not" "the toucans you're looking for"]}}})
   (tt/with-temp* [Database [{database-id :id}]
                   Table  [{table-id :id}  {:db_id database-id}]
                   Metric [{metric-id :id} {:table_id table-id}]]
@@ -142,16 +131,12 @@
 
 ;; delete-metric!
 (expect
-  {:creator_id              (user->id :rasta)
-   :creator                 (user-details :rasta)
-   :name                    "Toucans in the rainforest"
-   :description             "Lookin' for a blueberry"
-   :how_is_this_calculated  nil
-   :show_in_getting_started false
-   :caveats                 nil
-   :points_of_interest      nil
-   :is_active               false
-   :definition              {}}
+  (merge metric-defaults
+         {:creator_id  (user->id :rasta)
+          :creator     (user-details :rasta)
+          :name        "Toucans in the rainforest"
+          :description "Lookin' for a blueberry"
+          :is_active   false})
   (tt/with-temp* [Database [{database-id :id}]
                   Table    [{table-id :id}  {:db_id database-id}]
                   Metric   [{metric-id :id} {:table_id table-id}]]
@@ -165,18 +150,14 @@
 
 ;; serialize-metric
 (expect
-  {:id                      true
-   :table_id                true
-   :creator_id              (user->id :rasta)
-   :name                    "Toucans in the rainforest"
-   :description             "Lookin' for a blueberry"
-   :how_is_this_calculated  nil
-   :show_in_getting_started false
-   :caveats                 nil
-   :points_of_interest      nil
-   :definition              {:aggregation ["count"]
-                             :filter      ["AND" [">" 4 "2014-10-19"]]}
-   :is_active               true}
+  (merge metric-defaults
+         {:id          true
+          :table_id    true
+          :creator_id  (user->id :rasta)
+          :name        "Toucans in the rainforest"
+          :description "Lookin' for a blueberry"
+          :definition  {:aggregation ["count"]
+                        :filter      ["AND" [">" 4 "2014-10-19"]]}})
   (tt/with-temp* [Database [{database-id :id}]
                   Table    [{table-id :id} {:db_id database-id}]
                   Metric   [metric         {:table_id   table-id

--- a/test/metabase/permissions_collection_test.clj
+++ b/test/metabase/permissions_collection_test.clj
@@ -55,8 +55,10 @@
     (println "[In the occasionally failing test]") ; DEBUG
     (set-card-collection! collection)
     (permissions/grant-collection-read-permissions! (group/all-users) collection)
-    ;; try it twice because sometimes it randomly fails :unamused:
+    ;; try it a few times because sometimes it randomly fails :unamused:
     (or (can-run-query? :rasta)
+        (can-run-query? :rasta)
+        (Thread/sleep 1000)
         (can-run-query? :rasta))))
 
 ;; Make sure a User isn't allowed to save a Card they have collections readwrite permissions for

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -230,3 +230,15 @@
 (expect 1 (occurances-of-substring "WHERE ID = {{id}}"                                                                 "{{id}}"))
 (expect 2 (occurances-of-substring "WHERE ID = {{id}} OR USER_ID = {{id}}"                                             "{{id}}"))
 (expect 3 (occurances-of-substring "WHERE ID = {{id}} OR USER_ID = {{id}} OR TOUCAN_ID = {{id}} OR BIRD_ID = {{bird}}" "{{id}}"))
+
+
+;;; tests for `select-non-nil-keys` and `select-keys-when`
+(expect
+  {:a 100}
+  (select-non-nil-keys {:a 100, :b nil} #{:a :b :c}))
+
+(expect
+  {:a 100, :b nil, :d 200}
+  (select-keys-when {:a 100, :b nil, :d 200, :e nil}
+    :present #{:a :b :c}
+    :non-nil #{:d :e :f}))


### PR DESCRIPTION
Backported from PR #4855.

Basically I got sick of crazy logic like this (used in several places in API):

```clojure
(db/update! Card id
  (merge
   ;; `collection_id` and `description` can be `nil` (in order to unset them)
   (when (contains? body :collection_id)
     {:collection_id collection_id})
   (when (contains? body :description)
     {:description description})
   ;; other values should only be modified if they're passed in as non-nil
   (into {} (for [k     [:dataset_query :display :name :visualization_settings :archived :enable_embedding :embedding_params]
                  :let  [v (k body)]
                  :when (not (nil? v))]
              {k v}))))
```

So I wrote some new util functions to simplify the pattern:

```clojure
(db/update! Card id
  ;; `collection_id` and `description` can be `nil` (in order to unset them). Other values should only be modified if they're passed in as non-nil
  (u/select-keys-when body
    :present #{:collection_id :description}
    :non-nil #{:dataset_query :display :name :visualization_settings :archived :enable_embedding :embedding_params}))
```

Other various bits of cleanup as well.
