### PR TITLE
improve FF text rendering

### DIFF
--- a/frontend/src/metabase/css/core/base.css
+++ b/frontend/src/metabase/css/core/base.css
@@ -17,8 +17,10 @@ body {
     height: 100%; /* ensure the entire page will fill the window */
     display: flex;
     flex-direction: column;
+
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }
 
 /*


### PR DESCRIPTION
uses grayscale smoothing in firefox to make sure Lato renders similarly to how it does in Chrome.

addresses part of #5330 