### PR TITLE
Correct indecies to indices in migration file

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -3021,7 +3021,7 @@ databaseChangeLog:
             columnNames: group_id, object
         ############################################################ Tweaks to metabase_table ############################################################
         # Modify the length of metabase_table.schema from 256 -> 254
-        # It turns out MySQL InnoDB indecies have to be 767 bytes or less (at least for older versions of MySQL)
+        # It turns out MySQL InnoDB indices have to be 767 bytes or less (at least for older versions of MySQL)
         # and 'utf8' text columns can use up to 3 bytes per character in MySQL -- see http://stackoverflow.com/a/22515986/1198455
         # So 256 * 3 = 768 bytes (too large to index / add unique constraints)
         # Drop this to 254; 254 * 3 = 762, which should give us room to index it along with a 4-byte integer as well if need be
@@ -3323,7 +3323,7 @@ databaseChangeLog:
       id: 49
       author: camsaul
       changes:
-        ######################################## Card public_uuid & indecies ########################################
+        ######################################## Card public_uuid & indices ########################################
         - addColumn:
             tableName: report_card
             columns:
@@ -3346,7 +3346,7 @@ databaseChangeLog:
             columns:
               column:
                 name: public_uuid
-        ######################################## Dashboard public_uuid & indecies ########################################
+        ######################################## Dashboard public_uuid & indices ########################################
         - addColumn:
             tableName: report_dashboard
             columns:


### PR DESCRIPTION
A small typographical error in the migrations file
-  [x] Signed the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
