### PR TITLE
Added min/max metadata to numerics and a default binning strategy [WIP]

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -3646,3 +3646,23 @@ databaseChangeLog:
             columns:
               - column:
                   name: dashboard_id
+  - changeSet:
+      id: 56
+      author: senior
+      changes:
+        - addColumn:
+            tableName: metabase_field
+            columns:
+              - column:
+                  name: min_value
+                  type: float
+                  constraints:
+                    nullable: true
+        - addColumn:
+            tableName: metabase_field
+            columns:
+              - column:
+                  name: max_value
+                  type: float
+                  constraints:
+                    nullable: true

--- a/src/metabase/db/metadata_queries.clj
+++ b/src/metabase/db/metadata_queries.clj
@@ -54,3 +54,11 @@
   [{field-id :id :as field}]
   (-> (field-query field (ql/aggregation {} (ql/count (ql/field-id field-id))))
       first first int))
+
+(defn field-max-min
+  "Returns a pair [max min] for the given `FIELD`"
+  [{field-id :id :as field}]
+  (->> (field-query field (ql/aggregation {} [(ql/min (ql/field-id field-id))
+                                              (ql/max (ql/field-id field-id))]))
+       first
+       (map double)))

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -17,7 +17,7 @@
             [metabase.util.honeysql-extensions :as hx])
   (:import clojure.lang.Keyword
            java.sql.SQLException
-           [metabase.query_processor.interface AgFieldRef DateTimeField DateTimeValue Expression ExpressionRef Field RelativeDateTimeValue Value]))
+           [metabase.query_processor.interface AgFieldRef BinnedField DateTimeField DateTimeValue Expression ExpressionRef Field RelativeDateTimeValue Value]))
 
 (def ^:dynamic *query*
   "The outer query currently being processed."
@@ -33,11 +33,18 @@
 
 ;;; ## Formatting
 
+(defn qualified-alias
+  "Convert the given `FIELD` to a stringified alias"
+  [field]
+  (some->> field
+           (sql/field->alias (driver))
+           hx/qualify-and-escape-dots))
+
 (defn as
   "Generate a FORM `AS` FIELD alias using the name information of FIELD."
   [form field]
-  (if-let [alias (sql/field->alias (driver) field)]
-    [form (hx/qualify-and-escape-dots alias)]
+  (if-let [alias (qualified-alias field)]
+    [form alias]
     form))
 
 ;; TODO - Consider moving this into query processor interface and making it a method on `ExpressionRef` instead ?
@@ -80,6 +87,17 @@
   DateTimeField
   (formatted [{unit :unit, field :field}]
     (sql/date (driver) unit (formatted field)))
+
+  BinnedField
+  (formatted [{{:keys [min-value max-value] :as field} :field bins :num-bins}]
+    (let [bin-width (Math/ceil (/ (- (Math/floor max-value)
+                                     (Math/floor min-value))
+                                  bins))]
+      (-> field
+          formatted
+          (hx// bin-width)
+          hx/floor
+          (hx/* bin-width))))
 
   ;; e.g. the ["aggregation" 0] fields we allow in order-by
   AgFieldRef
@@ -158,17 +176,18 @@
         form
         (recur form more)))))
 
-
 (defn apply-breakout
   "Apply a `breakout` clause to HONEYSQL-FORM. Default implementation of `apply-breakout` for SQL drivers."
-  [_ honeysql-form {breakout-fields :breakout, fields-fields :fields}]
-  (-> honeysql-form
-      ;; Group by all the breakout fields
-      ((partial apply h/group) (map formatted breakout-fields))
-      ;; Add fields form only for fields that weren't specified in :fields clause -- we don't want to include it twice, or HoneySQL will barf
-      ((partial apply h/merge-select) (for [field breakout-fields
-                                            :when (not (contains? (set fields-fields) field))]
-                                        (as (formatted field) field)))))
+  [_ honeysql-form {breakout-fields :breakout, fields-fields :fields :as query}]
+  (as-> honeysql-form new-hsql
+    (apply h/merge-select new-hsql (for [field breakout-fields
+                                         :when (not (contains? (set fields-fields) field))]
+                                     (as (formatted field) field)))
+    (apply h/group new-hsql (map (fn [field]
+                                   (if (instance? BinnedField field)
+                                     (qualified-alias field)
+                                     (formatted field)))
+                                 breakout-fields))))
 
 (defn apply-fields
   "Apply a `fields` clause to HONEYSQL-FORM. Default implementation of `apply-fields` for SQL drivers."
@@ -227,14 +246,17 @@
 
 (defn apply-order-by
   "Apply `order-by` clause to HONEYSQL-FORM. Default implementation of `apply-order-by` for SQL drivers."
-  [_ honeysql-form {subclauses :order-by}]
-  (loop [honeysql-form honeysql-form, [{:keys [field direction]} & more] subclauses]
-    (let [honeysql-form (h/merge-order-by honeysql-form [(formatted field) (case direction
-                                                                             :ascending  :asc
-                                                                             :descending :desc)])]
-      (if (seq more)
-        (recur honeysql-form more)
-        honeysql-form))))
+  [_ honeysql-form {subclauses :order-by breakout-fields :breakout}]
+  (let [[{:keys [special-type] :as first-breakout-field}] breakout-fields]
+    (loop [honeysql-form honeysql-form, [{:keys [field direction]} & more] subclauses]
+      (let [honeysql-form (h/merge-order-by honeysql-form (if (instance? BinnedField field)
+                                                            (qualified-alias field)
+                                                            [(formatted field) (case direction
+                                                                                 :ascending  :asc
+                                                                                 :descending :desc)]))]
+        (if (seq more)
+          (recur honeysql-form more)
+          honeysql-form)))))
 
 (defn apply-page
   "Apply `page` clause to HONEYSQL-FORM. Default implementation of `apply-page` for SQL drivers."

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -88,6 +88,11 @@
   :type    :integer
   :default 10)
 
+(defsetting breakout-bins-num
+  "When using the default binning strategy and a number of bins is not
+  provided, this number will be used as the default."
+  :type :integer
+  :default 8)
 
 (defn remove-public-uuid-if-public-sharing-is-disabled
   "If public sharing is *disabled* and OBJECT has a `:public_uuid`, remove it so people don't try to use it (since it won't work).

--- a/src/metabase/query_processor/annotate.clj
+++ b/src/metabase/query_processor/annotate.clj
@@ -196,7 +196,9 @@
                           :schema-name        :schema_name
                           :special-type       :special_type
                           :table-id           :table_id
-                          :visibility-type    :visibility_type})
+                          :visibility-type    :visibility_type
+                          :min-value          :min_value
+                          :max-value          :max_value})
         (dissoc :position :clause-position :parent :parent-id :table-name))))
 
 (defn- fk-field->dest-fn

--- a/src/metabase/query_processor/expand.clj
+++ b/src/metabase/query_processor/expand.clj
@@ -6,6 +6,7 @@
              [core :as core]
              [string :as str]]
             [clojure.tools.logging :as log]
+            [metabase.public-settings :as public-settings]
             [metabase.query-processor.interface :as i]
             [metabase.util :as u]
             [metabase.util.schema :as su]
@@ -183,7 +184,9 @@
 
 (s/defn ^:ql ^:always-validate binning-strategy :- FieldPlaceholder
   "Reference to a `BinnedField`. This is just a `Field` reference with an associated `STRATEGY-NAME` and `STRATEGY-PARAM`"
-  ([f strategy-name strategy-param]   (assoc (field f) :binning-strategy strategy-param)))
+  ([f strategy-name & [strategy-param]]   (assoc (field f)
+                                            :binning-strategy (clojure.core/or strategy-param
+                                                                               (public-settings/breakout-bins-num)))))
 
 (defn- fields-list-clause
   ([k query] query)

--- a/src/metabase/query_processor/expand.clj
+++ b/src/metabase/query_processor/expand.clj
@@ -181,6 +181,10 @@
 
 ;;; ## breakout & fields
 
+(s/defn ^:ql ^:always-validate binning-strategy :- FieldPlaceholder
+  "Reference to a `BinnedField`. This is just a `Field` reference with an associated `STRATEGY-NAME` and `STRATEGY-PARAM`"
+  ([f strategy-name strategy-param]   (assoc (field f) :binning-strategy strategy-param)))
+
 (defn- fields-list-clause
   ([k query] query)
   ([k query & fields] (assoc query k (mapv field fields))))

--- a/src/metabase/query_processor/interface.clj
+++ b/src/metabase/query_processor/interface.clj
@@ -87,7 +87,9 @@
                     description        :- (s/maybe su/NonBlankString)
                     parent-id          :- (s/maybe su/IntGreaterThanZero)
                     ;; Field once its resolved; FieldPlaceholder before that
-                    parent             :- s/Any]
+                    parent             :- s/Any
+                    min-value          :- (s/maybe s/Num)
+                    max-value          :- (s/maybe s/Num)]
   clojure.lang.Named
   (getName [_] field-name) ; (name <field>) returns the *unqualified* name of the field, #obvi
 
@@ -125,6 +127,11 @@
 ;; wrapper around Field
 (s/defrecord DateTimeField [field :- Field
                             unit  :- DatetimeFieldUnit]
+  clojure.lang.Named
+  (getName [_] (name field)))
+
+(s/defrecord BinnedField [field :- Field
+                          num-bins  :- s/Int]
   clojure.lang.Named
   (getName [_] (name field)))
 
@@ -174,7 +181,8 @@
                                fk-field-id   :- (s/maybe (s/constrained su/IntGreaterThanZero
                                                                         (fn [_] (or (assert-driver-supports :foreign-keys) true))
                                                                         "foreign-keys is not supported by this driver."))
-                               datetime-unit :- (s/maybe (apply s/enum datetime-field-units))])
+                               datetime-unit :- (s/maybe (apply s/enum datetime-field-units))
+                               binning-strategy :- (s/maybe s/Int)])
 
 (s/defrecord AgFieldRef [index :- s/Int])
 

--- a/src/metabase/sync_database/analyze.clj
+++ b/src/metabase/sync_database/analyze.clj
@@ -75,7 +75,10 @@
       (and (nil? (:special_type field))
            (pos? (count distinct-values))) (assoc :special-type :type/Category))))
 
-(defn numeric-type? [{:keys [base_type] :as field}]
+(defn numeric-type?
+  "Returns true if the `FIELD` has a base_type that inherits
+  from :type/Number"
+  [{:keys [base_type] :as field}]
   (isa? base_type :type/Number))
 
 (defn test:add-min-max

--- a/src/metabase/sync_database/interface.clj
+++ b/src/metabase/sync_database/interface.clj
@@ -9,7 +9,9 @@
    (s/optional-key :fields)    [{:id                               su/IntGreaterThanZero
                                  (s/optional-key :special-type)    su/FieldType
                                  (s/optional-key :preview-display) s/Bool
-                                 (s/optional-key :values)          [s/Any]}]})
+                                 (s/optional-key :values)          [s/Any]
+                                 (s/optional-key :min-value)       s/Num
+                                 (s/optional-key :max-value)       s/Num}]})
 
 (def DescribeDatabase
   "Schema for the expected output of `describe-database`."

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -278,7 +278,9 @@
                                                        :visibility_type    "normal"
                                                        :fk_target_field_id $
                                                        :parent_id          nil
-                                                       :values             $})
+                                                       :values             $
+                                                       :min_value          1.0
+                                                       :max_value          75.0})
                                                     (match-$ (hydrate/hydrate (Field (id :categories :name)) :values)
                                                       {:description        nil
                                                        :table_id           (id :categories)
@@ -300,7 +302,9 @@
                                                        :visibility_type    "normal"
                                                        :fk_target_field_id $
                                                        :parent_id          nil
-                                                       :values             $})]
+                                                       :values             $
+                                                       :min_value          nil
+                                                       :max_value          nil})]
                           :segments                []
                           :metrics                 []
                           :rows                    75

--- a/test/metabase/api/field_test.clj
+++ b/test/metabase/api/field_test.clj
@@ -69,7 +69,9 @@
      :created_at         $
      :base_type          "type/Text"
      :fk_target_field_id nil
-     :parent_id          nil})
+     :parent_id          nil
+     :min_value          nil
+     :max_value          nil})
   ((user->client :rasta) :get 200 (format "field/%d" (id :users :name))))
 
 

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -73,7 +73,9 @@
    :visibility_type    "normal"
    :caveats            nil
    :points_of_interest nil
-   :parent_id          nil})
+   :parent_id          nil
+   :min_value          nil
+   :max_value          nil})
 
 
 ;; ## GET /api/table
@@ -147,7 +149,9 @@
                                                 :base_type          "type/BigInteger"
                                                 :fk_target_field_id $
                                                 :raw_column_id      $
-                                                :last_analyzed      $}))
+                                                :last_analyzed      $
+                                                :min_value          1.0
+                                                :max_value          75.0}))
                              (merge defaults (match-$ (Field (id :categories :name))
                                                {:special_type       "type/Name"
                                                 :name               "NAME"
@@ -207,7 +211,9 @@
                                                 :visibility_type    "normal"
                                                 :fk_target_field_id $
                                                 :raw_column_id      $
-                                                :last_analyzed      $}))
+                                                :last_analyzed      $
+                                                :min_value          1.0
+                                                :max_value          15.0}))
                              (merge defaults (match-$ (Field (id :users :last_login))
                                                {:special_type       nil
                                                 :name               "LAST_LOGIN"
@@ -286,7 +292,9 @@
                                                 :base_type          "type/BigInteger"
                                                 :fk_target_field_id $
                                                 :raw_column_id      $
-                                                :last_analyzed      $}))
+                                                :last_analyzed      $
+                                                :min_value          1.0
+                                                :max_value          15.0}))
                              (merge defaults (match-$ (Field (id :users :last_login))
                                                {:special_type       nil
                                                 :name               "LAST_LOGIN"
@@ -420,6 +428,8 @@
                                 :created_at         $
                                 :updated_at         $
                                 :last_analyzed      $
+                                :min_value          1.0
+                                :max_value          15.0
                                 :table              (merge (dissoc (table-defaults) :segments :field_values :metrics)
                                                            (match-$ (Table (id :checkins))
                                                              {:schema       "PUBLIC"
@@ -445,6 +455,8 @@
                                 :created_at         $
                                 :updated_at         $
                                 :last_analyzed      $
+                                :min_value          1.0
+                                :max_value          15.0
                                 :table              (merge (dissoc (table-defaults) :db :segments :field_values :metrics)
                                                            (match-$ (Table (id :users))
                                                              {:schema       "PUBLIC"

--- a/test/metabase/driver/generic_sql_test.clj
+++ b/test/metabase/driver/generic_sql_test.clj
@@ -68,15 +68,19 @@
 
 
 ;; ANALYZE-TABLE
-
 (expect
   {:row_count 100,
-   :fields    [{:id (id :venues :category_id)}
-               {:id (id :venues :id)}
-               {:id (id :venues :latitude)}
-               {:id (id :venues :longitude)}
+   :fields    [{:id (id :venues :category_id)
+                :min-value 2.0, :max-value 74.0}
+               {:id (id :venues :id)
+                :min-value 1.0, :max-value 100.0}
+               {:id (id :venues :latitude)
+                :min-value 10.0646, :max-value 40.7794}
+               {:id (id :venues :longitude)
+                :min-value -165.374, :max-value -73.9533}
                {:id (id :venues :name), :values (db/select-one-field :values 'FieldValues, :field_id (id :venues :name))}
-               {:id (id :venues :price), :values [1 2 3 4]}]}
+               {:id (id :venues :price), :values [1 2 3 4]
+                :min-value 1.0, :max-value 4.0}]}
   (driver/analyze-table (H2Driver.) @venues-table (set (mapv :id (table/fields @venues-table)))))
 
 (resolve-private-vars metabase.driver.generic-sql field-avg-length field-values-lazy-seq table-rows-seq)

--- a/test/metabase/query_processor/expand_resolve_test.clj
+++ b/test/metabase/query_processor/expand_resolve_test.clj
@@ -27,12 +27,14 @@
     :type     :query
     :query    {:source-table (id :venues)
                :filter       {:filter-type :>
-                              :field       {:field-id      (id :venues :price)
-                                            :fk-field-id   nil
-                                            :datetime-unit nil}
-                              :value       {:field-placeholder {:field-id      (id :venues :price)
-                                                                :fk-field-id   nil
-                                                                :datetime-unit nil}
+                              :field       {:field-id         (id :venues :price)
+                                            :fk-field-id      nil
+                                            :datetime-unit    nil
+                                            :binning-strategy nil}
+                              :value       {:field-placeholder {:field-id         (id :venues :price)
+                                                                :fk-field-id      nil
+                                                                :datetime-unit    nil
+                                                                :binning-strategy nil}
                                             :value             1}}}}
    ;; resolved form
    {:database     (id)
@@ -54,7 +56,9 @@
                                                 :position           nil
                                                 :description        nil
                                                 :parent-id          nil
-                                                :parent             nil}
+                                                :parent             nil
+                                                :min-value          1.0
+                                                :max-value          4.0}
                                   :value       {:value 1
                                                 :field {:field-id           (id :venues :price)
                                                         :fk-field-id        nil
@@ -69,12 +73,14 @@
                                                         :position           nil
                                                         :description        nil
                                                         :parent-id          nil
-                                                        :parent             nil}}}
+                                                        :parent             nil
+                                                        :min-value          1.0
+                                                        :max-value          4.0}}}
                    :join-tables  nil}
     :fk-field-ids #{}
     :table-ids    #{(id :venues)}}]
   (let [expanded-form (ql/expand (wrap-inner-query (query venues
-                                                        (ql/filter (ql/and (ql/> $price 1))))))]
+                                                          (ql/filter (ql/and (ql/> $price 1))))))]
     (mapv obj->map [expanded-form
                     (resolve/resolve expanded-form)])))
 
@@ -86,12 +92,14 @@
     :type     :query
     :query    {:source-table (id :venues)
                :filter       {:filter-type :=
-                              :field       {:field-id      (id :categories :name)
-                                            :fk-field-id   (id :venues :category_id)
-                                            :datetime-unit nil}
-                              :value       {:field-placeholder {:field-id      (id :categories :name)
-                                                                :fk-field-id   (id :venues :category_id)
-                                                                :datetime-unit nil}
+                              :field       {:field-id         (id :categories :name)
+                                            :fk-field-id      (id :venues :category_id)
+                                            :datetime-unit    nil
+                                            :binning-strategy nil}
+                              :value       {:field-placeholder {:field-id         (id :categories :name)
+                                                                :fk-field-id      (id :venues :category_id)
+                                                                :datetime-unit    nil
+                                                                :binning-strategy nil}
                                             :value             "abc"}}}}
    ;; resolved form
    {:database     (id)
@@ -113,7 +121,9 @@
                                                 :position           nil
                                                 :description        nil
                                                 :parent-id          nil
-                                                :parent             nil}
+                                                :parent             nil
+                                                :min-value          nil
+                                                :max-value          nil}
                                   :value       {:value "abc"
                                                 :field {:field-id           (id :categories :name)
                                                         :fk-field-id        (id :venues :category_id)
@@ -128,7 +138,9 @@
                                                         :position           nil
                                                         :description        nil
                                                         :parent-id          nil
-                                                        :parent             nil}}}
+                                                        :parent             nil
+                                                        :min-value          nil
+                                                        :max-value          nil}}}
                    :join-tables  [{:source-field {:field-id   (id :venues :category_id)
                                                   :field-name "CATEGORY_ID"}
                                    :pk-field     {:field-id   (id :categories :id)
@@ -140,8 +152,8 @@
     :fk-field-ids #{(id :venues :category_id)}
     :table-ids    #{(id :categories)}}]
   (let [expanded-form (ql/expand (wrap-inner-query (query venues
-                                                        (ql/filter (ql/= $category_id->categories.name
-                                                                         "abc")))))]
+                                                          (ql/filter (ql/= $category_id->categories.name
+                                                                           "abc")))))]
     (mapv obj->map [expanded-form
                     (resolve/resolve expanded-form)])))
 
@@ -153,12 +165,14 @@
     :type     :query
     :query    {:source-table (id :checkins)
                :filter       {:filter-type :>
-                              :field       {:field-id      (id :users :last_login)
-                                            :fk-field-id   (id :checkins :user_id)
-                                            :datetime-unit :year}
-                              :value       {:field-placeholder {:field-id      (id :users :last_login)
-                                                                :fk-field-id   (id :checkins :user_id)
-                                                                :datetime-unit :year}
+                              :field       {:field-id         (id :users :last_login)
+                                            :fk-field-id      (id :checkins :user_id)
+                                            :datetime-unit    :year
+                                            :binning-strategy nil}
+                              :value       {:field-placeholder {:field-id         (id :users :last_login)
+                                                                :fk-field-id      (id :checkins :user_id)
+                                                                :datetime-unit    :year
+                                                                :binning-strategy nil}
                                             :value             "1980-01-01"}}}}
    ;; resolved form
    {:database     (id)
@@ -180,7 +194,9 @@
                                                         :position           nil
                                                         :description        nil
                                                         :parent-id          nil
-                                                        :parent             nil}
+                                                        :parent             nil
+                                                        :min-value          nil
+                                                        :max-value          nil}
                                                 :unit  :year}
                                   :value       {:value (u/->Timestamp "1980-01-01")
                                                 :field {:field {:field-id           (id :users :last_login)
@@ -196,7 +212,9 @@
                                                                 :position           nil
                                                                 :description        nil
                                                                 :parent-id          nil
-                                                                :parent             nil}
+                                                                :parent             nil
+                                                                :min-value          nil
+                                                                :max-value          nil}
                                                         :unit  :year}}}
                    :join-tables  [{:source-field {:field-id   (id :checkins :user_id)
                                                   :field-name "USER_ID"}
@@ -225,32 +243,36 @@
                                :custom-name      nil
                                :field            {:field-id      (id :venues :price)
                                                   :fk-field-id   (id :checkins :venue_id)
-                                                  :datetime-unit nil}}]
+                                                  :datetime-unit nil
+                                                  :binning-strategy nil}}]
                :breakout     [{:field-id      (id :checkins :date)
                                :fk-field-id   nil
-                               :datetime-unit :day-of-week}]}}
+                               :datetime-unit :day-of-week
+                               :binning-strategy nil}]}}
    ;; resolved form
    {:database     (id)
     :type         :query
     :query        {:source-table {:schema "PUBLIC"
                                   :name   "CHECKINS"
                                   :id     (id :checkins)}
-                   :aggregation  [{:aggregation-type :sum
-                                   :custom-name      nil
-                                   :field            {:description        nil
-                                                      :base-type          :type/Integer
-                                                      :parent             nil
-                                                      :table-id           (id :venues)
-                                                      :special-type       :type/Category
-                                                      :field-name         "PRICE"
-                                                      :field-display-name "Price"
-                                                      :parent-id          nil
-                                                      :visibility-type    :normal
-                                                      :position           nil
-                                                      :field-id           (id :venues :price)
-                                                      :fk-field-id        (id :checkins :venue_id)
-                                                      :table-name         "VENUES__via__VENUE_ID"
-                                                      :schema-name        nil}}]
+                   :aggregation  [{:aggregation-type    :sum
+                                   :custom-name         nil
+                                   :field               {:description        nil
+                                                         :base-type          :type/Integer
+                                                         :parent             nil
+                                                         :table-id           (id :venues)
+                                                         :special-type       :type/Category
+                                                         :field-name         "PRICE"
+                                                         :field-display-name "Price"
+                                                         :parent-id          nil
+                                                         :visibility-type    :normal
+                                                         :position           nil
+                                                         :field-id           (id :venues :price)
+                                                         :fk-field-id        (id :checkins :venue_id)
+                                                         :table-name         "VENUES__via__VENUE_ID"
+                                                         :schema-name        nil
+                                                         :min-value          1.0
+                                                         :max-value          4.0}}]
                    :breakout     [{:field {:description        nil
                                            :base-type          :type/Date
                                            :parent             nil
@@ -264,7 +286,9 @@
                                            :field-id           (id :checkins :date)
                                            :fk-field-id        nil
                                            :table-name         "CHECKINS"
-                                           :schema-name        "PUBLIC"}
+                                           :schema-name        "PUBLIC"
+                                           :min-value          nil
+                                           :max-value          nil}
                                    :unit  :day-of-week}]
                    :join-tables  [{:source-field {:field-id   (id :checkins :venue_id)
                                                   :field-name "VENUE_ID"}
@@ -277,7 +301,7 @@
     :fk-field-ids #{(id :checkins :venue_id)}
     :table-ids    #{(id :venues) (id :checkins)}}]
   (let [expanded-form (ql/expand (wrap-inner-query (query checkins
-                                                     (ql/aggregation (ql/sum $venue_id->venues.price))
-                                                     (ql/breakout (ql/datetime-field $checkins.date :day-of-week)))))]
+                                                          (ql/aggregation (ql/sum $venue_id->venues.price))
+                                                          (ql/breakout (ql/datetime-field $checkins.date :day-of-week)))))]
     (mapv obj->map [expanded-form
                     (resolve/resolve expanded-form)])))

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -90,11 +90,13 @@
    :visibility_type :normal
    :schema_name     (data/default-schema)
    :source          :fields
-   :fk_field_id     nil})
+   :fk_field_id     nil
+   :min_value       nil
+   :max_value       nil})
 
 (defn- target-field [field]
   (when (data/fks-supported?)
-    (dissoc field :target :extra_info :schema_name :source :fk_field_id)))
+    (dissoc field :target :extra_info :schema_name :source :fk_field_id :min_value :max_value)))
 
 (defn categories-col
   "Return column information for the `categories` column named by keyword COL."
@@ -125,7 +127,9 @@
      :id         {:special_type :type/PK
                   :base_type    (data/id-field-type)
                   :name         (data/format-name "id")
-                  :display_name "ID"}
+                  :display_name "ID"
+                  :min_value 1.0
+                  :max_value 15.0}
      :name       {:special_type :type/Name
                   :base_type    (data/expected-base-type->actual :type/Text)
                   :name         (data/format-name "name")
@@ -153,7 +157,9 @@
      :id          {:special_type :type/PK
                    :base_type    (data/id-field-type)
                    :name         (data/format-name "id")
-                   :display_name "ID"}
+                   :display_name "ID"
+                   :min_value    1.0
+                   :max_value    100.0}
      :category_id {:extra_info   (if (data/fks-supported?)
                                    {:target_table_id (data/id :categories)}
                                    {})
@@ -163,28 +169,39 @@
                                    :type/Category)
                    :base_type    (data/expected-base-type->actual :type/Integer)
                    :name         (data/format-name "category_id")
-                   :display_name "Category ID"}
+                   :display_name "Category ID"
+                   :min_value    nil
+                   :max_value    nil}
      :price       {:special_type :type/Category
                    :base_type    (data/expected-base-type->actual :type/Integer)
                    :name         (data/format-name "price")
-                   :display_name "Price"}
+                   :display_name "Price"
+                   :min_value    1.0
+                   :max_value    4.0}
      :longitude   {:special_type :type/Longitude
                    :base_type    (data/expected-base-type->actual :type/Float)
                    :name         (data/format-name "longitude")
-                   :display_name "Longitude"}
+                   :display_name "Longitude"
+                   :min_value    nil
+                   :max_value    nil}
      :latitude    {:special_type :type/Latitude
                    :base_type    (data/expected-base-type->actual :type/Float)
                    :name         (data/format-name "latitude")
-                   :display_name "Latitude"}
+                   :display_name "Latitude"
+                   :min_value    nil
+                   :max_value    nil}
      :name        {:special_type :type/Name
                    :base_type    (data/expected-base-type->actual :type/Text)
                    :name         (data/format-name "name")
-                   :display_name "Name"})))
+                   :display_name "Name"
+                   :min_value    nil
+                   :max_value    nil})))
 
 (defn venues-cols
   "`cols` information for all the columns in `venues`."
   []
-  (mapv venues-col [:id :name :category_id :latitude :longitude :price]))
+  (mapv (comp #(assoc % :min_value nil :max_value nil) venues-col)
+        [:id :name :category_id :latitude :longitude :price]))
 
 ;; #### checkins
 (defn checkins-col
@@ -208,7 +225,9 @@
                                 :type/Category)
                 :base_type    (data/expected-base-type->actual :type/Integer)
                 :name         (data/format-name "venue_id")
-                :display_name "Venue ID"}
+                :display_name "Venue ID"
+                :min_value    1.0
+                :max_value    100.0}
      :user_id  {:extra_info   (if (data/fks-supported?) {:target_table_id (data/id :users)}
                                   {})
                 :target       (target-field (users-col :id))
@@ -217,7 +236,9 @@
                                 :type/Category)
                 :base_type    (data/expected-base-type->actual :type/Integer)
                 :name         (data/format-name "user_id")
-                :display_name "User ID"})))
+                :display_name "User ID"
+                :min_value     1.0
+                :max_value     15.0})))
 
 
 ;;; #### aggregate columns

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -13,7 +13,7 @@
 ;; Test the expansion of the expressions clause
 (expect
   {:expressions {:my-cool-new-field (qpi/map->Expression {:operator :*
-                                                          :args [{:field-id 10, :fk-field-id nil, :datetime-unit nil}
+                                                          :args [{:field-id 10, :fk-field-id nil, :datetime-unit nil, :binning-strategy nil}
                                                                  20.0]})}}                                            ; 20 should be converted to a FLOAT
   (ql/expressions {} {:my-cool-new-field (ql/* (ql/field-id 10) 20)}))
 

--- a/test/metabase/query_processor_test/field_visibility_test.clj
+++ b/test/metabase/query_processor_test/field_visibility_test.clj
@@ -18,10 +18,18 @@
   [(set (venues-cols))
    #{(venues-col :category_id)
      (venues-col :name)
-     (venues-col :latitude)
-     (venues-col :id)
-     (venues-col :longitude)
-     (assoc (venues-col :price) :visibility_type :details-only)}
+     (assoc (venues-col :latitude)
+       :min_value nil
+       :max_value nil)
+     (assoc (venues-col :id)
+       :min_value nil
+       :max_value nil)
+     (assoc (venues-col :longitude)
+       :min_value nil
+       :max_value nil)
+     (assoc (venues-col :price) :visibility_type :details-only
+            :min_value nil
+            :max_value nil)}
    (set (venues-cols))]
   [(get-col-names)
    (do (db/update! Field (data/id :venues :price), :visibility_type :details-only)
@@ -34,7 +42,9 @@
 ;;; Make sure :sensitive information fields are never returned by the QP
 (qp-expect-with-all-engines
   {:columns     (->columns "id" "name" "last_login")
-   :cols        [(users-col :id)
+   :cols        [(assoc (users-col :id)
+                   :min_value nil
+                   :max_value nil)
                  (users-col :name)
                  (users-col :last_login)],
    :rows        [[ 1 "Plato Yeshua"]

--- a/test/metabase/sync_database/sync_dynamic_test.clj
+++ b/test/metabase/sync_database/sync_dynamic_test.clj
@@ -35,7 +35,9 @@
    :fk_target_field_id false
    :last_analyzed      false
    :created_at         true
-   :updated_at         true})
+   :updated_at         true
+   :min_value          nil
+   :max_value          nil})
 
 ;; save-table-fields!  (also covers save-nested-fields!)
 (expect

--- a/test/metabase/sync_database/sync_test.clj
+++ b/test/metabase/sync_database/sync_test.clj
@@ -116,7 +116,9 @@
    :fk_target_field_id false
    :last_analyzed      false
    :created_at         true
-   :updated_at         true})
+   :updated_at         true
+   :min_value          nil
+   :max_value          nil})
 
 ;; save-table-fields!
 ;; this test also covers create-field-from-field-def! and update-field-from-field-def!

--- a/test/metabase/sync_database_test.clj
+++ b/test/metabase/sync_database_test.clj
@@ -361,7 +361,8 @@
   (tt/with-temp* [Database [database {:details (:details (Database (id))), :engine :h2}]
                   Table    [table    {:db_id (u/get-id database), :name "VENUES"}]]
     (sync-table! table)
-    [(db/select-one-field :min_value Field, :id (id :venues :longitude))
-     (db/select-one-field :max_value Field, :id (id :venues :longitude))
-     (db/select-one-field :min_value Field, :id (id :venues :latitude))
-     (db/select-one-field :max_value Field, :id (id :venues :latitude))]))
+    (map #(u/round-to-decimals 4 %)
+         [(db/select-one-field :min_value Field, :id (id :venues :longitude))
+          (db/select-one-field :max_value Field, :id (id :venues :longitude))
+          (db/select-one-field :min_value Field, :id (id :venues :latitude))
+          (db/select-one-field :max_value Field, :id (id :venues :latitude))])))

--- a/test/metabase/test/mock/moviedb.clj
+++ b/test/metabase/test/mock/moviedb.clj
@@ -184,7 +184,9 @@
    :position           0
    :visibility_type    :normal
    :preview_display    true
-   :created_at         true})
+   :created_at         true
+   :min_value          nil
+   :max_value          nil})
 
 (def ^:const moviedb-tables-and-fields
   [(merge table-defaults

--- a/test/metabase/test/mock/schema_per_customer.clj
+++ b/test/metabase/test/mock/schema_per_customer.clj
@@ -282,7 +282,9 @@
    :position           0
    :visibility_type    :normal
    :preview_display    true
-   :created_at         true})
+   :created_at         true
+   :min_value          nil
+   :max_value          nil})
 
 (def ^:const schema-per-customer-tables-and-fields
   [(merge table-defaults

--- a/test/metabase/test/mock/toucanery.clj
+++ b/test/metabase/test/mock/toucanery.clj
@@ -109,7 +109,9 @@
    :position           0
    :visibility_type    :normal
    :preview_display    true
-   :created_at         true})
+   :created_at         true
+   :min_value          nil
+   :max_value          nil})
 
 (def ^:const toucanery-tables-and-fields
   [(merge table-defaults


### PR DESCRIPTION
This commit adds new min/max metadata to all numeric columns. That
metadata is used in the automatic binning of breakout fields. This
commit also extends MBQL to indicate that a breakout column (or
columns) should be binned using a "default" strategy. The query must
also include the maximum number of bins. Using the number of bins with
the min/max values, the bin width is computed and used in the SQL
query to group data.

-------------------------------------------

This approach to automatic binning is probably the easiest but it does have some drawbacks. The query includes a "max number of bins". If there are no values for a bin, it does not emit a row. This is a by-product of how SQL works. It seems like this might be unintuitive for users. If the user said they wanted 20 bins, my guess is they'd probably like to see the begin/end range of the bin and 0 for the number of entries for the given bin. The breakout_test changes included in this PR show that unintuitive behavior. The test asks for 20 bins, but the data is very clumpy, so all of the data fits in 5 bins. Creating 20 bins with 0s in the empty bins would be a significantly more complicated query for the query processor, but it should be possible.

Something that @salsakran and I have discussed are various ways that users would want to bin discrete values (number of bins, user defined bins, regex on text) in addition to various defaults or predefined binning strategy values. This approach here assumes that the query includes the information needed to execute the query. With this approach, we could still have an admin setup and name an "age range bin" or "version regex" however the querying for that default/predefined bin would happen earlier in the query pipeline. That strategy would be expanded earlier in the pipeline and query processor would still be able to translate the query and execute it straight away. The query would look something like:

```
{:breakout [[:binning-strategy :version :user "version prefix regex"]]}
```

Which would expand internally to:

```
{:breakout [[:binning-strategy :version :regex "^(v.*)/.*" 1]]}
```

We wouldn't need to expose the flexibility to the user via the UI, it could be just an internal detail which allows a clear separation between query construction and user defined settings. It does seem like allowing users to supply this might be a nice future feature though. The user is clicking into a breakout, uses the admin defined regex, they want something a little bit different. The back-end would just get it's regex from the user rather than a setting.