### PR TITLE
only show Scalar title and description if in a dashboard

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Scalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar.jsx
@@ -193,29 +193,31 @@ export default class Scalar extends Component {
                         {compactScalarValue}
                     </span>
                 </Ellipsified>
-                <div className={styles.Title + " flex align-center relative"}>
-                    <Ellipsified tooltip={card.name}>
-                        <span
-                            onClick={onChangeCardAndRun && (() => onChangeCardAndRun({ nextCard: card }))}
-                            className={cx("fullscreen-normal-text fullscreen-night-text", {
-                                "cursor-pointer": !!onChangeCardAndRun
-                            })}
-                        >
-                            {settings["card.title"]}
-                        </span>
+                { this.props.isDashboard  && (
+                    <div className={styles.Title + " flex align-center relative"}>
+                        <Ellipsified tooltip={card.name}>
+                            <span
+                                onClick={onChangeCardAndRun && (() => onChangeCardAndRun({ nextCard: card }))}
+                                className={cx("fullscreen-normal-text fullscreen-night-text", {
+                                    "cursor-pointer": !!onChangeCardAndRun
+                                })}
+                            >
+                                {settings["card.title"]}
+                            </span>
 
-                    </Ellipsified>
-                    { description &&
-                        <div
-                            className="absolute top bottom hover-child flex align-center justify-center"
-                            style={{ right: -20, top: 2 }}
-                        >
-                          <Tooltip tooltip={description} maxWidth={'22em'}>
-                              <Icon name='infooutlined' />
-                          </Tooltip>
-                      </div>
-                    }
-                </div>
+                        </Ellipsified>
+                        { description &&
+                            <div
+                                className="absolute top bottom hover-child flex align-center justify-center"
+                                style={{ right: -20, top: 2 }}
+                            >
+                              <Tooltip tooltip={description} maxWidth={'22em'}>
+                                  <Icon name='infooutlined' />
+                              </Tooltip>
+                          </div>
+                        }
+                    </div>
+                )}
             </div>
         );
     }

--- a/frontend/src/metabase/visualizations/visualizations/Scalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar.jsx
@@ -202,7 +202,7 @@ export default class Scalar extends Component {
                                     "cursor-pointer": !!onChangeCardAndRun
                                 })}
                             >
-                                {settings["card.title"]}
+                                <span className="Scalar-title">{settings["card.title"]}</span>
                             </span>
 
                         </Ellipsified>

--- a/frontend/test/unit/visualizations/components/Visualization.spec.js
+++ b/frontend/test/unit/visualizations/components/Visualization.spec.js
@@ -1,6 +1,6 @@
 
 import React from "react";
-import { renderIntoDocument, scryRenderedComponentsWithType as scryWithType } from "react-dom/test-utils";
+import { renderIntoDocument, scryRenderedDOMComponentsWithClass, scryRenderedComponentsWithType as scryWithType } from "react-dom/test-utils";
 
 import Visualization from "metabase/visualizations/components/Visualization.jsx";
 
@@ -14,7 +14,7 @@ describe("Visualization", () => {
         describe("scalar card", () => {
             it("should not render title", () => {
                 let viz = renderVisualization({ series: [ScalarCard("Foo")] });
-                expect(getTitles(viz)).toEqual([]);
+                expect(getScalarTitles(viz)).toEqual([]);
             });
         });
 
@@ -38,9 +38,10 @@ describe("Visualization", () => {
 
     describe("in dashboard", () => {
         describe("scalar card", () => {
-            it("should not render title", () => {
-                let viz = renderVisualization({ series: [ScalarCard("Foo")], showTitle: true });
+            it("should render a scalar title, not a legend title", () => {
+                let viz = renderVisualization({ series: [ScalarCard("Foo")], showTitle: true, isDashboard: true });
                 expect(getTitles(viz)).toEqual([]);
+                expect(getScalarTitles(viz).length).toEqual(1);
             });
             it("should render title when loading", () => {
                 let viz = renderVisualization({ series: [ScalarCard("Foo", { data: null })], showTitle: true });
@@ -108,6 +109,10 @@ describe("Visualization", () => {
 
 function renderVisualization(props) {
     return renderIntoDocument(<Visualization className="spread" {...props} />);
+}
+
+function getScalarTitles (scalarComponent) {
+    return scryRenderedDOMComponentsWithClass(scalarComponent, 'Scalar-title')
 }
 
 function getTitles(viz) {


### PR DESCRIPTION
fixes #5159 

One odd thing is it looks like [there was a test for this in the visualizations spec](https://github.com/metabase/metabase/blob/master/frontend/test/unit/visualizations/components/Visualization.spec.js#L17) that has been passing?

Todos
- [x] Add and / or refactor test
