### PR TITLE
Code generator for frontend CRUD scaffolding [prototype]

### DIFF
--- a/bin/generate
+++ b/bin/generate
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+const fs = require("fs")
+const inflection = require("inflection")
+
+const BASE = "frontend/src/metabase";
+
+const action = process.argv[2];
+const args = process.argv.slice(3);
+
+const actions = {
+    ["frontend-crud"]: (args) => {
+        const name = args[0];
+        if (!name) {
+            throw new Error(`USAGE: generate crud-frontend NAME`);
+        }
+
+        const namePlural = inflection.pluralize(name);
+        const templateVariables = {
+            object_name: inflection.underscore(name),
+            OBJECT_NAME: inflection.underscore(name).toUpperCase(),
+            objectName: inflection.camelize(name),
+            ObjectName: inflection.camelize(name, false),
+            object_name_plural: inflection.underscore(namePlural),
+            OBJECT_NAME_PLURAL: inflection.underscore(namePlural).toUpperCase(),
+            objectNamePlural: inflection.camelize(namePlural),
+            ObjectNamePlural: inflection.camelize(namePlural, false)
+        }
+
+        const template = (filename) =>
+          evaluateTemplate(__dirname + "/generate-templates/frontend-crud/" + filename, templateVariables);
+
+        const { ObjectName } = templateVariables;
+
+        // root directory
+        fs.mkdirSync(`${BASE}/${name}`, 0744);
+
+        // routes, ducks
+        fs.writeFileSync(`${BASE}/${name}/routes.jsx`, template("routes.jsx"));
+        fs.writeFileSync(`${BASE}/${name}/duck.js`, template("duck.js"));
+
+        // services (appended to existing services.js)
+        fs.appendFileSync(`${BASE}/services.js`, template("services.js"));
+
+        // container components
+        fs.mkdirSync(`${BASE}/${name}/containers`, 0744);
+        for (const ContainerName of ["Create", "Edit", "Form", "List"]) {
+            fs.writeFileSync(`${BASE}/${name}/containers/${ObjectName}${ContainerName}.jsx`, template(`containers/ObjectName${ContainerName}.jsx`));
+        }
+    }
+}
+
+// simple templating system using dynamically evaluated ES6 template literals
+function evaluateTemplate(path, templateVariables) {
+    const template = fs.readFileSync(path);
+
+    const argNames = Object.keys(templateVariables);
+    const argValues = Object.values(templateVariables);
+    const functionBody = "return `" + template + "`";
+
+    return new Function(...argNames.concat(functionBody))(...argValues);
+}
+
+if (actions[action]) {
+    actions[action](args);
+} else {
+    throw new Error("Possible actions: " + Object.keys(actions).join(", "))
+}

--- a/bin/generate-templates/frontend-crud/containers/ObjectNameCreate.jsx
+++ b/bin/generate-templates/frontend-crud/containers/ObjectNameCreate.jsx
@@ -1,0 +1,35 @@
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { push } from "react-router-redux";
+
+import ${ObjectName}Form from "./${ObjectName}Form.jsx";
+
+import { create${ObjectName} } from "../duck";
+
+const mapStateToProps = (state, props) => ({
+    ${object_name}: null,
+    error: state.${object_name}.error,
+});
+
+const mapDispatchToProps = {
+    create${ObjectName},
+    onClose: () => push("/${object_name}")
+}
+
+@connect(mapStateToProps, mapDispatchToProps)
+export default class ${ObjectName}Create extends Component {
+
+    handleSubmit = (${object_name}) => {
+        this.props.create${ObjectName}(${object_name});
+        this.props.onClose();
+    }
+
+    render() {
+        return (
+            <${ObjectName}Form
+                {...this.props}
+                onSubmit={this.handleSubmit}
+            />
+        );
+    }
+}

