### PR TITLE
Fix karma test util warnings

### DIFF
--- a/frontend/test/unit/lib/formatting.spec.js
+++ b/frontend/test/unit/lib/formatting.spec.js
@@ -1,5 +1,5 @@
 
-import { isElementOfType } from "react-addons-test-utils";
+import { isElementOfType } from "react-dom/test-utils";
 
 import { formatNumber, formatValue, formatUrl } from 'metabase/lib/formatting';
 import ExternalLink from "metabase/components/ExternalLink.jsx";

--- a/frontend/test/unit/query_builder/components/FieldName.spec.js
+++ b/frontend/test/unit/query_builder/components/FieldName.spec.js
@@ -1,7 +1,7 @@
 
 import React from "react";
 import ReactDOM from "react-dom";
-import { renderIntoDocument } from "react-addons-test-utils";
+import { renderIntoDocument } from "react-dom/test-utils";
 
 import FieldName from "metabase/query_builder/components/FieldName.jsx";
 

--- a/frontend/test/unit/visualizations/components/LegendVertical.spec.js
+++ b/frontend/test/unit/visualizations/components/LegendVertical.spec.js
@@ -1,7 +1,7 @@
 
 import React from "react";
 import ReactDOM from "react-dom";
-import { renderIntoDocument } from "react-addons-test-utils";
+import { renderIntoDocument } from "react-dom/test-utils";
 
 import LegendVertical from "metabase/visualizations/components/LegendVertical.jsx";
 

--- a/frontend/test/unit/visualizations/components/Visualization.spec.js
+++ b/frontend/test/unit/visualizations/components/Visualization.spec.js
@@ -1,6 +1,6 @@
 
 import React from "react";
-import { renderIntoDocument, scryRenderedComponentsWithType as scryWithType } from "react-addons-test-utils";
+import { renderIntoDocument, scryRenderedComponentsWithType as scryWithType } from "react-dom/test-utils";
 
 import Visualization from "metabase/visualizations/components/Visualization.jsx";
 

--- a/package.json
+++ b/package.json
@@ -130,7 +130,6 @@
     "postcss-url": "^6.0.4",
     "prettier": "^0.22.0",
     "promise-loader": "^1.0.0",
-    "react-addons-test-utils": "^15.4.2",
     "react-hot-loader": "^1.3.0",
     "react-test-renderer": "^15.5.4",
     "sauce-connect-launcher": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6233,13 +6233,6 @@ react-addons-shallow-compare@^15.2.1:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
 
-react-addons-test-utils@^15.4.2:
-  version "15.5.1"
-  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.5.1.tgz#e0d258cda2a122ad0dff69f838260d0c3958f5f7"
-  dependencies:
-    fbjs "^0.8.4"
-    object-assign "^4.1.0"
-
 react-ansi-style@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/react-ansi-style/-/react-ansi-style-1.0.0.tgz#9b1d4c8eedfc56f4dcf359a3962184658c3e8c09"


### PR DESCRIPTION
Removes `react-addons-test-utils` as a dependency since apparently all that stuff got moved to `react-dom/test-utils.` Squashes a couple karma test warning lines as a result.