### PR TITLE
Name schemas LikeThis instead of like-this :shower:

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -418,7 +418,7 @@
   "Run the query associated with a Card, and return its results as a file in the specified format. Note that this expects the parameters as serialized JSON in the 'parameters' parameter"
   [card-id export-format parameters]
   {parameters    (s/maybe su/JSONString)
-   export-format dataset-api/export-format-schema}
+   export-format dataset-api/ExportFormat}
   (binding [cache/*ignore-cached-results* true]
     (dataset-api/as-format export-format
       (run-query-for-card card-id

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -79,7 +79,7 @@
            :ext          "json"
            :context      :json-download}})
 
-(def export-format-schema
+(def ExportFormat
   "Schema for valid export formats for downloading query results."
   (apply s/enum (keys export-formats)))
 
@@ -112,7 +112,7 @@
   "Execute a query and download the result data as a file in the specified format."
   [export-format query]
   {query         su/JSONString
-   export-format export-format-schema}
+   export-format ExportFormat}
   (let [query (json/parse-string query keyword)]
     (api/read-check Database (:database query))
     (as-format export-format

--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -279,7 +279,7 @@
 (api/defendpoint GET "/card/:token/query/:export-format"
   "Like `GET /api/embed/card/query`, but returns the results as a file in the specified format."
   [token export-format & query-params]
-  {export-format dataset-api/export-format-schema}
+  {export-format dataset-api/ExportFormat}
   (dataset-api/as-format export-format
     (run-query-for-unsigned-token (eu/unsign token) query-params, :constraints nil)))
 

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -118,7 +118,7 @@
   "Fetch a publically-accessible Card and return query results in the specified format. Does not require auth credentials. Public sharing must be enabled."
   [uuid export-format parameters]
   {parameters    (s/maybe su/JSONString)
-   export-format dataset-api/export-format-schema}
+   export-format dataset-api/ExportFormat}
   (dataset-api/as-format export-format
     (run-query-for-card-with-public-uuid uuid parameters, :constraints nil)))
 


### PR DESCRIPTION
One other bit of code cleanup I forgot from the Excel download PR.

Following the convention for [schema](https://github.com/plumatic/schema)s the schema that checks to make sure we have a valid export format should be called `ExportFormat` instead of `export-format-schema`
