### PR TITLE
Allow anonymous binding for the LDAP lookup user

### DIFF
--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -199,14 +199,12 @@ const SECTIONS = [
             {
                 key: "ldap-bind-dn",
                 display_name: "Username or DN",
-                type: "string",
-                required: true
+                type: "string"
             },
             {
                 key: "ldap-password",
                 display_name: "Password",
-                type: "password",
-                required: true
+                type: "password"
             },
             {
                 key: "ldap-user-base",

--- a/src/metabase/integrations/ldap.clj
+++ b/src/metabase/integrations/ldap.clj
@@ -35,7 +35,7 @@
              (setting/set-string! :ldap-security new-value)))
 
 (defsetting ldap-bind-dn
-  "The Distinguished Name to bind as, this user will be used to lookup information about other users.")
+  "The Distinguished Name to bind as (if any), this user will be used to lookup information about other users.")
 
 (defsetting ldap-password
   "The password to bind with for the lookup user.")
@@ -78,8 +78,6 @@
   []
   (boolean (and (ldap-enabled)
                 (ldap-host)
-                (ldap-bind-dn)
-                (ldap-password)
                 (ldap-user-base))))
 
 (defn- details->ldap-options [{:keys [host port bind-dn password security]}]

--- a/test/metabase/integrations/ldap_test.clj
+++ b/test/metabase/integrations/ldap_test.clj
@@ -27,6 +27,11 @@
   {:status :SUCCESS}
   (ldap/test-ldap-connection (get-ldap-details)))
 
+;; The connection test should allow anonymous binds
+(expect-with-ldap-server
+  {:status :SUCCESS}
+  (ldap/test-ldap-connection (dissoc (get-ldap-details) :bind-dn)))
+
 ;; The connection test should fail with an invalid user search base
 (expect-with-ldap-server
   :ERROR


### PR DESCRIPTION
Resolves #5460 

Didn't think of that when I initially made the LDAP integration. The only change required is to make the bind DN optional. Luckily the in-mem test server allows anonymous binds so I added a connection testing case for that.