### PR TITLE
suppress uglify js warnings in production

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -251,11 +251,15 @@ if (NODE_ENV !== "production") {
     config.output.devtoolModuleFilenameTemplate = '[absolute-resource-path]';
     config.output.pathinfo = true;
 } else {
-    // this is required to ensure we don't minify Chevrotain token identifiers
-    // https://github.com/SAP/chevrotain/tree/master/examples/parser/minification
     config.plugins.push(new webpack.optimize.UglifyJsPlugin({
-        warnings: false,
+        // suppress uglify warnings in production
+        // output from these warnings was causing Heroku builds to fail (#5410)
+        compress: {
+            warnings: false,
+        },
         mangle: {
+            // this is required to ensure we don't minify Chevrotain token identifiers
+            // https://github.com/SAP/chevrotain/tree/master/examples/parser/minification
             except: allTokens.map(function(currTok) {
                 return chevrotain.tokenName(currTok);
             })


### PR DESCRIPTION
Heroku stdout can get overwhelmed by the output causing a deploy to fail. fixes #5410 