### PR TITLE
Fix a regression causing "started from" without title to appear on new cards

### DIFF
--- a/frontend/src/metabase/lib/card.js
+++ b/frontend/src/metabase/lib/card.js
@@ -56,7 +56,7 @@ export function isCardDirty(card, originalCard) {
         }
     } else {
         const origCardSerialized = originalCard ? serializeCardForUrl(originalCard) : null;
-        const newCardSerialized = card ? serializeCardForUrl(card) : null;
+        const newCardSerialized = card ? serializeCardForUrl(_.omit(card, 'original_card_id')) : null;
         return (newCardSerialized !== origCardSerialized);
     }
 }

--- a/frontend/src/metabase/lib/card.spec.js
+++ b/frontend/src/metabase/lib/card.spec.js
@@ -1,0 +1,85 @@
+import { isCardDirty, serializeCardForUrl, deserializeCardFromUrl } from "./card";
+
+const CARD_ID = 31;
+
+// TODO Atte Keinänen 8/5/17: Create a reusable version `getCard` for reducing test code duplication
+const getCard = ({
+    newCard = false,
+    hasOriginalCard = false,
+    isNative = false,
+    database = 1,
+    display = "table",
+    queryFields = {},
+    table = undefined,
+ }) => {
+    const savedCardFields = {
+        name: "Example Saved Question",
+        description: "For satisfying your craving for information",
+        created_at: "2017-04-20T16:52:55.353Z",
+        id: CARD_ID
+    };
+
+    return {
+        "name": null,
+        "display": display,
+        "visualization_settings": {},
+        "dataset_query": {
+            "database": database,
+            "type": isNative ? "native" : "query",
+            ...(!isNative ? {
+                query: {
+                    ...(table ? {"source_table": table} : {}),
+                    ...queryFields
+                }
+            } : {}),
+            ...(isNative ? {
+                native: { query: "SELECT * FROM ORDERS"}
+            } : {})
+        },
+        ...(newCard ? {} : savedCardFields),
+        ...(hasOriginalCard ? {"original_card_id": CARD_ID} : {})
+    };
+};
+
+describe("browser", () => {
+    describe("isCardDirty", () => {
+        it("should consider a new card clean if no db table or native query is defined", () => {
+            expect(isCardDirty(
+                getCard({newCard: true}),
+                null
+            )).toBe(false);
+        });
+        it("should consider a new card dirty if a db table is chosen", () => {
+            expect(isCardDirty(
+                getCard({newCard: true, table: 5}),
+                null
+            )).toBe(true);
+        });
+        it("should consider a new card dirty if there is any content on the native query", () => {
+            expect(isCardDirty(
+                getCard({newCard: true, table: 5}),
+                null
+            )).toBe(true);
+        });
+        it("should consider a saved card and a matching original card identical", () => {
+            expect(isCardDirty(
+                getCard({hasOriginalCard: true}),
+                getCard({hasOriginalCard: false})
+            )).toBe(false);
+        });
+        it("should consider a saved card dirty if the current card doesn't match the last saved version", () => {
+            expect(isCardDirty(
+                getCard({hasOriginalCard: true, queryFields: [["field-id", 21]]}),
+                getCard({hasOriginalCard: false})
+            )).toBe(true);
+        });
+    });
+    describe("serializeCardForUrl", () => {
+        it("should include `original_card_id` property to the serialized URL", () => {
+            const cardAfterSerialization =
+                deserializeCardFromUrl(serializeCardForUrl(getCard({hasOriginalCard: true})));
+            expect(cardAfterSerialization).toHaveProperty("original_card_id", CARD_ID)
+
+        })
+    })
+});

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -481,12 +481,20 @@ export const reloadCard = createThunkAction(RELOAD_CARD, () => {
 });
 
 // setCardAndRun
+// Used when navigating browser history, when drilling through in visualizations / action widget,
+// and when having the entity details view open and clicking its cells
 export const SET_CARD_AND_RUN = "metabase/qb/SET_CARD_AND_RUN";
 export const setCardAndRun = createThunkAction(SET_CARD_AND_RUN, (nextCard, shouldUpdateUrl = true) => {
     return async (dispatch, getState) => {
         // clone
         const card = Utils.copy(nextCard);
-        const originalCard = card.original_card_id ? await loadCard(card.original_card_id) : card;
+
+        const originalCard = card.original_card_id ?
+            // If the original card id is present, dynamically load its information for showing lineage
+            await loadCard(card.original_card_id)
+            // Otherwise, use a current card as the original card if the card has been saved
+            // This is needed for checking whether the card is in dirty state or not
+            : (card.id ? card : null);
 
         dispatch(loadMetadataForCard(card));
 


### PR DESCRIPTION
This regression was caused by #4957. This appears when you create a new card and modify the original query or run a drill-through action. 

I added also some comments to better explain what is the purpose of `setCardAndRun`.