### PR TITLE
Show an appropriate message if a user tries to access an archived dashboard/question

### DIFF
--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -1,7 +1,7 @@
 /* @flow weak */
 
-import React, { Component } from "react";
-import { connect } from "react-redux";
+import React, {Component} from "react";
+import {connect} from "react-redux";
 
 import Navbar from "metabase/nav/containers/Navbar.jsx";
 
@@ -9,26 +9,33 @@ import UndoListing from "metabase/containers/UndoListing";
 
 import NotFound from "metabase/components/NotFound.jsx";
 import Unauthorized from "metabase/components/Unauthorized.jsx";
+import Archived from "metabase/components/Archived.jsx";
 
 const mapStateToProps = (state, props) => ({
     errorPage: state.app.errorPage
-})
+});
+
+const getErrorComponent = ({status, data, context}) => {
+    if (status === 403) {
+        return <Unauthorized />
+    } else if (data && data.error_code === "archived" && context === "dashboard") {
+        return <Archived entityName="dashboard" linkTo="/dashboards/archive" />
+    } else if (data && data.error_code === "archived" && context === "query-builder") {
+        return <Archived entityName="question" linkTo="/questions/archive" />
+    } else {
+        return <NotFound />
+    }
+}
 
 @connect(mapStateToProps)
 export default class App extends Component {
     render() {
         const { children, location, errorPage } = this.props;
+
         return (
             <div className="spread flex flex-column">
-                <Navbar location={location} className="flex-no-shrink" />
-                { errorPage && errorPage.status === 403 ?
-                    <Unauthorized />
-                : errorPage ?
-                    // TODO: different error page for non-404 errors
-                    <NotFound />
-                :
-                    children
-                }
+                <Navbar location={location} className="flex-no-shrink"/>
+                { errorPage ? getErrorComponent(errorPage) : children }
                 <UndoListing />
             </div>
         )

--- a/frontend/src/metabase/components/Archived.jsx
+++ b/frontend/src/metabase/components/Archived.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import EmptyState from "metabase/components/EmptyState";
+import Link from "metabase/components/Link";
+
+const Archived = ({ entityName, linkTo }) =>
+    <div className="full-height flex justify-center align-center">
+        <EmptyState
+            message={<div>
+                <div>This {entityName} has been archived</div>
+                <Link to={linkTo} className="my2 link" style={{fontSize: "14px"}}>View the archive</Link>
+            </div>}
+            icon="viewArchive"
+        />
+    </div>;
+
+export default Archived;

--- a/frontend/src/metabase/components/LoadingAndErrorWrapper.jsx
+++ b/frontend/src/metabase/components/LoadingAndErrorWrapper.jsx
@@ -28,7 +28,8 @@ export default class LoadingAndErrorWrapper extends Component {
     getErrorMessage() {
         const { error } = this.props;
         return (
-            error.data ||
+            // NOTE Atte Keinänen 5/10/17 Dashboard API endpoint returns the error as JSON with `message` field
+            error.data && (error.data.message ? error.data.message : error.data) ||
             error.statusText ||
             error.message ||
             "An error occured"

--- a/frontend/src/metabase/dashboard/components/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard.jsx
@@ -20,7 +20,6 @@ import type { Card, CardId, VisualizationSettings } from "metabase/meta/types/Ca
 import type { DashboardWithCards, DashboardId, DashCardId } from "metabase/meta/types/Dashboard";
 import type { RevisionId } from "metabase/meta/types/Revision";
 import type { Parameter, ParameterId, ParameterValues, ParameterOption } from "metabase/meta/types/Parameter";
-import * as Urls from "metabase/lib/urls";
 import Link from "metabase/components/Link";
 
 type Props = {
@@ -74,7 +73,8 @@ type Props = {
 }
 
 type State = {
-    error: ?ApiError
+    error: ?ApiError,
+    isArchived: boolean
 }
 
 @DashboardControls

--- a/frontend/src/metabase/dashboard/components/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard.jsx
@@ -6,7 +6,7 @@ import PropTypes from "prop-types";
 import DashboardHeader from "../components/DashboardHeader.jsx";
 import DashboardGrid from "../components/DashboardGrid.jsx";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper.jsx";
-import EmptyState from "metabase/components/EmptyState";
+
 import Parameters from "metabase/parameters/components/Parameters.jsx";
 
 import DashboardControls from "../hoc/DashboardControls";
@@ -20,7 +20,6 @@ import type { Card, CardId, VisualizationSettings } from "metabase/meta/types/Ca
 import type { DashboardWithCards, DashboardId, DashCardId } from "metabase/meta/types/Dashboard";
 import type { RevisionId } from "metabase/meta/types/Revision";
 import type { Parameter, ParameterId, ParameterValues, ParameterOption } from "metabase/meta/types/Parameter";
-import Link from "metabase/components/Link";
 
 type Props = {
     location:               LocationDescriptor,
@@ -73,15 +72,13 @@ type Props = {
 }
 
 type State = {
-    error: ?ApiError,
-    isArchived: boolean
+    error: ?ApiError
 }
 
 @DashboardControls
 export default class Dashboard extends Component<*, Props, State> {
     state = {
         error: null,
-        isArchived: false
     };
 
     static propTypes = {
@@ -141,12 +138,9 @@ export default class Dashboard extends Component<*, Props, State> {
             }
         } catch (error) {
             if (error.status === 404) {
-                if (error.data.error_code === "archived") {
-                     this.setState({ isArchived: true })
-                } else {
-                    setErrorPage(error);
-                }
+                setErrorPage({ ...error, context: "dashboard" });
             } else {
+                console.error(error);
                 this.setState({ error });
             }
         }
@@ -166,7 +160,7 @@ export default class Dashboard extends Component<*, Props, State> {
 
     render() {
         let { dashboard, isEditing, editingParameter, parameters, parameterValues, location, isFullscreen, isNightMode } = this.props;
-        let { error, isArchived } = this.state;
+        let { error } = this.state;
         isNightMode = isNightMode && isFullscreen;
 
         let parametersWidget;
@@ -193,55 +187,41 @@ export default class Dashboard extends Component<*, Props, State> {
             );
         }
 
-        const getDashboardArchivedState = () =>
-            <div className="full flex justify-center align-center">
-                <EmptyState
-                    message={<div>
-                        <div>This dashboard has been archived</div>
-                        <Link to={"/dashboards/archive"} className="my2 link" style={{fontSize: "14px"}}>View the archive</Link>
-                    </div>}
-                    icon="viewArchive"
-                />
-            </div>;
-
-        const getDashboardHeaderAndGrid = () =>
-            <div className="full pb4" style={{overflowX: "hidden"}}>
-                <header className="DashboardHeader relative z2">
-                    <DashboardHeader
-                        {...this.props}
-                        onEditingChange={this.setEditing}
-                        setDashboardAttribute={this.setDashboardAttribute}
-                        addParameter={this.props.addParameter}
-                        parameters={parametersWidget}
-                    />
-                </header>
-                {!isFullscreen && parametersWidget &&
-                <div className="wrapper flex flex-column align-start mt2 relative z2">
-                    {parametersWidget}
-                </div>
-                }
-                <div className="wrapper">
-                    { dashboard.ordered_cards.length === 0 ?
-                        <div className="absolute z1 top bottom left right flex flex-column layout-centered">
-                            <span className="QuestionCircle">?</span>
-                            <div className="text-normal mt3 mb1">This dashboard is looking empty.</div>
-                            <div className="text-normal text-grey-2">Add a question to start making it useful!</div>
-                        </div>
-                        :
-                        <DashboardGrid
-                            {...this.props}
-                            onEditingChange={this.setEditing}
-                        />
-                    }
-                </div>
-            </div>;
-
         return (
-            <LoadingAndErrorWrapper className={cx("Dashboard flex-full flex", {
-                "Dashboard--fullscreen": isFullscreen,
-                "Dashboard--night": isNightMode
-            })} loading={!dashboard && !isArchived} error={error}>
-                {() => isArchived ? getDashboardArchivedState() : getDashboardHeaderAndGrid() }
+            <LoadingAndErrorWrapper className={cx("Dashboard flex-full pb4", { "Dashboard--fullscreen": isFullscreen, "Dashboard--night": isNightMode})} loading={!dashboard} error={error}>
+                {() =>
+                    <div className="full" style={{ overflowX: "hidden" }}>
+                        <header className="DashboardHeader relative z2">
+                            <DashboardHeader
+                                {...this.props}
+                                onEditingChange={this.setEditing}
+                                setDashboardAttribute={this.setDashboardAttribute}
+                                addParameter={this.props.addParameter}
+                                parameters={parametersWidget}
+                            />
+                        </header>
+                        {!isFullscreen && parametersWidget &&
+                        <div className="wrapper flex flex-column align-start mt2 relative z2">
+                            {parametersWidget}
+                        </div>
+                        }
+                        <div className="wrapper">
+
+                            { dashboard.ordered_cards.length === 0 ?
+                                <div className="absolute z1 top bottom left right flex flex-column layout-centered">
+                                    <span className="QuestionCircle">?</span>
+                                    <div className="text-normal mt3 mb1">This dashboard is looking empty.</div>
+                                    <div className="text-normal text-grey-2">Add a question to start making it useful!</div>
+                                </div>
+                                :
+                                <DashboardGrid
+                                    {...this.props}
+                                    onEditingChange={this.setEditing}
+                                />
+                            }
+                        </div>
+                    </div>
+                }
             </LoadingAndErrorWrapper>
         );
     }

--- a/frontend/src/metabase/dashboard/components/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard.jsx
@@ -141,7 +141,7 @@ export default class Dashboard extends Component<*, Props, State> {
             }
         } catch (error) {
             if (error.status === 404) {
-                if (error.data === "The object has been archived.") {
+                if (error.data.error_code === "archived") {
                      this.setState({ isArchived: true })
                 } else {
                     setErrorPage(error);
@@ -194,7 +194,7 @@ export default class Dashboard extends Component<*, Props, State> {
         }
 
         const getDashboardArchivedState = () =>
-            <div className="full flex justify-center" style={{marginTop: "75px"}}>
+            <div className="full flex justify-center align-center">
                 <EmptyState
                     message={<div>
                         <div>This dashboard has been archived</div>
@@ -205,7 +205,7 @@ export default class Dashboard extends Component<*, Props, State> {
             </div>;
 
         const getDashboardHeaderAndGrid = () =>
-            <div className="full" style={{overflowX: "hidden"}}>
+            <div className="full pb4" style={{overflowX: "hidden"}}>
                 <header className="DashboardHeader relative z2">
                     <DashboardHeader
                         {...this.props}
@@ -237,7 +237,7 @@ export default class Dashboard extends Component<*, Props, State> {
             </div>;
 
         return (
-            <LoadingAndErrorWrapper className={cx("Dashboard flex-full pb4", {
+            <LoadingAndErrorWrapper className={cx("Dashboard flex-full flex", {
                 "Dashboard--fullscreen": isFullscreen,
                 "Dashboard--night": isNightMode
             })} loading={!dashboard && !isArchived} error={error}>

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -183,7 +183,7 @@ export const initializeQB = createThunkAction(INITIALIZE_QB, (location, params) 
                 MetabaseAnalytics.trackEvent("QueryBuilder", "Query Loaded", card.dataset_query.type);
 
                 // if we have deserialized card from the url AND loaded a card by id then the user should be dropped into edit mode
-                uiControls.isEditing = !!options.edit
+                uiControls.isEditing = !!options.edit;
 
                 // if this is the users first time loading a saved card on the QB then show them the newb modal
                 if (params.cardId && currentUser.is_qbnewb) {
@@ -191,9 +191,20 @@ export const initializeQB = createThunkAction(INITIALIZE_QB, (location, params) 
                     MetabaseAnalytics.trackEvent("QueryBuilder", "Show Newb Modal");
                 }
 
+                if (card.archived) {
+                    // use the error handler in App.jsx for showing "This question has been archived" message
+                    dispatch(setErrorPage({
+                        data: {
+                            error_code: "archived"
+                        },
+                        context: "query-builder"
+                    }));
+                    card = null;
+                }
+
                 preserveParameters = true;
             } catch(error) {
-                console.warn(error)
+                console.warn(error);
                 card = null;
                 dispatch(setErrorPage(error));
             }

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -1,12 +1,15 @@
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 import { connect } from "react-redux";
+import { Link } from "react-router";
 
 import cx from "classnames";
 import _ from "underscore";
 
 import { loadTableAndForeignKeys } from "metabase/lib/table";
 import { isPK, isFK } from "metabase/lib/types";
+
+import EmptyState from "metabase/components/EmptyState";
 
 import QueryBuilderTutorial from "metabase/tutorial/QueryBuilderTutorial.jsx";
 
@@ -209,6 +212,21 @@ class LegacyQueryBuilder extends Component {
         if (!card || !databases) {
             return (
                 <div></div>
+            );
+        }
+
+        if (card.archived) {
+            return (
+                <div className="flex full layout-centered flex-column">
+                    <EmptyState
+                        message={<div>
+                            <div>This question has been archived</div>
+                            <Link to={"/questions/archive"} className="my2 link" style={{fontSize: "14px"}}>View the
+                                archive</Link>
+                        </div>}
+                        icon="viewArchive"
+                    />
+                </div>
             );
         }
 

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -1,15 +1,12 @@
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 import { connect } from "react-redux";
-import { Link } from "react-router";
 
 import cx from "classnames";
 import _ from "underscore";
 
 import { loadTableAndForeignKeys } from "metabase/lib/table";
 import { isPK, isFK } from "metabase/lib/types";
-
-import EmptyState from "metabase/components/EmptyState";
 
 import QueryBuilderTutorial from "metabase/tutorial/QueryBuilderTutorial.jsx";
 
@@ -212,21 +209,6 @@ class LegacyQueryBuilder extends Component {
         if (!card || !databases) {
             return (
                 <div></div>
-            );
-        }
-
-        if (card.archived) {
-            return (
-                <div className="flex full layout-centered flex-column">
-                    <EmptyState
-                        message={<div>
-                            <div>This question has been archived</div>
-                            <Link to={"/questions/archive"} className="my2 link" style={{fontSize: "14px"}}>View the
-                                archive</Link>
-                        </div>}
-                        icon="viewArchive"
-                    />
-                </div>
             );
         }
 

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -156,9 +156,9 @@ export const getIsRunnable = createSelector(
 const getLastRunDatasetQuery = createSelector([getLastRunCard], (card) => card && card.dataset_query);
 const getNextRunDatasetQuery = createSelector([getCard], (card) => card && card.dataset_query);
 
-const getLastRunParameters = createSelector([getQueryResult], (queryResult) => queryResult && queryResult.json_query.parameters || [])
-const getLastRunParameterValues = createSelector([getLastRunParameters], (parameters) => parameters.map(parameter => parameter.value))
-const getNextRunParameterValues = createSelector([getParameters], (parameters) => parameters.map(parameter => parameter.value))
+const getLastRunParameters = createSelector([getQueryResult], (queryResult) => queryResult && queryResult.json_query && queryResult.json_query.parameters || []);
+const getLastRunParameterValues = createSelector([getLastRunParameters], (parameters) => parameters.map(parameter => parameter.value));
+const getNextRunParameterValues = createSelector([getParameters], (parameters) => parameters.map(parameter => parameter.value));
 
 export const getIsResultDirty = createSelector(
     [getLastRunDatasetQuery, getNextRunDatasetQuery, getLastRunParameterValues, getNextRunParameterValues],

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -680,7 +680,7 @@
 
 ;; Test that we *cannot* share a Card if the Card has been archived
 (expect
-  "The object has been archived."
+  {:message "The object has been archived.", :error_code "archived"}
   (tu/with-temporary-setting-values [enable-public-sharing true]
     (tt/with-temp Card [card {:archived true}]
       ((user->client :crowberto) :post 404 (format "card/%d/public_link" (u/get-id card))))))


### PR DESCRIPTION
Addresses #5025.

For questions this was really straightforward as `api/card/XX` returns the `archived` state. 

~For dashboards I had to check the error message value (`The object has been archived.`) and I'm not sure if that is a good approach.~ API returns now a JSON error message in format 
```
{message: ..., error_code: "archived"}
```
How these look like:

![screen shot 2017-05-10 at 17 07 27](https://cloud.githubusercontent.com/assets/6034928/25926985/98f889f6-35a7-11e7-9fc3-d5601bccc6f6.png)
![screen shot 2017-05-10 at 17 36 49](https://cloud.githubusercontent.com/assets/6034928/25926987/9d7f54b4-35a7-11e7-8c9a-1864a664829e.png)
