### PR TITLE
Cleanup backported from nested-queries branch

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -246,6 +246,7 @@
   (sample-data/add-sample-dataset!)
   (Database :is_sample true))
 
+
 ;;; ------------------------------------------------------------ PUT /api/database/:id ------------------------------------------------------------
 
 (api/defendpoint PUT "/:id"

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -88,11 +88,11 @@
   (card-with-uuid uuid))
 
 
-
 (defn run-query-for-card-with-id
   "Run the query belonging to Card with CARD-ID with PARAMETERS and other query options (e.g. `:constraints`)."
   [card-id parameters & options]
   (u/prog1 (-> (let [parameters (if (string? parameters) (json/parse-string parameters keyword) parameters)]
+                 ;; run this query with full superuser perms
                  (binding [api/*current-user-permissions-set*     (atom #{"/"})
                            qp/*allow-queries-with-no-executor-id* true]
                    (apply card-api/run-query-for-card card-id, :parameters parameters, :context :public-question, options)))

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -2,6 +2,7 @@
   "/api/table endpoints."
   (:require [clojure.tools.logging :as log]
             [compojure.core :refer [GET PUT]]
+            [medley.core :as m]
             [metabase
              [sync-database :as sync-database]
              [util :as u]]
@@ -87,6 +88,7 @@
   {include_sensitive_fields (s/maybe su/BooleanString)}
   (-> (api/read-check Table id)
       (hydrate :db [:fields :target] :field_values :segments :metrics)
+      (m/dissoc-in [:db :details])
       (update-in [:fields] (if (Boolean/parseBoolean include_sensitive_fields)
                              ;; If someone passes include_sensitive_fields return hydrated :fields as-is
                              identity

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -323,6 +323,17 @@
       (log/warn (format "Don't know how to map class '%s' to a Field base_type, falling back to :type/*." klass))
       :type/*))
 
+(defn values->base-type
+  "Given a sequence of VALUES, return the most common base type."
+  [values]
+  (->> values
+       (filter (complement nil?))                   ; filter out `nil` values
+       (take 1000)                                  ; take up to 1000 values
+       (group-by (comp class->base-type class))     ; now group by their base-type
+       (sort-by (comp (partial * -1) count second)) ; sort the map into pairs of [base-type count] with highest count as first pair
+       ffirst))                                     ; take the base-type from the first pair
+
+
 ;; ## Driver Lookup
 
 (defn engine->driver

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -220,6 +220,7 @@
 
 (defn honeysql-form->sql+args
   "Convert HONEYSQL-FORM to a vector of SQL string and params, like you'd pass to JDBC."
+  {:style/indent 1}
   [driver honeysql-form]
   {:pre [(map? honeysql-form)]}
   (let [[sql & args] (try (binding [hformat/*subquery?* false]

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -243,7 +243,7 @@
       (h/limit items)
       (h/offset (* items (dec page)))))
 
-(defn- apply-source-table [_ honeysql-form {{table-name :name, schema :schema} :source-table}]
+(defn- apply-source-table [honeysql-form {{table-name :name, schema :schema} :source-table}]
   {:pre [table-name]}
   (h/from honeysql-form (hx/qualify-and-escape-dots schema table-name)))
 
@@ -252,7 +252,7 @@
   ;;    will get swapped around and  we'll be left with old version of the function that nobody implements
   ;; 2) This is a vector rather than a map because the order the clauses get handled is important for some drivers.
   ;;    For example, Oracle needs to wrap the entire query in order to apply its version of limit (`WHERE ROWNUM`).
-  [:source-table apply-source-table
+  [:source-table (u/drop-first-arg apply-source-table)
    :aggregation  #'sql/apply-aggregation
    :breakout     #'sql/apply-breakout
    :fields       #'sql/apply-fields

--- a/src/metabase/driver/googleanalytics/query_processor.clj
+++ b/src/metabase/driver/googleanalytics/query_processor.clj
@@ -3,7 +3,7 @@
   (:require [clojure.string :as s]
             [clojure.tools.reader.edn :as edn]
             [medley.core :as m]
-            [metabase.query-processor.expand :as ql]
+            [metabase.query-processor.util :as qputil]
             [metabase.util :as u])
   (:import [com.google.api.services.analytics.model GaData GaData$ColumnHeaders]
            [metabase.query_processor.interface AgFieldRef DateTimeField DateTimeValue Field RelativeDateTimeValue Value]))
@@ -251,7 +251,7 @@
   [{query :query}]
   (let [[aggregation-type metric-name] (first-aggregation query)]
     (when (and aggregation-type
-               (= :metric (ql/normalize-token aggregation-type))
+               (= :metric (qputil/normalize-token aggregation-type))
                (string? metric-name))
       metric-name)))
 
@@ -266,7 +266,7 @@
 (defn- filter-type ^clojure.lang.Keyword [filter-clause]
   (when (and (sequential? filter-clause)
              (u/string-or-keyword? (first filter-clause)))
-    (ql/normalize-token (first filter-clause))))
+    (qputil/normalize-token (first filter-clause))))
 
 (defn- compound-filter? [filter-clause]
   (contains? #{:and :or :not} (filter-type filter-clause)))

--- a/src/metabase/driver/mongo/util.clj
+++ b/src/metabase/driver/mongo/util.clj
@@ -137,26 +137,3 @@
      (if *mongo-connection*
        (f# *mongo-connection*)
        (-with-mongo-connection f# ~database))))
-
-;; TODO - this isn't neccesarily Mongo-specific; consider moving
-(defn values->base-type
-  "Given a sequence of values, return `Field.base_type` in the most ghetto way possible.
-   This just gets counts the types of *every* value and returns the `base_type` for class whose count was highest."
-  [values-seq]
-  {:pre [(sequential? values-seq)]}
-  (or (->> values-seq
-           ;; TODO - why not do a query to return non-nil values of this column instead
-           (filter identity)
-           ;; it's probably fine just to consider the first 1,000 *non-nil* values when trying to type a column instead
-           ;; of iterating over the whole collection. (VALUES-SEQ should be up to 10,000 values, but we don't know how many are
-           ;; nil)
-           (take 1000)
-           (group-by type)
-           ;; create tuples like [Integer count].
-           (map (fn [[klass valus]]
-                  [klass (count valus)]))
-           (sort-by second)
-           last                     ; last result will be tuple with highest count
-           first                    ; keep just the type
-           driver/class->base-type) ; convert to Field base_type
-      :type/*))

--- a/src/metabase/query_processor/annotate.clj
+++ b/src/metabase/query_processor/annotate.clj
@@ -134,15 +134,18 @@
                        (expression-aggregate-field-info ag)
                        (aggregate-field-info ag))))))
 
-
 (defn- generic-info-for-missing-key
-  "Return a set of bare-bones metadata for a Field named K when all else fails."
-  [k]
-  {:base-type          :type/*
+  "Return a set of bare-bones metadata for a Field named K when all else fails.
+   Scan the INITIAL-VALUES of K in an attempt to determine the `base-type`."
+  [k & [initial-values]]
+  {:base-type          (if (seq initial-values)
+                         (driver/values->base-type initial-values)
+                         :type/*)
    :preview-display    true
    :special-type       nil
    :field-name         k
    :field-display-name k})
+
 
 (defn- info-for-duplicate-field
   "The Clojure JDBC driver automatically appends suffixes like `count_2` to duplicate columns if multiple columns come back with the same name;
@@ -159,14 +162,14 @@
 (defn- info-for-missing-key
   "Metadata for a field named K, which we weren't able to resolve normally.
    If possible, we work around This defaults to generic information "
-  [fields k]
+  [fields k initial-values]
   (or (info-for-duplicate-field fields k)
-      (generic-info-for-missing-key k)))
+      (generic-info-for-missing-key k initial-values)))
 
 (defn- add-unknown-fields-if-needed
   "When create info maps for any fields we didn't expect to come back from the query.
    Ideally, this should never happen, but on the off chance it does we still want to return it in the results."
-  [actual-keys fields]
+  [actual-keys initial-rows fields]
   {:pre [(set? actual-keys) (every? keyword? actual-keys)]}
   (let [expected-keys (u/prog1 (set (map :field-name fields))
                         (assert (every? keyword? <>)))
@@ -175,7 +178,7 @@
       (log/warn (u/format-color 'yellow "There are fields we weren't expecting in the results: %s\nExpected: %s\nActual: %s"
                   missing-keys expected-keys actual-keys)))
     (concat fields (for [k missing-keys]
-                     (info-for-missing-key fields k)))))
+                     (info-for-missing-key fields k (map k initial-rows))))))
 
 (defn- convert-field-to-expected-format
   "Rename keys, provide default values, etc. for FIELD so it is in the format expected by the frontend."
@@ -238,14 +241,14 @@
 (defn- resolve-sort-and-format-columns
   "Collect the Fields referenced in QUERY, sort them according to the rules at the top
    of this page, format them as expected by the frontend, and return the results."
-  [query result-keys]
+  [query result-keys initial-rows]
   {:pre [(set? result-keys)]}
   (when (seq result-keys)
     (->> (collect-fields (dissoc query :expressions))
          (map qualify-field-name)
          (add-aggregate-fields-if-needed query)
          (map (u/rpartial update :field-name keyword))
-         (add-unknown-fields-if-needed result-keys)
+         (add-unknown-fields-if-needed result-keys initial-rows)
          (sort/sort-fields query)
          (map convert-field-to-expected-format)
          (filter (comp (partial contains? result-keys) :name))
@@ -261,7 +264,7 @@
   [query {:keys [columns rows], :as results}]
   (let [row-maps (for [row rows]
                    (zipmap columns row))
-        cols    (resolve-sort-and-format-columns (:query query) (set columns))
+        cols    (resolve-sort-and-format-columns (:query query) (set columns) (take 10 row-maps))
         columns (mapv :name cols)]
     (assoc results
       :cols    (vec (for [col cols]

--- a/src/metabase/query_processor/interface.clj
+++ b/src/metabase/query_processor/interface.clj
@@ -33,13 +33,21 @@
    Not neccesarily bound when using various functions like `fk->` in the REPL."
   nil)
 
+(defn driver-supports?
+  "Does the currently bound `*driver*` support FEATURE?
+   (This returns `nil` if `*driver*` is unbound. `*driver*` is always bound when running queries the normal way,
+   but may not be when calling this function directly from the REPL.)"
+  [feature]
+  (when *driver*
+    ((resolve 'metabase.driver/driver-supports?) *driver* feature)))
+
 ;; `assert-driver-supports` doesn't run check when `*driver*` is unbound (e.g., when used in the REPL)
 ;; Allows flexibility when composing queries for tests or interactive development
 (defn assert-driver-supports
   "When `*driver*` is bound, assert that is supports keyword FEATURE."
   [feature]
   (when *driver*
-    (when-not (contains? ((resolve 'metabase.driver/features) *driver*) feature)
+    (when-not (driver-supports? feature)
       (throw (Exception. (str (name feature) " is not supported by this driver."))))))
 
 ;; Expansion Happens in a Few Stages:
@@ -70,9 +78,11 @@
     "Return a vector of name components of the form `[table-name parent-names... field-name]`"))
 
 
-;;; # ------------------------------------------------------------ "RESOLVED" TYPES: FIELD + VALUE ------------------------------------------------------------
+;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+;;; |                                                                             FIELDS                                                                             |
+;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
-;; Field is the expansion of a Field ID in the standard QL
+;; Field is the "expanded" form of a Field ID (field reference) in MBQL
 (s/defrecord Field [field-id           :- su/IntGreaterThanZero
                     field-name         :- su/NonBlankString
                     field-display-name :- su/NonBlankString
@@ -98,6 +108,7 @@
             [table-name])
           field-name)))
 
+;;; DateTimeField
 
 (def ^:const datetime-field-units
   "Valid units for a `DateTimeField`."
@@ -122,7 +133,7 @@
   (contains? relative-datetime-value-units (keyword unit)))
 
 
-;; wrapper around Field
+;; DateTimeField is just a simple wrapper around Field
 (s/defrecord DateTimeField [field :- Field
                             unit  :- DatetimeFieldUnit]
   clojure.lang.Named
@@ -136,11 +147,80 @@
     [nil expression-name]))
 
 
+;;; Placeholder Types
+
+;; Replace Field IDs with these during first pass
+(s/defrecord FieldPlaceholder [field-id      :- su/IntGreaterThanZero
+                               fk-field-id   :- (s/maybe (s/constrained su/IntGreaterThanZero
+                                                                        (fn [_] (or (assert-driver-supports :foreign-keys) true)) ; assert-driver-supports will throw Exception if driver is bound
+                                                                        "foreign-keys is not supported by this driver."))         ; and driver does not support foreign keys
+                               datetime-unit :- (s/maybe (apply s/enum datetime-field-units))])
+
+(s/defrecord AgFieldRef [index :- s/Int])
+;; TODO - add a method to get matching expression from the query?
+
+
+
+
+(def FieldPlaceholderOrExpressionRef
+  "Schema for either a `FieldPlaceholder` or `ExpressionRef`."
+  (s/named (s/cond-pre FieldPlaceholder ExpressionRef)
+           "Valid field or expression reference."))
+
+(s/defrecord RelativeDatetime [amount :- s/Int
+                               unit   :- DatetimeValueUnit])
+
+(declare Aggregation AnyField AnyValueLiteral)
+
+(def ^:private ExpressionOperator (s/named (s/enum :+ :- :* :/) "Valid expression operator"))
+
+(s/defrecord Expression [operator   :- ExpressionOperator
+                         args       :- [(s/cond-pre (s/recursive #'AnyValueLiteral)
+                                                    (s/recursive #'AnyField)
+                                                    (s/recursive #'Aggregation))]
+                         custom-name :- (s/maybe su/NonBlankString)])
+
+
+(def AnyField
+  "Schema for a anything that is considered a valid 'field'."
+  (s/named (s/cond-pre Field
+                       FieldPlaceholder
+                       AgFieldRef
+                       Expression
+                       ExpressionRef)
+           "AnyField: field, ag field reference, expression, expression reference, or field literal."))
+
+
+;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+;;; |                                                                             VALUES                                                                             |
+;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+(def LiteralDatetimeString
+  "Schema for an MBQL datetime string literal, in ISO-8601 format."
+  (s/constrained su/NonBlankString u/date-string? "Valid ISO-8601 datetime string literal"))
+
+(def LiteralDatetime
+  "Schema for an MBQL literal datetime value: and ISO-8601 string or `java.sql.Date`."
+  (s/named (s/cond-pre java.sql.Date LiteralDatetimeString) "Valid datetime literal (must be ISO-8601 string or java.sql.Date)"))
+
+(def Datetime
+  "Schema for an MBQL datetime value: an ISO-8601 string, `java.sql.Date`, or a relative dateitme form."
+  (s/named (s/cond-pre RelativeDatetime LiteralDatetime) "Valid datetime (must ISO-8601 string literal or a relative-datetime form)"))
+
+(def OrderableValue
+  "Schema for something that is orderable value in MBQL (either a number or datetime)."
+  (s/named (s/cond-pre s/Num Datetime) "Valid orderable value (must be number or datetime)"))
+
+(def AnyValueLiteral
+  "Schema for anything that is a considered a valid value literal in MBQL - `nil`, a `Boolean`, `Number`, `String`, or relative datetime form."
+  (s/named (s/maybe (s/cond-pre s/Bool su/NonBlankString OrderableValue)) "Valid value (must be nil, boolean, number, string, or a relative-datetime form)"))
+
+
 ;; Value is the expansion of a value within a QL clause
 ;; Information about the associated Field is included for convenience
-(s/defrecord Value [value   :- (s/maybe (s/cond-pre s/Bool s/Num su/NonBlankString))
-                    field   :- (s/named (s/cond-pre Field ExpressionRef)   ; TODO - Value doesn't need the whole field, just the relevant type info / units
-                                        "field or expression reference")])
+;; TODO - Value doesn't need the whole field, just the relevant type info / units
+(s/defrecord Value [value   :- AnyValueLiteral
+                    field   :- (s/recursive #'AnyField)])
 
 ;; e.g. an absolute point in time (literal)
 (s/defrecord DateTimeValue [value :- Timestamp
@@ -167,72 +247,12 @@
   (add-date-time-units [this n] (update this :amount (partial + n))))
 
 
-;;; # ------------------------------------------------------------ PLACEHOLDER TYPES: FIELDPLACEHOLDER + VALUEPLACEHOLDER ------------------------------------------------------------
-
-;; Replace Field IDs with these during first pass
-(s/defrecord FieldPlaceholder [field-id      :- su/IntGreaterThanZero
-                               fk-field-id   :- (s/maybe (s/constrained su/IntGreaterThanZero
-                                                                        (fn [_] (or (assert-driver-supports :foreign-keys) true))
-                                                                        "foreign-keys is not supported by this driver."))
-                               datetime-unit :- (s/maybe (apply s/enum datetime-field-units))])
-
-(s/defrecord AgFieldRef [index :- s/Int])
-
-;; TODO - add a method to get matching expression from the query?
-
-(def FieldPlaceholderOrAgRef
-  "Schema for either a `FieldPlaceholder` or `AgFieldRef`."
-  (s/named (s/cond-pre FieldPlaceholder AgFieldRef) "Valid field (not a field ID or aggregate field reference)"))
-
-(def FieldPlaceholderOrExpressionRef
-  "Schema for either a `FieldPlaceholder` or `ExpressionRef`."
-  (s/named (s/cond-pre FieldPlaceholder ExpressionRef)
-           "Valid field or expression reference."))
-
-
-(s/defrecord RelativeDatetime [amount :- s/Int
-                               unit   :- DatetimeValueUnit])
-
-
-(declare RValue Aggregation)
-
-(def ^:private ExpressionOperator (s/named (s/enum :+ :- :* :/) "Valid expression operator"))
-
-(s/defrecord Expression [operator   :- ExpressionOperator
-                         args       :- [(s/cond-pre (s/recursive #'RValue)
-                                                    (s/recursive #'Aggregation))]
-                         custom-name :- (s/maybe su/NonBlankString)])
-
-(def AnyFieldOrExpression
-  "Schema for a `FieldPlaceholder`, `AgRef`, or `Expression`."
-  (s/named (s/cond-pre ExpressionRef Expression FieldPlaceholderOrAgRef)
-           "Valid field, ag field reference, expression, or expression reference."))
-
-
-(def LiteralDatetimeString
-  "Schema for an MBQL datetime string literal, in ISO-8601 format."
-  (s/constrained su/NonBlankString u/date-string? "Valid ISO-8601 datetime string literal"))
-
-(def LiteralDatetime
-  "Schema for an MBQL literal datetime value: and ISO-8601 string or `java.sql.Date`."
-  (s/named (s/cond-pre java.sql.Date LiteralDatetimeString) "Valid datetime literal (must be ISO-8601 string or java.sql.Date)"))
-
-(def Datetime
-  "Schema for an MBQL datetime value: an ISO-8601 string, `java.sql.Date`, or a relative dateitme form."
-  (s/named (s/cond-pre RelativeDatetime LiteralDatetime) "Valid datetime (must ISO-8601 string literal or a relative-datetime form)"))
-
-(def OrderableValue
-  "Schema for something that is orderable value in MBQL (either a number or datetime)."
-  (s/named (s/cond-pre s/Num Datetime) "Valid orderable value (must be number or datetime)"))
-
-(def AnyValue
-  "Schema for anything that is a considered a valid value in MBQL - `nil`, a `Boolean`, `Number`, `String`, or relative datetime form."
-  (s/named (s/maybe (s/cond-pre s/Bool su/NonBlankString OrderableValue)) "Valid value (must be nil, boolean, number, string, or a relative-datetime form)"))
+;;; Placeholder Types
 
 ;; Replace values with these during first pass over Query.
 ;; Include associated Field ID so appropriate the info can be found during Field resolution
 (s/defrecord ValuePlaceholder [field-placeholder :- FieldPlaceholderOrExpressionRef
-                               value             :- AnyValue])
+                               value             :- AnyValueLiteral])
 
 (def OrderableValuePlaceholder
   "`ValuePlaceholder` schema with the additional constraint that the value be orderable (a number or datetime)."
@@ -242,21 +262,16 @@
   "`ValuePlaceholder` schema with the additional constraint that the value be a string/"
   (s/constrained ValuePlaceholder (comp string? :value) ":value must be a string"))
 
-(def FieldOrAnyValue
-  "Schema that accepts either a `FieldPlaceholder` or `ValuePlaceholder`."
-  (s/named (s/cond-pre FieldPlaceholder ValuePlaceholder) "Field or value"))
-
-;; (def FieldOrOrderableValue (s/named (s/cond-pre FieldPlaceholder OrderableValuePlaceholder) "Field or orderable value (number or datetime)"))
-;; (def FieldOrStringValue    (s/named (s/cond-pre FieldPlaceholder StringValuePlaceholder)    "Field or string literal"))
-
-(def RValue
-  "Schema for anything that can be an [RValue](https://github.com/metabase/metabase/wiki/Query-Language-'98#rvalues) -
-   a `Field`, `Value`, or `Expression`."
-  (s/named (s/cond-pre AnyValue FieldPlaceholderOrExpressionRef Expression)
-           "RValue"))
+(def AnyFieldOrValue
+  "Schema that accepts anything normally considered a field (including expressions and literals) *or* a value or value placehoder."
+  (s/named (s/cond-pre AnyField Value ValuePlaceholder) "Field or value"))
 
 
-;;; # ------------------------------------------------------------ CLAUSE SCHEMAS ------------------------------------------------------------
+;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+;;; |                                                                             CLAUSES                                                                            |
+;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+;;; aggregation
 
 (s/defrecord AggregationWithoutField [aggregation-type :- (s/named (s/enum :count :cumulative-count)
                                                                    "Valid aggregation type")
@@ -281,9 +296,11 @@
    "standard-deviation-aggregations is not supported by this driver."))
 
 
+;;; filter
+
 (s/defrecord EqualityFilter [filter-type :- (s/enum := :!=)
                              field       :- FieldPlaceholderOrExpressionRef
-                             value       :- FieldOrAnyValue])
+                             value       :- AnyFieldOrValue])
 
 (s/defrecord ComparisonFilter [filter-type :- (s/enum :< :<= :> :>=)
                                field       :- FieldPlaceholderOrExpressionRef
@@ -316,16 +333,21 @@
   (s/named (s/cond-pre SimpleFilterClause NotFilter CompoundFilter)
            "Valid filter clause"))
 
+
+;;; order-by
+
 (def OrderByDirection
   "Schema for the direction in an `OrderBy` subclause."
   (s/named (s/enum :ascending :descending) "Valid order-by direction"))
 
 (def OrderBy
   "Schema for top-level `order-by` clause in an MBQL query."
-  (s/named {:field     AnyFieldOrExpression
+  (s/named {:field     AnyField
             :direction OrderByDirection}
            "Valid order-by subclause"))
 
+
+;;; page
 
 (def Page
   "Schema for the top-level `page` clause in a MBQL query."
@@ -333,11 +355,16 @@
             :items su/IntGreaterThanZero}
            "Valid page clause"))
 
+
+;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+;;; |                                                                             QUERY                                                                              |
+;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
 (def Query
   "Schema for an MBQL query."
   {(s/optional-key :aggregation) [Aggregation]
    (s/optional-key :breakout)    [FieldPlaceholderOrExpressionRef]
-   (s/optional-key :fields)      [AnyFieldOrExpression]
+   (s/optional-key :fields)      [AnyField]
    (s/optional-key :filter)      Filter
    (s/optional-key :limit)       su/IntGreaterThanZero
    (s/optional-key :order-by)    [OrderBy]

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -5,12 +5,14 @@
             [metabase.util :as u]))
 
 (defn- check-query-permissions* [query]
-  ;; TODO - should we do anything if there is no *current-user-id* (for something like a pulse?)
   (u/prog1 query
     (when *current-user-id*
       (perms/check-query-permissions *current-user-id* query))))
 
 (defn check-query-permissions
-  "Middleware that check that the current user has permissions to run the current query."
+  "Middleware that check that the current user has permissions to run the current query.
+   This only applies if `*current-user-id*` is bound. In other cases, like when running
+   public Cards or sending pulses, permissions need to be checked separately before allowing
+   the relevant objects to be create (e.g., when saving a new Pulse or 'publishing' a Card)."
   [qp]
   (comp qp check-query-permissions*))

--- a/src/metabase/query_processor/permissions.clj
+++ b/src/metabase/query_processor/permissions.clj
@@ -62,6 +62,7 @@
 
 
 (defn- ^:deprecated table-id [source-or-join-table]
+  {:post [(integer? %)]}
   (or (:id source-or-join-table)
       (:table-id source-or-join-table)))
 
@@ -75,6 +76,7 @@
   (or (user-can-run-query-referencing-table? user-id (table-id table))
       (throw-permissions-exception "You do not have permissions to run queries referencing table '%s'." (table-identifier table))))
 
+;; TODO - why is this the only function here that takes `user-id`?
 (defn- throw-if-cannot-run-query
   "Throw an exception if USER-ID doesn't have permissions to run QUERY."
   [user-id {:keys [source-table join-tables]}]
@@ -118,8 +120,8 @@
 
 (defn check-query-permissions
   "Check that User with USER-ID has permissions to run QUERY, or throw an exception."
-  [user-id {query-type :type, database :database, query :query, {card-id :card-id} :info}]
-  {:pre [(integer? user-id)]}
+  [user-id {query-type :type, database :database, query :query, {card-id :card-id} :info, :as outer-query}]
+  {:pre [(integer? user-id) (map? outer-query)]}
   (let [native?       (= (keyword query-type) :native)
         collection-id (db/select-one-field :collection_id 'Card :id card-id)]
     (cond

--- a/src/metabase/query_processor/resolve.clj
+++ b/src/metabase/query_processor/resolve.clj
@@ -194,7 +194,7 @@
         ;; Otherwise fetch + resolve the Fields in question
         (let [fields (->> (u/key-by :id (db/select [field/Field :name :display_name :base_type :special_type :visibility_type :table_id :parent_id :description :id]
                                           :visibility_type [:not= "sensitive"]
-                                          :id [:in field-ids]))
+                                          :id              [:in field-ids]))
                           (m/map-vals rename-mb-field-keys)
                           (m/map-vals #(assoc % :parent (when-let [parent-id (:parent-id %)]
                                                           (i/map->FieldPlaceholder {:field-id parent-id})))))]
@@ -207,7 +207,11 @@
            ;; Recurse in case any new (nested) unresolved fields were found.
            (recur (dec max-iterations))))))))
 
-(defn- fk-field-ids->info [source-table-id fk-field-ids]
+(defn- fk-field-ids->info
+  "Given a SOURCE-TABLE-ID and collection of FK-FIELD-IDS, return a sequence of maps containing IDs and identifiers for those FK fields and their target tables and fields.
+   FK-FIELD-IDS are IDs of fields that belong to the source table. For example, SOURCE-TABLE-ID might be 'checkins' and FK-FIELD-IDS might have the IDs for 'checkins.user_id'
+   and the like."
+  [source-table-id fk-field-ids]
   (when (seq fk-field-ids)
     (db/query {:select    [[:source-fk.name      :source-field-name]
                            [:source-fk.id        :source-field-id]
@@ -219,8 +223,8 @@
                :from      [[field/Field :source-fk]]
                :left-join [[field/Field :target-pk] [:= :source-fk.fk_target_field_id :target-pk.id]
                            [Table :target-table]    [:= :target-pk.table_id :target-table.id]]
-               :where     [:and [:in :source-fk.id      (set fk-field-ids)]
-                                [:=  :source-fk.table_id     source-table-id]
+               :where     [:and [:in :source-fk.id       (set fk-field-ids)]
+                                [:=  :source-fk.table_id source-table-id]
                                 (mdb/isa :source-fk.special_type :type/FK)]})))
 
 (defn- fk-field-ids->joined-tables

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -3,7 +3,11 @@
   (:require [buddy.core
              [codecs :as codecs]
              [hash :as hash]]
-            [cheshire.core :as json]))
+            [cheshire.core :as json]
+            [clojure.string :as str]
+            [metabase.util :as u]
+            [metabase.util.schema :as su]
+            [schema.core :as s]))
 
 (defn mbql-query?
   "Is the given query an MBQL query?"
@@ -31,6 +35,69 @@
   (str "Metabase" (when info
                     (assert (instance? (Class/forName "[B") query-hash))
                     (format ":: userID: %s queryType: %s queryHash: %s" executed-by query-type (codecs/bytes->hex query-hash)))))
+
+
+;;; ------------------------------------------------------------ Normalization ------------------------------------------------------------
+
+;; The following functions make it easier to deal with MBQL queries, which are case-insensitive, string/keyword insensitive, and underscore/hyphen insensitive.
+;; These should be preferred instead of assuming the frontend will always pass in clauses the same way, since different variation are all legal under MBQL '98.
+
+;; TODO - In the future it might make sense to simply walk the entire query and normalize the whole thing when it comes in. I've tried implementing middleware
+;; to do that but it ended up breaking a few things that wrongly assume different clauses will always use a certain case (e.g. SQL `:template_tags`). Fixing
+;; all of that is out-of-scope for the nested queries PR but should possibly be revisited in the future.
+
+(s/defn ^:always-validate normalize-token :- s/Keyword
+  "Convert a string or keyword in various cases (`lisp-case`, `snake_case`, or `SCREAMING_SNAKE_CASE`) to a lisp-cased keyword."
+  [token :- su/KeywordOrString]
+  (-> (name token)
+      str/lower-case
+      (str/replace #"_" "-")
+      keyword))
+
+(defn get-normalized
+  "Get the value for normalized key K in map M, regardless of how the key was specified in M,
+   whether string or keyword, lisp-case, snake_case, or SCREAMING_SNAKE_CASE.
+
+     (get-normalized {\"NUM_TOUCANS\" 2} :num-toucans) ; -> 2"
+  ([m k]
+   {:pre [(or (u/maybe? map? m)
+              (println "Not a map:" m))]}
+   (let [k (normalize-token k)]
+     (some (fn [[map-k v]]
+             (when (= k (normalize-token map-k))
+               v))
+           m)))
+  ([m k not-found]
+   (or (get-normalized m k)
+       not-found)))
+
+(defn get-in-normalized
+  "Like `get-normalized`, but accepts a sequence of keys KS, like `get-in`.
+
+    (get-in-normalized {\"NUM_BIRDS\" {\"TOUCANS\" 2}} [:num-birds :toucans]) ; -> 2"
+  ([m ks]
+   {:pre [(u/maybe? sequential? ks)]}
+   (loop [m m, [k & more] ks]
+     (if-not k
+       m
+       (recur (get-normalized m k) more))))
+  ([m ks not-found]
+   (or (get-in-normalized m ks)
+       not-found)))
+
+(defn dissoc-normalized
+  "Remove all matching keys from map M regardless of case, string/keyword, or hypens/underscores.
+
+     (dissoc-normalized {\"NUM_TOUCANS\" 3} :num-toucans) ; -> {}"
+  [m k]
+  {:pre [(or (u/maybe? map? m)
+             (println "Not a map:" m))]}
+  (let [k (normalize-token k)]
+    (loop [m m, [map-k & more, :as ks] (keys m)]
+      (cond
+        (not (seq ks)) m
+        (= k (normalize-token map-k)) (recur (dissoc m map-k) more)
+        :else                         (recur m                more)))))
 
 
 ;;; ------------------------------------------------------------ Hashing ------------------------------------------------------------

--- a/src/metabase/sync_database/analyze.clj
+++ b/src/metabase/sync_database/analyze.clj
@@ -44,7 +44,7 @@
   (try
     (queries/table-row-count table)
     (catch Throwable e
-      (log/error (u/format-color 'red "Unable to determine row count for '%s': %s\n%s" (:name table) (.getMessage e) (u/pprint-to-str (u/filtered-stacktrace e)))))))
+      (log/warn (u/format-color 'red "Unable to determine row count for '%s': %s\n%s" (:name table) (.getMessage e) (u/pprint-to-str (u/filtered-stacktrace e)))))))
 
 (defn test-for-cardinality?
   "Should FIELD should be tested for cardinality?"

--- a/src/metabase/util/honeysql_extensions.clj
+++ b/src/metabase/util/honeysql_extensions.clj
@@ -84,6 +84,7 @@
                  (rest sql-string-or-vector))))))
 
 
+;; Single-quoted string literal
 (defrecord Literal [literal]
   ToSql
   (to-sql [_]

--- a/test/metabase/http_client.clj
+++ b/test/metabase/http_client.clj
@@ -67,7 +67,6 @@
    or throw an Exception if that fails."
   [{:keys [email password], :as credentials}]
   {:pre [(string? email) (string? password)]}
-  (println "Authenticating" email) ; DEBUG
   (try
     (:id (client :post 200 "session" credentials))
     (catch Throwable e

--- a/test/metabase/permissions_collection_test.clj
+++ b/test/metabase/permissions_collection_test.clj
@@ -18,9 +18,6 @@
 ;; but not Rasta (all-users)
 
 (defn- api-call-was-successful? {:style/indent 0} [response]
-  (when (and (string? response)
-             (not= response "You don't have permissions to do that."))
-    (println "RESPONSE:" response)) ; DEBUG
   (and (not= response "You don't have permissions to do that.")
        (not= response "Unauthenticated")))
 

--- a/test/metabase/permissions_test.clj
+++ b/test/metabase/permissions_test.clj
@@ -129,7 +129,7 @@
      :table_id      (u/get-id table)
      :dataset_query {:database (u/get-id db)
                      :type     "native"
-                     :query    (format "SELECT count(*) FROM \"%s\";" (:name table))}}))
+                     :native   {:query (format "SELECT count(*) FROM \"%s\";" (:name table))}}}))
 
 
 (def ^:dynamic *card:db1-count-of-venues*)

--- a/test/metabase/query_processor/util_test.clj
+++ b/test/metabase/query_processor/util_test.clj
@@ -105,3 +105,53 @@
     (qputil/query-hash {:database    2
                         :type        "native"
                         :native      {:query "SELECT pg_sleep(15), 2 AS two"}})))
+
+
+;;; ------------------------------------------------------------ Tests for get-normalized and get-in-normalized ------------------------------------------------------------
+
+(expect 2 (qputil/get-normalized {"num_toucans" 2} :num-toucans))
+(expect 2 (qputil/get-normalized {"NUM_TOUCANS" 2} :num-toucans))
+(expect 2 (qputil/get-normalized {"num-toucans" 2} :num-toucans))
+(expect 2 (qputil/get-normalized {:num_toucans 2}  :num-toucans))
+(expect 2 (qputil/get-normalized {:NUM_TOUCANS 2}  :num-toucans))
+(expect 2 (qputil/get-normalized {:num-toucans 2}  :num-toucans))
+
+(expect
+  nil
+  (qputil/get-normalized nil :num-toucans))
+
+(expect 2 (qputil/get-in-normalized {"BIRDS" {"NUM_TOUCANS" 2}} [:birds :num-toucans]))
+(expect 2 (qputil/get-in-normalized {"birds" {"num_toucans" 2}} [:birds :num-toucans]))
+(expect 2 (qputil/get-in-normalized {"birds" {"num-toucans" 2}} [:birds :num-toucans]))
+(expect 2 (qputil/get-in-normalized {:BIRDS  {:NUM_TOUCANS 2}}  [:birds :num-toucans]))
+(expect 2 (qputil/get-in-normalized {:birds  {:num_toucans 2}}  [:birds :num-toucans]))
+(expect 2 (qputil/get-in-normalized {:birds  {:num-toucans 2}}  [:birds :num-toucans]))
+
+(expect
+  2
+  (qputil/get-in-normalized {:num-toucans 2} [:num-toucans]))
+
+(expect
+  nil
+  (qputil/get-in-normalized nil [:birds :num-toucans]))
+
+(expect
+  10
+  (qputil/get-in-normalized
+   {"dataset_query" {"query" {"source_table" 10}}}
+   [:dataset-query :query :source-table]))
+
+(expect {} (qputil/dissoc-normalized {"NUM_TOUCANS" 3} :num-toucans))
+(expect {} (qputil/dissoc-normalized {"num_toucans" 3} :num-toucans))
+(expect {} (qputil/dissoc-normalized {"num-toucans" 3} :num-toucans))
+(expect {} (qputil/dissoc-normalized {:NUM_TOUCANS 3}  :num-toucans))
+(expect {} (qputil/dissoc-normalized {:num_toucans 3}  :num-toucans))
+(expect {} (qputil/dissoc-normalized {:num-toucans 3}  :num-toucans))
+
+(expect
+  {}
+  (qputil/dissoc-normalized {:num-toucans 3, "NUM_TOUCANS" 3, "num_toucans" 3} :num-toucans))
+
+(expect
+  nil
+  (qputil/dissoc-normalized nil :num-toucans))

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -120,7 +120,12 @@
   `(run-query* (query ~table ~@forms)))
 
 
-(defn format-name [nm]
+(defn format-name
+  "Format a SQL schema, table, or field identifier in the correct way for the current database by calling the
+   driver's implementation of `format-name`.
+   (Most databases use the default implementation of `identity`; H2 uses `clojure.string/upper-case`.)
+   This function DOES NOT quote the identifier."
+  [nm]
   (i/format-name *driver* (name nm)))
 
 (defn- get-table-id-or-explode [db-id table-name]

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -70,7 +70,6 @@
   {:pre [(string? email) (string? first) (string? last) (string? password) (m/boolean? superuser) (m/boolean? active)]}
   (wait-for-initiailization)
   (or (User :email email)
-      (println "Creating test user:" email) ; DEBUG
       (db/insert! User
         :email        email
         :first_name   first
@@ -139,7 +138,6 @@
         (when-not (= status-code 401)
           (throw e))
         ;; If we got a 401 unauthenticated clear the tokens cache + recur
-        (printf "Got 401 (Unauthenticated) for %s. Clearing cached auth tokens and retrying request.\n" username) ; DEBUG
         (reset! tokens {})
         (apply client-fn username args)))))
 

--- a/test_resources/log4j.properties
+++ b/test_resources/log4j.properties
@@ -16,8 +16,8 @@ log4j.appender.file.layout.ConversionPattern=%d [%t] %-5p%c - %m%n
 
 # customizations to logging by package
 log4j.logger.com.mchange=ERROR
+log4j.logger.org.eclipse.jetty.server.HttpChannel=ERROR
 log4j.logger.metabase=ERROR
-log4j.logger.metabase.middleware=INFO
 log4j.logger.metabase.test-setup=INFO
 log4j.logger.metabase.test.data.datasets=INFO
 log4j.logger.metabase.util.encryption=INFO


### PR DESCRIPTION
As I navigate the codebase working on things I find myself constantly adding comments and docstrings to better explain however something works (usually whenever I have to look at the code to figure out what's happening -- a prime indicator that more documentation is needed in my mind), and fixing indentation or other random bits and bobs. However that can lead to big PRs being artificially even bigger -- the `nested-queries` PR is well over 1000 LOC.

At such a point I usually split out the unrelated cleanup changed into a separate PR so I can narrow the focus of the feature PR, making it easier to review, work on, etc.

This PR contains changes such as:

-  Lots of additional dox
-  Indentation and whitespace fixes
-  Fixing some places where we `:refer :all` for required namespaces instead of using a namespace alias (which is preferable)
-  Remove some debugging logging that I forgot to remove in the past
-  reärrange a few things for clarity
-  extra tests
-  etc.

For those interested, this process is pretty simple:

```bash
git checkout master
git merge <pr-branch>
git reset origin/master
```
Then remove anything you don't want in the 'cleanup' PR (I usually use [SourceTree](https://www.sourcetreeapp.com/) for this) and create a new PR


