### PR TITLE
Make sure icon.attrs is defined before trying to get icon.attrs.className

### DIFF
--- a/frontend/src/metabase/components/Icon.jsx
+++ b/frontend/src/metabase/components/Icon.jsx
@@ -25,8 +25,7 @@ export default class Icon extends Component {
         if (!icon) {
             return null;
         }
-
-        const className = cx(icon.attrs.className, this.props.className)
+        const className = cx(icon.attrs && icon.attrs.className, this.props.className)
         const props = { ...icon.attrs, ...this.props, className };
         for (const prop of ["width", "height", "size", "scale"]) {
             if (typeof props[prop] === "string") {

--- a/frontend/src/metabase/icon_paths.js
+++ b/frontend/src/metabase/icon_paths.js
@@ -230,7 +230,7 @@ export function loadIcon(name) {
     }
 
     if (def.img) {
-        return def;
+        return { ...def, attrs: { ...def.attrs, className: 'Icon Icon-' + name } };
     }
 
     var icon = {


### PR DESCRIPTION
Fixes #4919. Apparently the Slack icon doesn't have an `attrs` property, it's just

```javascript
{img: "/app/img/slack.png"}
```

no idea what's going on here but this does fix it