### PR TITLE
add tests to make sure we don't sync hidden tables

### DIFF
--- a/test/metabase/sync_database/analyze_test.clj
+++ b/test/metabase/sync_database/analyze_test.clj
@@ -88,14 +88,14 @@
              (db/count Field :table_id table-id)))
     (db/count Field :last_analyzed nil :table_id table-id)))
 
-(defn get-latest-sync-time [db_id table-name]
+(defn latest-sync-time [db_id table-name]
   (let [table-id (db/select-one-id Table, :db_id db_id, :active true :name table-name)]
     (db/select-field :last_analyzed Field :table_id table-id)))
 
-(defn set-table-visibility-type! [table state]
+(defn set-table-visibility-type! [table visibility-type]
   ((user->client :crowberto) :put 200 (format "table/%d" (:id table)) {:display_name    "hiddentable"
                                                                        :entity_type     "person"
-                                                                       :visibility_type state
+                                                                       :visibility_type visibility-type
 
                                                                        :description     "What a nice table!"}))
 (defn api-sync-call [table]
@@ -150,6 +150,6 @@
                       Field [field {:table_id (:id table)}]]
   (do (set-table-visibility-type! table "hidden")
       (set-table-visibility-type! table nil)
-      (get-latest-sync-time (:db_id table) (:name table)))
+      (latest-sync-time (:db_id table) (:name table)))
   (do (set-table-visibility-type! table "hidden")
-      (get-latest-sync-time (:db_id table) (:name table))))
+      (latest-sync-time (:db_id table) (:name table))))

--- a/test/metabase/sync_database/analyze_test.clj
+++ b/test/metabase/sync_database/analyze_test.clj
@@ -98,6 +98,7 @@
                                                                        :visibility_type visibility-type
 
                                                                        :description     "What a nice table!"}))
+
 (defn api-sync-call [table]
   ((user->client :crowberto) :post 200 (format "database/%d/sync" (:db_id table)) {}))
 

