### PR TITLE
Fixed driver installation description.

### DIFF
--- a/docs/administration-guide/databases/vertica.md
+++ b/docs/administration-guide/databases/vertica.md
@@ -36,4 +36,5 @@ If you're running Metabase from the Mac App, the plugins directory defaults to `
 /Users/camsaul/Library/Application Support/Metabase/Plugins/vertica-jdbc-8.0.0-0.jar
 ```
 
-Finally, set the environment variable `MB_PLUGINS_DIR` to your plugins directory (in this case, `/app/plugins`).
+If you are running the Docker image or you want to use another directory for plugins, you should then specify a custom plugins directory by setting the environment variable `MB_PLUGINS_DIR`. 
+

--- a/docs/administration-guide/databases/vertica.md
+++ b/docs/administration-guide/databases/vertica.md
@@ -36,4 +36,4 @@ If you're running Metabase from the Mac App, the plugins directory defaults to `
 /Users/camsaul/Library/Application Support/Metabase/Plugins/vertica-jdbc-8.0.0-0.jar
 ```
 
-Finally, you can choose a custom plugins directory if the default doesn't suit your needs by setting the environment variable `MB_PLUGINS_DIR`.
+Finally, set the environment variable `MB_PLUGINS_DIR` to your plugins directory (in this case, `/app/plugins`).


### PR DESCRIPTION
`MB_PLUGINS_DIR` has to be set for the Vertica driver to work.



###### TODO 
-  [ ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
