### PR TITLE
Use the JSON encoders for XLSX objects with no encoders

### DIFF
--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -1,6 +1,8 @@
 (ns metabase.api.dataset-test
   "Unit tests for /api/dataset endpoints."
-  (:require [expectations :refer :all]
+  (:require [cheshire.generate :as generate]
+            [dk.ative.docjure.spreadsheet :as spreadsheet]
+            [expectations :refer :all]
             [medley.core :as m]
             [metabase.api.dataset :refer [default-query-constraints]]
             [metabase.models.query-execution :refer [QueryExecution]]
@@ -128,3 +130,26 @@
                                                                         :native   {:query "foobar"}})]
     [(check-error-message (format-response result))
      (check-error-message (format-response (most-recent-query-execution)))]))
+
+
+;;; Make sure that we're piggybacking off of the JSON encoding logic when encoding strange values in XLSX (#5145, #5220, #5459)
+(defrecord ^:private SampleNastyClass [^String v])
+
+(generate/add-encoder
+ SampleNastyClass
+ (fn [obj, ^com.fasterxml.jackson.core.JsonGenerator json-generator]
+   (.writeString json-generator (:v obj))))
+
+(defrecord ^:private AnotherNastyClass [^String v])
+
+(expect
+  [{"Values" "values"}
+   {"Values" "Hello XLSX World!"}   ; should use the JSON encoding implementation for object
+   {"Values" "{:v \"No Encoder\"}"} ; fall back to the implementation of `str` for an object if no JSON encoder exists rather than barfing
+   {"Values" "ABC"}]
+  (->> (spreadsheet/create-workbook "Results" [["values"]
+                                               [(SampleNastyClass. "Hello XLSX World!")]
+                                               [(AnotherNastyClass. "No Encoder")]
+                                               ["ABC"]])
+       (spreadsheet/select-sheet "Results")
+       (spreadsheet/select-columns {:A "Values"})))


### PR DESCRIPTION
Tell Docjure to reüse our already defined JSON encoders for various types it doesn't know how to encode (such as CLOBs and BSON types). For things neither knows how to encode use the fallback implementation of calling `str` on it rather than throwing an Exception and barfing. Includes test.

Fixes #5145 
Fixes #5220
Fixes #5459 