### PR TITLE
More improvements backported from nested-queries

### DIFF
--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -1,6 +1,7 @@
 (ns metabase.models.user
   (:require [cemerick.friend.credentials :as creds]
             [clojure.string :as s]
+            [clojure.tools.logging :as log]
             [metabase
              [public-settings :as public-settings]
              [util :as u]]
@@ -42,12 +43,12 @@
   (u/prog1 user
     ;; add the newly created user to the magic perms groups
     (binding [perm-membership/*allow-changing-all-users-group-members* true]
-      #_(log/info (format "Adding user %d to All Users permissions group..." user-id))
+      (log/info (format "Adding user %d to All Users permissions group..." user-id))
       (db/insert! PermissionsGroupMembership
         :user_id  user-id
         :group_id (:id (group/all-users))))
     (when superuser?
-      #_(log/info (format "Adding user %d to Admin permissions group..." user-id))
+      (log/info (format "Adding user %d to Admin permissions group..." user-id))
       (db/insert! PermissionsGroupMembership
         :user_id  user-id
         :group_id (:id (group/admin))))))

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -8,7 +8,7 @@
              [field :refer [Field]]
              [table :refer [Table]]]
             [metabase.test
-             [data :refer :all]
+             [data :as data :refer :all]
              [util :as tu :refer [match-$]]]
             [metabase.test.data
              [datasets :as datasets]
@@ -49,24 +49,28 @@
          (u/ignore-exceptions (first @~result)) ; in case @result# barfs we don't want the test to succeed (Exception == Exception for expectations)
          (second @~result)))))
 
+(def ^:private default-db-details
+  {:engine             "h2"
+   :name               "test-data"
+   :is_sample          false
+   :is_full_sync       true
+   :description        nil
+   :caveats            nil
+   :points_of_interest nil})
+
 
 (defn- db-details
+  "Return default column values for a database (either the test database, via `(db)`, or optionally passed in)."
   ([]
    (db-details (db)))
   ([db]
-   (match-$ db
-     {:created_at         $
-      :engine             "h2"
-      :id                 $
-      :details            $
-      :updated_at         $
-      :name               "test-data"
-      :is_sample          false
-      :is_full_sync       true
-      :description        nil
-      :caveats            nil
-      :points_of_interest nil
-      :features           (mapv name (driver/features (driver/engine->driver (:engine db))))})))
+   (merge default-db-details
+          (match-$ db
+            {:created_at $
+             :id         $
+             :details    $
+             :updated_at $
+             :features   (mapv name (driver/features (driver/engine->driver (:engine db))))}))))
 
 
 ;; # DB LIFECYCLE ENDPOINTS
@@ -85,19 +89,16 @@
 ;; ## POST /api/database
 ;; Check that we can create a Database
 (expect-with-temp-db-created-via-api [db {:is_full_sync false}]
-  (match-$ db
-    {:created_at         $
-     :engine             :postgres
-     :id                 $
-     :details            {:host "localhost", :port 5432, :dbname "fakedb", :user "cam", :ssl true}
-     :updated_at         $
-     :name               $
-     :is_sample          false
-     :is_full_sync       false
-     :description        nil
-     :caveats            nil
-     :points_of_interest nil
-     :features           (driver/features (driver/engine->driver :postgres))})
+  (merge default-db-details
+         (match-$ db
+           {:created_at         $
+            :engine             :postgres
+            :is_full_sync       false
+            :id                 $
+            :details            {:host "localhost", :port 5432, :dbname "fakedb", :user "cam", :ssl true}
+            :updated_at         $
+            :name               $
+            :features           (driver/features (driver/engine->driver :postgres))}))
   (Database (:id db)))
 
 
@@ -122,26 +123,38 @@
       (dissoc (into {} (db/select-one [Database :name :engine :details :is_full_sync], :id db-id))
               :features)))
 
+:description             nil
+                               :entity_type             nil
+                               :caveats                 nil
+                               :points_of_interest      nil
+                               :visibility_type         nil
+(def ^:private default-table-details
+  {:description             nil
+   :entity_name             nil
+   :entity_type             nil
+   :caveats                 nil
+   :points_of_interest      nil
+   :visibility_type         nil
+   :active                  true
+   :show_in_getting_started false})
 
 (defn- table-details [table]
-  (match-$ table
-    {:description             $
-     :entity_type             $
-     :caveats                 nil
-     :points_of_interest      nil
-     :visibility_type         $
-     :schema                  $
-     :name                    $
-     :display_name            $
-     :rows                    $
-     :updated_at              $
-     :entity_name             $
-     :active                  $
-     :id                      $
-     :db_id                   $
-     :show_in_getting_started false
-     :raw_table_id            $
-     :created_at              $}))
+  (merge default-table-details
+         (match-$ table
+           {:description     $
+            :entity_type     $
+            :visibility_type $
+            :schema          $
+            :name            $
+            :display_name    $
+            :rows            $
+            :updated_at      $
+            :entity_name     $
+            :active          $
+            :id              $
+            :db_id           $
+            :raw_table_id    $
+            :created_at      $})))
 
 
 ;; TODO - this is a test code smell, each test should clean up after itself and this step shouldn't be neccessary. One day we should be able to remove this!
@@ -163,32 +176,24 @@
 (expect-with-temp-db-created-via-api [{db-id :id}]
   (set (filter identity (conj (for [engine datasets/all-valid-engines]
                                 (datasets/when-testing-engine engine
-                                  (match-$ (get-or-create-test-data-db! (driver/engine->driver engine))
-                                    {:created_at         $
-                                     :engine             (name $engine)
-                                     :id                 $
-                                     :updated_at         $
-                                     :name               "test-data"
-                                     :native_permissions "write"
-                                     :is_sample          false
-                                     :is_full_sync       true
-                                     :description        nil
-                                     :caveats            nil
-                                     :points_of_interest nil
-                                     :features           (map name (driver/features (driver/engine->driver engine)))})))
-                              (match-$ (Database db-id)
-                                {:created_at         $
-                                 :engine             "postgres"
-                                 :id                 $
-                                 :updated_at         $
-                                 :name               $
-                                 :native_permissions "write"
-                                 :is_sample          false
-                                 :is_full_sync       true
-                                 :description        nil
-                                 :caveats            nil
-                                 :points_of_interest nil
-                                 :features           (map name (driver/features (driver/engine->driver :postgres)))}))))
+                                  (merge default-db-details
+                                         (match-$ (get-or-create-test-data-db! (driver/engine->driver engine))
+                                           {:created_at         $
+                                            :engine             (name $engine)
+                                            :id                 $
+                                            :updated_at         $
+                                            :name               "test-data"
+                                            :native_permissions "write"
+                                            :features           (map name (driver/features (driver/engine->driver engine)))}))))
+                              (merge default-db-details
+                                     (match-$ (Database db-id)
+                                       {:created_at         $
+                                        :engine             "postgres"
+                                        :id                 $
+                                        :updated_at         $
+                                        :name               $
+                                        :native_permissions "write"
+                                        :features           (map name (driver/features (driver/engine->driver :postgres)))})))))
   (do
     (delete-randomly-created-databases! :skip [db-id])
     (set ((user->client :rasta) :get 200 "database"))))
@@ -197,121 +202,98 @@
 
 ;; GET /api/databases (include tables)
 (expect-with-temp-db-created-via-api [{db-id :id}]
-  (set (cons (match-$ (Database db-id)
-               {:created_at         $
-                :engine             "postgres"
-                :id                 $
-                :updated_at         $
-                :name               $
-                :native_permissions "write"
-                :is_sample          false
-                :is_full_sync       true
-                :description        nil
-                :caveats            nil
-                :points_of_interest nil
-                :tables             []
-                :features           (map name (driver/features (driver/engine->driver :postgres)))})
+  (set (cons (merge default-db-details
+                    (match-$ (Database db-id)
+                      {:created_at         $
+                       :engine             "postgres"
+                       :id                 $
+                       :updated_at         $
+                       :name               $
+                       :native_permissions "write"
+                       :tables             []
+                       :features           (map name (driver/features (driver/engine->driver :postgres)))}))
              (filter identity (for [engine datasets/all-valid-engines]
                                 (datasets/when-testing-engine engine
                                   (let [database (get-or-create-test-data-db! (driver/engine->driver engine))]
-                                    (match-$ database
-                                      {:created_at         $
-                                       :engine             (name $engine)
-                                       :id                 $
-                                       :updated_at         $
-                                       :name               "test-data"
-                                       :native_permissions "write"
-                                       :is_sample          false
-                                       :is_full_sync       true
-                                       :description        nil
-                                       :caveats            nil
-                                       :points_of_interest nil
-                                       :tables             (sort-by :name (for [table (db/select Table, :db_id (:id database))]
-                                                                            (table-details table)))
-                                       :features           (map name (driver/features (driver/engine->driver engine)))})))))))
+                                    (merge default-db-details
+                                           (match-$ database
+                                             {:created_at         $
+                                              :engine             (name $engine)
+                                              :id                 $
+                                              :updated_at         $
+                                              :name               "test-data"
+                                              :native_permissions "write"
+                                              :tables             (sort-by :name (for [table (db/select Table, :db_id (:id database))]
+                                                                                   (table-details table)))
+                                              :features           (map name (driver/features (driver/engine->driver engine)))}))))))))
   (do
     (delete-randomly-created-databases! :skip [db-id])
     (set ((user->client :rasta) :get 200 "database" :include_tables true))))
 
+(def ^:private default-field-details
+  {:description        nil
+   :caveats            nil
+   :points_of_interest nil
+   :active             true
+   :position           0
+   :target             nil
+   :preview_display    true
+   :parent_id          nil})
+
 ;; ## GET /api/meta/table/:id/query_metadata
 ;; TODO - add in example with Field :values
 (expect
-  (match-$ (db)
-    {:created_at      $
-     :engine          "h2"
-     :id              $
-     :updated_at      $
-     :name            "test-data"
-     :is_sample       false
-     :is_full_sync    true
-     :description     nil
-     :caveats         nil
-     :points_of_interest nil
-     :features        (mapv name (driver/features (driver/engine->driver :h2)))
-     :tables          [(match-$ (Table (id :categories))
-                         {:description             nil
-                          :entity_type             nil
-                          :caveats                 nil
-                          :points_of_interest      nil
-                          :visibility_type         nil
-                          :schema                  "PUBLIC"
-                          :name                    "CATEGORIES"
-                          :display_name            "Categories"
-                          :fields                  [(match-$ (hydrate/hydrate (Field (id :categories :id)) :values)
-                                                      {:description        nil
-                                                       :table_id           (id :categories)
-                                                       :caveats            nil
-                                                       :points_of_interest nil
-                                                       :special_type       "type/PK"
-                                                       :name               "ID"
-                                                       :display_name       "ID"
-                                                       :updated_at         $
-                                                       :active             true
-                                                       :id                 $
-                                                       :raw_column_id      $
-                                                       :position           0
-                                                       :target             nil
-                                                       :preview_display    true
-                                                       :created_at         $
-                                                       :last_analyzed      $
-                                                       :base_type          "type/BigInteger"
-                                                       :visibility_type    "normal"
-                                                       :fk_target_field_id $
-                                                       :parent_id          nil
-                                                       :values             $})
-                                                    (match-$ (hydrate/hydrate (Field (id :categories :name)) :values)
-                                                      {:description        nil
-                                                       :table_id           (id :categories)
-                                                       :caveats            nil
-                                                       :points_of_interest nil
-                                                       :special_type       "type/Name"
-                                                       :name               "NAME"
-                                                       :display_name       "Name"
-                                                       :updated_at         $
-                                                       :active             true
-                                                       :id                 $
-                                                       :raw_column_id      $
-                                                       :position           0
-                                                       :target             nil
-                                                       :preview_display    true
-                                                       :created_at         $
-                                                       :last_analyzed      $
-                                                       :base_type          "type/Text"
-                                                       :visibility_type    "normal"
-                                                       :fk_target_field_id $
-                                                       :parent_id          nil
-                                                       :values             $})]
-                          :segments                []
-                          :metrics                 []
-                          :rows                    75
-                          :updated_at              $
-                          :entity_name             nil
-                          :active                  true
-                          :id                      (id :categories)
-                          :raw_table_id            $
-                          :db_id                   (id)
-                          :show_in_getting_started false
-                          :created_at              $})]})
+  (merge default-db-details
+         (match-$ (db)
+           {:created_at $
+            :engine     "h2"
+            :id         $
+            :updated_at $
+            :name       "test-data"
+            :features   (mapv name (driver/features (driver/engine->driver :h2)))
+            :tables     [(merge default-table-details
+                                (match-$ (Table (id :categories))
+                                  {:schema       "PUBLIC"
+                                   :name         "CATEGORIES"
+                                   :display_name "Categories"
+                                   :fields       [(merge default-field-details
+                                                         (match-$ (hydrate/hydrate (Field (id :categories :id)) :values)
+                                                           {:table_id           (id :categories)
+                                                            :special_type       "type/PK"
+                                                            :name               "ID"
+                                                            :display_name       "ID"
+                                                            :updated_at         $
+                                                            :id                 $
+                                                            :raw_column_id      $
+                                                            :created_at         $
+                                                            :last_analyzed      $
+                                                            :base_type          "type/BigInteger"
+                                                            :visibility_type    "normal"
+                                                            :fk_target_field_id $
+                                                            :values             $}))
+                                                  (merge default-field-details
+                                                         (match-$ (hydrate/hydrate (Field (id :categories :name)) :values)
+                                                           {:table_id           (id :categories)
+                                                            :special_type       "type/Name"
+                                                            :name               "NAME"
+                                                            :display_name       "Name"
+                                                            :updated_at         $
+                                                            :id                 $
+                                                            :raw_column_id      $
+                                                            :created_at         $
+                                                            :last_analyzed      $
+                                                            :base_type          "type/Text"
+                                                            :visibility_type    "normal"
+                                                            :fk_target_field_id $
+                                                            :values             $}))]
+                                   :segments     []
+                                   :metrics      []
+                                   :rows         75
+                                   :updated_at   $
+                                   :id           (id :categories)
+                                   :raw_table_id $
+                                   :db_id        (id)
+                                   :created_at   $}))]}))
   (let [resp ((user->client :rasta) :get 200 (format "database/%d/metadata" (id)))]
     (assoc resp :tables (filter #(= "CATEGORIES" (:name %)) (:tables resp)))))
 

--- a/test/metabase/events/activity_feed_test.clj
+++ b/test/metabase/events/activity_feed_test.clj
@@ -26,83 +26,84 @@
 
 
 ;; `:card-create` event
-(tt/expect-with-temp [Card [card {:name "My Cool Card"}]]
+(expect
   {:topic       :card-create
    :user_id     (user->id :rasta)
    :model       "card"
-   :model_id    (:id card)
    :database_id nil
    :table_id    nil
    :details     {:name "My Cool Card", :description nil}}
-  (with-temp-activities
-    (process-activity-event! {:topic :card-create, :item card})
-    (db/select-one [Activity :topic :user_id :model :model_id :database_id :table_id :details]
-      :topic    "card-create"
-      :model_id (:id card))))
+  (tt/with-temp Card [card {:name "My Cool Card"}]
+    (with-temp-activities
+      (process-activity-event! {:topic :card-create, :item card})
+      (db/select-one [Activity :topic :user_id :model :database_id :table_id :details]
+        :topic    "card-create"
+        :model_id (:id card)))))
+
 
 
 ;; `:card-update` event
-(tt/expect-with-temp [Card [card {:name "My Cool Card"}]]
+(expect
   {:topic       :card-update
    :user_id     (user->id :rasta)
    :model       "card"
-   :model_id    (:id card)
    :database_id nil
    :table_id    nil
    :details     {:name "My Cool Card", :description nil}}
-  (with-temp-activities
-    (process-activity-event! {:topic :card-update, :item card})
-    (db/select-one [Activity :topic :user_id :model :model_id :database_id :table_id :details]
-      :topic    "card-update"
-      :model_id (:id card))))
+  (tt/with-temp Card [card {:name "My Cool Card"}]
+    (with-temp-activities
+      (process-activity-event! {:topic :card-update, :item card})
+      (db/select-one [Activity :topic :user_id :model :database_id :table_id :details]
+        :topic    "card-update"
+        :model_id (:id card)))))
 
 
 ;; `:card-delete` event
-(tt/expect-with-temp [Card [card {:name "My Cool Card"}]]
+(expect
   {:topic       :card-delete
    :user_id     (user->id :rasta)
    :model       "card"
-   :model_id    (:id card)
    :database_id nil
    :table_id    nil
    :details     {:name "My Cool Card", :description nil}}
-  (with-temp-activities
-    (process-activity-event! {:topic :card-delete, :item card})
-    (db/select-one [Activity :topic :user_id :model :model_id :database_id :table_id :details]
-      :topic    "card-delete"
-      :model_id (:id card))))
+  (tt/with-temp Card [card {:name "My Cool Card"}]
+    (with-temp-activities
+      (process-activity-event! {:topic :card-delete, :item card})
+      (db/select-one [Activity :topic :user_id :model :database_id :table_id :details]
+        :topic    "card-delete"
+        :model_id (:id card)))))
 
 
 ;; `:dashboard-create` event
-(tt/expect-with-temp [Dashboard [dashboard {:name "My Cool Dashboard"}]]
+(expect
   {:topic       :dashboard-create
    :user_id     (user->id :rasta)
    :model       "dashboard"
-   :model_id    (:id dashboard)
    :database_id nil
    :table_id    nil
    :details     {:name "My Cool Dashboard", :description nil}}
-  (with-temp-activities
-    (process-activity-event! {:topic :dashboard-create, :item dashboard})
-    (db/select-one [Activity :topic :user_id :model :model_id :database_id :table_id :details]
-      :topic    "dashboard-create"
-      :model_id (:id dashboard))))
+  (tt/with-temp Dashboard [dashboard {:name "My Cool Dashboard"}]
+    (with-temp-activities
+      (process-activity-event! {:topic :dashboard-create, :item dashboard})
+      (db/select-one [Activity :topic :user_id :model :database_id :table_id :details]
+        :topic    "dashboard-create"
+        :model_id (:id dashboard)))))
 
 
 ;; `:dashboard-delete` event
-(tt/expect-with-temp [Dashboard [dashboard {:name "My Cool Dashboard"}]]
+(expect
   {:topic       :dashboard-delete
    :user_id     (user->id :rasta)
    :model       "dashboard"
-   :model_id    (:id dashboard)
    :database_id nil
    :table_id    nil
    :details     {:name "My Cool Dashboard", :description nil}}
-  (with-temp-activities
-    (process-activity-event! {:topic :dashboard-delete, :item dashboard})
-    (db/select-one [Activity :topic :user_id :model :model_id :database_id :table_id :details]
-      :topic    "dashboard-delete"
-      :model_id (:id dashboard))))
+  (tt/with-temp Dashboard [dashboard {:name "My Cool Dashboard"}]
+    (with-temp-activities
+      (process-activity-event! {:topic :dashboard-delete, :item dashboard})
+      (db/select-one [Activity :topic :user_id :model :database_id :table_id :details]
+        :topic    "dashboard-delete"
+        :model_id (:id dashboard)))))
 
 
 ;; `:dashboard-add-cards` event

--- a/test/metabase/query_processor/middleware/limit_test.clj
+++ b/test/metabase/query_processor/middleware/limit_test.clj
@@ -1,4 +1,4 @@
-(ns metabase.query-processor-test.middleware.limit-test
+(ns metabase.query-processor.middleware.limit-test
   "Tests for the `:limit` clause and `:max-results` constraints."
   (:require [expectations :refer :all]
             [metabase.query-processor.interface :as i]

--- a/test/metabase/test/data/bigquery.clj
+++ b/test/metabase/test/data/bigquery.clj
@@ -147,7 +147,7 @@
     (for [[i row] (m/indexed rows)]
       (assoc (zipmap field-names (for [v row]
                                    (u/prog1 (if (instance? java.util.Date v)
-                                              (DateTime. v)             ; convert to Google version of DateTime, otherwise it doesn't work (!)
+                                              (DateTime. ^java.util.Date v) ; convert to Google version of DateTime, otherwise it doesn't work (!)
                                               v)
                                             (assert (not (nil? <>)))))) ; make sure v is non-nil
              :id (inc i)))))


### PR DESCRIPTION
Some more random cleanup backported from `nested-queries`. That PR again passed 1200 LOC so time to try to strip out unrelated fixes and cleanup I made while working on it.

*  Move `metabase.query-processor-test.middleware.limit-test` to `metabase.query-processor.middleware.limit-test`so it can be with all its friends AKA all the other middleware test namespaces 
*  Cleanup the `api.database-test` namespace so we don't have to repeat a bunch of `nil` values for random column over and over again
*  Some refactoring for the code that gets required permissions for a Card for clarity
*  Reënable some commented out permissions logging
*  Don't use `tt/expect-with-temp` when we can just use `expect` (SAD!)
*  Fix some reflection warnings in test code
*  Reörganize "QP" pipeline a bit so we can add a new function that does all the preprocessing steps but doesn't execute the query. This makes it easier to test things like checking that the right SQL gets generated (without having to run a query) or test that pre or post-processing does something specific