### PR TITLE
Only show supported aggregation drill-throughs for a field

### DIFF
--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -480,6 +480,9 @@ export function getAggregator(short) {
     return _.findWhere(Aggregators, { short: short });
 }
 
+export const isCompatibleAggregatorForField = (aggregator, field) =>
+    aggregator.validFieldsFilters.every(filter => filter([field]).length === 1)
+
 export function getBreakouts(fields) {
     var result = populateFields(BreakoutAggregator, fields);
     result.fields = result.fields[0];

--- a/frontend/src/metabase/qb/components/drill/SummarizeColumnByTimeDrill.js
+++ b/frontend/src/metabase/qb/components/drill/SummarizeColumnByTimeDrill.js
@@ -4,7 +4,11 @@ import React from "react";
 
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 import { getFieldRefFromColumn } from "metabase/qb/lib/actions";
-import { isNumeric, isDate, getAggregator, isCompatibleAggregatorForField } from "metabase/lib/schema_metadata";
+import {
+    isDate,
+    getAggregator,
+    isCompatibleAggregatorForField
+} from "metabase/lib/schema_metadata";
 import { capitalize } from "metabase/lib/formatting";
 
 import type {
@@ -20,11 +24,7 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
 
     const dateField = query.table().fields.filter(isDate)[0];
     if (
-        !dateField ||
-        !clicked ||
-        !clicked.column ||
-        clicked.value !== undefined ||
-        !isNumeric(clicked.column)
+        !dateField || !clicked || !clicked.column || clicked.value !== undefined
     ) {
         return [];
     }
@@ -32,7 +32,8 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
 
     return ["sum", "count"]
         .map(getAggregator)
-        .filter((aggregator) => isCompatibleAggregatorForField(aggregator, column))
+        .filter(aggregator =>
+            isCompatibleAggregatorForField(aggregator, column))
         .map(aggregator => ({
             name: "summarize-by-time",
             section: "sum",

--- a/frontend/src/metabase/qb/components/drill/SummarizeColumnDrill.js
+++ b/frontend/src/metabase/qb/components/drill/SummarizeColumnDrill.js
@@ -47,24 +47,26 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
     }
     const { column } = clicked;
 
-    return Object.entries(AGGREGATIONS)
-        .map(([aggregationShort, action]) => [
-            getAggregator(aggregationShort),
-            action
-        ])
-        .filter(([aggregator]) =>
-            isCompatibleAggregatorForField(aggregator, column))
-        // $FlowFixMe
-        .map(([aggregator, action]: [any, {
-            section: string,
-            title: string
-        }]) => ({
-            name: action.title.toLowerCase(),
-            ...action,
-            question: () =>
-                question.summarize([
-                    aggregator.short,
-                    getFieldRefFromColumn(column)
-                ])
-        }));
+    return (
+        Object.entries(AGGREGATIONS)
+            .map(([aggregationShort, action]) => [
+                getAggregator(aggregationShort),
+                action
+            ])
+            .filter(([aggregator]) =>
+                isCompatibleAggregatorForField(aggregator, column))
+            // $FlowFixMe
+            .map(([aggregator, action]: [any, {
+                section: string,
+                title: string
+            }]) => ({
+                name: action.title.toLowerCase(),
+                ...action,
+                question: () =>
+                    question.summarize([
+                        aggregator.short,
+                        getFieldRefFromColumn(column)
+                    ])
+            }))
+    );
 };

--- a/frontend/src/metabase/qb/components/drill/SummarizeColumnDrill.js
+++ b/frontend/src/metabase/qb/components/drill/SummarizeColumnDrill.js
@@ -1,7 +1,10 @@
 /* @flow */
 
 import { getFieldRefFromColumn } from "metabase/qb/lib/actions";
-import { getAggregator, isCompatibleAggregatorForField, isNumeric, isSummable } from "metabase/lib/schema_metadata";
+import {
+    getAggregator,
+    isCompatibleAggregatorForField
+} from "metabase/lib/schema_metadata";
 
 import type {
     ClickAction,
@@ -37,24 +40,31 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
         !clicked.column ||
         clicked.value !== undefined ||
         clicked.column.source !== "fields"
+    ) {
         // TODO Atte Keinänen 7/21/17: Does it slow down the drill-through option calculations remarkably
         // that I removed the `isSummable` condition from here and use `isCompatibleAggregator` method below instead?
-    ) {
         return [];
     }
     const { column } = clicked;
 
-    // $FlowFixMe
     return Object.entries(AGGREGATIONS)
-        .map(([aggregationShort, action]) => [getAggregator(aggregationShort), action])
-        .filter(([aggregator]) => isCompatibleAggregatorForField(aggregator, column))
-        .map(([aggregator, action]: [string, {
+        .map(([aggregationShort, action]) => [
+            getAggregator(aggregationShort),
+            action
+        ])
+        .filter(([aggregator]) =>
+            isCompatibleAggregatorForField(aggregator, column))
+        // $FlowFixMe
+        .map(([aggregator, action]: [any, {
             section: string,
             title: string
         }]) => ({
             name: action.title.toLowerCase(),
             ...action,
             question: () =>
-                question.summarize([aggregator.short, getFieldRefFromColumn(column)])
+                question.summarize([
+                    aggregator.short,
+                    getFieldRefFromColumn(column)
+                ])
         }));
 };


### PR DESCRIPTION
Fixes #5326 and #5029. Applies to summarization drill-through the same field filters that aggregation picker uses.