### PR TITLE
clean up modal background and animation

### DIFF
--- a/frontend/src/metabase/components/Modal.jsx
+++ b/frontend/src/metabase/components/Modal.jsx
@@ -1,11 +1,9 @@
 import React, { Component } from "react";
-import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
 import cx from "classnames";
 
 import { getScrollX, getScrollY } from "metabase/lib/dom";
 
-import ReactCSSTransitionGroup from "react-addons-css-transition-group";
 import { Motion, spring } from "react-motion";
 
 import OnClickOutsideWrapper from "./OnClickOutsideWrapper.jsx";
@@ -24,13 +22,9 @@ function getModalContent(props) {
 }
 
 export class WindowModal extends Component {
-    static propTypes = {
-        isOpen: PropTypes.bool
-    };
 
     static defaultProps = {
         className: "Modal",
-        backdropClassName: "Modal-backdrop"
     };
 
     componentWillMount() {
@@ -76,16 +70,34 @@ export class WindowModal extends Component {
     }
 
     _renderPopover() {
-        const { backdropClassName, isOpen, style } = this.props;
-        const backdropClassnames = 'flex justify-center align-center fixed top left bottom right';
+        const { isOpen } = this.props;
+        const backdropClassnames = 'Modal-backdrop flex justify-center align-center fixed top left bottom right';
+
         ReactDOM.unstable_renderSubtreeIntoContainer(this,
-            <ReactCSSTransitionGroup transitionName="Modal" transitionAppear={true} transitionAppearTimeout={250} transitionEnterTimeout={250} transitionLeaveTimeout={250}>
-                { isOpen &&
-                    <div key="modal" className={cx(backdropClassName, backdropClassnames)} style={style}>
-                        {this._modalComponent()}
+            <Motion
+                defaultStyle={{ opacity: 0, translate: 250 }}
+                style={isOpen ?
+                    { opacity: spring(1), translate: spring(0) } :
+                    { opacity: spring(0), translate: spring(250)}
+                }
+            >
+                { style =>
+                    <div>
+                        { isOpen &&
+                                <div key="modal" className={backdropClassnames} style={{
+                                    opacity: style.opacity
+                                }}>
+                                    <div style={{
+                                        opacity: style.opacity,
+                                        transform: `translateY(${style.translate})px`
+                                    }}>
+                                        {this._modalComponent()}
+                                    </div>
+                            </div>
+                        }
                     </div>
                 }
-            </ReactCSSTransitionGroup>
+            </Motion>
         , this._modalElement);
     }
 

--- a/frontend/src/metabase/css/components/modal.css
+++ b/frontend/src/metabase/css/components/modal.css
@@ -1,6 +1,8 @@
-.ModalContainer {
-    z-index: 4;
+:root {
+  --modalBackdropColor: rgba(46, 53, 59, 0.6);
 }
+
+.ModalContainer { z-index: 4; }
 
 .Modal {
   margin: auto;
@@ -12,7 +14,7 @@
 
 /* On IE11, single flex item with `margin: auto` gets shifted to flex end
  * https://github.com/philipwalton/flexbugs/issues/157
- * Set margin to zero when using Flexbox in `WindowModal` component 
+ * Set margin to zero when using Flexbox in `WindowModal` component
  */
 .Modal-backdrop > .Modal, .Modal-backdrop--dark > .Modal {
   margin: 0;
@@ -37,60 +39,6 @@
 }
 
 .Modal-backdrop {
-    background-color: rgba(255, 255, 255, 0.6);
+    background-color: var(--modalBackdropColor)
 }
 
-.Modal-backdrop--dark {
-    background-color: rgba(75, 75, 75, 0.7);
-}
-
-/* TRANSITIONS */
-
-/* backdrop */
-
-.Modal-backdrop.Modal-appear,
-.Modal-backdrop.Modal-enter {
-  transition: background-color 200ms ease-in-out;
-  background-color: rgba(255, 255, 255, 0.01);
-}
-
-.Modal-backdrop.Modal-appear-active,
-.Modal-backdrop.Modal-enter-active {
-  background-color: rgba(255, 255, 255, 0.6);
-}
-
-.Modal-backdrop.Modal-leave {
-  transition: background-color 200ms ease-in-out 100ms;
-  background-color: rgba(255, 255, 255, 0.6);
-}
-
-.Modal-backdrop.Modal-leave-active {
-  background-color: rgba(255, 255, 255, 0.01);
-}
-
-
-/* modal */
-
-.Modal-backdrop.Modal-appear .Modal,
-.Modal-backdrop.Modal-enter .Modal {
-  transition: opacity 200ms linear 100ms, transform 200ms ease-in-out 100ms;
-  opacity: 0.01;
-  transform: translate(0, 40px);
-}
-
-.Modal-backdrop.Modal-appear-active .Modal,
-.Modal-backdrop.Modal-enter-active .Modal {
-  opacity: 1;
-  transform: translate(0, 0);
-}
-
-.Modal-backdrop.Modal-leave .Modal {
-  transition: opacity 200ms linear, transform 200ms ease-in-out;
-  opacity: 1;
-  transform: translate(0, 0);
-}
-
-.Modal-backdrop.Modal-leave-active .Modal {
-  opacity: 0.01;
-  transform: translate(0, -40px);
-}


### PR DESCRIPTION
Moves modal backdrops to a darker color to improve contrast (and makes sure all modals use this color for consistency).

![screen shot 2017-06-21 at 2 21 19 pm](https://user-images.githubusercontent.com/5248953/27407418-0958d6a0-568d-11e7-96ee-0435a12c3ac5.png)

This also moves to using `react-motion` for the modal entry animation (like we do for the `full` modals) to keep things colocated. One known issue is that due to how the modal component removes its elements from the DOM we don't get an exit animation. That's fixable using `TransitionMotion from that library but its API is a bit intense and I haven't had time to figure out how to get it to work correctly yet.
