### PR TITLE
Substitute SQL parameters using `unprepare` when converting to native

### DIFF
--- a/src/metabase/driver/bigquery.clj
+++ b/src/metabase/driver/bigquery.clj
@@ -297,7 +297,7 @@
 
 (defn- execute-query [{{{:keys [dataset-id]} :details, :as database} :database, {sql :query, params :params, :keys [table-name mbql?]} :native, :as outer-query}]
   (let [sql     (str "-- " (qputil/query->remark outer-query) "\n" (if (seq params)
-                                                                     (unprepare/unprepare (cons sql params))
+                                                                     (unprepare/unprepare (cons sql params) :iso-8601-fn :timestamp)
                                                                      sql))
         results (process-native* database sql)
         results (if mbql?

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -86,6 +86,11 @@
 
      Return `nil` to prevent FIELD from being aliased.")
 
+  (iso-8601->timestamp [this iso-timestamp]
+    "*OPTIONAL*.  Perform any conversion required from ISO 8601 timestamp to a native timestamp literal.
+    This function takes a string as argument and returns the appropriate HoneySQL form
+    For example:  (hsql/call :timestamp (hx/literal iso-timestamp))")
+
   (prepare-sql-param [this obj]
     "*OPTIONAL*. Do any neccesary type conversions, etc. to an object being passed as a prepared statment argument in a parameterized raw SQL query.
      For example, a raw SQL query with a date param, `x`, e.g. `WHERE date > {{x}}`, is converted to SQL like `WHERE date > ?`, and the value of
@@ -460,6 +465,7 @@
    :prepare-value        (u/drop-first-arg :value)
    :quote-style          (constantly :ansi)
    :set-timezone-sql     (constantly nil)
+   :iso-8601->timestamp  (u/drop-first-arg hx/literal)
    :stddev-fn            (constantly :STDDEV)})
 
 

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -10,6 +10,7 @@
              [driver :as driver]
              [util :as u]]
             [metabase.driver.generic-sql :as sql]
+            [metabase.driver.generic-sql.util.unprepare :as unprepare]
             [metabase.query-processor
              [annotate :as annotate]
              [interface :as i]
@@ -288,8 +289,7 @@
   (binding [*query* outer-query]
     (let [honeysql-form (build-honeysql-form driver outer-query)
           [sql & args]  (sql/honeysql-form->sql+args driver honeysql-form)]
-      {:query  sql
-       :params args})))
+      {:query (unprepare/unprepare (cons sql args) :iso-8601-fn (partial sql/iso-8601->timestamp driver))})))
 
 (defn- run-query
   "Run the query itself."

--- a/src/metabase/driver/generic_sql/util/unprepare.clj
+++ b/src/metabase/driver/generic_sql/util/unprepare.clj
@@ -4,7 +4,7 @@
             [honeysql.core :as hsql]
             [metabase.util :as u]
             [metabase.util.honeysql-extensions :as hx])
-  (:import java.util.Date))
+  (:import (java.util Date UUID)))
 
 (defprotocol ^:private IUnprepare
   (^:private unprepare-arg ^String [this settings]))
@@ -14,11 +14,18 @@
   String  (unprepare-arg [this {:keys [quote-escape]}] (str \' (str/replace this "'" (str quote-escape "'")) \')) ; escape single-quotes
   Boolean (unprepare-arg [this _] (if this "TRUE" "FALSE"))
   Number  (unprepare-arg [this _] (str this))
-  Date    (unprepare-arg [this {:keys [iso-8601-fn]}] (first (hsql/format (hsql/call iso-8601-fn (hx/literal (u/date->iso-8601 this)))))))
+  UUID    (unprepare-arg [this _] (str \' this \'))
+  Date    (unprepare-arg [this {:keys [iso-8601-fn]}]
+                            (let [date-exp (u/date->iso-8601 this)]
+                              (first (hsql/format
+                                      (cond
+                                        (fn? iso-8601-fn) (iso-8601-fn date-exp)
+                                        (keyword? iso-8601-fn) (hsql/call iso-8601-fn (hx/literal date-exp))
+                                        :otherwise (hx/literal date-exp)))))))
 
 (defn unprepare
   "Convert a normal SQL `[statement & prepared-statement-args]` vector into a flat, non-prepared statement."
-  ^String [[sql & args] & {:keys [quote-escape iso-8601-fn], :or {quote-escape "\\\\", iso-8601-fn :timestamp}}]
+  ^String [[sql & args] & {:keys [quote-escape iso-8601-fn], :or {quote-escape "\\\\", iso-8601-fn nil}}]
   (loop [sql sql, [arg & more-args, :as args] args]
     (if-not (seq args)
       sql

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -119,6 +119,7 @@
              expr
              (hsql/raw "timestamp '1970-01-01T00:00:00Z'")))
 
+(defn- iso-8601->timestamp [expr] (hsql/raw (format "timestamp '%s'" expr)))
 
 (defn- check-native-query-not-using-default-user [{query-type :type, database-id :database, :as query}]
   {:pre [(integer? database-id)]}
@@ -223,6 +224,7 @@
           :connection-details->spec  (u/drop-first-arg connection-details->spec)
           :date                      (u/drop-first-arg date)
           :string-length-fn          (u/drop-first-arg string-length-fn)
+          :iso-8601->timestamp       (u/drop-first-arg iso-8601->timestamp)
           :unix-timestamp->timestamp (u/drop-first-arg unix-timestamp->timestamp)}))
 
 (driver/register-driver! :h2 (H2Driver.))

--- a/test/metabase/driver/generic_sql/util/unprepare_test.clj
+++ b/test/metabase/driver/generic_sql/util/unprepare_test.clj
@@ -3,7 +3,7 @@
             [metabase.driver.generic-sql.util.unprepare :as unprepare]))
 
 (expect
-  "SELECT 'Cam\\'s Cool Toucan' FROM TRUE WHERE x ?? y AND z = timestamp('2017-01-01T00:00:00.000Z')"
+  "SELECT 'Cam\\'s Cool Toucan' FROM TRUE WHERE x ?? y AND z = '2017-01-01T00:00:00.000Z'"
   (unprepare/unprepare ["SELECT ? FROM ? WHERE x ?? y AND z = ?"
                         "Cam's Cool Toucan"
                         true


### PR DESCRIPTION
Fixes #3549 by calling unprepare in the generic SQL driver when converting queries to native.

I tested locally with H2 and postgres and `lein test`.  Going to see if CI picks up anything in engines I didn't test.

###### TODO 
-  [ x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
