### PR TITLE
Allow a date/time field to be used multiple times in breakouts [WIP]

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
@@ -11,6 +11,7 @@ import Q_deprecated, {
 } from "metabase/lib/query";
 import { format as formatExpression } from "metabase/lib/expressions/formatter";
 import { getAggregator } from "metabase/lib/schema_metadata";
+import { isDatetimeField } from "metabase/lib/query/field";
 
 import _ from "underscore";
 import { chain, assoc, updateIn } from "icepick";
@@ -397,6 +398,9 @@ export default class StructuredQuery extends AtomicQuery {
         const usedFields = new Set(
             this.breakouts()
                 .filter(b => !_.isEqual(b, includedBreakout))
+                // As datetimes breakouts can have different granularities, allow the same datetime field
+                // to be used multiple times in breakouts of a query
+                .filter(b => !isDatetimeField(b))
                 .map(b => Q_deprecated.getFieldTargetId(b))
         );
 


### PR DESCRIPTION
This is a naive starting point for addressing #4726 and following the suggestion in https://github.com/metabase/metabase/issues/4726#issuecomment-292638209 that we should remove the uniqueness requirement for date/time breakouts. 

Issues I've encountered so far:
1) If you group by the same date field multiple times with different granularities, the backend response lacks `id`, `table_id`, `unit` and some other properties for the column of second breakout. Frontend is unable to display the column correctly because of that. The dataset query body for reproducing this:
```
{"database":1,"type":"query","query":{"source_table":1,"aggregation":[["sum",["field-id",6]]],"breakout":[["datetime-field",["field-id",1],"month-of-year"],["datetime-field",["field-id",1],"year"]]},"parameters":[]}
```
2) Using the same granularity for two breakouts with same field leads to a query error. Probably we shouldn't allow adding multiple exactly same date breakouts, i.e. we should hide the used granularities when adding a new breakout with a same field.

I don't know how easy/complicated it would be fix (1) in the query processor backend code. Fixing (2) in the frontend shouldn't be too hard.