### PR TITLE
Parisholley fix postgres timezone

### DIFF
--- a/docs/operations-guide/start.md
+++ b/docs/operations-guide/start.md
@@ -98,7 +98,7 @@ If this happens, setting a few JVM options should fix your issue:
 
 You can also pass JVM arguments by setting the environment variable `JAVA_TOOL_OPTIONS`, e.g.
 
-    JAVA_TOOL_OPTIONS=`-XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:MaxPermSize=256m`
+    JAVA_TOOL_OPTIONS='-XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:MaxPermSize=256m'
 
 Alternatively, you can upgrade to Java 8 instead, which will fix the issue as well.
 

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -5,12 +5,14 @@
             [metabase.models
              [database :refer [Database]]
              field
-             [setting :refer [defsetting]]]
+             [setting :refer [defsetting]]
+             table]
             [metabase.util :as u]
             [toucan.db :as db])
   (:import clojure.lang.Keyword
            metabase.models.database.DatabaseInstance
-           metabase.models.field.FieldInstance))
+           metabase.models.field.FieldInstance
+           metabase.models.table.TableInstance))
 
 ;;; ## INTERFACE + CONSTANTS
 

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -108,9 +108,10 @@
         (hsql/format ... :quoting (quote-style driver))")
 
   (set-timezone-sql ^String [this]
-    "*OPTIONAL*. This should be a prepared JDBC SQL statement string to be used to set the timezone for the current transaction.
+    "*OPTIONAL*. This should be a format string containing a SQL statement to be used to set the timezone for the current transaction.
+     The `%s` will be replaced with a string literal for a timezone, e.g. `US/Pacific`.
 
-       \"SET @@session.timezone = ?;\"")
+       \"SET @@session.timezone = %s;\"")
 
   (stddev-fn ^clojure.lang.Keyword [this]
     "*OPTIONAL*. Keyword name of the SQL function that should be used to do a standard deviation aggregation. Defaults to `:STDDEV`.")

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -329,11 +329,12 @@
 (defn- set-timezone!
   "Set the timezone for the current connection."
   [driver settings connection]
-  (let [timezone (:report-timezone settings)
-        sql      (sql/set-timezone-sql driver)
-        replaced (clojure.string/replace sql "?" (str "'" (re-matches #"[A-z\/_]+" timezone) "'"))]
-    (log/debug (u/pprint-to-str 'green [replaced]))
-    (jdbc/db-do-prepared connection [replaced])))
+  (let [timezone      (u/prog1 (:report-timezone settings)
+                        (assert (re-matches #"[A-Za-z\/_]+" <>)))
+        format-string (sql/set-timezone-sql driver)
+        sql           (format format-string (str \' timezone \'))]
+    (log/debug (u/format-color 'green "Setting timezone with statement: %s" sql))
+    (jdbc/db-do-prepared connection [sql])))
 
 (defn- run-query-without-timezone [driver settings connection query]
   (do-in-transaction connection (partial run-query query)))

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -341,9 +341,10 @@
   "Set the timezone for the current connection."
   [driver settings connection]
   (let [timezone (:report-timezone settings)
-        sql      (sql/set-timezone-sql driver)]
-    (log/debug (u/pprint-to-str 'green [sql timezone]))
-    (jdbc/db-do-prepared connection [sql timezone])))
+        sql      (sql/set-timezone-sql driver)
+        replaced (clojure.string/replace sql "?" (str "'" (re-matches #"[A-z\/_]+" timezone) "'"))]
+    (log/debug (u/pprint-to-str 'green [replaced]))
+    (jdbc/db-do-prepared connection [replaced])))
 
 (defn- run-query-without-timezone [driver settings connection query]
   (do-in-transaction connection (partial run-query query)))

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -191,7 +191,7 @@
           ;; run the command `mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root mysql`
           ;; See https://dev.mysql.com/doc/refman/5.7/en/time-zone-support.html for details
           ;; TODO - This can also be set via `sessionVariables` in the connection string, if that's more useful (?)
-          :set-timezone-sql          (constantly "SET @@session.time_zone = ?;")
+          :set-timezone-sql          (constantly "SET @@session.time_zone = %s;")
           :unix-timestamp->timestamp (u/drop-first-arg unix-timestamp->timestamp)}))
 
 (driver/register-driver! :mysql (MySQLDriver.))

--- a/src/metabase/driver/oracle.clj
+++ b/src/metabase/driver/oracle.clj
@@ -254,9 +254,7 @@
                                           (require 'metabase.test.data.oracle)
                                           ((resolve 'metabase.test.data.oracle/non-session-schemas)))))
           :field-percent-urls        sql/slow-field-percent-urls
-          ;; TODO - we *should* be able to set timezone using the SQL below, but I think the SQL doesn't work with prepared params (i.e., '?')
-          ;; Find some way to work around this for Oracle
-          ;; :set-timezone-sql          (constantly "ALTER session SET time_zone = ?")
+          :set-timezone-sql          (constantly "ALTER session SET time_zone = %s")
           :prepare-value             (u/drop-first-arg prepare-value)
           :string-length-fn          (u/drop-first-arg string-length-fn)
           :unix-timestamp->timestamp (u/drop-first-arg unix-timestamp->timestamp)}))

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -213,7 +213,7 @@
           :connection-details->spec  (u/drop-first-arg connection-details->spec)
           :date                      (u/drop-first-arg date)
           :prepare-value             (u/drop-first-arg prepare-value)
-          :set-timezone-sql          (constantly "UPDATE pg_settings SET setting = ? WHERE name ILIKE 'timezone';")
+          :set-timezone-sql          (constantly "SET SESSION TIMEZONE TO ?;")
           :string-length-fn          (u/drop-first-arg string-length-fn)
           :unix-timestamp->timestamp (u/drop-first-arg unix-timestamp->timestamp)}))
 

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -192,7 +192,7 @@
           :connection-details->spec  (u/drop-first-arg connection-details->spec)
           :date                      (u/drop-first-arg date)
           :prepare-value             (u/drop-first-arg prepare-value)
-          :set-timezone-sql          (constantly "SET SESSION TIMEZONE TO ?;")
+          :set-timezone-sql          (constantly "SET SESSION TIMEZONE TO %s;")
           :string-length-fn          (u/drop-first-arg string-length-fn)
           :unix-timestamp->timestamp (u/drop-first-arg unix-timestamp->timestamp)}))
 

--- a/src/metabase/driver/vertica.clj
+++ b/src/metabase/driver/vertica.clj
@@ -127,7 +127,7 @@
          {:column->base-type         (u/drop-first-arg column->base-type)
           :connection-details->spec  (u/drop-first-arg connection-details->spec)
           :date                      (u/drop-first-arg date)
-          :set-timezone-sql          (constantly "SET TIME ZONE TO ?;")
+          :set-timezone-sql          (constantly "SET TIME ZONE TO %s;")
           :string-length-fn          (u/drop-first-arg string-length-fn)
           :unix-timestamp->timestamp (u/drop-first-arg unix-timestamp->timestamp)}))
 

--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -1,6 +1,6 @@
 (ns metabase.driver-test
   (:require [expectations :refer :all]
-            [metabase.driver :refer :all]))
+            [metabase.driver :as driver]))
 
 
 (defrecord TestDriver []
@@ -8,11 +8,11 @@
   (getName [_] "TestDriver"))
 
 (extend TestDriver
-  IDriver
+  driver/IDriver
   {:features (constantly #{:a})})
 
 
 ;; driver-supports?
 
-(expect true (driver-supports? (TestDriver.) :a))
-(expect false (driver-supports? (TestDriver.) :b))
+(expect true  (driver/driver-supports? (TestDriver.) :a))
+(expect false (driver/driver-supports? (TestDriver.) :b))

--- a/test/metabase/test/data/oracle.clj
+++ b/test/metabase/test/data/oracle.clj
@@ -86,11 +86,13 @@
 
   i/IDatasetLoader
   (merge generic/IDatasetLoaderMixin
-         {:database->connection-details (fn [& _] @db-connection-details)
-          :default-schema               (constantly session-schema)
-          :engine                       (constantly :oracle)
-          :expected-base-type->actual   (u/drop-first-arg expected-base-type->actual)
-          :id-field-type                (constantly :type/Decimal)}))
+         {:database->connection-details       (fn [& _] @db-connection-details)
+          :default-schema                     (constantly session-schema)
+          :engine                             (constantly :oracle)
+          :expected-base-type->actual         (u/drop-first-arg expected-base-type->actual)
+          :id-field-type                      (constantly :type/Decimal)
+          ;; TODO - Not sure why we need to do this
+          :has-questionable-timezone-support? (constantly true)}))
 
 (defn- dbspec [& _]
   (sql/connection-details->spec (OracleDriver.) @db-connection-details))


### PR DESCRIPTION
Forgot to push this yesterday.

PR #4062 with cleanup and fixes to some of the behavior.

I've also been able to enable timezone support for Oracle through this so some test fixes might be needed before we can merge.