### PR TITLE
Minor improvements to function that generates API dox from schemas

### DIFF
--- a/test/metabase/util/schema_test.clj
+++ b/test/metabase/util/schema_test.clj
@@ -1,0 +1,9 @@
+(ns metabase.util.schema-test
+  (:require [metabase.util.schema :as su]
+            [schema.core :as s]
+            [expectations :refer :all]))
+
+;; check that the API error message generation is working as intended
+(expect
+  "value may be nil, or if non-nil, value must satisfy one of the following requirements: 1) value must be a boolean. 2) value must be a valid boolean string ('true' or 'false')."
+  (su/api-error-message (s/maybe (s/cond-pre s/Bool su/BooleanString))))


### PR DESCRIPTION
Minor tweak to the function that generates API errors and documentation from API param schemas to support `cond-pre` forms.

e.g. a schema like

```clojure
(s/maybe (s/cond-pre s/Bool su/BooleanString)))
```

Produces output like

> value may be nil, or if non-nil, value must satisfy one of the following requirements: 1) value must be a boolean. 2) value must be a valid boolean string ('true' or 'false').

Sophisticated. 

Backported from a different experimental branch. Includes test