### PR TITLE
Take foreign keys into account when showing available aggregation options

### DIFF
--- a/frontend/src/metabase/lib/expressions/formatter.js
+++ b/frontend/src/metabase/lib/expressions/formatter.js
@@ -3,8 +3,8 @@ import _ from "underscore";
 
 import {
     VALID_OPERATORS, VALID_AGGREGATIONS,
-    isField, isMath, isMetric, isAggregation, isExpressionReference,
-    formatMetricName, formatFieldName, formatExpressionName
+    isField, isFkTargetField, isMath, isMetric, isAggregation, isExpressionReference,
+    formatMetricName, formatFieldName,formatFkTargetFieldName, formatExpressionName
 } from "../expressions";
 
 // convert a MBQL expression back into an expression string
@@ -23,6 +23,9 @@ export function format(expr, {
     }
     if (isField(expr)) {
         return formatField(expr, info);
+    }
+    if (isFkTargetField(expr)) {
+        return formatFkTargetField(expr, info);
     }
     if (isMetric(expr)) {
         return formatMetric(expr, info);
@@ -49,6 +52,18 @@ function formatField([, fieldId], { tableMetadata: { fields } }) {
         throw 'field with ID does not exist: ' + fieldId;
     }
     return formatFieldName(field);
+}
+
+function formatFkTargetField([, fkFieldId, targetFieldId], { tableMetadata: { fields } }) {
+    const fkField = _.findWhere(fields, { id: fkFieldId });
+    if (!fkField) {
+        throw 'field with ID does not exist: ' + fkFieldId;
+    }
+    const targetField = fkField.target && _.findWhere(fkField.target.table.fields, { id: targetFieldId });
+    if (!targetField) {
+        throw 'FK target field with ID does not exist in the target table:' + targetFieldId;
+    }
+    return formatFkTargetFieldName(fkField, targetField);
 }
 
 function formatMetric([, metricId], { tableMetadata: { metrics } }) {

--- a/frontend/src/metabase/lib/expressions/index.js
+++ b/frontend/src/metabase/lib/expressions/index.js
@@ -1,6 +1,7 @@
 
 import _ from "underscore";
 import { mbqlEq } from "../query/util";
+import { stripId } from "../formatting";
 
 import { VALID_OPERATORS, VALID_AGGREGATIONS } from "./config";
 export { VALID_OPERATORS, VALID_AGGREGATIONS } from "./config";
@@ -37,6 +38,10 @@ export function formatFieldName(field) {
     return formatIdentifier(field.display_name);
 }
 
+export function formatFkTargetFieldName(fkField, targetField) {
+    return formatIdentifier(`${stripId(fkField.display_name)} → ${targetField.display_name}`);
+}
+
 export function formatExpressionName(name) {
     return formatIdentifier(name);
 }
@@ -49,6 +54,10 @@ export function isExpression(expr) {
 
 export function isField(expr) {
     return Array.isArray(expr) && expr.length === 2 && mbqlEq(expr[0], 'field-id') && typeof expr[1] === 'number';
+}
+
+export function isFkTargetField(expr) {
+    return Array.isArray(expr) && expr.length === 3 && mbqlEq(expr[0], 'fk->') && typeof expr[1] === 'number' && typeof expr[2] === 'number';
 }
 
 export function isMetric(expr) {
@@ -69,5 +78,5 @@ export function isExpressionReference(expr) {
 }
 
 export function isValidArg(arg) {
-    return isExpression(arg) || isField(arg) || typeof arg === 'number';
+    return isExpression(arg) || isField(arg) || isFkTargetField(arg)|| typeof arg === 'number';
 }


### PR DESCRIPTION
Fixes #4489.

Before:
<img width="500" alt="screen shot 2017-07-26 at 14 40 26" src="https://user-images.githubusercontent.com/6034928/28644944-6a5f37fc-7210-11e7-9d83-deb9f2c5aea4.png">
Now:
<img width="500" alt="screen shot 2017-07-26 at 14 40 36" src="https://user-images.githubusercontent.com/6034928/28644950-6e6b0b96-7210-11e7-9a7a-98c878846172.png">

Additionally adds support for foreign keys in the custom expressions editor as it was natural to implement at the same time. Not sure if there is an existing issue for that bug. Looks like this:

<img width="550" alt="screen shot 2017-07-26 at 14 41 31" src="https://user-images.githubusercontent.com/6034928/28644975-8b05c764-7210-11e7-9806-09b16d2d0f08.png">
