### PR TITLE
Change buildpack URL

### DIFF
--- a/docs/operations-guide/running-metabase-on-heroku.md
+++ b/docs/operations-guide/running-metabase-on-heroku.md
@@ -58,7 +58,7 @@ git remote add heroku https://git.heroku.com/your-metabase-app.git
 
 * If you are upgrading from a version that is lower than 0.25, add the Metabase buildpack to your Heroku app:
 ```
-heroku buildpacks:add https://github.com/metabase/metabase-heroku
+heroku buildpacks:add https://github.com/metabase/metabase-buildpack
 ```
 
 * Force push the new version to Heroku:


### PR DESCRIPTION
To point to the same buildpack as is used in metabase-deploy. The current URL causes git push to fail because it can't find the buildpack.



###### TODO 
-  [ ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
