### PR TITLE
Backported cleanup from sync refactor :shower: [ci drivers]

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -184,8 +184,7 @@
     {:where    [:and [:= :db_id db-id]
                      [:= :active true]
                      [:like :%lower.name (str (str/lower-case prefix) "%")]
-                     [:or [:= :visibility_type nil]
-                          [:not= :visibility_type "hidden"]]]
+                     [:= :visibility_type nil]]
      :order-by [[:%lower.name :asc]]}))
 
 (defn- autocomplete-fields [db-id prefix]

--- a/src/metabase/api/field.clj
+++ b/src/metabase/api/field.clj
@@ -154,7 +154,7 @@
   [_ _]
   empty-field-values)
 
-(defn validate-human-readable-pairs
+(defn- validate-human-readable-pairs
   "Human readable values are optional, but if present they must be
   present for each field value. Throws if invalid, returns a boolean
   indicating whether human readable values were found."

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -45,40 +45,35 @@
   (-> (api/read-check Table id)
       (hydrate :db :pk_field)))
 
-(defn- visible-state?
-  "only the nil state is considered visible."
-  [state]
-  {:pre [(or (nil? state) (table/visibility-types state))]}
-  (if (nil? state)
-    :show
-    :hide))
 
 (api/defendpoint PUT "/:id"
   "Update `Table` with ID."
-  [id :as {{:keys [display_name entity_type visibility_type description caveats points_of_interest show_in_getting_started]} :body}]
-  {display_name    (s/maybe su/NonBlankString)
-   entity_type     (s/maybe TableEntityType)
-   visibility_type (s/maybe TableVisibilityType)}
+  [id :as {{:keys [display_name entity_type visibility_type description caveats points_of_interest show_in_getting_started], :as body} :body}]
+  {display_name            (s/maybe su/NonBlankString)
+   entity_type             (s/maybe TableEntityType)
+   visibility_type         (s/maybe TableVisibilityType)
+   description             (s/maybe su/NonBlankString)
+   caveats                 (s/maybe su/NonBlankString)
+   points_of_interest      (s/maybe su/NonBlankString)
+   show_in_getting_started (s/maybe s/Bool)}
   (api/write-check Table id)
-  (let [original-visibility-type (:visibility_type (Table :id id))]
-    (api/check-500 (db/update-non-nil-keys! Table id
-                     :display_name            display_name
-                     :caveats                 caveats
-                     :points_of_interest      points_of_interest
-                     :show_in_getting_started show_in_getting_started
-                     :entity_type             entity_type
-                     :description             description))
-    (api/check-500 (db/update! Table id, :visibility_type visibility_type))
-    (let [updated-table (Table id)
-          new-visibility (visible-state? (:visibility_type updated-table))
-          old-visibility (visible-state? original-visibility-type)
-          visibility-changed? (and (not= new-visibility
-                                         old-visibility)
-                                   (= :show new-visibility))]
-      (when visibility-changed?
-        (log/debug (u/format-color 'green "Table visibility changed, resyncing %s -> %s : %s") original-visibility-type visibility_type visibility-changed?)
+  (let [original-visibility-type (db/select-one-field :visibility_type Table :id id)]
+    ;; always update visibility type; update display_name, show_in_getting_started, entity_type if non-nil; update description and related fields if passed in
+    (api/check-500
+     (db/update! Table id
+       (assoc (u/select-keys-when body
+                :non-nil [:display_name :show_in_getting_started :entity_type]
+                :present [:description :caveats :points_of_interest])
+         :visibility_type visibility_type)))
+    (let [updated-table   (Table id)
+          now-visible?    (nil? (:visibility_type updated-table)) ; only Tables with `nil` visibility type are visible
+          was-visible?    (nil? original-visibility-type)
+          became-visible? (and now-visible? (not was-visible?))]
+      (when became-visible?
+        (log/info (u/format-color 'green "Table '%s' is now visible. Resyncing." (:name updated-table)))
         (sync-database/sync-table! updated-table))
       updated-table)))
+
 
 (defn- format-fields-for-response [resp]
   (update resp :fields

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -397,8 +397,8 @@
 (defn join
   "Convenience for generating a HoneySQL `JOIN` clause.
 
-     (db/select-ids Table
-       (mdb/join [Table :raw_table_id] [RawTable :id])
+     (db/select-ids FieldValues
+       (mdb/join [FieldValues :field_id] [Field :id])
        :active true)"
   [[source-entity fk] [dest-entity pk]]
   {:left-join [(db/resolve-model dest-entity) [:= (db/qualify source-entity fk)

--- a/src/metabase/db/metadata_queries.clj
+++ b/src/metabase/db/metadata_queries.clj
@@ -1,13 +1,17 @@
 (ns metabase.db.metadata-queries
   "Predefined MBQL queries for getting metadata about an external database."
-  (:require [metabase
+  (:require [clojure.tools.logging :as log]
+            [metabase
              [query-processor :as qp]
              [util :as u]]
-            [metabase.models.table :refer [Table]]
+            [metabase.models
+             [field-values :as field-values]
+             [table :refer [Table]]]
             [metabase.query-processor.middleware.expand :as ql]
             [toucan.db :as db]))
 
 (defn- qp-query [db-id query]
+  {:pre [(integer? db-id)]}
   (-> (qp/process-query
        {:type     :query
         :database db-id
@@ -26,15 +30,19 @@
   [table]
   {:pre  [(map? table)]
    :post [(integer? %)]}
-  (-> (qp-query (:db_id table) (ql/query (ql/source-table (:id table))
-                                         (ql/aggregation (ql/count))))
-      first first long))
+  (let [results (qp-query (:db_id table) (ql/query (ql/source-table (:id table))
+                                                   (ql/aggregation (ql/count))))]
+    (try (-> results first first long)
+         (catch Throwable e
+           (log/error "Error fetching table row count. Query returned:\n"
+                      (u/pprint-to-str results))
+           (throw e)))))
 
 (defn field-distinct-values
   "Return the distinct values of FIELD.
    This is used to create a `FieldValues` object for `:type/Category` Fields."
   ([field]
-   (field-distinct-values field @(resolve 'metabase.sync-database.analyze/low-cardinality-threshold)))
+   (field-distinct-values field field-values/low-cardinality-threshold))
   ([field max-results]
    {:pre [(integer? max-results)]}
    (mapv first (field-query field (-> {}

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -372,6 +372,15 @@
       (when-let [engine (db-id->engine db-id)]
         (engine->driver engine)))))
 
+(defn ->driver
+  "Return an appropraiate driver for ENGINE-OR-DATABASE-OR-DB-ID.
+   Offered since this is somewhat more flexible in the arguments it accepts."
+  ;; TODO - we should make `engine->driver` and `database-id->driver` private and just use this for everything
+  [engine-or-database-or-db-id]
+  (if (keyword? engine-or-database-or-db-id)
+    (engine->driver engine-or-database-or-db-id)
+    (database-id->driver (u/get-id engine-or-database-or-db-id))))
+
 
 ;; ## Implementation-Agnostic Driver API
 

--- a/src/metabase/driver/druid/query_processor.clj
+++ b/src/metabase/driver/druid/query_processor.clj
@@ -107,7 +107,7 @@
       (instance? DateTimeField arg)))
 
 (defn- expression->field-names [{:keys [args]}]
-  {:post [(every? u/string-or-keyword? %)]}
+  {:post [(every? (some-fn keyword? string?) %)]}
   (flatten (for [arg   args
                  :when (or (field? arg)
                            (instance? Expression arg))]

--- a/src/metabase/driver/googleanalytics/query_processor.clj
+++ b/src/metabase/driver/googleanalytics/query_processor.clj
@@ -57,7 +57,7 @@
 ;;; ### source-table
 
 (defn- handle-source-table [{{source-table-name :name} :source-table}]
-  {:pre [(u/string-or-keyword? source-table-name)]}
+  {:pre [((some-fn keyword? string?) source-table-name)]}
   {:ids (str "ga:" source-table-name)})
 
 
@@ -265,7 +265,7 @@
 
 (defn- filter-type ^clojure.lang.Keyword [filter-clause]
   (when (and (sequential? filter-clause)
-             (u/string-or-keyword? (first filter-clause)))
+             ((some-fn keyword? string?) (first filter-clause)))
     (qputil/normalize-token (first filter-clause))))
 
 (defn- compound-filter? [filter-clause]

--- a/src/metabase/driver/mongo/query_processor.clj
+++ b/src/metabase/driver/mongo/query_processor.clj
@@ -413,7 +413,7 @@
      (form->encoded-fn-name [:___ObjectId \"583327789137b2700a1621fb\"]) -> :ObjectId"
   [form]
   (when (vector? form)
-    (when (u/string-or-keyword? (first form))
+    (when ((some-fn keyword? string?) (first form))
       (when-let [[_ k] (re-matches #"^___(\w+$)" (name (first form)))]
         (let [k (keyword k)]
           (when (contains? fn-name->decoder k)

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -5,6 +5,19 @@
              [db :as db]
              [models :as models]]))
 
+(def ^:const ^Integer low-cardinality-threshold
+  "Fields with less than this many distinct values should automatically be given a special type of `:type/Category`."
+  300)
+
+(def ^:private ^:const ^Integer entry-max-length
+  "The maximum character length for a stored `FieldValues` entry."
+  100)
+
+(def ^:const ^Integer total-max-length
+  "Maximum total length for a `FieldValues` entry (combined length of all values for the field)."
+  (* low-cardinality-threshold entry-max-length))
+
+
 ;; ## Entity + DB Multimethods
 
 (models/defmodel FieldValues :metabase_fieldvalues)
@@ -16,13 +29,6 @@
           :types       (constantly {:human_readable_values :json, :values :json})
           :post-select (u/rpartial update :human_readable_values #(or % {}))}))
 
-;; columns:
-;; *  :id
-;; *  :field_id
-;; *  :updated_at             WHY! I *DESPISE* THESE USELESS FIELDS
-;; *  :created_at
-;; *  :values                 (JSON-encoded array like ["table" "scalar" "pie"])
-;; *  :human_readable_values  (JSON-encoded map like {:table "Table" :scalar "Scalar"}
 
 ;; ## `FieldValues` Helper Functions
 
@@ -39,26 +45,52 @@
            (isa? (keyword special_type) :type/Category)
            (isa? (keyword special_type) :type/Enum))))
 
-(defn- create-field-values!
-  "Create `FieldValues` for a `Field`."
-  {:arglists '([field] [field human-readable-values])}
-  [{field-id :id, field-name :name, :as field} & [human-readable-values]]
-  {:pre [(integer? field-id)]}
-  (log/debug (format "Creating FieldValues for Field %s..." (or field-name field-id))) ; use field name if available
-  (db/insert! FieldValues
-    :field_id              field-id
-    :values                ((resolve 'metabase.db.metadata-queries/field-distinct-values) field)
-    :human_readable_values human-readable-values))
 
-(defn update-field-values!
-  "Update the `FieldValues` for FIELD, creating them if needed"
-  [{field-id :id, :as field}]
-  {:pre [(integer? field-id)
-         (field-should-have-field-values? field)]}
-  (if-let [field-values (FieldValues :field_id field-id)]
-    (db/update! FieldValues (u/get-id field-values)
-      :values ((resolve 'metabase.db.metadata-queries/field-distinct-values) field))
-    (create-field-values! field)))
+(defn- values-less-than-total-max-length?
+  "`true` if the combined length of all the values in DISTINCT-VALUES is below the
+   threshold for what we'll allow in a FieldValues entry."
+  [distinct-values]
+  (let [total-length (reduce + (map (comp count str)
+                                    distinct-values))]
+    (<= total-length total-max-length)))
+
+
+(defn- distinct-values
+  "Fetch a sequence of distinct values for FIELD that are below the `total-max-length` threshold.
+   If the values are past the threshold, this returns `nil`."
+  [field]
+  (let [values ((resolve 'metabase.db.metadata-queries/field-distinct-values) field)]
+    (when (values-less-than-total-max-length? values)
+      values)))
+
+
+(defn create-or-update-field-values!
+  "Create or update the FieldValues object for FIELD."
+  [field & [human-readable-values]]
+  (let [field-values (FieldValues :field_id (u/get-id field))
+        values       (distinct-values field)
+        field-name   (or (:name field) (:id field))]
+    (cond
+      ;; if the FieldValues object already exists then update values in it
+      (and field-values values)
+      (do
+        (log/debug (format "Updating FieldValues for Field %s..." field-name))
+        (db/update! FieldValues (u/get-id field-values)
+          :values values))
+      ;; if FieldValues object doesn't exist create one
+      values
+      (do
+        (log/debug (format "Creating FieldValues for Field %s..." field-name))
+        (db/insert! FieldValues
+          :field_id              (u/get-id field)
+          :values                values
+          :human_readable_values human-readable-values))
+      ;; otherwise this Field isn't eligible, so delete any FieldValues that might exist
+      :else
+      (do
+        (log/debug (format "Values for field %s exceed the total max length threshold." field-name))
+        (db/delete! FieldValues :field_id (u/get-id field))))))
+
 
 (defn field-values->pairs
   "Returns a list of pairs (or single element vectors if there are no
@@ -76,7 +108,7 @@
   {:pre [(integer? field-id)]}
   (when (field-should-have-field-values? field)
     (or (FieldValues :field_id field-id)
-        (create-field-values! field human-readable-values))))
+        (create-or-update-field-values! field human-readable-values))))
 
 (defn save-field-values!
   "Save the `FieldValues` for FIELD-ID, creating them if needed, otherwise updating them."

--- a/src/metabase/models/permissions_group.clj
+++ b/src/metabase/models/permissions_group.clj
@@ -41,7 +41,7 @@
 (defn exists-with-name?
   "Does a `PermissionsGroup` with GROUP-NAME exist in the DB? (case-insensitive)"
   ^Boolean [group-name]
-  {:pre [(u/string-or-keyword? group-name)]}
+  {:pre [((some-fn keyword? string?) group-name)]}
   (db/exists? PermissionsGroup
     :%lower.name (s/lower-case (name group-name))))
 

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -758,12 +758,6 @@
   `(do-with-auto-retries ~num-retries
      (fn [] ~@body)))
 
-(defn string-or-keyword?
-  "Is X a `String` or a `Keyword`?"
-  [x]
-  (or (string? x)
-      (keyword? x)))
-
 (defn key-by
   "Convert a sequential COLL to a map of `(f item)` -> `item`.
    This is similar to `group-by`, but the resultant map's values are single items from COLL rather than sequences of items.

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -131,7 +131,7 @@
   (i/format-name *driver* (name nm)))
 
 (defn- get-table-id-or-explode [db-id table-name]
-  {:pre [(integer? db-id) (u/string-or-keyword? table-name)]}
+  {:pre [(integer? db-id) ((some-fn keyword? string?) table-name)]}
   (let [table-name (format-name table-name)]
     (or (db/select-one-id Table, :db_id db-id, :name table-name)
         (db/select-one-id Table, :db_id db-id, :name (i/db-qualified-table-name (db/select-one-field :name Database :id db-id) table-name))

--- a/test/metabase/test/mock/moviedb.clj
+++ b/test/metabase/test/mock/moviedb.clj
@@ -4,77 +4,96 @@
 
 
 (def ^:private ^:const moviedb-tables
-  {"movies"  {:name   "movies"
-              :schema nil
-              :fields #{{:name      "id"
-                         :base-type :type/Integer}
-                        {:name      "title"
-                         :base-type :type/Text}
-                        {:name      "filming"
-                         :base-type :type/Boolean}}}
-   "actors"  {:name   "actors"
-              :schema nil
-              :fields #{{:name      "id"
-                         :base-type :type/Integer}
-                        {:name      "name"
-                         :base-type :type/Text}}}
-   "roles"   {:name   "roles"
-              :schema nil
-              :fields #{{:name      "id"
-                         :base-type :type/Integer}
-                        {:name      "movie_id"
-                         :base-type :type/Integer}
-                        {:name      "actor_id"
-                         :base-type :type/Integer}
-                        {:name      "character"
-                         :base-type :type/Text}
-                        {:name      "salary"
-                         :base-type :type/Decimal}}
-              :fks    #{{:fk-column-name   "movie_id"
-                         :dest-table       {:name "movies"
-                                            :schema nil}
-                         :dest-column-name "id"}
-                        {:fk-column-name   "actor_id"
-                         :dest-table       {:name "actors"
-                                            :schema nil}
-                         :dest-column-name "id"}}}
-   "reviews" {:name   "reviews"
-              :schema nil
-              :fields #{{:name      "id"
-                         :base-type :type/Integer}
-                        {:name      "movie_id"
-                         :base-type :type/Integer}
-                        {:name      "stars"
-                         :base-type :type/Integer}}
-              :fks    #{{:fk-column-name   "movie_id"
-                         :dest-table       {:name   "movies"
-                                            :schema nil}
-                         :dest-column-name "id"}}}})
+  {"movies"
+   {:name   "movies"
+    :schema nil
+    :fields #{{:name      "id"
+               :base-type :type/Integer}
+              {:name      "title"
+               :base-type :type/Text}
+              {:name      "filming"
+               :base-type :type/Boolean}}}
+
+   "actors"
+   {:name   "actors"
+    :schema nil
+    :fields #{{:name      "id"
+               :base-type :type/Integer}
+              {:name      "name"
+               :base-type :type/Text}}}
+
+   "roles"
+   {:name   "roles"
+    :schema nil
+    :fields #{{:name      "id"
+               :base-type :type/Integer}
+              {:name      "movie_id"
+               :base-type :type/Integer}
+              {:name      "actor_id"
+               :base-type :type/Integer}
+              {:name      "character"
+               :base-type :type/Text}
+              {:name      "salary"
+               :base-type :type/Decimal}}
+    :fks    #{{:fk-column-name   "movie_id"
+               :dest-table       {:name   "movies"
+                                  :schema nil}
+               :dest-column-name "id"}
+              {:fk-column-name   "actor_id"
+               :dest-table       {:name   "actors"
+                                  :schema nil}
+               :dest-column-name "id"}}}
+
+   "reviews"
+   {:name   "reviews"
+    :schema nil
+    :fields #{{:name      "id"
+               :base-type :type/Integer}
+              {:name      "movie_id"
+               :base-type :type/Integer}
+              {:name      "stars"
+               :base-type :type/Integer}}
+    :fks    #{{:fk-column-name   "movie_id"
+               :dest-table       {:name   "movies"
+                                  :schema nil}
+               :dest-column-name "id"}}}})
+
 
 (defrecord MovieDbDriver []
   clojure.lang.Named
   (getName [_] "MovieDbDriver"))
 
+
+(defn- describe-database [_ {:keys [exclude-tables]}]
+  (let [tables (for [table (vals moviedb-tables)
+                     :when (not (contains? exclude-tables (:name table)))]
+                 (select-keys table [:schema :name]))]
+    {:tables (set tables)}))
+
+(defn- describe-table [_ _ table]
+  (-> (get moviedb-tables (:name table))
+      (dissoc :fks)))
+
+(defn- describe-table-fks [_ _ table]
+  (-> (get moviedb-tables (:name table))
+      :fks
+      set))
+
+(defn- table-rows-seq [_ _ table]
+  [{:keypath "movies.filming.description", :value "If the movie is currently being filmed."}
+   {:keypath "movies.description", :value "A cinematic adventure."}])
+
+
 (extend MovieDbDriver
   driver/IDriver
   (merge driver/IDriverDefaultsMixin
          {:analyze-table      (constantly nil)
-          :describe-database  (fn [_ {:keys [exclude-tables]}]
-                                (let [tables (for [table (vals moviedb-tables)
-                                                   :when (not (contains? exclude-tables (:name table)))]
-                                               (select-keys table [:schema :name]))]
-                                  {:tables (set tables)}))
-          :describe-table     (fn [_ _ table]
-                                (-> (get moviedb-tables (:name table))
-                                    (dissoc :fks)))
-          :describe-table-fks (fn [_ _ table]
-                                (-> (get moviedb-tables (:name table))
-                                    :fks
-                                    set))
+          :describe-database  describe-database
+          :describe-table     describe-table
+          :describe-table-fks describe-table-fks
           :features           (constantly #{:foreign-keys})
           :details-fields     (constantly [])
-          :table-rows-seq     (constantly [{:keypath "movies.filming.description", :value "If the movie is currently being filmed."}
-                                           {:keypath "movies.description", :value "A cinematic adventure."}])}))
+          :table-rows-seq     table-rows-seq}))
 
 (driver/register-driver! :moviedb (MovieDbDriver.))
 


### PR DESCRIPTION
Things like indentations fixes, extra comments/docstrings, general code cleanup, etc. backported from #5510 because they aren't specific to refactoring the sync process.