### PR TITLE
Don't use expect-with-temp when temp objects aren't used in expected

### DIFF
--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -18,27 +18,27 @@
   ((user->client :crowberto) :get 200 "collection"))
 
 ;; check that we don't see collections if we don't have permissions for them
-(tt/expect-with-temp [Collection [collection-1 {:name "Collection 1"}]
-                      Collection [collection-2 {:name "Collection 2"}]]
+(expect
   ["Collection 1"]
-  (do
+  (tt/with-temp* [Collection [collection-1 {:name "Collection 1"}]
+                  Collection [collection-2 {:name "Collection 2"}]]
     (perms/grant-collection-read-permissions! (group/all-users) collection-1)
     (map :name ((user->client :rasta) :get 200 "collection"))))
 
 ;; check that we don't see collections if they're archived
-(tt/expect-with-temp [Collection [collection-1 {:name "Archived Collection", :archived true}]
-                      Collection [collection-2 {:name "Regular Collection"}]]
+(expect
   ["Regular Collection"]
-  (do
+  (tt/with-temp* [Collection [collection-1 {:name "Archived Collection", :archived true}]
+                  Collection [collection-2 {:name "Regular Collection"}]]
     (perms/grant-collection-read-permissions! (group/all-users) collection-1)
     (perms/grant-collection-read-permissions! (group/all-users) collection-2)
     (map :name ((user->client :rasta) :get 200 "collection"))))
 
 ;; Check that if we pass `?archived=true` we instead see archived cards
-(tt/expect-with-temp [Collection [collection-1 {:name "Archived Collection", :archived true}]
-                      Collection [collection-2 {:name "Regular Collection"}]]
+(expect
   ["Archived Collection"]
-  (do
+  (tt/with-temp* [Collection [collection-1 {:name "Archived Collection", :archived true}]
+                  Collection [collection-2 {:name "Regular Collection"}]]
     (perms/grant-collection-read-permissions! (group/all-users) collection-1)
     (perms/grant-collection-read-permissions! (group/all-users) collection-2)
     (map :name ((user->client :rasta) :get 200 "collection" :archived :true))))
@@ -100,7 +100,8 @@
    {:name "My Beautiful Collection", :color "#ABCDEF"}))
 
 ;; check that non-admins aren't allowed to update a collection
-(tt/expect-with-temp [Collection [collection]]
+(expect
   "You don't have permissions to do that."
-  ((user->client :rasta) :put 403 (str "collection/" (u/get-id collection))
-   {:name "My Beautiful Collection", :color "#ABCDEF"}))
+  (tt/with-temp Collection [collection]
+    ((user->client :rasta) :put 403 (str "collection/" (u/get-id collection))
+     {:name "My Beautiful Collection", :color "#ABCDEF"})))

--- a/test/metabase/api/label_test.clj
+++ b/test/metabase/api/label_test.clj
@@ -9,8 +9,8 @@
 
 ;;; GET /api/label -- list all labels
 (tt/expect-with-temp [Label [{label-1-id :id} {:name "Toucan-Approved"}]
-                   Label [{label-2-id :id} {:name "non-Toucan-Approved"}]]
-  [{:id label-2-id, :name "non-Toucan-Approved", :slug "non_toucan_approved", :icon nil}  ; should be sorted by name, case-insensitive
+                      Label [{label-2-id :id} {:name "non-Toucan-Approved"}]]
+  [{:id label-2-id, :name "non-Toucan-Approved", :slug "non_toucan_approved", :icon nil} ; should be sorted by name, case-insensitive
    {:id label-1-id, :name "Toucan-Approved",     :slug "toucan_approved",     :icon nil}]
   ((user->client :rasta) :get 200, "label"))
 
@@ -27,7 +27,8 @@
   ((user->client :rasta) :put 200, (str "label/" label-id) {:name "Bird-Friendly"}))
 
 ;;; DELETE /api/label/:id -- delete a label
-(tt/expect-with-temp [Label [{label-id :id} {:name "This will make the toucan very cross!"}]]
+(expect
   nil
-  (do ((user->client :rasta) :delete 204, (str "label/" label-id))
-      (Label label-id)))
+  (tt/with-temp Label [{label-id :id} {:name "This will make the toucan very cross!"}]
+    ((user->client :rasta) :delete 204, (str "label/" label-id))
+    (Label label-id)))

--- a/test/metabase/api/pulse_test.clj
+++ b/test/metabase/api/pulse_test.clj
@@ -174,9 +174,9 @@
 
 
 ;; ## DELETE /api/pulse/:id
-(tt/expect-with-temp [Pulse [pulse]]
+(expect
   nil
-  (do
+  (tt/with-temp Pulse [pulse]
     ((user->client :rasta) :delete 204 (format "pulse/%d" (:id pulse)))
     (pulse/retrieve-pulse (:id pulse))))
 

--- a/test/metabase/api/segment_test.clj
+++ b/test/metabase/api/segment_test.clj
@@ -372,10 +372,11 @@
 
 
 ;;; PUT /api/segment/id. Can I update a segment's name without specifying `:points_of_interest` and `:show_in_getting_started`?
-(tt/expect-with-temp [Segment [segment]]
-  :ok
-  (do ((user->client :crowberto) :put 200 (str "segment/" (u/get-id segment))
-       {:name             "Cool name"
-        :revision_message "WOW HOW COOL"
-        :definition       {}})
-      :ok))
+(expect
+  (tt/with-temp Segment [segment]
+    ;; just make sure API call doesn't barf
+    ((user->client :crowberto) :put 200 (str "segment/" (u/get-id segment))
+     {:name             "Cool name"
+      :revision_message "WOW HOW COOL"
+      :definition       {}})
+    true))


### PR DESCRIPTION
clean up a few tests that were written in a goofy way