### PR TITLE
Simplify Mac App setup steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ OSX/Resources/metabase.jar
 OSX/build
 /osx-artifacts
 OSX/dsa_priv.pem
-bin/config.json
 bin/release/aws-eb/metabase-aws-eb.zip
 *.sqlite
 /reset-password-artifacts

--- a/bin/config.json
+++ b/bin/config.json
@@ -1,6 +1,5 @@
 {
     "codesigningIdentity": "Developer ID Application: Metabase, Inc",
-    "slackWebhookURL": "",
     "awsProfile": "metabase",
-    "awsBucket": ""
+    "awsBucket": "downloads.metabase.com"
 }

--- a/bin/osx-release
+++ b/bin/osx-release
@@ -8,11 +8,9 @@ use File::Copy 'copy';
 use File::Copy::Recursive 'rcopy';   # CPAN
 use File::Path 'remove_tree';
 use File::stat 'stat';
-use JSON 'encode_json', 'from_json'; # CPAN
 use Readonly;                        # CPAN
 use String::Util 'trim';             # CPAN
 use Text::Caml;                      # CPAN
-use WWW::Curl::Simple;               # CPAN
 
 use Metabase::Util;
 
@@ -298,30 +296,6 @@ sub create_dmg {
 
 # ------------------------------------------------------------ UPLOADING ------------------------------------------------------------
 
-sub announce_on_slack {
-    Readonly my $slack_url => config('slackWebhookURL') or return;
-    Readonly my $version   => version();
-    Readonly my $awsURL    => 'https://s3.amazonaws.com/' . config('awsBucket') . '/' . upload_subdir() . '/Metabase.dmg';
-    my $text = "Metabase OS X $version 'Complexity-Embracing Toucan' Is Now Available!\n\n" .
-               "Get it here: $awsURL\n\n";
-
-    open(my $file, get_file_or_die($release_notes)) or die $!;
-    while (<$file>) {
-        m/^\s+<li>.*$/ && s|^\s+<li>(.*)</li>$|$1| && ($text .= '*  ' . $_);
-    }
-
-    my $json = encode_json {
-        channel    => '#general',
-        username   => 'OS X Bot',
-        icon_emoji => ':bird:',
-        text       => trim($text)
-    };
-
-    my $curl = WWW::Curl::Simple->new;
-    unless ((my $response = $curl->post($slack_url, $json))->code == 200) {
-        die 'Error posting to slack: ' . $response->code . ' ' . $response->content . "\n";
-    }
-}
 
 # Upload artifacts to AWS
 # Make sure to run `aws configure --profile metabase` first to set up your ~/.aws/config file correctly
@@ -351,8 +325,6 @@ sub upload {
            '--region', 'us-east-1',
            's3', 'cp', $upload_dir,
            "s3://$aws_bucket") == 0 or die "Upload failed: $!\n";
-
-    announce_on_slack;
 
     announce "Upload finished."
 }

--- a/docs/developers-guide-osx.md
+++ b/docs/developers-guide-osx.md
@@ -1,49 +1,23 @@
 # Metabase OS X App
 