--- a/bin/generate-templates/frontend-crud/containers/ObjectNameEdit.jsx
+++ b/bin/generate-templates/frontend-crud/containers/ObjectNameEdit.jsx
@@ -1,0 +1,41 @@
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { goBack } from "react-router-redux";
+
+import ${ObjectName}Form from "./${ObjectName}Form.jsx";
+
+import { update${ObjectName}, load${ObjectName} } from "../duck";
+
+const mapStateToProps = (state, props) => ({
+    ${object_name}: state.${object_name}.${object_name_plural}[props.params.id],
+    error: state.${object_name}.error,
+});
+
+const mapDispatchToProps = {
+    load${ObjectName},
+    update${ObjectName},
+    onClose: goBack
+};
+
+@connect(mapStateToProps, mapDispatchToProps)
+export default class ${ObjectName}Edit extends Component {
+
+    componentWillMount() {
+        this.props.load${ObjectName}(this.props.params.id);
+    }
+
+    handleSubmit = (${object_name}) => {
+        this.props.update${ObjectName}(${object_name});
+        this.props.onClose();
+    }
+
+    render() {
+        return (
+            <${ObjectName}Form
+                {...this.props}
+                onSubmit={this.handleSubmit}
+                initialValues={this.props.${object_name}}
+            />
+        );
+    }
+}

--- a/bin/generate-templates/frontend-crud/containers/ObjectNameForm.jsx
+++ b/bin/generate-templates/frontend-crud/containers/ObjectNameForm.jsx
@@ -1,0 +1,88 @@
+import React, { Component } from "react";
+import { reduxForm } from "redux-form";
+
+import Button from "metabase/components/Button";
+import FormField from "metabase/components/FormField";
+import Input from "metabase/components/Input";
+import Modal from "metabase/components/Modal";
+
+const formConfig = {
+    form: '${object_name}',
+    fields: ['id', 'name', 'description'],
+    validate: (values) => {
+        const errors = {};
+        if (!values.name) {
+            errors.name = "Name is required";
+        }
+        return errors;
+    },
+    initialValues: {
+        id: null,
+        name: "",
+        description: "",
+    }
+}
+
+export const getFormTitle = ({ id, name }) =>
+    id.value != null ? name.value : "New ${object_name}"
+
+export const getActionText = ({ id }) =>
+    id.value != null ? "Update": "Create"
+
+export class ${ObjectName}Form extends Component {
+    props: {
+        fields: Object,
+        onClose: Function,
+        invalid: Boolean,
+        handleSubmit: Function,
+    }
+
+    render() {
+        const { fields, onClose } = this.props;
+        return (
+            <Modal
+                inline
+                form
+                title={getFormTitle(fields)}
+                footer={<${ObjectName}FormActions {...this.props} />}
+                onClose={onClose}
+            >
+                <div className="NewForm ml-auto mr-auto mt4 pt2" style={{ width: 540 }}>
+                    <FormField
+                        displayName="Name"
+                        {...fields.name}
+                    >
+                        <Input
+                            className="Form-input full"
+                            placeholder="My new fantastic ${object_name}"
+                            autoFocus
+                            {...fields.name}
+                        />
+                    </FormField>
+                    <FormField
+                        displayName="Description"
+                        {...fields.description}
+                    >
+                        <textarea
+                            className="Form-input full"
+                            placeholder="It's optional but oh, so helpful"
+                            {...fields.description}
+                        />
+                    </FormField>
+                </div>
+            </Modal>
+        )
+    }
+}
+
+export const ${ObjectName}FormActions = ({ handleSubmit, invalid, onClose, fields}) =>
+    <div>
+        <Button className="mr1" onClick={onClose}>
+            Cancel
+        </Button>
+        <Button primary disabled={invalid} onClick={handleSubmit}>
+            { getActionText(fields) }
+        </Button>
+    </div>
+
+export default reduxForm(formConfig)(${ObjectName}Form)

