### PR TITLE
Omit schema name in FK target field list if DB has no schemas / all target fields are from same schema

### DIFF
--- a/frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx
@@ -171,6 +171,10 @@ export class SpecialTypeAndTargetPicker extends Component {
 
         const showFKTargetSelect = isFK(field.special_type);
 
+        // If all FK target fields are in the same schema (like `PUBLIC` for sample dataset)
+        // or if there are no schemas at all, omit the schema name
+        const includeSchemaName = _.uniq(idfields.map((idField) => idField.table.schema)).length > 1
+
         return (
             <div>
                 <Select
@@ -188,8 +192,11 @@ export class SpecialTypeAndTargetPicker extends Component {
                     placeholder="Select a target"
                     value={field.fk_target_field_id && _.find(idfields, (idField) => idField.id === field.fk_target_field_id)}
                     options={idfields}
-                    // "PUBLIC" is the default schema name used only in the sample dataset; for truly schemaless dbs the schema value is `null`
-                    optionNameFn={(idField) => idField.table.schema && idField.table.schema !== "PUBLIC" ? titleize(humanize(idField.table.schema)) + "." + idField.displayName : idField.displayName}
+                    optionNameFn={
+                        (idField) => includeSchemaName
+                            ? titleize(humanize(idField.table.schema)) + "." + idField.displayName
+                            : idField.displayName
+                    }
                     onChange={this.onTargetChange}
                 /> }
             </div>

--- a/frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx
@@ -188,7 +188,8 @@ export class SpecialTypeAndTargetPicker extends Component {
                     placeholder="Select a target"
                     value={field.fk_target_field_id && _.find(idfields, (idField) => idField.id === field.fk_target_field_id)}
                     options={idfields}
-                    optionNameFn={(idField) => idField.table.schema && idField.table.schema !== "public" ? titleize(humanize(idField.table.schema)) + "." + idField.displayName : idField.displayName}
+                    // "PUBLIC" is the default schema name used only in the sample dataset; for truly schemaless dbs the schema value is `null`
+                    optionNameFn={(idField) => idField.table.schema && idField.table.schema !== "PUBLIC" ? titleize(humanize(idField.table.schema)) + "." + idField.displayName : idField.displayName}
                     onChange={this.onTargetChange}
                 /> }
             </div>

--- a/frontend/src/metabase/admin/datamodel/containers/FieldApp.integ.spec.js
+++ b/frontend/src/metabase/admin/datamodel/containers/FieldApp.integ.spec.js
@@ -153,7 +153,7 @@ describe("FieldApp", () => {
         it("shows the correct default special type for a foreign key", async () => {
             const { fieldApp } = await initFieldApp({ fieldId: PRODUCT_ID_FK_ID });
             const picker = fieldApp.find(SpecialTypeAndTargetPicker).text()
-            expect(picker).toMatch(/Foreign KeyPublic.Products → ID/);
+            expect(picker).toMatch(/Foreign KeyProducts → ID/);
         })
 
         it("lets you change the type to 'No special type'", async () => {
@@ -208,7 +208,7 @@ describe("FieldApp", () => {
 
             productIdField.simulate('click')
             await store.waitForActions([UPDATE_FIELD])
-            expect(picker.text()).toMatch(/Foreign KeyPublic.Products → ID/);
+            expect(picker.text()).toMatch(/Foreign KeyProducts → ID/);
         })
 
         afterAll(async () => {


### PR DESCRIPTION
Addresses #5535. 

Not sure if we should always hide the schema prefix if the db has <= 1 schemas? I don't really like using `PUBLIC` magic constant in the frontend source code.