-NOTE: These instructions are only for packaging a built Metabase uberjar into `Metabase.app`. They are not useful if your goal is to work on Metabase itself; for development, please see our [developers' guide](developers-guide.md). 
+NOTE: These instructions are only for packaging a built Metabase uberjar into `Metabase.app`. They are not useful if your goal is to work on Metabase itself; for development, please see our [developers' guide](developers-guide.md).
 
 ## Prereqs
 
 1.  Install XCode.
 
-2.  Run `./bin/build` to build the latest version of the uberjar.
+1.  Run `./bin/build` to build the latest version of the uberjar.
 
-3.  Update Perl. I'm not sure these steps are actually needed, so feel free to try skipping it and come back to it if it fails:
-  
-    ```bash
-      # Upgrade Perl
-      brew install perl
-      
-      # Add new version of perl to your $PATH
-      # (replace "5.24.0_1" below with whatever version you installed)
-      echo 'export PATH="/usr/local/Cellar/perl/5.24.0_1/bin:$PATH"' >> ~/.bash_profile
-      source ~/.bash_profile
-      
-      # Double-check that we're using the newer version of CPAN
-      # (If this is your first time running CPAN, use the default config settings when prompted)
-      cpan --version # You should see a line like "running under Perl version 5.24.0."
-    ```
-
-4.  Next, you'll need to run the following commands before building the app:
+1.  Next, you'll need to run the following commands before building the app:
 
     ```bash
       # Fetch and initialize git submodule
       git submodule update --init
-      
-      # Install libcurl (needed by WWW::Curl::Simple (I think))
-      brew install curl && brew link curl --force
-      
-      # The new version of LLVM is snippy so have CPAN pass compiler flags to fix errors
-      # (Make sure this file exists first. If you didn't upgrade Perl in the step above, 
-      # it might be in a different location; perhaps called "Config.pm". 
-      # You may need to run "cpan" (no arguments) to generate an appropriate initial config. 
-      # As above, you can go with the defaults).
-      sed -i '' -e "s/'make_arg' => q\[\]/'make_arg' => q\[CCFLAGS=\"-Wno-return-type\"\]/" ~/.cpan/CPAN/MyConfig.pm
 
       # Install Perl modules used by ./bin/osx-setup and ./bin/osx-release
       # You may have to run this as sudo if you didn't upgrade perl as described in step above
-      cpan install File::Copy::Recursive JSON Readonly String::Util Text::Caml WWW::Curl::Simple
-      
+      cpan install File::Copy::Recursive Readonly String::Util Text::Caml
+
       # Copy JRE and uberjar
       ./bin/osx-setup
     ```
@@ -66,16 +40,12 @@ brew install awscli
 # You just need the access key ID and secret key; use the defaults for locale and other options.
 aws configure --profile metabase
 
-# Copy & Edit Config file. Alternative ask Cam for a copy of his
-cp bin/config.json.template bin/config.json
-emacs bin/config.json
-
 # Obtain a copy of the private key used for signing the app (ask Cam)
 # and put a copy of it at ./dsa_priv.pem
 cp /path/to/private/key.pem OSX/dsa_priv.pem
 ```
 
-You'll probably also want an Apple Developer ID Application Certificate in your computer's keychain. You'll need to generate a Certificate Signing Request from Keychain Access, and have Sameer go to [the Apple Developer Site](https://developer.apple.com/account/mac/certificate/) and generate one for you, then load the file on your computer. 
+You'll probably also want an Apple Developer ID Application Certificate in your computer's keychain. You'll need to generate a Certificate Signing Request from Keychain Access, and have Sameer go to [the Apple Developer Site](https://developer.apple.com/account/mac/certificate/) and generate one for you, then load the file on your computer.
 
 After that, you are good to go:
 ```bash

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -135,7 +135,7 @@
   [include_tables include_cards]
   {include_tables (s/maybe su/BooleanString)
    include_cards  (s/maybe su/BooleanString)}
-  (or (dbs-list include_tables include_cards)
+  (or (dbs-list (Boolean/parseBoolean include_tables) (Boolean/parseBoolean include_cards))
       []))
 
 


### PR DESCRIPTION
Getting your Mac set up to build the Mac App is 20x harder than it needs to be, mostly because installing the Perl module `WWW::Curl::Simple` is a gigantic PITA on macOS versions newer than Mavericks. On some versions it required configuring the compiler flags that get passed in to the `make` command and installing a newer version of `perl` via Homebrew. On newer versions you also need to do some hackery to override the C preprocessor and other sorts of Makefile hacks I don't find as enjoyable now that I'm not doing full-time C++ development any more.

Anyway those modules were only used for the `announce_on_slack` subroutine, which was arguably of very little utility. So by taking out the in-house Slack announcement code from the script we make the process of setting up a computer to build the  Mac App much, much, much easier. Yay