### PR TITLE
Multimetrics [WIP]

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.spec.js
+++ b/frontend/src/metabase-lib/lib/Question.spec.js
@@ -78,6 +78,43 @@ const ORDERS_PRODUCT_CATEGORY = [
 ];
 
 describe("Question", () => {
+    describe("can Run", () => {
+        it("return false when a single metric can't run", () => {
+            const question = new Question(
+                METADATA,
+                CARD_WITH_ONE_METRIC
+            ).convertToMultiQuery();
+            question.multiQuery().atomicQueries()[0].canRun = () => false;
+            expect(question.canRun()).toBe(false);
+        });
+        it("return true when a single metric can run", () => {
+            const question = new Question(
+                METADATA,
+                CARD_WITH_ONE_METRIC
+            ).convertToMultiQuery();
+            question.multiQuery().atomicQueries()[0].canRun = () => true;
+            expect(question.canRun()).toBe(true);
+        });
+        it("return false when one of two metrics can't run", () => {
+            const question = new Question(
+                METADATA,
+                CARD_WITH_TWO_METRICS
+            ).convertToMultiQuery();
+            question.multiQuery().atomicQueries()[0].canRun = () => true;
+            question.multiQuery().atomicQueries()[1].canRun = () => false;
+            expect(question.canRun()).toBe(false);
+        });
+        it("return true when both metrics can run", () => {
+            const question = new Question(
+                METADATA,
+                CARD_WITH_TWO_METRICS
+            ).convertToMultiQuery();
+            question.multiQuery().atomicQueries()[0].canRun = () => true;
+            question.multiQuery().atomicQueries()[1].canRun = () => true;
+            expect(question.canRun()).toBe(true);
+        });
+    });
+
     describe("can Create properly", () => {
         const question = new Question(metadata, ordersRawDataCard);
         it("a newly created question has a name", () => {
@@ -88,6 +125,9 @@ describe("Question", () => {
         });
         it("a newly created question is not empty", () => {
             expect(question.displayName()).toBe(ordersRawDataCard.name);
+        });
+        it("a newly created question is not a multiQuery", () => {
+            expect(question.isMultiQuery()).toBe(false);
         });
         it("a newly created question can be run", () => {
             expect(question.canRun()).toBe(true);

--- a/frontend/src/metabase-lib/lib/queries/MultiQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/MultiQuery.js
@@ -1,0 +1,302 @@
+/* @flow weak */
+
+import Question from "../Question";
+import Query from "./Query";
+
+import _ from "underscore";
+
+import StructuredQuery from "./StructuredQuery";
+import NativeQuery from "./NativeQuery";
+import { memoize } from "metabase-lib/lib/utils";
+import Action, { ActionClick } from "../Action";
+import Dimension from "metabase-lib/lib/Dimension";
+
+import type {
+    AtomicDatasetQuery,
+    DatasetQuery,
+    MultiDatasetQuery
+} from "metabase/meta/types/Card";
+import AtomicQuery from "metabase-lib/lib/queries/AtomicQuery";
+import Metric from "metabase-lib/lib/metadata/Metric";
+import Field from "metabase-lib/lib/metadata/Field";
+
+export const MULTI_QUERY_TEMPLATE: MultiDatasetQuery = {
+    type: "multi",
+    queries: []
+};
+
+export function createAtomicQuery(
+    question: Question,
+    datasetQuery: AtomicDatasetQuery
+): Query {
+    if (StructuredQuery.isDatasetQueryType(datasetQuery)) {
+        return new StructuredQuery(question, datasetQuery);
+    } else if (NativeQuery.isDatasetQueryType(datasetQuery)) {
+        return new NativeQuery(question, datasetQuery);
+    }
+
+    throw new Error("Unknown query type: " + datasetQuery.type);
+}
+
+// TODO Atte Keinänen 6/8/17: Write comprehensive unit tests for this class and exported methods
+
+/**
+ * Converts a {@link DatasetQuery} to a {@link MultiDatasetQuery}.
+ *
+ * Because each query contained by MultiDatasetQuery should have just a single aggregation, {@link StructuredQuery}s
+ * with two or more aggregations are broken into queries with one of those aggregations in each.
+ */
+export function convertToMultiDatasetQuery(
+    question: Question,
+    datasetQuery: DatasetQuery
+) {
+    const getConvertedQueries = () => {
+        if (StructuredQuery.isDatasetQueryType(datasetQuery)) {
+            const structuredQuery: StructuredQuery = new StructuredQuery(
+                question,
+                datasetQuery
+            );
+            const aggregations = structuredQuery.aggregations();
+            const isMultiAggregationQuery = aggregations.length > 1;
+
+            if (isMultiAggregationQuery) {
+                // Each aggregation is isolated to its own StructuredQuery
+                return aggregations.map(aggregation =>
+                    structuredQuery
+                        .clearAggregations()
+                        .addAggregation(aggregation)
+                        .datasetQuery());
+            } else {
+                return [datasetQuery];
+            }
+        } else {
+            throw new Error(
+                "Native queries can't yet be converted to MultiDatasetQuery"
+            );
+        }
+    };
+
+    if (MultiQuery.isDatasetQueryType(datasetQuery)) return datasetQuery;
+
+    return {
+        ...MULTI_QUERY_TEMPLATE,
+        queries: getConvertedQueries()
+    };
+}
+
+/**
+ * Represents a composite query that is composed from multiple structured / native queries.
+ */
+export default class MultiQuery extends Query {
+    static isDatasetQueryType(datasetQuery: DatasetQuery) {
+        return datasetQuery.type === MULTI_QUERY_TEMPLATE.type;
+    }
+
+    // For Flow type completion
+    _multiDatasetQuery: MultiDatasetQuery;
+
+    getInvalidParamsError = message =>
+        new Error(
+            `You've tried to call MultiQuery constructor with invalid parameters: ${message}`
+        );
+
+    constructor(
+        question: Question,
+        datasetQuery?: MultiDatasetQuery = MULTI_QUERY_TEMPLATE
+    ) {
+        super(question, datasetQuery);
+
+        this._multiDatasetQuery = datasetQuery;
+
+        if (this._multiDatasetQuery.type !== "multi") {
+            throw this.getInvalidParamsError(
+                "The type of datasetQuery isn't `multi`"
+            );
+        }
+        if (!_.isArray(this._multiDatasetQuery.queries)) {
+            throw this.getInvalidParamsError(
+                "datasetQuery doesn't contain the `queries` array"
+            );
+        }
+    }
+
+    /******* Query superclass methods *******/
+
+    canRun(): boolean {
+        return _.every(this.atomicQueries(), query => query.canRun());
+    }
+
+    /**
+     * Top level actions that can be performed on this query
+     * TODO: Move the current actions code from Questions and adapt for multi-queries
+     */
+    actions(): Action[] {
+        // Notes from Slack conversation:
+        // sameer: the bottom right actions should always refer to the thing in the entire query builder
+        // if you click on the series name in a legend it might make sense to show its actions
+        // [...] a question has actions available to it that are determined by its contents (and potentially the user),
+        // regardless of whether it has a single or multiple queries inside of it
+        return [];
+    }
+
+    /**
+     * Drill through actions that can be performed on a part of the result setParameter
+     * TODO: Move the current actions code from Questions and adapt for multi-queries
+     */
+    actionsForClick(click: ActionClick): Action[] {
+        return [];
+    }
+
+    /******* Methods unique to this query type *******/
+
+    /* Access to / manipulation of the query list */
+
+    /**
+     * Wrap individual queries to Query objects for a convenient access
+     */
+    @memoize atomicQueries(): AtomicQuery[] {
+        return this._multiDatasetQuery.queries.map(datasetQuery =>
+            createAtomicQuery(this._originalQuestion, datasetQuery));
+    }
+
+    /**
+     * Replaces the atomic query at an index with the given atomic query
+     */
+    setQueryAtIndex(index: number, atomicQuery: AtomicQuery): MultiQuery {
+        return this._updateQueries(
+            this.atomicQueries().map(
+                (query, i) => index === i ? atomicQuery : query
+            )
+        );
+    }
+
+    /**
+     * Sets the atomic query at an index using a given updater function in a similar fashion as Icepick's `updateIn`
+     */
+    setQueryAtIndexWith(
+        index: number,
+        updater: (AtomicQuery) => AtomicQuery
+    ): MultiQuery {
+        return this.setQueryAtIndex(
+            index,
+            updater(this.atomicQueries()[index])
+        );
+    }
+
+    canRemoveQuery(): boolean {
+        return this.atomicQueries().length > 1;
+    }
+
+    removeQueryAtIndex(index: number): MultiQuery {
+        return this._updateQueries(
+            this.atomicQueries().filter((_, i) => i !== index)
+        );
+    }
+
+    canAddQuery(): boolean {
+        return true;
+    }
+
+    addQuery(atomicQuery: AtomicQuery): MultiQuery {
+        return this._updateQueries([...this.atomicQueries(), atomicQuery]);
+    }
+
+    /**
+     * Compatible field breakout logic
+     */
+    compatibleFieldsFor(query: StructuredQuery) {
+        const baseDimension = this.baseBreakoutDimension();
+        return query
+            .table()
+            .fields.filter(field =>
+                field.isCompatibleWith(baseDimension.field()));
+    }
+
+    breakoutDimensionFor(field: Field) {
+        const baseDimension = this.baseBreakoutDimension();
+        if (!baseDimension._parent) {
+            return new baseDimension.constructor(
+                null,
+                [field.id],
+                baseDimension._metadata
+            );
+        } else {
+            return new baseDimension.constructor(
+                field.dimension(),
+                baseDimension._args,
+                baseDimension._metadata
+            );
+        }
+    }
+
+    addQueryWithInferredBreakout(query: StructuredQuery): MultiQuery {
+        const compatibleFields = this.compatibleFieldsFor(query);
+        if (compatibleFields.length === 0) {
+            throw new Error(
+                "Tried to add a metric that doesn't have any compatible fields for the shared breakout"
+            );
+        }
+
+        const baseField = this.baseBreakoutDimension().field();
+
+        const isEqualOrCloseToBaseField = compatibleField => {
+            return compatibleField.id === baseField.id ||
+                compatibleField.name === baseField.name;
+        };
+        const field = compatibleFields.find(isEqualOrCloseToBaseField) ||
+            compatibleFields[0];
+
+        return this.addQuery(
+            query.addBreakout(this.breakoutDimensionFor(field).mbql())
+        );
+    }
+
+    addSavedMetric(metric: Metric): MultiQuery {
+        const metricQuery = StructuredQuery.newStucturedQuery({
+            question: this._originalQuestion,
+            databaseId: metric.table.db.id,
+            tableId: metric.table.id
+        }).addAggregation(metric.aggregationClause());
+
+        return this.addQueryWithInferredBreakout(metricQuery);
+    }
+
+    /* Shared x-axis dimension */
+
+    /**
+     * Returns the breakout dimension that is currently the basis for all new atomic queries.
+     */
+    baseBreakoutDimension(): Dimension {
+        const firstQuery = this.atomicQueries()[0];
+
+        if (
+            firstQuery instanceof StructuredQuery &&
+            firstQuery.breakouts().length === 1
+        ) {
+            return Dimension.parseMBQL(
+                firstQuery.breakouts()[0],
+                this._metadata
+            );
+        } else {
+            throw new Error(
+                "Cannot infer the shared breakout dimension from the first query of MultiQuery"
+            );
+        }
+    }
+
+    /**
+     * Helper for updating with functions that expect a DatasetQuery
+     */
+    update(fn: (datasetQuery: DatasetQuery) => void) {
+        return fn(this.datasetQuery());
+    }
+
+    /* Internal methods */
+    _updateQueries(queries: AtomicQuery[]) {
+        const datasetQuery: DatasetQuery = this.datasetQuery();
+        return new MultiQuery(this._originalQuestion, {
+            ...datasetQuery,
+            queries: queries.map(query => query.datasetQuery())
+        });
+    }
+}

--- a/frontend/src/metabase-lib/lib/queries/MultiQuery.spec.js
+++ b/frontend/src/metabase-lib/lib/queries/MultiQuery.spec.js
@@ -1,0 +1,98 @@
+// HACK: needed due to cyclical dependency issue
+import "metabase-lib/lib/Question";
+
+import { question } from "metabase/__support__/sample_dataset_fixture";
+
+import MultiQuery, { convertToMultiDatasetQuery } from "./MultiQuery";
+import type { StructuredDatasetQuery } from "metabase/meta/types/Card";
+import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
+import Metric from "metabase-lib/lib/metadata/Metric";
+
+/**
+ * NOTE: These have been migrated from Questions which it used to have multimetrics methods
+ * Test stubs (and later implementations) for other MultiQuery methods should be added as well
+ */
+const METRIC = {
+    id: 123,
+    table: {
+        db: {
+            id: 1
+        }
+    }
+};
+const DATASET_QUERY_WITH_ONE_METRIC: StructuredDatasetQuery = {
+    type: "query",
+    query: {
+        aggregation: [["count"]]
+    }
+};
+const DATASET_QUERY_WITH_TWO_METRICS: StructuredDatasetQuery = {
+    type: "query",
+    query: {
+        aggregation: [["count"], ["sum", ["field-id", 1]]]
+    }
+};
+
+describe("MultiQuery", () => {
+    it("work with one query", () => {
+        const query = new MultiQuery(
+            question,
+            convertToMultiDatasetQuery(question, DATASET_QUERY_WITH_ONE_METRIC)
+        );
+        expect(query.atomicQueries()).toHaveLength(1);
+    });
+
+    it("should add a new atomic query", () => {
+        const newDatasetQuery = {
+            type: "query",
+            query: {
+                aggregation: [["sum", ["field-id", 1]]]
+            }
+        };
+        const query = new MultiQuery(
+            question,
+            convertToMultiDatasetQuery(question, DATASET_QUERY_WITH_ONE_METRIC)
+        ).addQuery(new StructuredQuery(question, newDatasetQuery));
+
+        expect(query.atomicQueries()).toHaveLength(2);
+        expect(query.datasetQuery()).toEqual({
+            type: "multi",
+            queries: [DATASET_QUERY_WITH_ONE_METRIC, newDatasetQuery]
+        });
+    });
+
+    // Needs the actual metadata
+    xit("should add a new saved metric", () => {
+        const query = new MultiQuery(
+            question,
+            convertToMultiDatasetQuery(question, DATASET_QUERY_WITH_ONE_METRIC)
+        ).addSavedMetric(new Metric(METRIC));
+
+        expect(query.atomicQueries()).toHaveLength(2);
+        expect(query.datasetQuery()).toEqual({
+            type: "multi",
+            queries: [
+                DATASET_QUERY_WITH_ONE_METRIC,
+                {
+                    type: "query",
+                    query: {
+                        aggregation: [["count"], ["METRIC", 123]]
+                    }
+                }
+            ]
+        });
+    });
+
+    it("should remove a query", () => {
+        let query = new MultiQuery(
+            question,
+            convertToMultiDatasetQuery(question, DATASET_QUERY_WITH_TWO_METRICS)
+        ).removeQueryAtIndex(1);
+
+        expect(query.atomicQueries()).toHaveLength(1);
+        expect(query.datasetQuery()).toEqual({
+            type: "multi",
+            queries: [DATASET_QUERY_WITH_ONE_METRIC]
+        });
+    });
+});

--- a/frontend/src/metabase-lib/lib/queries/Query.js
+++ b/frontend/src/metabase-lib/lib/queries/Query.js
@@ -10,7 +10,7 @@ import type { ActionClick } from "metabase-lib/lib/Action";
 import { memoize } from "metabase-lib/lib/utils";
 
 /**
- * An abstract class for all query types (StructuredQuery & NativeQuery)
+ * An abstract class for all query types (StructuredQuery & AtomicQuery (NativeQuery + MultiQuery))
  */
 export default class Query {
     _metadata: Metadata;

--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
@@ -2,6 +2,11 @@
 
 /**
  * Represents a structured MBQL query.
+ *
+ * Although MultiQuery has superseded the multi-aggregation functionality of StructuredQuery, this class still
+ * contains the multi-aggregation support for dealing with `dataset_query` objects that are in a legacy format.
+ *
+ * TODO Atte Keinänen 6/6/17: Should the multi-aggregation questions be automatically converted to MultiQuery or not?
  */
 
 import * as Q from "metabase/lib/query/query";

--- a/frontend/src/metabase/meta/Card.js
+++ b/frontend/src/metabase/meta/Card.js
@@ -11,7 +11,7 @@ import _ from "underscore";
 import { assoc, updateIn } from "icepick";
 
 import type { StructuredQuery, NativeQuery, TemplateTag } from "metabase/meta/types/Query";
-import type { Card, DatasetQuery, StructuredDatasetQuery, NativeDatasetQuery } from "metabase/meta/types/Card";
+import type { Card, DatasetQuery, StructuredDatasetQuery, NativeDatasetQuery, MultiDatasetQuery } from "metabase/meta/types/Card";
 import type { Parameter, ParameterMapping, ParameterValues } from "metabase/meta/types/Parameter";
 import type { Metadata, TableMetadata } from "metabase/meta/types/Metadata";
 
@@ -40,6 +40,11 @@ export const NATIVE_QUERY_TEMPLATE: NativeDatasetQuery = {
         query: "",
         template_tags: {}
     }
+};
+
+export const MULTI_QUERY_TEMPLATE: MultiDatasetQuery = {
+    type: "multi",
+    queries: []
 };
 
 export function isStructured(card: Card): bool {

--- a/frontend/src/metabase/meta/types/Card.js
+++ b/frontend/src/metabase/meta/types/Card.js
@@ -45,6 +45,20 @@ export type NativeDatasetQuery = {
 };
 
 /**
+ * The type for MultiDatasetQuery children
+ */
+export type AtomicDatasetQuery = StructuredDatasetQuery | NativeDatasetQuery;
+
+/**
+ * A compound type for supporting multi-query questions without having to change the data model of Card
+ */
+export type MultiDatasetQuery = {
+    type: "multi",
+    queries: AtomicDatasetQuery[],
+    parameters?: Array<ParameterInstance>,
+};
+
+/**
  * All possible formats for `dataset_query`
  */
-export type DatasetQuery = StructuredDatasetQuery | NativeDatasetQuery;
+export type DatasetQuery = AtomicDatasetQuery | MultiDatasetQuery;

--- a/frontend/src/metabase/new_query/containers/NewQueryBar.jsx
+++ b/frontend/src/metabase/new_query/containers/NewQueryBar.jsx
@@ -1,0 +1,47 @@
+/* @flow */
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+
+import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
+
+import { getQuery } from "../selectors";
+
+type Props = {
+    query: StructuredQuery
+}
+
+export class NewQueryBar extends Component {
+
+    props: Props
+
+    render () {
+        const { query } = this.props
+
+        if (!query) {
+            return null;
+        }
+
+        const database = query.database()
+        const table = query.table()
+
+        return (
+            <ol className="bordered rounded shadowed py2 flex align-center">
+                <li>{ database ? database.name : 'Select a database'}</li>
+                <li>{ table ? table.display_name : 'Select a table' }</li>
+                { database && table && (
+                    <li>
+                        <div className="input">
+                            Super cool aggregation box
+                        </div>
+                    </li>
+                )}
+            </ol>
+        )
+    }
+}
+
+const mapStateToProps = state => ({
+    query: getQuery(state)
+})
+
+export default connect(mapStateToProps)(NewQueryBar)

--- a/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
+++ b/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
@@ -1,0 +1,171 @@
+/* @flow */
+
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+
+import { fetchDatabases, fetchTableMetadata } from 'metabase/redux/metadata'
+import { resetQuery, updateQuery } from '../new_query'
+
+import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
+
+import { getQuery } from "../selectors";
+import Question from "metabase-lib/lib/Question";
+import Table from "metabase-lib/lib/metadata/Table";
+import Database from "metabase-lib/lib/metadata/Database";
+import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery"
+import AggregationOption from "metabase-lib/lib/metadata/AggregationOption";
+
+import type { Field } from "metabase/meta/types/Field";
+import type { TableId } from "metabase/meta/types/Table";
+import Metadata from "metabase-lib/lib/metadata/Metadata";
+import { getMetadata, getTables } from "metabase/selectors/metadata";
+
+class OptionListItem extends Component {
+    props: {
+        item: any,
+        action: (any) => void,
+        children?: React$Element<any>
+    }
+    onClick = () => { this.props.action(this.props.item); }
+
+    render() {
+        return (
+            <li onClick={this.onClick}>
+                { this.props.children }
+            </li>
+        );
+    }
+}
+
+const mapStateToProps = state => ({
+    query: getQuery(state),
+    metadata: getMetadata(state),
+    tables: getTables(state)
+})
+
+const mapDispatchToProps = {
+    fetchDatabases,
+    fetchTableMetadata,
+    resetQuery,
+    updateQuery
+}
+
+type Props = {
+    // Component parameters
+    question: Question,
+    onComplete: (StructuredQuery) => void,
+
+    // Properties injected with redux connect
+    query: StructuredQuery,
+    resetQuery: () => void,
+    updateQuery: (StructuredQuery) => void,
+
+    fetchDatabases: () => void,
+    fetchTableMetadata: (TableId) => void,
+
+    metadata: Metadata
+}
+
+/**
+ * NewQueryOptions forms together with NewQueryBar the elements of new query flow.
+ * It renders the current options to choose from (for instance databases, tables or metrics).
+ */
+export class NewQueryOptions extends Component {
+    props: Props
+
+    componentWillMount() {
+        this.props.fetchDatabases();
+        this.props.resetQuery();
+    }
+
+    setDatabase = (database: Database) => {
+        this.props.updateQuery(this.props.query.setDatabase(database))
+    }
+
+    setTable = (table: Table) => {
+        this.props.fetchTableMetadata(table.id);
+        this.props.updateQuery(this.props.query.setTable(table))
+    }
+
+    setAggregation = (option: AggregationOption) => {
+        const updatedQuery = this.props.query.addAggregation(option.toAggregation().clause);
+        if (option.hasFields()) {
+            this.props.updateQuery(updatedQuery)
+        } else {
+            this.props.onComplete(updatedQuery);
+        }
+    }
+
+    setAggregationField = (field: Field) => {
+        const { query } = this.props;
+        const aggregation = query.aggregationsWrapped()[0];
+        if (!aggregation) throw new Error("Trying to set the field of a non-existing aggregation");
+
+        const updatedQuery = this.props.query.updateAggregation(0, aggregation.setField(field.id).clause);
+        this.props.onComplete(updatedQuery);
+    }
+
+    render() {
+        const { query, metadata } = this.props
+
+        if (!query) {
+            return <LoadingAndErrorWrapper loading={true}/>
+        }
+
+        const database = query.database()
+        const table = query.table()
+        const aggregation = query.aggregationsWrapped()[0]
+        const aggregationOption = aggregation && aggregation.getOption()
+
+        return (
+            <LoadingAndErrorWrapper loading={!query}>
+                <div className="wrapper wrapper--trim">
+                    { !database && (
+                        <div>
+                            <h2>Pick a database</h2>
+                            <ol>
+                                { metadata.databasesList().map(database =>
+                                    <OptionListItem key={database.id} item={database} action={this.setDatabase}>
+                                        { database.name }
+                                    </OptionListItem>
+                                )}
+                            </ol>
+                        </div>
+                    )}
+                    { database && !table && (
+                        <div>
+                            <h2>Pick a table</h2>
+                            <ol>
+                                { database.tables.map(table =>
+                                    <OptionListItem key={table.id} item={table} action={this.setTable}>
+                                        { table.display_name }
+                                    </OptionListItem>
+                                )}
+                            </ol>
+                        </div>
+                    )}
+                    { table && !aggregationOption && (
+                        <ol>
+                            { query.aggregationOptionsWithoutRows().map(option =>
+                                <OptionListItem key={option.short} item={option} action={this.setAggregation}>
+                                    {option.name}
+                                </OptionListItem>
+                            )}
+                        </ol>
+                    )}
+                    { aggregationOption && (
+                        <ol>
+                            { aggregationOption.fields[0].map(field =>
+                                <OptionListItem key={field.id} item={field} action={this.setAggregationField}>
+                                    {field.name}
+                                </OptionListItem>
+                            )}
+                        </ol>
+                    )}
+                </div>
+            </LoadingAndErrorWrapper>
+        )
+    }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(NewQueryOptions)

--- a/frontend/src/metabase/new_query/new_query.js
+++ b/frontend/src/metabase/new_query/new_query.js
@@ -1,0 +1,39 @@
+/**
+ * Redux actions and reducers for the new query flow
+ * (used both for new questions and for adding "ad-hoc metrics" to multi-query questions)
+ */
+
+import { handleActions, combineReducers } from "metabase/lib/redux";
+import StructuredQuery, { STRUCTURED_QUERY_TEMPLATE } from "metabase-lib/lib/queries/StructuredQuery";
+import type { DatasetQuery } from "metabase/meta/types/Card";
+
+/**
+ * Initializes the new query flow for a given question
+ */
+export const RESET_QUERY = "metabase/new_query/RESET_QUERY";
+export function resetQuery() {
+    return function(dispatch, getState) {
+        dispatch.action(RESET_QUERY, STRUCTURED_QUERY_TEMPLATE)
+    }
+}
+
+export const UPDATE_QUERY = "metabase/new_query/UPDATE_QUERY";
+export function updateQuery(updatedQuery: StructuredQuery) {
+    return function(dispatch, getState) {
+        dispatch.action(UPDATE_QUERY, updatedQuery.datasetQuery())
+    }
+}
+
+/**
+ * The current query that we are creating
+ */
+// TODO Atte Keinänen 6/12/17: Test later how Flow typing with redux-actions could work best for our reducers
+// something like const query = handleActions<DatasetQuery>({
+const datasetQuery = handleActions({
+    [RESET_QUERY]: (state, { payload }): DatasetQuery => payload,
+    [UPDATE_QUERY]: (state, { payload }): DatasetQuery => payload
+}, STRUCTURED_QUERY_TEMPLATE);
+
+export default combineReducers({
+    datasetQuery
+});

--- a/frontend/src/metabase/new_query/new_query.spec.js
+++ b/frontend/src/metabase/new_query/new_query.spec.js
@@ -1,0 +1,8 @@
+/**
+ * Would possibly be nice to test the whole action-reducer-selector loop in here
+ */
+describe("New query flow", () => {
+    it("temporary placeholder test", () => {
+       expect(true).toEqual(true);
+    })
+});

--- a/frontend/src/metabase/new_query/selectors.js
+++ b/frontend/src/metabase/new_query/selectors.js
@@ -1,0 +1,9 @@
+/**
+ * Redux selectors for the new query flow
+ * (used both for new questions and for adding "ad-hoc metrics" to multi-query questions)
+ */
+
+import { getQuestion } from "metabase/query_builder/selectors";
+import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
+
+export const getQuery = state => new StructuredQuery(getQuestion(state), state.new_query.datasetQuery);

--- a/frontend/src/metabase/qb/components/actions/AddMetricAction.jsx
+++ b/frontend/src/metabase/qb/components/actions/AddMetricAction.jsx
@@ -1,0 +1,20 @@
+/* @flow */
+
+import type {
+    ClickAction,
+    ClickActionProps
+} from "metabase/meta/types/Visualization";
+
+export default ({ question }: ClickActionProps): ClickAction[] => {
+    if (question.canConvertToMultiQuery()) {
+        return [
+            {
+                name: "add-metric",
+                title: "Add a metric",
+                icon: "add",
+                question: () => question.newQuestion().convertToMultiQuery()
+            }
+        ];
+    }
+    return [];
+};

--- a/frontend/src/metabase/qb/components/actions/index.js
+++ b/frontend/src/metabase/qb/components/actions/index.js
@@ -1,6 +1,8 @@
 /* @flow */
 
+// import AddMetricAction from "./AddMetricAction";
 import UnderlyingDataAction from "./UnderlyingDataAction";
 import UnderlyingRecordsAction from "./UnderlyingRecordsAction";
 
+// With multimetrics: export const DEFAULT_ACTIONS = [AddMetricAction, UnderlyingDataAction, UnderlyingRecordsAction];
 export const DEFAULT_ACTIONS = [UnderlyingDataAction, UnderlyingRecordsAction];

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -45,6 +45,7 @@ import {getCardAfterVisualizationClick} from "metabase/visualizations/lib/utils"
 import type { Card } from "metabase/meta/types/Card";
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
+import MultiQuery from "metabase-lib/lib/queries/MultiQuery";
 
 type UiControls = {
     isEditing?: boolean,
@@ -380,7 +381,11 @@ export const loadMetadataForCard = createThunkAction(LOAD_METADATA_FOR_CARD, (ca
         }
 
         if (query) {
-            loadMetadataForAtomicQuery(query);
+            if (query instanceof MultiQuery) {
+                query.atomicQueries().map(loadMetadataForAtomicQuery);
+            } else {
+                loadMetadataForAtomicQuery(query);
+            }
         }
     }
 });

--- a/frontend/src/metabase/query_builder/components/AddMetricDialog.jsx
+++ b/frontend/src/metabase/query_builder/components/AddMetricDialog.jsx
@@ -1,0 +1,283 @@
+import React, { Component } from "react";
+import _ from "underscore";
+
+import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper.jsx";
+import Icon from "metabase/components/Icon.jsx";
+import CheckBox from "metabase/components/CheckBox.jsx";
+
+import cx from "classnames";
+import VisualizationResult from "metabase/query_builder/components/VisualizationResult";
+import MetricList from "metabase/query_builder/components/MetricList";
+import { getDisplayTypeForCard } from "metabase/query_builder/actions";
+import MetricDimensionOptions from "metabase/query_builder/components/MetricDimensionOptions";
+import Question from "metabase-lib/lib/Question";
+import MultiQuery from "metabase-lib/lib/queries/MultiQuery";
+import Metric from "metabase-lib/lib/metadata/Metric";
+import Metadata from "metabase-lib/lib/metadata/Metadata";
+import NewQueryBar from "metabase/new_query/containers/NewQueryBar";
+import NewQueryOptions from "metabase/new_query/containers/NewQueryOptions";
+import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
+
+type Props = {
+    onClose: () => void,
+    question: Question,
+    // TODO Add correct type for the query result
+    results: any,
+    metadata: Metadata
+}
+
+export default class AddMetricDialog extends Component {
+    props: Props;
+
+    constructor(props, context) {
+        super(props, context);
+        const { question, results } = this.props;
+
+        this.state = {
+            currentQuestion: question,
+            currentResults: results,
+            // The initial queries are only set when the selector view is opened
+            initialQueries: question.atomicQueries(),
+            addedMetrics: {},
+            searchValue: "",
+            showNewAdHocMetricFlow: false
+        };
+    }
+
+    onSearchChange = (e) => {
+        this.setState({ searchValue: e.target.value.toLowerCase() });
+    };
+
+    updateQuestionAndFetchResults = (updatedQuestion) => {
+        // TODO: Should we have some kind of loading state here?
+        updatedQuestion.getResults()
+            .then((newResults) => {
+                // TODO: Should the display type be automatically updated when adding a metric? Probably it should?
+                // Requires more elaborate listing of scenarios where it could possibly change
+                updatedQuestion.setDisplay(getDisplayTypeForCard(updatedQuestion.card(), newResults));
+
+                this.setState({
+                    currentQuestion: updatedQuestion,
+                    currentResults: newResults
+                });
+            })
+            .catch((error) => {
+                this.setState({
+                    currentQuestion: updatedQuestion,
+                    error
+                });
+            })
+    };
+
+    updateQuery = (query) => {
+        this.updateQuestionAndFetchResults(this.state.currentQuestion.setQuery(query));
+    }
+
+    addMetric = (metricWrapper) => {
+        // TODO Maybe don't use global state, maintain local query instead; this code is helpful for that
+        const { addedMetrics, currentQuestion } = this.state;
+
+        this.setState({
+            addedMetrics: {
+                ...addedMetrics,
+                [metricWrapper.id]: true
+            }
+        });
+
+        const updatedQuestion = currentQuestion.multiQuery().addSavedMetric(metricWrapper).question();
+        this.updateQuestionAndFetchResults(updatedQuestion);
+    };
+
+    queryHasMetricAggregation = (query, metric) =>
+        query.aggregationsWrapped().filter((agg) => agg.isMetric() && agg.getMetric() === metric.id).length > 0
+
+    removeMetric = (metric: Metric) => {
+        const { addedMetrics, currentQuestion } = this.state;
+
+        const queries = currentQuestion.atomicQueries();
+        const index = _.findIndex(queries, (query) => this.queryHasMetricAggregation(query, metric));
+
+        if (index !== -1) {
+            const updatedQuestion = currentQuestion.multiQuery().removeQueryAtIndex(index).question();
+            this.updateQuestionAndFetchResults(updatedQuestion);
+        } else {
+            console.error("Removing the metric from aggregations failed");
+        }
+
+        this.setState({
+            addedMetrics: _.omit(addedMetrics, metric.id)
+        });
+    };
+
+    onToggleMetric = (metric, e) => {
+        const checked = e.target.checked;
+
+        try {
+            if (checked) {
+                this.addMetric(metric);
+            } else {
+                this.removeMetric(metric)
+            }
+
+        } catch(e) {
+            console.error("onToggleMetric", e);
+        }
+
+    };
+
+    onDone = () => {
+        const { currentQuestion } = this.state;
+        const { onClose, updateQuestion, runQuestionQuery } = this.props;
+
+        onClose();
+        // Show the result in normal QB view
+        setTimeout(() => {
+            updateQuestion(currentQuestion);
+            runQuestionQuery({ ignoreCache: true });
+        });
+    };
+
+    // TODO Atte Keinänen 6/8/17: Consider moving the filtering logic to Redux selectors
+    filteredMetrics = () => {
+        const { metadata } = this.props;
+        const { searchValue, initialQueries, currentQuestion } = this.state;
+
+        if (!currentQuestion) return [];
+
+
+        return metadata.metricsList().filter(metric => {
+            if (!metric.is_active) {
+                return false;
+            }
+            if (_.find(initialQueries, (query) => this.queryHasMetricAggregation(query, metric))) {
+                return false;
+            }
+
+            return !(
+                searchValue &&
+                (metric.name || "").toLowerCase().indexOf(searchValue) < 0 &&
+                (metric.description || "").toLowerCase().indexOf(searchValue) < 0
+            );
+        });
+    };
+
+    showNewAdHocMetricFlow = () => {
+        this.setState({ showNewAdHocMetricFlow: true });
+    }
+
+    onNewAdHocMetricFlowComplete = (adHocQuery: StructuredQuery) => {
+        const { currentQuestion } = this.state;
+        const updatedQuestion: MultiQuery = currentQuestion
+            .multiQuery()
+            .addQueryWithInferredBreakout(adHocQuery)
+            .question();
+
+        this.updateQuestionAndFetchResults(updatedQuestion);
+        this.setState({ showNewAdHocMetricFlow: false });
+    }
+
+    onNewAdHocMetricFlowCancel = () => {
+        this.setState({ showNewAdHocMetricFlow: false });
+    }
+
+    render() {
+        const { question, onClose } = this.props;
+        const { showNewAdHocMetricFlow, currentResults, currentQuestion, addedMetrics } = this.state;
+
+        const filteredMetrics = this.filteredMetrics();
+        const error = filteredMetrics.length === 0 ? new Error("Whoops, no compatible metrics match your search.") : null;
+        const badMetrics = [];
+
+        if (showNewAdHocMetricFlow) {
+            return (
+                <div className="spread flex">
+                    <div className="flex flex-column flex-full bg-white">
+                        <NewQueryBar />
+                        <NewQueryOptions
+                            question={question}
+                            onComplete={this.onNewAdHocMetricFlowComplete}
+                            onCancel={this.onNewAdHocMetricFlowCancel}
+                        />
+                    </div>
+                </div>
+            )
+        }
+
+        const AddNewMetricListItem = () =>
+            <li
+                className="my1 pl2 py1 flex align-center text-brand-saturated text-bold cursor-pointer"
+                onClick={this.showNewAdHocMetricFlow}
+            >
+                <span className="px1 flex-no-shrink" style={{ height: "16px" }}>
+                    <Icon
+                        name="add"
+                        className="text-brand-hover"
+                        size={16}
+                    />
+                </span>
+                <span className="px1">
+                    New metric
+                </span>
+            </li>;
+
+        const MetricListItem = ({metric}) =>
+            <li className={cx("my1 pl2 py1 flex align-center", {disabled: badMetrics[metric.id]})}>
+                <span className="px1 flex-no-shrink">
+                    <CheckBox checked={addedMetrics[metric.id]}
+                              onChange={this.onToggleMetric.bind(this, metric)}/>
+                </span>
+                <span className="px1">
+                    {metric.name}
+                </span>
+            </li>;
+
+        return (
+            <div className="spread flex">
+                <div className="flex flex-column flex-full bg-white">
+                    <div className="flex-no-shrink h3 pl4 pt4 pb1 text-bold">
+                        <MetricList {...this.props} hideAddButton hideClearButton />
+                    </div>
+                    <div className="flex-no-shrink px4 pt1 pb1 text-bold">
+                        <MetricDimensionOptions query={currentQuestion.query()} updateQuery={this.updateQuery} />
+                    </div>
+                    <div className="flex-full mx1 relative">
+                        <VisualizationResult
+                            // onUpdateWarnings={(warnings) => this.setState({ warnings })}
+                            // onOpenChartSettings={() => this.refs.settings.open()}
+                            className="spread pb1"
+                            {...this.props}
+                            question={currentQuestion}
+                            results={currentResults}
+                        />
+                        {/*{ this.state.state &&*/}
+                        {/*<div className="spred flex layout-centered" style={{ backgroundColor: "rgba(255,255,255,0.80)" }}>*/}
+                            {/*{ this.state.state === "loading" ?*/}
+                                {/*<div className="h3 rounded bordered p3 bg-white shadowed">Applying Metric</div>*/}
+                                {/*: null }*/}
+                        {/*</div>*/}
+                        {/*}*/}
+                    </div>
+                </div>
+                <div className="border-left flex flex-column" style={{width: 370, backgroundColor: "#F8FAFA", borderColor: "#DBE1DF" }}>
+                    <div className="flex-no-shrink border-bottom flex flex-row align-center" style={{ borderColor: "#DBE1DF" }}>
+                        <Icon className="ml2" name="search" size={16} />
+                        <input className="h4 input full pl1" style={{ border: "none", backgroundColor: "transparent" }} type="search" placeholder="Search for a metric" onFocus={this.onSearchFocus} onChange={this.onSearchChange}/>
+                    </div>
+                    <LoadingAndErrorWrapper className="flex flex-full" loading={!filteredMetrics} error={error} noBackground>
+                        { () =>
+                            <ul className="flex-full scroll-y scroll-show pr1">
+                                <AddNewMetricListItem />
+                                {filteredMetrics.map(m => <MetricListItem key={m.id} metric={m} />)}
+                            </ul>
+                        }
+                    </LoadingAndErrorWrapper>
+                    <div className="flex-no-shrink pr2 pb2 pt1 flex border-top" style={{ borderColor: "#DBE1DF" }}>
+                        <div className="flex-full">{/* TODO: How to implement a full-width border-top without this extra component? */}</div>
+                        <button data-metabase-event={"Dashboard;Edit Series Modal;cancel"} className="Button Button--borderless" onClick={onClose}>Cancel</button>
+                        <button className="Button Button--primary" onClick={this.onDone}>Done</button>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}

--- a/frontend/src/metabase/query_builder/components/MetricDimensionOptions.jsx
+++ b/frontend/src/metabase/query_builder/components/MetricDimensionOptions.jsx
@@ -1,0 +1,82 @@
+/* @flow */
+import React, { Component } from "react";
+import Select, { Option } from "metabase/components/Select";
+import MultiQuery from "metabase-lib/lib/queries/MultiQuery";
+import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
+import Dimension from "metabase-lib/lib/Dimension";
+import MetricWidget from "metabase/query_builder/components/MetricWidget";
+import Field from "metabase-lib/lib/metadata/Field";
+
+type ChildQueryDimensionSelectProps = {
+    multiQuery: MultiQuery,
+    atomicQuery: StructuredQuery,
+    index: number,
+    updateBreakoutField: (any) => void
+}
+
+const ChildQueryBreakoutFieldSelect = ({ multiQuery, atomicQuery, index, updateBreakoutField } : ChildQueryDimensionSelectProps) => {
+    const compatibleFields = multiQuery.compatibleFieldsFor(atomicQuery);
+
+    const currentField = Dimension.parseMBQL(atomicQuery.breakouts()[0], atomicQuery.metadata()).field();
+
+    return (
+        <div className="pr1">
+            <MetricWidget
+                key={"metric" + index}
+                metric={atomicQuery}
+            />
+            <Select
+                className="border-med bg-white block"
+                value={currentField}
+                onChange={({ target: { value: newField } }) => updateBreakoutField({ index, newField })}
+                isInitiallyOpen={false}
+                placeholder="Select…"
+            >
+                { compatibleFields.map(field =>
+                    <Option key={field.name} value={field}>{field.display_name}</Option>
+                )}
+            </Select>
+        </div>
+    )
+}
+
+export default class MultiQueryDimensionOptions extends Component {
+    props: {
+        query: MultiQuery,
+        updateQuery: (MultiQuery) => void
+    }
+
+    updateAtomicQueryBreakoutField = ({ index, newField }: { index: number, newField: Field }) => {
+        const { query, updateQuery } = this.props;
+
+        const breakoutDimension = query.breakoutDimensionFor(newField);
+
+        const updatedMultiQuery = query.setQueryAtIndexWith(index, (atomicQuery) =>
+            atomicQuery instanceof StructuredQuery
+                ? atomicQuery.updateBreakout(0, breakoutDimension.mbql())
+                : atomicQuery
+        );
+
+        updateQuery(updatedMultiQuery);
+    }
+
+    render() {
+        const { query } = this.props;
+
+        const atomicQueries: StructuredQuery[] = query.atomicQueries();
+
+        // Somehow fetch the dimension name from metadata
+        return (
+            <div className="align-center flex-full flex flex-wrap">
+                { atomicQueries.map((atomicQuery, index) =>
+                    <ChildQueryBreakoutFieldSelect key={index}
+                                               index={index}
+                                               atomicQuery={atomicQuery}
+                                               multiQuery={query}
+                                               updateBreakoutField={this.updateAtomicQueryBreakoutField}/>)
+                }
+            </div>
+        )
+    }
+}
+

--- a/frontend/src/metabase/query_builder/components/MetricList.jsx
+++ b/frontend/src/metabase/query_builder/components/MetricList.jsx
@@ -1,0 +1,67 @@
+import React from "react";
+import _ from "underscore";
+
+import {getCardColors} from "metabase/visualizations/lib/utils";
+import MetricWidget from "metabase/query_builder/components/MetricWidget";
+import ModalWithTrigger from "metabase/components/ModalWithTrigger";
+import Tooltip from "metabase/components/Tooltip";
+import AddButton from "metabase/components/AddButton";
+import AddMetricDialog from "metabase/query_builder/components/AddMetricDialog";
+import ModalContent from "metabase/components/ModalContent";
+
+// ModalWithTrigger injects `onClose` to its child so this React component exists for handling that properly
+const AddMetricDialogModalContent = ({ onClose, ...props }) =>
+    <ModalContent
+        fullPageModal={true}
+        className="bg-grey-0"
+        onClose={onClose}
+    >
+        <AddMetricDialog onClose={onClose} {...props} />
+    </ModalContent>
+
+// TODO: Containerize this component in order to reduce the props passing in QB
+const MetricList = ({...props}) => {
+    const { question, updateQuestion, hideAddButton, hideClearButton } = props;
+
+    const atomicQueries = question.atomicQueries();
+    const metricColors = getCardColors(question.card());
+
+    const showAddMetricButton = !hideAddButton;
+    const canAddMetricToVisualization = _.contains(["line", "area", "bar"], question.display());
+    const metricsAreRemovable = !hideClearButton && question.multiQuery().canRemoveQuery();
+
+    const addMetricButton =
+        <ModalWithTrigger
+            full
+            disabled={!canAddMetricToVisualization}
+            triggerElement={
+                <Tooltip
+                    key="addmetric"
+                    tooltip={canAddMetricToVisualization ? "Add metric" : "In proto you can only add metrics to line/area/bar visualizations"}
+                >
+                    <AddButton />
+                </Tooltip>
+            }
+        >
+            <AddMetricDialogModalContent {...props} />
+        </ModalWithTrigger>;
+
+    return (
+        <div className="align-center flex flex-full">
+            { atomicQueries.map((atomicQuery, index) =>
+                <MetricWidget
+                    key={"metric" + index}
+                    question={question}
+                    metric={atomicQuery}
+                    metricIndex={index}
+                    updateQuestion={updateQuestion}
+                    clearable={metricsAreRemovable}
+                    color={metricColors[index]}
+                />
+            )}
+            {showAddMetricButton && addMetricButton}
+        </div>
+    )
+};
+
+export default MetricList;

--- a/frontend/src/metabase/query_builder/components/MetricWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/MetricWidget.jsx
@@ -1,0 +1,81 @@
+import React, { Component } from "react";
+import Clearable from './Clearable.jsx';
+import cx from "classnames";
+import Query from "metabase-lib/lib/queries/Query";
+import Question from "metabase-lib/lib/Question";
+import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
+
+type Props = {
+    metric: Query,
+    editable?: boolean,
+    clearable?: boolean,
+    // metricIndex and updateQuestion are only needed if clearable = true
+    // TODO: Get rid of metricIndex as we can add Question.removeMetric that accepts a metric object or just use MultiQuery API directly
+    metricIndex?: number,
+    updateQuestion?: (question: Question) => void,
+    color: string,
+};
+
+export default class MetricWidget extends Component {
+    props: Props;
+
+    constructor(props, context) {
+        super(props, context);
+
+        this.state = {
+            isOpen: false
+        };
+    }
+
+    static defaultProps = {
+        editable: false,
+        clearable: false
+    };
+
+    removeMetric = () => {
+        const { metricIndex, updateQuestion } = this.props;
+        updateQuestion(this.metric.question().removeMetric(metricIndex));
+    }
+
+    open() {
+        if (!this.props.editable) return;
+
+        this.setState({ isOpen: true });
+    }
+
+    close() {
+        this.setState({ isOpen: false });
+    }
+
+    render() {
+        const { metric, editable, color, clearable } = this.props;
+
+        if (metric instanceof StructuredQuery && !metric.isBareRows()) {
+            let aggregationName = metric.aggregationName();
+
+            const metricTitle =
+                <div id="Query-section-aggregation" onClick={this.open} className={cx("Query-section Query-section-aggregation", {"cursor-pointer": editable})}>
+                    <div
+                        className={cx("flex-no-shrink", "inline-block circular")}
+                        style={{width: 15, height: 15, backgroundColor: color }}
+                    />
+                    <span className={cx("QueryOption py1 mx1", {"text-success": editable}, {"text-grey-0": !editable})}>
+                        { aggregationName == null ? "Choose an aggregation" : aggregationName }
+                    </span>
+                </div>;
+
+            return (
+                <div className={cx("Query-section Query-section-aggregation mr1", { "selected": this.state.isOpen })}>
+                    <div>
+                        { clearable ?
+                            <Clearable className="pr1" onClear={this.removeMetric}>{metricTitle}</Clearable>
+                            : metricTitle
+                        }
+                    </div>
+                </div>
+            );
+        } else {
+            return null;
+        }
+    }
+}

--- a/frontend/src/metabase/query_builder/components/QuestionEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/QuestionEditor.jsx
@@ -1,0 +1,235 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import ReactDOM from "react-dom";
+import cx from "classnames";
+import _ from "underscore";
+
+import { duration } from "metabase/lib/formatting";
+import MetabaseSettings from "metabase/lib/settings";
+
+import QueryModeButton from "metabase/query_builder/components/QueryModeButton";
+import ButtonBar from "metabase/components/ButtonBar";
+import QueryDownloadWidget from "metabase/query_builder/components/QueryDownloadWidget";
+import QuestionEmbedWidget from "metabase/query_builder/containers/QuestionEmbedWidget";
+import RunButton from "metabase/query_builder/components/RunButton";
+import Tooltip from "metabase/components/Tooltip";
+import MetricList from "metabase/query_builder/components/MetricList";
+import {REFRESH_TOOLTIP_THRESHOLD} from "metabase/query_builder/components/QueryVisualization";
+
+import type { TableId } from "metabase/meta/types/Table";
+import type { DatabaseId } from "metabase/meta/types/Database";
+import type { DatasetQuery } from "metabase/meta/types/Card";
+import type { TableMetadata, DatabaseMetadata } from "metabase/meta/types/Metadata";
+import type { Children } from 'react';
+import Query from "metabase-lib/lib/queries/Query";
+
+type Props = {
+    children?: Children,
+
+    features: {
+        data?: boolean,
+        filter?: boolean,
+        aggregation?: boolean,
+        breakout?: boolean,
+        sort?: boolean,
+        limit?: boolean
+    },
+
+    query: Query,
+
+    databases: DatabaseMetadata[],
+    tables: TableMetadata[],
+
+    supportMultipleAggregations?: boolean,
+
+    setDatabaseFn: (id: DatabaseId) => void,
+    setSourceTableFn: (id: TableId) => void,
+    setDatasetQuery: (datasetQuery: DatasetQuery) => void,
+
+    isShowingTutorial: boolean,
+    isShowingDataReference: boolean,
+}
+
+type State = {
+    expanded: boolean
+}
+
+export default class QuestionEditor extends Component {
+    props: Props;
+    state: State = {
+        expanded: true
+    };
+
+    static propTypes = {
+        databases: PropTypes.array,
+        isShowingDataReference: PropTypes.bool.isRequired,
+        setDatasetQuery: PropTypes.func.isRequired,
+        setDatabaseFn: PropTypes.func,
+        setSourceTableFn: PropTypes.func,
+        features: PropTypes.object,
+        supportMultipleAggregations: PropTypes.bool
+    };
+
+    static defaultProps = {
+        features: {
+            data: true,
+            filter: true,
+            aggregation: true,
+            breakout: true,
+            sort: true,
+            limit: true
+        },
+        supportMultipleAggregations: true
+    };
+
+    renderMetricSection() {
+        const { features, question } = this.props;
+
+        if (!features.aggregation && !features.breakout) {
+            return;
+        }
+
+        // TODO Atte Keinänen 5/25/17 How should `isEditable` work for multimetric questions?
+        if (question.query().isEditable()) {
+            return <MetricList {...this.props} />
+        } else {
+            // TODO: move this into AggregationWidget?
+            return (
+                <div className="Query-section Query-section-aggregation disabled">
+                    <a className="QueryOption p1 flex align-center"></a>
+                </div>
+            );
+        }
+    }
+
+    renderButtons = () => {
+        // NOTE: Most of stuff is replicated from QueryVisualization header
+        const { question, isResultDirty, isAdmin, result, setQueryModeFn, tableMetadata, isRunnable, isRunning, runQuestionQuery, cancelQuery } = this.props;
+
+        const isPublicLinksEnabled = MetabaseSettings.get("public_sharing");
+        const isEmbeddingEnabled = MetabaseSettings.get("embedding");
+
+        const getQueryModeButton = () =>
+            <QueryModeButton
+                key="queryModeToggle"
+                mode={question.query().datasetQuery().type}
+                allowNativeToQuery={false}
+                allowQueryToNative={false}
+                /*allowNativeToQuery={isNew && !isDirty}
+                allowQueryToNative={tableMetadata ?
+                    // if a table is selected, only enable if user has native write permissions for THAT database
+                    tableMetadata.db && tableMetadata.db.native_permissions === "write" :
+                    // if no table is selected, only enable if user has native write permissions for ANY database
+                    _.any(databases, (db) => db.native_permissions === "write")
+                }*/
+                nativeForm={result && result.data && result.data.native_form}
+                onSetMode={setQueryModeFn}
+                tableMetadata={tableMetadata}
+            />;
+
+        const getQueryDownloadWidget = () =>
+            <QueryDownloadWidget
+                key="querydownload"
+                className="hide sm-show"
+                card={question.card()}
+                result={result}
+            />;
+
+        const getQueryEmbedWidget = () =>
+            <QuestionEmbedWidget key="questionembed" className="hide sm-show" card={question.card()} />;
+
+        const getRunButton = () => {
+            const { question } = this.props;
+            const runQueryWithoutCache = () => runQuestionQuery({ overrideWithCard: question.card(), ignoreCache: true });
+
+            let runButtonTooltip;
+            if (!isResultDirty && result && result.cached && result.average_execution_time > REFRESH_TOOLTIP_THRESHOLD) {
+                runButtonTooltip = `This question will take approximately ${duration(result.average_execution_time)} to refresh`;
+            }
+
+            return (
+                <Tooltip key="runbutton" tooltip={runButtonTooltip}>
+                    <RunButton
+                        isRunnable={isRunnable}
+                        isDirty={isResultDirty}
+                        isRunning={isRunning}
+                        onRun={runQueryWithoutCache}
+                        onCancel={cancelQuery}
+                    />
+                </Tooltip>
+            )
+        }
+
+
+        const queryHasCleanResult  = !isResultDirty && result && !result.error;
+        const isEmbeddable = question.isSaved() && (
+                (isPublicLinksEnabled && (isAdmin || question.card().public_uuid)) ||
+                (isEmbeddingEnabled && isAdmin)
+        );
+
+        const buttons = [
+            getQueryModeButton(),
+            isEmbeddable && getQueryEmbedWidget(),
+            queryHasCleanResult && getQueryDownloadWidget(),
+            getRunButton()
+        ].filter(_.isObject);
+
+        return (
+            <ButtonBar buttons={buttons.map(b => [b])} className="borderless pr1 mr2" />
+        );
+    };
+
+    componentDidUpdate() {
+        const guiBuilder = ReactDOM.findDOMNode(this.refs.guiBuilder);
+        if (!guiBuilder) {
+            return;
+        }
+
+        // HACK: magic number "5" accounts for the borders between the sections?
+        let contentWidth = ["data", "filter", "view", "groupedBy","sortLimit"].reduce((acc, ref) => {
+            let node = ReactDOM.findDOMNode(this.refs[`${ref}Section`]);
+            return acc + (node ? node.offsetWidth : 0);
+        }, 0) + 5;
+        let guiBuilderWidth = guiBuilder.offsetWidth;
+
+        let expanded = (contentWidth < guiBuilderWidth);
+        if (this.state.expanded !== expanded) {
+            this.setState({ expanded });
+        }
+    }
+
+    render() {
+        const { datasetQuery, databases } = this.props;
+        const readOnly = datasetQuery.database != null && !_.findWhere(databases, { id: datasetQuery.database });
+        if (readOnly) {
+            return <div className="border-bottom border-med" />
+        }
+
+        return (
+            <div className={cx("GuiBuilder rounded shadowed flex", {
+                "GuiBuilder--expand": this.state.expanded,
+                disabled: readOnly
+            })} ref="guiBuilder">
+                <div className="GuiBuilder-section flex-full flex align-center px2" ref="viewSection">
+                    {this.renderMetricSection()}
+                </div>
+                <div className="GuiBuilder-section flex align-center justify-end">
+                    {this.renderButtons()}
+                </div>
+                {/*<div className="GuiBuilder-row flex">
+                 {this.renderDataSection()}
+                 {this.renderFilterSection()}
+                 </div>
+                 <div className="GuiBuilder-row flex flex-full">
+                 {this.renderMetricSection()}
+                 {this.renderGroupedBySection()}
+                 <div className="flex-full"></div>
+                 {this.props.children}
+                 <ExtendedOptions
+                 {...this.props}
+                 />
+                 </div>*/}
+            </div>
+        );
+    }
+}

--- a/frontend/src/metabase/query_builder/components/QuestionHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/QuestionHeader.jsx
@@ -1,0 +1,452 @@
+import React, { Component } from "react";
+import { Link } from "react-router";
+
+import ActionButton from 'metabase/components/ActionButton.jsx';
+import AddToDashSelectDashModal from 'metabase/containers/AddToDashSelectDashModal.jsx';
+import ButtonBar from "metabase/components/ButtonBar.jsx";
+import HeaderBar from "metabase/components/HeaderBar.jsx";
+import HistoryModal from "metabase/components/HistoryModal.jsx";
+import Icon from "metabase/components/Icon.jsx";
+import Modal from "metabase/components/Modal.jsx";
+import ModalWithTrigger from "metabase/components/ModalWithTrigger.jsx";
+import QuestionSavedModal from 'metabase/components/QuestionSavedModal.jsx';
+import Tooltip from "metabase/components/Tooltip.jsx";
+import MoveToCollection from "metabase/questions/containers/MoveToCollection.jsx";
+import ArchiveQuestionModal from "metabase/query_builder/containers/ArchiveQuestionModal"
+
+import SaveQuestionModal from 'metabase/containers/SaveQuestionModal.jsx';
+
+import { CardApi, RevisionApi } from "metabase/services";
+
+import MetabaseAnalytics from "metabase/lib/analytics";
+import Query from "metabase/lib/query";
+import { cancelable } from "metabase/lib/promise";
+import * as Urls from "metabase/lib/urls";
+
+import cx from "classnames";
+import _ from "underscore";
+import Button from "metabase/components/Button";
+import type Question from "metabase-lib/lib/Question";
+import type {Card} from "metabase/meta/types/Card";
+import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
+
+type Props = {
+    question: Question,
+    // TODO Atte Keinänen 5/25/17: Replace originalCard with `Question` object
+    originalCard?: Card,
+    isEditing: boolean,
+    // tableMetadata isn't present if the query is a native query or the metadata is still loading
+    tableMetadata?: TableMetadata,
+    onSetCardAttribute: (string, any) => void,
+    reloadCardFn: () => void,
+    // TODO Atte Keinänen 5/25/17: Define a union type for allowed query modes
+    setQueryModeFn: (string) => void,
+    isShowingDataReference: boolean,
+    toggleDataReferenceFn: () => void,
+    onChangeLocation: (string) => void,
+    isNew: boolean,
+    isEditing: boolean,
+    isDirty: boolean
+}
+
+export default class QuestionHeader extends Component {
+    props: Props;
+    
+    constructor(props, context) {
+        super(props, context);
+
+        this.state = {
+            recentlySaved: null,
+            modal: null,
+            revisions: null
+        };
+    }
+    
+    componentWillUnmount() {
+        clearTimeout(this.timeout);
+        if (this.requestPromise) {
+            this.requestPromise.cancel();
+        }
+    }
+
+    resetStateOnTimeout = () => {
+        // clear any previously set timeouts then start a new one
+        clearTimeout(this.timeout);
+        this.timeout = setTimeout(() =>
+            this.setState({ recentlySaved: null })
+        , 5000);
+    };
+
+    // onCreate = (question, addToDash) => {
+    //     if (question.datasetQuery().query) {
+    //         Query.cleanQuery(question.datasetQuery().query);
+    //     }
+    //
+    //     // TODO: reduxify
+    //     this.requestPromise = cancelable(CardApi.create(card));
+    //     return this.requestPromise.then(newCard => {
+    //         this.props.notifyCardCreatedFn(newCard);
+    //
+    //         this.setState({
+    //             recentlySaved: "created",
+    //             modal: addToDash ? "add-to-dashboard" : "saved"
+    //         }, this.resetStateOnTimeout);
+    //     });
+    // }
+
+    onSave = (card, addToDash) => {
+        // MBQL->NATIVE
+        // if we are a native query with an MBQL query definition, remove the old MBQL stuff (happens when going from mbql -> native)
+        // if (question.datasetQuery().type === "native" && question.datasetQuery().query) {
+        //     delete question.datasetQuery().query;
+        // } else if (question.datasetQuery().type === "query" && question.datasetQuery().native) {
+        //     delete question.datasetQuery().native;
+        // }
+
+        const { fromUrl, notifyCardUpdatedFn } = this.props;
+
+        const datasetQuery = card.dataset_query;
+        if (datasetQuery.query) {
+            Query.cleanQuery(datasetQuery.query);
+        }
+
+        // TODO: reduxify
+        this.requestPromise = cancelable(CardApi.update(card));
+        return this.requestPromise.then(updatedCard => {
+            if (fromUrl) {
+                this.onGoBack();
+                return;
+            }
+
+            notifyCardUpdatedFn(updatedCard);
+
+            this.setState({
+                recentlySaved: "updated",
+                modal: addToDash ? "add-to-dashboard" : null
+            }, this.resetStateOnTimeout);
+        });
+    };
+
+    onBeginEditing = () => {
+        this.props.onBeginEditing();
+    };
+
+    onCancel = async () => {
+        if (this.props.fromUrl) {
+            this.onGoBack();
+        } else {
+            this.props.onCancelEditing();
+        }
+    };
+
+    onDelete = async () => {
+        // TODO: reduxify
+        await CardApi.delete({ 'cardId': this.props.card.id });
+        this.onGoBack();
+        MetabaseAnalytics.trackEvent("QueryBuilder", "Delete");
+    };
+
+    onFollowBreadcrumb = () => {
+        this.props.onRestoreOriginalQuery();
+    };
+
+    onToggleDataReference = () => {
+        this.props.toggleDataReferenceFn();
+    };
+
+    onGoBack = () => {
+        this.props.onChangeLocation(this.props.fromUrl || "/");
+    };
+
+    onFetchRevisions = async ({ entity, id }) => {
+        // TODO: reduxify
+        var revisions = await RevisionApi.list({ entity, id });
+        this.setState({ revisions });
+    };
+
+    onRevertToRevision = ({ entity, id, revision_id }) => {
+        // TODO: reduxify
+        return RevisionApi.revert({ entity, id, revision_id });
+    };
+
+    onRevertedRevision = () => {
+        this.props.reloadCardFn();
+        this.refs.cardHistory.toggle();
+    };
+
+    getHeaderButtons = () => {
+        const {
+            question,
+            originalCard,
+            isNew,
+            isDirty,
+            isEditing,
+            uiControls,
+            toggleTemplateTagsEditor,
+            isShowingDataReference,
+            onSetCardAttribute
+        } = this.props;
+
+        const card = question.card();
+
+        // TODO Atte Keinänen 5/20/17 Add multi-query support to all components that need metadata
+        // These only fetch the database and table metadata of first available query
+        const tableMetadata = question.atomicQueries()[0].tableMetadata();
+        const database = question && question.atomicQueries()[0].database();
+
+        const SaveNewCardButton = () =>
+            <ModalWithTrigger
+                form
+                key="save"
+                triggerClasses="h4 text-grey-4 text-brand-hover text-uppercase"
+                triggerElement="Save"
+            >
+                <SaveQuestionModal
+                    card={card}
+                    originalCard={originalCard}
+                    tableMetadata={tableMetadata}
+                    addToDashboard={false}
+                    saveFn={this.onSave}
+                    createFn={this.onCreate}
+                />
+            </ModalWithTrigger>;
+
+        const ConfirmationOfSavedCard = () =>
+            <button
+                key="recentlySaved"
+                className="cursor-pointer bg-white text-success text-strong text-uppercase"
+            >
+                <span>
+                    <Icon name='check' size={12}/>
+                    <span className="ml1">Saved</span>
+                </span>
+            </button>;
+
+        const EditCardButton = () =>
+            <Tooltip key="edit" tooltip="Edit question">
+                <a className="cursor-pointer text-brand-hover" onClick={this.onBeginEditing}>
+                    <Icon name="pencil" size={16}/>
+                </a>
+            </Tooltip>;
+
+        const SaveEditedCardButton = () =>
+            <ActionButton
+                key="save"
+                actionFn={() => this.onSave(card, false)}
+                className="cursor-pointer text-brand-hover bg-white text-grey-4 text-uppercase"
+                normalText="SAVE CHANGES"
+                activeText="Saving…"
+                failedText="Save failed"
+                successText="Saved"
+            />;
+
+        const CancelEditingButton = () =>
+            <a key="cancel" className="cursor-pointer text-brand-hover text-grey-4 text-uppercase" onClick={this.onCancel}>
+                CANCEL
+            </a>;
+
+        const DeleteCardButton = () =>
+            <ArchiveQuestionModal questionId={card.id}/>;
+
+        const MoveQuestionToCollectionButton = () =>
+            <ModalWithTrigger
+                key="move"
+                full
+                triggerElement={
+                    <Tooltip tooltip="Move question">
+                        <Icon name="move" />
+                    </Tooltip>
+                }
+            >
+                <MoveToCollection
+                    questionId={card.id}
+                    initialCollectionId={card && card.collection_id}
+                    setCollection={(questionId, collection) => {
+                        onSetCardAttribute('collection', collection)
+                        onSetCardAttribute('collection_id', collection.id)
+                    }}
+                />
+            </ModalWithTrigger>;
+
+        const ToggleTemplateTagsEditorButton = () => {
+            const parametersButtonClasses = cx('transition-color', {
+                'text-brand': uiControls.isShowingTemplateTagsEditor,
+                'text-brand-hover': !uiControls.isShowingTemplateTagsEditor
+            });
+            return (
+                <Tooltip key="parameterEdititor" tooltip="Variables">
+                    <a className={parametersButtonClasses}>
+                        <Icon name="variable" size={16} onClick={toggleTemplateTagsEditor}/>
+                    </a>
+                </Tooltip>
+            );
+        };
+
+        const AddSavedCardToDashboardButton = () =>
+            <Tooltip key="addtodash" tooltip="Add to dashboard">
+                    <span data-metabase-event={"QueryBuilder;AddToDash Modal;normal"} className="cursor-pointer text-brand-hover" onClick={() => this.setState({ modal: "add-to-dashboard" })}>
+                        <Icon name="addtodash" size={16} />
+                    </span>
+            </Tooltip>;
+
+        const SaveNewCardAndAddToDashboardButton = () =>
+            <Tooltip key="addtodashsave" tooltip="Add to dashboard">
+                <ModalWithTrigger
+                    triggerClasses="h4 text-brand-hover text-uppercase"
+                    triggerElement={
+                        <Button data-metabase-event="QueryBuilder;AddToDash Modal;pre-save"
+                                icon="addtodash"
+                                iconSize={16}
+                                onlyIcon
+                        />
+                    }
+                >
+                    <SaveQuestionModal
+                        card={card}
+                        originalCard={originalCard}
+                        tableMetadata={tableMetadata}
+                        addToDashboard={true}
+                        saveFn={this.onSave}
+                        createFn={this.onCreate}
+                    />
+                </ModalWithTrigger>
+            </Tooltip>;
+
+        // Don't treat as functional component due to refs
+        const getHistoryRevisionsButton = () =>
+            <Tooltip key="history" tooltip="Revision history">
+                <ModalWithTrigger
+                    ref="cardHistory"
+                    triggerElement={<Button icon="history" onlyIcon />}
+                >
+                    <HistoryModal
+                        revisions={this.state.revisions}
+                        entityType="card"
+                        entityId={card.id}
+                        onFetchRevisions={this.onFetchRevisions}
+                        onRevertToRevision={this.onRevertToRevision}
+                        onClose={() => this.refs.cardHistory.toggle()}
+                        onReverted={this.onRevertedRevision}
+                    />
+                </ModalWithTrigger>
+            </Tooltip>;
+
+        const DataReferenceButton = () => {
+            const dataReferenceButtonClasses = cx('transition-color', {
+                'text-brand': isShowingDataReference,
+                'text-brand-hover': !this.state.isShowingDataReference
+            });
+
+            return (
+                <Tooltip key="dataReference" tooltip="Learn about your data">
+                    <a className={dataReferenceButtonClasses}>
+                        <Icon name='reference' size={16} onClick={this.onToggleDataReference} />
+                    </a>
+                </Tooltip>
+            );
+        };
+
+        const isNewCardThatCanBeSaved = isNew && isDirty;
+        const isSaved = !isNew;
+        const isEditableSavedCard = isSaved && question.canWrite();
+        const isNativeQuery = question.query() instanceof NativeQuery;
+        const isNativeQueryWithParameters = isNativeQuery && database && _.contains(database.features, "native-parameters");
+
+        const getPersistenceButtons = () => {
+            if (isEditableSavedCard) {
+                if (!isEditing) {
+                    if (this.state.recentlySaved) {
+                        return [ <ConfirmationOfSavedCard /> ];
+                    } else {
+                        return [ <EditCardButton key="edit" /> ];
+                    }
+                } else {
+                    return [
+                        <SaveEditedCardButton />,
+                        <CancelEditingButton />,
+                        <DeleteCardButton />,
+                        <MoveQuestionToCollectionButton />
+                    ]
+                }
+            } else {
+                return [];
+            }
+        };
+
+        const buttons = [
+            isNewCardThatCanBeSaved && <SaveNewCardButton />,
+            ...getPersistenceButtons(),
+            isNativeQueryWithParameters && <ToggleTemplateTagsEditorButton />,
+            isSaved && !isEditing && <AddSavedCardToDashboardButton key="addtodash" />,
+            isNewCardThatCanBeSaved && <SaveNewCardAndAddToDashboardButton />,
+            // TODO: See what kind of modifications the revisions feature requires
+            isSaved && getHistoryRevisionsButton(),
+            // TODO: See how SQL will be supported and move this to the QuestionEditor banner
+            // <QueryModeToggleButton />,
+            <DataReferenceButton key="datareference" />
+        ].filter(_.isObject);
+
+        return (
+            <ButtonBar buttons={buttons.map(b => [b])} className="mr2 pr1 borderless" />
+        );
+    };
+
+    onCloseModal = () => {
+        this.setState({ modal: null });
+    };
+
+    render() {
+        const { question, originalCard, isEditing, isNew, onSetCardAttribute, onChangeLocation } = this.props;
+        const badgeItemStyle = "text-uppercase flex align-center no-decoration text-bold";
+        const description = question.card().description;
+
+        return (
+            <div className="relative">
+                <HeaderBar
+                    isEditing={isEditing}
+                    name={isNew ? "New question" : question.card().name}
+                    description={description}
+                    breadcrumb={(!question.card().id && originalCard) ? (<span className="pl2">started from <a className="link" onClick={this.onFollowBreadcrumb}>{originalCard.name}</a></span>) : null }
+                    buttons={this.getHeaderButtons()}
+                    setItemAttributeFn={onSetCardAttribute}
+                    badge={question.card().collection &&
+                        <div className="flex">
+                            <Link
+                                to={Urls.collection(question.card().collection)}
+                                className={badgeItemStyle}
+                                style={{color: question.card().collection.color, fontSize: 12}}
+                            >
+                                <Icon name="collection" size={14} style={{marginRight: "0.5em"}}/>
+                                {question.card().collection.name}
+                            </Link>
+                            { description &&
+                                <div
+                                    className={cx("ml2", badgeItemStyle)}
+                                    style={{fontSize: 12}}
+                                >
+                                    <Icon name="infooutlined" size={14} style={{marginRight: "0.5em"}}/>
+                                    Details
+                                </div>
+                            }
+                        </div>
+                    }
+                />
+
+                <Modal small isOpen={this.state.modal === "saved"} onClose={this.onCloseModal}>
+                    <QuestionSavedModal
+                        addToDashboardFn={() => this.setState({ modal: "add-to-dashboard" })}
+                        onClose={this.onCloseModal}
+                    />
+                </Modal>
+
+                <Modal isOpen={this.state.modal === "add-to-dashboard"} onClose={this.onCloseModal}>
+                    <AddToDashSelectDashModal
+                        card={question.card()}
+                        onClose={this.onCloseModal}
+                        onChangeLocation={onChangeLocation}
+                    />
+                </Modal>
+            </div>
+        );
+    }
+}

--- a/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
@@ -5,17 +5,15 @@ import QueryVisualizationObjectDetailTable from './QueryVisualizationObjectDetai
 import VisualizationErrorMessage from './VisualizationErrorMessage';
 import Visualization from "metabase/visualizations/components/Visualization.jsx";
 import { datasetContainsNoResults } from "metabase/lib/dataset";
-import { DatasetQuery } from "metabase/meta/types/Card";
 
 type Props = {
     question: Question,
     isObjectDetail: boolean,
     result: any,
     results: any[],
-    lastRunDatasetQuery: DatasetQuery,
     navigateToNewCardInsideQB: (any) => void
 }
-const VisualizationResult = ({question, isObjectDetail, lastRunDatasetQuery, navigateToNewCardInsideQB, result, results, ...props}: Props) => {
+const VisualizationResult = ({question, isObjectDetail, navigateToNewCardInsideQB, result, results, ...props}: Props) => {
     const noResults = datasetContainsNoResults(result.data);
 
     if (isObjectDetail) {
@@ -36,10 +34,12 @@ const VisualizationResult = ({question, isObjectDetail, lastRunDatasetQuery, nav
         // we want to provide the visualization with a card containing the latest
         // "display", "visualization_settings", etc, (to ensure the correct visualization is shown)
         // BUT the last executed "dataset_query" (to ensure data matches the query)
+
+        // TODO: Atte Keinänen 6/2/17: Should we provide a `lastRunDatasetQueries` or similar?
         const series = question.atomicQueries().map((metricQuery, index) => ({
             card: {
                 ...question.card(),
-                dataset_query: lastRunDatasetQuery
+                dataset_query: metricQuery.datasetQuery()
             },
             data: results[index] && results[index].data
         }));

--- a/frontend/src/metabase/reducers-main.js
+++ b/frontend/src/metabase/reducers-main.js
@@ -21,6 +21,7 @@ import dashboard from "metabase/dashboard/dashboard";
 import * as home from "metabase/home/reducers";
 
 /* questions / query builder */
+import new_query from "metabase/new_query/new_query";
 import questions from "metabase/questions/questions";
 import labels from "metabase/questions/labels";
 import collections from "metabase/questions/collections";
@@ -39,6 +40,7 @@ export default {
     dashboards,
     dashboard,
     home: combineReducers(home),
+    new_query,
     pulse: combineReducers(pulse),
     qb: combineReducers(qb),
     questions,


### PR DESCRIPTION
Ad-hoc question flow
- [x] Merge Kyle's branch to `multi-metrics-proto`, fix Flow errors
- [x] Add the "New metric" button to "Add metric" dialog for starting the ad-hoc metric flow inside the same modal
- [x] Add the resulting metric to current multi-metric query (with the naive aggregation selector)
- [ ] Aggregation expression editor
    - [ ] Try to simply embed the current expression editor first (no actions below the expressions editor yet)
    - [ ] Extend the expression editor component so that we can get listen to of all expression changes. Propagate that information to `NewQueryOptions` (the container shown in the place of visualization in QB) for being able to provide contextual actions.
    - [ ] Show the aggregation option list view and the field list view in relevant contexts. No interactive behavior yet on this stage.
    - [ ] Glue the aggregation / field actions to the expressions editor, maybe by abstracting some expression manipulation logic to metabase-lib

Add Metric dialog
- [ ] Open the "Add Metric" dialog immediately after clicking the "Add a Metric" action widget action
- [ ] Fix: The "Add Metric" dialog misbehaves if the original ad-hoc metric has a filter in it
- [ ] In the dimension selector, show an input box without the dropdown toggle if no other compatible dimensions than the currently active one are available
- [ ] Sort metrics alphabetically
- [ ] Show non-compatible metrics in disabled state after the compatible metrics

Editor bar
- [ ] Clicking the metric name should take you to the source table with the current aggregation and breakout (i.e. redirect to the current query of that metric)

Visualizations
- [ ] Show correct legends for each metric; this probably means modifying the logic behind `VisualizationResult`
- [ ] Improve table visualization so that it accepts multiple series as a data source if their first column is equal; that way we're able to combine multiple metrics that use the same breakout
- [ ] Activate the timeseries mode for multimetric line/area/bar visualization; currently it's not available
- [ ] Try to port dashcard multiscalars to multimetrics query builder (this is also an nice pathway for opening the discussion of deprecating dashcards)

Drill-through / query widget actions
- [ ] Follow this logic in query widget actions: "I can view the current chart as a table, but I can’t use the 'underlying rows' action."
- [ ] Add an action for changing the breakout type

Saving 
- [ ] Rudimentary saving (encoding + decoding in QB action?) of multiqueries so that we are saving them as metadata to `visualization_options` whereas `dataset_query` might be just the first query of the multiquery question so that stuff like pulses don't totally crash

Misc
- [ ] Check how easy/hard it is to make the download button functionality work correctly (after the table visualization improvements have been done)