### PR TITLE
Sort everything with clj refactor part two

### DIFF
--- a/reset_password/metabase/reset_password/core.clj
+++ b/reset_password/metabase/reset_password/core.clj
@@ -1,8 +1,8 @@
 (ns metabase.reset-password.core
   (:gen-class)
-  (:require [toucan.db :as db]
-            [metabase.db :as mdb]
-            [metabase.models.user :as user]))
+  (:require [metabase.db :as mdb]
+            [metabase.models.user :as user]
+            [toucan.db :as db]))
 
 (defn- set-reset-token!
   "Set and return a new `reset_token` for the user with EMAIL-ADDRESS."

--- a/sample_dataset/metabase/sample_dataset/generate.clj
+++ b/sample_dataset/metabase/sample_dataset/generate.clj
@@ -1,15 +1,17 @@
 (ns metabase.sample-dataset.generate
   "Logic for generating the sample dataset.
    Run this with `lein generate-sample-dataset`."
-  (:require (clojure.java [io :as io]
-                          [jdbc :as jdbc])
+  (:require [clojure.java
+             [io :as io]
+             [jdbc :as jdbc]]
             [clojure.math.numeric-tower :as math]
             [clojure.string :as s]
-            (faker [address :as address]
-                   [company :as company]
-                   [lorem :as lorem]
-                   [internet :as internet]
-                   [name :as name])
+            [faker
+             [address :as address]
+             [company :as company]
+             [internet :as internet]
+             [lorem :as lorem]
+             [name :as name]]
             [incanter.distributions :as dist]
             [metabase.db.spec :as dbspec]
             [metabase.util :as u])

--- a/test/metabase/api/activity_test.clj
+++ b/test/metabase/api/activity_test.clj
@@ -1,16 +1,16 @@
 (ns metabase.api.activity-test
   "Tests for /api/activity endpoints."
   (:require [expectations :refer :all]
-            [toucan.db :as db]
-            [toucan.util.test :as tt]
-            (metabase.models [activity :refer [Activity]]
-                             [card :refer [Card]]
-                             [dashboard :refer [Dashboard]]
-                             [view-log :refer [ViewLog]])
-            [metabase.test.data :refer :all]
+            [metabase.models
+             [activity :refer [Activity]]
+             [card :refer [Card]]
+             [dashboard :refer [Dashboard]]
+             [view-log :refer [ViewLog]]]
             [metabase.test.data.users :refer :all]
-            [metabase.test.util :refer [match-$ resolve-private-vars], :as tu]
-            [metabase.util :as u]))
+            [metabase.test.util :as tu :refer [match-$ resolve-private-vars]]
+            [metabase.util :as u]
+            [toucan.db :as db]
+            [toucan.util.test :as tt]))
 
 ;; GET /
 

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -3,24 +3,27 @@
   (:require [cheshire.core :as json]
             [expectations :refer :all]
             [medley.core :as m]
-            [toucan.db :as db]
-            [toucan.util.test :as tt]
-            [metabase.http-client :refer :all, :as http]
-            [metabase.middleware :as middleware]
-            (metabase.models [card :refer [Card]]
-                             [card-favorite :refer [CardFavorite]]
-                             [card-label :refer [CardLabel]]
-                             [collection :refer [Collection]]
-                             [database :refer [Database]]
-                             [label :refer [Label]]
-                             [permissions :refer [Permissions], :as perms]
-                             [permissions-group :as perms-group]
-                             [table :refer [Table]]
-                             [view-log :refer [ViewLog]])
-            [metabase.test.data :refer :all]
+            [metabase
+             [http-client :as http :refer :all]
+             [middleware :as middleware]
+             [util :as u]]
+            [metabase.models
+             [card :refer [Card]]
+             [card-favorite :refer [CardFavorite]]
+             [card-label :refer [CardLabel]]
+             [collection :refer [Collection]]
+             [database :refer [Database]]
+             [label :refer [Label]]
+             [permissions :as perms]
+             [permissions-group :as perms-group]
+             [table :refer [Table]]
+             [view-log :refer [ViewLog]]]
+            [metabase.test
+             [data :refer :all]
+             [util :as tu :refer [match-$ random-name]]]
             [metabase.test.data.users :refer :all]
-            [metabase.test.util :refer [match-$ random-name obj->json->obj], :as tu]
-            [metabase.util :as u])
+            [toucan.db :as db]
+            [toucan.util.test :as tt])
   (:import java.util.UUID))
 
 ;;; CARD LIFECYCLE

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -1,15 +1,16 @@
 (ns metabase.api.collection-test
   "Tests for /api/collection endpoints."
   (:require [expectations :refer :all]
-            [toucan.db :as db]
-            [toucan.util.test :as tt]
-            (metabase.models [card :refer [Card]]
-                             [collection :refer [Collection]]
-                             [permissions :as perms]
-                             [permissions-group :as group])
+            [metabase.models
+             [card :refer [Card]]
+             [collection :refer [Collection]]
+             [permissions :as perms]
+             [permissions-group :as group]]
             [metabase.test.data.users :refer [user->client]]
             [metabase.test.util :as tu]
-            [metabase.util :as u]))
+            [metabase.util :as u]
+            [toucan.db :as db]
+            [toucan.util.test :as tt]))
 
 ;; check that we can get a basic list of collections
 (tt/expect-with-temp [Collection [collection]]

--- a/test/metabase/api/common/internal_test.clj
+++ b/test/metabase/api/common/internal_test.clj
@@ -1,7 +1,7 @@
 (ns metabase.api.common.internal-test
   (:require [expectations :refer :all]
             [medley.core :as m]
-            (metabase.api.common [internal :refer :all])
+            [metabase.api.common.internal :refer :all]
             [metabase.util :as u]))
 
 ;;; TESTS FOR ROUTE-FN-NAME

--- a/test/metabase/api/common_test.clj
+++ b/test/metabase/api/common_test.clj
@@ -3,9 +3,7 @@
             [metabase.api.common :refer :all]
             [metabase.api.common.internal :refer :all]
             [metabase.test.data :refer :all]
-            [metabase.test.util :refer :all]
             [metabase.util.schema :as su]))
-
 
 ;;; TESTS FOR CHECK (ETC)
 

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -2,24 +2,22 @@
   "Tests for /api/dashboard endpoints."
   (:require [expectations :refer :all]
             [medley.core :as m]
-            (toucan [db :as db]
-                    [hydrate :refer [hydrate]])
-            [toucan.util.test :as tt]
+            [metabase
+             [http-client :as http]
+             [middleware :as middleware]
+             [util :as u]]
             [metabase.api.card-test :as card-api-test]
-            (metabase [http-client :as http]
-                      [middleware :as middleware])
-            (metabase.models [card :refer [Card]]
-                             [dashboard :refer [Dashboard]]
-                             [dashboard-card :refer [DashboardCard retrieve-dashboard-card]]
-                             [dashboard-card-series :refer [DashboardCardSeries]]
-                             [revision :refer [Revision]]
-                             [user :refer [User]])
-            [metabase.test.data :refer :all]
+            [metabase.models
+             [card :refer [Card]]
+             [dashboard :refer [Dashboard]]
+             [dashboard-card :refer [DashboardCard retrieve-dashboard-card]]
+             [dashboard-card-series :refer [DashboardCardSeries]]
+             [revision :refer [Revision]]]
             [metabase.test.data.users :refer :all]
             [metabase.test.util :as tu]
-            [metabase.util :as u])
+            [toucan.db :as db]
+            [toucan.util.test :as tt])
   (:import java.util.UUID))
-
 
 ;; ## Helper Fns
 

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -1,17 +1,21 @@
 (ns metabase.api.database-test
   (:require [expectations :refer :all]
-            (toucan [db :as db]
-                    [hydrate :as hydrate])
-            [toucan.util.test :as tt]
-            [metabase.driver :as driver]
-            (metabase.models [database :refer [Database]]
-                             [field :refer [Field]]
-                             [table :refer [Table]])
-            [metabase.test.data :refer :all]
-            (metabase.test.data [datasets :as datasets]
-                                [users :refer :all])
-            [metabase.test.util :refer [match-$ random-name], :as tu]
-            [metabase.util :as u]))
+            [metabase
+             [driver :as driver]
+             [util :as u]]
+            [metabase.models
+             [database :refer [Database]]
+             [field :refer [Field]]
+             [table :refer [Table]]]
+            [metabase.test
+             [data :refer :all]
+             [util :as tu :refer [match-$]]]
+            [metabase.test.data
+             [datasets :as datasets]
+             [users :refer :all]]
+            [toucan
+             [db :as db]
+             [hydrate :as hydrate]]))
 
 ;; HELPER FNS
 

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -1,16 +1,14 @@
 (ns metabase.api.dataset-test
   "Unit tests for /api/dataset endpoints."
-  (:require [clojure.string :as s]
-            [expectations :refer :all]
-            [toucan.db :as db]
+  (:require [expectations :refer :all]
             [metabase.api.dataset :refer [default-query-constraints]]
-            (metabase.models [card :refer [Card]]
-                             [query-execution :refer [QueryExecution]])
+            [metabase.models.query-execution :refer [QueryExecution]]
             [metabase.query-processor.expand :as ql]
+            [metabase.test
+             [data :refer :all]
+             [util :as tu]]
             [metabase.test.data.users :refer :all]
-            [metabase.test.data :refer :all]
-            [metabase.test.util :as tu]))
-
+            [toucan.db :as db]))
 
 (defn user-details [user]
   (tu/match-$ user

--- a/test/metabase/api/email_test.clj
+++ b/test/metabase/api/email_test.clj
@@ -1,9 +1,7 @@
 (ns metabase.api.email-test
   (:require [expectations :refer :all]
-            [metabase.email-test :refer [with-fake-inbox inbox]]
             [metabase.models.setting :as setting]
-            [metabase.test.data.users :refer :all]))
-
+            [metabase.test.data.users :refer [user->client]]))
 
 (defn- email-settings
   []

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -2,16 +2,18 @@
   (:require [buddy.sign.jwt :as jwt]
             [crypto.random :as crypto-random]
             [expectations :refer :all]
-            [toucan.util.test :as tt]
-            [metabase.http-client :as http]
+            [metabase
+             [http-client :as http]
+             [util :as u]]
             [metabase.api.public-test :as public-test]
-            (metabase.models [card :refer [Card]]
-                             [dashboard :refer [Dashboard]]
-                             [dashboard-card :refer [DashboardCard]])
-            (metabase.test [data :as data]
-                           [util :as tu])
-            [metabase.util :as u]
-            [metabase.util.embed :as eu]))
+            [metabase.models
+             [card :refer [Card]]
+             [dashboard :refer [Dashboard]]
+             [dashboard-card :refer [DashboardCard]]]
+            [metabase.test
+             [data :as data]
+             [util :as tu]]
+            [toucan.util.test :as tt]))
 
 (defn random-embedding-secret-key [] (crypto-random/hex 32))
 

--- a/test/metabase/api/field_test.clj
+++ b/test/metabase/api/field_test.clj
@@ -1,15 +1,16 @@
 (ns metabase.api.field-test
   (:require [expectations :refer :all]
-            [toucan.db :as db]
-            [toucan.util.test :as tt]
             [metabase.driver :as driver]
-            (metabase.models [database :refer [Database]]
-                             [field :refer [Field]]
-                             [field-values :refer [FieldValues]]
-                             [table :refer [Table]])
-            [metabase.test.data :refer :all]
+            [metabase.models
+             [field :refer [Field]]
+             [field-values :refer [FieldValues]]
+             [table :refer [Table]]]
+            [metabase.test
+             [data :refer :all]
+             [util :as tu]]
             [metabase.test.data.users :refer :all]
-            [metabase.test.util :as tu]))
+            [toucan.db :as db]
+            [toucan.util.test :as tt]))
 
 ;; Helper Fns
 

--- a/test/metabase/api/geojson_test.clj
+++ b/test/metabase/api/geojson_test.clj
@@ -1,10 +1,10 @@
 (ns metabase.api.geojson-test
   (:require [expectations :refer :all]
-            [schema.core :as s]
             [metabase.api.geojson :refer [custom-geojson]]
             [metabase.test.data.users :refer [user->client]]
             [metabase.test.util :as tu]
-            [metabase.util :as u]))
+            [metabase.util :as u]
+            [schema.core :as s]))
 
 (tu/resolve-private-vars metabase.api.geojson
   valid-json-url?

--- a/test/metabase/api/label_test.clj
+++ b/test/metabase/api/label_test.clj
@@ -1,11 +1,11 @@
 (ns metabase.api.label-test
   "Tests for `/api/label` endpoints."
   (:require [expectations :refer [expect]]
-            [toucan.db :as db]
-            [toucan.util.test :as tt]
             [metabase.models.label :refer [Label]]
             [metabase.test.data.users :refer [user->client]]
-            [metabase.util :as u]))
+            [metabase.util :as u]
+            [toucan.db :as db]
+            [toucan.util.test :as tt]))
 
 ;;; GET /api/label -- list all labels
 (tt/expect-with-temp [Label [{label-1-id :id} {:name "Toucan-Approved"}]

--- a/test/metabase/api/metric_test.clj
+++ b/test/metabase/api/metric_test.clj
@@ -1,17 +1,20 @@
 (ns metabase.api.metric-test
   "Tests for /api/metric endpoints."
   (:require [expectations :refer :all]
-            [toucan.hydrate :refer [hydrate]]
-            [toucan.util.test :as tt]
-            (metabase [http-client :as http]
-                      [middleware :as middleware])
-            (metabase.models [database :refer [Database]]
-                             [metric :refer [Metric], :as metric]
-                             [revision :refer [Revision]]
-                             [table :refer [Table]])
-            [metabase.test.data :refer :all, :as data]
+            [metabase
+             [http-client :as http]
+             [middleware :as middleware]]
+            [metabase.models
+             [database :refer [Database]]
+             [metric :as metric :refer [Metric]]
+             [revision :refer [Revision]]
+             [table :refer [Table]]]
+            [metabase.test
+             [data :as data :refer :all]
+             [util :as tu]]
             [metabase.test.data.users :refer :all]
-            [metabase.test.util :as tu]))
+            [toucan.hydrate :refer [hydrate]]
+            [toucan.util.test :as tt]))
 
 ;; ## Helper Fns
 

