### PR TITLE
WIP: Proposal for Pulse attachments

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -3670,3 +3670,29 @@ databaseChangeLog:
                   name: result_metadata
                   type: text
                   remarks: 'Serialized JSON containing metadata about the result columns from running the query.'
+  - changeSet:
+      id: 58
+      author: vilppuvuorinen
+      changes:
+        - addColumn:
+            tableName: pulse_card
+            columns:
+              - column:
+                  name: attach_csv
+                  type: boolean
+                  defaultValue: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: attach_xlsx
+                  type: boolean
+                  defaultValue: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: attach_json
+                  type: boolean
+                  defaultValue: false
+                  constraints:
+                    nullable: false
+

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -1,11 +1,9 @@
 (ns metabase.api.dataset
   "/api/dataset endpoints."
   (:require [cheshire.core :as json]
-            [clojure.data.csv :as csv]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [compojure.core :refer [POST]]
-            [dk.ative.docjure.spreadsheet :as spreadsheet]
             [metabase
              [middleware :as middleware]
              [query-processor :as qp]
@@ -17,7 +15,9 @@
              [database :as database :refer [Database]]
              [query :as query]]
             [metabase.query-processor.util :as qputil]
-            [metabase.util.schema :as su]
+            [metabase.util
+             [format :as fmt]
+             [schema :as su]]
             [schema.core :as s])
   (:import [java.io ByteArrayInputStream ByteArrayOutputStream]
            org.apache.poi.ss.usermodel.Cell))
@@ -66,71 +66,29 @@
 
 ;;; ------------------------------------------------------------ Downloading Query Results in Other Formats ------------------------------------------------------------
 
