### PR TITLE
Rename IGenericSQLDatasetLoader -> IGenericSQLTestExtensions

### DIFF
--- a/test/metabase/test/data/crate.clj
+++ b/test/metabase/test/data/crate.clj
@@ -54,7 +54,7 @@
   (constantly {:hosts "localhost:5200"}))
 
 (extend CrateDriver
-  generic/IGenericSQLDatasetLoader
+  generic/IGenericSQLTestExtensions
   (merge generic/DefaultsMixin
          {:execute-sql!              generic/sequentially-execute-sql!
           :field-base-type->sql-type (u/drop-first-arg field-base-type->sql-type)

--- a/test/metabase/test/data/generic_sql.clj
+++ b/test/metabase/test/data/generic_sql.clj
@@ -17,9 +17,9 @@
 
 ;;; ## ------------------------------------------------------------ IGenericDatasetLoader + default impls ------------------------------------------------------------
 
-(defprotocol IGenericSQLDatasetLoader
+(defprotocol IGenericSQLTestExtensions
   "Methods for loading `DatabaseDefinition` in a SQL database.
-   A type that implements `IGenericSQLDatasetLoader` can be made to implement most of `IDriverTestExtensions`
+   A type that implements `IGenericSQLTestExtensions` can be made to implement most of `IDriverTestExtensions`
    by using the `IDriverTestExtensionsMixin`.
 
    Methods marked *Optional* below have a default implementation specified in `DefaultsMixin`."
@@ -259,7 +259,7 @@
 
 
 (def DefaultsMixin
-  "Default implementations for methods marked *Optional* in `IGenericSQLDatasetLoader`."
+  "Default implementations for methods marked *Optional* in `IGenericSQLTestExtensions`."
   {:add-fk-sql                default-add-fk-sql
    :create-db-sql             default-create-db-sql
    :create-table-sql          default-create-table-sql
@@ -316,7 +316,7 @@
     (load-data! driver dbdef tabledef)))
 
 (def IDriverTestExtensionsMixin
-  "Mixin for `IGenericSQLDatasetLoader` types to implement `create-db!` from `IDriverTestExtensions`."
+  "Mixin for `IGenericSQLTestExtensions` types to implement `create-db!` from `IDriverTestExtensions`."
   (merge i/IDriverTestExtensionsDefaultsMixin
          {:create-db! create-db!}))
 

--- a/test/metabase/test/data/h2.clj
+++ b/test/metabase/test/data/h2.clj
@@ -51,7 +51,7 @@
 
 
 (u/strict-extend H2Driver
-  generic/IGenericSQLDatasetLoader
+  generic/IGenericSQLTestExtensions
   (let [{:keys [execute-sql!], :as mixin} generic/DefaultsMixin]
     (merge mixin
            {:create-db-sql             (constantly create-db-sql)

--- a/test/metabase/test/data/mysql.clj
+++ b/test/metabase/test/data/mysql.clj
@@ -35,7 +35,7 @@
   (str \` nm \`))
 
 (u/strict-extend MySQLDriver
-  generic/IGenericSQLDatasetLoader
+  generic/IGenericSQLTestExtensions
   (merge generic/DefaultsMixin
          {:database->spec            (comp add-connection-params (:database->spec generic/DefaultsMixin))
           :execute-sql!              generic/sequentially-execute-sql! ; TODO - we might be able to do SQL all at once by setting `allowMultiQueries=true` on the connection string

--- a/test/metabase/test/data/oracle.clj
+++ b/test/metabase/test/data/oracle.clj
@@ -72,7 +72,7 @@
 
 
 (extend OracleDriver
-  generic/IGenericSQLDatasetLoader
+  generic/IGenericSQLTestExtensions
   (merge generic/DefaultsMixin
          {:create-db-sql             (constantly nil)
           :drop-db-if-exists-sql     (constantly nil)

--- a/test/metabase/test/data/postgres.clj
+++ b/test/metabase/test/data/postgres.clj
@@ -46,7 +46,7 @@
 
 
 (u/strict-extend PostgresDriver
-  generic/IGenericSQLDatasetLoader
+  generic/IGenericSQLTestExtensions
   (merge generic/DefaultsMixin
          {:drop-db-if-exists-sql     drop-db-if-exists-sql
           :drop-table-if-exists-sql  generic/drop-table-if-exists-cascade-sql

--- a/test/metabase/test/data/redshift.clj
+++ b/test/metabase/test/data/redshift.clj
@@ -48,7 +48,7 @@
 
 
 (u/strict-extend RedshiftDriver
-  generic/IGenericSQLDatasetLoader
+  generic/IGenericSQLTestExtensions
   (merge generic/DefaultsMixin
          {:create-db-sql             (constantly nil)
           :drop-db-if-exists-sql     (constantly nil)

--- a/test/metabase/test/data/sqlite.clj
+++ b/test/metabase/test/data/sqlite.clj
@@ -32,7 +32,7 @@
                                (hsql/call :datetime (hx/literal (u/date->iso-8601 v))))]))))))
 
 (u/strict-extend SQLiteDriver
-  generic/IGenericSQLDatasetLoader
+  generic/IGenericSQLTestExtensions
   (merge generic/DefaultsMixin
          {:add-fk-sql                (constantly nil) ; TODO - fix me
           :create-db-sql             (constantly nil)

--- a/test/metabase/test/data/sqlserver.clj
+++ b/test/metabase/test/data/sqlserver.clj
@@ -75,7 +75,7 @@
 
 
 (u/strict-extend SQLServerDriver
-  generic/IGenericSQLDatasetLoader
+  generic/IGenericSQLTestExtensions
   (merge generic/DefaultsMixin
          {:drop-db-if-exists-sql     (u/drop-first-arg drop-db-if-exists-sql)
           :drop-table-if-exists-sql  (u/drop-first-arg drop-table-if-exists-sql)

--- a/test/metabase/test/data/vertica.clj
+++ b/test/metabase/test/data/vertica.clj
@@ -40,7 +40,7 @@
 
 
 (u/strict-extend VerticaDriver
-  generic/IGenericSQLDatasetLoader
+  generic/IGenericSQLTestExtensions
   (merge generic/DefaultsMixin
          {:create-db-sql             (constantly nil)
           :drop-db-if-exists-sql     (constantly nil)


### PR DESCRIPTION
More cleanup. Rename the `IGenericSQLDatasetLoader` to `IGenericSQLTestExtensions` which better explains its purpose