### PR TITLE
Allow for custom setCollection function in MoveToCollection

### DIFF
--- a/frontend/src/metabase/query_builder/components/QueryHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryHeader.jsx
@@ -288,6 +288,10 @@ export default class QueryHeader extends Component {
                         <MoveToCollection
                             questionId={this.props.card.id}
                             initialCollectionId={this.props.card && this.props.card.collection_id}
+                            setCollection={(props, collection) => {
+                                this.props.onSetCardAttribute('collection', collection)
+                                this.props.onSetCardAttribute('collection_id', collection.id)
+                            }}
                         />
                     </ModalWithTrigger>
                 ]);

--- a/frontend/src/metabase/query_builder/components/QueryHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryHeader.jsx
@@ -288,7 +288,7 @@ export default class QueryHeader extends Component {
                         <MoveToCollection
                             questionId={this.props.card.id}
                             initialCollectionId={this.props.card && this.props.card.collection_id}
-                            setCollection={(props, collection) => {
+                            setCollection={(questionId, collection) => {
                                 this.props.onSetCardAttribute('collection', collection)
                                 this.props.onSetCardAttribute('collection_id', collection.id)
                             }}

--- a/frontend/src/metabase/questions/containers/MoveToCollection.jsx
+++ b/frontend/src/metabase/questions/containers/MoveToCollection.jsx
@@ -16,10 +16,10 @@ const mapStateToProps = (state, props) => ({
 
 })
 
-const mapDispatchToProps = (dispatch) => ({
+const mapDispatchToProps = {
     loadCollections,
-    dispatch
-})
+    defaultSetCollection: setCollection
+}
 
 @connect(mapStateToProps, mapDispatchToProps)
 export default class MoveToCollection extends Component {
@@ -38,10 +38,11 @@ export default class MoveToCollection extends Component {
     async onMove(collection) {
         try {
             this.setState({ error: null })
-            this.props.setCollection(this.props, collection, true);
+            const setCollection = this.props.setCollection || this.props.defaultSetCollection
+            await setCollection(this.props.questionId, collection, true);
             this.props.onClose();
-        } catch (e) {
-            this.setState({ error: e })
+        } catch (error) {
+            this.setState({ error })
         }
     }
 
@@ -95,8 +96,3 @@ export default class MoveToCollection extends Component {
     }
 }
 
-MoveToCollection.defaultProps = {
-    setCollection: async (props, collection) => {
-        await props.dispatch(setCollection(props.questionId, collection.id, true))
-    }
-}

--- a/frontend/src/metabase/questions/containers/MoveToCollection.jsx
+++ b/frontend/src/metabase/questions/containers/MoveToCollection.jsx
@@ -16,28 +16,29 @@ const mapStateToProps = (state, props) => ({
 
 })
 
-const mapDispatchToProps = {
+const mapDispatchToProps = (dispatch) => ({
     loadCollections,
-    setCollection
-}
+    dispatch
+})
 
 @connect(mapStateToProps, mapDispatchToProps)
 export default class MoveToCollection extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            collectionId: props.initialCollectionId
+            currentCollection: { id:  props.initialCollectionId }
         }
+
     }
 
     componentWillMount() {
         this.props.loadCollections()
     }
 
-    async onMove(collectionId) {
+    async onMove(collection) {
         try {
             this.setState({ error: null })
-            await this.props.setCollection(this.props.questionId, collectionId, true);
+            this.props.setCollection(this.props, collection, true);
             this.props.onClose();
         } catch (e) {
             this.setState({ error: e })
@@ -46,7 +47,7 @@ export default class MoveToCollection extends Component {
 
     render() {
         const { onClose } = this.props;
-        const { collectionId, error } = this.state;
+        const { currentCollection, error } = this.state;
         return (
             <ModalContent
                 title="Which collection should this be in?"
@@ -58,7 +59,7 @@ export default class MoveToCollection extends Component {
                         <Button className="mr1" onClick={onClose}>
                             Cancel
                         </Button>
-                        <Button primary disabled={collectionId === undefined} onClick={() => this.onMove(collectionId)}>
+                        <Button primary disabled={currentCollection.id === undefined} onClick={() => this.onMove(currentCollection)}>
                             Move
                         </Button>
                     </div>
@@ -71,9 +72,9 @@ export default class MoveToCollection extends Component {
                         <ol className="List text-brand ml-auto mr-auto" style={{ width: 520 }}>
                             { [{ name: "None", id: null }].concat(collections).map((collection, index) =>
                                 <li
-                                    className={cx("List-item flex align-center cursor-pointer mb1 p1", { "List-item--selected": collection.id === collectionId })}
+                                    className={cx("List-item flex align-center cursor-pointer mb1 p1", { "List-item--selected": collection.id === currentCollection.id })}
                                     key={index}
-                                    onClick={() => this.setState({ collectionId: collection.id })}
+                                    onClick={() => this.setState({ currentCollection: collection })}
                                 >
                                     <Icon
                                         className="Icon mr2"
@@ -91,5 +92,11 @@ export default class MoveToCollection extends Component {
                 </CollectionList>
             </ModalContent>
         )
+    }
+}
+
+MoveToCollection.defaultProps = {
+    setCollection: async (props, collection) => {
+        await props.dispatch(setCollection(props.questionId, collection.id, true))
     }
 }

--- a/frontend/src/metabase/questions/questions.js
+++ b/frontend/src/metabase/questions/questions.js
@@ -178,6 +178,7 @@ export const setCollection = createThunkAction(SET_COLLECTION, (cardId, collecti
             selected.map(item => dispatch(setCollection(item.id, collectionId)));
         } else {
             const collection = _.findWhere(state.collections.collections, { id: collectionId });
+
             if (undoable) {
                 dispatch(addUndo(createUndo(
                     "moved",

--- a/frontend/src/metabase/questions/questions.js
+++ b/frontend/src/metabase/questions/questions.js
@@ -162,9 +162,10 @@ export const setLabeled = createThunkAction(SET_LABELED, (cardId, labelId, label
 
 const getCardCollectionId = (state, cardId) => getIn(state, ["questions", "entities", "cards", cardId, "collection_id"])
 
-export const setCollection = createThunkAction(SET_COLLECTION, (cardId, collectionId, undoable = false) => {
+export const setCollection = createThunkAction(SET_COLLECTION, (cardId, collection, undoable = false) => {
     return async (dispatch, getState) => {
         const state = getState();
+        const collectionId = collection.id;
         if (cardId == null) {
             // bulk move
             let selected = getSelectedEntities(getState());


### PR DESCRIPTION
Fixes #4891 

Previously when you hit "Move to collection" while in edit mode on a saved card we'd actually update the collection the question was in without updating the state in the QB and effectively ignore any intent to "Cancel". In addition the collection change wouldn't be reflected in edit mode the same way name and description changes are.

I opted for this approach of passing a custom setCollection function for this particular case that used `setCardAttribute` to update the collection just like we do name and description and then in other instances on the Question page etc things work just like they used to and it dispatches `setCollection`. This seemed like the cleanest way to get the state reflected properly and to cancel to work since otherwise it would have required a fair bit of custom logic in `setCollection` which didn't seem appropriate.
