### PR TITLE
Open a new tab if control/command button is pressed [WIP]

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -134,8 +134,8 @@ export default class DashCard extends Component {
                     onUpdateVisualizationSettings={this.props.onUpdateVisualizationSettings}
                     replacementContent={isEditingParameter && <DashCardParameterMapper dashcard={dashcard} />}
                     metadata={metadata}
-                    onChangeCardAndRun={ navigateToNewCard ? (card: UnsavedCard) => {
-                        navigateToNewCard(card, dashcard)
+                    onChangeCardAndRun={ navigateToNewCard ? (nextCard, previousCard) => {
+                        navigateToNewCard(nextCard, previousCard, dashcard)
                     } : null}
                 />
             </div>

--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -34,6 +34,7 @@ export default class DashCard extends Component {
         parameterValues: PropTypes.object.isRequired,
         markNewCardSeen: PropTypes.func.isRequired,
         fetchCardData: PropTypes.func.isRequired,
+        navigateToNewCardFromDashboard: PropTypes.func.isRequired
     };
 
     async componentDidMount() {
@@ -60,7 +61,7 @@ export default class DashCard extends Component {
             isEditingParameter,
             onAddSeries,
             onRemove,
-            navigateToNewCard,
+            navigateToNewCardFromDashboard,
             metadata
         } = this.props;
 
@@ -134,8 +135,9 @@ export default class DashCard extends Component {
                     onUpdateVisualizationSettings={this.props.onUpdateVisualizationSettings}
                     replacementContent={isEditingParameter && <DashCardParameterMapper dashcard={dashcard} />}
                     metadata={metadata}
-                    onChangeCardAndRun={ navigateToNewCard ? (nextCard, previousCard) => {
-                        navigateToNewCard(nextCard, previousCard, dashcard)
+                    onChangeCardAndRun={ navigateToNewCardFromDashboard ? ({ clickEvent, nextCard, previousCard }) => {
+                        // navigateToNewCardFromDashboard needs `dashcard` for applying active filters to the query
+                        navigateToNewCardFromDashboard({ clickEvent, nextCard, previousCard, dashcard })
                     } : null}
                 />
             </div>

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -193,7 +193,7 @@ export default class DashboardGrid extends Component {
                 onAddSeries={this.onDashCardAddSeries.bind(this, dc)}
                 onUpdateVisualizationSettings={this.props.onUpdateDashCardVisualizationSettings.bind(this, dc.id)}
                 onReplaceAllVisualizationSettings={this.props.onReplaceAllDashCardVisualizationSettings.bind(this, dc.id)}
-                navigateToNewCard={this.props.navigateToNewCard}
+                navigateToNewCard={this.props.navigateToNewCardFromDashboard}
                 metadata={this.props.metadata}
             />
         )

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -193,7 +193,7 @@ export default class DashboardGrid extends Component {
                 onAddSeries={this.onDashCardAddSeries.bind(this, dc)}
                 onUpdateVisualizationSettings={this.props.onUpdateDashCardVisualizationSettings.bind(this, dc.id)}
                 onReplaceAllVisualizationSettings={this.props.onReplaceAllDashCardVisualizationSettings.bind(this, dc.id)}
-                navigateToNewCard={this.props.navigateToNewCardFromDashboard}
+                navigateToNewCardFromDashboard={this.props.navigateToNewCardFromDashboard}
                 metadata={this.props.metadata}
             />
         )

--- a/frontend/src/metabase/dashboard/dashboard.js
+++ b/frontend/src/metabase/dashboard/dashboard.js
@@ -524,6 +524,7 @@ export const navigateToNewCardFromDashboard = createThunkAction(
                 dashcard && dashcard.parameter_mappings
             );
 
+
             dispatch(push(url));
         }
 );

--- a/frontend/src/metabase/dashboard/dashboard.js
+++ b/frontend/src/metabase/dashboard/dashboard.js
@@ -25,6 +25,7 @@ import { push } from "react-router-redux";
 import { DashboardApi, CardApi, RevisionApi, PublicApi, EmbedApi } from "metabase/services";
 
 import { getDashboard, getDashboardComplete } from "./selectors";
+import {getCardAfterVisualizationClick} from "metabase/visualizations/lib/utils";
 
 const DATASET_SLOW_TIMEOUT = 15 * 1000;
 
@@ -491,24 +492,41 @@ export const deletePublicLink = createAction(DELETE_PUBLIC_LINK, async ({ id }) 
     return { id };
 });
 
-/** All navigation actions from dashboards to cards (e.x. clicking a title, drill through)
- *  should go through this action, which merges any currently applied dashboard filters
- *  into the new card / URL parameters.
+/**
+ * All navigation actions from dashboards to cards (e.x. clicking a title, drill through)
+ * should go through this action, which merges any currently applied dashboard filters
+ * into the new card / URL parameters.
+ *
+ * User-triggered events that are handled here:
+ *     - clicking a dashcard legend:
+ *         * question title legend (only for single-question cards)
+ *         * series legend (multi-aggregation, multi-breakout, multiple questions)
+ *     - clicking the visualization inside dashcard
+ *         * drill-through (single series, multi-aggregation, multi-breakout, multiple questions)
+ *         * (not in 0.24.2 yet: drag on line/area/bar visualization)
  */
 
-// TODO Atte Keinänen 5/2/17: This could be combined with `setCardAndRun` of query_builder/actions.js
-// Having two separate actions for very similar behavior was a source of initial confusion for me
 const NAVIGATE_TO_NEW_CARD = "metabase/dashboard/NAVIGATE_TO_NEW_CARD";
-export const navigateToNewCard = createThunkAction(NAVIGATE_TO_NEW_CARD, (card: UnsavedCard, dashcard: DashCard) =>
-    (dispatch, getState) => {
-        const { metadata } = getState();
-        const { dashboardId, dashboards, parameterValues } = getState().dashboard;
-        const dashboard = dashboards[dashboardId];
+export const navigateToNewCardFromDashboard = createThunkAction(
+    NAVIGATE_TO_NEW_CARD,
+    (nextCard: UnsavedCard, previousCard: SavedCard, dashcard: DashCard, dirty = true) =>
+        (dispatch, getState) => {
+            const {metadata} = getState();
+            const {dashboardId, dashboards, parameterValues} = getState().dashboard;
+            const dashboard = dashboards[dashboardId];
 
-        // $FlowFixMe
-        const url = questionUrlWithParameters(card, metadata, dashboard.parameters, parameterValues, dashcard && dashcard.parameter_mappings);
-        dispatch(push(url));
-    });
+            // $FlowFixMe
+            const url = questionUrlWithParameters(
+                getCardAfterVisualizationClick(nextCard, previousCard),
+                metadata,
+                dashboard.parameters,
+                parameterValues,
+                dashcard && dashcard.parameter_mappings
+            );
+
+            dispatch(push(url));
+        }
+);
 
 // reducers
 

--- a/frontend/src/metabase/dashboard/dashboard.js
+++ b/frontend/src/metabase/dashboard/dashboard.js
@@ -14,7 +14,7 @@ import { applyParameters, questionUrlWithParameters } from "metabase/meta/Card";
 import { getParametersBySlug } from "metabase/meta/Parameter";
 
 import type { DashboardWithCards, DashCard, DashCardId } from "metabase/meta/types/Dashboard";
-import type { UnsavedCard, Card, CardId } from "metabase/meta/types/Card";
+import type { Card, CardId } from "metabase/meta/types/Card";
 
 import Utils from "metabase/lib/utils";
 import { getPositionForNewDashCard } from "metabase/lib/dashboard_grid";
@@ -509,7 +509,7 @@ export const deletePublicLink = createAction(DELETE_PUBLIC_LINK, async ({ id }) 
 const NAVIGATE_TO_NEW_CARD = "metabase/dashboard/NAVIGATE_TO_NEW_CARD";
 export const navigateToNewCardFromDashboard = createThunkAction(
     NAVIGATE_TO_NEW_CARD,
-    (nextCard: UnsavedCard, previousCard: SavedCard, dashcard: DashCard, dirty = true) =>
+    ({ nextCard, previousCard, dashcard, clickEvent }) =>
         (dispatch, getState) => {
             const {metadata} = getState();
             const {dashboardId, dashboards, parameterValues} = getState().dashboard;
@@ -524,8 +524,11 @@ export const navigateToNewCardFromDashboard = createThunkAction(
                 dashcard && dashcard.parameter_mappings
             );
 
-
-            dispatch(push(url));
+            if (clickEvent && (clickEvent.ctrlKey || clickEvent.metaKey)) {
+                window.open(url, '_blank');
+            } else {
+                dispatch(push(url));
+            }
         }
 );
 

--- a/frontend/src/metabase/meta/types/Visualization.js
+++ b/frontend/src/metabase/meta/types/Visualization.js
@@ -53,7 +53,7 @@ export type ClickActionProps = {
 }
 
 export type ClickActionPopoverProps = {
-    onChangeCardAndRun: (card: ?Card) => void,
+    onChangeCardAndRun: (Object) => void,
     onClose: () => void,
 }
 
@@ -83,7 +83,7 @@ export type VisualizationProps = {
     onHoverChange: (?HoverObject) => void,
     onVisualizationClick: (?ClickObject) => void,
     visualizationIsClickable: (?ClickObject) => boolean,
-    onChangeCardAndRun: (card: Card) => void,
+    onChangeCardAndRun: (Object) => void,
 
     onUpdateVisualizationSettings: ({ [key: string]: any }) => void
 }

--- a/frontend/src/metabase/qb/components/actions/PivotByAction.jsx
+++ b/frontend/src/metabase/qb/components/actions/PivotByAction.jsx
@@ -89,7 +89,7 @@ export default (name: string, icon: string, fieldFilter: FieldFilter) =>
                         customFieldOptions={customFieldOptions}
                         onCommitBreakout={breakout => {
                             onChangeCardAndRun(
-                                pivot(card, breakout, tableMetadata, dimensions)
+                                { nextCard: pivot(card, breakout, tableMetadata, dimensions) }
                             );
                         }}
                         onClose={onClose}

--- a/frontend/src/metabase/qb/components/actions/SummarizeBySegmentMetricAction.jsx
+++ b/frontend/src/metabase/qb/components/actions/SummarizeBySegmentMetricAction.jsx
@@ -34,9 +34,7 @@ export default ({ card, tableMetadata }: ClickActionProps): ClickAction[] => {
                     customFields={Query.getExpressions(query)}
                     availableAggregations={tableMetadata.aggregation_options}
                     onCommitAggregation={aggregation => {
-                        onChangeCardAndRun(
-                            summarize(card, aggregation, tableMetadata)
-                        );
+                        onChangeCardAndRun({ nextCard: summarize(card, aggregation, tableMetadata) });
                         onClose && onClose();
                     }}
                 />

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -533,7 +533,7 @@ export const setCardAndRun = createThunkAction(SET_CARD_AND_RUN, (nextCard, shou
  * All these events can be applied either for an unsaved question or a saved question.
  */
 export const NAVIGATE_TO_NEW_CARD = "metabase/qb/NAVIGATE_TO_NEW_CARD";
-export const navigateToNewCardInsideQB = createThunkAction(NAVIGATE_TO_NEW_CARD, (nextCard, previousCard) => {
+export const navigateToNewCardInsideQB = createThunkAction(NAVIGATE_TO_NEW_CARD, ({ nextCard, previousCard, clickEvent }) => {
     return async (dispatch, getState) => {
         const nextCardIsClean = !nextCard.dataset_query;
 

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -534,8 +534,15 @@ export const setCardAndRun = createThunkAction(SET_CARD_AND_RUN, (nextCard, shou
  */
 export const NAVIGATE_TO_NEW_CARD = "metabase/qb/NAVIGATE_TO_NEW_CARD";
 export const navigateToNewCardInsideQB = createThunkAction(NAVIGATE_TO_NEW_CARD, (nextCard, previousCard) => {
-    return (dispatch, getState) => {
-        dispatch(setCardAndRun(getCardAfterVisualizationClick(nextCard, previousCard)));
+    return async (dispatch, getState) => {
+        const nextCardIsClean = !nextCard.dataset_query;
+
+        if (nextCardIsClean) {
+            // This is mainly a fallback for scenarios where a visualization legend is clicked inside QB
+            dispatch(setCardAndRun(await loadCard(nextCard.id)));
+        } else {
+            dispatch(setCardAndRun(getCardAfterVisualizationClick(nextCard, previousCard)));
+        }
     }
 });
 

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -29,6 +29,7 @@ import { MetabaseApi, CardApi, UserApi } from "metabase/services";
 
 import { parse as urlParse } from "url";
 import querystring from "querystring";
+import {getCardAfterVisualizationClick} from "metabase/visualizations/lib/utils";
 
 export const SET_CURRENT_STATE = "metabase/qb/SET_CURRENT_STATE"; const setCurrentState = createAction(SET_CURRENT_STATE);
 
@@ -491,9 +492,12 @@ export const reloadCard = createThunkAction(RELOAD_CARD, () => {
     };
 });
 
-// setCardAndRun
-// Used when navigating browser history, when drilling through in visualizations / action widget,
-// and when having the entity details view open and clicking its cells
+/**
+ * `setCardAndRun` is used when:
+ *     - navigating browser history
+ *     - clicking in the entity details view
+ *     - `navigateToNewCardInsideQB` is being called (see below)
+ */
 export const SET_CARD_AND_RUN = "metabase/qb/SET_CARD_AND_RUN";
 export const setCardAndRun = createThunkAction(SET_CARD_AND_RUN, (nextCard, shouldUpdateUrl = true) => {
     return async (dispatch, getState) => {
@@ -518,8 +522,23 @@ export const setCardAndRun = createThunkAction(SET_CARD_AND_RUN, (nextCard, shou
     };
 });
 
+/**
+ * User-triggered events that are handled with this action:
+ *     - clicking a legend:
+ *         * series legend (multi-aggregation, multi-breakout, multiple questions)
+ *     - clicking the visualization itself
+ *         * drill-through (single series, multi-aggregation, multi-breakout, multiple questions)
+ *         * (not in 0.24.2 yet: drag on line/area/bar visualization)
+ *
+ * All these events can be applied either for an unsaved question or a saved question.
+ */
+export const NAVIGATE_TO_NEW_CARD = "metabase/qb/NAVIGATE_TO_NEW_CARD";
+export const navigateToNewCardInsideQB = createThunkAction(NAVIGATE_TO_NEW_CARD, (nextCard, previousCard) => {
+    return (dispatch, getState) => {
+        dispatch(setCardAndRun(getCardAfterVisualizationClick(nextCard, previousCard)));
+    }
+});
 
-// setDatasetQuery
 export const SET_DATASET_QUERY = "metabase/qb/SET_DATASET_QUERY";
 export const setDatasetQuery = createThunkAction(SET_DATASET_QUERY, (dataset_query, run = false) => {
     return (dispatch, getState) => {

--- a/frontend/src/metabase/query_builder/components/ActionsWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/ActionsWidget.jsx
@@ -71,12 +71,12 @@ export default class ActionsWidget extends Component<*, Props, *> {
         });
     };
 
-    handleOnChangeCardAndRun(nextCard: UnsavedCard|Card) {
+    handleOnChangeCardAndRun({ nextCard, clickEvent }) {
         const { card: previousCard } = this.props;
-        this.props.navigateToNewCardInsideQB(nextCard, previousCard);
+        this.props.navigateToNewCardInsideQB({ nextCard, previousCard, clickEvent });
     }
 
-    handleActionClick = (index: number) => {
+    handleActionClick = (clickEvent, index: number) => {
         const { mode, card, tableMetadata } = this.props;
         const action = getModeActions(mode, card, tableMetadata)[index];
         if (action && action.popover) {
@@ -85,7 +85,7 @@ export default class ActionsWidget extends Component<*, Props, *> {
             const nextCard = action.card();
             if (nextCard) {
                 MetabaseAnalytics.trackEvent("Actions", "Executed Action", `${action.section||""}:${action.name||""}`);
-                this.handleOnChangeCardAndRun(nextCard);
+                this.handleOnChangeCardAndRun({ nextCard, clickEvent });
             }
             this.close();
         }
@@ -161,12 +161,12 @@ export default class ActionsWidget extends Component<*, Props, *> {
                                           </div>
                                       </div>
                                       <PopoverComponent
-                                          onChangeCardAndRun={(card) => {
-                                              if (card) {
+                                          onChangeCardAndRun={({ nextCard, clickEvent }) => {
+                                              if (nextCard) {
                                                   if (selectedAction) {
                                                       MetabaseAnalytics.trackEvent("Actions", "Executed Action", `${selectedAction.section||""}:${selectedAction.name||""}`);
                                                   }
-                                                  this.handleOnChangeCardAndRun(card)
+                                                  this.handleOnChangeCardAndRun({ nextCard, clickEvent })
                                               }
                                           }}
                                           onClose={this.close}
@@ -176,8 +176,8 @@ export default class ActionsWidget extends Component<*, Props, *> {
                                       <div
                                           key={index}
                                           className="p2 flex align-center text-grey-4 brand-hover cursor-pointer"
-                                          onClick={() =>
-                                              this.handleActionClick(index)}
+                                          onClick={(clickEvent) =>
+                                              this.handleActionClick(clickEvent, index)}
                                       >
                                           {action.icon &&
                                               <Icon

--- a/frontend/src/metabase/query_builder/components/ActionsWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/ActionsWidget.jsx
@@ -21,7 +21,7 @@ type Props = {
     mode: QueryMode,
     card: Card,
     tableMetadata: TableMetadata,
-    setCardAndRun: (card: Card) => void
+    navigateToNewCardInsideQB: (nextCard: Card, previousCard: Card) => void
 };
 
 const CIRCLE_SIZE = 48;
@@ -72,17 +72,8 @@ export default class ActionsWidget extends Component<*, Props, *> {
     };
 
     handleOnChangeCardAndRun(nextCard: UnsavedCard|Card) {
-        const { card } = this.props;
-
-        // Include the original card id if present for showing the lineage next to title
-        const nextCardWithOriginalId = {
-            ...nextCard,
-            // $FlowFixMe
-            original_card_id: card.id || card.original_card_id
-        };
-        if (nextCardWithOriginalId) {
-            this.props.setCardAndRun(nextCardWithOriginalId);
-        }
+        const { card: previousCard } = this.props;
+        this.props.navigateToNewCardInsideQB(nextCard, previousCard);
     }
 
     handleActionClick = (index: number) => {

--- a/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
@@ -7,7 +7,7 @@ import VisualizationErrorMessage from './VisualizationErrorMessage';
 import Visualization from "metabase/visualizations/components/Visualization.jsx";
 import { datasetContainsNoResults } from "metabase/lib/dataset";
 
-const VisualizationResult = ({card, isObjectDetail, lastRunDatasetQuery, result, ...props}) => {
+const VisualizationResult = ({card, isObjectDetail, lastRunDatasetQuery, navigateToNewCardInsideQB, result, ...props}) => {
     const noResults = datasetContainsNoResults(result.data);
 
     if (isObjectDetail) {
@@ -34,7 +34,7 @@ const VisualizationResult = ({card, isObjectDetail, lastRunDatasetQuery, result,
         };
         return <Visualization
                   series={[{ card: vizCard, data: result.data }]}
-                  onChangeCardAndRun={props.setCardAndRun}
+                  onChangeCardAndRun={navigateToNewCardInsideQB}
                   isEditing={true}
                   // Table:
                   {...props}
@@ -43,11 +43,11 @@ const VisualizationResult = ({card, isObjectDetail, lastRunDatasetQuery, result,
 }
 
 VisualizationResult.propTypes = {
-    card:                   PropTypes.object.isRequired,
-    isObjectDetail:         PropTypes.bool.isRequired,
-    lastRunDatasetQuery:    PropTypes.object.isRequired,
-    result:                 PropTypes.object.isRequired,
-    setCardAndRun:          PropTypes.func,
+    card:                     PropTypes.object.isRequired,
+    isObjectDetail:           PropTypes.bool.isRequired,
+    lastRunDatasetQuery:      PropTypes.object.isRequired,
+    result:                   PropTypes.object.isRequired,
+    navigateToNewCardInsideQB:  PropTypes.func,
 }
 
 export default VisualizationResult;

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -9,7 +9,6 @@ import Popover from "metabase/components/Popover";
 import MetabaseAnalytics from "metabase/lib/analytics";
 
 import type { ClickObject, ClickAction } from "metabase/meta/types/Visualization";
-import type { Card } from "metabase/meta/types/Card";
 
 import _ from "underscore";
 
@@ -54,7 +53,7 @@ Object.values(SECTIONS).map((section, index) => {
 type Props = {
     clicked: ClickObject,
     clickActions: ?ClickAction[],
-    onChangeCardAndRun: (card: ?Card) => void,
+    onChangeCardAndRun: (Object) => void,
     onClose: () => void
 };
 
@@ -74,14 +73,14 @@ export default class ChartClickActions extends Component<*, Props, State> {
         }
     }
 
-    handleClickAction = (action: ClickAction) => {
+    handleClickAction = (clickEvent, action: ClickAction) => {
         const { onChangeCardAndRun } = this.props;
         if (action.popover) {
             this.setState({ popoverAction: action });
         } else if (action.card) {
-            const card = action.card();
+            const nextCard = action.card();
             MetabaseAnalytics.trackEvent("Actions", "Executed Click Action", `${action.section||""}:${action.name||""}`);
-            onChangeCardAndRun(card);
+            onChangeCardAndRun({ nextCard, clickEvent });
             this.close();
         }
     }
@@ -99,11 +98,11 @@ export default class ChartClickActions extends Component<*, Props, State> {
             const PopoverContent = popoverAction.popover;
             popover = (
                 <PopoverContent
-                    onChangeCardAndRun={(card) => {
+                    onChangeCardAndRun={({ nextCard, clickEvent }) => {
                         if (popoverAction) {
                             MetabaseAnalytics.trackEvent("Action", "Executed Click Action", `${popoverAction.section||""}:${popoverAction.name||""}`);
                         }
-                        onChangeCardAndRun(card);
+                        onChangeCardAndRun({ nextCard, clickEvent });
                     }}
                     onClose={() => {
                         MetabaseAnalytics.trackEvent("Action", "Dismissed Click Action Menu");
@@ -143,7 +142,7 @@ export default class ChartClickActions extends Component<*, Props, State> {
                                     <div
                                         key={index}
                                         className={cx("text-brand-hover cursor-pointer", { "pr2": index === actions.length - 1, "pr4": index != actions.length - 1})}
-                                        onClick={() => this.handleClickAction(action)}
+                                        onClick={(event) => this.handleClickAction(event, action)}
                                     >
                                         {action.title}
                                     </div>

--- a/frontend/src/metabase/visualizations/components/LegendHeader.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendHeader.jsx
@@ -72,7 +72,7 @@ export default class LegendHeader extends Component {
                             ((e) => onVisualizationClick({ ...s.clicked, element: e.currentTarget }))
                         : onChangeCardAndRun ?
                             // Navigating to a saved, clean card; providing only the card id to `onChangeCardAndRun` is sufficient
-                            ((e) => onChangeCardAndRun({ id: s.card.id }))
+                            ((clickEvent) => onChangeCardAndRun({ nextCard: { id: s.card.id }, clickEvent }))
                         : null }
                     />,
                     onRemoveSeries && index > 0 &&

--- a/frontend/src/metabase/visualizations/components/LegendHeader.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendHeader.jsx
@@ -71,7 +71,8 @@ export default class LegendHeader extends Component {
                         onClick={s.clicked && visualizationIsClickable(s.clicked) ?
                             ((e) => onVisualizationClick({ ...s.clicked, element: e.currentTarget }))
                         : onChangeCardAndRun ?
-                            ((e) => onChangeCardAndRun(s.card))
+                            // Navigating to a saved, clean card; providing only the card id to `onChangeCardAndRun` is sufficient
+                            ((e) => onChangeCardAndRun({ id: s.card.id }))
                         : null }
                     />,
                     onRemoveSeries && index > 0 &&

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -224,13 +224,13 @@ export default class Visualization extends Component<*, Props, State> {
     };
 
     // Add the underlying card of current series to onChangeCardAndRun if available
-    handleOnChangeCardAndRun = (nextCard: UnsavedCard|Card) => {
+    handleOnChangeCardAndRun = ({ nextCard, clickEvent }) => {
         const { series, clicked } = this.state;
 
         const index = (clicked && clicked.seriesIndex) || 0;
         const previousCard = series && series[index] && series[index].card;
 
-        this.props.onChangeCardAndRun(nextCard, previousCard);
+        this.props.onChangeCardAndRun({ nextCard, previousCard, clickEvent });
     }
 
     onRender = ({ yAxisSplit, warnings = [] } = {}) => {

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -221,27 +221,16 @@ export default class Visualization extends Component<*, Props, State> {
         setTimeout(() => {
             this.setState({ clicked });
         }, 100);
-    }
+    };
 
-    handleOnChangeCardAndRun = (card: UnsavedCard) => {
+    // Add the underlying card of current series to onChangeCardAndRun if available
+    handleOnChangeCardAndRun = (nextCard: UnsavedCard|Card) => {
         const { series, clicked } = this.state;
 
         const index = (clicked && clicked.seriesIndex) || 0;
-        const originalCard = series && series[index] && series[index].card;
+        const previousCard = series && series[index] && series[index].card;
 
-        let cardId = card.id || card.original_card_id;
-        // if the supplied card doesn't have an id, get it from the original card
-        if (cardId == null && originalCard) {
-            // $FlowFixMe
-            cardId = originalCard.id || originalCard.original_card_id;
-        }
-
-        this.props.onChangeCardAndRun({
-            ...card,
-            id: cardId,
-            // $FlowFixMe
-            original_card_id: cardId
-        });
+        this.props.onChangeCardAndRun(nextCard, previousCard);
     }
 
     onRender = ({ yAxisSplit, warnings = [] } = {}) => {

--- a/frontend/src/metabase/visualizations/lib/utils.js
+++ b/frontend/src/metabase/visualizations/lib/utils.js
@@ -249,3 +249,26 @@ function wrapMethod(object, name, method) {
         }
     }
 }
+
+export function getCardAfterVisualizationClick(nextCard, previousCard) {
+    const cardIsDirty = !!nextCard.dataset_query;
+
+    if (cardIsDirty) {
+        const isMultiseriesQuestion = !nextCard.id;
+        const alreadyHadLineage = !!previousCard.original_card_id;
+
+        return {
+            ...nextCard,
+            // Original card id is needed for showing the "started from" lineage in dirty cards.
+            original_card_id: alreadyHadLineage
+                // Just recycle the original card id of previous card if there was one
+                ? previousCard.original_card_id
+                // A multi-aggregation or multi-breakout series legend / drill-through action
+                // should always use the id of the underlying/previous card
+                : (isMultiseriesQuestion ? previousCard.id : nextCard.id)
+        }
+    } else {
+        return nextCard;
+    }
+}
+

--- a/frontend/src/metabase/visualizations/lib/utils.js
+++ b/frontend/src/metabase/visualizations/lib/utils.js
@@ -264,7 +264,7 @@ export function getCardAfterVisualizationClick(nextCard, previousCard) {
                 // Just recycle the original card id of previous card if there was one
                 ? previousCard.original_card_id
                 // A multi-aggregation or multi-breakout series legend / drill-through action
-                // should always use the id of the underlying/previous card
+                // should always use the id of underlying/previous card
                 : (isMultiseriesQuestion ? previousCard.id : nextCard.id)
         }
     } else {

--- a/frontend/src/metabase/visualizations/visualizations/Scalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar.jsx
@@ -194,7 +194,8 @@ export default class Scalar extends Component<*, VisualizationProps, *> {
                 <div className={styles.Title + " flex align-center"}>
                     <Ellipsified tooltip={card.name}>
                         <span
-                            onClick={onChangeCardAndRun && (() => onChangeCardAndRun(card))}
+                            // Navigating to a saved, clean card; providing only the card id to `onChangeCardAndRun` is sufficient
+                            onClick={onChangeCardAndRun && (() => onChangeCardAndRun({ id: card.id }))}
                             className={cx("fullscreen-normal-text fullscreen-night-text", {
                                 "cursor-pointer": !!onChangeCardAndRun
                             })}

--- a/frontend/src/metabase/visualizations/visualizations/Scalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar.jsx
@@ -195,7 +195,7 @@ export default class Scalar extends Component<*, VisualizationProps, *> {
                     <Ellipsified tooltip={card.name}>
                         <span
                             // Navigating to a saved, clean card; providing only the card id to `onChangeCardAndRun` is sufficient
-                            onClick={onChangeCardAndRun && (() => onChangeCardAndRun({ id: card.id }))}
+                            onClick={onChangeCardAndRun && ((clickEvent) => onChangeCardAndRun({ nextCard: { id: card.id }, clickEvent }))}
                             className={cx("fullscreen-normal-text fullscreen-night-text", {
                                 "cursor-pointer": !!onChangeCardAndRun
                             })}


### PR DESCRIPTION
Experimenting with opening a new tab if control/command button is pressed when clicking at dashboard card legends or drill-through actions. Doesn't work on query builder although that would be a logical next step

This has diverged from fix-lineage-issues branch. For seeing the relevant changes, please check out https://github.com/metabase/metabase/commit/93d779e39a7c6ab6fabe8114a4e7e29c3a5fc857