--- a/test/metabase/api/permissions_test.clj
+++ b/test/metabase/api/permissions_test.clj
@@ -1,11 +1,10 @@
 (ns metabase.api.permissions-test
   "Tests for `/api/permissions` endpoints."
   (:require [expectations :refer :all]
-            [toucan.util.test :as tt]
-            [metabase.models.permissions-group :refer [PermissionsGroup], :as group]
+            [metabase.models.permissions-group :as group :refer [PermissionsGroup]]
             [metabase.test.data.users :as test-users]
-            [metabase.util :as u]))
-
+            [metabase.util :as u]
+            [toucan.util.test :as tt]))
 
 ;; GET /permissions/group
 ;; Should *not* include inactive users in the counts.

--- a/test/metabase/api/preview_embed_test.clj
+++ b/test/metabase/api/preview_embed_test.clj
@@ -1,13 +1,11 @@
 (ns metabase.api.preview-embed-test
   (:require [expectations :refer :all]
-            [toucan.util.test :as tt]
             [metabase.api.embed-test :as embed-test]
-            (metabase.models [card :refer [Card]]
-                             [dashboard :refer [Dashboard]]
-                             [dashboard-card :refer [DashboardCard]])
+            [metabase.models.dashboard :refer [Dashboard]]
             [metabase.test.data.users :as test-users]
             [metabase.test.util :as tu]
-            [metabase.util :as u]))
+            [metabase.util :as u]
+            [toucan.util.test :as tt]))
 
 ;;; ------------------------------------------------------------ GET /api/preview_embed/card/:token ------------------------------------------------------------
 

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -2,22 +2,23 @@
   "Tests for `api/public/` (public links) endpoints."
   (:require [cheshire.core :as json]
             [expectations :refer :all]
-            [toucan.db :as db]
-            [toucan.util.test :as tt]
-            [metabase.http-client :as http]
-            (metabase.models [card :refer [Card]]
-                             [dashboard :refer [Dashboard]]
-                             [dashboard-card :refer [DashboardCard]]
-                             [dashboard-card-series :refer [DashboardCardSeries]]
-                             [field-values :refer [FieldValues]])
-            metabase.public-settings ; for `enable-public-sharing
-            [metabase.query-processor-test :as qp-test]
-            [metabase.test.data :as data]
+            [metabase
+             [http-client :as http]
+             [query-processor-test :as qp-test]
+             [util :as u]]
+            [metabase.models
+             [card :refer [Card]]
+             [dashboard :refer [Dashboard]]
+             [dashboard-card :refer [DashboardCard]]
+             [dashboard-card-series :refer [DashboardCardSeries]]
+             [field-values :refer [FieldValues]]]
+            [metabase.test
+             [data :as data]
+             [util :as tu]]
             [metabase.test.data.users :as test-users]
-            [metabase.test.util :as tu]
-            [metabase.util :as u])
+            [toucan.db :as db]
+            [toucan.util.test :as tt])
   (:import java.util.UUID))
-
 
 ;;; ------------------------------------------------------------ Helper Fns ------------------------------------------------------------
 

--- a/test/metabase/api/pulse_test.clj
+++ b/test/metabase/api/pulse_test.clj
@@ -1,17 +1,16 @@
 (ns metabase.api.pulse-test
   "Tests for /api/pulse endpoints."
   (:require [expectations :refer :all]
-            [toucan.db :as db]
-            [toucan.util.test :as tt]
-            (metabase [http-client :as http]
-                      [middleware :as middleware])
-            (metabase.models [card :refer [Card]]
-                             [database :refer [Database]]
-                             [pulse :refer [Pulse], :as pulse])
-            [metabase.test.data :refer :all]
+            [metabase
+             [http-client :as http]
+             [middleware :as middleware]]
+            [metabase.models
+             [card :refer [Card]]
+             [pulse :as pulse :refer [Pulse]]]
             [metabase.test.data.users :refer :all]
             [metabase.test.util :as tu]
-            [metabase.util :as u]))
+            [toucan.db :as db]
+            [toucan.util.test :as tt]))
 
 ;; ## Helper Fns
 

--- a/test/metabase/api/revision_test.clj
+++ b/test/metabase/api/revision_test.clj
@@ -1,14 +1,14 @@
 (ns metabase.api.revision-test
   (:require [expectations :refer :all]
-            [metabase.api.revision :refer :all]
-            [toucan.db :as db]
-            [toucan.util.test :as tt]
-            (metabase.models [card :refer [Card serialize-instance]]
-                             [dashboard :refer [Dashboard]]
-                             [dashboard-card :refer [DashboardCard]]
-                             [revision :refer [Revision push-revision! revert! revisions]])
+            [metabase.models
+             [card :refer [Card serialize-instance]]
+             [dashboard :refer [Dashboard]]
+             [dashboard-card :refer [DashboardCard]]
+             [revision :refer [push-revision! Revision revisions]]]
             [metabase.test.data :refer :all]
-            [metabase.test.data.users :refer :all]))
+            [metabase.test.data.users :refer :all]
+            [toucan.db :as db]
+            [toucan.util.test :as tt]))
 
 (def ^:private rasta-revision-info
   (delay {:id (user->id :rasta), :common_name "Rasta Toucan", :first_name "Rasta", :last_name "Toucan"}))

--- a/test/metabase/api/segment_test.clj
+++ b/test/metabase/api/segment_test.clj
@@ -1,18 +1,21 @@
 (ns metabase.api.segment-test
   "Tests for /api/segment endpoints."
   (:require [expectations :refer :all]
-            [toucan.hydrate :refer [hydrate]]
-            [toucan.util.test :as tt]
-            (metabase [http-client :as http]
-                      [middleware :as middleware])
-            (metabase.models [database :refer [Database]]
-                             [revision :refer [Revision]]
-                             [segment :refer [Segment], :as segment]
-                             [table :refer [Table]])
+            [metabase
+             [http-client :as http]
+             [middleware :as middleware]
+             [util :as u]]
+            [metabase.models
+             [database :refer [Database]]
+             [revision :refer [Revision]]
+             [segment :as segment :refer [Segment]]
+             [table :refer [Table]]]
+            [metabase.test
+             [data :refer :all]
+             [util :as tu]]
             [metabase.test.data.users :refer :all]
-            [metabase.test.data :refer :all]
-            [metabase.test.util :as tu]
-            [metabase.util :as u]))
+            [toucan.hydrate :refer [hydrate]]
+            [toucan.util.test :as tt]))
 
 ;; ## Helper Fns
 

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -1,18 +1,20 @@
 (ns metabase.api.session-test
   "Tests for /api/session"
-  (:require [cemerick.friend.credentials :as creds]
-            [expectations :refer :all]
-            [toucan.db :as db]
-            [toucan.util.test :as tt]
+  (:require [expectations :refer :all]
+            [metabase
+             [http-client :refer :all]
+             [public-settings :as public-settings]
+             [util :as u]]
             [metabase.api.session :refer :all]
-            [metabase.http-client :refer :all]
-            (metabase.models [session :refer [Session]]
-                             [user :refer [User]])
-            [metabase.public-settings :as public-settings]
-            [metabase.test.data :refer :all]
+            [metabase.models
+             [session :refer [Session]]
+             [user :refer [User]]]
+            [metabase.test
+             [data :refer :all]
+             [util :as tu :refer [resolve-private-vars]]]
             [metabase.test.data.users :refer :all]
-            [metabase.util :as u]
-            [metabase.test.util :refer [random-name resolve-private-vars with-temporary-setting-values], :as tu]))
+            [toucan.db :as db]
+            [toucan.util.test :as tt]))
 
 ;; ## POST /api/session
 ;; Test that we can login

--- a/test/metabase/api/setting_test.clj
+++ b/test/metabase/api/setting_test.clj
@@ -1,11 +1,6 @@
 (ns metabase.api.setting-test
   (:require [expectations :refer :all]
-            (metabase.models [setting :as setting]
-                             [setting-test :refer [set-settings!
-                                                   setting-exists-in-db?
-                                                   test-setting-1
-                                                   test-setting-2]])
-            [metabase.test.data :refer :all]
+            [metabase.models.setting-test :refer [set-settings! test-setting-1 test-setting-2]]
             [metabase.test.data.users :refer :all]))
 
 ;; ## Helper Fns

--- a/test/metabase/api/setup_test.clj
+++ b/test/metabase/api/setup_test.clj
@@ -1,17 +1,11 @@
 (ns metabase.api.setup-test
   "Tests for /api/setup endpoints."
   (:require [expectations :refer :all]
-            [toucan.db :as db]
-            [metabase.http-client :as http]
-            (metabase.models [session :refer [Session]]
-                             [setting :as setting]
-                             [user :refer [User]])
-            (metabase [public-settings :as public-settings]
-                      [setup :as setup])
-            (metabase.test [data :refer :all]
-                           [util :refer [match-$], :as tu])
-            [metabase.util :as u]))
-
+            [metabase
+             [http-client :as http]
+             [public-settings :as public-settings]
+             [setup :as setup]]
+            [metabase.test.util :as tu]))
 
 ;; ## POST /api/setup/user
 ;; Check that we can create a new superuser via setup-token

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -1,23 +1,25 @@
 (ns metabase.api.table-test
   "Tests for /api/table endpoints."
   (:require [expectations :refer :all]
-            (toucan [db :as db]
-                    [hydrate :as hydrate])
-            [toucan.util.test :as tt]
-            (metabase [driver :as driver]
-                      [http-client :as http]
-                      [middleware :as middleware])
-            (metabase.models [database :refer [Database]]
-                             [field :refer [Field]]
-                             [table :refer [Table]]
-                             [permissions :as perms]
-                             [permissions-group :as perms-group])
-            [metabase.test.data :refer :all]
-            (metabase.test.data [dataset-definitions :as defs]
-                                [datasets :as datasets]
-                                [users :refer :all])
-            [metabase.test.util :refer [match-$ resolve-private-vars], :as tu]
-            [metabase.util :as u]))
+            [metabase
+             [driver :as driver]
+             [http-client :as http]
+             [middleware :as middleware]
+             [util :as u]]
+            [metabase.models
+             [database :refer [Database]]
+             [field :refer [Field]]
+             [permissions :as perms]
+             [permissions-group :as perms-group]
+             [table :refer [Table]]]
+            [metabase.test
+             [data :refer :all]
+             [util :as tu :refer [match-$ resolve-private-vars]]]
+            [metabase.test.data
+             [dataset-definitions :as defs]
+             [users :refer :all]]
+            [toucan.hydrate :as hydrate]
+            [toucan.util.test :as tt]))
 
 (resolve-private-vars metabase.models.table pk-field-id)
 

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -1,16 +1,17 @@
 (ns metabase.api.user-test
   "Tests for /api/user endpoints."
   (:require [expectations :refer :all]
-            [toucan.db :as db]
-            [toucan.util.test :as tt]
-            (metabase [http-client :as http]
-                      [middleware :as middleware])
-            (metabase.models [session :refer [Session]]
-                             [user :refer [User]])
-            [metabase.test.data :refer :all]
+            [metabase
+             [http-client :as http]
+             [middleware :as middleware]
+             [util :as u]]
+            [metabase.models.user :refer [User]]
+            [metabase.test
+             [data :refer :all]
+             [util :as tu :refer [match-$ random-name]]]
             [metabase.test.data.users :refer :all]
-            [metabase.test.util :refer [match-$ random-name], :as tu]
-            [metabase.util :as u]))
+            [toucan.db :as db]
+            [toucan.util.test :as tt]))
 
 ;; ## /api/user/* AUTHENTICATION Tests
 ;; We assume that all endpoints for a given context are enforced by the same middleware, so we don't run the same

--- a/test/metabase/cmd/load_from_h2_test.clj
+++ b/test/metabase/cmd/load_from_h2_test.clj
@@ -2,8 +2,8 @@
   (:require [clojure.java.classpath :as classpath]
             [clojure.tools.namespace.find :as ns-find]
             [expectations :refer :all]
-            [toucan.models :as models]
-            metabase.cmd.load-from-h2))
+            metabase.cmd.load-from-h2
+            [toucan.models :as models]))
 
 ;; Check to make sure we're migrating all of our entities.
 ;; This fetches the `metabase.cmd.load-from-h2/entities` and compares it all existing entities

--- a/test/metabase/db/metadata_queries_test.clj
+++ b/test/metabase/db/metadata_queries_test.clj
@@ -1,13 +1,11 @@
 (ns metabase.db.metadata-queries-test
-  (:require [expectations :refer :all]
-            [toucan.db :as db]
-            [metabase.db.metadata-queries :refer :all]
-            (metabase.models [field :refer [Field]]
-                             [table :refer [Table]])
+  (:require [metabase.db.metadata-queries :refer :all]
+            [metabase.models
+             [field :refer [Field]]
+             [table :refer [Table]]]
             [metabase.query-processor-test :as qp-test]
             [metabase.test.data :refer :all]
             [metabase.test.data.datasets :as datasets]))
-
 
 ;; Redshift & Crate tests are randomly failing -- see https://github.com/metabase/metabase/issues/2767
 (def ^:private ^:const metadata-queries-test-engines

--- a/test/metabase/db_test.clj
+++ b/test/metabase/db_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.db-test
   (:require [expectations :refer :all]
-            metabase.db
             [metabase.test.util :as tu]))
 
 (tu/resolve-private-vars metabase.db parse-connection-string)

--- a/test/metabase/driver/bigquery_test.clj
+++ b/test/metabase/driver/bigquery_test.clj
@@ -1,15 +1,13 @@
 (ns metabase.driver.bigquery-test
   (:require [expectations :refer :all]
-            metabase.driver.bigquery
-            [metabase.models.database :as database]
-            [metabase.query-processor :as qp]
+            [metabase
+             [query-processor :as qp]
+             [query-processor-test :as qptest]]
             [metabase.query-processor.expand :as ql]
-            [metabase.query-processor-test :as qptest]
-            [metabase.test.data :as data]
-            (metabase.test.data [datasets :refer [expect-with-engine]]
-                                [interface :refer [def-database-definition]])
-            [metabase.test.util :as tu]))
-
+            [metabase.test
+             [data :as data]
+             [util :as tu]]
+            [metabase.test.data.datasets :refer [expect-with-engine]]))
 
 ;; Test native queries
 (expect-with-engine :bigquery

--- a/test/metabase/driver/druid_test.clj
+++ b/test/metabase/driver/druid_test.clj
@@ -1,15 +1,15 @@
 (ns metabase.driver.druid-test
   (:require [cheshire.core :as json]
-            [expectations :refer :all]
-            [toucan.util.test :as tt]
+            [metabase
+             [query-processor :as qp]
+             [query-processor-test :refer [rows rows+column-names]]
+             [timeseries-query-processor-test :as timeseries-qp-test]
+             [util :as u]]
             [metabase.models.metric :refer [Metric]]
-            [metabase.query-processor :as qp]
             [metabase.query-processor.expand :as ql]
-            [metabase.query-processor-test :refer [rows rows+column-names]]
             [metabase.test.data :as data]
-            [metabase.test.data.datasets :as datasets, :refer [expect-with-engine]]
-            [metabase.timeseries-query-processor-test :as timeseries-qp-test]
-            [metabase.util :as u]))
+            [metabase.test.data.datasets :as datasets :refer [expect-with-engine]]
+            [toucan.util.test :as tt]))
 
 (def ^:const ^:private ^String native-query-1
   (json/generate-string

--- a/test/metabase/driver/generic_sql/native_test.clj
+++ b/test/metabase/driver/generic_sql/native_test.clj
@@ -1,9 +1,9 @@
 (ns metabase.driver.generic-sql.native-test
   (:require [expectations :refer :all]
-            [toucan.db :as db]
             [metabase.models.database :refer [Database]]
             [metabase.query-processor :as qp]
-            [metabase.test.data :refer :all]))
+            [metabase.test.data :refer :all]
+            [toucan.db :as db]))
 
 ;; Just check that a basic query works
 (expect {:status :completed

--- a/test/metabase/driver/generic_sql_test.clj
+++ b/test/metabase/driver/generic_sql_test.clj
@@ -1,15 +1,15 @@
 (ns metabase.driver.generic-sql-test
   (:require [expectations :refer :all]
-            [toucan.db :as db]
             [metabase.driver :as driver]
-            (metabase.driver [generic-sql :refer :all]
-                             h2)
-            (metabase.models [field :refer [Field]]
-                             [table :refer [Table], :as table])
-            [metabase.test.data :refer :all]
-            (metabase.test.data [dataset-definitions :as defs]
-                                [datasets :as datasets])
-            [metabase.test.util :refer [resolve-private-vars]])
+            [metabase.driver.generic-sql :refer :all]
+            [metabase.models
+             [field :refer [Field]]
+             [table :as table :refer [Table]]]
+            [metabase.test
+             [data :refer :all]
+             [util :refer [resolve-private-vars]]]
+            [metabase.test.data.datasets :as datasets]
+            [toucan.db :as db])
   (:import metabase.driver.h2.H2Driver))
 
 (def ^:private users-table      (delay (Table :name "USERS")))

--- a/test/metabase/driver/google_analytics_test.clj
+++ b/test/metabase/driver/google_analytics_test.clj
@@ -1,13 +1,8 @@
 (ns metabase.driver.google-analytics-test
   "Tests for the Google Analytics driver and query processor."
   (:require [expectations :refer :all]
-            [toucan.db :as db]
-            [metabase.driver.googleanalytics :as ga]
             [metabase.driver.googleanalytics.query-processor :as qp]
-            [metabase.models.database :refer [Database]]
-            (metabase.query-processor [expand :as ql]
-                                      [interface :as qpi])
-            [metabase.test.util :as tu]
+            [metabase.query-processor.interface :as qpi]
             [metabase.util :as u]))
 
 ;;; +------------------------------------------------------------------------------------------------------------------------+

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -1,7 +1,8 @@
 (ns metabase.driver.h2-test
   (:require [expectations :refer :all]
-            [metabase.db :as mdb]
-            [metabase.driver :as driver]
+            [metabase
+             [db :as mdb]
+             [driver :as driver]]
             [metabase.driver.h2 :refer :all]
             [metabase.test.util :refer [resolve-private-vars]])
   (:import metabase.driver.h2.H2Driver))

--- a/test/metabase/driver/mongo_test.clj
+++ b/test/metabase/driver/mongo_test.clj
@@ -1,23 +1,25 @@
 (ns metabase.driver.mongo-test
   "Tests for Mongo driver."
-  (:require [clojure.walk :as walk]
-            [expectations :refer :all]
-            [toucan.db :as db]
-            [metabase.driver :as driver]
-            (metabase.models [database :refer [Database]]
-                             [field :refer [Field]]
-                             [field-values :refer [FieldValues]]
-                             [table :refer [Table] :as table])
-            [metabase.query-processor :as qp]
+  (:require [expectations :refer :all]
+            [metabase
+             [driver :as driver]
+             [query-processor :as qp]
+             [query-processor-test :refer [rows]]]
+            [metabase.models
+             [field :refer [Field]]
+             [field-values :refer [FieldValues]]
+             [table :as table :refer [Table]]]
             [metabase.query-processor.expand :as ql]
-            [metabase.query-processor-test :refer [rows]]
-            [metabase.test.data :as data]
-            [metabase.test.data.datasets :as datasets]
-            [metabase.test.data.interface :as i]
-            [metabase.test.util :as tu])
-  (:import org.bson.types.ObjectId
-           org.joda.time.DateTime
-           metabase.driver.mongo.MongoDriver))
+            [metabase.test
+             [data :as data]
+             [util :as tu]]
+            [metabase.test.data
+             [datasets :as datasets]
+             [interface :as i]]
+            [toucan.db :as db])
+  (:import metabase.driver.mongo.MongoDriver
+           org.bson.types.ObjectId
+           org.joda.time.DateTime))
 
 ;; ## Constants + Helper Fns/Macros
 ;; TODO - move these to metabase.test-data ?

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -1,16 +1,16 @@
 (ns metabase.driver.mysql-test
   (:require [expectations :refer :all]
-            [toucan.db :as db]
-            [toucan.util.test :as tt]
-            (metabase.driver [generic-sql :as sql]
-                             mysql)
+            [metabase
+             [sync-database :as sync-db]
+             [util :as u]]
+            [metabase.driver.generic-sql :as sql]
             [metabase.models.database :refer [Database]]
-            [metabase.sync-database :as sync-db]
             [metabase.test.data :as data]
-            (metabase.test.data [datasets :refer [expect-with-engine]]
-                                [interface :refer [def-database-definition]])
-            [metabase.test.util :as tu]
-            [metabase.util :as u])
+            [metabase.test.data
+             [datasets :refer [expect-with-engine]]
+             [interface :refer [def-database-definition]]]
+            [toucan.db :as db]
+            [toucan.util.test :as tt])
   (:import metabase.driver.mysql.MySQLDriver))
 
 ;; MySQL allows 0000-00-00 dates, but JDBC does not; make sure that MySQL is converting them to NULL when returning them like we asked

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -2,21 +2,25 @@
   (:require [clojure.java.jdbc :as jdbc]
             [expectations :refer :all]
             [honeysql.core :as hsql]
-            [toucan.db :as db]
-            [toucan.util.test :as tt]
-            [metabase.driver :as driver]
+            [metabase
+             [driver :as driver]
+             [query-processor-test :refer [rows]]
+             [sync-database :as sync-db]
+             [util :as u]]
             [metabase.driver.generic-sql :as sql]
-            (metabase.models [database :refer [Database]]
-                             [field :refer [Field]]
-                             [table :refer [Table]])
-            [metabase.query-processor-test :refer [rows]]
+            [metabase.models
+             [database :refer [Database]]
+             [field :refer [Field]]
+             [table :refer [Table]]]
             [metabase.query-processor.expand :as ql]
-            [metabase.sync-database :as sync-db]
-            [metabase.test.data :as data]
-            (metabase.test.data [datasets :refer [expect-with-engine]]
-                                [interface :as i])
-            [metabase.test.util :as tu]
-            [metabase.util :as u])
+            [metabase.test
+             [data :as data]
+             [util :as tu]]
+            [metabase.test.data
+             [datasets :refer [expect-with-engine]]
+             [interface :as i]]
+            [toucan.db :as db]
+            [toucan.util.test :as tt])
   (:import metabase.driver.postgres.PostgresDriver))
 
 (def ^:private ^PostgresDriver pg-driver (PostgresDriver.))

--- a/test/metabase/driver/presto_test.clj
+++ b/test/metabase/driver/presto_test.clj
@@ -1,13 +1,14 @@
 (ns metabase.driver.presto-test
   (:require [expectations :refer :all]
-            [toucan.db :as db]
             [metabase.driver :as driver]
             [metabase.driver.generic-sql :as sql]
             [metabase.models.table :as table]
-            [metabase.test.data :as data]
+            [metabase.test
+             [data :as data]
+             [util :refer [resolve-private-vars]]]
             [metabase.test.data.datasets :as datasets]
-            [metabase.test.util :refer [resolve-private-vars]])
-  (:import (metabase.driver.presto PrestoDriver)))
+            [toucan.db :as db])
+  (:import metabase.driver.presto.PrestoDriver))
 
 (resolve-private-vars metabase.driver.presto details->uri details->request parse-presto-results quote-name quote+combine-names apply-page)
 

--- a/test/metabase/driver/sqlserver_test.clj
+++ b/test/metabase/driver/sqlserver_test.clj
@@ -1,10 +1,10 @@
 (ns metabase.driver.sqlserver-test
-  (:require  [cheshire.core :as json]
-             [expectations :refer :all]
-             [metabase.test.data :as data]
-             (metabase.test.data [datasets :refer [expect-with-engine]]
-                                 [interface :refer [def-database-definition]])
-             [metabase.test.util :refer [obj->json->obj]]))
+  (:require [metabase.test
+             [data :as data]
+             [util :refer [obj->json->obj]]]
+            [metabase.test.data
+             [datasets :refer [expect-with-engine]]
+             [interface :refer [def-database-definition]]]))
 
 ;;; ------------------------------------------------------------ VARCHAR(MAX) ------------------------------------------------------------
 ;; VARCHAR(MAX) comes back from jTDS as a "ClobImpl" so make sure it gets encoded like a normal string by Cheshire

--- a/test/metabase/email/messages_test.clj
+++ b/test/metabase/email/messages_test.clj
@@ -1,7 +1,7 @@
 (ns metabase.email.messages-test
   (:require [expectations :refer :all]
-            [metabase.email-test :refer [with-fake-inbox inbox]]
-            [metabase.email.messages :refer :all]))
+            [metabase.email-test :refer [inbox with-fake-inbox]]
+            [metabase.email.messages :refer [send-new-user-email! send-password-reset-email!]]))
 
 ;; new user email
 ;; NOTE: we are not validating the content of the email body namely because it's got randomized elements and thus

--- a/test/metabase/events/activity_feed_test.clj
+++ b/test/metabase/events/activity_feed_test.clj
@@ -1,23 +1,18 @@
 (ns metabase.events.activity-feed-test
   (:require [expectations :refer :all]
-            [toucan.db :as db]
-            [toucan.util.test :as tt]
             [metabase.events.activity-feed :refer :all]
-            (metabase.models [activity :refer [Activity]]
-                             [card :refer [Card]]
-                             [dashboard :refer [Dashboard]]
-                             [dashboard-card :refer [DashboardCard]]
-                             [database :refer [Database]]
-                             [metric :refer [Metric]]
-                             [pulse :refer [Pulse]]
-                             [segment :refer [Segment]]
-                             [session :refer [Session]]
-                             [table :refer [Table]]
-                             [user :refer [User]])
+            [metabase.models
+             [activity :refer [Activity]]
+             [card :refer [Card]]
+             [dashboard :refer [Dashboard]]
+             [dashboard-card :refer [DashboardCard]]
+             [metric :refer [Metric]]
+             [pulse :refer [Pulse]]
+             [segment :refer [Segment]]]
             [metabase.test.data :refer :all]
             [metabase.test.data.users :refer [user->id]]
-            [metabase.test.util :as tu]
-            [metabase.test-setup :refer :all]))
+            [toucan.db :as db]
+            [toucan.util.test :as tt]))
 
 (defn- do-with-temp-activities [f]
   (db/delete! Activity)                  ; Not 100% sure this is neccessary anymore

--- a/test/metabase/events/dependencies_test.clj
+++ b/test/metabase/events/dependencies_test.clj
@@ -1,19 +1,15 @@
 (ns metabase.events.dependencies-test
   (:require [expectations :refer :all]
-            [toucan.db :as db]
-            [toucan.util.test :as tt]
             [metabase.events.dependencies :refer :all]
-            (metabase.models [card :refer [Card]]
-                             [database :refer [Database]]
-                             [dependency :refer [Dependency]]
-                             [metric :refer [Metric]]
-                             [segment :refer [Segment]]
-                             [table :refer [Table]])
+            [metabase.models
+             [card :refer [Card]]
+             [database :refer [Database]]
+             [dependency :refer [Dependency]]
+             [metric :refer [Metric]]
+             [table :refer [Table]]]
             [metabase.test.data :refer :all]
-            [metabase.test.data.users :refer :all]
-            [metabase.test.util :as tu]
-            [metabase.test-setup :refer :all]))
-
+            [toucan.db :as db]
+            [toucan.util.test :as tt]))
 
 ;; `:card-create` event
 (expect

--- a/test/metabase/events/last_login_test.clj
+++ b/test/metabase/events/last_login_test.clj
@@ -1,10 +1,8 @@
 (ns metabase.events.last-login-test
   (:require [expectations :refer :all]
-            [toucan.util.test :as tt]
             [metabase.events.last-login :refer [process-last-login-event]]
             [metabase.models.user :refer [User]]
-            [metabase.test.util :as tu]))
-
+            [toucan.util.test :as tt]))
 
 ;; `:user-login` event
 (expect

--- a/test/metabase/events/revision_test.clj
+++ b/test/metabase/events/revision_test.clj
@@ -1,20 +1,20 @@
 (ns metabase.events.revision-test
   (:require [expectations :refer :all]
-            [toucan.db :as db]
-            [toucan.util.test :as tt]
             [metabase.events.revision :refer [process-revision-event!]]
-            (metabase.models [card :refer [Card]]
-                             [dashboard :refer [Dashboard]]
-                             [dashboard-card :refer [DashboardCard]]
-                             [database :refer [Database]]
-                             [metric :refer [Metric]]
-                             [revision :refer [Revision revisions]]
-                             [segment :refer [Segment]]
-                             [table :refer [Table]])
+            [metabase.models
+             [card :refer [Card]]
+             [dashboard :refer [Dashboard]]
+             [dashboard-card :refer [DashboardCard]]
+             [database :refer [Database]]
+             [metric :refer [Metric]]
+             [revision :refer [Revision]]
+             [segment :refer [Segment]]
+             [table :refer [Table]]]
             [metabase.test.data :refer :all]
             [metabase.test.data.users :refer :all]
-            [metabase.test.util :as tu]
-            [metabase.util :as u]))
+            [metabase.util :as u]
+            [toucan.db :as db]
+            [toucan.util.test :as tt]))
 
 (defn- card-properties
   "Some default properties for `Cards` for use in tests in this namespace."

--- a/test/metabase/events/view_log_test.clj
+++ b/test/metabase/events/view_log_test.clj
@@ -1,16 +1,12 @@
 (ns metabase.events.view-log-test
-  (:require [expectations :refer :all]
+  (:require [metabase.events.view-log :refer :all]
+            [metabase.models
+             [card :refer [Card]]
+             [dashboard :refer [Dashboard]]
+             [user :refer [User]]
+             [view-log :refer [ViewLog]]]
             [toucan.db :as db]
-            [toucan.util.test :as tt]
-            [metabase.events.view-log :refer :all]
-            (metabase.models [card :refer [Card]]
-                             [dashboard :refer [Dashboard]]
-                             [user :refer [User]]
-                             [view-log :refer [ViewLog]])
-            [metabase.test.data :refer :all]
-            [metabase.test.util :as tu]
-            [metabase.test-setup :refer :all]))
-
+            [toucan.util.test :as tt]))
 
 ;; `:card-create` event
 (tt/expect-with-temp [User [user]

--- a/test/metabase/http_client.clj
+++ b/test/metabase/http_client.clj
@@ -1,12 +1,12 @@
 (ns metabase.http-client
   "HTTP client for making API calls against the Metabase API. For test/REPL purposes."
-  (:require [clojure.string :as s]
-            [clojure.tools.logging :as log]
-            [cheshire.core :as json]
+  (:require [cheshire.core :as json]
             [clj-http.client :as client]
-            [metabase.config :as config]
-            [metabase.util :as u]))
-
+            [clojure.string :as s]
+            [clojure.tools.logging :as log]
+            [metabase
+             [config :as config]
+             [util :as u]]))
 
 ;;; build-url
 

--- a/test/metabase/middleware_test.clj
+++ b/test/metabase/middleware_test.clj
@@ -1,15 +1,14 @@
 (ns metabase.middleware-test
   (:require [cheshire.core :as json]
             [expectations :refer :all]
-            [ring.mock.request :as mock]
-            [toucan.db :as db]
-            [metabase.api.common :refer [*current-user-id* *current-user*]]
-            [metabase.middleware :refer :all]
+            [metabase
+             [middleware :refer :all]
+             [util :as u]]
+            [metabase.api.common :refer [*current-user* *current-user-id*]]
             [metabase.models.session :refer [Session]]
-            [metabase.test.data :refer :all]
             [metabase.test.data.users :refer :all]
-            [metabase.util :as u]))
-
+            [ring.mock.request :as mock]
+            [toucan.db :as db]))
 
 ;;  ===========================  TEST wrap-session-id middleware  ===========================
 

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -1,19 +1,20 @@
 (ns metabase.models.card-test
   (:require [expectations :refer :all]
-            [metabase.api.common :refer [*current-user-permissions-set* *is-superuser?*]]
-            [toucan.db :as db]
-            [toucan.util.test :as tt]
-            (metabase.models [card :refer :all]
-                             [dashboard :refer [Dashboard]]
-                             [dashboard-card :refer [DashboardCard]]
-                             [interface :as mi]
-                             [permissions :as perms])
+            [metabase.api.common :refer [*current-user-permissions-set*]]
+            [metabase.models
+             [card :refer :all]
+             [dashboard :refer [Dashboard]]
+             [dashboard-card :refer [DashboardCard]]
+             [interface :as mi]
+             [permissions :as perms]]
             [metabase.query-processor.expand :as ql]
-            [metabase.test.data :refer [id]]
+            [metabase.test
+             [data :refer [id]]
+             [util :as tu :refer [random-name]]]
             [metabase.test.data.users :refer :all]
-            [metabase.test.util :refer [random-name], :as tu]
-            [metabase.util :as u]))
-
+            [metabase.util :as u]
+            [toucan.db :as db]
+            [toucan.util.test :as tt]))
 
 (defn- create-dash! [dash-name]
   ((user->client :rasta) :post 200 "dashboard" {:name dash-name}))

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -1,11 +1,11 @@
 (ns metabase.models.collection-test
   (:require [expectations :refer :all]
+            [metabase.models
+             [card :refer [Card]]
+             [collection :refer [Collection]]]
+            [metabase.util :as u]
             [toucan.db :as db]
-            [toucan.util.test :as tt]
-            (metabase.models [card :refer [Card]]
-                             [collection :refer [Collection]])
-            [metabase.test.util :as tu]
-            [metabase.util :as u]))
+            [toucan.util.test :as tt]))
 
 ;; test that we can create a new Collection with valid inputs
 (expect

--- a/test/metabase/models/dashboard_card_test.clj
+++ b/test/metabase/models/dashboard_card_test.clj
@@ -1,15 +1,13 @@
 (ns metabase.models.dashboard-card-test
   (:require [expectations :refer :all]
-            [toucan.db :as db]
-            [toucan.util.test :as tt]
-            [metabase.models.card :refer [Card]]
-            [metabase.models.dashboard :refer [Dashboard]]
-            [metabase.models.dashboard-card :refer :all]
-            [metabase.models.dashboard-card-series :refer [DashboardCardSeries]]
-            [metabase.test.data :refer :all]
+            [metabase.models
+             [card :refer [Card]]
+             [dashboard :refer [Dashboard]]
+             [dashboard-card :refer :all]
+             [dashboard-card-series :refer [DashboardCardSeries]]]
             [metabase.test.data.users :refer :all]
-            [metabase.test.util :as tu]))
-
+            [toucan.db :as db]
+            [toucan.util.test :as tt]))
 
 (defn remove-ids-and-timestamps [m]
   (let [f (fn [v]

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -1,15 +1,16 @@
 (ns metabase.models.dashboard-test
   (:require [expectations :refer :all]
-            (toucan [db :as db]
-                    [hydrate :refer [hydrate]])
-            [toucan.util.test :as tt]
-            (metabase.models [card :refer [Card]]
-                             [dashboard :refer :all]
-                             [dashboard-card :refer [DashboardCard], :as dashboard-card]
-                             [dashboard-card-series :refer [DashboardCardSeries]])
-            [metabase.test.data :refer :all]
+            [metabase.models
+             [card :refer [Card]]
+             [dashboard :refer :all]
+             [dashboard-card :as dashboard-card :refer [DashboardCard]]
+             [dashboard-card-series :refer [DashboardCardSeries]]]
+            [metabase.test
+             [data :refer :all]
+             [util :as tu]]
             [metabase.test.data.users :refer :all]
-            [metabase.test.util :as tu]))
+            [toucan.db :as db]
+            [toucan.util.test :as tt]))
 
 ;; ## Dashboard Revisions
 

--- a/test/metabase/models/dependency_test.clj
+++ b/test/metabase/models/dependency_test.clj
@@ -1,14 +1,12 @@
 (ns metabase.models.dependency-test
   (:require [expectations :refer :all]
-            (toucan [db :as db]
-                    [models :as models])
-            [toucan.util.test :as tt]
-            (metabase.models [dependency :refer :all]
-                             [interface :as i])
+            [metabase.models.dependency :refer :all]
             [metabase.test.data :refer :all]
-            [metabase.test.data.users :refer :all]
-            [metabase.test.util :as tu]
-            [metabase.util :as u]))
+            [metabase.util :as u]
+            [toucan
+             [db :as db]
+             [models :as models]]
+            [toucan.util.test :as tt]))
 
 (models/defmodel Mock :mock)
 

--- a/test/metabase/models/field_test.clj
+++ b/test/metabase/models/field_test.clj
@@ -1,10 +1,9 @@
 (ns metabase.models.field-test
   (:require [expectations :refer :all]
-            (metabase.models [field :refer :all]
-                             [field-values :refer :all])
-            [metabase.test.data :refer :all]
+            [metabase.models
+             [field :refer :all]
+             [field-values :refer :all]]
             [metabase.test.util :as tu]))
-
 
 ;; field-should-have-field-values?
 

--- a/test/metabase/models/field_values_test.clj
+++ b/test/metabase/models/field_values_test.clj
@@ -1,12 +1,12 @@
 (ns metabase.models.field-values-test
   (:require [expectations :refer :all]
+            [metabase.models
+             [database :refer [Database]]
+             [field :refer [Field]]
+             [field-values :refer :all]
+             [table :refer [Table]]]
             [toucan.db :as db]
-            [toucan.util.test :as tt]
-            (metabase.models [database :refer [Database]]
-                             [field :refer [Field]]
-                             [field-values :refer :all]
-                             [table :refer [Table]])
-            [metabase.test.util :as tu]))
+            [toucan.util.test :as tt]))
 
 ;; ## TESTS FOR FIELD-SHOULD-HAVE-FIELD-VALUES?
 

--- a/test/metabase/models/humanization_test.clj
+++ b/test/metabase/models/humanization_test.clj
@@ -1,11 +1,12 @@
 (ns metabase.models.humanization-test
   (:require [expectations :refer :all]
+            [metabase.models
+             [field :refer [Field]]
+             [humanization :refer :all]
+             [table :refer [Table]]]
+            [metabase.test.util :as tu]
             [toucan.db :as db]
-            [toucan.util.test :as tt]
-            (metabase.models [field :refer [Field]]
-                             [humanization :refer :all]
-                             [table :refer [Table]])
-            [metabase.test.util :as tu]))
+            [toucan.util.test :as tt]))
 
 (tu/resolve-private-vars metabase.models.humanization
   name->human-readable-name:simple name->human-readable-name:advanced)

--- a/test/metabase/models/label_test.clj
+++ b/test/metabase/models/label_test.clj
@@ -1,8 +1,8 @@
 (ns metabase.models.label-test
   (:require [expectations :refer :all]
+            [metabase.models.label :refer [Label]]
             [toucan.db :as db]
-            [toucan.util.test :as tt]
-            [metabase.models.label :refer [Label]]))
+            [toucan.util.test :as tt]))
 
 ;; Check that we can create a label with the name "Cam" (slug "cam")
 ;; and update the name to something that will produce the same slug ("cam") without getting a "name already taken" exception

--- a/test/metabase/models/metric_test.clj
+++ b/test/metabase/models/metric_test.clj
@@ -1,14 +1,15 @@
 (ns metabase.models.metric-test
   (:require [expectations :refer :all]
-            [toucan.hydrate :refer [hydrate]]
-            [toucan.util.test :as tt]
-            (metabase.models [database :refer [Database]]
-                             [metric :refer :all, :as metric]
-                             [table :refer [Table]])
-            [metabase.test.data :refer :all]
+            [metabase.models
+             [database :refer [Database]]
+             [metric :as metric :refer :all]
+             [table :refer [Table]]]
+            [metabase.test
+             [data :refer :all]
+             [util :as tu]]
             [metabase.test.data.users :refer :all]
-            [metabase.test.util :as tu]
-            [metabase.util :as u]))
+            [metabase.util :as u]
+            [toucan.util.test :as tt]))
 
 (def ^:private ^:const metric-defaults
   {:description             nil

--- a/test/metabase/models/permissions_group_test.clj
+++ b/test/metabase/models/permissions_group_test.clj
@@ -1,16 +1,15 @@
 (ns metabase.models.permissions-group-test
   (:require [expectations :refer :all]
-            [toucan.db :as db]
-            [toucan.util.test :as tt]
-            (metabase.models [database :refer [Database]]
-                             [permissions :refer [Permissions], :as perms]
-                             [permissions-group :refer [PermissionsGroup], :as perm-group]
-                             [permissions-group-membership :refer [PermissionsGroupMembership]]
-                             [table :refer [Table]]
-                             [user :refer [User]])
+            [metabase.models
+             [database :refer [Database]]
+             [permissions :as perms :refer [Permissions]]
+             [permissions-group :as perm-group :refer [PermissionsGroup]]
+             [permissions-group-membership :refer [PermissionsGroupMembership]]
+             [user :refer [User]]]
             [metabase.test.data.users :as test-users]
-            [metabase.test.util :as tu]
-            [metabase.util.honeysql-extensions :as hx])
+            [metabase.util.honeysql-extensions :as hx]
+            [toucan.db :as db]
+            [toucan.util.test :as tt])
   (:import metabase.models.permissions_group.PermissionsGroupInstance))
 
 ;;; ---------------------------------------- Check that the root entry for Admin was created ----------------------------------------

--- a/test/metabase/models/permissions_test.clj
+++ b/test/metabase/models/permissions_test.clj
@@ -1,16 +1,13 @@
 (ns metabase.models.permissions-test
   (:require [expectations :refer :all]
-            [toucan.db :as db]
-            [toucan.util.test :as tt]
-            (metabase.models [database :refer [Database]]
-                             [permissions :as perms]
-                             [permissions-group :refer [PermissionsGroup]]
-                             [permissions-group-membership :refer [PermissionsGroupMembership]]
-                             [table :refer [Table]])
+            [metabase.models
+             [database :refer [Database]]
+             [permissions :as perms]
+             [permissions-group :refer [PermissionsGroup]]
+             [table :refer [Table]]]
             [metabase.test.data :as data]
-            [metabase.test.util :as tu]
-            [metabase.util :as u]))
-
+            [metabase.util :as u]
+            [toucan.util.test :as tt]))
 
 ;;; ------------------------------------------------------------ valid-object-path? ------------------------------------------------------------
 

--- a/test/metabase/models/pulse_channel_test.clj
+++ b/test/metabase/models/pulse_channel_test.clj
@@ -1,16 +1,16 @@
 (ns metabase.models.pulse-channel-test
   (:require [expectations :refer :all]
-            (toucan [db :as db]
-                    [hydrate :refer [hydrate]])
-            [toucan.util.test :as tt]
-            (metabase.models [pulse :refer :all]
-                             [pulse-channel :refer :all]
-                             [pulse-channel-recipient :refer :all])
+            [medley.core :as m]
+            [metabase.models
+             [pulse :refer :all]
+             [pulse-channel :refer :all]
+             [pulse-channel-recipient :refer :all]]
             [metabase.test.data :refer :all]
             [metabase.test.data.users :refer :all]
-            [metabase.test.util :as tu]
-            [medley.core :as m]))
-
+            [toucan
+             [db :as db]
+             [hydrate :refer [hydrate]]]
+            [toucan.util.test :as tt]))
 
 ;; Test out our predicate functions
 

--- a/test/metabase/models/pulse_test.clj
+++ b/test/metabase/models/pulse_test.clj
@@ -1,18 +1,19 @@
 (ns metabase.models.pulse-test
   (:require [expectations :refer :all]
             [medley.core :as m]
-            (toucan [db :as db]
-                    [hydrate :refer [hydrate]])
-            [toucan.util.test :as tt]
-            (metabase.models [card :refer [Card]]
-                             [pulse :refer :all]
-                             [pulse-card :refer :all]
-                             [pulse-channel :refer :all]
-                             [pulse-channel-recipient :refer :all])
+            [metabase.models
+             [card :refer [Card]]
+             [pulse :refer :all]
+             [pulse-card :refer :all]
+             [pulse-channel :refer :all]
+             [pulse-channel-recipient :refer :all]]
             [metabase.test.data :refer :all]
             [metabase.test.data.users :refer :all]
-            [metabase.test.util :as tu]
-            [metabase.util :as u]))
+            [metabase.util :as u]
+            [toucan
+             [db :as db]
+             [hydrate :refer [hydrate]]]
+            [toucan.util.test :as tt]))
 
 (defn- user-details
   [username]

--- a/test/metabase/models/revision/diff_test.clj
+++ b/test/metabase/models/revision/diff_test.clj
@@ -1,8 +1,7 @@
 (ns metabase.models.revision.diff-test
   (:require [clojure.data :as data]
-            [metabase.models.revision.diff :refer :all]
-            [expectations :refer :all]))
-
+            [expectations :refer :all]
+            [metabase.models.revision.diff :refer :all]))
 
 ;; Check that pattern matching allows specialization and that string only reflects the keys that have changed
 (expect "renamed this card from \"Tips by State\" to \"Spots by State\"."

--- a/test/metabase/models/revision_test.clj
+++ b/test/metabase/models/revision_test.clj
@@ -1,13 +1,12 @@
 (ns metabase.models.revision-test
   (:require [expectations :refer :all]
-            [medley.core :as m]
-            (toucan [db :as db]
-                    [models :as models])
-            [toucan.util.test :as tt]
-            (metabase.models [card :refer [Card]]
-                             [revision :refer :all])
+            [metabase.models
+             [card :refer [Card]]
+             [revision :refer :all]]
             [metabase.test.data.users :refer :all]
-            [metabase.util :as u]))
+            [metabase.util :as u]
+            [toucan.models :as models]
+            [toucan.util.test :as tt]))
 
 (def ^:private reverted-to
   (atom nil))

--- a/test/metabase/models/segment_test.clj
+++ b/test/metabase/models/segment_test.clj
@@ -1,14 +1,15 @@
 (ns metabase.models.segment-test
   (:require [expectations :refer :all]
-            [toucan.hydrate :refer [hydrate]]
-            [toucan.util.test :as tt]
-            (metabase.models [database :refer [Database]]
-                             [segment :refer :all, :as segment]
-                             [table :refer [Table]])
-            [metabase.test.data :refer :all]
+            [metabase.models
+             [database :refer [Database]]
+             [segment :as segment :refer :all]
+             [table :refer [Table]]]
+            [metabase.test
+             [data :refer :all]
+             [util :as tu]]
             [metabase.test.data.users :refer :all]
-            [metabase.test.util :as tu]
-            [metabase.util :as u]))
+            [metabase.util :as u]
+            [toucan.util.test :as tt]))
 
 (defn- user-details
   [username]

--- a/test/metabase/models/session_test.clj
+++ b/test/metabase/models/session_test.clj
@@ -1,12 +1,13 @@
 (ns metabase.models.session-test
   (:require [expectations :refer :all]
-            [toucan.db :as db]
-            [toucan.util.test :as tt]
-            (metabase.models [session :refer :all]
-                             [user :refer [User]])
-            [metabase.test.data.users :refer :all]
+            [metabase.models
+             [session :refer :all]
+             [user :refer [User]]]
             [metabase.test.util :as tu]
-            [metabase.util :as u]))
+            [metabase.util :as u]
+            [toucan.db :as db]
+            [toucan.util.test :as tt]))
+
 ;; first-session-for-user
 (expect
   "the-greatest-day-ever"

--- a/test/metabase/models/setting_test.clj
+++ b/test/metabase/models/setting_test.clj
@@ -1,10 +1,8 @@
 (ns metabase.models.setting-test
   (:require [expectations :refer :all]
-            [medley.core :as m]
-            [toucan.db :as db]
-            [metabase.models.setting :refer [defsetting Setting], :as setting]
-            (metabase.test [data :refer :all]
-                           [util :refer :all])))
+            [metabase.models.setting :as setting :refer [defsetting Setting]]
+            [metabase.test.util :refer :all]
+            [toucan.db :as db]))
 
 ;; ## TEST SETTINGS DEFINITIONS
 ;; TODO! These don't get loaded by `lein ring server` unless this file is touched

--- a/test/metabase/models/user_test.clj
+++ b/test/metabase/models/user_test.clj
@@ -1,18 +1,18 @@
 (ns metabase.models.user-test
   (:require [clojure.string :as str]
             [expectations :refer :all]
-            [toucan.db :as db]
-            [toucan.util.test :as tt]
-            [metabase.email-test :as email-test]
-            [metabase.http-client :as http]
-            (metabase.models [permissions :as perms]
-                             [permissions-group :refer [PermissionsGroup]]
-                             [permissions-group-membership :refer [PermissionsGroupMembership]]
-                             [user :refer [User], :as user])
-            [metabase.test.data.users :as test-users, :refer [user->id]]
+            [metabase
+             [email-test :as email-test]
+             [http-client :as http]]
+            [metabase.models
+             [permissions :as perms]
+             [permissions-group :refer [PermissionsGroup]]
+             [permissions-group-membership :refer [PermissionsGroupMembership]]
+             [user :as user :refer [User]]]
+            [metabase.test.data.users :as test-users :refer [user->id]]
             [metabase.test.util :as tu]
-            [metabase.util :as u]))
-
+            [toucan.db :as db]
+            [toucan.util.test :as tt]))
 
 ;;; Tests for permissions-set
 

--- a/test/metabase/permissions_collection_test.clj
+++ b/test/metabase/permissions_collection_test.clj
@@ -1,17 +1,18 @@
 (ns metabase.permissions-collection-test
   "A test suite for permissions `Collections`. Reüses functions from `metabase.permissions-test`."
-  (:require  [expectations :refer :all]
-             [toucan.db :as db]
-             [toucan.util.test :as tt]
-             (metabase.models [card :refer [Card], :as card]
-                              [collection :refer [Collection]]
-                              [permissions :as permissions]
-                              [permissions-group :as group]
-                              [revision :refer [Revision]])
-             [metabase.permissions-test :as perms-test, :refer [*card:db2-count-of-venues* *db2*]]
-             [metabase.test.data.users :as test-users]
-             [metabase.test.util :as tu]
-             [metabase.util :as u]))
+  (:require [expectations :refer :all]
+            [metabase
+             [permissions-test :as perms-test :refer [*card:db2-count-of-venues* *db2*]]
+             [util :as u]]
+            [metabase.models
+             [card :as card :refer [Card]]
+             [collection :refer [Collection]]
+             [permissions :as permissions]
+             [permissions-group :as group]
+             [revision :refer [Revision]]]
+            [metabase.test.data.users :as test-users]
+            [toucan.db :as db]
+            [toucan.util.test :as tt]))
 
 ;; the Card used in the tests below is one Crowberto (an admin) should be allowed to read/write based on data permissions,
 ;; but not Rasta (all-users)

--- a/test/metabase/permissions_test.clj
+++ b/test/metabase/permissions_test.clj
@@ -2,29 +2,28 @@
   "A test suite around permissions. Nice!"
   (:require [clojure.string :as s]
             [expectations :refer :all]
-            [toucan.db :as db]
-            [toucan.util.test :as tt]
-            (metabase.models [card :refer [Card]]
-                             [dashboard :refer [Dashboard]]
-                             [dashboard-card :refer [DashboardCard]]
-                             [database :refer [Database]]
-                             [field :refer [Field]]
-                             [metric :refer [Metric]]
-                             [permissions :refer [Permissions], :as perms]
-                             [permissions-group :refer [PermissionsGroup], :as group]
-                             [permissions-group-membership :refer [PermissionsGroupMembership]]
-                             [pulse :refer [Pulse]]
-                             [pulse-card :refer [PulseCard]]
-                             [pulse-channel :refer [PulseChannel]]
-                             [pulse-channel-recipient :refer [PulseChannelRecipient]]
-                             [segment :refer [Segment]]
-                             [table :refer [Table]])
+            [metabase.models
+             [card :refer [Card]]
+             [dashboard :refer [Dashboard]]
+             [dashboard-card :refer [DashboardCard]]
+             [database :refer [Database]]
+             [field :refer [Field]]
+             [metric :refer [Metric]]
+             [permissions :as perms]
+             [permissions-group :as group :refer [PermissionsGroup]]
+             [permissions-group-membership :refer [PermissionsGroupMembership]]
+             [pulse :refer [Pulse]]
+             [pulse-card :refer [PulseCard]]
+             [pulse-channel :refer [PulseChannel]]
+             [pulse-channel-recipient :refer [PulseChannelRecipient]]
+             [segment :refer [Segment]]
+             [table :refer [Table]]]
             [metabase.query-processor.expand :as ql]
-            [metabase.sync-database :as sync]
             [metabase.test.data :as data]
             [metabase.test.data.users :as test-users]
-            [metabase.test.util :as tu]
-            [metabase.util :as u]))
+            [metabase.util :as u]
+            [toucan.db :as db]
+            [toucan.util.test :as tt]))
 
 ;; 3 users:
 ;; crowberto, member of Admin, All Users

--- a/test/metabase/query_processor/macros_test.clj
+++ b/test/metabase/query_processor/macros_test.clj
@@ -1,19 +1,20 @@
 (ns metabase.query-processor.macros-test
   (:require [expectations :refer :all]
-            [toucan.util.test :as tt]
-            [metabase.models.database :refer [Database]]
-            [metabase.models.metric :refer [Metric]]
-            [metabase.models.segment :refer [Segment]]
-            [metabase.models.table :refer [Table]]
-            [metabase.query-processor :as qp]
-            (metabase.query-processor [expand :as ql]
-                                      [macros :refer :all])
-            [metabase.query-processor-test :refer :all]
+            [metabase
+             [query-processor :as qp]
+             [query-processor-test :refer :all]
+             [util :as u]]
+            [metabase.models
+             [database :refer [Database]]
+             [metric :refer [Metric]]
+             [segment :refer [Segment]]
+             [table :refer [Table]]]
+            [metabase.query-processor
+             [expand :as ql]
+             [macros :refer :all]]
             [metabase.test.data :as data]
-            (metabase.test.data [datasets :as datasets]
-                                [users :refer :all])
-            [metabase.test.util :as tu]
-            [metabase.util :as u]))
+            [metabase.test.data.datasets :as datasets]
+            [toucan.util.test :as tt]))
 
 ;; expand-macros
 

--- a/test/metabase/query_processor/middleware/annotate_and_sort_test.clj
+++ b/test/metabase/query_processor/middleware/annotate_and_sort_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.query-processor.middleware.annotate-and-sort-test
   (:require [expectations :refer :all]
-            metabase.query-processor.middleware.annotate-and-sort
             [metabase.test.util :as tu]))
 
 (tu/resolve-private-vars metabase.query-processor.middleware.annotate-and-sort

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -1,10 +1,10 @@
 (ns metabase.query-processor.middleware.cache-test
   "Tests for the Query Processor cache."
   (:require [expectations :refer :all]
-            [toucan.db :as db]
             [metabase.models.query-cache :refer [QueryCache]]
             [metabase.query-processor.middleware.cache :as cache]
-            [metabase.test.util :as tu]))
+            [metabase.test.util :as tu]
+            [toucan.db :as db]))
 
 (tu/resolve-private-vars metabase.query-processor.middleware.cache
   is-cacheable?

--- a/test/metabase/query_processor/parameters_test.clj
+++ b/test/metabase/query_processor/parameters_test.clj
@@ -1,21 +1,15 @@
 (ns metabase.query-processor.parameters-test
   "Tests for *MBQL* parameter substitution."
-  (:require (clj-time [core :as t]
-                      [format :as tf])
+  (:require [clj-time.core :as t]
             [expectations :refer :all]
-            [metabase.driver :as driver]
-            (metabase.models [database :refer [Database]]
-                             [metric :refer [Metric]]
-                             [segment :refer [Segment]]
-                             [table :refer [Table]])
-            [metabase.query-processor :as qp]
-            (metabase.query-processor [expand :as ql]
-                                      [parameters :refer :all])
-            [metabase.query-processor-test :refer [non-timeseries-engines first-row format-rows-by]]
+            [metabase
+             [query-processor :as qp]
+             [query-processor-test :refer [first-row format-rows-by non-timeseries-engines]]]
+            [metabase.query-processor
+             [expand :as ql]
+             [parameters :refer :all]]
             [metabase.test.data :as data]
-            (metabase.test.data [datasets :as datasets]
-                                [users :refer :all])
-            [metabase.test.util :as tu]))
+            [metabase.test.data.datasets :as datasets]))
 
 ;; we hard code "now" to a specific point in time so that we can control the test output
 (defn- test-date->range [value]

--- a/test/metabase/query_processor/qp_middleware_test.clj
+++ b/test/metabase/query_processor/qp_middleware_test.clj
@@ -1,13 +1,13 @@
 (ns metabase.query_processor.qp-middleware-test
-  (:require [expectations :refer :all]
-            [clj-time.coerce :as tc]
+  (:require [clj-time.coerce :as tc]
+            [expectations :refer :all]
             [metabase.driver :as driver]
             [metabase.models.setting :as setting]
-            (metabase.query-processor.middleware [add-row-count-and-status :as add-row-count-and-status]
-                                                 [add-settings :as add-settings]
-                                                 [catch-exceptions :as catch-exceptions]
-                                                 [format-rows :as format-rows])))
-
+            [metabase.query-processor.middleware
+             [add-row-count-and-status :as add-row-count-and-status]
+             [add-settings :as add-settings]
+             [catch-exceptions :as catch-exceptions]
+             [format-rows :as format-rows]]))
 
 (defrecord TestDriver []
   clojure.lang.Named

--- a/test/metabase/query_processor/sql_parameters_test.clj
+++ b/test/metabase/query_processor/sql_parameters_test.clj
@@ -1,19 +1,18 @@
 (ns metabase.query-processor.sql-parameters-test
   (:require [clj-time.core :as t]
             [expectations :refer :all]
-            [toucan.db :as db]
-            [metabase.driver :as driver]
-            [metabase.models.table :as table]
-            [metabase.query-processor :as qp]
+            [metabase
+             [driver :as driver]
+             [query-processor :as qp]
+             [query-processor-test :refer [engines-that-support first-row format-rows-by]]]
             [metabase.query-processor.sql-parameters :refer :all]
-            [metabase.query-processor-test :refer [engines-that-support first-row format-rows-by]]
-            [metabase.test.data :as data]
-            [metabase.test.data.datasets :as datasets]
-            [metabase.test.data.generic-sql :as generic-sql]
-            [metabase.test.util :as tu]
-            [metabase.test.data.generic-sql :as generic]
-            [metabase.util :as u]))
-
+            [metabase.test
+             [data :as data]
+             [util :as tu]]
+            [metabase.test.data
+             [datasets :as datasets]
+             [generic-sql :as generic-sql]]
+            [toucan.db :as db]))
 
 ;;; ------------------------------------------------------------ simple substitution -- {{x}} ------------------------------------------------------------
 

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -4,12 +4,11 @@
    Event-based DBs such as Druid are tested in `metabase.driver.event-query-processor-test`."
   (:require [clojure.set :as set]
             [clojure.tools.logging :as log]
-            [expectations :refer :all]
-            [metabase.driver :as driver]
+            [metabase
+             [driver :as driver]
+             [util :as u]]
             [metabase.test.data :as data]
-            [metabase.test.data.datasets :as datasets]
-            metabase.test.data.interface
-            [metabase.util :as u]))
+            [metabase.test.data.datasets :as datasets]))
 
 ;; make sure all the driver test extension namespaces are loaded <3
 ;; if this isn't done some things will get loaded at the wrong time which can end up causing test databases to be created more than once, which fails

--- a/test/metabase/query_processor_test/aggregation_test.clj
+++ b/test/metabase/query_processor_test/aggregation_test.clj
@@ -1,11 +1,11 @@
 (ns metabase.query-processor-test.aggregation-test
   "Tests for MBQL aggregations."
-  (:require [expectations :refer :all]
+  (:require [metabase
+             [query-processor-test :refer :all]
+             [util :as u]]
             [metabase.query-processor.expand :as ql]
-            [metabase.query-processor-test :refer :all]
             [metabase.test.data :as data]
-            [metabase.test.data.datasets :as datasets]
-            [metabase.util :as u]))
+            [metabase.test.data.datasets :as datasets]))
 
 ;;; ------------------------------------------------------------ "COUNT" AGGREGATION ------------------------------------------------------------
 

--- a/test/metabase/query_processor_test/breakout_test.clj
+++ b/test/metabase/query_processor_test/breakout_test.clj
@@ -1,10 +1,8 @@
 (ns metabase.query-processor-test.breakout-test
   "Tests for the `:breakout` clause."
-  (:require [expectations :refer :all]
+  (:require [metabase.query-processor-test :refer :all]
             [metabase.query-processor.expand :as ql]
-            [metabase.query-processor-test :refer :all]
-            [metabase.test.data :as data]
-            [metabase.util :as u]))
+            [metabase.test.data :as data]))
 
 ;;; single column
 (qp-expect-with-all-engines

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -1,14 +1,15 @@
 (ns metabase.query-processor-test.date-bucketing-test
   "Tests for date bucketing."
-  (:require [expectations :refer :all]
-            [metabase.driver :as driver]
+  (:require [metabase
+             [driver :as driver]
+             [query-processor-test :refer :all]
+             [util :as u]]
             [metabase.query-processor.expand :as ql]
-            [metabase.query-processor-test :refer :all]
             [metabase.test.data :as data]
-            (metabase.test.data [dataset-definitions :as defs]
-                                [datasets :as datasets, :refer [*driver* *engine*]]
-                                [interface :as i])
-            [metabase.util :as u]))
+            [metabase.test.data
+             [dataset-definitions :as defs]
+             [datasets :as datasets :refer [*driver* *engine*]]
+             [interface :as i]]))
 
 (defn- ->long-if-number [x]
   (if (number? x)

--- a/test/metabase/query_processor_test/expression_aggregations_test.clj
+++ b/test/metabase/query_processor_test/expression_aggregations_test.clj
@@ -1,16 +1,15 @@
 (ns metabase.query-processor-test.expression-aggregations-test
   "Tests for expression aggregations and for named aggregations."
-  (:require [expectations :refer :all]
-            [toucan.util.test :as tt]
-            [metabase.driver :as driver]
+  (:require [metabase
+             [driver :as driver]
+             [query-processor :as qp]
+             [query-processor-test :refer :all]
+             [util :as u]]
             [metabase.models.metric :refer [Metric]]
-            [metabase.query-processor :as qp]
             [metabase.query-processor.expand :as ql]
-            [metabase.query-processor-test :refer :all]
             [metabase.test.data :as data]
-            [metabase.test.data.datasets :as datasets, :refer [*engine* *driver*]]
-            [metabase.test.util :as tu]
-            [metabase.util :as u]))
+            [metabase.test.data.datasets :as datasets :refer [*driver* *engine*]]
+            [toucan.util.test :as tt]))
 
 ;; sum, *
 (datasets/expect-with-engines (engines-that-support :expression-aggregations)

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -1,12 +1,14 @@
 (ns metabase.query-processor-test.expressions-test
   "Tests for expressions (calculated columns)."
   (:require [expectations :refer :all]
-            (metabase.query-processor [expand :as ql]
-                                      [interface :as qpi])
-            [metabase.query-processor-test :refer :all]
+            [metabase
+             [query-processor-test :refer :all]
+             [util :as u]]
+            [metabase.query-processor
+             [expand :as ql]
+             [interface :as qpi]]
             [metabase.test.data :as data]
-            [metabase.test.data.datasets :as datasets]
-            [metabase.util :as u]))
+            [metabase.test.data.datasets :as datasets]))
 
 ;; Test the expansion of the expressions clause
 (expect

--- a/test/metabase/query_processor_test/field_visibility_test.clj
+++ b/test/metabase/query_processor_test/field_visibility_test.clj
@@ -1,12 +1,10 @@
 (ns metabase.query-processor-test.field-visibility-test
   "Tests for behavior of fields with different visibility settings."
-  (:require [expectations :refer :all]
-            [toucan.db :as db]
-            [metabase.models.field :refer [Field]]
-            [metabase.query-processor.expand :as ql]
+  (:require [metabase.models.field :refer [Field]]
             [metabase.query-processor-test :refer :all]
+            [metabase.query-processor.expand :as ql]
             [metabase.test.data :as data]
-            [metabase.util :as u]))
+            [toucan.db :as db]))
 
 ;;; ------------------------------------------------------------ :details-only fields  ------------------------------------------------------------
 ;; make sure that rows where visibility_type = details-only are included and properly marked up

--- a/test/metabase/query_processor_test/fields_test.clj
+++ b/test/metabase/query_processor_test/fields_test.clj
@@ -1,10 +1,8 @@
 (ns metabase.query-processor-test.fields-test
   "Tests for the `:fields` clause."
-  (:require [expectations :refer :all]
+  (:require [metabase.query-processor-test :refer :all]
             [metabase.query-processor.expand :as ql]
-            [metabase.query-processor-test :refer :all]
-            [metabase.test.data :as data]
-            [metabase.util :as u]))
+            [metabase.test.data :as data]))
 
 ;; Test that we can restrict the Fields that get returned to the ones specified, and that results come back in the order of the IDs in the `fields` clause
 (qp-expect-with-all-engines

--- a/test/metabase/query_processor_test/filter_test.clj
+++ b/test/metabase/query_processor_test/filter_test.clj
@@ -1,12 +1,8 @@
 (ns metabase.query-processor-test.filter-test
   "Tests for the `:filter` clause."
-  (:require [expectations :refer :all]
-            (metabase.query-processor [expand :as ql]
-                                      [interface :as qpi])
-            [metabase.query-processor-test :refer :all]
-            [metabase.test.data :as data]
-            [metabase.test.data.datasets :as datasets]
-            [metabase.util :as u]))
+  (:require [metabase.query-processor-test :refer :all]
+            [metabase.query-processor.expand :as ql]
+            [metabase.test.data :as data]))
 
 ;;; ------------------------------------------------------------ "FILTER" CLAUSE ------------------------------------------------------------
 

--- a/test/metabase/query_processor_test/joins_test.clj
+++ b/test/metabase/query_processor_test/joins_test.clj
@@ -1,11 +1,9 @@
 (ns metabase.query-processor-test.joins-test
   "Test for JOIN behavior."
-  (:require [expectations :refer :all]
+  (:require [metabase.query-processor-test :refer :all]
             [metabase.query-processor.expand :as ql]
-            [metabase.query-processor-test :refer :all]
             [metabase.test.data :as data]
-            [metabase.test.data.datasets :as datasets]
-            [metabase.util :as u]))
+            [metabase.test.data.datasets :as datasets]))
 
 ;; The top 10 cities by number of Tupac sightings
 ;; Test that we can breakout on an FK field (Note how the FK Field is returned in the results)

--- a/test/metabase/query_processor_test/middleware/limit_test.clj
+++ b/test/metabase/query_processor_test/middleware/limit_test.clj
@@ -1,11 +1,8 @@
 (ns metabase.query-processor-test.middleware.limit-test
   "Tests for the `:limit` clause and `:max-results` constraints."
   (:require [expectations :refer :all]
-            (metabase.query-processor [expand :as ql]
-                                      [interface :as i])
-            [metabase.query-processor.middleware.limit :as limit]
-            [metabase.query-processor-test :refer :all]
-            [metabase.util :as u]))
+            [metabase.query-processor.interface :as i]
+            [metabase.query-processor.middleware.limit :as limit]))
 
 ;;; ------------------------------------------------------------ LIMIT-MAX-RESULT-ROWS ------------------------------------------------------------
 ;; Apply limit-max-result-rows to an infinite sequence and make sure it gets capped at `i/absolute-max-results`

--- a/test/metabase/query_processor_test/nested_field_test.clj
+++ b/test/metabase/query_processor_test/nested_field_test.clj
@@ -1,11 +1,9 @@
 (ns metabase.query-processor-test.nested-field-test
   "Tests for nested field access."
-  (:require [expectations :refer :all]
+  (:require [metabase.query-processor-test :refer :all]
             [metabase.query-processor.expand :as ql]
-            [metabase.query-processor-test :refer :all]
             [metabase.test.data :as data]
-            [metabase.test.data.datasets :as datasets]
-            [metabase.util :as u]))
+            [metabase.test.data.datasets :as datasets]))
 
 ;;; Nested Field in FILTER
 ;; Get the first 10 tips where tip.venue.name == "Kyle's Low-Carb Grill"

--- a/test/metabase/query_processor_test/order_by_test.clj
+++ b/test/metabase/query_processor_test/order_by_test.clj
@@ -1,12 +1,10 @@
 (ns metabase.query-processor-test.order-by-test
   "Tests for the `:order-by` clause."
   (:require [clojure.math.numeric-tower :as math]
-            [expectations :refer :all]
-            [metabase.query-processor.expand :as ql]
             [metabase.query-processor-test :refer :all]
+            [metabase.query-processor.expand :as ql]
             [metabase.test.data :as data]
-            [metabase.test.data.datasets :as datasets, :refer [*engine*]]
-            [metabase.util :as u]))
+            [metabase.test.data.datasets :as datasets :refer [*engine*]]))
 
 (expect-with-non-timeseries-dbs
   [[1 12 375]

--- a/test/metabase/query_processor_test/page_test.clj
+++ b/test/metabase/query_processor_test/page_test.clj
@@ -1,10 +1,8 @@
 (ns metabase.query-processor-test.page-test
   "Tests for the `:page` clause."
-  (:require [expectations :refer :all]
+  (:require [metabase.query-processor-test :refer :all]
             [metabase.query-processor.expand :as ql]
-            [metabase.query-processor-test :refer :all]
-            [metabase.test.data :as data]
-            [metabase.util :as u]))
+            [metabase.test.data :as data]))
 
 ;; Test that we can get "pages" of results.
 

--- a/test/metabase/query_processor_test/parameters_test.clj
+++ b/test/metabase/query_processor_test/parameters_test.clj
@@ -1,11 +1,10 @@
 (ns metabase.query-processor-test.parameters_test
   "Tests for query parameters."
-  (:require [expectations :refer :all]
-            [metabase.query-processor :as qp]
+  (:require [metabase
+             [query-processor :as qp]
+             [query-processor-test :refer :all]]
             [metabase.query-processor.expand :as ql]
-            [metabase.query-processor-test :refer :all]
-            [metabase.test.data :as data]
-            [metabase.util :as u]))
+            [metabase.test.data :as data]))
 
 (expect-with-non-timeseries-dbs
   [[9 "Nils Gotam"]]

--- a/test/metabase/query_processor_test/unix_timestamp_test.clj
+++ b/test/metabase/query_processor_test/unix_timestamp_test.clj
@@ -1,12 +1,11 @@
 (ns metabase.query-processor-test.unix-timestamp-test
   "Tests for UNIX timestamp support."
-  (:require [expectations :refer :all]
+  (:require [metabase.query-processor-test :refer :all]
             [metabase.query-processor.expand :as ql]
-            [metabase.query-processor-test :refer :all]
             [metabase.test.data :as data]
-            (metabase.test.data [datasets :as datasets, :refer [*engine* *driver*]]
-                                [interface :as i])
-            [metabase.util :as u]))
+            [metabase.test.data
+             [datasets :as datasets :refer [*driver* *engine*]]
+             [interface :as i]]))
 
 ;; There were 9 "sad toucan incidents" on 2015-06-02
 (expect-with-non-timeseries-dbs

--- a/test/metabase/sync_database/introspect_test.clj
+++ b/test/metabase/sync_database/introspect_test.clj
@@ -1,15 +1,16 @@
 (ns metabase.sync-database.introspect-test
   (:require [expectations :refer :all]
-            (toucan [db :as db]
-                    [hydrate :refer [hydrate]])
-            [toucan.util.test :as tt]
-            (metabase.models [database :refer [Database]]
-                             [raw-column :refer [RawColumn]]
-                             [raw-table :refer [RawTable]])
+            [metabase.models
+             [database :refer [Database]]
+             [raw-column :refer [RawColumn]]
+             [raw-table :refer [RawTable]]]
             [metabase.sync-database.introspect :as introspect]
             [metabase.test.mock.moviedb :as moviedb]
             [metabase.test.util :as tu]
-            [metabase.util :as u]))
+            [toucan
+             [db :as db]
+             [hydrate :refer [hydrate]]]
+            [toucan.util.test :as tt]))
 
 (tu/resolve-private-vars metabase.sync-database.introspect
   save-all-table-columns! save-all-table-fks! create-raw-table! update-raw-table! disable-raw-tables!)

--- a/test/metabase/sync_database/sync_dynamic_test.clj
+++ b/test/metabase/sync_database/sync_dynamic_test.clj
@@ -1,16 +1,19 @@
 (ns metabase.sync-database.sync-dynamic-test
   (:require [expectations :refer :all]
-            (toucan [db :as db]
-                    [hydrate :refer [hydrate]])
-            [toucan.util.test :as tt]
-            (metabase.models [database :refer [Database]]
-                             [field :refer [Field]]
-                             [raw-table :refer [RawTable]]
-                             [table :refer [Table]])
-            (metabase.sync-database [introspect :as introspect]
-                                    [sync-dynamic :refer :all])
+            [metabase.models
+             [database :refer [Database]]
+             [field :refer [Field]]
+             [raw-table :refer [RawTable]]
+             [table :refer [Table]]]
+            [metabase.sync-database
+             [introspect :as introspect]
+             [sync-dynamic :refer :all]]
             [metabase.test.mock.toucanery :as toucanery]
-            [metabase.test.util :as tu]))
+            [metabase.test.util :as tu]
+            [toucan
+             [db :as db]
+             [hydrate :refer [hydrate]]]
+            [toucan.util.test :as tt]))
 
 (tu/resolve-private-vars metabase.sync-database.sync-dynamic
   save-table-fields!)

--- a/test/metabase/sync_database/sync_test.clj
+++ b/test/metabase/sync_database/sync_test.clj
@@ -1,20 +1,25 @@
 (ns metabase.sync-database.sync-test
   (:require [expectations :refer :all]
-            (toucan [db :as db]
-                    [hydrate :refer [hydrate]])
-            [toucan.util.test :as tt]
-            (metabase.models [database :refer [Database]]
-                             [field :refer [Field]]
-                             [raw-column :refer [RawColumn]]
-                             [raw-table :refer [RawTable]]
-                             [table :refer [Table]])
-            (metabase.sync-database [introspect :as introspect]
-                                    [sync :refer :all])
-            [metabase.test.data :as data]
+            [metabase.models
+             [database :refer [Database]]
+             [field :refer [Field]]
+             [raw-column :refer [RawColumn]]
+             [raw-table :refer [RawTable]]
+             [table :refer [Table]]]
+            [metabase.sync-database
+             [introspect :as introspect]
+             [sync :refer :all]]
+            [metabase.test
+             [data :as data]
+             [util :as tu]]
             [metabase.test.data.interface :as i]
-            (metabase.test.mock [moviedb :as moviedb]
-                                [schema-per-customer :as schema-per-customer])
-            [metabase.test.util :as tu]))
+            [metabase.test.mock
+             [moviedb :as moviedb]
+             [schema-per-customer :as schema-per-customer]]
+            [toucan
+             [db :as db]
+             [hydrate :refer [hydrate]]]
+            [toucan.util.test :as tt]))
 
 (tu/resolve-private-vars metabase.sync-database.sync
   save-fks! save-table-fields!)

--- a/test/metabase/sync_database_test.clj
+++ b/test/metabase/sync_database_test.clj
@@ -2,23 +2,24 @@
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.string :as str]
             [expectations :refer :all]
-            (toucan [db :as db]
-                    [hydrate :refer [hydrate]])
-            [toucan.util.test :as tt]
-            (metabase [db :as mdb]
-                      [driver :as driver])
+            [metabase
+             [db :as mdb]
+             [driver :as driver]
+             [sync-database :refer :all]
+             [util :as u]]
             [metabase.driver.generic-sql :as sql]
-            (metabase.models [database :refer [Database]]
-                             [field :refer [Field]]
-                             [field-values :refer [FieldValues]]
-                             [raw-table :refer [RawTable]]
-                             [table :refer [Table]])
-            [metabase.sync-database :refer :all]
+            [metabase.models
+             [database :refer [Database]]
+             [field :refer [Field]]
+             [field-values :refer [FieldValues]]
+             [raw-table :refer [RawTable]]
+             [table :refer [Table]]]
             metabase.sync-database.analyze
-            [metabase.test.data :refer :all]
-            [metabase.test.data.interface :as i]
-            [metabase.test.util :refer [resolve-private-vars] :as tu]
-            [metabase.util :as u]))
+            [metabase.test
+             [data :refer :all]
+             [util :as tu]]
+            [toucan.db :as db]
+            [toucan.util.test :as tt]))
 
 (def ^:private ^:const sync-test-tables
   {"movie"  {:name "movie"

--- a/test/metabase/task/follow_up_emails_test.clj
+++ b/test/metabase/task/follow_up_emails_test.clj
@@ -1,7 +1,6 @@
 (ns metabase.task.follow-up-emails-test
   (:require [expectations :refer :all]
-            [metabase.email-test :refer [with-fake-inbox inbox]]
-            metabase.task.follow-up-emails
+            [metabase.email-test :refer [inbox with-fake-inbox]]
             [metabase.test.data.users :as test-users]
             [metabase.test.util :as tu]))
 

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -1,27 +1,28 @@
 (ns metabase.test.data
   "Code related to creating and deleting test databases + datasets."
-  (:require (clojure [string :as str]
-                     [walk :as walk])
+  (:require [clojure
+             [string :as str]
+             [walk :as walk]]
             [clojure.tools.logging :as log]
+            [metabase
+             [driver :as driver]
+             [query-processor :as qp]
+             [sync-database :as sync-database]
+             [util :as u]]
+            [metabase.models
+             [database :refer [Database]]
+             [field :as field :refer [Field]]
+             [table :refer [Table]]]
+            [metabase.query-processor
+             [expand :as ql]
+             [interface :as qi]]
+            [metabase.test.data
+             [dataset-definitions :as defs]
+             [datasets :refer [*driver*]]
+             [interface :as i]]
             [schema.core :as s]
-            [toucan.db :as db]
-            [metabase.driver :as driver]
-            (metabase.models [database :refer [Database]]
-                             [field :refer [Field] :as field]
-                             [table :refer [Table]])
-            [metabase.query-processor :as qp]
-            [metabase.query-processor.expand :as ql]
-            [metabase.query-processor.interface :as qi]
-            [metabase.sync-database :as sync-database]
-            (metabase.test.data [datasets :refer [*driver*]]
-                                [dataset-definitions :as defs]
-                                [h2 :as h2]
-                                [interface :as i])
-            [metabase.util :as u])
-  (:import clojure.lang.Keyword
-           (metabase.test.data.interface DatabaseDefinition
-                                         FieldDefinition
-                                         TableDefinition)))
+            [toucan.db :as db])
+  (:import [metabase.test.data.interface DatabaseDefinition TableDefinition]))
 
 (declare get-or-create-database!)
 

--- a/test/metabase/test/data/bigquery.clj
+++ b/test/metabase/test/data/bigquery.clj
@@ -2,17 +2,17 @@
   (:require [clojure.string :as s]
             [environ.core :refer [env]]
             [medley.core :as m]
-            [metabase.driver.google :as google]
-            [metabase.driver.bigquery :as bigquery]
-            (metabase.test.data [dataset-definitions :as defs]
-                                [datasets :as datasets]
-                                [interface :as i])
+            [metabase.driver
+             [bigquery :as bigquery]
+             [google :as google]]
+            [metabase.test.data
+             [datasets :as datasets]
+             [interface :as i]]
             [metabase.test.util :refer [resolve-private-vars]]
             [metabase.util :as u])
-  (:import java.util.Arrays
-           com.google.api.client.util.DateTime
+  (:import com.google.api.client.util.DateTime
            com.google.api.services.bigquery.Bigquery
-           (com.google.api.services.bigquery.model Dataset DatasetReference QueryRequest Table TableDataInsertAllRequest TableDataInsertAllRequest$Rows TableFieldSchema TableReference TableRow TableSchema)
+           [com.google.api.services.bigquery.model Dataset DatasetReference QueryRequest Table TableDataInsertAllRequest TableDataInsertAllRequest$Rows TableFieldSchema TableReference TableRow TableSchema]
            metabase.driver.bigquery.BigQueryDriver))
 
 (resolve-private-vars metabase.driver.bigquery post-process-native)

--- a/test/metabase/test/data/druid.clj
+++ b/test/metabase/test/data/druid.clj
@@ -1,11 +1,10 @@
 (ns metabase.test.data.druid
-  (:require [clojure.java.io :as io]
-            [cheshire.core :as json]
+  (:require [cheshire.core :as json]
+            [clojure.java.io :as io]
             [environ.core :refer [env]]
-            [metabase.driver.druid :as druid]
-            (metabase.test.data [dataset-definitions :as defs]
-                                [datasets :as datasets]
-                                [interface :as i])
+            [metabase.test.data
+             [dataset-definitions :as defs]
+             [interface :as i]]
             [metabase.test.util :refer [resolve-private-vars]]
             [metabase.util :as u])
   (:import metabase.driver.druid.DruidDriver))

--- a/test/metabase/test/data/generic_sql.clj
+++ b/test/metabase/test/data/generic_sql.clj
@@ -2,22 +2,20 @@
   "Common functionality for various Generic SQL dataset drivers."
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.string :as s]
-            [clojure.tools.logging :as log]
-            (honeysql [core :as hsql]
-                      [format :as hformat]
-                      [helpers :as h])
+            [honeysql
+             [core :as hsql]
+             [format :as hformat]
+             [helpers :as h]]
             [medley.core :as m]
-            [metabase.driver :as driver]
             [metabase.driver.generic-sql :as sql]
-            (metabase.test.data [datasets :as datasets]
-                                [interface :as i])
+            [metabase.test.data
+             [datasets :as datasets]
+             [interface :as i]]
             [metabase.util :as u]
             [metabase.util.honeysql-extensions :as hx])
-  (:import java.sql.SQLException
-           clojure.lang.Keyword
-           (metabase.test.data.interface DatabaseDefinition
-                                         FieldDefinition
-                                         TableDefinition)))
+  (:import clojure.lang.Keyword
+           java.sql.SQLException
+           [metabase.test.data.interface DatabaseDefinition FieldDefinition TableDefinition]))
 
 ;;; ## ------------------------------------------------------------ IGenericDatasetLoader + default impls ------------------------------------------------------------
 

--- a/test/metabase/test/data/h2.clj
+++ b/test/metabase/test/data/h2.clj
@@ -1,11 +1,10 @@
 (ns metabase.test.data.h2
   "Code for creating / destroying an H2 database from a `DatabaseDefinition`."
-  (:require [clojure.core.reducers :as r]
-            [clojure.string :as s]
+  (:require [clojure.string :as s]
             [metabase.db.spec :as dbspec]
-            metabase.driver.h2
-            (metabase.test.data [generic-sql :as generic]
-                                [interface :as i])
+            [metabase.test.data
+             [generic-sql :as generic]
+             [interface :as i]]
             [metabase.util :as u])
   (:import metabase.driver.h2.H2Driver))
 

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -4,14 +4,16 @@
    Objects that implement `IDatasetLoader` know how to load a `DatabaseDefinition` into an
    actual physical RDMS database. This functionality allows us to easily test with multiple datasets."
   (:require [clojure.string :as str]
-            [schema.core :as s]
-            (metabase [db :as db]
-                      [driver :as driver])
-            (metabase.models [database :refer [Database]]
-                             [field :refer [Field] :as field]
-                             [table :refer [Table]])
-            [metabase.util :as u]
-            [metabase.util.schema :as su])
+            [metabase
+             [db :as db]
+             [driver :as driver]
+             [util :as u]]
+            [metabase.models
+             [database :refer [Database]]
+             [field :as field :refer [Field]]
+             [table :refer [Table]]]
+            [metabase.util.schema :as su]
+            [schema.core :as s])
   (:import clojure.lang.Keyword))
 
 (s/defrecord FieldDefinition [field-name      :- su/NonBlankString

--- a/test/metabase/test/data/mongo.clj
+++ b/test/metabase/test/data/mongo.clj
@@ -1,10 +1,10 @@
 (ns metabase.test.data.mongo
-  (:require (monger [collection :as mc]
-                    [core :as mg])
-            metabase.driver.mongo
-            [metabase.driver.mongo.util :refer [with-mongo-connection]]
+  (:require [metabase.driver.mongo.util :refer [with-mongo-connection]]
             [metabase.test.data.interface :as i]
-            [metabase.util :as u])
+            [metabase.util :as u]
+            [monger
+             [collection :as mc]
+             [core :as mg]])
   (:import metabase.driver.mongo.MongoDriver))
 
 (defn- database->connection-details

--- a/test/metabase/test/data/mysql.clj
+++ b/test/metabase/test/data/mysql.clj
@@ -1,10 +1,9 @@
 (ns metabase.test.data.mysql
   "Code for creating / destroying a MySQL database from a `DatabaseDefinition`."
-  (:require [clojure.string :as s]
-            [environ.core :refer [env]]
-            metabase.driver.mysql
-            (metabase.test.data [generic-sql :as generic]
-                                [interface :as i])
+  (:require [environ.core :refer [env]]
+            [metabase.test.data
+             [generic-sql :as generic]
+             [interface :as i]]
             [metabase.util :as u])
   (:import metabase.driver.mysql.MySQLDriver))
 

--- a/test/metabase/test/data/oracle.clj
+++ b/test/metabase/test/data/oracle.clj
@@ -3,10 +3,9 @@
             [clojure.string :as s]
             [environ.core :refer [env]]
             [metabase.driver.generic-sql :as sql]
-            [metabase.test.data :as data]
-            (metabase.test.data [datasets :as datasets]
-                                [generic-sql :as generic]
-                                [interface :as i])
+            [metabase.test.data
+             [generic-sql :as generic]
+             [interface :as i]]
             [metabase.util :as u])
   (:import metabase.driver.oracle.OracleDriver))
 

--- a/test/metabase/test/data/postgres.clj
+++ b/test/metabase/test/data/postgres.clj
@@ -1,10 +1,9 @@
 (ns metabase.test.data.postgres
   "Code for creating / destroying a Postgres database from a `DatabaseDefinition`."
   (:require [environ.core :refer [env]]
-            (metabase.driver [generic-sql :as sql]
-                             postgres)
-            (metabase.test.data [generic-sql :as generic]
-                                [interface :as i])
+            [metabase.test.data
+             [generic-sql :as generic]
+             [interface :as i]]
             [metabase.util :as u])
   (:import metabase.driver.postgres.PostgresDriver))
 

--- a/test/metabase/test/data/presto.clj
+++ b/test/metabase/test/data/presto.clj
@@ -1,16 +1,15 @@
 (ns metabase.test.data.presto
   (:require [clojure.string :as s]
             [environ.core :refer [env]]
-            (honeysql [core :as hsql]
-                      [helpers :as h])
+            [honeysql
+             [core :as hsql]
+             [helpers :as h]]
             [metabase.driver.generic-sql.util.unprepare :as unprepare]
             [metabase.test.data.interface :as i]
             [metabase.test.util :refer [resolve-private-vars]]
-            [metabase.util :as u]
-            [metabase.util.honeysql-extensions :as hx])
+            [metabase.util :as u])
   (:import java.util.Date
-           metabase.driver.presto.PrestoDriver
-           (metabase.query_processor.interface DateTimeValue Value)))
+           metabase.driver.presto.PrestoDriver))
 
 (resolve-private-vars metabase.driver.presto execute-presto-query! presto-type->base-type quote-name quote+combine-names)
 

--- a/test/metabase/test/data/redshift.clj
+++ b/test/metabase/test/data/redshift.clj
@@ -1,13 +1,10 @@
 (ns metabase.test.data.redshift
-  (:require [clojure.java.jdbc :as jdbc]
-            [clojure.tools.logging :as log]
-            [clojure.string :as s]
+  (:require [clojure.string :as s]
             [environ.core :refer [env]]
-            (metabase.driver [generic-sql :as sql]
-                             redshift)
-            (metabase.test.data [generic-sql :as generic]
-                                [interface :as i]
-                                [postgres :as postgres])
+            [metabase.driver.generic-sql :as sql]
+            [metabase.test.data
+             [generic-sql :as generic]
+             [interface :as i]]
             [metabase.util :as u])
   (:import metabase.driver.redshift.RedshiftDriver))
 

--- a/test/metabase/test/data/sqlite.clj
+++ b/test/metabase/test/data/sqlite.clj
@@ -1,9 +1,8 @@
 (ns metabase.test.data.sqlite
-  (:require [clojure.string :as s]
-            [honeysql.core :as hsql]
-            metabase.driver.sqlite
-            (metabase.test.data [generic-sql :as generic]
-                                [interface :as i])
+  (:require [honeysql.core :as hsql]
+            [metabase.test.data
+             [generic-sql :as generic]
+             [interface :as i]]
             [metabase.util :as u]
             [metabase.util.honeysql-extensions :as hx])
   (:import metabase.driver.sqlite.SQLiteDriver))

--- a/test/metabase/test/data/sqlserver.clj
+++ b/test/metabase/test/data/sqlserver.clj
@@ -3,11 +3,11 @@
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.string :as s]
             [environ.core :refer [env]]
-            (metabase.driver [generic-sql :as sql]
-                             sqlserver)
-            (metabase.test.data [datasets :as datasets]
-                                [generic-sql :as generic]
-                                [interface :as i])
+            [metabase.driver.generic-sql :as sql]
+            [metabase.test.data
+             [datasets :as datasets]
+             [generic-sql :as generic]
+             [interface :as i]]
             [metabase.util :as u])
   (:import metabase.driver.sqlserver.SQLServerDriver))
 

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -1,15 +1,13 @@
 (ns metabase.test.data.users
   "Code related to creating / managing fake `Users` for testing purposes."
-  ;; TODO - maybe this namespace should just be `metabase.test.users`.
   (:require [medley.core :as m]
-            [toucan.db :as db]
-            [metabase.config :as config]
+            [metabase
+             [config :as config]
+             [http-client :as http]
+             [util :as u]]
             [metabase.core.initialization-status :as init-status]
-            [metabase.http-client :as http]
-            (metabase.models [permissions-group :as perms-group]
-                             [user :refer [User]])
-            [metabase.util :as u]
-            [metabase.test.util :refer [random-name]])
+            [metabase.models.user :refer [User]]
+            [toucan.db :as db])
   (:import clojure.lang.ExceptionInfo))
 
 ;;; ------------------------------------------------------------ User Definitions ------------------------------------------------------------

--- a/test/metabase/test/data/vertica.clj
+++ b/test/metabase/test/data/vertica.clj
@@ -1,10 +1,10 @@
 (ns metabase.test.data.vertica
   "Code for creating / destroying a Vertica database from a `DatabaseDefinition`."
   (:require [environ.core :refer [env]]
-            (metabase.driver [generic-sql :as sql]
-                             vertica)
-            (metabase.test.data [generic-sql :as generic]
-                                [interface :as i])
+            [metabase.driver.generic-sql :as sql]
+            [metabase.test.data
+             [generic-sql :as generic]
+             [interface :as i]]
             [metabase.util :as u])
   (:import metabase.driver.vertica.VerticaDriver))
 

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -1,31 +1,30 @@
 (ns metabase.test.util
   "Helper functions and macros for writing unit tests."
-  (:require [clojure.tools.logging :as log]
+  (:require [cheshire.core :as json]
+            [clojure.tools.logging :as log]
             [clojure.walk :as walk]
-            [cheshire.core :as json]
             [expectations :refer :all]
-            (toucan [db :as db]
-                    [models :as models])
-            [toucan.util.test :as test]
-            (metabase.models [card :refer [Card]]
-                             [collection :refer [Collection]]
-                             [dashboard :refer [Dashboard]]
-                             [dashboard-card-series :refer [DashboardCardSeries]]
-                             [database :refer [Database]]
-                             [field :refer [Field]]
-                             [metric :refer [Metric]]
-                             [permissions-group :refer [PermissionsGroup]]
-                             [pulse :refer [Pulse]]
-                             [pulse-channel :refer [PulseChannel]]
-                             [raw-column :refer [RawColumn]]
-                             [raw-table :refer [RawTable]]
-                             [revision :refer [Revision]]
-                             [segment :refer [Segment]]
-                             [setting :as setting]
-                             [table :refer [Table]]
-                             [user :refer [User]])
+            [metabase.models
+             [card :refer [Card]]
+             [collection :refer [Collection]]
+             [dashboard :refer [Dashboard]]
+             [dashboard-card-series :refer [DashboardCardSeries]]
+             [database :refer [Database]]
+             [field :refer [Field]]
+             [metric :refer [Metric]]
+             [permissions-group :refer [PermissionsGroup]]
+             [pulse :refer [Pulse]]
+             [pulse-channel :refer [PulseChannel]]
+             [raw-column :refer [RawColumn]]
+             [raw-table :refer [RawTable]]
+             [revision :refer [Revision]]
+             [segment :refer [Segment]]
+             [setting :as setting]
+             [table :refer [Table]]
+             [user :refer [User]]]
             [metabase.test.data :as data]
-            [metabase.util :as u]))
+            [metabase.util :as u]
+            [toucan.util.test :as test]))
 
 (declare $->prop)
 

--- a/test/metabase/test_setup.clj
+++ b/test/metabase/test_setup.clj
@@ -1,19 +1,16 @@
 (ns metabase.test-setup
   "Functions that run before + after unit tests (setup DB, start web server, load test data)."
-  (:require clojure.data
-            [clojure.java.io :as io]
-            [clojure.set :as set]
+  (:require [clojure data
+             [set :as set]]
             [clojure.tools.logging :as log]
             [expectations :refer :all]
-            [metabase.core :as core]
+            [metabase
+             [core :as core]
+             [db :as mdb]
+             [driver :as driver]
+             [util :as u]]
             [metabase.core.initialization-status :as init-status]
-            (metabase [db :as mdb]
-                      [driver :as driver])
-            (metabase.models [setting :as setting]
-                             [table :refer [Table]])
-            [metabase.test.data :as data]
-            [metabase.test.data.datasets :as datasets]
-            [metabase.util :as u]))
+            [metabase.models.setting :as setting]))
 
 ;; # ---------------------------------------- EXPECTAIONS FRAMEWORK SETTINGS ------------------------------
 

--- a/test/metabase/timeseries_query_processor_test.clj
+++ b/test/metabase/timeseries_query_processor_test.clj
@@ -1,14 +1,15 @@
 (ns metabase.timeseries-query-processor-test
   "Query processor tests for DBs that are event-based, like Druid.
    There architecture is different enough that we can't test them along with our 'normal' DBs in `query-procesor-test`."
-  (:require [expectations :refer :all]
+  (:require [metabase
+             [query-processor-test :refer [first-row format-rows-by rows]]
+             [util :as u]]
             [metabase.query-processor.expand :as ql]
-            [metabase.query-processor-test :refer [format-rows-by rows first-row]]
             [metabase.test.data :as data]
-            (metabase.test.data [dataset-definitions :as defs]
-                                [datasets :as datasets]
-                                [interface :as i])
-            [metabase.util :as u]))
+            [metabase.test.data
+             [dataset-definitions :as defs]
+             [datasets :as datasets]
+             [interface :as i]]))
 
 (def ^:private ^:const event-based-dbs
   #{:druid})

--- a/test/metabase/util/schema_test.clj
+++ b/test/metabase/util/schema_test.clj
@@ -1,7 +1,7 @@
 (ns metabase.util.schema-test
-  (:require [metabase.util.schema :as su]
-            [schema.core :as s]
-            [expectations :refer :all]))
+  (:require [expectations :refer :all]
+            [metabase.util.schema :as su]
+            [schema.core :as s]))
 
 ;; check that the API error message generation is working as intended
 (expect

--- a/test/metabase/util/stats_test.clj
+++ b/test/metabase/util/stats_test.clj
@@ -1,9 +1,9 @@
 (ns metabase.util.stats-test
   (:require [expectations :refer :all]
-            [toucan.db :as db]
             [metabase.models.query-execution :refer [QueryExecution]]
+            [metabase.test.util :as tu]
             [metabase.util.stats :refer :all]
-            [metabase.test.util :as tu]))
+            [toucan.db :as db]))
 
 (tu/resolve-private-vars metabase.util.stats
   bin-micro-number bin-medium-number bin-large-number)


### PR DESCRIPTION
Realized I forgot to run the cleanup code from #4869 over the test namespaces.

Luckily this was pretty easy and only required a couple of manual fixes so only took a few minutes
