### PR TITLE
decreased the default limit of topN results to 1000

### DIFF
--- a/src/metabase/driver/druid/query_processor.clj
+++ b/src/metabase/driver/druid/query_processor.clj
@@ -84,7 +84,7 @@
      ::total              (merge defaults {:queryType :timeseries})
      ::grouped-timeseries (merge defaults {:queryType :timeseries})
      ::topN               (merge defaults {:queryType :topN
-                                           :threshold 1000})
+                                           :threshold i/druid-topN-max-results})
      ::groupBy            (merge defaults {:queryType :groupBy})}))
 
 

--- a/src/metabase/driver/druid/query_processor.clj
+++ b/src/metabase/driver/druid/query_processor.clj
@@ -84,7 +84,7 @@
      ::total              (merge defaults {:queryType :timeseries})
      ::grouped-timeseries (merge defaults {:queryType :timeseries})
      ::topN               (merge defaults {:queryType :topN
-                                           :threshold i/absolute-max-results})
+                                           :threshold 1000})
      ::groupBy            (merge defaults {:queryType :groupBy})}))
 
 

--- a/src/metabase/query_processor/interface.clj
+++ b/src/metabase/query_processor/interface.clj
@@ -19,6 +19,13 @@
    https://support.office.com/en-nz/article/Excel-specifications-and-limits-1672b34d-7043-467e-8e27-269d656771c3"
   1048576)
 
+(def ^:const druid-topN-max-results
+  "Maximum number of rows the topN query in Druid should return. Huge values cause significant issues with the engine.
+
+   Coming from the default value hardcoded in the Druid engine itself
+   http://druid.io/docs/latest/querying/topnquery.html"
+  1000)
+
 
 ;;; # ------------------------------------------------------------ DYNAMIC VARS ------------------------------------------------------------
 


### PR DESCRIPTION
This PR is a simple fix for the issue described in #4907 . 

Our code on production already runs with this patch and we don't experience downtimes when unaware users forget to specify the result limit.