### PR TITLE
Fix race conditions in e2e tests

### DIFF
--- a/src/metabase/models/query.clj
+++ b/src/metabase/models/query.clj
@@ -25,17 +25,34 @@
     :unsigned
     :integer))
 
+(defn- update-rolling-average-execution-time!
+  "Update the rolling average execution time for query with QUERY-HASH. Returns `true` if a record was updated,
+   or `false` if no matching records were found."
+  ^Boolean [^bytes query-hash, ^Integer execution-time-ms]
+  (db/update-where! Query {:query_hash query-hash}
+    :average_execution_time (hx/cast (int-casting-type) (hx/round (hx/+ (hx/* 0.9 :average_execution_time)
+                                                                        (*    0.1 execution-time-ms))
+                                                                  0))))
+
+(defn- record-new-execution-time!
+  "Record the execution time for a query with QUERY-HASH that's not already present in the DB.
+   EXECUTION-TIME-MS is used as a starting point."
+  [^bytes query-hash, ^Integer execution-time-ms]
+  (db/insert! Query
+    :query_hash             query-hash
+    :average_execution_time execution-time-ms))
+
 (defn update-average-execution-time!
   "Update the recorded average execution time for query with QUERY-HASH."
-  ^Integer [^bytes query-hash, ^Integer execution-time-ms]
+  [^bytes query-hash, ^Integer execution-time-ms]
   {:pre [(instance? (Class/forName "[B") query-hash)]}
   (or
    ;; if there's already a matching Query update the rolling average
-   (db/update-where! Query {:query_hash query-hash}
-     :average_execution_time (hx/cast (int-casting-type) (hx/round (hx/+ (hx/* 0.9 :average_execution_time)
-                                                                         (*    0.1 execution-time-ms))
-                                                                   0)))
-   ;; otherwise add a new entry, using the value of EXECUTION-TIME-MS as a starting point
-   (db/insert! Query
-     :query_hash             query-hash
-     :average_execution_time execution-time-ms)))
+   (update-rolling-average-execution-time! query-hash execution-time-ms)
+   ;; otherwise try adding a new entry. If for some reason there was a race condition and a Query entry was added in the meantime
+   ;; we'll try updating that existing record
+   (try (record-new-execution-time! query-hash execution-time-ms)
+        (catch Throwable e
+          (or (update-rolling-average-execution-time! query-hash execution-time-ms)
+              ;; rethrow e if updating an existing average execution time failed
+              (throw e))))))


### PR DESCRIPTION
Fix a race condition in the e2e tests that @attekei found. Basically if you issue multiple requests to run the same brand-new query in the same millisecond or so it will try to do two INSERTs for new Query records instead of doing an INSERT and an UPDATE.

Fix this by wrapping INSERT in a try-catch and trying UPDATE if the INSERT fails

Fixes #5044