### PR TITLE
Improve the error message when using wrong ssh tunnel host

### DIFF
--- a/src/metabase/driver/mongo.clj
+++ b/src/metabase/driver/mongo.clj
@@ -47,7 +47,7 @@
     #"^com.jcraft.jsch.JSchException: Auth fail$"
     (driver/connection-error-messages :ssh-tunnel-auth-fail)
 
-    #"j^ava.net.ConnectException: Connection refused (Connection refused)$"
+    #".*JSchException: java.net.ConnectException: Connection refused.*"
     (driver/connection-error-messages :ssh-tunnel-connection-fail)
 
     #".*"                               ; default


### PR DESCRIPTION
use a human friendly error message when sshd is not running.
Or when running the tests on a computer thats not running sshd



