### PR TITLE
Fix the expression editor in recent versions of Chrome and Firefox

### DIFF
--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -90,7 +90,8 @@ export function getSelectionPosition(element) {
     else {
         try {
             const selection = window.getSelection();
-            const range = selection.getRangeAt(0);
+            // Clone the Range otherwise setStart/setEnd will mutate the actual selection in Chrome 58+ and Firefox!
+            const range = selection.getRangeAt(0).cloneRange();
             const { startContainer, startOffset } = range;
             range.setStart(element, 0);
             const end = range.toString().length;

--- a/frontend/test/unit/lib/dom.spec.js
+++ b/frontend/test/unit/lib/dom.spec.js
@@ -26,4 +26,14 @@ describe("getSelectionPosition/setSelectionPosition", () => {
         const position = getSelectionPosition(contenteditable);
         expect(position).toEqual([3, 6]);
     });
+    it("should not mutate the actual selection", () => {
+        let contenteditable = document.createElement("div");
+        container.appendChild(contenteditable);
+        contenteditable.textContent = "<div>hello world</div>"
+        setSelectionPosition(contenteditable, [3, 6]);
+        const position = getSelectionPosition(contenteditable);
+        expect(position).toEqual([3, 6]);
+        const position2 = getSelectionPosition(contenteditable);
+        expect(position2).toEqual([3, 6]);
+    })
 })


### PR DESCRIPTION
Resolves #4906

Apparently in recent versions of FF and Chrome `window.getSelection().getRangeAt(0).setStart(element, 0);` will actually mutate the live selection, which is cool, but not what the previous code expected.