### PR TITLE
Fix permissions page for dbs that don't have schemas

### DIFF
--- a/frontend/src/metabase/admin/permissions/selectors.js
+++ b/frontend/src/metabase/admin/permissions/selectors.js
@@ -147,7 +147,7 @@ function getRevokingAccessToAllTablesWarningModal(database, permissions, groupId
         // allTableEntityIds contains tables from all schemas
         const allTableEntityIds = database.tables().map((table) => ({
             databaseId: table.db_id,
-            schemaName: table.schema,
+            schemaName: table.schema || "",
             tableId: table.id
         }));
 

--- a/frontend/src/metabase/admin/permissions/selectors.js
+++ b/frontend/src/metabase/admin/permissions/selectors.js
@@ -457,7 +457,7 @@ export const getDatabasesPermissionsGrid = createSelector(
 
 const getCollections = (state) => state.admin.permissions.collections;
 const getCollectionPermission = (permissions, groupId, { collectionId }) =>
-    getIn(permissions, [groupId, collectionId])
+    getIn(permissions, [groupId, collectionId]);
 
 export const getCollectionsPermissionsGrid = createSelector(
     getCollections, getGroups, getPermissions,
@@ -504,7 +504,6 @@ export const getCollectionsPermissionsGrid = createSelector(
         }
     }
 );
-
 
 export const getDiff = createSelector(
     getMeta, getGroups, getPermissions, getOriginalPermissions,

--- a/frontend/src/metabase/admin/permissions/selectors.spec.fixtures.js
+++ b/frontend/src/metabase/admin/permissions/selectors.spec.fixtures.js
@@ -1,39 +1,12 @@
-// Database 1 contains the stripped metadata of sample dataset as of 5/24/17
 import {getMetadata} from "metabase/selectors/metadata";
 // Database 2 contains an imaginary multi-schema database (like Redshift for instance)
 // Database 3 contains an imaginary database which doesn't have any schemas (like MySQL)
+// (A single-schema database was originally Database 1 but it got removed as testing against it felt redundant)
 
 export const normalizedMetadata = {
     "metrics": {},
     "segments": {},
     "databases": {
-        "1": {
-            "description": null,
-            "features": [
-                "basic-aggregations",
-                "standard-deviation-aggregations",
-                "expression-aggregations",
-                "foreign-keys",
-                "native-parameters",
-                "expressions"
-            ],
-            "name": "Sample Dataset",
-            "caveats": null,
-            "tables": [
-                1,
-                2,
-                3,
-                4
-            ],
-            "is_full_sync": true,
-            "updated_at": "2017-05-15T18:05:07.493Z",
-            "native_permissions": "write",
-            "is_sample": true,
-            "id": 1,
-            "engine": "h2",
-            "created_at": "2017-05-15T18:05:07.493Z",
-            "points_of_interest": null
-        },
         "2": {
             "name": "Imaginary Multi-Schema Dataset",
             "tables": [
@@ -59,106 +32,6 @@ export const normalizedMetadata = {
         }
     },
     "tables": {
-        "1": {
-            "description": "This is a confirmed order for a product from a user.",
-            "entity_type": null,
-            "schema": "PUBLIC",
-            "raw_table_id": 2,
-            "show_in_getting_started": false,
-            "name": "ORDERS",
-            "caveats": null,
-            "rows": 17624,
-            "updated_at": "2017-05-15T18:05:08.417Z",
-            "entity_name": null,
-            "active": true,
-            "id": 1,
-            "db_id": 1,
-            "visibility_type": null,
-            "display_name": "Orders",
-            "created_at": "2017-05-15T18:05:07.787Z",
-            "points_of_interest": null,
-            "db": 1,
-            // "fields": [1, 2, 3, 4, 5, 6, 7],
-            "fields": [],
-            "segments": [],
-            "field_values": {/* stripped out */},
-            "metrics": []
-        },
-        "2": {
-            "description": "This is a user account. Note that employees and customer support staff will have accounts.",
-            "entity_type": null,
-            "schema": "PUBLIC",
-            "raw_table_id": 3,
-            "show_in_getting_started": false,
-            "name": "PEOPLE",
-            "caveats": null,
-            "rows": 2500,
-            "updated_at": "2017-05-15T18:05:08.723Z",
-            "entity_name": null,
-            "active": true,
-            "id": 2,
-            "db_id": 1,
-            "visibility_type": null,
-            "display_name": "People",
-            "created_at": "2017-05-15T18:05:07.821Z",
-            "points_of_interest": null,
-            "db": 1,
-            // "fields": [8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
-            "fields": [],
-            "segments": [],
-            "field_values": {/* stripped out */},
-            "metrics": []
-        },
-        "3": {
-            "description": "This is our product catalog. It includes all products ever sold by the Sample Company.",
-            "entity_type": null,
-            "schema": "PUBLIC",
-            "raw_table_id": 1,
-            "show_in_getting_started": false,
-            "name": "PRODUCTS",
-            "caveats": null,
-            "rows": 200,
-            "updated_at": "2017-05-15T18:05:08.818Z",
-            "entity_name": null,
-            "active": true,
-            "id": 3,
-            "db_id": 1,
-            "visibility_type": null,
-            "display_name": "Products",
-            "created_at": "2017-05-15T18:05:07.854Z",
-            "points_of_interest": null,
-            "db": 1,
-            // "fields": [21, 22, 23, 24, 25, 26, 27, 28],
-            "fields": [],
-            "segments": [],
-            "field_values": {/* stripped out */},
-            "metrics": []
-        },
-        "4": {
-            "description": "These are reviews our customers have left on products. Note that these are not tied to orders so it is possible people have reviewed products they did not purchase from us.",
-            "entity_type": null,
-            "schema": "PUBLIC",
-            "raw_table_id": 5,
-            "show_in_getting_started": false,
-            "name": "REVIEWS",
-            "caveats": null,
-            "rows": 1078,
-            "updated_at": "2017-05-15T18:05:08.876Z",
-            "entity_name": null,
-            "active": true,
-            "id": 4,
-            "db_id": 1,
-            "visibility_type": null,
-            "display_name": "Reviews",
-            "created_at": "2017-05-15T18:05:07.873Z",
-            "points_of_interest": null,
-            "db": 1,
-            // "fields": [29, 30, 31, 32, 33, 34],
-            "fields": [],
-            "segments": [],
-            "field_values": {/* stripped out */},
-            "metrics": []
-        },
         "5": {
             "schema": "schema_1",
             "name": "Avian Singles Messages",
@@ -216,7 +89,7 @@ export const normalizedMetadata = {
     },
     "fields": {/* stripped out */},
     "revisions": {},
-    "databasesList": [1, 2, 3]
+    "databasesList": [2, 3]
 };
 
 export const denormalizedMetadata = getMetadata({metadata: normalizedMetadata});

--- a/frontend/src/metabase/admin/permissions/selectors.spec.fixtures.js
+++ b/frontend/src/metabase/admin/permissions/selectors.spec.fixtures.js
@@ -1,0 +1,207 @@
+// Database 1 contains the stripped metadata of sample dataset as of 5/24/17
+import {getMetadata} from "metabase/selectors/metadata";
+// Database 2 contains an imaginary multi-schema database (like Redshift for instance)
+// Database 3 contains an imaginary database which doesn't have any schemas (like MySQL)
+
+export const normalizedMetadata = {
+    "metrics": {},
+    "segments": {},
+    "databases": {
+        "1": {
+            "description": null,
+            "features": [
+                "basic-aggregations",
+                "standard-deviation-aggregations",
+                "expression-aggregations",
+                "foreign-keys",
+                "native-parameters",
+                "expressions"
+            ],
+            "name": "Sample Dataset",
+            "caveats": null,
+            "tables": [
+                1,
+                2,
+                3,
+                4
+            ],
+            "is_full_sync": true,
+            "updated_at": "2017-05-15T18:05:07.493Z",
+            "native_permissions": "write",
+            "is_sample": true,
+            "id": 1,
+            "engine": "h2",
+            "created_at": "2017-05-15T18:05:07.493Z",
+            "points_of_interest": null
+        },
+        "2": {
+            "name": "Imaginary Multi-Schema Dataset",
+            "tables": [
+                // In schema_1
+                5,
+                6,
+                // In schema_2
+                7,
+                8,
+                9
+            ],
+            "id": 2
+        },
+        "3": {
+            "name": "Imaginary Schemaless Dataset",
+            "tables": [
+                10,
+                11,
+                12
+            ],
+            "id": 3
+        }
+    },
+    "tables": {
+        "1": {
+            "description": "This is a confirmed order for a product from a user.",
+            "entity_type": null,
+            "schema": "PUBLIC",
+            "raw_table_id": 2,
+            "show_in_getting_started": false,
+            "name": "ORDERS",
+            "caveats": null,
+            "rows": 17624,
+            "updated_at": "2017-05-15T18:05:08.417Z",
+            "entity_name": null,
+            "active": true,
+            "id": 1,
+            "db_id": 1,
+            "visibility_type": null,
+            "display_name": "Orders",
+            "created_at": "2017-05-15T18:05:07.787Z",
+            "points_of_interest": null,
+            "db": 1,
+            // "fields": [1, 2, 3, 4, 5, 6, 7],
+            "fields": [],
+            "segments": [],
+            "field_values": {/* stripped out */},
+            "metrics": []
+        },
+        "2": {
+            "description": "This is a user account. Note that employees and customer support staff will have accounts.",
+            "entity_type": null,
+            "schema": "PUBLIC",
+            "raw_table_id": 3,
+            "show_in_getting_started": false,
+            "name": "PEOPLE",
+            "caveats": null,
+            "rows": 2500,
+            "updated_at": "2017-05-15T18:05:08.723Z",
+            "entity_name": null,
+            "active": true,
+            "id": 2,
+            "db_id": 1,
+            "visibility_type": null,
+            "display_name": "People",
+            "created_at": "2017-05-15T18:05:07.821Z",
+            "points_of_interest": null,
+            "db": 1,
+            // "fields": [8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+            "fields": [],
+            "segments": [],
+            "field_values": {/* stripped out */},
+            "metrics": []
+        },
+        "3": {
+            "description": "This is our product catalog. It includes all products ever sold by the Sample Company.",
+            "entity_type": null,
+            "schema": "PUBLIC",
+            "raw_table_id": 1,
+            "show_in_getting_started": false,
+            "name": "PRODUCTS",
+            "caveats": null,
+            "rows": 200,
+            "updated_at": "2017-05-15T18:05:08.818Z",
+            "entity_name": null,
+            "active": true,
+            "id": 3,
+            "db_id": 1,
+            "visibility_type": null,
+            "display_name": "Products",
+            "created_at": "2017-05-15T18:05:07.854Z",
+            "points_of_interest": null,
+            "db": 1,
+            // "fields": [21, 22, 23, 24, 25, 26, 27, 28],
+            "fields": [],
+            "segments": [],
+            "field_values": {/* stripped out */},
+            "metrics": []
+        },
+        "4": {
+            "description": "These are reviews our customers have left on products. Note that these are not tied to orders so it is possible people have reviewed products they did not purchase from us.",
+            "entity_type": null,
+            "schema": "PUBLIC",
+            "raw_table_id": 5,
+            "show_in_getting_started": false,
+            "name": "REVIEWS",
+            "caveats": null,
+            "rows": 1078,
+            "updated_at": "2017-05-15T18:05:08.876Z",
+            "entity_name": null,
+            "active": true,
+            "id": 4,
+            "db_id": 1,
+            "visibility_type": null,
+            "display_name": "Reviews",
+            "created_at": "2017-05-15T18:05:07.873Z",
+            "points_of_interest": null,
+            "db": 1,
+            // "fields": [29, 30, 31, 32, 33, 34],
+            "fields": [],
+            "segments": [],
+            "field_values": {/* stripped out */},
+            "metrics": []
+        },
+        "5": {
+            "schema": "schema_1",
+            "name": "Avian Singles Messages",
+            "id": 5
+        },
+        "6": {
+            "schema": "schema_1",
+            "name": "Avian Singles Users",
+            "id": 6
+        },
+        "7": {
+            "schema": "schema_2",
+            "name": "Tupac Sightings Sightings",
+            "id": 7
+        },
+        "8": {
+            "schema": "schema_2",
+            "name": "Tupac Sightings Categories",
+            "id": 8
+        },
+        "9": {
+            "schema": "schema_2",
+            "name": "Tupac Sightings Cities",
+            "id": 9
+        },
+        "10": {
+            "schema": null,
+            "name": "Badminton Men's Double Results",
+            "id": 10
+        },
+        "11": {
+            "schema": null,
+            "name": "Badminton Mixed Double Results",
+            "id": 11
+        },
+        "12": {
+            "schema": null,
+            "name": "Badminton Women's Singles Results",
+            "id": 12
+        },
+    },
+    "fields": {/* stripped out */},
+    "revisions": {},
+    "databasesList": [1, 2, 3]
+};
+
+export const denormalizedMetadata = getMetadata({metadata: normalizedMetadata});

--- a/frontend/src/metabase/admin/permissions/selectors.spec.fixtures.js
+++ b/frontend/src/metabase/admin/permissions/selectors.spec.fixtures.js
@@ -52,7 +52,8 @@ export const normalizedMetadata = {
             "tables": [
                 10,
                 11,
-                12
+                12,
+                13
             ],
             "id": 3
         }
@@ -161,42 +162,56 @@ export const normalizedMetadata = {
         "5": {
             "schema": "schema_1",
             "name": "Avian Singles Messages",
-            "id": 5
+            "id": 5,
+            "db_id": 2
         },
         "6": {
             "schema": "schema_1",
             "name": "Avian Singles Users",
-            "id": 6
+            "id": 6,
+            "db_id": 2
         },
         "7": {
             "schema": "schema_2",
             "name": "Tupac Sightings Sightings",
-            "id": 7
+            "id": 7,
+            "db_id": 2
         },
         "8": {
             "schema": "schema_2",
             "name": "Tupac Sightings Categories",
-            "id": 8
+            "id": 8,
+            "db_id": 2
         },
         "9": {
             "schema": "schema_2",
             "name": "Tupac Sightings Cities",
-            "id": 9
+            "id": 9,
+            "db_id": 2
         },
         "10": {
             "schema": null,
             "name": "Badminton Men's Double Results",
-            "id": 10
+            "id": 10,
+            "db_id": 3
         },
         "11": {
             "schema": null,
             "name": "Badminton Mixed Double Results",
-            "id": 11
+            "id": 11,
+            "db_id": 3
         },
         "12": {
             "schema": null,
             "name": "Badminton Women's Singles Results",
-            "id": 12
+            "id": 12,
+            "db_id": 3
+        },
+        "13": {
+            "schema": null,
+            "name": "Badminton Mixed Singles Results",
+            "id": 13,
+            "db_id": 3
         },
     },
     "fields": {/* stripped out */},

--- a/frontend/src/metabase/admin/permissions/selectors.spec.js
+++ b/frontend/src/metabase/admin/permissions/selectors.spec.js
@@ -1,0 +1,127 @@
+/**
+ * This test simulates a scenario where permissions to a database with multiple schemas (like Redshift)
+ * and multiple user groups are being modified using the methods provided by the getXPermissionsGrid selectors.
+ */
+
+jest.mock('metabase/lib/analytics');
+
+import {GroupsPermissions} from "metabase/meta/types/Permissions";
+import { denormalizedMetadata } from "./selectors.spec.fixtures";
+import { getTablesPermissionsGrid, getSchemasPermissionsGrid, getDatabasesPermissionsGrid } from "./selectors";
+import Metadata from "metabase/meta/metadata/Metadata";
+
+// Members of Group 1 have a full access to all databases but the admins plan to restrict its access
+// Members of Group 2 has mixed very restricted access to databases, and admins want to grant them some more freedom
+
+const groups = [{
+    id: 1,
+    name: "Executive team",
+}, {
+    id: 2,
+    name: "Customer assistance team",
+}];
+
+const initialPermissions: GroupsPermissions = {
+    1: {
+        // Sample dataset
+        1: {
+            "native": "write",
+            "schemas": "all"
+        },
+        // Imaginary multi-schema
+        2: {
+            "native": "write",
+            "schemas": "all"
+        },
+        // Imaginary schemaless
+        3: {
+            "native": "none",
+            "schemas": "none"
+        }
+    },
+    2: {
+        // Sample dataset
+        1: {
+            "native": "write",
+            "schemas": "all"
+        },
+        // Imaginary multi-schema
+        2: {
+            "native": "read",
+            "schemas": {
+                "schema_1": "none",
+                "schema_2": {
+                    "7": "all",
+                    "8": "none",
+                    "9": "none",
+                },
+            }
+        },
+        // Imaginary schemaless
+        3: {
+            "native": "write",
+            "schemas": "all"
+        }
+    }
+};
+
+const reduxState = {
+    admin: {
+        permissions: {
+            permissions: initialPermissions,
+            originalPermissions: initialPermissions,
+            groups,
+            databases: denormalizedMetadata.databases
+        }
+    }
+};
+
+const getProps = ({ databaseId, schemaName }) => ({
+    params: {
+        databaseId,
+            schemaName
+    }
+});
+
+describe("permissions selectors", () => {
+    const sampleDatasetEntityId = {databaseId: 1, schemaName: "PUBLIC"};
+
+    it("should behave correctly when restricting access to the sample dataset", () => {
+        const grid = getTablesPermissionsGrid(reduxState, getProps(sampleDatasetEntityId));
+        const updatedPermissions = grid.permissions.fields.updater(1, {...sampleDatasetEntityId, tableId: 1}, "none");
+
+        expect(updatedPermissions).toMatchObject({
+           "1": {
+               "1": {
+                   // should downgrade to read native permission
+                   "native": "read",
+                   "schemas": {
+                       "PUBLIC": {
+                           "1": "none",
+                           "2": "all",
+                           "3": "all",
+                           "4": "all"
+                       }
+                   }
+               }
+           }
+        });
+    });
+    // it("should behave correctly when granting more access to the sample dataset", () => {
+    //
+    // });
+    //
+    // it("should behave correctly when restricting access to a multi-schema dataset", () => {
+    //
+    // });
+    // it("should behave correctly when granting more access to a multi-schema dataset", () => {
+    //
+    // });
+    //
+    // it("should behave correctly when restricting access to a schemaless dataset", () => {
+    //
+    // });
+    // it("should behave correctly when granting more access to a schemaless dataset", () => {
+    //
+    // });
+});

--- a/frontend/src/metabase/admin/permissions/selectors.spec.js
+++ b/frontend/src/metabase/admin/permissions/selectors.spec.js
@@ -272,21 +272,28 @@ describe("permissions selectors", () => {
                 }
             });
 
-            // Revoking access to the rest of tables in schema one-by-one
-            schema1.changeTablePermissions({ tableId: 6, groupId: 1, permission: "none" });
-
-            expect(schema1.getPermissions({groupId: 1})).toMatchObject({
-                "native": "read",
-                "schemas": {
-                    "schema_1": "none",
-                    "schema_2": "all"
-                }
-            });
-
-            // An intermediary state
+            // State where both schemas have mixed permissions
             schema2.changeTablePermissions({ tableId: 8, groupId: 1, permission: "none" });
             schema2.changeTablePermissions({ tableId: 9, groupId: 1, permission: "none" });
             expect(schema2.getPermissions({groupId: 1})).toMatchObject({
+                "native": "read",
+                "schemas": {
+                    "schema_1": {
+                        "5": "none",
+                        "6": "all"
+                    },
+                    "schema_2": {
+                        "7": "all",
+                        "8": "none",
+                        "9": "none"
+                    }
+                }
+            });
+
+            // Completely revoke access to the first schema with table-level changes
+            schema1.changeTablePermissions({ tableId: 6, groupId: 1, permission: "none" });
+
+            expect(schema1.getPermissions({groupId: 1})).toMatchObject({
                 "native": "read",
                 "schemas": {
                     "schema_1": "none",
@@ -333,7 +340,7 @@ describe("permissions selectors", () => {
                 "schemas": "all"
             });
 
-            // Should not let change the native permission to none
+            // Should let change the native permission to none
             schema1.changeDbNativePermissions({ groupId: 1, permission: "none" });
             expect(schema1.getPermissions({groupId: 1})).toMatchObject({
                 "native": "none",
@@ -364,13 +371,33 @@ describe("permissions selectors", () => {
                 }
             });
 
-            // Grant the access to rest of tables in that schema
+            // State where both schemas have mixed permissions
+            schema1.changeTablePermissions({ tableId: 5, groupId: 2, permission: "all" });
+            expect(schema1.getPermissions({groupId: 2})).toMatchObject({
+                "native": "none",
+                "schemas": {
+                    "schema_1": {
+                        "5": "all",
+                        "6": "none"
+                    },
+                    "schema_2": {
+                        "7": "all",
+                        "8": "none",
+                        "9": "none"
+                    }
+                }
+            });
+
+            // Grant full access to the second schema
             schema2.changeTablePermissions({ tableId: 8, groupId: 2, permission: "all" });
             schema2.changeTablePermissions({ tableId: 9, groupId: 2, permission: "all" });
             expect(schema2.getPermissions({groupId: 2})).toMatchObject({
                 "native": "none",
                 "schemas": {
-                    "schema_1": "none",
+                    "schema_1": {
+                        "5": "all",
+                        "6": "none"
+                    },
                     "schema_2": "all"
                 }
             });

--- a/frontend/src/metabase/admin/permissions/selectors.spec.js
+++ b/frontend/src/metabase/admin/permissions/selectors.spec.js
@@ -1,6 +1,8 @@
 /**
- * This test simulates a scenario where permissions to a database with multiple schemas (like Redshift)
- * and multiple user groups are being modified using the methods provided by the getXPermissionsGrid selectors.
+ * Tests granting and revoking permissions against three kinds of datasets:
+ * - dataset with tables in a single PUBLIC schema (for instance H2 or PostgreSQL if no custom schemas created)
+ * - dataset with no schemas (for instance MySQL)
+ * - dataset with multiple schemas (for instance Redshift)
  */
 
 import { setIn } from "icepick";
@@ -13,14 +15,12 @@ import { getTablesPermissionsGrid, getSchemasPermissionsGrid, getDatabasesPermis
 
 /******** INITIAL TEST STATE ********/
 
-// Members of Group 1 have a full access to all databases but the admins plan to restrict its access
-// Members of Group 2 has mixed very restricted access to databases, and admins want to grant them some more freedom
 const groups = [{
     id: 1,
-    name: "Executive team",
+    name: "Group starting with full access",
 }, {
     id: 2,
-    name: "Customer assistance team",
+    name: "Group starting with no access at all",
 }];
 
 const initialPermissions: GroupsPermissions = {
@@ -37,8 +37,8 @@ const initialPermissions: GroupsPermissions = {
         },
         // Imaginary schemaless
         3: {
-            "native": "none",
-            "schemas": "none"
+            "native": "write",
+            "schemas": "all"
         }
     },
     2: {
@@ -49,15 +49,8 @@ const initialPermissions: GroupsPermissions = {
         },
         // Imaginary multi-schema
         2: {
-            "native": "read",
-            "schemas": {
-                "schema_1": "none",
-                "schema_2": {
-                    "7": "all",
-                    "8": "none",
-                    "9": "none",
-                },
-            }
+            "native": "none",
+            "schemas": "none"
         },
         // Imaginary schemaless
         3: {
@@ -139,7 +132,10 @@ const getMethodsForDbAndSchema = (entityId) => ({
 /******** ACTUAL TESTS ********/
 
 describe("permissions selectors", () => {
-    describe("for sample dataset", () => {
+    beforeEach(resetState);
+
+    // TODO: Consider the removal of this test as multi-schema scenario is more extensive
+    describe("for a sample dataset", () => {
         const sampleDataset = getMethodsForDbAndSchema({ databaseId: 1, schemaName: "PUBLIC" });
 
         it("should restrict access correctly on table level", () => {
@@ -170,8 +166,22 @@ describe("permissions selectors", () => {
         });
 
         it("should restrict access correctly on db level", () => {
+            // Should let change the native permission to "read"
+            sampleDataset.changeDbNativePermissions({ groupId: 1, permission: "read" });
+            expect(sampleDataset.getPermissions({groupId: 1})).toMatchObject({
+                "native": "read",
+                "schemas": "all"
+            });
+
+            // Should not let change the native permission to none
+            sampleDataset.changeDbNativePermissions({ groupId: 1, permission: "none" });
+            expect(sampleDataset.getPermissions({groupId: 1})).toMatchObject({
+                "native": "none",
+                "schemas": "all"
+            });
+
+            resetState(); // ad-hoc state reset for the next test
             // Revoking the data access to the database at once should revoke all permissions for that database
-            resetState();
             sampleDataset.changeDbDataPermissions({ groupId: 1, permission: "none" });
             expect(sampleDataset.getPermissions({groupId: 1})).toMatchObject({
                 "native": "none",
@@ -181,7 +191,6 @@ describe("permissions selectors", () => {
 
         it("should grant more access correctly on table level", () => {
             // Simply grant an access to a single table
-            resetState();
             sampleDataset.changeTablePermissions({ tableId: 3, groupId: 2, permission: "all" });
             expect(sampleDataset.getPermissions({groupId: 2})).toMatchObject({
                 "native": "none",
@@ -203,7 +212,311 @@ describe("permissions selectors", () => {
                 "native": "none",
                 "schemas": "all"
             });
+
+
+            // Should pass changes to native permissions through
+            sampleDataset.changeDbNativePermissions({ groupId: 2, permission: "read" });
+            expect(sampleDataset.getPermissions({ groupId: 2 })).toMatchObject({
+                "native": "read",
+                "schemas": "all"
+            });
         });
+
+        it("should grant more access correctly on db level", () => {
+            // Setting limited access should produce a permission tree where each schema has "none" access
+            // (this is a strange, rather no-op edge case but the UI currently enables this)
+            sampleDataset.changeDbDataPermissions({ groupId: 2, permission: "controlled" });
+            expect(sampleDataset.getPermissions({ groupId: 2 })).toMatchObject({
+                "native": "none",
+                "schemas": {
+                    "PUBLIC": "none"
+                }
+            });
+
+            // Granting native access should also grant a full write access
+            sampleDataset.changeDbNativePermissions({ groupId: 2, permission: "write" });
+            expect(sampleDataset.getPermissions({ groupId: 2 })).toMatchObject({
+                "native": "write",
+                "schemas": "all"
+            });
+
+            resetState(); // ad-hoc reset (normally run before tests)
+            // test that setting full access works too
+            sampleDataset.changeDbDataPermissions({ groupId: 2, permission: "all" });
+            expect(sampleDataset.getPermissions({ groupId: 2 })).toMatchObject({
+                "native": "none",
+                "schemas": "all"
+            });
+        })
+    });
+
+    describe("for a schemaless dataset", () => {
+        // Schema "name" (better description would be a "permission path identifier") is simply an empty string
+        // for databases where the metadata value for table schema is `null`
+        const schemalessDataset = getMethodsForDbAndSchema({ databaseId: 3, schemaName: "" });
+
+        it("should restrict access correctly on table level", () => {
+            // Revoking access to one table should downgrade the native permissions to "read"
+            schemalessDataset.changeTablePermissions({ tableId: 10, groupId: 1, permission: "none" });
+            expect(schemalessDataset.getPermissions({ groupId: 1})).toMatchObject({
+                "native": "read",
+                "schemas": {
+                    "": {
+                        "10": "none",
+                        "11": "all",
+                        "12": "all",
+                        "13": "all"
+                    }
+                }
+            });
+
+            // Revoking access to the rest of tables one-by-one...
+            schemalessDataset.changeTablePermissions({ tableId: 11, groupId: 1, permission: "none" });
+            schemalessDataset.changeTablePermissions({ tableId: 12, groupId: 1, permission: "none" });
+            schemalessDataset.changeTablePermissions({ tableId: 13, groupId: 1, permission: "none" });
+
+            expect(schemalessDataset.getPermissions({groupId: 1})).toMatchObject({
+                // ...should revoke all permissions for that database
+                "native": "none",
+                "schemas": "none"
+            });
+
+        });
+
+        it("should restrict access correctly on db level", () => {
+            // Should let change the native permission to "read"
+            schemalessDataset.changeDbNativePermissions({ groupId: 1, permission: "read" });
+            expect(schemalessDataset.getPermissions({groupId: 1})).toMatchObject({
+                "native": "read",
+                "schemas": "all"
+            });
+
+            // Should not let change the native permission to none
+            schemalessDataset.changeDbNativePermissions({ groupId: 1, permission: "none" });
+            expect(schemalessDataset.getPermissions({groupId: 1})).toMatchObject({
+                "native": "none",
+                "schemas": "all"
+            });
+
+            resetState(); // ad-hoc state reset for the next test
+            // Revoking the data access to the database at once should revoke all permissions for that database
+            schemalessDataset.changeDbDataPermissions({ groupId: 1, permission: "none" });
+            expect(schemalessDataset.getPermissions({groupId: 1})).toMatchObject({
+                "native": "none",
+                "schemas": "none"
+            });
+        });
+
+        it("should grant more access correctly on table level", () => {
+            // Simply grant an access to a single table
+            schemalessDataset.changeTablePermissions({ tableId: 12, groupId: 2, permission: "all" });
+            expect(schemalessDataset.getPermissions({groupId: 2})).toMatchObject({
+                "native": "none",
+                "schemas": {
+                    "": {
+                        "10": "none",
+                        "11": "none",
+                        "12": "all",
+                        "13": "none"
+                    }
+                }
+            });
+
+            // Grant the access to rest of tables
+            schemalessDataset.changeTablePermissions({ tableId: 10, groupId: 2, permission: "all" });
+            schemalessDataset.changeTablePermissions({ tableId: 11, groupId: 2, permission: "all" });
+            schemalessDataset.changeTablePermissions({ tableId: 13, groupId: 2, permission: "all" });
+            expect(schemalessDataset.getPermissions({groupId: 2})).toMatchObject({
+                "native": "none",
+                "schemas": "all"
+            });
+
+
+            // Should pass changes to native permissions through
+            schemalessDataset.changeDbNativePermissions({ groupId: 2, permission: "read" });
+            expect(schemalessDataset.getPermissions({ groupId: 2 })).toMatchObject({
+                "native": "read",
+                "schemas": "all"
+            });
+        });
+
+        it("should grant more access correctly on db level", () => {
+            // Setting limited access should produce a permission tree where each schema has "none" access
+            // (this is a strange, rather no-op edge case but the UI currently enables this)
+            schemalessDataset.changeDbDataPermissions({ groupId: 2, permission: "controlled" });
+            expect(schemalessDataset.getPermissions({ groupId: 2 })).toMatchObject({
+                "native": "none",
+                "schemas": {
+                    "": "none"
+                }
+            });
+
+            // Granting native access should also grant a full write access
+            schemalessDataset.changeDbNativePermissions({ groupId: 2, permission: "write" });
+            expect(schemalessDataset.getPermissions({ groupId: 2 })).toMatchObject({
+                "native": "write",
+                "schemas": "all"
+            });
+
+            resetState(); // ad-hoc reset (normally run before tests)
+            // test that setting full access works too
+            schemalessDataset.changeDbDataPermissions({ groupId: 2, permission: "all" });
+            expect(schemalessDataset.getPermissions({ groupId: 2 })).toMatchObject({
+                "native": "none",
+                "schemas": "all"
+            });
+        })
+    });
+
+    describe("for a dataset with schemas", () => {
+        const schema1 = getMethodsForDbAndSchema({ databaseId: 2, schemaName: "schema_1" });
+        const schema2 = getMethodsForDbAndSchema({ databaseId: 2, schemaName: "schema_2" });
+
+        it("should restrict access correctly on table level", () => {
+            // Revoking access to one table should downgrade the native permissions to "read"
+            schema1.changeTablePermissions({ tableId: 5, groupId: 1, permission: "none" });
+            expect(schema1.getPermissions({ groupId: 1})).toMatchObject({
+                "native": "read",
+                "schemas": {
+                    "schema_1": {
+                        "5": "none",
+                        "6": "all"
+                    },
+                    "schema_2": "all"
+                }
+            });
+
+            // Revoking access to the rest of tables in schema one-by-one
+            schema1.changeTablePermissions({ tableId: 6, groupId: 1, permission: "none" });
+
+            expect(schema1.getPermissions({groupId: 1})).toMatchObject({
+                "native": "read",
+                "schemas": {
+                    "schema_1": "none",
+                    "schema_2": "all"
+                }
+            });
+
+            // An intermediary state
+            schema2.changeTablePermissions({ tableId: 8, groupId: 1, permission: "none" });
+            schema2.changeTablePermissions({ tableId: 9, groupId: 1, permission: "none" });
+            expect(schema2.getPermissions({groupId: 1})).toMatchObject({
+                "native": "read",
+                "schemas": {
+                    "schema_1": "none",
+                    "schema_2": {
+                        "7": "all",
+                        "8": "none",
+                        "9": "none"
+                    }
+                }
+            });
+
+            // Revoking all permissions of the other schema should revoke all db permissions too
+            schema2.changeTablePermissions({ tableId: 7, groupId: 1, permission: "none" });
+            expect(schema2.getPermissions({groupId: 1})).toMatchObject({
+                "native": "none",
+                "schemas": "none"
+            });
+        });
+
+        it("should restrict access correctly on db level", () => {
+            // Should let change the native permission to "read"
+            schema1.changeDbNativePermissions({ groupId: 1, permission: "read" });
+            expect(schema1.getPermissions({groupId: 1})).toMatchObject({
+                "native": "read",
+                "schemas": "all"
+            });
+
+            // Should not let change the native permission to none
+            schema1.changeDbNativePermissions({ groupId: 1, permission: "none" });
+            expect(schema1.getPermissions({groupId: 1})).toMatchObject({
+                "native": "none",
+                "schemas": "all"
+            });
+
+            resetState(); // ad-hoc state reset for the next test
+            // Revoking the data access to the database at once should revoke all permissions for that database
+            schema1.changeDbDataPermissions({ groupId: 1, permission: "none" });
+            expect(schema1.getPermissions({groupId: 1})).toMatchObject({
+                "native": "none",
+                "schemas": "none"
+            });
+        });
+
+        it("should grant more access correctly on schema level", () => {
+
+        });
+
+        it("should grant more access correctly on table level", () => {
+            // Simply grant an access to a single table
+            schema2.changeTablePermissions({ tableId: 7, groupId: 2, permission: "all" });
+            expect(schema2.getPermissions({groupId: 2})).toMatchObject({
+                "native": "none",
+                "schemas": {
+                    "schema_1": "none",
+                    "schema_2": {
+                        "7": "all",
+                        "8": "none",
+                        "9": "none"
+                    }
+                }
+            });
+
+            // Grant the access to rest of tables in that schema
+            schema2.changeTablePermissions({ tableId: 8, groupId: 2, permission: "all" });
+            schema2.changeTablePermissions({ tableId: 9, groupId: 2, permission: "all" });
+            expect(schema2.getPermissions({groupId: 2})).toMatchObject({
+                "native": "none",
+                "schemas": {
+                    "schema_1": "none",
+                    "schema_2": "all"
+                }
+            });
+
+            // Grant the access to whole db (no native yet)
+            schema1.changeTablePermissions({ tableId: 5, groupId: 2, permission: "all" });
+            schema1.changeTablePermissions({ tableId: 6, groupId: 2, permission: "all" });
+            expect(schema1.getPermissions({groupId: 2})).toMatchObject({
+                "native": "none",
+                "schemas": "all"
+            });
+
+            // Should pass changes to native permissions through
+            schema1.changeDbNativePermissions({ groupId: 2, permission: "read" });
+            expect(schema1.getPermissions({ groupId: 2 })).toMatchObject({
+                "native": "read",
+                "schemas": "all"
+            });
+        });
+
+        it("should grant more access correctly on db level", () => {
+            // Setting limited access should produce a permission tree where each schema has "none" access
+            // (this is a strange, rather no-op edge case but the UI currently enables this)
+            schema1.changeDbDataPermissions({ groupId: 2, permission: "controlled" });
+            expect(schema1.getPermissions({ groupId: 2 })).toMatchObject({
+                "native": "none",
+                "schemas": {
+                    "schema_1": "none",
+                    "schema_2": "none"
+                }
+            });
+
+            // Granting native access should also grant a full write access
+            schema1.changeDbNativePermissions({ groupId: 2, permission: "write" });
+            expect(schema1.getPermissions({ groupId: 2 })).toMatchObject({
+                "native": "write",
+                "schemas": "all"
+            });
+
+            resetState(); // ad-hoc reset (normally run before tests)
+            // test that setting full access works too
+            schema1.changeDbDataPermissions({ groupId: 2, permission: "all" });
+            expect(schema1.getPermissions({ groupId: 2 })).toMatchObject({
+                "native": "none",
+                "schemas": "all"
+            });
+        })
     });
 
     //

--- a/frontend/src/metabase/admin/permissions/selectors.spec.js
+++ b/frontend/src/metabase/admin/permissions/selectors.spec.js
@@ -3,16 +3,18 @@
  * and multiple user groups are being modified using the methods provided by the getXPermissionsGrid selectors.
  */
 
+import { setIn } from "icepick";
+
 jest.mock('metabase/lib/analytics');
 
 import {GroupsPermissions} from "metabase/meta/types/Permissions";
 import { denormalizedMetadata } from "./selectors.spec.fixtures";
 import { getTablesPermissionsGrid, getSchemasPermissionsGrid, getDatabasesPermissionsGrid } from "./selectors";
-import Metadata from "metabase/meta/metadata/Metadata";
+
+/******** INITIAL TEST STATE ********/
 
 // Members of Group 1 have a full access to all databases but the admins plan to restrict its access
 // Members of Group 2 has mixed very restricted access to databases, and admins want to grant them some more freedom
-
 const groups = [{
     id: 1,
     name: "Executive team",
@@ -65,7 +67,10 @@ const initialPermissions: GroupsPermissions = {
     }
 };
 
-const reduxState = {
+
+/******** MANAGING THE CURRENT (SIMULATED) STATE TREE ********/
+
+const initialState = {
     admin: {
         permissions: {
             permissions: initialPermissions,
@@ -76,6 +81,13 @@ const reduxState = {
     }
 };
 
+var state = initialState;
+const resetState = () => { state = initialState };
+const getPermissions = () => state.admin.permissions.permissions;
+const updatePermissionsInState = (permissions) => {
+    state = setIn(state, ["admin", "permissions", "permissions"], permissions);
+};
+
 const getProps = ({ databaseId, schemaName }) => ({
     params: {
         databaseId,
@@ -83,33 +95,94 @@ const getProps = ({ databaseId, schemaName }) => ({
     }
 });
 
+/******** HIGH-LEVEL METHODS FOR UPDATING PERMISSIONS ********/
+
+const changePermissionsForEntityInGrid = (grid, category, entityId, permission) => {
+    const newPermissions = grid.permissions[category].updater(entityId.databaseId, entityId, permission);
+    updatePermissionsInState(newPermissions);
+    return newPermissions;
+};
+
+const changeDbDataPermissionsForEntity = (entityId, permission) => {
+    const grid = getDatabasesPermissionsGrid(state, getProps(entityId));
+    changePermissionsForEntityInGrid(grid, "schemas", entityId, permission);
+};
+
+const changeSchemaPermissionsForEntity = (entityId, permission) => {
+    const grid = getSchemasPermissionsGrid(state, getProps(entityId));
+    changePermissionsForEntityInGrid(grid, "tables", entityId, permission);
+};
+
+const changeTablePermissionsForEntity = (entityId, permission) => {
+    const grid = getTablesPermissionsGrid(state, getProps(entityId));
+    changePermissionsForEntityInGrid(grid, "fields", entityId, permission);
+};
+
+/******** ACTUAL TESTS ********/
+
 describe("permissions selectors", () => {
-    const sampleDatasetEntityId = {databaseId: 1, schemaName: "PUBLIC"};
+    describe("for sample dataset", () => {
+        // Local helpers for current database
+        const sampleDatasetEntityId = {databaseId: 1, schemaName: "PUBLIC"};
+        const changeDbDataPermissions = (permission) =>
+            changeDbDataPermissionsForEntity(sampleDatasetEntityId, permission);
+        const changeTablePermissions = (tableId, permission) =>
+            changeTablePermissionsForEntity({...sampleDatasetEntityId, tableId}, permission);
 
-    it("should behave correctly when restricting access to the sample dataset", () => {
-        const grid = getTablesPermissionsGrid(reduxState, getProps(sampleDatasetEntityId));
-        const updatedPermissions = grid.permissions.fields.updater(1, {...sampleDatasetEntityId, tableId: 1}, "none");
+        it("should restrict access correctly", () => {
+            // Revoking access to one table...
+            changeTablePermissions(1, "none");
 
-        expect(updatedPermissions).toMatchObject({
-           "1": {
-               "1": {
-                   // should downgrade to read native permission
-                   "native": "read",
-                   "schemas": {
-                       "PUBLIC": {
-                           "1": "none",
-                           "2": "all",
-                           "3": "all",
-                           "4": "all"
-                       }
-                   }
-               }
-           }
+            expect(getPermissions()).toMatchObject({
+                "1": {
+                    "1": {
+                        // ...should downgrade the native permissions to "read"
+                        "native": "read",
+                        "schemas": {
+                            "PUBLIC": {
+                                "1": "none",
+                                "2": "all",
+                                "3": "all",
+                                "4": "all"
+                            }
+                        }
+                    }
+                }
+            });
+
+            // Revoking access to the rest of tables one-by-one...
+            changeTablePermissions(2, "none");
+            changeTablePermissions(3, "none");
+            changeTablePermissions(4, "none");
+
+            expect(getPermissions()).toMatchObject({
+                "1": {
+                    "1": {
+                        // ...should revoke all permissions for that database
+                        "native": "none",
+                        "schemas": "none"
+                    }
+                }
+            });
+
+            // Expect a similar result also when revoking the data access to the database at once
+            resetState();
+            changeDbDataPermissions("none");
+            expect(getPermissions()).toMatchObject({
+                "1": {
+                    "1": {
+                        // ...should revoke all permissions for that database
+                        "native": "none",
+                        "schemas": "none"
+                    }
+                }
+            });
         });
     });
-    // it("should behave correctly when granting more access to the sample dataset", () => {
-    //
-    // });
+
+    it("should behave correctly when granting more access to the sample dataset", () => {
+
+    });
     //
     // it("should behave correctly when restricting access to a multi-schema dataset", () => {
     //

--- a/frontend/src/metabase/lib/permissions.js
+++ b/frontend/src/metabase/lib/permissions.js
@@ -113,9 +113,9 @@ export function downgradeNativePermissionsIfNeeded(permissions: GroupsPermission
 const metadataTableToTableEntityId = (table: Table): TableEntityId => ({ databaseId: table.db_id, schemaName: table.schema || "", tableId: table.id });
 const entityIdToMetadataTableFields = (entityId: EntityId) => ({
     ...(entityId.databaseId ? {db_id: entityId.databaseId} : {}),
-    ...(entityId.schemaName ? {schema: entityId.schemaName} : {}),
+    ...(entityId.schemaName ? {schema: entityId.schemaName !== "" ? entityId.schemaName : null} : {}),
     ...(entityId.tableId ? {tableId: entityId.tableId} : {})
-})
+});
 
 function inferEntityPermissionValueFromChildTables(permissions: GroupsPermissions, groupId: GroupId, entityId: DatabaseEntityId|SchemaEntityId, metadata: Metadata) {
     const { databaseId } = entityId;

--- a/frontend/src/metabase/lib/permissions.js
+++ b/frontend/src/metabase/lib/permissions.js
@@ -109,12 +109,14 @@ export function downgradeNativePermissionsIfNeeded(permissions: GroupsPermission
     }
 }
 
-// $FlowFixMe
 const metadataTableToTableEntityId = (table: Table): TableEntityId => ({ databaseId: table.db_id, schemaName: table.schema || "", tableId: table.id });
+
+// TODO Atte Keinänen 6/24/17 See if this method could be simplified
 const entityIdToMetadataTableFields = (entityId: EntityId) => ({
     ...(entityId.databaseId ? {db_id: entityId.databaseId} : {}),
-    ...(entityId.schemaName ? {schema: entityId.schemaName !== "" ? entityId.schemaName : null} : {}),
-    ...(entityId.tableId ? {tableId: entityId.tableId} : {})
+    // $FlowFixMe Because schema name can be an empty string, which means an empty schema, this check becomes a little nasty
+    ...(entityId.schemaName !== undefined ? {schema: entityId.schemaName !== "" ? entityId.schemaName : null} : {}),
+    ...(entityId.tableId ? {id: entityId.tableId} : {})
 });
 
 function inferEntityPermissionValueFromChildTables(permissions: GroupsPermissions, groupId: GroupId, entityId: DatabaseEntityId|SchemaEntityId, metadata: Metadata) {
@@ -188,7 +190,7 @@ export function updateTablesPermission(permissions: GroupsPermissions, groupId: 
 export function updateSchemasPermission(permissions: GroupsPermissions, groupId: GroupId, { databaseId }: DatabaseEntityId, value: string, metadata: Metadata): GroupsPermissions {
     const database = metadata.database(databaseId);
     const schemaNames = database && database.schemaNames();
-    const schemaNamesOrNoSchema = schemaNames.length > 0 ? schemaNames : [""];
+    const schemaNamesOrNoSchema = (schemaNames && schemaNames.length > 0) ? schemaNames : [""];
 
     permissions = downgradeNativePermissionsIfNeeded(permissions, groupId, { databaseId }, value, metadata);
     return updatePermission(permissions, groupId, [databaseId, "schemas"], value, schemaNamesOrNoSchema);


### PR DESCRIPTION
Fixes two issues:

- #5158 Can't save table permission changes if the database doesn't have schemas. This is a regression caused by #4847.
- If your user group has full data access to a table, and you then try to revoke an access to a single table, then the access to every table is revoked instead. This applies only if the database doesn't have schemas.

I won't merge this before I've written tests for both issues.