### PR TITLE
Streaming response

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -76,7 +76,8 @@
                  [postgresql "9.3-1102.jdbc41"]                       ; Postgres driver
                  [io.crate/crate-jdbc "2.1.6"]                        ; Crate JDBC driver
                  [prismatic/schema "1.1.5"]                           ; Data schema declaration and validation library
-                 [ring/ring-jetty-adapter "1.5.1"]                    ; Ring adapter using Jetty webserver (used to run a Ring server for unit tests)
+                 [ring/ring-core "1.6.0"]
+                 [ring/ring-jetty-adapter "1.6.0"]                    ; Ring adapter using Jetty webserver (used to run a Ring server for unit tests)
                  [ring/ring-json "0.4.0"]                             ; Ring middleware for reading/writing JSON automatically
                  [stencil "0.5.0"]                                    ; Mustache templates for Clojure
                  [toucan "1.0.2"                                      ; Model layer, hydration, and DB utilities

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -5,6 +5,7 @@
             [compojure.core :refer [DELETE GET POST PUT]]
             [metabase
              [events :as events]
+             [middleware :as middleware]
              [public-settings :as public-settings]
              [query-processor :as qp]
              [util :as u]]
@@ -12,6 +13,7 @@
              [common :as api]
              [dataset :as dataset-api]
              [label :as label-api]]
+            [metabase.api.common.internal :refer [route-fn-name]]
             [metabase.models
              [card :as card :refer [Card]]
              [card-favorite :refer [CardFavorite]]
@@ -31,8 +33,7 @@
             [schema.core :as s]
             [toucan
              [db :as db]
-             [hydrate :refer [hydrate]]]
-            [metabase.middleware :as middleware])
+             [hydrate :refer [hydrate]]])
   (:import java.util.UUID))
 
 ;;; ------------------------------------------------------------ Hydration ------------------------------------------------------------
@@ -468,6 +469,5 @@
   (api/check-embedding-enabled)
   (db/select [Card :name :id], :enable_embedding true, :archived false))
 
-
 (api/define-routes
-  (middleware/streaming-json-response POST_:card-id_query))
+  (middleware/streaming-json-response (route-fn-name 'POST "/:card-id/query")))

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -31,7 +31,8 @@
             [schema.core :as s]
             [toucan
              [db :as db]
-             [hydrate :refer [hydrate]]])
+             [hydrate :refer [hydrate]]]
+            [metabase.middleware :as middleware])
   (:import java.util.UUID))
 
 ;;; ------------------------------------------------------------ Hydration ------------------------------------------------------------
@@ -468,4 +469,5 @@
   (db/select [Card :name :id], :enable_embedding true, :archived false))
 
 
-(api/define-routes)
+(api/define-routes
+  (middleware/streaming-json-response POST_:card-id_query))

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -264,7 +264,7 @@
                                                            (s/replace #"^metabase\." "")
                                                            (s/replace #"\." "/"))
                                                        (u/pprint-to-str (concat api-routes additional-routes))))
-       ~@api-routes ~@additional-routes)))
+       ~@additional-routes ~@api-routes)))
 
 
 ;;; ------------------------------------------------------------ PERMISSIONS CHECKING HELPER FNS ------------------------------------------------------------

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -6,16 +6,17 @@
             [compojure.core :refer [POST]]
             [dk.ative.docjure.spreadsheet :as spreadsheet]
             [metabase
+             [middleware :as middleware]
              [query-processor :as qp]
              [util :as u]]
             [metabase.api.common :as api]
+            [metabase.api.common.internal :refer [route-fn-name]]
             [metabase.models
              [database :refer [Database]]
              [query :as query]]
             [metabase.query-processor.util :as qputil]
             [metabase.util.schema :as su]
