### PR TITLE
Pass arguments to Docker entry point at runtime

### DIFF
--- a/bin/docker/run_metabase.sh
+++ b/bin/docker/run_metabase.sh
@@ -119,4 +119,4 @@ fi
 # Launch the application
 # exec is here twice on purpose to  ensure that metabase runs as PID 1 (the init process)
 # and thus receives signals sent to the container. This allows it to shutdown cleanly on exit
-exec su metabase -s /bin/sh -c "exec java $JAVA_OPTS -jar /app/metabase.jar"
+exec su metabase -s /bin/sh -c "exec java $JAVA_OPTS -jar /app/metabase.jar $@"


### PR DESCRIPTION
Simple modification to allow command-line arguments to be passed to the Docker entry point script. There isn't much practical use here, as far as I know, but it was necessary to migrate from H2 to another supported backend database using the argument `load-from-h2`. And it shouldn't impact normal use at all.

###### TODO 
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
