### PR TITLE
Backported tweaks & improvements from nested-queries (part 3)

### DIFF
--- a/frontend/src/metabase/query_builder/components/QueryHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryHeader.jsx
@@ -63,8 +63,8 @@ export default class QueryHeader extends Component {
 
     componentWillUnmount() {
         clearTimeout(this.timeout);
-        if (this.requesetPromise) {
-            this.requesetPromise.cancel();
+        if (this.requestPromise) {
+            this.requestPromise.cancel();
         }
     }
 
@@ -90,8 +90,8 @@ export default class QueryHeader extends Component {
         }
 
         // TODO: reduxify
-        this.requesetPromise = cancelable(CardApi.create(card));
-        return this.requesetPromise.then(newCard => {
+        this.requestPromise = cancelable(CardApi.create(card));
+        return this.requestPromise.then(newCard => {
             this.props.notifyCardCreatedFn(newCard);
 
             this.setState({
@@ -115,8 +115,8 @@ export default class QueryHeader extends Component {
         }
 
         // TODO: reduxify
-        this.requesetPromise = cancelable(CardApi.update(card));
-        return this.requesetPromise.then(updatedCard => {
+        this.requestPromise = cancelable(CardApi.update(card));
+        return this.requestPromise.then(updatedCard => {
             if (this.props.fromUrl) {
                 this.onGoBack();
                 return;

--- a/frontend/src/metabase/query_builder/components/dataref/TablePane.jsx
+++ b/frontend/src/metabase/query_builder/components/dataref/TablePane.jsx
@@ -115,7 +115,7 @@ export default class TablePane extends Component {
                     <h1>{table.display_name}</h1>
                     {description}
                     {queryButton}
-                    { table.metrics.length > 0 &&
+                    { table.metrics && (table.metrics.length > 0) &&
                         <ExpandableItemList
                             name="Metrics"
                             type="metrics"
@@ -123,7 +123,7 @@ export default class TablePane extends Component {
                             items={table.metrics}
                         />
                     }
-                    { table.segments.length > 0 &&
+                    { table.segments && (table.segments.length > 0) &&
                         <ExpandableItemList
                             name="Segments"
                             type="segments"

--- a/src/metabase/api/pulse.clj
+++ b/src/metabase/api/pulse.clj
@@ -104,7 +104,7 @@
   "Get HTML rendering of a `Card` with ID."
   [id]
   (let [card   (api/read-check Card id)
-        result (qp/dataset-query (:dataset_query card) {:executed-by api/*current-user-id*, :context :pulse, :card-id id})]
+        result (qp/process-query-and-save-execution! (:dataset_query card) {:executed-by api/*current-user-id*, :context :pulse, :card-id id})]
     {:status 200, :body (html [:html [:body {:style "margin: 0;"} (binding [render/*include-title* true
                                                                             render/*include-buttons* true]
                                                                     (render/render-pulse-card card result))]])}))
@@ -113,7 +113,7 @@
   "Get JSON object containing HTML rendering of a `Card` with ID and other information."
   [id]
   (let [card      (api/read-check Card id)
-        result    (qp/dataset-query (:dataset_query card) {:executed-by api/*current-user-id*, :context :pulse, :card-id id})
+        result    (qp/process-query-and-save-execution! (:dataset_query card) {:executed-by api/*current-user-id*, :context :pulse, :card-id id})
         data      (:data result)
         card-type (render/detect-pulse-card-type card data)
         card-html (html (binding [render/*include-title* true]
@@ -127,7 +127,7 @@
   "Get PNG rendering of a `Card` with ID."
   [id]
   (let [card   (api/read-check Card id)
-        result (qp/dataset-query (:dataset_query card) {:executed-by api/*current-user-id*, :context :pulse, :card-id id})
+        result (qp/process-query-and-save-execution! (:dataset_query card) {:executed-by api/*current-user-id*, :context :pulse, :card-id id})
         ba     (binding [render/*include-title* true]
                  (render/render-pulse-card-to-png card result))]
     {:status 200, :headers {"Content-Type" "image/png"}, :body (ByteArrayInputStream. ba)}))

--- a/src/metabase/api/tiles.clj
+++ b/src/metabase/api/tiles.clj
@@ -129,7 +129,7 @@
         lon-col-idx   (Integer/parseInt lon-col-idx)
         query         (json/parse-string query keyword)
         updated-query (update query :query (u/rpartial query-with-inside-filter lat-field-id lon-field-id x y zoom))
-        result        (qp/dataset-query updated-query {:executed-by api/*current-user-id*, :context :map-tiles})
+        result        (qp/process-query-and-save-execution! updated-query {:executed-by api/*current-user-id*, :context :map-tiles})
         points        (for [row (-> result :data :rows)]
                         [(nth row lat-col-idx) (nth row lon-col-idx)])]
     ;; manual ring response here.  we simply create an inputstream from the byte[] of our image

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -23,8 +23,9 @@
     (let [{:keys [creator_id dataset_query]} card]
       (try
         {:card   card
-         :result (qp/dataset-query dataset_query (merge {:executed-by creator_id, :context :pulse, :card-id card-id}
-                                                        options))}
+         :result (qp/process-query-and-save-execution! dataset_query
+                   (merge {:executed-by creator_id, :context :pulse, :card-id card-id}
+                          options))}
         (catch Throwable t
           (log/warn (format "Error running card query (%n)" card-id) t))))))
 

--- a/src/metabase/query_processor/annotate.clj
+++ b/src/metabase/query_processor/annotate.clj
@@ -10,7 +10,9 @@
             [metabase
              [driver :as driver]
              [util :as u]]
-            [metabase.models.field :refer [Field]]
+            [metabase.models
+             [field :refer [Field]]
+             [humanization :as humanization]]
             [metabase.query-processor
              [interface :as i]
              [sort :as sort]]
@@ -145,7 +147,7 @@
    :preview-display    true
    :special-type       nil
    :field-name         k
-   :field-display-name k})
+   :field-display-name (humanization/name->human-readable-name (name k))})
 
 
 (defn- info-for-duplicate-field

--- a/src/metabase/util/schema.clj
+++ b/src/metabase/util/schema.clj
@@ -79,9 +79,16 @@
   (s/named (s/cond-pre s/Keyword s/Str) "Keyword or string"))
 
 (def FieldType
-  "Schema for a valid Field type (does it derive from `:type/*`?"
+  "Schema for a valid Field type (does it derive from `:type/*`)?"
   (with-api-error-message (s/pred (u/rpartial isa? :type/*) "Valid field type")
     "value must be a valid field type."))
+
+(def FieldTypeKeywordOrString
+  "Like `FieldType` (e.g. a valid derivative of `:type/*`) but allows either a keyword or a string.
+   This is useful especially for validating API input or objects coming out of the DB as it is unlikely
+   those values will be encoded as keywords at that point."
+  (with-api-error-message (s/pred #(isa? (keyword %) :type/*) "Valid field type (keyword or string)")
+    "value must be a valid field type (keyword or string)."))
 
 (def Map
   "Schema for a valid map."

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -20,15 +20,13 @@
              [table :refer [Table]]
              [view-log :refer [ViewLog]]]
             [metabase.test
-             [data :refer :all]
+             [data :as data :refer :all]
              [util :as tu :refer [match-$ random-name]]]
             [metabase.test.data.users :refer :all]
             [toucan.db :as db]
             [toucan.util.test :as tt])
   (:import java.io.ByteArrayInputStream
            java.util.UUID))
-
-;;; CARD LIFECYCLE
 
 ;;; Helpers
 
@@ -44,7 +42,38 @@
    :query_type        "query"
    :cache_ttl         nil})
 
-;; ## GET /api/card
+(defn- do-with-self-cleaning-random-card-name
+  "Generate a random card name (or use CARD-NAME), pass it to F, then delete any Cards with that name afterwords."
+  [f & [card-name]]
+  (let [card-name (or card-name (random-name))]
+    (try (f card-name)
+         (finally (db/delete! Card :name card-name)))))
+
+(defmacro ^:private with-self-cleaning-random-card-name
+  "Generate a random card name (or optionally use CARD-NAME) and bind it to CARD-NAME-BINDING.
+   Execute BODY and then delete and Cards with that name afterwards."
+  {:style/indent 1, :arglists '([[card-name-binding] & body] [[card-name-binding card-name] & body])}
+  [[card-name-binding card-name] & body]
+  `(do-with-self-cleaning-random-card-name (fn [~card-name-binding]
+                                             ~@body)
+                                           ~@(when card-name [card-name])))
+
+(defn- mbql-count-query [database-id table-id]
+  {:database database-id
+   :type     "query"
+   :query    {:source-table table-id, :aggregation {:aggregation-type "count"}}})
+
+(defn- card-with-name-and-query [card-name query]
+  {:name                   card-name
+   :display                "scalar"
+   :dataset_query          query
+   :visualization_settings {:global {:title nil}}})
+
+
+;;; +------------------------------------------------------------------------------------------------------------------------+
+;;; |                                               FETCHING CARDS & FILTERING                                               |
+;;; +------------------------------------------------------------------------------------------------------------------------+
+
 ;; Filter cards by database
 (expect
   [true
@@ -169,15 +198,18 @@
             :visualization_settings {:global {:title nil}}
             :database_id            database-id ; these should be inferred automatically
             :table_id               table-id})
-    ;; make sure we clean up after ourselves as well and delete the Card we create
-    (dissoc (u/prog1 ((user->client :rasta) :post 200 "card" {:name                   card-name
-                                                              :display                "scalar"
-                                                              :dataset_query          (mbql-count-query database-id table-id)
-                                                              :visualization_settings {:global {:title nil}}})
-              (db/delete! Card :id (u/get-id <>)))
-            :created_at :updated_at :id)))
+    (with-self-cleaning-random-card-name [_ card-name]
+      (dissoc ((user->client :rasta) :post 200 "card" {:name                   card-name
+                                                       :display                "scalar"
+                                                       :dataset_query          (mbql-count-query database-id table-id)
+                                                       :visualization_settings {:global {:title nil}}})
+              :created_at :updated_at :id))))
 
-;; ## GET /api/card/:id
+
+;;; +------------------------------------------------------------------------------------------------------------------------+
+;;; |                                                FETCHING A SPECIFIC CARD                                                |
+;;; +------------------------------------------------------------------------------------------------------------------------+
+
 ;; Test that we can fetch a card
 (tt/expect-with-temp [Database  [{database-id :id}]
                       Table     [{table-id :id}   {:db_id database-id}]
@@ -221,7 +253,10 @@
     ;; now a non-admin user shouldn't be able to fetch this card
     ((user->client :rasta) :get 403 (str "card/" (u/get-id card)))))
 
-;; ## PUT /api/card/:id
+
+;;; +------------------------------------------------------------------------------------------------------------------------+
+;;; |                                                    UPDATING A CARD                                                     |
+;;; +------------------------------------------------------------------------------------------------------------------------+
 
 ;; updating a card that doesn't exist should give a 404
 (expect "Not found."
@@ -297,10 +332,14 @@
     (Card id)))
 
 ;; deleting a card that doesn't exist should return a 404 (#1957)
-(expect "Not found."
+(expect
+  "Not found."
   ((user->client :crowberto) :delete 404 "card/12345"))
 
-;; # CARD FAVORITE STUFF
+
+;;; +------------------------------------------------------------------------------------------------------------------------+
+;;; |                                                       FAVORITING                                                       |
+;;; +------------------------------------------------------------------------------------------------------------------------+
 
 ;; Helper Functions
 (defn- fave? [card]
@@ -343,6 +382,10 @@
          (fave? card))]))
 
 
+;;; +------------------------------------------------------------------------------------------------------------------------+
+;;; |                                                         LABELS                                                         |
+;;; +------------------------------------------------------------------------------------------------------------------------+
+
 ;;; POST /api/card/:id/labels
 ;; Check that we can update card labels
 (tt/expect-with-temp [Card  [{card-id :id}]
@@ -361,6 +404,10 @@
      (update-labels [label-1-id label-2-id]) ; (2)
      (update-labels [])]))                   ; (3)
 
+
+;;; +------------------------------------------------------------------------------------------------------------------------+
+;;; |                                                CSV/JSON/XLSX DOWNLOADS                                                 |
+;;; +------------------------------------------------------------------------------------------------------------------------+
 
 ;;; POST /api/:card-id/query/csv
 
@@ -461,6 +508,7 @@
            (spreadsheet/select-sheet "Query result")
            (spreadsheet/select-columns {:A :col})))))
 
+
 ;;; +------------------------------------------------------------------------------------------------------------------------+
 ;;; |                                                      COLLECTIONS                                                       |
 ;;; +------------------------------------------------------------------------------------------------------------------------+
@@ -468,26 +516,19 @@
 ;; Make sure we can create a card and specify its `collection_id` at the same time
 (tt/expect-with-temp [Collection [collection]]
   (u/get-id collection)
-  (do
+  (with-self-cleaning-random-card-name [card-name]
     (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
-    (let [{card-id :id} ((user->client :rasta) :post 200 "card" {:name                   "My Cool Card"
-                                                                 :display                "scalar"
-                                                                 :dataset_query          (mbql-count-query (id) (id :venues))
-                                                                 :visualization_settings {:global {:title nil}}
-                                                                 :collection_id          (u/get-id collection)})]
-      ;; make sure we clean up after ourselves and delete the newly created Card
-      (u/prog1 (db/select-one-field :collection_id Card :id card-id)
-        (db/delete! Card :id card-id)))))
+    (let [{card-id :id} ((user->client :rasta) :post 200 "card" (assoc (card-with-name-and-query card-name (mbql-count-query (data/id) (data/id :venues)))
+                                                                  :collection_id (u/get-id collection)))]
+      (db/select-one-field :collection_id Card :id card-id))))
 
 ;; Make sure we card creation fails if we try to set a `collection_id` we don't have permissions for
 (expect
   "You don't have permissions to do that."
-  (tt/with-temp Collection [collection]
-    ((user->client :rasta) :post 403 "card" {:name                   "My Cool Card"
-                                             :display                "scalar"
-                                             :dataset_query          (mbql-count-query (id) (id :venues))
-                                             :visualization_settings {:global {:title nil}}
-                                             :collection_id          (u/get-id collection)})))
+  (with-self-cleaning-random-card-name [card-name]
+    (tt/with-temp Collection [collection]
+      ((user->client :rasta) :post 403 "card" (assoc (card-with-name-and-query card-name (mbql-count-query (data/id) (data/id :venues)))
+                                                :collection_id (u/get-id collection))))))
 
 ;; Make sure we can change the `collection_id` of a Card if it's not in any collection
 (tt/expect-with-temp [Card       [card]

--- a/test/metabase/driver/generic_sql/native_test.clj
+++ b/test/metabase/driver/generic_sql/native_test.clj
@@ -1,33 +1,35 @@
 (ns metabase.driver.generic-sql.native-test
   (:require [expectations :refer :all]
+            [medley.core :as m]
             [metabase.models.database :refer [Database]]
             [metabase.query-processor :as qp]
             [metabase.test.data :refer :all]
             [toucan.db :as db]))
 
 ;; Just check that a basic query works
-(expect {:status :completed
-         :row_count 2
-         :data {:rows [[100]
-                       [99]]
-                :columns ["ID"]
-                :cols [{:name "ID", :base_type :type/Integer}]
-                :native_form {:query "SELECT ID FROM VENUES ORDER BY ID DESC LIMIT 2;"}}}
+(expect
+  {:status :completed
+   :row_count 2
+   :data {:rows [[100]
+                 [99]]
+          :columns ["ID"]
+          :cols [{:name "ID", :base_type :type/Integer}]
+          :native_form {:query "SELECT ID FROM VENUES ORDER BY ID DESC LIMIT 2;"}}}
   (qp/process-query {:native   {:query "SELECT ID FROM VENUES ORDER BY ID DESC LIMIT 2;"}
                      :type     :native
                      :database (id)}))
 
 ;; Check that column ordering is maintained
 (expect
-    {:status :completed
-     :row_count 2
-     :data {:rows [[100 "Mohawk Bend" 46]
-                   [99 "Golden Road Brewing" 10]]
-            :columns ["ID" "NAME" "CATEGORY_ID"]
-            :cols [{:name "ID", :base_type :type/Integer}
-                   {:name "NAME", :base_type :type/Text}
-                   {:name "CATEGORY_ID", :base_type :type/Integer}]
-            :native_form {:query "SELECT ID, NAME, CATEGORY_ID FROM VENUES ORDER BY ID DESC LIMIT 2;"}}}
+  {:status :completed
+   :row_count 2
+   :data {:rows [[100 "Mohawk Bend" 46]
+                 [99 "Golden Road Brewing" 10]]
+          :columns ["ID" "NAME" "CATEGORY_ID"]
+          :cols [{:name "ID", :base_type :type/Integer}
+                 {:name "NAME", :base_type :type/Text}
+                 {:name "CATEGORY_ID", :base_type :type/Integer}]
+          :native_form {:query "SELECT ID, NAME, CATEGORY_ID FROM VENUES ORDER BY ID DESC LIMIT 2;"}}}
   (qp/process-query {:native   {:query "SELECT ID, NAME, CATEGORY_ID FROM VENUES ORDER BY ID DESC LIMIT 2;"}
                      :type     :native
                      :database (id)}))

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -285,7 +285,9 @@
                                          (printf "(%s %s) failed: %s" f v (.getMessage e))
                                          (throw e)))))))))))
 
-(def formatted-venues-rows (partial format-rows-by [int str int (partial u/round-to-decimals 4) (partial u/round-to-decimals 4) int]))
+(def ^{:arglists '([results])} formatted-venues-rows
+  "Helper function to format the rows in RESULTS when running a 'raw data' query against the Venues test table."
+  (partial format-rows-by [int str int (partial u/round-to-decimals 4) (partial u/round-to-decimals 4) int]))
 
 
 (defn rows

--- a/test/metabase/query_processor_test/aggregation_test.clj
+++ b/test/metabase/query_processor_test/aggregation_test.clj
@@ -153,7 +153,7 @@
 (datasets/expect-with-engines (disj non-timeseries-engines :mongo :bigquery :presto)
   [(aggregate-col :count)
    (assoc (aggregate-col :count)
-     :display_name    "count_2"
+     :display_name    "Count 2"
      :name            "count_2"
      :preview_display true)]
   (-> (data/run-query venues

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -211,6 +211,12 @@
     ;; add extra metadata for fields
     (add-extra-metadata! database-definition <>)))
 
+(defn- reload-test-extensions [engine]
+  (println "Reloading test extensions for driver:" engine)
+  (let [extension-ns (symbol (str "metabase.test.data." (name engine)))]
+    (println (format "(require '%s 'metabase.test.data.datasets :reload)" extension-ns))
+    (require extension-ns 'metabase.test.data.datasets :reload)))
+
 (defn get-or-create-database!
   "Create DBMS database associated with DATABASE-DEFINITION, create corresponding Metabase `Databases`/`Tables`/`Fields`, and sync the `Database`.
    DRIVER should be an object that implements `IDriverTestExtensions`; it defaults to the value returned by the method `driver` for the
@@ -218,9 +224,18 @@
   ([database-definition]
    (get-or-create-database! *driver* database-definition))
   ([driver database-definition]
-   (let [engine (i/engine driver)]
-     (or (i/metabase-instance database-definition engine)
-         (create-database! database-definition engine driver)))))
+   (let [engine         (i/engine driver)
+         get-or-create! (fn []
+                          (or (i/metabase-instance database-definition engine)
+                              (create-database! database-definition engine driver)))]
+     (try
+       (get-or-create!)
+       ;; occasionally we'll see an error like
+       ;; java.lang.IllegalArgumentException: No implementation of method: :database->connection-details of protocol: IDriverTestExtensions found for class: metabase.driver.h2.H2Driver
+       ;; to fix this we just need to reload a couple namespaces and then try again
+       (catch IllegalArgumentException _
+         (reload-test-extensions engine)
+         (get-or-create!))))))
 
 
 (defn do-with-temp-db


### PR DESCRIPTION
Since `nested-queries` is now over 1500 LOC it's time to backport some more random improvements

-  typo fixes
-  extra docstrings & comments (I can't help myself)
-  better organization of a few namespaces
-  some test helper functions in `metabase.api.card` to make it harder to write bad tests
-  breaking up massive functions into easier-to-understand chunks
-  Giving a few things better names
-  whitespace/indentation fixes