### PR TITLE
Fix drill-through lineage (composed cards, browser history, pivots/actions inside QB)

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -134,7 +134,7 @@ export default class DashCard extends Component {
                     onUpdateVisualizationSettings={this.props.onUpdateVisualizationSettings}
                     replacementContent={isEditingParameter && <DashCardParameterMapper dashcard={dashcard} />}
                     metadata={metadata}
-                    onChangeCardAndRun={(card: UnsavedCard|Card) => {
+                    onChangeCardAndRun={(card: UnsavedCard) => {
                         navigateToNewCard(card, dashcard)
                     }}
                 />

--- a/frontend/src/metabase/dashboard/dashboard.js
+++ b/frontend/src/metabase/dashboard/dashboard.js
@@ -499,7 +499,7 @@ export const deletePublicLink = createAction(DELETE_PUBLIC_LINK, async ({ id }) 
 // TODO Atte Keinänen 5/2/17: This could be combined with `setCardAndRun` of query_builder/actions.js
 // Having two separate actions for very similar behavior was a source of initial confusion for me
 const NAVIGATE_TO_NEW_CARD = "metabase/dashboard/NAVIGATE_TO_NEW_CARD";
-export const navigateToNewCard = createThunkAction(NAVIGATE_TO_NEW_CARD, (card: UnsavedCard|Card, dashcard: DashCard) =>
+export const navigateToNewCard = createThunkAction(NAVIGATE_TO_NEW_CARD, (card: UnsavedCard, dashcard: DashCard) =>
     (dispatch, getState) => {
         const { metadata } = getState();
         const { dashboardId, dashboards, parameterValues } = getState().dashboard;

--- a/frontend/src/metabase/lib/card.js
+++ b/frontend/src/metabase/lib/card.js
@@ -80,13 +80,13 @@ export function serializeCardForUrl(card) {
     }
 
     var cardCopy = {
-        id: card.id,
         name: card.name,
         description: card.description,
         dataset_query: dataset_query,
         display: card.display,
         parameters: card.parameters,
-        visualization_settings: card.visualization_settings
+        visualization_settings: card.visualization_settings,
+        original_card_id: card.original_card_id
     };
 
     return utf8_to_b64url(JSON.stringify(cardCopy));

--- a/frontend/src/metabase/meta/Card.spec.js
+++ b/frontend/src/metabase/meta/Card.spec.js
@@ -1,6 +1,6 @@
 import * as Card from "./Card";
 
-import { assocIn } from "icepick";
+import { assocIn, dissoc } from "icepick";
 
 describe("metabase/meta/Card", () => {
     describe("questionUrlWithParameters", () => {
@@ -59,7 +59,7 @@ describe("metabase/meta/Card", () => {
                 expect(parseUrl(url)).toEqual({
                     pathname: "/question",
                     query: {},
-                    card: card,
+                    card: dissoc(card, "id")
                 });
             });
             it("should return question URL with query string parameter", () => {
@@ -73,7 +73,7 @@ describe("metabase/meta/Card", () => {
                 expect(parseUrl(url)).toEqual({
                     pathname: "/question",
                     query: { baz: "bar" },
-                    card: card,
+                    card: dissoc(card, "id")
                 });
             });
         });
@@ -114,7 +114,7 @@ describe("metabase/meta/Card", () => {
                 expect(parseUrl(url)).toEqual({
                     pathname: "/question",
                     query: {},
-                    card
+                    card: dissoc(card, "id")
                 });
             });
             it("should return question URL with string MBQL filter added", () => {
@@ -129,7 +129,7 @@ describe("metabase/meta/Card", () => {
                     pathname: "/question",
                     query: {},
                     card: assocIn(
-                        card,
+                        dissoc(card, "id"),
                         ["dataset_query", "query", "filter"],
                         ["AND", ["=", ["field-id", 1], "bar"]]
                     )
@@ -147,7 +147,7 @@ describe("metabase/meta/Card", () => {
                     pathname: "/question",
                     query: {},
                     card: assocIn(
-                        card,
+                        dissoc(card, "id"),
                         ["dataset_query", "query", "filter"],
                         ["AND", ["=", ["field-id", 2], 123]]
                     )
@@ -166,7 +166,7 @@ describe("metabase/meta/Card", () => {
                     pathname: "/question",
                     query: {},
                     card: assocIn(
-                        card,
+                        dissoc(card, "id"),
                         ["dataset_query", "query", "filter"],
                         ["AND", ["=", ["datetime-field", ["field-id", 3], "month"], "2017-05-01"]]
                     )
@@ -184,7 +184,7 @@ describe("metabase/meta/Card", () => {
                     pathname: "/question",
                     query: {},
                     card: assocIn(
-                        card,
+                        dissoc(card, "id"),
                         ["dataset_query", "query", "filter"],
                         ["AND", ["=", ["datetime-field", ["fk->", 4, 5], "month"], "2017-05-01"]]
                     )

--- a/frontend/src/metabase/meta/types/Card.js
+++ b/frontend/src/metabase/meta/types/Card.js
@@ -22,7 +22,6 @@ export type Card = {
     display: string,
     visualization_settings: VisualizationSettings,
     parameters?: Array<Parameter>,
-    original_card_id?: CardId
 };
 
 export type StructuredDatasetQuery = {

--- a/frontend/src/metabase/meta/types/Card.js
+++ b/frontend/src/metabase/meta/types/Card.js
@@ -10,16 +10,19 @@ export type UnsavedCard = {
     dataset_query: DatasetQuery,
     display: string,
     visualization_settings: VisualizationSettings,
-    parameters?: Array<Parameter>
+    parameters?: Array<Parameter>,
+    original_card_id?: CardId
 }
 
-export type SavedCardFields = {
+export type Card = {
     id: CardId,
-    name?: string,
-    description?: string,
-}
-
-export type Card = UnsavedCard & SavedCardFields;
+    name: ?string,
+    description: ?string,
+    dataset_query: DatasetQuery,
+    display: string,
+    visualization_settings: VisualizationSettings,
+    parameters?: Array<Parameter>
+};
 
 export type StructuredDatasetQuery = {
     type: "query",

--- a/frontend/src/metabase/meta/types/Card.js
+++ b/frontend/src/metabase/meta/types/Card.js
@@ -21,7 +21,8 @@ export type Card = {
     dataset_query: DatasetQuery,
     display: string,
     visualization_settings: VisualizationSettings,
-    parameters?: Array<Parameter>
+    parameters?: Array<Parameter>,
+    original_card_id?: CardId
 };
 
 export type StructuredDatasetQuery = {

--- a/frontend/src/metabase/qb/components/TimeseriesFilterWidget.jsx
+++ b/frontend/src/metabase/qb/components/TimeseriesFilterWidget.jsx
@@ -144,8 +144,8 @@ export default class TimeseriesFilterWidget extends Component<*, Props, State> {
                                 } else {
                                     query = Query.addFilter(query, filter);
                                 }
+                                // $FlowFixMe
                                 const datasetQuery: DatasetQuery = {
-                                    // $FlowFixMe
                                     ...card.dataset_query,
                                     query
                                 };

--- a/frontend/src/metabase/qb/components/TimeseriesGroupingWidget.jsx
+++ b/frontend/src/metabase/qb/components/TimeseriesGroupingWidget.jsx
@@ -60,8 +60,8 @@ export default class TimeseriesGroupingWidget extends Component<*, Props, *> {
                                     0,
                                     breakout
                                 );
+                                // $FlowFixMe
                                 const datasetQuery: DatasetQuery = {
-                                    // $FlowFixMe
                                     ...card.dataset_query,
                                     query
                                 };

--- a/frontend/src/metabase/qb/lib/actions.js
+++ b/frontend/src/metabase/qb/lib/actions.js
@@ -207,7 +207,6 @@ export const pivot = (
     }
 
     let newCard = startNewCard("query");
-    // $FlowFixMe
     newCard.dataset_query = card.dataset_query;
 
     for (const dimension of dimensions) {
@@ -227,6 +226,7 @@ export const pivot = (
     }
 
     newCard.dataset_query.query = Query.addBreakout(
+        // $FlowFixMe
         newCard.dataset_query.query,
         breakout
     );

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -478,10 +478,10 @@ export const reloadCard = createThunkAction(RELOAD_CARD, () => {
 
 // setCardAndRun
 export const SET_CARD_AND_RUN = "metabase/qb/SET_CARD_AND_RUN";
-export const setCardAndRun = createThunkAction(SET_CARD_AND_RUN, (runCard, shouldUpdateUrl = true) => {
+export const setCardAndRun = createThunkAction(SET_CARD_AND_RUN, (nextCard, shouldUpdateUrl = true) => {
     return async (dispatch, getState) => {
         // clone
-        const card = Utils.copy(runCard);
+        const card = Utils.copy(nextCard);
         const originalCard = card.original_card_id ? await loadCard(card.original_card_id) : card;
 
         dispatch(loadMetadataForCard(card));

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -168,6 +168,9 @@ export const initializeQB = createThunkAction(INITIALIZE_QB, (location, params) 
                     card = await loadCard(params.cardId);
                     // when we are loading from a card id we want an explicit clone of the card we loaded which is unmodified
                     originalCard = Utils.copy(card);
+                    // for showing the "started from" lineage correctly when adding filters/breakouts and when going back and forth
+                    // in browser history, the original_card_id has to be set for the current card (simply the id of card itself for now)
+                    card.original_card_id = card.id;
                 } else if (card.original_card_id) {
                     // deserialized card contains the original card id, so just populate originalCard
                     originalCard = await loadCard(card.original_card_id);

--- a/frontend/src/metabase/query_builder/components/ActionsWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/ActionsWidget.jsx
@@ -66,15 +66,28 @@ export default class ActionsWidget extends Component<*, Props, *> {
         });
     };
 
+    handleOnChangeCardAndRun(nextCard) {
+        const { card } = this.props;
+
+        // Include the original card id if present for showing the lineage next to title
+        const nextCardWithOriginalId = {
+            ...nextCard,
+            original_card_id: card.id || card.original_card_id
+        };
+        if (nextCardWithOriginalId) {
+            this.props.setCardAndRun(nextCardWithOriginalId);
+        }
+    }
+
     handleActionClick = (index: number) => {
         const { mode, card, tableMetadata } = this.props;
         const action = getModeActions(mode, card, tableMetadata)[index];
         if (action && action.popover) {
             this.setState({ selectedActionIndex: index });
         } else if (action && action.card) {
-            const card = action.card();
-            if (card) {
-                this.props.setCardAndRun(card);
+            const nextCard = action.card();
+            if (nextCard) {
+                this.handleOnChangeCardAndRun(nextCard);
             }
             this.close();
         }
@@ -149,7 +162,7 @@ export default class ActionsWidget extends Component<*, Props, *> {
                                       <PopoverComponent
                                           onChangeCardAndRun={(card) => {
                                               if (card) {
-                                                  this.props.setCardAndRun(card);
+                                                  this.handleOnChangeCardAndRun(card)
                                               }
                                           }}
                                           onClose={this.close}

--- a/frontend/src/metabase/query_builder/components/ActionsWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/ActionsWidget.jsx
@@ -10,7 +10,7 @@ import { getModeActions } from "metabase/qb/lib/modes";
 import cx from "classnames";
 import _ from "underscore";
 
-import type { Card } from "metabase/meta/types/Card";
+import type { Card, UnsavedCard } from "metabase/meta/types/Card";
 import type { QueryMode, ClickAction } from "metabase/meta/types/Visualization";
 import type { TableMetadata } from "metabase/meta/types/Metadata";
 
@@ -66,7 +66,7 @@ export default class ActionsWidget extends Component<*, Props, *> {
         });
     };
 
-    handleOnChangeCardAndRun(nextCard) {
+    handleOnChangeCardAndRun(nextCard: UnsavedCard|Card) {
         const { card } = this.props;
 
         // Include the original card id if present for showing the lineage next to title

--- a/frontend/src/metabase/query_builder/components/ActionsWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/ActionsWidget.jsx
@@ -72,6 +72,7 @@ export default class ActionsWidget extends Component<*, Props, *> {
         // Include the original card id if present for showing the lineage next to title
         const nextCardWithOriginalId = {
             ...nextCard,
+            // $FlowFixMe
             original_card_id: card.id || card.original_card_id
         };
         if (nextCardWithOriginalId) {

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -78,7 +78,7 @@ export const card = handleActions({
     [INITIALIZE_QB]: { next: (state, { payload }) => payload ? payload.card : null },
     [RELOAD_CARD]: { next: (state, { payload }) => payload },
     [CANCEL_EDITING]: { next: (state, { payload }) => payload },
-    [SET_CARD_AND_RUN]: { next: (state, { payload }) => payload },
+    [SET_CARD_AND_RUN]: { next: (state, { payload }) => payload.card },
     [NOTIFY_CARD_CREATED]: { next: (state, { payload }) => payload },
     [NOTIFY_CARD_UPDATED]: { next: (state, { payload }) => payload },
 
@@ -110,7 +110,7 @@ export const originalCard = handleActions({
     [INITIALIZE_QB]: { next: (state, { payload }) => payload.originalCard ? Utils.copy(payload.originalCard) : null },
     [RELOAD_CARD]: { next: (state, { payload }) => payload.id ? Utils.copy(payload) : null },
     [CANCEL_EDITING]: { next: (state, { payload }) => payload.id ? Utils.copy(payload) : null },
-    [SET_CARD_AND_RUN]: { next: (state, { payload }) => payload.id ? Utils.copy(payload) : null },
+    [SET_CARD_AND_RUN]: { next: (state, { payload }) => payload.originalCard ? Utils.copy(payload.originalCard) : null },
     [NOTIFY_CARD_CREATED]: { next: (state, { payload }) => Utils.copy(payload) },
     [NOTIFY_CARD_UPDATED]: { next: (state, { payload }) => Utils.copy(payload) },
 }, null);

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -230,7 +230,6 @@ export default class Visualization extends Component<*, Props, State> {
         // $FlowFixMe
         const hasOriginalCard = series[index] && series[index].card && (series[index].card.id || series[index].card.original_card_id);
         if (hasOriginalCard) {
-            console.log('woohoo has original card', series[index].card, series[index].card.id || series[index].card.original_card_id);
             const cardWithOriginalId: UnsavedCard = {
                 ...card,
                 // $FlowFixMe

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -62,7 +62,7 @@ type Props = {
 
     // for click actions
     metadata: Metadata,
-    onChangeCardAndRun: (card: UnsavedCard|CardObject) => void,
+    onChangeCardAndRun: (card: UnsavedCard) => void,
 
     // used for showing content in place of visualization, e.x. dashcard filter mapping
     replacementContent: Element<any>,
@@ -191,9 +191,7 @@ export default class Visualization extends Component<*, Props, State> {
         const seriesIndex = clicked.seriesIndex || 0;
         const card = series[seriesIndex].card;
         const tableMetadata = card && Card.getTableMetadata(card, metadata);
-        // $FlowFixMe
         const mode = getMode(card, tableMetadata);
-        // $FlowFixMe
         return getModeDrills(mode, card, tableMetadata, clicked);
     }
 
@@ -224,20 +222,22 @@ export default class Visualization extends Component<*, Props, State> {
     }
 
     handleOnChangeCardAndRun = (card: UnsavedCard) => {
-        // If the current card is saved, carry that information to the new card for showing lineage
         const { series, clicked } = this.state;
 
+        // If the current card is saved or is based on a saved question,
+        // carry that information to the new card for showing lineage
         const index = (clicked && clicked.seriesIndex) || 0;
-
         // $FlowFixMe
-        const cardId = series[index] && series[index].card && series[index].card.id;
-        if (cardId) {
-            const savedCard: CardObject = {
+        const hasOriginalCard = series[index] && series[index].card && (series[index].card.id || series[index].card.original_card_id);
+        if (hasOriginalCard) {
+            console.log('woohoo has original card', series[index].card, series[index].card.id || series[index].card.original_card_id);
+            const cardWithOriginalId: UnsavedCard = {
                 ...card,
-                id: cardId
+                // $FlowFixMe
+                original_card_id: series[index].card.id || series[index].card.original_card_id
             };
 
-            this.props.onChangeCardAndRun(savedCard)
+            this.props.onChangeCardAndRun(cardWithOriginalId)
         } else {
             this.props.onChangeCardAndRun(card)
         }

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -227,18 +227,13 @@ export default class Visualization extends Component<*, Props, State> {
         // If the current card is saved, carry that information to the new card for showing lineage
         const { series, clicked } = this.state;
 
-        if (clicked == null) {
-            console.error("The visualization wasn't clicked before calling `onChangeCardAndRun`");
-            return;
-        }
-        const index = clicked.seriesIndex;
+        const index = (clicked && clicked.seriesIndex) || 0;
 
         // $FlowFixMe
         const cardId = series[index] && series[index].card && series[index].card.id;
         if (cardId) {
             const savedCard: CardObject = {
                 ...card,
-                // $FlowFixMe
                 id: cardId
             };
 

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -62,7 +62,7 @@ type Props = {
 
     // for click actions
     metadata: Metadata,
-    onChangeCardAndRun: (card: CardObject) => void,
+    onChangeCardAndRun: (card: UnsavedCard|CardObject) => void,
 
     // used for showing content in place of visualization, e.x. dashcard filter mapping
     replacementContent: Element<any>,
@@ -225,19 +225,25 @@ export default class Visualization extends Component<*, Props, State> {
 
     handleOnChangeCardAndRun = (card: UnsavedCard) => {
         // If the current card is saved, carry that information to the new card for showing lineage
-        const { series } = this.state
+        const { series, clicked } = this.state;
+
+        if (clicked == null) {
+            console.error("The visualization wasn't clicked before calling `onChangeCardAndRun`");
+            return;
+        }
+        const index = clicked.seriesIndex;
+
         // $FlowFixMe
-        const currentlyInSavedCard = series[0] && series[0].card && series[0].card.id
-        if (currentlyInSavedCard) {
+        const cardId = series[index] && series[index].card && series[index].card.id;
+        if (cardId) {
             const savedCard: CardObject = {
                 ...card,
                 // $FlowFixMe
-                id: series[0].card.id
+                id: cardId
             };
 
             this.props.onChangeCardAndRun(savedCard)
         } else {
-            // $FlowFixMe
             this.props.onChangeCardAndRun(card)
         }
     }

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -30,7 +30,7 @@ import cx from "classnames";
 export const ERROR_MESSAGE_GENERIC = "There was a problem displaying this chart.";
 export const ERROR_MESSAGE_PERMISSION = "Sorry, you don't have permission to see this card."
 
-import type {Card as CardObject, UnsavedCard, VisualizationSettings} from "metabase/meta/types/Card";
+import type { UnsavedCard, VisualizationSettings} from "metabase/meta/types/Card";
 import type { HoverObject, ClickObject, Series } from "metabase/meta/types/Visualization";
 import type { Metadata } from "metabase/meta/types/Metadata";
 

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "test": "yarn run test-jest && yarn run test-karma",
     "test-karma": "karma start frontend/test/karma.conf.js --single-run",
     "test-karma-watch": "karma start frontend/test/karma.conf.js --auto-watch --reporters nyan",
-    "test-jest": "jest frontend/src/",
+    "test-jest": "jest",
     "test-jest-watch": "jest --watch",
     "test-e2e": "JASMINE_CONFIG_PATH=./frontend/test/e2e/support/jasmine.json jasmine",
     "test-e2e-dev": "./frontend/test/e2e-with-persistent-browser.js",


### PR DESCRIPTION
Adds a new `original_card_id` card property which supersedes the previous lineage implementation. 

Effectively this
* fixes the lineage when drilling through dashcards composed of multiple cards
* adds the lineage when drilling inside QB (both visualization and ActionsWidget actions)
* retains the lineage correctly when you go back/forward in the browser history, applying not only to drills but also other situations where you modify a saved question (for instance adding a filter/breakout)