### PR TITLE
Combine admin auth options into own section.

### DIFF
--- a/frontend/src/metabase/__support__/integrated_tests.js
+++ b/frontend/src/metabase/__support__/integrated_tests.js
@@ -108,7 +108,7 @@ api._makeRequest = async (method, url, headers, requestBody, data, options) => {
         const error = { status: result.status, data: resultBody, isCancelled: false }
         if (!simulateOfflineMode) {
             console.log('A request made in a test failed with the following error:');
-            console.dir(error, { depth: null });
+            console.log(error, { depth: null });
             console.log(`The original request: ${method} ${url}`);
             if (requestBody) console.log(`Original payload: ${requestBody}`);
         }
@@ -135,14 +135,14 @@ if (process.env.E2E_HOST) {
  *     * getting a React container subtree for the current route
  */
 
-export const createTestStore = () => {
+export const createTestStore = async () => {
     hasCreatedStore = true;
 
     const history = useRouterHistory(createMemoryHistory)();
     const store = getStore(reducers, history, undefined, (createStore) => testStoreEnhancer(createStore, history));
     store.setFinalStoreInstance(store);
 
-    store.dispatch(refreshSiteSettings());
+    await store.dispatch(refreshSiteSettings());
     return store;
 }
 
@@ -217,6 +217,7 @@ const testStoreEnhancer = (createStore, history) => {
             },
 
             pushPath: (path) => history.push(path),
+            goBack: () => history.goBack(),
             getPath: () => urlFormat(history.getCurrentLocation()),
 
             connectContainer: (reactContainer) => {

--- a/frontend/src/metabase/admin/settings/components/SettingsAuthenticationForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsAuthenticationForm.jsx
@@ -1,9 +1,6 @@
 import React, { Component } from 'react'
 import { Link } from 'react-router'
 
-import Button from 'metabase/components/Button'
-import Toggle from 'metabase/components/Toggle'
-
 class SettingsAuthenticationForm extends Component {
     render () {
         return (
@@ -12,12 +9,7 @@ class SettingsAuthenticationForm extends Component {
                     <div className="bordered rounded shadowed bg-white p4">
                         <h2>Sign in with Google</h2>
                         <p>Allows users with existing Metabase accounts to login with a Google account that matches their email address in addition to their Metabase username and password.</p>
-                        <div className="flex align-center mt3">
-                            <Toggle />
-                            <div className="ml-auto">
-                                <Link className="Button" to="/admin/settings/authentication/google">Configure</Link>
-                            </div>
-                        </div>
+                        <Link className="Button" to="/admin/settings/authentication/google">Configure</Link>
                     </div>
                 </li>
 
@@ -25,12 +17,7 @@ class SettingsAuthenticationForm extends Component {
                     <div className="bordered rounded shadowed bg-white p4">
                         <h2>LDAP</h2>
                         <p>Allows users within your LDAP directory to log in to Metabase with their LDAP credentials, and allows automatic mapping of LDAP groups to Metabase groups.</p>
-                        <div className="flex align-center mt3">
-                            <Toggle />
-                            <div className="ml-auto">
-                                <Link className="Button" to="/admin/settings/authentication/ldap">Configure</Link>
-                            </div>
-                        </div>
+                        <Link className="Button" to="/admin/settings/authentication/ldap">Configure</Link>
                     </div>
                 </li>
             </ul>

--- a/frontend/src/metabase/admin/settings/components/SettingsAuthenticationForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsAuthenticationForm.jsx
@@ -1,0 +1,41 @@
+import React, { Component } from 'react'
+import { Link } from 'react-router'
+
+import Button from 'metabase/components/Button'
+import Toggle from 'metabase/components/Toggle'
+
+class SettingsAuthenticationForm extends Component {
+    render () {
+        return (
+            <ul className="text-measure">
+                <li>
+                    <div className="bordered rounded shadowed bg-white p4">
+                        <h2>Sign in with Google</h2>
+                        <p>Allows users with existing Metabase accounts to login with a Google account that matches their email address in addition to their Metabase username and password.</p>
+                        <div className="flex align-center mt3">
+                            <Toggle />
+                            <div className="ml-auto">
+                                <Link className="Button" to="/admin/settings/authentication/google">Configure</Link>
+                            </div>
+                        </div>
+                    </div>
+                </li>
+
+                <li className="mt2">
+                    <div className="bordered rounded shadowed bg-white p4">
+                        <h2>LDAP</h2>
+                        <p>Allows users within your LDAP directory to log in to Metabase with their LDAP credentials, and allows automatic mapping of LDAP groups to Metabase groups.</p>
+                        <div className="flex align-center mt3">
+                            <Toggle />
+                            <div className="ml-auto">
+                                <Link className="Button" to="/admin/settings/authentication/ldap">Configure</Link>
+                            </div>
+                        </div>
+                    </div>
+                </li>
+            </ul>
+        )
+    }
+}
+
+export default SettingsAuthenticationForm

--- a/frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.integ.spec.js
+++ b/frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.integ.spec.js
@@ -1,0 +1,48 @@
+import {
+    login,
+    createTestStore,
+    clickRouterLink,
+} from "metabase/__support__/integrated_tests";
+
+import { mount } from "enzyme";
+
+import SettingsEditorApp from "metabase/admin/settings/containers/SettingsEditorApp"
+import SettingsAuthenticationOptions from "metabase/admin/settings/components/SettingsAuthenticationOptions"
+import SettingsSingleSignOnForm from "../components/SettingsSingleSignOnForm.jsx";
+import SettingsLdapForm from "../components/SettingsLdapForm.jsx";
+
+import { INITIALIZE_SETTINGS } from "metabase/admin/settings/settings"
+
+describe('Admin Auth Options', () => {
+    beforeAll(async () => {
+        await login()
+    })
+
+    it('it should render the proper configuration form', async () => {
+        const store = await createTestStore()
+
+        store.pushPath("/admin/settings");
+
+        const app = mount(store.getAppContainer())
+        await store.waitForActions([INITIALIZE_SETTINGS])
+        const settingsWrapper = app.find(SettingsEditorApp)
+        const authListItem = settingsWrapper.find('span[children="Authentication"]')
+
+        clickRouterLink(authListItem)
+
+        expect(settingsWrapper.find(SettingsAuthenticationOptions).length).toBe(1)
+
+        // test google
+        const googleConfigButton = settingsWrapper.find('.Button').first()
+        clickRouterLink(googleConfigButton)
+
+        expect(settingsWrapper.find(SettingsSingleSignOnForm).length).toBe(1)
+
+        store.goBack()
+
+        // test ldap
+        const ldapConfigButton = settingsWrapper.find('.Button').last()
+        clickRouterLink(ldapConfigButton)
+        expect(settingsWrapper.find(SettingsLdapForm).length).toBe(1)
+    })
+})

--- a/frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { Link } from 'react-router'
 
-class SettingsAuthenticationForm extends Component {
+class SettingsAuthenticationOptions extends Component {
     render () {
         return (
             <ul className="text-measure">
@@ -25,4 +25,4 @@ class SettingsAuthenticationForm extends Component {
     }
 }
 
-export default SettingsAuthenticationForm
+export default SettingsAuthenticationOptions

--- a/frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx
@@ -5,6 +5,7 @@ import cx from "classnames";
 
 import Collapse from "react-collapse";
 
+import Breadcrumbs from "metabase/components/Breadcrumbs";
 import DisclosureTriangle from "metabase/components/DisclosureTriangle";
 import MetabaseUtils from "metabase/lib/utils";
 import SettingsSetting from "./SettingsSetting";
@@ -219,6 +220,13 @@ export default class SettingsLdapForm extends Component {
 
         return (
             <form noValidate>
+                <Breadcrumbs
+                    crumbs={[
+                        ["Authentication", "/admin/settings/authentication"],
+                        ["LDAP"]
+                    ]}
+                    className="ml2 mb3"
+                />
                 <h2 className="mx2">Server Settings</h2>
                 <ul>{serverSettings}</ul>
                 <h2 className="mx2">User Schema</h2>

--- a/frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import cx from "classnames";
 import _ from "underscore";
 
+import Breadcrumbs from "metabase/components/Breadcrumbs.jsx";
 import Input from "metabase/components/Input.jsx";
 
 export default class SettingsSingleSignOnForm extends Component {
@@ -100,8 +101,17 @@ export default class SettingsSingleSignOnForm extends Component {
 
         return (
             <form noValidate>
-                <div className="px2"
-                     style={{maxWidth: "585px"}}>
+                <div
+                    className="px2"
+                    style={{maxWidth: "585px"}}
+                >
+                    <Breadcrumbs
+                        crumbs={[
+                            ["Authentication", "/admin/settings/authentication"],
+                            ["Google Sign-In"]
+                        ]}
+                        className="mb2"
+                    />
                     <h2>Sign in with Google</h2>
                     <p className="text-grey-4">
                         Allows users with existing Metabase accounts to login with a Google account that matches their email address in addition to their Metabase username and password.

--- a/frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx
+++ b/frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx
@@ -15,7 +15,7 @@ import SettingsLdapForm from "../components/SettingsLdapForm.jsx";
 import SettingsSetupList from "../components/SettingsSetupList.jsx";
 import SettingsUpdatesForm from "../components/SettingsUpdatesForm.jsx";
 import SettingsSingleSignOnForm from "../components/SettingsSingleSignOnForm.jsx";
-import SettingsAuthenticationForm from "../components/SettingsAuthenticationForm.jsx";
+import SettingsAuthenticationOptions from "../components/SettingsAuthenticationOptions.jsx";
 
 import { prepareAnalyticsValue } from 'metabase/admin/settings/utils'
 
@@ -163,7 +163,7 @@ export default class SettingsEditorApp extends Component {
                     )
                 }
             } else {
-                return (<SettingsAuthenticationForm />)
+                return (<SettingsAuthenticationOptions />)
             }
         } else {
             return (

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -149,6 +149,7 @@ const SECTIONS = [
     },
     {
         name: "Single Sign-On",
+        sidebar: false,
         settings: [
             {
                 key: "google-auth-client-id"
@@ -159,7 +160,12 @@ const SECTIONS = [
         ]
     },
     {
+        name: "Authentication",
+        settings: []
+    },
+    {
         name: "LDAP",
+        sidebar: false,
         settings: [
             {
                 key: "ldap-enabled",

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -259,6 +259,7 @@ export const getRoutes = (store) =>
                 <Route path="settings" title="Settings">
                     <IndexRedirect to="/admin/settings/setup" />
                     {/* <IndexRoute component={SettingsEditorApp} /> */}
+                    <Route path=":section/:authType" component={SettingsEditorApp} />
                     <Route path=":section" component={SettingsEditorApp} />
                 </Route>
 


### PR DESCRIPTION
Implements #5426 

Because of the way the admin settings section does its "routing" right now, doing sub pages is a bit tricky but I managed to figure out a way to pretend in the short term. 

We should look at moving the admin setting sections to more explicit routes to make this kind of thing a bit easier and less hacky.