### PR TITLE
Docker: set timezone to UTC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ENV LEIN_ROOT 1
 
 ENV FC_LANG en-US
 ENV LC_CTYPE en_US.UTF-8
+ENV TZ UTC
 
 # install core build tools
 RUN apk add --update nodejs git wget bash python make g++ java-cacerts ttf-dejavu fontconfig && \


### PR DESCRIPTION
I believe the `Report Timezone` field needs clarification. Here it says "Defaults to __system timezone__."

<img width="532" alt="screen shot 2017-04-27 at 2 43 49 pm" src="https://cloud.githubusercontent.com/assets/1240531/25505837/7ffcf364-2b58-11e7-9238-d88d2cf825d0.png">

... while the select field then says __Database default__.

<img width="252" alt="screen shot 2017-04-27 at 2 44 09 pm" src="https://cloud.githubusercontent.com/assets/1240531/25505840/8210af38-2b58-11e7-8c21-ab17f88d2c93.png">

The database timezone and the system timezone are two different things. I *believe* metabase in this context actually uses the system timezone but means database default? This needs to be addressed on its own.

---

I opened this PR to set the default system's timezone to `UTC` when metabase is run inside Docker. As of today, the Java Runtime doesn't take the underlying OS' timezone into account. Metabase, when run with Docker, defaults to GMT and I think UTC is the better default here. 