--- a/test/metabase/sync_database/analyze_test.clj
+++ b/test/metabase/sync_database/analyze_test.clj
@@ -2,9 +2,15 @@
   (:require [clojure.string :as str]
             [expectations :refer :all]
             [metabase.db.metadata-queries :as metadata-queries]
+            [metabase.models
+             [field :refer [Field]]
+             [table :as table :refer [Table]]]
             [metabase.sync-database.analyze :refer :all]
-            [metabase.test.util :as tu]))
-
+            [metabase.test.data.users :refer :all]
+            [metabase.test.util :as tu]
+            [toucan.db :as db]
+            [toucan.util.test :as tt]
+            [metabase.driver :as driver]))
 
 ;; test:cardinality-and-extract-field-values
 ;; (#2332) check that if field values are long we skip over them
@@ -72,3 +78,80 @@
 (expect false (values-are-valid-emails? [100]))
 (expect false (values-are-valid-emails? ["true"]))
 (expect false (values-are-valid-emails? ["false"]))
+
+;; Tests to avoid analyzing hidden tables
+(defn count-un-analyzed-fields [db_id table-name]
+  (let [table-id (db/select-one-id table/Table, :db_id db_id, :active true :name table-name)]
+    (assert (pos? ;; don't let ourselves be fooled if the test passes because the table is
+                  ;; totally broken or has no fields. Make sure we actually test something
+             (db/count metabase.models.field/Field :table_id table-id)))
+    (db/count metabase.models.field/Field :last_analyzed nil :table_id table-id)))
+
+(defn get-latest-sync-time [db_id table-name]
+  (let [table-id (db/select-one-id table/Table, :db_id db_id, :active true :name table-name)]
+    (db/select-field :last_analyzed metabase.models.field/Field :table_id table-id)))
+
+
+(defn api-table-call [state table]
+  ((user->client :crowberto) :put 200 (format "table/%d" (:id table)) {:display_name    "hiddentable"
+                                                                       :entity_type     "person"
+                                                                       :visibility_type state
+
+                                                                       :description     "What a nice table!"}))
+(defn api-sync-call [table]
+  ((user->client :crowberto) :post 200 (format "database/%d/sync" (:db_id table)) {}))
+
+(defn sync-call [table]
+  (let [db-id(:db_id table)]
+    (analyze-data-shape-for-tables! (driver/database-id->driver db-id) {:id db-id})))
+
+;; expect all the kinds of hidden tables to stay un-analyzed through transitions and repeated syncing
+(tt/expect-with-temp [Table [table {:rows 15}]
+                      Field [field {:table_id (:id table)}]]
+  1
+  (do (api-table-call "hidden" table)
+      (api-sync-call table)
+      (api-table-call "cruft" table)
+      (api-table-call "cruft" table)
+      (api-sync-call table)
+      (api-table-call "technical" table)
+      (api-sync-call table)
+      (api-table-call "technical" table)
+      (api-sync-call table)
+      (api-sync-call table)
+      (count-un-analyzed-fields (:db_id table) (:name table))))
+
+;; same test not coming through the api
+(tt/expect-with-temp [Table [table {:rows 15}]
+                      Field [field {:table_id (:id table)}]]
+  1
+  (do (api-table-call "hidden" table)
+      (sync-call table)
+      (api-table-call "cruft" table)
+      (api-table-call "cruft" table)
+      (sync-call table)
+      (api-table-call "technical" table)
+      (sync-call table)
+      (api-table-call "technical" table)
+      (sync-call table)
+      (sync-call table)
+      (count-un-analyzed-fields (:db_id table) (:name table))))
+
+;; un-hiding a table should cause it to be analyzed
+(tt/expect-with-temp [Table [table {:rows 15}]
+                      Field [field {:table_id (:id table)}]]
+  0
+  (do (api-table-call "hidden" table)
+      (api-table-call nil table)
+      (count-un-analyzed-fields (:db_id table) (:name table))))
+
+;; re-hiding a table should not cause it to be analyzed
+(tt/expect-with-temp [Table [table {:rows 15}]
+                      Field [field {:table_id (:id table)}]]
+  (do (api-table-call "hidden" table)
+      (api-table-call nil table)
+      (println (get-latest-sync-time (:db_id table) (:name table)))
+      (get-latest-sync-time (:db_id table) (:name table)))
+  (do (api-table-call "hidden" table)
+      (println (get-latest-sync-time (:db_id table) (:name table)))
+      (get-latest-sync-time (:db_id table) (:name table))))

--- a/test/metabase/sync_database/analyze_test.clj
+++ b/test/metabase/sync_database/analyze_test.clj
@@ -148,8 +148,10 @@
 ;; re-hiding a table should not cause it to be analyzed
 (tt/expect-with-temp [Table [table {:rows 15}]
                       Field [field {:table_id (:id table)}]]
-  (do (set-table-visibility-type! table "hidden")
-      (set-table-visibility-type! table nil)
-      (latest-sync-time (:db_id table) (:name table)))
-  (do (set-table-visibility-type! table "hidden")
-      (latest-sync-time (:db_id table) (:name table))))
+  true
+  (do (set-table-visibility-type! table "hidden") ;; start with it not visible
+      (set-table-visibility-type! table nil)      ;; make it visible to trigger analysis
+      (let [initial-sync-time (latest-sync-time (:db_id table) (:name table))]
+        ;; make it invisible which should not trigger analysis
+        (set-table-visibility-type! table "hidden")
+        (= initial-sync-time (latest-sync-time (:db_id table) (:name table))))))

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -9,6 +9,7 @@
              [query-processor :as qp]
              [sync-database :as sync-database]
              [util :as u]]
+            metabase.driver.h2
             [metabase.models
              [database :refer [Database]]
              [field :as field :refer [Field]]
@@ -19,6 +20,7 @@
             [metabase.test.data
              [dataset-definitions :as defs]
              [datasets :refer [*driver*]]
+             h2
              [interface :as i]]
             [schema.core :as s]
             [toucan.db :as db])


### PR DESCRIPTION
add meaningful tests to make sure that unwanted analysis of hidden tables does not happen.