### PR TITLE
Fix some unneeded QP logging

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -207,7 +207,6 @@
    Otherwise returns the connection error message."
   [engine details]
   (let [error (test-database-connection engine details)]
-    (println "error:" error) ; NOCOMMIT
     (if (and error
              (true? (:ssl details)))
       (recur engine (assoc details :ssl false))

--- a/src/metabase/query_processor/macros.clj
+++ b/src/metabase/query_processor/macros.clj
@@ -1,6 +1,14 @@
 (ns metabase.query-processor.macros
-  "TODO - this namespace is ancient and written with MBQL '95 in mind, e.g. it is case-sensitive.
-   At some point this ought to be reworked to be case-insensitive and cleaned up."
+  "Code in charge of expanding [\"METRIC\" ...] and [\"SEGMENT\" ...] forms in MBQL queries.
+   (METRIC forms are expanded into aggregations and sometimes filter clauses, while SEGMENT forms
+    are expanded into filter clauses.)
+
+   TODO - this namespace is ancient and written with MBQL '95 in mind, e.g. it is case-sensitive.
+   At some point this ought to be reworked to be case-insensitive and cleaned up.
+
+   TODO - The actual middleware that applies these functions lives in `metabase.query-processor.middleware.expand-macros`.
+   Not sure those two namespaces need to be divided. We can probably move all the functions in this namespace into that
+   one; that might require shuffling around some tests as well."
   (:require [clojure.core.match :refer [match]]
             [clojure.walk :as walk]
             [toucan.db :as db]))
@@ -77,10 +85,15 @@
                      (expand-metric form filter-clauses-atom)))
                  query-dict))
 
-(defn- add-metrics-filter-clauses [query-dict filter-clauses]
-  (update-in query-dict [:query :filter] merge-filter-clauses (if (> (count filter-clauses) 1)
-                                                                (cons "AND" filter-clauses)
-                                                                (first filter-clauses))))
+(defn- add-metrics-filter-clauses
+  "Add any FILTER-CLAUSES to the QUERY-DICT. If query has existing filter clauses, the new ones are
+   combined with an `:and` filter clause."
+  [query-dict filter-clauses]
+  (if-not (seq filter-clauses)
+    query-dict
+    (update-in query-dict [:query :filter] merge-filter-clauses (if (> (count filter-clauses) 1)
+                                                                  (cons "AND" filter-clauses)
+                                                                  (first filter-clauses)))))
 
 (defn- expand-metrics [query-dict]
   (let [filter-clauses-atom (atom [])

--- a/src/metabase/query_processor/middleware/expand_macros.clj
+++ b/src/metabase/query_processor/middleware/expand_macros.clj
@@ -15,5 +15,5 @@
         (log/debug (u/format-color 'cyan "\n\nMACRO/SUBSTITUTED: %s\n%s" (u/emoji "😻") (u/pprint-to-str <>)))))))
 
 (defn expand-macros
-  "Look for `METRIC` and `SEGMENT` macros in an unexpanded MBQL query and substitute the macros for their contents."
+  "Middleware that looks for `METRIC` and `SEGMENT` macros in an unexpanded MBQL query and substitute the macros for their contents."
   [qp] (comp qp expand-macros*))


### PR DESCRIPTION
While looking at some stuff with @thearthur today I realized the QP was doing logging for the "macroexpansion" stage of query processing (i.e., expanding `METRIC` and `SEGMENT` clauses) even if none were present in the query. This is supposed to only log things if changes are made, but the code was written in such a way that it always added an empty `:filter` clause to the query when it processed it.

Tweak the code to avoid changing the query dictionary if unneeded which keeps the unnecessary logging from taking place. :1st_place_medal: 