### PR TITLE
non blocking database deletion

### DIFF
--- a/frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx
+++ b/frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx
@@ -23,6 +23,8 @@ export default class DeleteDatabaseModal extends Component {
     async deleteDatabase() {
         try {
             this.props.onDelete(this.props.database);
+            // immediately call on close because database deletion should be non blocking
+            this.props.onClose()
         } catch (error) {
             this.setState({ error });
         }

--- a/frontend/src/metabase/admin/databases/containers/DatabaseListApp.integ.spec.js
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseListApp.integ.spec.js
@@ -1,0 +1,73 @@
+import {
+    login,
+    createTestStore,
+} from "metabase/__support__/integrated_tests";
+
+import { mount } from "enzyme";
+import { FETCH_DATABASES, DELETE_DATABASE } from "metabase/admin/databases/database"
+import DatabaseListApp from "metabase/admin/databases/containers/DatabaseListApp";
+import { delay } from "metabase/lib/promise"
+
+import { MetabaseApi } from 'metabase/services'
+
+
+import { TestModal } from "metabase/components/Modal"
+
+describe('dashboard list', () => {
+
+    beforeAll(async () => {
+        await login()
+    })
+
+    it('should render', async () => {
+        const store = await createTestStore()
+        store.pushPath("/admin/databases");
+
+        const app = mount(store.getAppContainer())
+
+        await store.waitForActions([FETCH_DATABASES])
+
+        const wrapper = app.find(DatabaseListApp)
+        expect(wrapper.length).toEqual(1)
+
+    })
+
+    describe('deletes', () => {
+        it('should not block deletes', async () => {
+            // mock the db_delete method call to simulate a longer running delete
+            MetabaseApi.db_delete = () => delay(5000)
+
+            const store = await createTestStore()
+            store.pushPath("/admin/databases");
+
+            const app = mount(store.getAppContainer())
+            await store.waitForActions([FETCH_DATABASES])
+
+            const wrapper = app.find(DatabaseListApp)
+            const dbCount = wrapper.find('tr').length
+
+            const deleteButton = wrapper.find('.Button.Button--danger').first()
+
+            deleteButton.simulate('click')
+
+            const deleteModal = wrapper.find('.test-modal')
+            deleteModal.find('.Form-input').simulate('change', { target: { value: "DELETE" }})
+            deleteModal.find('.Button.Button--danger').simulate('click')
+
+            // test that the modal is gone
+            expect(wrapper.find('.test-modal').length).toEqual(0)
+
+            // we should now have a disabled db row during delete
+            expect(wrapper.find('tr.disabled').length).toEqual(1)
+
+            // db delete finishes
+            await store.waitForActions([DELETE_DATABASE])
+
+            // there should be no disabled db rows now
+            expect(wrapper.find('tr.disabled').length).toEqual(0)
+
+            // we should now have one less database in the list
+            expect(wrapper.find('tr').length).toEqual(dbCount - 1)
+        })
+    })
+})

--- a/frontend/src/metabase/admin/databases/containers/DatabaseListApp.integ.spec.js
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseListApp.integ.spec.js
@@ -10,9 +10,6 @@ import { delay } from "metabase/lib/promise"
 
 import { MetabaseApi } from 'metabase/services'
 
-
-import { TestModal } from "metabase/components/Modal"
-
 describe('dashboard list', () => {
 
     beforeAll(async () => {

--- a/frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx
@@ -23,7 +23,8 @@ const mapStateToProps = (state, props) => {
         created:              props.location.query.created,
         databases:            getDatabasesSorted(state),
         hasSampleDataset:     hasSampleDataset(state),
-        engines:              MetabaseSettings.get('engines')
+        engines:              MetabaseSettings.get('engines'),
+        deletes:              state.admin.databases.deletes
     }
 }
 
@@ -63,29 +64,41 @@ export default class DatabaseList extends Component {
                         </thead>
                         <tbody>
                             { databases ?
-                                databases.map(database =>
-                                    <tr key={database.id}>
-                                        <td>
-                                            <Link to={"/admin/databases/"+database.id} className="text-bold link">{database.name}</Link>
-                                        </td>
-                                        <td>
-                                            {engines && engines[database.engine] ? engines[database.engine]['driver-name'] : database.engine}
-                                        </td>
-                                        <td className="Table-actions">
-                                            <ModalWithTrigger
-                                                ref={"deleteDatabaseModal_"+database.id}
-                                                triggerClasses="Button Button--danger"
-                                                triggerElement="Delete"
-                                            >
-                                                <DeleteDatabaseModal
-                                                    database={database}
-                                                    onClose={() => this.refs["deleteDatabaseModal_"+database.id].close()}
-                                                    onDelete={() => this.props.deleteDatabase(database.id)}
-                                                />
-                                            </ModalWithTrigger>
-                                        </td>
-                                    </tr>
-                                )
+                                databases.map(database => {
+                                    const isDeleting = this.props.deletes.indexOf(database.id) !== -1
+                                    return (
+                                        <tr
+                                            key={database.id}
+                                            className={cx({'disabled': isDeleting })}
+                                        >
+                                            <td>
+                                                <Link to={"/admin/databases/"+database.id} className="text-bold link">
+                                                    {database.name}
+                                                </Link>
+                                            </td>
+                                            <td>
+                                                {engines && engines[database.engine] ? engines[database.engine]['driver-name'] : database.engine}
+                                            </td>
+                                            { isDeleting
+                                                ? (<td className="text-right">Deleting...</td>)
+                                                : (
+                                                    <td className="Table-actions">
+                                                        <ModalWithTrigger
+                                                            ref={"deleteDatabaseModal_"+database.id}
+                                                            triggerClasses="Button Button--danger"
+                                                            triggerElement="Delete"
+                                                        >
+                                                            <DeleteDatabaseModal
+                                                                database={database}
+                                                                onClose={() => this.refs["deleteDatabaseModal_"+database.id].close()}
+                                                                onDelete={() => this.props.deleteDatabase(database.id)}
+                                                            />
+                                                        </ModalWithTrigger>
+                                                    </td>
+                                                )
+                                            }
+                                        </tr>
+                                    )})
                             :
                                 <tr>
                                     <td colSpan={4}>

--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -11,11 +11,11 @@ import { MetabaseApi } from "metabase/services";
 
 const RESET = "metabase/admin/databases/RESET";
 const SELECT_ENGINE = "metabase/admin/databases/SELECT_ENGINE";
-const FETCH_DATABASES = "metabase/admin/databases/FETCH_DATABASES";
+export const FETCH_DATABASES = "metabase/admin/databases/FETCH_DATABASES";
 const INITIALIZE_DATABASE = "metabase/admin/databases/INITIALIZE_DATABASE";
 const ADD_SAMPLE_DATASET = "metabase/admin/databases/ADD_SAMPLE_DATASET";
 const SAVE_DATABASE = "metabase/admin/databases/SAVE_DATABASE";
-const DELETE_DATABASE = "metabase/admin/databases/DELETE_DATABASE";
+export const DELETE_DATABASE = "metabase/admin/databases/DELETE_DATABASE";
 const SYNC_DATABASE = "metabase/admin/databases/SYNC_DATABASE";
 
 export const reset = createAction(RESET);

--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -164,10 +164,7 @@ const deletes = handleActions({
         next: (state, { payload }) => state.concat([payload])
     },
     [DELETE_DATABASE]: {
-        next: (state, { payload }) => {
-            console.log(state.indexOf(payload))
-            return state.splice(state.indexOf(payload), 1)
-        }
+        next: (state, { payload }) => state.splice(state.indexOf(payload), 1)
     }
 }, []);
 


### PR DESCRIPTION
an attempt at a fix for #2655

keeps track of database deletes by adding them to an array when the
delete starts and then removing them when the API tells us the delete is
done. allows us to show deletion status without blocking the UI for situations where a DB is large or something else is causing the API to take a bit.

@camsaul / @attekei let me know if you think this solution is reasonable and if so I'll add some tests and clean things up a bit.