### PR TITLE
Increase max uncompressed size of Mac App DMG [ci skip]

### DIFF
--- a/bin/osx-release
+++ b/bin/osx-release
@@ -187,8 +187,10 @@ sub create_dmg_from_source_dir {
            '-fs', 'HFS+',
            '-fsargs', '-c c=64,a=16,e=16',
            '-format', 'UDRW',
-           '-size', '256MB',          # it looks like this can be whatever size we want; compression slims it down
+           '-size', '512MB',          # has to be big enough to hold everything uncompressed, but doesn't matter if there's extra space -- compression slims it down
            $dmg_filename) == 0 or die $!;
+
+    announce "$dmg_filename created.";
 }
 
 # Mount the disk image, return the device name


### PR DESCRIPTION
Increase the max size limit of the uncompressed DMG a bit to fix issues building the DMG (or JAR has slightly outgrown the previous limits, which left no room on the DMG to add the shortcut to `/Applications`).