### PR TITLE
Fix to issue 5190: run lein before running build to fix dependency issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN rm -f /usr/lib/jvm/default-jvm/jre/lib/security/cacerts && \
 # install lein
 ADD https://raw.github.com/technomancy/leiningen/stable/bin/lein /usr/local/bin/lein
 RUN chmod 744 /usr/local/bin/lein
+RUN lein
 
 # add the application source to the image
 ADD . /app/source


### PR DESCRIPTION

This is related to this issue https://github.com/metabase/metabase/issues/5190

Docker build is failing due to dependencies issue to solve this just need to run lein before running build.
