### PR TITLE
Point type support [WIP]

### DIFF
--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -122,6 +122,8 @@ export const isCoordinate   = (field) => isa(field && field.special_type, TYPE.C
 export const isLatitude     = (field) => isa(field && field.special_type, TYPE.Latitude);
 export const isLongitude    = (field) => isa(field && field.special_type, TYPE.Longitude);
 
+export const isPoint        = (field) => isa(field && field.base_type, TYPE.Point);
+
 // operator argument constructors:
 
 function freeformArgument(field, table) {
@@ -503,6 +505,10 @@ export function hasLatitudeAndLongitudeColumns(columnDefs) {
         }
     }
     return hasLatitude && hasLongitude;
+}
+
+export function hasPointColumn(columnDefs) {
+    return _.any(columnDefs, isPoint);
 }
 
 export function foreignKeyCountsByOriginTable(fks) {

--- a/frontend/src/metabase/visualizations/visualizations/Map.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Map.jsx
@@ -6,7 +6,7 @@ import ChoroplethMap from "../components/ChoroplethMap.jsx";
 import PinMap from "../components/PinMap.jsx";
 
 import { ChartSettingsError } from "metabase/visualizations/lib/errors";
-import { isNumeric, isLatitude, isLongitude, hasLatitudeAndLongitudeColumns } from "metabase/lib/schema_metadata";
+import { isNumeric, isLatitude, isLongitude, hasLatitudeAndLongitudeColumns, isPoint, hasPointColumn } from "metabase/lib/schema_metadata";
 import { metricSetting, dimensionSetting, fieldSetting } from "metabase/visualizations/lib/settings";
 import MetabaseSettings from "metabase/lib/settings";
 
@@ -47,7 +47,7 @@ export default class Map extends Component {
                     case "pin_map":
                         return "pin";
                     default:
-                        if (hasLatitudeAndLongitudeColumns(cols)) {
+                        if (hasLatitudeAndLongitudeColumns(cols) || hasPointColumn(cols)) {
                             return "pin";
                         } else {
                             return "region";
@@ -55,17 +55,23 @@ export default class Map extends Component {
                 }
             }
         },
+        "map.point_column": {
+            title: "Latitude and Longitude",
+            ...fieldSetting("map.point_column", isNumeric,
+                ([{ data: { cols }}]) => (_.find(cols, isPoint) || {}).name),
+            getHidden: (series, vizSettings) => vizSettings["map.type"] !== "pin" || hasPointColumn(series[0].data.cols)
+        },
         "map.latitude_column": {
             title: "Latitude field",
             ...fieldSetting("map.latitude_column", isNumeric,
                 ([{ data: { cols }}]) => (_.find(cols, isLatitude) || {}).name),
-            getHidden: (series, vizSettings) => vizSettings["map.type"] !== "pin"
+            getHidden: (series, vizSettings) => vizSettings["map.type"] !== "pin" || !hasLatitudeAndLongitudeColumns(series[0].data.cols)
         },
         "map.longitude_column": {
             title: "Longitude field",
             ...fieldSetting("map.longitude_column", isNumeric,
                 ([{ data: { cols }}]) => (_.find(cols, isLongitude) || {}).name),
-            getHidden: (series, vizSettings) => vizSettings["map.type"] !== "pin"
+            getHidden: (series, vizSettings) => vizSettings["map.type"] !== "pin" || !hasLatitudeAndLongitudeColumns(series[0].data.cols)
         },
         "map.region": {
             title: "Region map",
@@ -116,7 +122,7 @@ export default class Map extends Component {
 
     static checkRenderable([{ data: { cols, rows} }], settings) {
         if (settings["map.type"] === "pin") {
-            if (!settings["map.longitude_column"] || !settings["map.latitude_column"]) {
+            if (!settings["map.point_column"] && (!settings["map.longitude_column"] || !settings["map.latitude_column"])) {
                 throw new ChartSettingsError("Please select longitude and latitude columns in the chart settings.", "Data");
             }
         } else if (settings["map.type"] === "region"){

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -46,7 +46,7 @@
    :numeric       :type/Decimal
    :path          :type/*
    :pg_lsn        :type/Integer         ; PG Log Sequence #
-   :point         :type/*
+   :point         :type/Point
    :real          :type/Float
    :serial        :type/Integer
    :serial2       :type/Integer

--- a/src/metabase/types.clj
+++ b/src/metabase/types.clj
@@ -21,6 +21,8 @@
 (derive :type/Latitude :type/Coordinate)
 (derive :type/Longitude :type/Coordinate)
 
+(derive :type/Point :type/*)
+
 
 ;;; Text Types
 


### PR DESCRIPTION
Resolves #2327

* [x] add `:TYPE/Point`
 * [ ] should we also have a `special_type` `:TYPE/LatLon`?
* Add relevant database type mappings
  * [x] Postgres `point`
  * [ ] PostGIS `ST_Point`
  * [ ] others?
* [x] add support to Pin maps
* [ ] add support to `contains` operator
* [ ] add better parsing/serialization on backend (currently returns string `(x,y)` which we have to parse in the frontend