### PR TITLE
Decrease memory usage, increase performance

### DIFF
--- a/bin/docker/run_metabase.sh
+++ b/bin/docker/run_metabase.sh
@@ -110,7 +110,7 @@ export MB_DB_FILE=$new_db_dir/$(basename $db_file)
 chown metabase:metabase $new_db_dir $new_db_dir/* 2>/dev/null  # all that fussing makes this safe
 
 # Setup Java Options
-JAVA_OPTS="${JAVA_OPTS} -Dlogfile.path=target/log -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -server"
+JAVA_OPTS="${JAVA_OPTS} -Dlogfile.path=target/log -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:+UseCompressedOops -server"
 
 if [ ! -z "$JAVA_TIMEZONE" ]; then
     JAVA_OPTS="${JAVA_OPTS} -Duser.timezone=${JAVA_TIMEZONE}"

--- a/bin/start
+++ b/bin/start
@@ -82,4 +82,4 @@ if [ ! -z "$RDS_HOSTNAME" ]; then
     export MB_DB_PORT=$RDS_PORT
 fi
 
-exec java -Dfile.encoding=UTF-8 $JAVA_OPTS -jar ./target/uberjar/metabase.jar
+exec java -Dfile.encoding=UTF-8 -XX:+UseCompressedOops $JAVA_OPTS -jar ./target/uberjar/metabase.jar

--- a/project.clj
+++ b/project.clj
@@ -92,6 +92,7 @@
              "-Xverify:none"                                          ; disable bytecode verification when running in dev so it starts slightly faster
              "-XX:+CMSClassUnloadingEnabled"                          ; let Clojure's dynamically generated temporary classes be GC'ed from PermGen
              "-XX:+UseConcMarkSweepGC"                                ; Concurrent Mark Sweep GC needs to be used for Class Unloading (above)
+             "-XX:+UseCompressedOops"                                 ; use 32-bit Ordinary Object Pointers instead of 64-bit, which saves memory and increases performance
              "-Djava.awt.headless=true"]                              ; prevent Java icon from randomly popping up in dock when running `lein ring server`
   :javac-options ["-target" "1.7", "-source" "1.7"]
   :uberjar-name "metabase.jar"


### PR DESCRIPTION
I was looking at ways to decrease memory usage and increase performance and apparently the `-XX:+UseCompressedOops` JVM flag comes universally highly recommended if your application is running with less than 32GB of RAM. The basic idea is to tell the JVM to use 32-bit "Ordinary Object Pointers" instead of 64-bit ones which decreases memory usage and as a side effect increases performance (as the Oracle dox put it, "bandwidth and cache are in short supply").

For more details see: 
*  http://javarevisited.blogspot.com/2012/06/what-is-xxusecompressedoops-in-64-bit.html
*  https://docs.oracle.com/javase/7/docs/technotes/guides/vm/performance-enhancements-7.html#compressedOop
*  http://stackoverflow.com/a/37448602/1198455