--- a/bin/generate-templates/frontend-crud/containers/ObjectNameList.jsx
+++ b/bin/generate-templates/frontend-crud/containers/ObjectNameList.jsx
@@ -1,0 +1,72 @@
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { Link } from "react-router";
+
+import Button from "metabase/components/Button";
+import Confirm from "metabase/components/Confirm";
+
+import { load${ObjectNamePlural}, delete${ObjectName} } from "../duck";
+
+const mapStateToProps = (state, props) => ({
+    ${object_name_plural}: Object.values(state.${object_name}.${object_name_plural})
+})
+
+const mapDispatchToProps = {
+    load${ObjectNamePlural},
+    delete${ObjectName}
+}
+
+@connect(mapStateToProps, mapDispatchToProps)
+export default class ${ObjectName}List extends Component {
+    componentWillMount() {
+        this.props.load${ObjectNamePlural}();
+    }
+
+    render() {
+        const { ${object_name_plural} } = this.props;
+        return (
+            <div className="m2">
+                { ${object_name_plural}.length > 0 ?
+                    <table className="mb2">
+                        <thead>
+                            <tr>
+                                {Object.keys(${object_name_plural}[0]).map(key =>
+                                    <th>{key}</th>
+                                )}
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {${object_name_plural}.map(${object_name} =>
+                                <tr>
+                                    {Object.values(${object_name}).map(value =>
+                                        <td>{value}</td>
+                                    )}
+                                    <td>
+                                        <Link to={"/${object_name}/" + ${object_name}.id}>
+                                            <Button primary small>Edit</Button>
+                                        </Link>
+                                    </td>
+                                    <td>
+                                        <Confirm
+                                            title="Delete this ${object_name}?"
+                                            action={() => this.props.delete${ObjectName}(${object_name}.id)}
+                                        >
+                                            <Button warning small>Delete</Button>
+                                        </Confirm>
+                                    </td>
+                                </tr>
+                            )}
+                        </tbody>
+                    </table>
+                :
+                    <div className="mb2">No ${object_name_plural}</div>
+                }
+                <div>
+                    <Link to="/${object_name}/create">
+                        <Button primary>Create ${ObjectName}</Button>
+                    </Link>
+                </div>
+            </div>
+        );
+    }
+}

--- a/bin/generate-templates/frontend-crud/duck.js
+++ b/bin/generate-templates/frontend-crud/duck.js
@@ -1,0 +1,50 @@
+
+// ${object_name} duck
+
+import { createAction, handleActions, combineReducers } from "metabase/lib/redux";
+import { assoc, dissoc } from "icepick";
+
+import { ${ObjectName}Api } from "metabase/services";
+
+export const LOAD_${OBJECT_NAME_PLURAL} = "metabase/${object_name}/LOAD_${OBJECT_NAME_PLURAL}";
+export const load${ObjectNamePlural} = createAction(LOAD_${OBJECT_NAME_PLURAL}, () => ${ObjectName}Api.list());
+
+export const LOAD_${OBJECT_NAME} = "metabase/${object_name}/LOAD_${OBJECT_NAME}";
+export const load${ObjectName} = createAction(LOAD_${OBJECT_NAME}, (id) => ${ObjectName}Api.get({ id }));
+
+export const CREATE_${OBJECT_NAME} = "metabase/${object_name}/CREATE_${OBJECT_NAME}";
+export const create${ObjectName} = createAction(CREATE_${OBJECT_NAME}, (${object_name}) => ${ObjectName}Api.create(${object_name}));
+
+export const UPDATE_${OBJECT_NAME} = "metabase/${object_name}/UPDATE_${OBJECT_NAME}";
+export const update${ObjectName} = createAction(UPDATE_${OBJECT_NAME}, (${object_name}) => ${ObjectName}Api.update(${object_name}));
+
+export const DELETE_${OBJECT_NAME} = "metabase/${object_name}/DELETE_${OBJECT_NAME}";
+export const delete${ObjectName} = createAction(DELETE_${OBJECT_NAME}, (id) => ${ObjectName}Api.delete({ id }));
+
+// TODO: better reducer
+const ${object_name_plural} = handleActions({
+    [LOAD_${OBJECT_NAME_PLURAL}]:  { next: (state, { payload }) => payload.reduce((${object_name_plural}, ${object_name}) => assoc(${object_name_plural}, ${object_name}.id, ${object_name}), {}) },
+    [LOAD_${OBJECT_NAME}]:   { next: (state, { payload }) => assoc(state, payload.id, payload) },
+    [CREATE_${OBJECT_NAME}]: { next: (state, { payload }) => assoc(state, payload.id, payload) },
+    [UPDATE_${OBJECT_NAME}]: { next: (state, { payload }) => assoc(state, payload.id, payload) },
+    [DELETE_${OBJECT_NAME}]: { next: (state, { payload }) => dissoc(state, payload) },
+}, {});
+
+// TODO: better error handling
+const DEFAULT_ERROR_HANDLER = {
+    next: (state, { payload }) => null,
+    throws: (state, { payload }) => payload
+};
+
+const error = handleActions({
+    [LOAD_${OBJECT_NAME_PLURAL}]:  DEFAULT_ERROR_HANDLER,
+    [LOAD_${OBJECT_NAME}]:   DEFAULT_ERROR_HANDLER,
+    [CREATE_${OBJECT_NAME}]: DEFAULT_ERROR_HANDLER,
+    [UPDATE_${OBJECT_NAME}]: DEFAULT_ERROR_HANDLER,
+    [DELETE_${OBJECT_NAME}]: DEFAULT_ERROR_HANDLER,
+}, null);
+
+export default combineReducers({
+    ${object_name_plural},
+    error
+});

