### PR TITLE
Symbol sql Variables type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ pom.xml.asc
 /.lein-failures
 /.lein-repl-history
 /.nrepl-port
+.DS_Store
 .idea/
 /docs/uberdoc.html
 profiles.clj

--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -5,6 +5,7 @@ import { isa, isFK, TYPE } from "metabase/lib/types";
 // primary field types used for picking operators, etc
 export const NUMBER = "NUMBER";
 export const STRING = "STRING";
+export const SYMBOL = "SYMBOL";
 export const STRING_LIKE = "STRING_LIKE";
 export const BOOLEAN = "BOOLEAN";
 export const DATE_TIME = "DATE_TIME";
@@ -29,6 +30,9 @@ const TYPES = {
     [NUMBER]: {
         base: [TYPE.Number],
         special: [TYPE.Number]
+    },
+    [SYMBOL]: {
+        base: [TYPE.Symbol]
     },
     [STRING]: {
         base: [TYPE.Text],
@@ -93,7 +97,7 @@ export function isFieldType(type, field) {
 
 export function getFieldType(field) {
     // try more specific types first, then more generic types
-    for (const type of [DATE_TIME, LOCATION, COORDINATE, NUMBER, STRING, STRING_LIKE, BOOLEAN]) {
+    for (const type of [DATE_TIME, LOCATION, COORDINATE, NUMBER, STRING, STRING_LIKE, SYMBOL, BOOLEAN]) {
         if (isFieldType(type, field)) return type;
     }
 }
@@ -102,6 +106,7 @@ export const isDate = isFieldType.bind(null, DATE_TIME);
 export const isNumeric = isFieldType.bind(null, NUMBER);
 export const isBoolean = isFieldType.bind(null, BOOLEAN);
 export const isString = isFieldType.bind(null, STRING);
+export const isSymbol = isFieldType.bind(null, SYMBOL);
 export const isSummable = isFieldType.bind(null, SUMMABLE);
 export const isCategory = isFieldType.bind(null, CATEGORY);
 
@@ -273,6 +278,9 @@ const OPERATORS_BY_TYPE_ORDERED = {
         { name: "<=",               verboseName: "Less than or equal to", advanced: true },
         { name: "IS_NULL",          verboseName: "Is empty", advanced: true },
         { name: "NOT_NULL",         verboseName: "Not empty", advanced: true }
+    ],
+    [SYMBOL]: [
+        { name: "=",                verboseName: "Is" },
     ],
     [STRING]: [
         { name: "=",                verboseName: "Is" },
@@ -529,6 +537,7 @@ export const ICON_MAPPING = {
     [COORDINATE]: 'location',
     [STRING]: 'string',
     [STRING_LIKE]: 'string',
+    [SYMBOL]: 'string',
     [NUMBER]: 'int',
     [BOOLEAN]: 'io'
 };

--- a/frontend/src/metabase/meta/Dashboard.js
+++ b/frontend/src/metabase/meta/Dashboard.js
@@ -73,6 +73,10 @@ export const PARAMETER_OPTIONS: Array<ParameterOption> = [
         type: "category",
         name: "Category"
     },
+    {
+        type: "symbol",
+        name: "Symbol"
+    },
 ];
 
 type ParameterSection = {
@@ -86,7 +90,7 @@ export const PARAMETER_SECTIONS: Array<ParameterSection> = [
     { id: "date",     name: "Time",             description: "Date range, relative date, time of day, etc.", options: [] },
     { id: "location", name: "Location",         description: "City, State, Country, ZIP code.", options: [] },
     { id: "id",       name: "ID",               description: "User ID, product ID, event ID, etc.", options: [] },
-    { id: "category", name: "Other Categories", description: "Category, Type, Model, Rating, etc.", options: [] },
+    { id: "category", name: "Other Categories", description: "Category, Type, Model, Rating, Symbols, etc.", options: [] },
 ];
 
 for (const option of PARAMETER_OPTIONS) {
@@ -216,6 +220,7 @@ export function fieldFilterForParameterType(parameterType: ParameterType): Field
         case "date":        return (field: Field) => field.isDate();
         case "id":          return (field: Field) => field.isID();
         case "category":    return (field: Field) => field.isCategory();
+        case "symbol":      return (field: Field) => field.isSymbol();
     }
     switch (parameterType) {
         case "location/city":     return (field: Field) => isa(field.special_type, TYPE.City);
@@ -237,6 +242,7 @@ function tagFilterForParameter(parameter: Parameter): TemplateTagFilter {
         case "location":    return (tag: TemplateTag) => tag.type === "number" || tag.type === "text";
         case "id":          return (tag: TemplateTag) => tag.type === "number" || tag.type === "text";
         case "category":    return (tag: TemplateTag) => tag.type === "number" || tag.type === "text";
+        case "symbol":      return (tag: TemplateTag) =>  tag.type === "symbol";
     }
     return (tag: TemplateTag) => false;
 }

--- a/frontend/src/metabase/meta/metadata/Field.js
+++ b/frontend/src/metabase/meta/metadata/Field.js
@@ -7,7 +7,7 @@ import type { FieldId, Field as FieldObject } from "metabase/meta/types/Field";
 import type { TableId } from "metabase/meta/types/Table";
 
 import { getFieldValues } from "metabase/lib/query/field";
-import { isDate, isNumeric, isBoolean, isString, isSummable, isCategory, isDimension, isMetric, getIconForField } from "metabase/lib/schema_metadata";
+import { isDate, isNumeric, isBoolean, isString, isSummable, isCategory, isSymbol, isDimension, isMetric, getIconForField } from "metabase/lib/schema_metadata";
 import { isPK, isFK } from "metabase/lib/types";
 
 export default class Field extends Base {
@@ -40,6 +40,7 @@ export default class Field extends Base {
     isNumeric()   { return isNumeric(this._object); }
     isBoolean()   { return isBoolean(this._object); }
     isString()    { return isString(this._object); }
+    isSymbol()    { return isSymbol(this._object); }
     isSummable()  { return isSummable(this._object); }
     isCategory()  { return isCategory(this._object); }
     isMetric()    { return isMetric(this._object); }

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
@@ -120,6 +120,7 @@ export default class TagEditorParam extends Component {
                         <Option value="number">Number</Option>
                         <Option value="date">Date</Option>
                         <Option value="dimension">Field Filter</Option>
+                        <Option value="symbol">Symbol</Option>
                     </Select>
                 </div>
 

--- a/test/metabase/query_processor/sql_parameters_test.clj
+++ b/test/metabase/query_processor/sql_parameters_test.clj
@@ -291,6 +291,18 @@
                    :parameters [{:type "category", :target ["variable" ["template-tag" "category"]], :value "Gizmo"}]}))
 
 
+
+(expect
+  {:query  "SELECT * FROM products_tablenamepart WHERE a = 1;"
+   :params []}
+  (expand-params* {:native     {:query "SELECT * FROM products_{{symbol1}} WHERE a = 1;"
+                                :template_tags {:symbol1 {:name "symbol1", :display_name "Symbol1", :type "symbol"}}}
+                   :parameters [{:type "symbol", :target ["variable" ["template-tag" "symbol1"]], :value "tablenamepart\"; DROP TABLES"}]}
+                  )
+  )
+
+
+
 ;;; ------------------------------------------------------------ expansion tests: dimensions ------------------------------------------------------------
 
 (defn- expand-with-dimension-param [dimension-param]


### PR DESCRIPTION
Allows for SQL template like this:
```
SELECT count(distinct {{col1}}) as foo1 FROM {{table1}} WHERE  {{filter_column1}} = "foo2"
```
While I realise this this is frowned upon, it is required for our specific use case.
The symbol value is  `(re-find #"\w+" value)`'ed  so should be fairly safe to sql injection.

Works in Questions and as a dashboard parameter

Question view:
![screen shot 2017-06-01 at 16 44 35](https://cloud.githubusercontent.com/assets/664042/26688144/c87247a0-46e9-11e7-83f4-91a343aa326e.png)

Dashboard filter creation:
`What do you want to filter?` -> `Other Categories`
This now has a new second selection (which previously was skipped) like so
![screen shot 2017-06-01 at 16 47 20](https://cloud.githubusercontent.com/assets/664042/26688258/126a292c-46ea-11e7-83e5-8a272ad3e5a1.png)

Only Symbols can be chosen from a question for a symbol filter
![screen shot 2017-06-01 at 16 51 38](https://cloud.githubusercontent.com/assets/664042/26688520/bed0787e-46ea-11e7-9295-232c5f3b612a.png)




