### PR TITLE
add site_url to public settings

### DIFF
--- a/frontend/src/metabase/lib/urls.js
+++ b/frontend/src/metabase/lib/urls.js
@@ -70,12 +70,12 @@ export function label(label) {
 }
 
 export function publicCard(uuid, type = null) {
-    const siteUrl = MetabaseSettings.get("site-url");
+    const siteUrl = MetabaseSettings.get("site_url");
     return `${siteUrl}/public/question/${uuid}` + (type ? `.${type}` : ``);
 }
 
 export function publicDashboard(uuid) {
-    const siteUrl = MetabaseSettings.get("site-url");
+    const siteUrl = MetabaseSettings.get("site_url");
     return `${siteUrl}/public/dashboard/${uuid}`;
 }
 

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -130,6 +130,7 @@
    :report_timezone       (setting/get :report-timezone)
    :setup_token           ((resolve 'metabase.setup/token-value))
    :site_name             (site-name)
+   :site_url              (site-url)
    :timezone_short        (short-timezone-name (setting/get :report-timezone))
    :timezones             common/timezones
    :types                 (types/types->parents)


### PR DESCRIPTION
Fixes #5336 

The site-url wasn't being returned as part of the public settings used in the `window.MetabaseBootstrap` object that the `publicDashboard` and `publicCard` url generators look for, so as a result they were creating malformed urls when users weren't logged in. 