-;; add a generic implementation for the method that writes values to XLSX cells that just piggybacks off the implementations
-;; we've already defined for encoding things as JSON. These implementations live in `metabase.middleware`.
-(defmethod spreadsheet/set-cell! Object [^Cell cell, value]
-  (when (= (.getCellType cell) Cell/CELL_TYPE_FORMULA)
-    (.setCellType cell Cell/CELL_TYPE_STRING))
-  ;; stick the object in a JSON map and encode it, which will force conversion to a string. Then unparse that JSON and use the resulting value
-  ;; as the cell's new String value.
-  ;; There might be some more efficient way of doing this but I'm not sure what it is.
-  (.setCellValue cell (str (-> (json/generate-string {:v value})
-                               (json/parse-string keyword)
-                               :v))))
-
-(defn- export-to-xlsx [columns rows]
-  (let [wb  (spreadsheet/create-workbook "Query result" (cons (mapv name columns) rows))
-        ;; note: byte array streams don't need to be closed
-        out (ByteArrayOutputStream.)]
-    (spreadsheet/save-workbook! out wb)
-    (ByteArrayInputStream. (.toByteArray out))))
-
-(defn- export-to-csv [columns rows]
-  (with-out-str
-    ;; turn keywords into strings, otherwise we get colons in our output
-    (csv/write-csv *out* (into [(mapv name columns)] rows))))
-
-(defn- export-to-json [columns rows]
-  (for [row rows]
-    (zipmap columns row)))
-
-(def ^:private export-formats
-  {"csv"  {:export-fn    export-to-csv
-           :content-type "text/csv"
-           :ext          "csv"
-           :context      :csv-download},
-   "xlsx" {:export-fn    export-to-xlsx
-           :content-type "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-           :ext          "xlsx"
-           :context      :xlsx-download},
-   "json" {:export-fn    export-to-json
-           :content-type "applicaton/json"
-           :ext          "json"
-           :context      :json-download}})
-
 (def ExportFormat
   "Schema for valid export formats for downloading query results."
-  (apply s/enum (keys export-formats)))
+  fmt/ExportFormat)
 
 (defn export-format->context
   "Return the `:context` that should be used when saving a QueryExecution triggered by a request to download results in EXPORT-FORAMT.
 
      (export-format->context :json) ;-> :json-download"
   [export-format]
-  (or (get-in export-formats [export-format :context])
+  (or (get-in fmt/export-formats [export-format :context])
       (throw (Exception. (str "Invalid export format: " export-format)))))
 
 (defn as-format
   "Return a response containing the RESULTS of a query in the specified format."
   {:style/indent 1, :arglists '([export-format results])}
-  [export-format {{:keys [columns rows]} :data, :keys [status], :as response}]
-  (api/let-404 [export-conf (export-formats export-format)]
+  [export-format {:keys [status], :as response}]
+  (api/let-404 [export-result (fmt/as-format export-format response)]
     (if (= status :completed)
       ;; successful query, send file
       {:status  200
-       :body    ((:export-fn export-conf) columns rows)
-       :headers {"Content-Type"        (str (:content-type export-conf) "; charset=utf-8")
-                 "Content-Disposition" (str "attachment; filename=\"query_result_" (u/date->iso-8601) "." (:ext export-conf) "\"")}}
+       :body    (:body export-result)
+       :headers {"Content-Type"        (str (:content-type export-result) "; charset=utf-8")
+                 "Content-Disposition" (str "attachment; filename=\"query_result_" (u/date->iso-8601) "." (:ext export-result) "\"")}}
       ;; failed query, send error message
       {:status 500
        :body   (:error response)})))
@@ -140,7 +98,7 @@
    Inteneded for use in an endpoint definition:
 
      (api/defendpoint POST [\"/:export-format\", :export-format export-format-regex]"
-  (re-pattern (str "(" (str/join "|" (keys export-formats)) ")")))
+  (re-pattern (str "(" (str/join "|" (keys fmt/export-formats)) ")")))
 
 (api/defendpoint POST ["/:export-format", :export-format export-format-regex]
   "Execute a query and download the result data as a file in the specified format."

--- a/src/metabase/util/format.clj
+++ b/src/metabase/util/format.clj
@@ -1,0 +1,84 @@
+(ns metabase.util.format
+  "Functions for transforming query results into files"
+  (:require [cheshire.core :as json]
+            [clojure.data.csv :as csv]
+            [clojure.java.io :as io]
+            [dk.ative.docjure.spreadsheet :as spreadsheet]
+            [schema.core :as s])
+  (:import [java.io BufferedWriter ByteArrayInputStream ByteArrayOutputStream]
+           org.apache.poi.ss.usermodel.Cell))
+
+;; add a generic implementation for the method that writes values to XLSX cells that just piggybacks off the implementations
+;; we've already defined for encoding things as JSON. These implementations live in `metabase.middleware`.
+(defmethod spreadsheet/set-cell! Object [^Cell cell, value]
+  (when (= (.getCellType cell) Cell/CELL_TYPE_FORMULA)
+    (.setCellType cell Cell/CELL_TYPE_STRING))
+  ;; stick the object in a JSON map and encode it, which will force conversion to a string. Then unparse that JSON and use the resulting value
+  ;; as the cell's new String value.
+  ;; There might be some more efficient way of doing this but I'm not sure what it is.
+  (.setCellValue cell (str (-> (json/generate-string {:v value})
+                               (json/parse-string keyword)
+                               :v))))
+
+(defn- export-to-xlsx [columns rows]
+  (let [wb  (spreadsheet/create-workbook "Query result" (cons (mapv name columns) rows))
+        ;; note: byte array streams don't need to be closed
+        out (ByteArrayOutputStream.)]
+    (spreadsheet/save-workbook! out wb)
+    (ByteArrayInputStream. (.toByteArray out))))
+
+(defn- export-to-csv [columns rows]
+  (with-out-str
+    ;; turn keywords into strings, otherwise we get colons in our output
+    (csv/write-csv *out* (into [(mapv name columns)] rows))))
+
+(defn- export-to-json [columns rows]
+  (for [row rows]
+    (zipmap columns row)))
+
+(defn- str-to-stream
+	[input-str out-stream]
+	(.write out-stream (.getBytes input-str)))
+
+(defn- copy-stream
+	[in-stream out-stream]
+  (with-open [input in-stream]
+    (io/copy input out-stream)))
+
+(defn- map-to-json-stream
+	[in-map out-stream]
+  (with-open [os-writer (java.io.OutputStreamWriter. out-stream)
+              bw        (BufferedWriter. os-writer)]
+    (json/generate-stream in-map bw)))
+
+(def export-formats
+  {"csv"  {:export-fn    export-to-csv
+					 :to-stream    str-to-stream
+           :content-type "text/csv"
+           :ext          "csv"
+           :context      :csv-download},
+   "xlsx" {:export-fn    export-to-xlsx
+					 :to-stream    copy-stream
+           :content-type "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+           :ext          "xlsx"
+           :context      :xlsx-download},
+   "json" {:export-fn    export-to-json
+					 :to-stream    map-to-json-stream
+           :content-type "applicaton/json"
+           :ext          "json"
+           :context      :json-download}})
+
+(def ExportFormat
+  "Schema for valid export formats for downloading query results."
+  (apply s/enum (keys export-formats)))
+
+(defn as-format
+  "Return map containing format info and the RESULTS of a query in the specified format."
+  {:style/indent 1, :arglists '([export-format results])}
+  [export-format {{:keys [columns rows]} :data}]
+  (let [export-conf (export-formats export-format)
+        body ((:export-fn export-conf) columns rows)]
+    {:body         body
+     :to-stream    (partial (:to-stream export-conf) body)
+     :content-type (str (:content-type export-conf) "; charset=utf-8")
+     :ext          (:ext export-conf)}))


### PR DESCRIPTION
Proposal for implementation of Pulse attachments described in #2623. This implementation allows describing multiple formats for attachments, but does not allow defining the cards that are attached.

Notes
* Non-trivial refactoring was required to allow the use of result formatting functions from email/messages.
* No card level inclusion / format toggles as it would add to amount of UI/UX changes and require changes in pulse <-> card relationship.
* UI element to toggle attachment formats is required to the Email settings.
* Attachments are named using quite naive sanitization that replaces/removes all characters not matched by `[A-Za-z_]`.
* Results are not truncated which could lead to extremely large attachments in some cases.