-            [schema.core :as s]
-            [metabase.middleware :as middleware])
+            [schema.core :as s])
   (:import [java.io ByteArrayInputStream ByteArrayOutputStream]))
 
 (def ^:private ^:const max-results-bare-rows
@@ -126,4 +127,4 @@
         {:executed-by api/*current-user-id*, :context (export-format->context export-format)}))))
 
 (api/define-routes
-  (middleware/streaming-json-response POST_))
+  (middleware/streaming-json-response (route-fn-name 'POST "/")))

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -14,7 +14,8 @@
              [query :as query]]
             [metabase.query-processor.util :as qputil]
             [metabase.util.schema :as su]
-            [schema.core :as s])
+            [schema.core :as s]
+            [metabase.middleware :as middleware])
   (:import [java.io ByteArrayInputStream ByteArrayOutputStream]))
 
 (def ^:private ^:const max-results-bare-rows
@@ -124,5 +125,5 @@
       (qp/dataset-query (dissoc query :constraints)
         {:executed-by api/*current-user-id*, :context (export-format->context export-format)}))))
 
-
-(api/define-routes)
+(api/define-routes
+  (middleware/streaming-json-response POST_))

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -37,7 +37,7 @@
 
 (def ^:private app
   "The primary entry point to the Ring HTTP server."
-  (-> #'routes/routes
+  (-> routes/routes
       mb-middleware/log-api-call
       mb-middleware/add-security-headers ; Add HTTP headers to API responses to prevent them from being cached
       (wrap-json-body                    ; extracts json POST body and makes it avaliable on request
@@ -164,7 +164,7 @@
       (log/info "Launching Embedded Jetty Webserver with config:\n" (with-out-str (pprint/pprint (m/filter-keys #(not (re-matches #".*password.*" (str %)))
                                                                                                                 jetty-config))))
       ;; NOTE: we always start jetty w/ join=false so we can start the server first then do init in the background
-      (->> (ring-jetty/run-jetty #'app (assoc jetty-config :join? false))
+      (->> (ring-jetty/run-jetty app (assoc jetty-config :join? false))
            (reset! jetty-instance)))))
 
 (defn stop-jetty!

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -164,7 +164,7 @@
       (log/info "Launching Embedded Jetty Webserver with config:\n" (with-out-str (pprint/pprint (m/filter-keys #(not (re-matches #".*password.*" (str %)))
                                                                                                                 jetty-config))))
       ;; NOTE: we always start jetty w/ join=false so we can start the server first then do init in the background
-      (->> (ring-jetty/run-jetty app (assoc jetty-config :join? false))
+      (->> (ring-jetty/run-jetty #'app (assoc jetty-config :join? false))
            (reset! jetty-instance)))))
 
 (defn stop-jetty!

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -37,7 +37,7 @@
 
 (def ^:private app
   "The primary entry point to the Ring HTTP server."
-  (-> #'routes/routes
+  (-> #'routes/routes                    ; the #' is to allow tests to redefine endpoints
       mb-middleware/log-api-call
       mb-middleware/add-security-headers ; Add HTTP headers to API responses to prevent them from being cached
       (wrap-json-body                    ; extracts json POST body and makes it avaliable on request

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -37,7 +37,7 @@
 
 (def ^:private app
   "The primary entry point to the Ring HTTP server."
-  (-> routes/routes
+  (-> #'routes/routes
       mb-middleware/log-api-call
       mb-middleware/add-security-headers ; Add HTTP headers to API responses to prevent them from being cached
       (wrap-json-body                    ; extracts json POST body and makes it avaliable on request

--- a/src/metabase/middleware.clj
+++ b/src/metabase/middleware.clj
@@ -371,10 +371,10 @@
    requests like queries that take a long time to complete."
   (* 1 1000))
 
-;; Handle ring response maps that contain a LinkedBlockingQueue in the :body key:
+;; Handle ring response maps that contain a core.async chan in the :body key:
 ;;
 ;; {:status 200
-;;  :body (LinkedBlockingQueue.)}
+;;  :body (async/chan)}
 ;;
 ;; and send each string sent to that queue back to the browser as it arrives
 ;; this avoids output buffering in the default stream handling which was not sending

--- a/src/metabase/middleware.clj
+++ b/src/metabase/middleware.clj
@@ -393,11 +393,6 @@
               (throw e)))
           (recur (async/<!! output-queue)))))))
 
-(def ^:private ^:const streaming-response-keep-alive-interval-ms
-  "Interval between sending whitespace bytes to keep Heroku from terminating
-   requests like queries that take a long time to complete."
-  (* 1 1000))
-
 (defn streaming-json-response
   "This midelware assumes handlers fail early or return success
    Run the handler in a future and send newlines to keep the connection open

--- a/src/metabase/routes.clj
+++ b/src/metabase/routes.clj
@@ -12,12 +12,8 @@
              [routes :as api]]
             [metabase.core.initialization-status :as init-status]
             [metabase.util.embed :as embed]
-            [ring.util
-             [io :as ring-io]
-             [response :as resp]]
-            [stencil.core :as stencil]
-            [clojure.tools.logging :as log]
-            [metabase.middleware :as middleware]))
+            [ring.util.response :as resp]
+            [stencil.core :as stencil]))
 
 (defn- load-file-at-path [path]
   (slurp (or (io/resource path)
@@ -51,18 +47,6 @@
        (resp/redirect (format "/api/embed/card/%s/query/%s" token export-format)))
   (GET "*" [] embed))
 
-(defn- some-very-long-handler [_]
-  (log/error (u/format-color 'blue "starting some-very-long-handler"))
-  (Thread/sleep 7000)
-  (log/error (u/format-color 'blue "finished some-very-long-handler"))
-  {:success true})
-
-(defn- some-naughty-handler-that-barfs [_]
-  (throw (Exception. "BARF!")))
-
-
-
-
 ;; Redirect naughty users who try to visit a page other than setup if setup is not yet complete
 (defroutes ^{:doc "Top-level ring routes for Metabase."} routes
   ;; ^/$ -> index.html
@@ -87,10 +71,5 @@
   (context "/public" [] public-routes)
   ;; ^/emebed/ -> Embed frontend and download routes
   (context "/embed" [] embed-routes)
-  (context "/stream-test" []
-    (middleware/streaming-response some-very-long-handler))
-
-  (context "/stream-test-2" []
-      (streaming-response some-naughty-handler-that-barfs))
   ;; Anything else (e.g. /user/edit_current) should serve up index.html; React app will handle the rest
   (GET "*" [] index))

--- a/src/metabase/routes.clj
+++ b/src/metabase/routes.clj
@@ -50,24 +50,32 @@
   (GET "*" [] embed))
 
 (defn- some-very-long-handler [_]
-  (Thread/sleep 3000)
+  (Thread/sleep 30000)
   {:success true})
+
+(def ^:private ^:const streaming-response-keep-alive-interval-ms
+  "Interval between sending whitespace bytes to keep Heroku from terminating
+   requests like queries that take a long time to complete."
+  (* 20 1000)) ; every 20 ms
 
 (defn- streaming-response [handler]
   (fn [request]
     ;; TODO - handle exceptions  & have some sort of maximum timeout for these requests
-    (let [response (future (handler request))
-          f        (fn [^java.io.PipedOutputStream ostream]
-                     (if (realized? response)
-                       (json/generate-stream @response (io/writer ostream))
-                       (do
-                         (println "Response not ready, writing one byte & sleeping 500ms...")
-                         (.write ostream (byte \ ))
-                         (.flush ostream)
-                         (Thread/sleep 500)
-                         (recur ostream))))]
-      (-> (resp/response (ring-io/piped-input-stream f))
-          (resp/content-type "application/json")))))
+    (-> (fn [^java.io.PipedOutputStream ostream]
+          (let [response       (future (handler request))
+                write-response (future (json/generate-stream @response (io/writer ostream))
+                                       (println "Done! closing ostream...")
+                                       (.close ostream))]
+            (loop []
+              (Thread/sleep streaming-response-keep-alive-interval-ms)
+              (when-not (realized? response)
+                (println "Response not ready, writing one byte & sleeping...")
+                (.write ostream (byte \ ))
+                (.flush ostream)
+                (recur)))))
+        ring-io/piped-input-stream
+        resp/response
+        (resp/content-type "application/json"))))
 
 ;; Redirect naughty users who try to visit a page other than setup if setup is not yet complete
 (defroutes ^{:doc "Top-level ring routes for Metabase."} routes

--- a/test/metabase/middleware_test.clj
+++ b/test/metabase/middleware_test.clj
@@ -1,14 +1,21 @@
 (ns metabase.middleware-test
   (:require [cheshire.core :as json]
+            [clojure.core.async :as async]
+            [clojure.java.io :as io]
+            [compojure.core :refer [GET]]
             [expectations :refer :all]
             [metabase
-             [middleware :refer :all]
+             [middleware :as middleware :refer :all]
+             [routes :as routes]
              [util :as u]]
             [metabase.api.common :refer [*current-user* *current-user-id*]]
             [metabase.models.session :refer [Session]]
             [metabase.test.data.users :refer :all]
             [ring.mock.request :as mock]
-            [toucan.db :as db]))
+            [ring.util.response :as resp]
+            [toucan.db :as db]
+            [metabase.config :as config]
+            [clojure.tools.logging :as log]))
 
 ;;  ===========================  TEST wrap-session-id middleware  ===========================
 
@@ -176,3 +183,95 @@
 (expect "{\"my-bytes\":\"0xC42360D7\"}"
         (json/generate-string {:my-bytes (byte-array [196 35  96 215  8 106 108 248 183 215 244 143  17 160 53 186
                                                       213 30 116  25 87  31 123 172 207 108  47 107 191 215 76  92])}))
+;;; stuff here
+
+(defn- streaming-fast-success [_]
+  (resp/response {:success true}))
+
+(defn- streaming-fast-failure [_]
+  (throw (Exception. "immediate failure")))
+
+(defn- streaming-slow-success [_]
+  (Thread/sleep 7000)
+  (resp/response {:success true}))
+
+(defn- streaming-slow-failure [_]
+  (Thread/sleep 7000)
+  (throw (Exception. "delayed failure")))
+
+(defn- test-streaming-endpoint [handler]
+  (let [path (str handler)]
+    (with-redefs [metabase.routes/routes (compojure.core/routes
+                                          (GET (str "/" path) [] (middleware/streaming-response
+                                                                  handler)))]
+      (let  [connection (async/chan 1000)
+             reader (io/input-stream (str "http://localhost:" (config/config-int :mb-jetty-port) "/" path))]
+        (async/go-loop [next-char (.read reader)]
+          (if (pos? next-char)
+            (do
+              (async/>! connection (char next-char))
+              (recur (.read reader)))
+            (async/close! connection)))
+        (let [_ (Thread/sleep 1500)
+              first-second (async/poll! connection)
+              _ (Thread/sleep 1000)
+              second-second (async/poll! connection)
+              eventually (apply str (async/<!! (async/into [] connection)))]
+          [first-second second-second eventually])))))
+
+
+;;slow success
+(expect
+  [\newline \newline "\n\n\n{:success true}"]
+  (test-streaming-endpoint streaming-slow-success))
+
+;; immediate success should have no padding
+(expect
+  [\{ \" "success\":true}"]
+  (test-streaming-endpoint streaming-fast-success))
+
+;; we know delayed failures (exception thrown) will just drop the connection
+(expect
+  [\newline \newline "\n\n\n"]
+  (test-streaming-endpoint streaming-slow-failure))
+
+;; immediate failures (where an exception is thown will return a 500
+(expect
+  #"Server returned HTTP response code: 500 for URL:.*"
+  (try
+    (test-streaming-endpoint streaming-fast-failure)
+    (catch java.io.IOException e
+      (.getMessage e))))
+
+;; test that handler is killed when connection closes
+(def test-slow-handler-state (atom :unset))
+
+(defn- test-slow-handler [_]
+  (log/debug (u/format-color 'yellow "starting test-slow-handler"))
+  (Thread/sleep 7000)  ;; this is somewhat long to make sure the keepalive polling has time to kill it.
+  (reset! test-slow-handler-state :ran-to-compleation)
+  (log/debug (u/format-color 'yellow "finished test-slow-handler"))
+  (resp/response {:success true}))
+
+(defn- start-and-maybe-kill-test-request [kill?]
+  (reset! test-slow-handler-state :initial-state)
+  (let [path "test-slow-handler"]
+    (with-redefs [metabase.routes/routes (compojure.core/routes
+                                          (GET (str "/" path) [] (middleware/streaming-response
+                                                                  test-slow-handler)))]
+      (let  [reader (io/input-stream (str "http://localhost:" (config/config-int :mb-jetty-port) "/" path))]
+        (Thread/sleep 1500)
+        (when kill?
+          (.close reader))
+        (Thread/sleep 10000)))) ;; this is long enough to ensure that the handler has run to completion if it was not killed.
+  @test-slow-handler-state)
+
+;; In this first test we will close the connection before the test handler gets to change the state
+(expect
+  :initial-state
+  (start-and-maybe-kill-test-request true))
+
+;; and to make sure this test actually works, run the same test again and let it change the state.
+(expect
+  :ran-to-compleation
+  (start-and-maybe-kill-test-request false))

--- a/test/metabase/middleware_test.clj
+++ b/test/metabase/middleware_test.clj
@@ -2,9 +2,11 @@
   (:require [cheshire.core :as json]
             [clojure.core.async :as async]
             [clojure.java.io :as io]
+            [clojure.tools.logging :as log]
             [compojure.core :refer [GET]]
             [expectations :refer :all]
             [metabase
+             [config :as config]
              [middleware :as middleware :refer :all]
              [routes :as routes]
              [util :as u]]
@@ -13,9 +15,7 @@
             [metabase.test.data.users :refer :all]
             [ring.mock.request :as mock]
             [ring.util.response :as resp]
-            [toucan.db :as db]
-            [metabase.config :as config]
-            [clojure.tools.logging :as log]))
+            [toucan.db :as db]))
 
 ;;  ===========================  TEST wrap-session-id middleware  ===========================
 

--- a/test/metabase/middleware_test.clj
+++ b/test/metabase/middleware_test.clj
@@ -202,7 +202,7 @@
 (defn- test-streaming-endpoint [handler]
   (let [path (str handler)]
     (with-redefs [metabase.routes/routes (compojure.core/routes
-                                          (GET (str "/" path) [] (middleware/streaming-response
+                                          (GET (str "/" path) [] (middleware/streaming-json-response
                                                                   handler)))]
       (let  [connection (async/chan 1000)
              reader (io/input-stream (str "http://localhost:" (config/config-int :mb-jetty-port) "/" path))]
@@ -257,7 +257,7 @@
   (reset! test-slow-handler-state :initial-state)
   (let [path "test-slow-handler"]
     (with-redefs [metabase.routes/routes (compojure.core/routes
-                                          (GET (str "/" path) [] (middleware/streaming-response
+                                          (GET (str "/" path) [] (middleware/streaming-json-response
                                                                   test-slow-handler)))]
       (let  [reader (io/input-stream (str "http://localhost:" (config/config-int :mb-jetty-port) "/" path))]
         (Thread/sleep 1500)

--- a/test/metabase/middleware_test.clj
+++ b/test/metabase/middleware_test.clj
@@ -222,7 +222,7 @@
 
 ;;slow success
 (expect
-  [\newline \newline "\n\n\n{:success true}"]
+  [\newline \newline "\n\n\n{\"success\":true}"]
   (test-streaming-endpoint streaming-slow-success))
 
 ;; immediate success should have no padding


### PR DESCRIPTION
Add ring middleware to stream responses back to the browser and send newlines to keep the connection alive and detect when it has been closed. when it is closed the query thread is promptly killed.

This covers most (all?) of the symptoms of  #2399 for generic sql drivers