### PR TITLE
Remove needless closing bracket from data ref segment empty state

### DIFF
--- a/frontend/src/metabase/reference/segments/SegmentList.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentList.jsx
@@ -62,7 +62,7 @@ export default class SegmentList extends Component {
 
         return (
             <div style={style} className="full">
-                <ReferenceHeader 
+                <ReferenceHeader
                     name="Segments"
                 />
                 <LoadingAndErrorWrapper loading={!loadingError && loading} error={loadingError}>
@@ -88,8 +88,7 @@ export default class SegmentList extends Component {
                     </div>
                     :
                     <div className={S.empty}>
-                        <AdminAwareEmptyState {...emptyStateData}/>
-                        }
+                        <AdminAwareEmptyState {...emptyStateData} />
                     </div>
                 }
                 </LoadingAndErrorWrapper>


### PR DESCRIPTION
There was an extra closing bracket on the data reference's segments page empty state that was rendering next to the content area heading.