### PR TITLE
Fix MySQL & Postgres tests on localhost w/o password

### DIFF
--- a/test/metabase/test/data/mysql.clj
+++ b/test/metabase/test/data/mysql.clj
@@ -21,8 +21,9 @@
   (merge {:host         (i/db-test-env-var-or-throw :mysql :host "localhost")
           :port         (i/db-test-env-var-or-throw :mysql :port 3306)
           :user         (i/db-test-env-var :mysql :user "root")
-          :password     (i/db-test-env-var :mysql :password)
           :timezone     :America/Los_Angeles}
+         (when-let [password (i/db-test-env-var :mysql :password)]
+           {:password password})
          (when (= context :db)
            {:db database-name})))
 

--- a/test/metabase/test/data/postgres.clj
+++ b/test/metabase/test/data/postgres.clj
@@ -22,9 +22,11 @@
 (defn- database->connection-details [context {:keys [database-name]}]
   (merge {:host     (i/db-test-env-var-or-throw :postgresql :host "localhost")
           :port     (i/db-test-env-var-or-throw :postgresql :port 5432)
-          :user     (i/db-test-env-var :postgresql :user)
-          :password (i/db-test-env-var :postgresql :password)
           :timezone :America/Los_Angeles}
+         (when-let [user (i/db-test-env-var :postgresql :user)]
+           {:user user})
+         (when-let [password (i/db-test-env-var :postgresql :password)]
+           {:password password})
          (when (= context :db)
            {:db database-name})))
 


### PR DESCRIPTION
Unfortunately specifying `{:user nil}` and `{:password nil}` is not the same thing as not specifying them at all for these DB config options. e.g. for`:password` supplying `nil` will try to do password-based authentication when what we want is password-free auth
