### PR TITLE
Better week formatting

### DIFF
--- a/frontend/src/metabase/components/Value.jsx
+++ b/frontend/src/metabase/components/Value.jsx
@@ -1,8 +1,17 @@
+/* @flow */
+
 import React from "react";
 
 import { formatValue } from "metabase/lib/formatting";
 
-const Value = ({ value, ...options }) => {
+import type { Value as ValueType } from "metabase/meta/types/Dataset";
+import type { FormattingOptions } from "metabase/lib/formatting"
+
+type Props = {
+    value: ValueType
+} & FormattingOptions;
+
+const Value = ({ value, ...options }: Props) => {
     let formatted = formatValue(value, { ...options, jsx: true });
     if (React.isValidElement(formatted)) {
         return formatted;

--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -1,3 +1,5 @@
+/* @flow */
+
 import d3 from "d3";
 import inflection from "inflection";
 import moment from "moment";
@@ -10,12 +12,24 @@ import { isDate, isNumber, isCoordinate } from "metabase/lib/schema_metadata";
 import { isa, TYPE } from "metabase/lib/types";
 import { parseTimestamp } from "metabase/lib/time";
 
+import type { Column, Value } from "metabase/meta/types/Dataset";
+import type { DatetimeUnit } from "metabase/meta/types/Query";
+
+export type FormattingOptions = {
+    column?: Column,
+    majorWidth?: number,
+    type?: "axis"|"cell"|"tooltip",
+    comma?: boolean,
+    jsx?: boolean,
+    compact?: boolean,
+}
+
 const PRECISION_NUMBER_FORMATTER      = d3.format(".2r");
 const FIXED_NUMBER_FORMATTER          = d3.format(",.f");
 const FIXED_NUMBER_FORMATTER_NO_COMMA = d3.format(".f");
 const DECIMAL_DEGREES_FORMATTER       = d3.format(".08f");
 
-export function formatNumber(number, options = {}) {
+export function formatNumber(number: number, options: FormattingOptions = {}) {
     options = { comma: true, ...options};
     if (options.compact) {
         if (number === 0) {
@@ -64,20 +78,54 @@ function formatMajorMinor(major, minor, options = {}) {
     }
 }
 
-export function formatTimeWithUnit(value, unit, options = {}) {
+export function formatTimeRangeWithUnit(value: Value, unit: DatetimeUnit, options: FormattingOptions = {}) {
     let m = parseTimestamp(value, unit);
     if (!m.isValid()) {
         return String(value);
     }
+
+    // Tooltips should show full month name, but condense "MMMM D, YYYY - MMMM D, YYYY" to "MMMM D - D, YYYY" etc
+    const monthFormat = options.type === "tooltip" ? "MMMM" : "MMM";
+    const condensed = options.type === "tooltip";
+    // use en dashes, for Maz
+    const separator = ` – `;
+
+    const start = m.clone().startOf(unit);
+    const end = m.clone().endOf(unit);
+    if (start.isValid() && end.isValid()) {
+        if (!condensed || start.year() !== end.year()) {
+            return start.format(`${monthFormat} D, YYYY`) + separator + end.format(`${monthFormat} D, YYYY`);
+        } else if (start.month() !== end.month()) {
+            return start.format(`${monthFormat} D`) + separator + end.format(`${monthFormat} D, YYYY`);
+        } else {
+            return start.format(`${monthFormat} D`) + separator + end.format(`D, YYYY`);
+        }
+    }
+}
+
+export function formatTimeWithUnit(value: Value, unit: DatetimeUnit, options: FormattingOptions = {}) {
+    let m = parseTimestamp(value, unit);
+    if (!m.isValid()) {
+        return String(value);
+    }
+
     switch (unit) {
         case "hour": // 12 AM - January 1, 2015
             return formatMajorMinor(m.format("h A"), m.format("MMMM D, YYYY"), options);
         case "day": // January 1, 2015
             return m.format("MMMM D, YYYY");
         case "week": // 1st - 2015
-            // force 'en' locale for now since our weeks currently always start on Sundays
-            m = m.locale("en");
-            return formatMajorMinor(m.format("wo"), m.format("gggg"), options);
+            if (options.type === "tooltip") {
+                return formatTimeRangeWithUnit(value, unit, options);
+            } else if (options.type === "cell") {
+                return formatTimeRangeWithUnit(value, unit, options);
+            } else if (options.type === "axis") {
+                return m.clone().startOf(unit).format(`MMM D`);
+            } else {
+                // force 'en' locale for now since our weeks currently always start on Sundays
+                m = m.locale("en");
+                return formatMajorMinor(m.format("wo"), m.format("gggg"), options);
+            }
         case "month": // January 2015
             return options.jsx ?
                 <div><span className="text-bold">{m.format("MMMM")}</span> {m.format("YYYY")}</div> :
@@ -89,12 +137,14 @@ export function formatTimeWithUnit(value, unit, options = {}) {
         case "hour-of-day": // 12 AM
             return moment().hour(value).format("h A");
         case "day-of-week": // Sunday
+            // $FlowFixMe:
             return moment().day(value - 1).format("dddd");
         case "day-of-month":
             return moment().date(value).format("D");
         case "week-of-year": // 1st
             return moment().week(value).format("wo");
         case "month-of-year": // January
+            // $FlowFixMe:
             return moment().month(value - 1).format("MMMM");
         case "quarter-of-year": // January
             return moment().quarter(value).format("[Q]Q");
@@ -106,27 +156,29 @@ export function formatTimeWithUnit(value, unit, options = {}) {
 // https://github.com/angular/angular.js/blob/v1.6.3/src/ng/directive/input.js#L27
 const EMAIL_WHITELIST_REGEX = /^(?=.{1,254}$)(?=.{1,64}@)[-!#$%&'*+/0-9=?A-Z^_`a-z{|}~]+(\.[-!#$%&'*+/0-9=?A-Z^_`a-z{|}~]+)*@[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$/;
 
-export function formatEmail(value, { jsx } = {}) {
-    if (jsx && EMAIL_WHITELIST_REGEX.test(value)) {
-        return <ExternalLink href={"mailto:" + value}>{value}</ExternalLink>;
+export function formatEmail(value: Value, { jsx }: FormattingOptions = {}) {
+    const email = String(value);
+    if (jsx && EMAIL_WHITELIST_REGEX.test(email)) {
+        return <ExternalLink href={"mailto:" + email}>{email}</ExternalLink>;
     } else {
-        return value;
+        return email;
     }
 }
 
 // based on https://github.com/angular/angular.js/blob/v1.6.3/src/ng/directive/input.js#L25
 const URL_WHITELIST_REGEX = /^(https?|mailto):\/*(?:[^:@]+(?::[^@]+)?@)?(?:[^\s:/?#]+|\[[a-f\d:]+])(?::\d+)?(?:\/[^?#]*)?(?:\?[^#]*)?(?:#.*)?$/i;
 
-export function formatUrl(value, { jsx } = {}) {
-    if (jsx && URL_WHITELIST_REGEX.test(value)) {
-        return <ExternalLink href={value}>{value}</ExternalLink>;
+export function formatUrl(value: Value, { jsx }: FormattingOptions = {}) {
+    const url = String(value);
+    if (jsx && URL_WHITELIST_REGEX.test(url)) {
+        return <ExternalLink href={url}>{url}</ExternalLink>;
     } else {
-        return value;
+        return url;
     }
 }
 
 // fallback for formatting a string without a column special_type
-function formatStringFallback(value, options = {}) {
+function formatStringFallback(value: Value, options: FormattingOptions = {}) {
     value = formatUrl(value, options);
     if (typeof value === 'string') {
         value = formatEmail(value, options);
@@ -134,7 +186,7 @@ function formatStringFallback(value, options = {}) {
     return value;
 }
 
-export function formatValue(value, options = {}) {
+export function formatValue(value: Value, options: FormattingOptions = {}) {
     let column = options.column;
     options = {
         jsx: false,
@@ -167,31 +219,37 @@ export function formatValue(value, options = {}) {
     }
 }
 
+// $FlowFixMe
 export function singularize(...args) {
     return inflection.singularize(...args);
 }
 
+// $FlowFixMe
 export function pluralize(...args) {
     return inflection.pluralize(...args);
 }
 
+// $FlowFixMe
 export function capitalize(...args) {
     return inflection.capitalize(...args);
 }
 
+// $FlowFixMe
 export function inflect(...args) {
     return inflection.inflect(...args);
 }
 
+// $FlowFixMe
 export function titleize(...args) {
     return inflection.titleize(...args);
 }
 
+// $FlowFixMe
 export function humanize(...args) {
     return inflection.humanize(...args);
 }
 
-export function duration(milliseconds) {
+export function duration(milliseconds: number) {
     if (milliseconds < 60000) {
         let seconds = Math.round(milliseconds / 1000);
         return seconds + " " + inflect("second", seconds);
@@ -202,15 +260,15 @@ export function duration(milliseconds) {
 }
 
 // Removes trailing "id" from field names
-export function stripId(name) {
+export function stripId(name: string) {
     return name && name.replace(/ id$/i, "");
 }
 
-export function slugify(name) {
+export function slugify(name: string) {
     return name && name.toLowerCase().replace(/[^a-z0-9_]/g, "_");
 }
 
-export function assignUserColors(userIds, currentUserId, colorClasses = ['bg-brand', 'bg-purple', 'bg-error', 'bg-green', 'bg-gold', 'bg-grey-2']) {
+export function assignUserColors(userIds: number[], currentUserId: number, colorClasses: string[] = ['bg-brand', 'bg-purple', 'bg-error', 'bg-green', 'bg-gold', 'bg-grey-2']) {
     let assignments = {};
 
     const currentUserColor = colorClasses[0];
@@ -230,7 +288,7 @@ export function assignUserColors(userIds, currentUserId, colorClasses = ['bg-bra
     return assignments;
 }
 
-export function formatSQL(sql) {
+export function formatSQL(sql: string) {
     if (typeof sql === "string") {
         sql = sql.replace(/\sFROM/, "\nFROM");
         sql = sql.replace(/\sLEFT JOIN/, "\nLEFT JOIN");

--- a/frontend/src/metabase/meta/types/Dataset.js
+++ b/frontend/src/metabase/meta/types/Dataset.js
@@ -3,6 +3,7 @@
 import type { ISO8601Time } from ".";
 import type { FieldId } from "./Field";
 import type { DatasetQuery } from "./Card";
+import type { DatetimeUnit } from "./Query";
 
 export type ColumnName = string;
 
@@ -13,7 +14,8 @@ export type Column = {
     display_name: string,
     base_type: string,
     special_type: ?string,
-    source?: "fields"|"aggregation"|"breakout"
+    source?: "fields"|"aggregation"|"breakout",
+    unit?: DatetimeUnit
 };
 
 export type Value = string|number|ISO8601Time|boolean|null|{};

--- a/frontend/src/metabase/meta/types/index.js
+++ b/frontend/src/metabase/meta/types/index.js
@@ -27,3 +27,9 @@ export type ApiError = {
     status: number, // HTTP status
     // TODO: incomplete
 }
+
+// FIXME: actual moment.js type
+export type Moment = {
+    locale: () => Moment,
+    format: (format: string) => string
+};

--- a/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
@@ -72,7 +72,12 @@ const TooltipRow = ({ name, value, column }) =>
             { React.isValidElement(value) ?
                 value
             :
-                <Value value={value} column={column} majorWidth={0} />
+                <Value
+                    type="tooltip"
+                    value={value}
+                    column={column}
+                    majorWidth={0}
+                />
             }
         </td>
     </tr>

--- a/frontend/src/metabase/visualizations/components/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive.jsx
@@ -234,7 +234,13 @@ export default class TableInteractive extends Component<*, Props, State> {
                     onVisualizationClick({ ...clicked, element: e.currentTarget });
                 })}
             >
-                <Value className="link" value={value} column={column} onResize={this.onCellResize.bind(this, columnIndex)} />
+                <Value
+                    className="link"
+                    type="cell"
+                    value={value}
+                    column={column}
+                    onResize={this.onCellResize.bind(this, columnIndex)}
+                />
             </div>
         );
     }

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -131,15 +131,23 @@ function applyChartTimeseriesXAxis(chart, settings, series, xValues, xDomain, xI
             dimensionColumn = { ...dimensionColumn, unit: dataInterval.interval };
         }
 
+        if (dataInterval.interval === "week") {
+            const newTickInterval = computeTimeseriesTicksInterval(xDomain, tickInterval, chart.width(), MIN_PIXELS_PER_TICK.x);
+            if (newTickInterval.interval !== tickInterval.interval || newTickInterval.count !== tickInterval.count) {
+                dimensionColumn = { ...dimensionColumn, unit: "month" },
+                tickInterval = { interval: "month", count: 1 };
+            }
+        }
+
         chart.xAxis().tickFormat(timestamp => {
             // timestamp is a plain Date object which discards the timezone,
             // so add it back in so it's formatted correctly
             const timestampFixed = moment(timestamp).utcOffset(dataOffset).format();
-            return formatValue(timestampFixed, { column: dimensionColumn })
+            return formatValue(timestampFixed, { column: dimensionColumn, type: "axis" })
         });
 
         // Compute a sane interval to display based on the data granularity, domain, and chart width
-        tickInterval = computeTimeseriesTicksInterval(xDomain, dataInterval, chart.width(), MIN_PIXELS_PER_TICK.x, );
+        tickInterval = computeTimeseriesTicksInterval(xDomain, tickInterval, chart.width(), MIN_PIXELS_PER_TICK.x);
         chart.xAxis().ticks(d3.time[tickInterval.interval], tickInterval.count);
     } else {
         chart.xAxis().ticks(0);

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -131,7 +131,10 @@ function applyChartTimeseriesXAxis(chart, settings, series, xValues, xDomain, xI
             dimensionColumn = { ...dimensionColumn, unit: dataInterval.interval };
         }
 
+        // special handling for weeks
+        // TODO: are there any other cases where we should do this?
         if (dataInterval.interval === "week") {
+            // if tick interval is compressed then show months instead of weeks because they're nicer formatted
             const newTickInterval = computeTimeseriesTicksInterval(xDomain, tickInterval, chart.width(), MIN_PIXELS_PER_TICK.x);
             if (newTickInterval.interval !== tickInterval.interval || newTickInterval.count !== tickInterval.count) {
                 dimensionColumn = { ...dimensionColumn, unit: "month" },

--- a/frontend/src/metabase/visualizations/lib/timeseries.js
+++ b/frontend/src/metabase/visualizations/lib/timeseries.js
@@ -1,6 +1,7 @@
 /* @flow weak */
 
 import moment from "moment";
+import _ from "underscore";
 
 import { isDate } from "metabase/lib/schema_metadata";
 import { parseTimestamp } from "metabase/lib/time";
@@ -101,7 +102,7 @@ export function computeTimeseriesTicksInterval(xDomain, xInterval, chartWidth, m
     // If the interval that matches the data granularity results in too many ticks reduce the granularity until it doesn't.
     // TODO: compute this directly instead of iteratively
     let maxTickCount = Math.round(chartWidth / minPixels);
-    let index = TIMESERIES_INTERVALS.indexOf(xInterval);
+    let index = _.findIndex(TIMESERIES_INTERVALS, ({ interval, count }) => interval === xInterval.interval && count === xInterval.count);
     while (index < TIMESERIES_INTERVALS.length - 1) {
         let interval = TIMESERIES_INTERVALS[index];
         let intervalMs = moment(0).add(interval.count, interval.interval).valueOf();


### PR DESCRIPTION
#Resolves #3449

* tooltips: `January 1 - 7, 2017` (consolidates same month/year, with full month name, so it looks nicer)
* tables: `Jan 1, 2017 - Jan 7, 2017` (not consolidated so it lines up better)
* axis: `Jan 1` if showing every week tick, or `January 2017` if only showing monthly ticks (based on density of points according to existing rules)