### PR TITLE
Rename functions with µ to microseconds [ci drivers]

### DIFF
--- a/src/metabase/driver/bigquery.clj
+++ b/src/metabase/driver/bigquery.clj
@@ -210,15 +210,15 @@
 (defn- date-add [unit timestamp interval]
   (hsql/call :date_add timestamp interval (hx/literal unit)))
 
-;; µs = unix timestamp in microseconds. Most BigQuery functions like strftime require timestamps in this format
+;; microseconds = unix timestamp in microseconds. Most BigQuery functions like strftime require timestamps in this format
 
-(def ^:private ->µs (partial hsql/call :timestamp_to_usec))
+(def ^:private ->microseconds (partial hsql/call :timestamp_to_usec))
 
-(defn- µs->str [format-str µs]
+(defn- microseconds->str [format-str µs]
   (hsql/call :strftime_utc_usec µs (hx/literal format-str)))
 
 (defn- trunc-with-format [format-str timestamp]
-  (hx/->timestamp (µs->str format-str (->µs timestamp))))
+  (hx/->timestamp (microseconds->str format-str (->microseconds timestamp))))
 
 (defn- date [unit expr]
   {:pre [expr]}


### PR DESCRIPTION
The unicode character in the function name can cause problems with AOT
generated class names that have that µ in the filename. On some users
systems if this isn't encoded properly it can replace the µ with a ?
and cause failures compiling metabase.

Fixes #4441
