### PR TITLE
Add Locale configuration setting and Postgres date trunc correction

### DIFF
--- a/bin/version
+++ b/bin/version
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-VERSION="v0.25.0-snapshot"
+VERSION="v0.25.1-snapshot"
 
 # dynamically pull more interesting stuff from latest git commit
 HASH=$(git show-ref --head --hash=7 head)            # first 7 letters of hash should be enough; that's what GitHub uses

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -51,6 +51,13 @@ const SECTIONS = [
                 allowValueCollection: true
             },
             {
+                key: "locale",
+                display_name: "Locale",
+                type: "string",
+                defaultValue: "en",
+                note: "This uses Sunday as first day of the week. If you would like Monday as first day of week, please use \"en_gb\" (without quotes)."
+            },
+            {
                 key: "anon-tracking-enabled",
                 display_name: "Anonymous Tracking",
                 type: "boolean"

--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -16,6 +16,9 @@ import type { Column, Value } from "metabase/meta/types/Dataset";
 import type { DatetimeUnit } from "metabase/meta/types/Query";
 import type { Moment } from "metabase/meta/types";
 
+// fix local to GB so that time and dates follow close to UTC instead of forcing US standards.
+moment.locale('en-gb');
+
 export type FormattingOptions = {
     column?: Column,
     majorWidth?: number,
@@ -109,7 +112,8 @@ export function formatTimeRangeWithUnit(value: Value, unit: DatetimeUnit, option
 
 function formatWeek(m: Moment, options: FormattingOptions = {}) {
     // force 'en' locale for now since our weeks currently always start on Sundays
-    m = m.locale("en");
+//    m = m.locale("en");
+    console.log('yolo', m, options);
     return formatMajorMinor(m.format("Wo"), m.format("GGGG"), options);
 }
 

--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -110,7 +110,7 @@ export function formatTimeRangeWithUnit(value: Value, unit: DatetimeUnit, option
 function formatWeek(m: Moment, options: FormattingOptions = {}) {
     // force 'en' locale for now since our weeks currently always start on Sundays
     m = m.locale("en");
-    return formatMajorMinor(m.format("wo"), m.format("gggg"), options);
+    return formatMajorMinor(m.format("Wo"), m.format("GGGG"), options);
 }
 
 export function formatTimeWithUnit(value: Value, unit: DatetimeUnit, options: FormattingOptions = {}) {
@@ -153,7 +153,7 @@ export function formatTimeWithUnit(value: Value, unit: DatetimeUnit, options: Fo
         case "day-of-month":
             return moment().date(value).format("D");
         case "week-of-year": // 1st
-            return moment().week(value).format("wo");
+            return moment().week(value).format("Wo");
         case "month-of-year": // January
             // $FlowFixMe:
             return moment().month(value - 1).format("MMMM");

--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -1,5 +1,5 @@
 /* @flow */
-
+import MetabaseSettings from "metabase/lib/settings";
 import d3 from "d3";
 import inflection from "inflection";
 import moment from "moment";
@@ -16,8 +16,8 @@ import type { Column, Value } from "metabase/meta/types/Dataset";
 import type { DatetimeUnit } from "metabase/meta/types/Query";
 import type { Moment } from "metabase/meta/types";
 
-// fix local to GB so that time and dates follow close to UTC instead of forcing US standards.
-moment.locale('en-gb');
+// use setting value to configure locale for dates
+moment.locale(MetabaseSettings.get("locale"));
 
 export type FormattingOptions = {
     column?: Column,

--- a/frontend/src/metabase/lib/settings.js
+++ b/frontend/src/metabase/lib/settings.js
@@ -35,6 +35,10 @@ const MetabaseSettings = {
         return mb_settings.admin_email;
     },
 
+    locale: function() {
+        return mb_settings.locale;
+    },
+
     isEmailConfigured: function() {
         return mb_settings.email_configured;
     },

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -134,9 +134,8 @@
     :day-of-month    (extract-integer :day expr)
     :day-of-year     (extract-integer :doy expr)
     ;; Postgres weeks start on Monday, so shift this date into the proper bucket and then decrement the resulting day
-    :week            (hx/- (date-trunc :week (hx/+ (hx/->timestamp expr) one-day))
-                           one-day)
-    :week-of-year    (extract-integer :week (hx/+ (hx/->timestamp expr) one-day))
+    :week            (date-trunc :week expr)
+    :week-of-year    (extract-integer :week expr)
     :month           (date-trunc :month expr)
     :month-of-year   (extract-integer :month expr)
     :quarter         (date-trunc :quarter expr)

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -36,6 +36,10 @@
 (defsetting admin-email
   "The email address users should be referred to if they encounter a problem.")
 
+(defsetting locale
+            "Locale for displaying dates and times. Default is \"en\" (US)."
+            :default "en")
+
 (defsetting anon-tracking-enabled
   "Enable the collection of anonymous usage data in order to help Metabase improve."
   :type   :boolean
@@ -132,4 +136,5 @@
    :timezone_short        (short-timezone-name (setting/get :report-timezone))
    :timezones             common/timezones
    :types                 (types/types->parents)
-   :version               config/mb-version-info})
+   :version               config/mb-version-info
+   :locale                (locale)})


### PR DESCRIPTION
# Overview
This PR adds a configurable Locale setting to Metabase. This is used only to configure the locale for `moment.js` and does not affect language and number formatting. The default is kept as `en` (US) locale but allows changing based on any locale listed [here](https://github.com/moment/moment/tree/master/locale).

The second change is that for Postgres data source _only_ the date trunc transformation for week is now an unmodified implementation. This follows postgres' standard of defining week boundaries instead of Metabase deciding the week boundary. 

Locale Setting UI:
![image](https://cloud.githubusercontent.com/assets/14027470/26067289/949d4110-3991-11e7-8825-61f62fedabfa.png)

Locale Setting effect (default):
![image](https://cloud.githubusercontent.com/assets/14027470/26067297/a1fbdc90-3991-11e7-98bd-1e318c3f3e70.png)

Locale Setting using `en_gb` locale:
![image](https://cloud.githubusercontent.com/assets/14027470/26067310/af08d32a-3991-11e7-8e2a-719750f43ba9.png)

Locale Setting using `ja` locale:
![image](https://cloud.githubusercontent.com/assets/14027470/26067325/b7d06428-3991-11e7-9a8e-2fc547606bcf.png)

One thing to be mindful of is the language is still English so other than the symbols defined in locale files, everything will be in English. 

# Related Issues
- https://github.com/metabase/metabase/issues/4910
- https://github.com/metabase/metabase/issues/1779
- https://github.com/metabase/metabase/issues/2517

# Comments/Questions
- Should the locale setting be a drop down list similar to timezone setting?
- Verify other areas of Metabase which might need modification. 
  - Other data sources (not applicable to Hudl).
- What other changes need to be made related to this?

###### TODO 
-  [ ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
