### PR TITLE
Fix Jest OOM errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "test": "yarn run test-jest && yarn run test-karma",
     "test-karma": "karma start frontend/test/karma.conf.js --single-run",
     "test-karma-watch": "karma start frontend/test/karma.conf.js --auto-watch --reporters nyan",
-    "test-jest": "jest",
+    "test-jest": "jest --maxWorkers=10",
     "test-jest-watch": "jest --watch",
     "test-e2e": "JASMINE_CONFIG_PATH=./frontend/test/e2e/support/jasmine.json jasmine",
     "test-e2e-dev": "./frontend/test/e2e-with-persistent-browser.js",


### PR DESCRIPTION
Based on https://12108-30203935-gh.circle-artifacts.com/5/tmp/memory-usage.txt it looks like jest worker processes are the cause of the CI Out of Memory errors. 

Not sure if 10 is too many, but figured it worth trying. If this doesn't work, going to bump it down to 5.