--- a/bin/generate-templates/frontend-crud/routes.jsx
+++ b/bin/generate-templates/frontend-crud/routes.jsx
@@ -1,0 +1,18 @@
+// ${object_name} routes
+
+import React from "react";
+import { Route } from "metabase/hoc/Title";
+import { IndexRoute } from "react-router";
+
+import ${ObjectName}List from "./containers/${ObjectName}List";
+import ${ObjectName}Create from "./containers/${ObjectName}Create";
+import ${ObjectName}Edit from "./containers/${ObjectName}Edit";
+
+const getRoutes = (store) =>
+    <Route title="${ObjectName}" path="${object_name}">
+        <IndexRoute component={${ObjectName}List} />
+        <Route path="create" component={${ObjectName}Create} />
+        <Route path=":id" component={${ObjectName}Edit} />
+    </Route>
+
+export default getRoutes;

--- a/bin/generate-templates/frontend-crud/services.js
+++ b/bin/generate-templates/frontend-crud/services.js
@@ -1,0 +1,19 @@
+// ${object_name} services
+
+export const ${ObjectName}Api = {
+    // list:                        GET("/api/${object_name}"),
+    // create:                     POST("/api/${object_name}"),
+    // get:                         GET("/api/${object_name}/:id"),
+    // update:                      PUT("/api/${object_name}/:id"),
+    // delete:                   DELETE("/api/${object_name}/:id"),
+
+    // TODO: placeholder implementations. replace with API calls above
+    list:   ()       => new Promise(r => r(${object_name_plural}.filter(item => item !== undefined))),
+    create: (item)   => new Promise(r => r(${object_name_plural}[${object_name_plural}.length] = { ...item, id: ${object_name_plural}.length })),
+    get:    ({ id }) => new Promise(r => r(${object_name_plural}[id])),
+    update: (item)   => new Promise(r => r(${object_name_plural}[item.id] = item)),
+    delete: ({ id }) => new Promise(r => { delete ${object_name_plural}[id]; r(id); }),
+};
+
+// TODO: remove this when replacing placeholder implementations above
+const ${object_name_plural} = [];

--- a/frontend/src/metabase/app-main.js
+++ b/frontend/src/metabase/app-main.js
@@ -2,7 +2,8 @@
 import { push } from 'react-router-redux'
 
 import { init } from "metabase/app";
