### PR TITLE
Update Postgres driver dep. Fixes support for Postgres 10 beta

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -74,7 +74,7 @@
                  [org.slf4j/slf4j-log4j12 "1.7.25"]                   ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
                  [org.yaml/snakeyaml "1.18"]                          ; YAML parser (required by liquibase)
                  [org.xerial/sqlite-jdbc "3.16.1"]                    ; SQLite driver
-                 [postgresql "9.3-1102.jdbc41"]                       ; Postgres driver
+                 [org.postgresql/postgresql "42.1.3.jre7"]            ; Postgres driver
                  [io.crate/crate-jdbc "2.1.6"]                        ; Crate JDBC driver
                  [prismatic/schema "1.1.5"]                           ; Data schema declaration and validation library
                  [ring/ring-core "1.6.0"]


### PR DESCRIPTION
Fixes #5424 

I didn't realize our Postgres JDBC driver was out-of-date. I'm checked our dependencies with [`lein-ancient`](https://github.com/xsc/lein-ancient) but Postgres didn't show up as out-of-date. I'm guessing it's because we're still on a 9.3.x driver and Postgres recently had that [huge version bump where they went from 9.x to 42.0](https://jdbc.postgresql.org/documentation/faq.html#version-change)