### PR TITLE
template for running EBS inside a CloudFormation stack

### DIFF
--- a/bin/aws-eb-docker/cloudformation-elasticbeanstalk.json.template
+++ b/bin/aws-eb-docker/cloudformation-elasticbeanstalk.json.template
@@ -1,0 +1,149 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Deploys Metabase by creating an ElasticBeanstalk application in an contained in a CloudFormation stack.",
+    "Parameters": {
+        "MetabaseVersion": {
+            "Description": "Metabase Version",
+            "Type": "String",
+            "Default": "@@MB_TAG@@"
+        },
+        "KeyName": {
+            "Description": "Name of an existing EC2 KeyPair to enable SSH access to the AWS Elastic Beanstalk instance",
+            "Type": "AWS::EC2::KeyPair::KeyName"
+        },
+        "instanceType": {
+            "Description": "The Type of EC2 instance to use for running Metabase",
+            "Type": "String",
+            "Default": "t2.small"
+        },
+        "VPCid": {
+            "Description": "The VPC to use for running Metabase",
+            "Type": "AWS::EC2::VPC::Id"
+        },
+        "Subnets": {
+            "Description": "The VPC subnet(s) to use for running Metabase",
+            "Type": "List<AWS::EC2::Subnet::Id>"
+        }
+    },
+    "Resources": {
+        "metabaseApplication": {
+            "Type": "AWS::ElasticBeanstalk::Application",
+            "Properties": {
+                "Description": "Metabase Application",
+                "ApplicationVersions": [
+                    {
+                        "VersionLabel": {
+                            "Ref": "MetabaseVersion"
+                        },
+                        "Description": "Metabase Application Version",
+                        "SourceBundle": {
+                            "S3Bucket": "downloads.metabase.com",
+                            "S3Key": {
+                                "Fn::Join": [
+                                    "/",
+                                    [
+                                        {
+                                            "Ref": "MetabaseVersion"
+                                        },
+                                        "metabase-aws-eb.zip"
+                                    ]
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "ConfigurationTemplates": [
+                    {
+                        "TemplateName": "MetabaseConfiguration",
+                        "Description": "Metabase Application Configuration",
+                        "SolutionStackName": "64bit Amazon Linux 2017.03 v2.7.0 running Docker 17.03.1-ce",
+                        "OptionSettings": [
+                            {
+                                "Namespace": "aws:autoscaling:launchconfiguration",
+                                "OptionName": "EC2KeyName",
+                                "Value": {
+                                    "Ref": "KeyName"
+                                }
+                            },
+                            {
+                                "Namespace": "aws:rds:dbinstance",
+                                "OptionName": "DBEngine",
+                                "Value": "postgres"
+                            },
+                            {
+                                "Namespace": "aws:rds:dbinstance",
+                                "OptionName": "DBAllocatedStorage",
+                                "Value": "10"
+                            },
+                            {
+                                "Namespace": "aws:rds:dbinstance",
+                                "OptionName": "DBInstanceClass",
+                                "Value": "db.t2.small"
+                            },
+                            {
+                                "Namespace": "aws:rds:dbinstance",
+                                "OptionName": "MultiAZDatabase",
+                                "Value": "false"
+                            },
+                            {
+                                "Namespace": "aws:rds:dbinstance",
+                                "OptionName": "DBDeletionPolicy",
+                                "Value": "Snapshot"
+                            },
+                            {
+                                "Namespace": "aws:autoscaling:launchconfiguration",
+                                "OptionName": "InstanceType",
+                                "Value": {
+                                    "Ref": "instanceType"
+                                }
+                            },
+                            {
+                                "Namespace": "aws:ec2:vpc",
+                                "OptionName": "VPCId",
+                                "Value": {
+                                    "Ref": "VPCid"
+                                }
+                            },
+                            {
+                                "Namespace": "aws:ec2:vpc",
+                                "OptionName": "Subnets",
+                                "Value": {
+                                    "Fn::Join": [
+                                        ",",
+                                        {
+                                            "Ref": "Subnets"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "metabaseEnvironment": {
+            "Type": "AWS::ElasticBeanstalk::Environment",
+            "Properties": {
+                "ApplicationName": {
+                    "Ref": "metabaseApplication"
+                },
+                "Description": "AWS Elastic Beanstalk Environment for Metabase",
+                "TemplateName": "MetabaseConfiguration",
+                "VersionLabel": {
+                    "Ref": "MetabaseVersion"
+                }
+            }
+        }
+    },
+    "Outputs": {
+        "URL": {
+            "Description": "Metabase URL",
+            "Value": {
+                "Fn::GetAtt": [
+                    "metabaseEnvironment",
+                    "EndpointURL"
+                ]
+            }
+        }
+    }
+}

--- a/bin/aws-eb-docker/functions
+++ b/bin/aws-eb-docker/functions
@@ -12,6 +12,9 @@ export LANG=en_US.UTF-8
 export LANGUAGE=$LANG
 export LC_ALL=$LANG
 
+CF_TEMPLATE=cloudformation-elasticbeanstalk.json
+CF_TEMPLATE_PATH=/tmp/$CF_TEMPLATE
+S3_CF_TEMPLATE_PATH=s3://$ARTIFACTS_S3BUCKET/eb/$CF_TEMPLATE
 
 make_eb_version() {
     MB_TAG=$1
@@ -37,6 +40,9 @@ make_eb_version() {
     sed "s/@@MB_REPOSITORY@@/${MB_DOCKER_REPOSITORY}/" < ${BASEDIR}/Dockerrun.aws.json.template > ${BASEDIR}/Dockerrun.aws.json.tmp
     sed "s/@@MB_TAG@@/${MB_TAG}/" < ${BASEDIR}/Dockerrun.aws.json.tmp > ${BASEDIR}/Dockerrun.aws.json
 
+    # set the default version in the cloudformation template from the template-template (yo dawg i heard you like templates ;)
+    sed "s/@@MB_TAG@@/${MB_TAG}/" < ${BASEDIR}/$CF_TEMPLATE.template > $CF_TEMPLATE_PATH
+
     # create our EB zip file
     cd $BASEDIR; zip -r ${RELEASE_FILE} .ebextensions Dockerrun.aws.json; cd $CURRENTDIR
 
@@ -57,6 +63,10 @@ upload_eb_version() {
 
     echo "uploading /tmp/${MB_TAG}.zip -> $ARTIFACTS_S3BUCKET/eb/"
     aws s3 cp /tmp/${MB_TAG}.zip s3://$ARTIFACTS_S3BUCKET/eb/${MB_TAG}.zip
+
+    echo "uploading $CF_TEMPLATE_PATH -> $S3_CF_TEMPLATE_PATH"
+    aws s3 cp $CF_TEMPLATE_PATH $S3_CF_TEMPLATE_PATH
+
 }
 
 create_eb_version() {


### PR DESCRIPTION
this template gets uploaded to s3 as part of a release that can then be used as a source when deploying CF stacks