### PR TITLE
Migrate nest query action to new query-lib

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -246,6 +246,25 @@ export default class Question {
     toUnderlyingData(): Question {
         return this.setDisplay("table");
     }
+
+    composeThisQuery(): ?Question {
+        const SAVED_QUESTIONS_FAUX_DATABASE = -1337;
+
+        if (this.id()) {
+            const card = {
+                display: "table",
+                dataset_query: {
+                    type: "query",
+                    database: SAVED_QUESTIONS_FAUX_DATABASE,
+                    query: {
+                        source_table: "card__" + this.id()
+                    }
+                }
+            };
+            return this.setCard(card);
+        }
+    }
+
     drillPK(field: Field, value: Value): ?Question {
         const query = this.query();
         if (query instanceof StructuredQuery) {

--- a/frontend/src/metabase/__support__/sample_dataset_fixture.js
+++ b/frontend/src/metabase/__support__/sample_dataset_fixture.js
@@ -1450,7 +1450,20 @@ export const orders_count_card = {
 };
 
 export const native_orders_count_card = {
-    id: 2,
+    id: 3,
+    name: "# orders data",
+    display: 'table',
+    visualization_settings: {},
+    dataset_query: {
+        type: "native",
+        database: DATABASE_ID,
+        native: {
+            query: "SELECT count(*) FROM orders"
+        }
+    }
+};
+
+export const unsaved_native_orders_count_card = {
     name: "# orders data",
     display: 'table',
     visualization_settings: {},

--- a/frontend/src/metabase/qb/components/actions/CompoundQueryAction.jsx
+++ b/frontend/src/metabase/qb/components/actions/CompoundQueryAction.jsx
@@ -1,7 +1,5 @@
 /* @flow */
 
-import { nestThisQuery } from "metabase/qb/lib/actions";
-
 import type {
     ClickAction,
     ClickActionProps

--- a/frontend/src/metabase/qb/components/actions/CompoundQueryAction.spec.js
+++ b/frontend/src/metabase/qb/components/actions/CompoundQueryAction.spec.js
@@ -1,44 +1,42 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 
 import CompoundQueryAction from "./CompoundQueryAction";
+import Question from "metabase-lib/lib/Question";
 
 import {
-    savedCard,
-    nativeCard,
-    savedNativeCard,
-    tableMetadata
-} from "../__support__/fixtures";
+    native_orders_count_card,
+    orders_count_card,
+    unsaved_native_orders_count_card,
+    metadata
+} from "metabase/__support__/sample_dataset_fixture";
 
 describe("CompoundQueryAction", () => {
     it("should not suggest a compount query for an unsaved native query", () => {
-        expect(
-            CompoundQueryAction({
-                card: nativeCard,
-                tableMetadata: tableMetadata
-            })
-        ).toHaveLength(0);
+        const question = new Question(
+            metadata,
+            unsaved_native_orders_count_card
+        );
+        expect(CompoundQueryAction({ question })).toHaveLength(0);
     });
     it("should suggest a compound query for a mbql query", () => {
-        const actions = CompoundQueryAction({
-            card: savedCard,
-            tableMetadata: tableMetadata
-        });
+        const question = new Question(metadata, orders_count_card);
+
+        const actions = CompoundQueryAction({ question });
         expect(actions).toHaveLength(1);
-        const newCard = actions[0].card();
+        const newCard = actions[0].question().card();
         expect(newCard.dataset_query.query).toEqual({
-            source_table: "card__1"
+            source_table: "card__2"
         });
     });
 
     it("should return a nested query for a saved native card", () => {
-        const actions = CompoundQueryAction({
-            card: savedNativeCard,
-            tableMetadata: tableMetadata
-        });
+        const question = new Question(metadata, native_orders_count_card);
+
+        const actions = CompoundQueryAction({ question });
         expect(actions).toHaveLength(1);
-        const newCard = actions[0].card();
+        const newCard = actions[0].question().card();
         expect(newCard.dataset_query.query).toEqual({
-            source_table: "card__2"
+            source_table: "card__3"
         });
     });
 });

--- a/frontend/src/metabase/qb/components/actions/CompoundQueryAction.spec.js
+++ b/frontend/src/metabase/qb/components/actions/CompoundQueryAction.spec.js
@@ -1,6 +1,7 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 
 import CompoundQueryAction from "./CompoundQueryAction";
+
 import Question from "metabase-lib/lib/Question";
 
 import {

--- a/frontend/src/metabase/qb/lib/actions.js
+++ b/frontend/src/metabase/qb/lib/actions.js
@@ -20,8 +20,6 @@ import { parseTimestamp } from "metabase/lib/time";
 
 // TODO: use icepick instead of mutation, make they handle frozen cards
 
-const SAVED_QUESTIONS_FAUX_DATABASE = -1337;
-
 export const toUnderlyingData = (card: CardObject): ?CardObject => {
     const newCard = startNewCard("query");
     newCard.dataset_query = Utils.copy(card.dataset_query);
@@ -41,15 +39,6 @@ export const toUnderlyingRecords = (card: CardObject): ?CardObject => {
         newCard.dataset_query.query.filter = query.filter;
         return newCard;
     }
-};
-
-export const nestThisQuery = question => {
-    const newCard = startNewCard(
-        "query",
-        SAVED_QUESTIONS_FAUX_DATABASE,
-        "card__" + question.id()
-    );
-    return newCard;
 };
 
 export const getFieldRefFromColumn = col => {


### PR DESCRIPTION
I don't really like this, and would love feedback on how to make this suck a little less.

This feels very un-zen.

@tlrobinson or @attekei any suggestions on how this should read? There was a git snafu, and this should be read with https://github.com/metabase/metabase/commit/045026e13d72df755739e6696c6fa390bf148409#diff-48efb9187c68361e36b08d230be4e67cR18 which calls it.