-import { getRoutes } from "metabase/routes.jsx";
+
+import { getRoutes } from "metabase/routes-main";
 import reducers from 'metabase/reducers-main';
 
 import api from "metabase/lib/api";

--- a/frontend/src/metabase/reducers-main.js
+++ b/frontend/src/metabase/reducers-main.js
@@ -32,8 +32,24 @@ import reference from "metabase/reference/reference";
 /* pulses */
 import * as pulse from "metabase/pulse/reducers";
 
+
+// dynamically require "duck.js" files
+const duckRequire = require.context(
+    "metabase",
+    true,
+    /^\.\/[^\/]+\/duck\.js$/
+);
+const ducks = {};
+duckRequire.keys().map(key => {
+    const duckName = key.match(/^\.\/([^\/]+)\/duck\.js$/)[1];
+    ducks[duckName] = duckRequire(key).default;
+});
+
+
 export default {
     ...commonReducers,
+
+    ...ducks,
 
     // main app reducers
     dashboards,

--- a/frontend/src/metabase/routes-main.jsx
+++ b/frontend/src/metabase/routes-main.jsx
@@ -56,7 +56,7 @@ import Unauthorized from "metabase/components/Unauthorized.jsx";
 
 // Reference Guide
 import GettingStartedGuideContainer from "metabase/reference/guide/GettingStartedGuideContainer.jsx";
-// Reference Metrics 
+// Reference Metrics
 import MetricListContainer from "metabase/reference/metrics/MetricListContainer.jsx";
 import MetricDetailContainer from "metabase/reference/metrics/MetricDetailContainer.jsx";
 import MetricQuestionsContainer from "metabase/reference/metrics/MetricQuestionsContainer.jsx";
@@ -86,6 +86,15 @@ import GroupDetailApp from "metabase/admin/people/containers/GroupDetailApp.jsx"
 
 import PublicQuestion from "metabase/public/containers/PublicQuestion.jsx";
 import PublicDashboard from "metabase/public/containers/PublicDashboard.jsx";
+
+
+// dynamically require "routes.jsx" files
+const routesRequire = require.context(
+    "metabase",
+    true,
+    /^\.\/[^\/]+\/routes\.jsx$/
+);
+const routeGetters = routesRequire.keys().map(key => routesRequire(key).default);
 
 const MetabaseIsSetup = UserAuthWrapper({
     predicate: authData => !authData.hasSetupToken,
@@ -282,6 +291,9 @@ export const getRoutes = (store) =>
 
                 {getAdminPermissionsRoutes(store)}
             </Route>
+
+            {/* DYNAMICALLY REQUIRED */}
+            { routeGetters.map(getRoutes => getRoutes(store))}
 
             {/* INTERNAL */}
             <Route

--- a/frontend/src/metabase/store.js
+++ b/frontend/src/metabase/store.js
@@ -41,7 +41,7 @@ export function getStore(reducers, history, intialState, enhancer = (a) => a) {
 
     middleware.push(routerMiddleware(history));
 
-    return createStore(reducer, intialState, compose(
+    return window.store = createStore(reducer, intialState, compose(
         applyMiddleware(...middleware),
         devToolsExtension,
         enhancer,


### PR DESCRIPTION
This is meant to be a starting point for conversations around improving basic CRUD type development on the frontend. Ideally we wouldn't need to generate a bunch of boilerplate like this for basic operators, but such is life with Redux (or at least with our current approach?). Even if we don't want a code generator we should turn this into a canonical example with proper error handling, etc.

Run this using `./bin/generate frontend-crud foo_bar` to get a service (`FooBarApi.create`, etc), duck with reducer and actions (`createFooBar`, etc), routes (`/foo_bar/create` etc), and components (`FooBarCreate`, etc).

* [ ] improve error handling
* [ ] ensure we're doing everything the "right" Redux way (we probably aren't)
* [ ] reduce some of the boilerplate?
* [ ] should the duck live in `metabase/redux/`?
* [ ] bonus: backend? could include DB migration
* [ ] bonus: infer form fields from a Flow type or Clojure schema?