### PR TITLE
Don't run H2 in AUTO_SERVER mode

### DIFF
--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -34,7 +34,7 @@
            ;; File-based DB
            (let [db-file-name (config/config-str :mb-db-file)
                  db-file      (io/file db-file-name)
-                 options      ";AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1"]
+                 options      ";DB_CLOSE_DELAY=-1"]
              (apply str "file:" (if (.isAbsolute db-file)
                                   ;; when an absolute path is given for the db file then don't mess with it
                                   [db-file-name options]


### PR DESCRIPTION
Fixes an entire class of problems where Metabase wouldn't launch on various people's computers. (#5249, various issues on Windows computers with firewalls, discussed in #1871.) Might help eliminate other dreaded H2 hanging and corruption issues as well. The downside is you won't be able to run a REPL and a server process at the same time anymore if you're using H2 (heads up @metabase/core-developers).

Implements #2774
