### PR TITLE
clean up HeaderBar component [WIP]

### DIFF
--- a/frontend/src/metabase/components/HeaderBar.jsx
+++ b/frontend/src/metabase/components/HeaderBar.jsx
@@ -1,6 +1,5 @@
 /* @flow */
 import React, { Component } from "react";
-import cx from "classnames";
 
 import Input from "metabase/components/Input.jsx";
 import TitleAndDescription from "metabase/components/TitleAndDescription.jsx";

--- a/frontend/src/metabase/components/HeaderBar.jsx
+++ b/frontend/src/metabase/components/HeaderBar.jsx
@@ -1,53 +1,40 @@
+/* @flow */
 import React, { Component } from "react";
+import cx from "classnames";
 
 import Input from "metabase/components/Input.jsx";
 import TitleAndDescription from "metabase/components/TitleAndDescription.jsx";
 
-import cx from "classnames";
-
-export default class Header extends Component {
+export default class HeaderBar extends Component {
 
     static defaultProps = {
         buttons: null,
-        className: "py1 lg-py2 xl-py3 wrapper",
-        breadcrumb: null
     };
 
     render() {
-        const { isEditing, name, description, breadcrumb, buttons, className, badge } = this.props;
-
-        let titleAndDescription;
-        if (isEditing) {
-            titleAndDescription = (
-                <div className="Header-title flex flex-column flex-full bordered rounded my1">
-                    <Input className="AdminInput text-bold border-bottom rounded-top h3" type="text" value={name} onChange={(e) => this.props.setItemAttributeFn("name", e.target.value)} />
-                    <Input className="AdminInput rounded-bottom h4" type="text" value={description} onChange={(e) => this.props.setItemAttributeFn("description", e.target.value)} placeholder="No description yet" />
-                </div>
-            );
-        } else {
-            if (name && description) {
-                titleAndDescription = (
-                    <TitleAndDescription
-                        title={name}
-                        description={description}
-                    />
-                );
-            } else {
-                titleAndDescription = (
-                    <div className="flex align-baseline">
-                        <h1 className="Header-title-name my1">{name}</h1> {breadcrumb}
-                    </div>
-                );
-            }
-        }
+        const { isEditing, name, description, buttons, badge } = this.props;
 
         return (
-            <div className={cx("QueryBuilder-section pt2 sm-pt2 flex align-center", className)}>
-                <div className={cx("px2 sm-px0 pt2 relative flex-full")}>
-                    { badge &&
-                        <div className="absolute top left ml2 sm-ml2">{badge}</div>
+            <div className="wrapper sm-py3 flex align-center">
+                <div className="flex-full">
+                    { isEditing
+                            ? (
+                                <div className="Header-title flex flex-column flex-full bordered rounded my1">
+                                    <Input className="AdminInput text-bold border-bottom rounded-top h3" type="text" value={name} onChange={(e) => this.props.setItemAttributeFn("name", e.target.value)} />
+                                    <Input className="AdminInput rounded-bottom h4" type="text" value={description} onChange={(e) => this.props.setItemAttributeFn("description", e.target.value)} placeholder="No description yet" />
+                                </div>
+
+                            )
+                            : (
+                                <div className="sm-ml1">
+                                    { badge && <span className="mb2">{badge}</span>}
+                                    <TitleAndDescription
+                                        title={name}
+                                        description={description}
+                                    />
+                                </div>
+                            )
                     }
-                    {titleAndDescription}
                 </div>
 
                 <div className="flex-align-right hide sm-show">

--- a/frontend/src/metabase/components/HeaderBar.spec.js
+++ b/frontend/src/metabase/components/HeaderBar.spec.js
@@ -1,0 +1,50 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import HeaderBar from 'metabase/components/HeaderBar';
+import Input from "metabase/components/Input.jsx";
+import TitleAndDescription from 'metabase/components/TitleAndDescription';
+
+describe('HeaderBar', () => {
+
+    it('should render a TitleAndDescription component when name and description are passed', () => {
+        const component = shallow(<HeaderBar name='This is a thing' description='This is the description of the thing' />)
+
+        expect(component.find(TitleAndDescription).length).toEqual(1)
+    })
+
+    describe('badges, of which we have no stinking need ', () => {
+        it('should provide space for and render a badge if a badge is passed as props', () => {
+            const component = shallow(<HeaderBar name='Name' badge='derp' />)
+
+            expect(component.contains('derp')).toEqual(true)
+        })
+    })
+
+    describe('breadcrumbs', () => {
+        it('')
+    })
+
+
+    describe('editing', () => {
+        it('should render inputs if the name and description are being edited', () => {
+            const component = shallow(<HeaderBar name='Name' isEditing={true}  />)
+
+            expect(component.find(Input).length).toEqual(2)
+        })
+    })
+
+    describe('buttons', () => {
+        it('should render buttons passed to it', () => {
+            const buttons = [
+                <div>Hey</div>,
+                <div>Yo</div>
+            ]
+
+            const component = shallow(<HeaderBar name='Name' buttons={buttons} />)
+
+            expect(component.contains(<div>Hey</div>)).toEqual(true)
+            expect(component.contains(<div>Yo</div>)).toEqual(true)
+        })
+    })
+})


### PR DESCRIPTION
addresses #4885 

adds tests and refactors the markup for the HeaderBar component.

Todos: 

- [ ] handle breadcrumbs and add test
- [ ] check mobile rendering
- [ ] make sure other instances of `<HeaderBar />` (are there any?) work ok.
- [ ] add test ensuring that the change props are called on inputs