### PR TITLE
sync favorited item star color

### DIFF
--- a/frontend/src/metabase/questions/components/Item.jsx
+++ b/frontend/src/metabase/questions/components/Item.jsx
@@ -135,7 +135,7 @@ const ItemBody = pure(({ entity, id, name, description, labels, favorite, collec
                         className={cx(
                             "flex cursor-pointer text-brand-hover transition-color",
                             {"hover-child text-light-blue": !favorite},
-                            {"visible text-brand": favorite}
+                            {"visible text-gold": favorite}
                         )}
                         name={favorite ? "star" : "staroutline"}
                         size={ITEM_ICON_SIZE}

--- a/frontend/src/metabase/questions/components/Item.jsx
+++ b/frontend/src/metabase/questions/components/Item.jsx
@@ -133,8 +133,8 @@ const ItemBody = pure(({ entity, id, name, description, labels, favorite, collec
                 <Tooltip tooltip={favorite ? "Unfavorite" : "Favorite"}>
                     <Icon
                         className={cx(
-                            "flex cursor-pointer text-brand-hover transition-color",
-                            {"hover-child text-light-blue": !favorite},
+                            "flex cursor-pointer",
+                            {"hover-child text-light-blue text-brand-hover": !favorite},
                             {"visible text-gold": favorite}
                         )}
                         name={favorite ? "star" : "staroutline"}


### PR DESCRIPTION
Favorited items on dashboard were using gold stars and questions on the listing page were using blue. I figure we should standardize on gold for contrast and good feeling reasons.