### PR TITLE
fix #5225

### DIFF
--- a/frontend/src/metabase/css/core/inputs.css
+++ b/frontend/src/metabase/css/core/inputs.css
@@ -48,3 +48,9 @@
 .no-focus:focus {
   outline: 0;
 }
+
+/* prevent safari from forcing type="search" styles - issue #5225 */
+.input[type="search"] {
+  -webkit-appearance: none;
+}
+


### PR DESCRIPTION
looks like the browser defaults for `[type=search]` inputs type became specific than some of our own settings in a more recent version of safari.