### PR TITLE
Add cache to anonymous backend metrics

### DIFF
--- a/test/metabase/util/stats_test.clj
+++ b/test/metabase/util/stats_test.clj
@@ -6,7 +6,7 @@
             [toucan.db :as db]))
 
 (tu/resolve-private-vars metabase.util.stats
-  bin-micro-number bin-medium-number bin-large-number)
+  bin-micro-number bin-small-number bin-medium-number bin-large-number)
 
 
 (expect "0" (bin-micro-number 0))
@@ -15,15 +15,15 @@
 (expect "3+" (bin-micro-number 3))
 (expect "3+" (bin-micro-number 100))
 
-#_(expect "0" (bin-small-number 0))
-#_(expect "1-5" (bin-small-number 1))
-#_(expect "1-5" (bin-small-number 5))
-#_(expect "6-10" (bin-small-number 6))
-#_(expect "6-10" (bin-small-number 10))
-#_(expect "11-25" (bin-small-number 11))
-#_(expect "11-25" (bin-small-number 25))
-#_(expect "25+" (bin-small-number 26))
-#_(expect "25+" (bin-small-number 500))
+(expect "0" (bin-small-number 0))
+(expect "1-5" (bin-small-number 1))
+(expect "1-5" (bin-small-number 5))
+(expect "6-10" (bin-small-number 6))
+(expect "6-10" (bin-small-number 10))
+(expect "11-25" (bin-small-number 11))
+(expect "11-25" (bin-small-number 25))
+(expect "25+" (bin-small-number 26))
+(expect "25+" (bin-small-number 500))
 
 (expect "0" (bin-medium-number 0))
 (expect "1-5" (bin-medium-number 1))


### PR DESCRIPTION
@salsakran let me know if this works.

Cache metrics look like

```clojure
{:average_entry_size 315, :num_queries_cached "1-5"}
```

