### PR TITLE
Better UI state for db adding in admin section

### DIFF
--- a/frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx
@@ -4,9 +4,7 @@ import cx from "classnames";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper.jsx";
 import DatabaseDetailsForm from "metabase/components/DatabaseDetailsForm.jsx";
 
-
 export default class DatabaseEditForms extends Component {
-
     static propTypes = {
         database: PropTypes.object,
         details: PropTypes.object,
@@ -18,7 +16,7 @@ export default class DatabaseEditForms extends Component {
     };
 
     render() {
-        let { database, details, hiddenFields, engines, formState: { formError, formSuccess } } = this.props;
+        let { database, details, hiddenFields, engines, formState: { formError, formSuccess, isSubmitting } } = this.props;
 
         let errors = {};
         return (
@@ -44,7 +42,8 @@ export default class DatabaseEditForms extends Component {
                               formSuccess={formSuccess}
                               hiddenFields={hiddenFields}
                               submitFn={(database) => this.props.save({ ...database, id: this.props.database.id }, database.details)}
-                              submitButtonText={'Save'}>
+                              submitButtonText={'Save'}
+                              submitting={isSubmitting}>
                           </DatabaseDetailsForm>
                           : null }
                     </div>

--- a/frontend/src/metabase/admin/databases/containers/DatabaseListApp.integ.spec.js
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseListApp.integ.spec.js
@@ -5,13 +5,27 @@ import {
 
 import { mount } from "enzyme";
 import {
-    FETCH_DATABASES, DELETE_DATABASE, SAVE_DATABASE, INITIALIZE_DATABASE,
-    START_ADD_DATABASE
-} from "metabase/admin/databases/database"
+    FETCH_DATABASES,
+    initializeDatabase,
+    INITIALIZE_DATABASE,
+    DELETE_DATABASE_FAILED,
+    DELETE_DATABASE,
+    CREATE_DATABASE_STARTED,
+    CREATE_DATABASE_FAILED,
+    CREATE_DATABASE,
+    UPDATE_DATABASE_STARTED,
+    UPDATE_DATABASE_FAILED,
+    UPDATE_DATABASE,
+} from "../database"
+
 import DatabaseListApp from "metabase/admin/databases/containers/DatabaseListApp";
 
 import { MetabaseApi } from 'metabase/services'
 import DatabaseEditApp from "metabase/admin/databases/containers/DatabaseEditApp";
+import { delay } from "metabase/lib/promise"
+import { getEditingDatabase } from "metabase/admin/databases/selectors";
+import FormMessage, { SERVER_ERROR_MESSAGE } from "metabase/components/form/FormMessage";
+import CreatedDatabaseModal from "metabase/admin/databases/components/CreatedDatabaseModal";
 
 describe('dashboard list', () => {
 
@@ -33,8 +47,8 @@ describe('dashboard list', () => {
     })
 
     describe('adds', () => {
-        it('should not block adding a new db', async () => {
-            MetabaseApi.db_create = async (db) => { return {...db, id: 10}; };
+        it("should work and shouldn't let you accidentally add db twice", async () => {
+            MetabaseApi.db_create = async (db) => { await delay(10); return {...db, id: 10}; };
 
             const store = await createTestStore()
             store.pushPath("/admin/databases");
@@ -61,31 +75,73 @@ describe('dashboard list', () => {
             updateInputValue("dbname", "test_postgres_db");
             updateInputValue("user", "uberadmin");
 
-            expect(dbDetailsForm.find('button[children="Save"]').props().disabled).toBe(false)
-            dbDetailsForm.find('button[children="Save"]').simulate("submit");
+            const saveButton = dbDetailsForm.find('button[children="Save"]')
 
-            await store.waitForActions([START_ADD_DATABASE])
+            expect(saveButton.props().disabled).toBe(false)
+            saveButton.simulate("submit");
 
-            expect(store.getPath()).toEqual("/admin/databases")
+            // Now the submit button should be disabled so that you aren't able to trigger the db creation action twice
+            await store.waitForActions([CREATE_DATABASE_STARTED])
+            expect(saveButton.text()).toBe("Saving...");
+            expect(saveButton.props().disabled).toBe(true);
 
-            const listAppAfterAdd = app.find(DatabaseListApp)
-            expect(listAppAfterAdd.length).toBe(1);
+            await store.waitForActions([CREATE_DATABASE]);
 
-            // we should now have a disabled db row during the add
-            expect(listAppAfterAdd.find('tr.disabled').length).toEqual(1)
-
-            // wait until db creation finishes
-            await store.waitForActions([SAVE_DATABASE])
-
-            // there should be no disabled db rows now
-            expect(listAppAfterAdd.find('tr.disabled').length).toEqual(0)
+            expect(store.getPath()).toEqual("/admin/databases?created=10")
+            expect(app.find(CreatedDatabaseModal).length).toBe(1);
         })
+
+        it('should show error correctly on failure', async () => {
+            MetabaseApi.db_create = async () => {
+                await delay(10);
+                return Promise.reject({
+                    status: 400,
+                    data: {},
+                    isCancelled: false
+                })
+            }
+
+            const store = await createTestStore()
+            store.pushPath("/admin/databases");
+
+            const app = mount(store.getAppContainer())
+            await store.waitForActions([FETCH_DATABASES])
+
+            const listAppBeforeAdd = app.find(DatabaseListApp)
+
+            const addDbButton = listAppBeforeAdd.find('.Button.Button--primary').first()
+            clickRouterLink(addDbButton)
+
+            const dbDetailsForm = app.find(DatabaseEditApp);
+            expect(dbDetailsForm.length).toBe(1);
+
+            await store.waitForActions([INITIALIZE_DATABASE]);
+
+            const saveButton = dbDetailsForm.find('button[children="Save"]')
+            expect(saveButton.props().disabled).toBe(true)
+
+            const updateInputValue = (name, value) =>
+                dbDetailsForm.find(`input[name="${name}"]`).simulate('change', { target: { value } });
+
+            updateInputValue("name", "Test db name");
+            updateInputValue("dbname", "test_postgres_db");
+            updateInputValue("user", "uberadmin");
+
+            expect(saveButton.props().disabled).toBe(false)
+            saveButton.simulate("submit");
+
+            await store.waitForActions([CREATE_DATABASE_STARTED])
+            expect(saveButton.text()).toBe("Saving...");
+
+            await store.waitForActions([CREATE_DATABASE_FAILED]);
+            expect(dbDetailsForm.find(FormMessage).text()).toEqual(SERVER_ERROR_MESSAGE);
+            expect(saveButton.text()).toBe("Save");
+        });
     })
 
     describe('deletes', () => {
         it('should not block deletes', async () => {
-            // mock the db_delete method call to simulate a longer running delete
-            MetabaseApi.db_delete = () => {}
+            MetabaseApi.db_delete = async () => await delay(10)
 
             const store = await createTestStore()
             store.pushPath("/admin/databases");
@@ -116,8 +172,143 @@ describe('dashboard list', () => {
             // there should be no disabled db rows now
             expect(wrapper.find('tr.disabled').length).toEqual(0)
 
-            // we should now have one less database in the list
+            // we should now have one database less in the list
             expect(wrapper.find('tr').length).toEqual(dbCount - 1)
         })
+
+        it('should show error correctly on failure', async () => {
+            MetabaseApi.db_delete = async () => {
+                await delay(10);
+                return Promise.reject({
+                    status: 400,
+                    data: {},
+                    isCancelled: false
+                })
+            }
+
+            const store = await createTestStore()
+            store.pushPath("/admin/databases");
+
+            const app = mount(store.getAppContainer())
+            await store.waitForActions([FETCH_DATABASES])
+
+            const wrapper = app.find(DatabaseListApp)
+            const dbCount = wrapper.find('tr').length
+
+            const deleteButton = wrapper.find('.Button.Button--danger').first()
+
+            deleteButton.simulate('click')
+
+            const deleteModal = wrapper.find('.test-modal')
+            deleteModal.find('.Form-input').simulate('change', { target: { value: "DELETE" }})
+            deleteModal.find('.Button.Button--danger').simulate('click')
+
+            // test that the modal is gone
+            expect(wrapper.find('.test-modal').length).toEqual(0)
+
+            // we should now have a disabled db row during delete
+            expect(wrapper.find('tr.disabled').length).toEqual(1)
+
+            // db delete fails
+            await store.waitForActions([DELETE_DATABASE_FAILED])
+
+            // there should be no disabled db rows now
+            expect(wrapper.find('tr.disabled').length).toEqual(0)
+
+            // the db count should be same as before
+            expect(wrapper.find('tr').length).toEqual(dbCount)
+
+            expect(wrapper.find(FormMessage).text()).toBe(SERVER_ERROR_MESSAGE);
+        })
+    })
+
+    describe('editing', () => {
+        const newName = "Ex-Sample Data Set";
+
+        it('should be able to edit database name', async () => {
+            const store = await createTestStore()
+            store.pushPath("/admin/databases");
+
+            const app = mount(store.getAppContainer())
+            await store.waitForActions([FETCH_DATABASES])
+
+            const wrapper = app.find(DatabaseListApp)
+            const sampleDatasetEditLink = wrapper.find('a[children="Sample Dataset"]').first()
+            clickRouterLink(sampleDatasetEditLink);
+
+            expect(store.getPath()).toEqual("/admin/databases/1")
+            await store.waitForActions([INITIALIZE_DATABASE]);
+
+            const dbDetailsForm = app.find(DatabaseEditApp);
+            expect(dbDetailsForm.length).toBe(1);
+
+            const nameField = dbDetailsForm.find(`input[name="name"]`);
+            expect(nameField.props().value).toEqual("Sample Dataset")
+
+            nameField.simulate('change', { target: { value: newName } });
+
+            const saveButton = dbDetailsForm.find('button[children="Save"]')
+            saveButton.simulate("submit");
+
+            await store.waitForActions([UPDATE_DATABASE_STARTED]);
+            expect(saveButton.text()).toBe("Saving...");
+            expect(saveButton.props().disabled).toBe(true);
+
+            await store.waitForActions([UPDATE_DATABASE]);
+            expect(saveButton.props().disabled).toBe(undefined);
+            expect(dbDetailsForm.find(FormMessage).text()).toEqual("Successfully saved!");
+        })
+
+        it('should show the updated database name', async () => {
+            const store = await createTestStore()
+            store.pushPath("/admin/databases/1");
+
+            const app = mount(store.getAppContainer())
+            await store.waitForActions([INITIALIZE_DATABASE]);
+
+            const dbDetailsForm = app.find(DatabaseEditApp);
+            expect(dbDetailsForm.length).toBe(1);
+
+            const nameField = dbDetailsForm.find(`input[name="name"]`);
+            expect(nameField.props().value).toEqual(newName)
+        });
+
+        it('should show an error if saving fails', async () => {
+            const store = await createTestStore()
+            store.pushPath("/admin/databases/1");
+
+            const app = mount(store.getAppContainer())
+            await store.waitForActions([INITIALIZE_DATABASE]);
+
+            const dbDetailsForm = app.find(DatabaseEditApp);
+            expect(dbDetailsForm.length).toBe(1);
+
+            const tooLongName = "too long name ".repeat(100);
+            const nameField = dbDetailsForm.find(`input[name="name"]`);
+            nameField.simulate('change', { target: { value: tooLongName } });
+
+            const saveButton = dbDetailsForm.find('button[children="Save"]')
+            saveButton.simulate("submit");
+
+            await store.waitForActions([UPDATE_DATABASE_STARTED]);
+            expect(saveButton.text()).toBe("Saving...");
+            expect(saveButton.props().disabled).toBe(true);
+
+            await store.waitForActions([UPDATE_DATABASE_FAILED]);
+            expect(saveButton.props().disabled).toBe(undefined);
+            expect(dbDetailsForm.find(".Form-message.text-error").length).toBe(1);
+        });
+
+        afterAll(async () => {
+            const store = await createTestStore()
+            store.dispatch(initializeDatabase(1));
+            await store.waitForActions([INITIALIZE_DATABASE])
+            const sampleDatasetDb = getEditingDatabase(store.getState())
+
+            await MetabaseApi.db_update({
+                ...sampleDatasetDb,
+                name: "Sample Dataset"
+            });
+        });
     })
 })

--- a/frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx
@@ -13,10 +13,12 @@ import DeleteDatabaseModal from "../components/DeleteDatabaseModal.jsx";
 
 import {
     getDatabasesSorted,
-    hasSampleDataset
+    hasSampleDataset,
+    getDeletes,
+    getDeletionError
 } from "../selectors";
 import * as databaseActions from "../database";
-
+import FormMessage from "metabase/components/form/FormMessage";
 
 const mapStateToProps = (state, props) => {
     return {
@@ -24,8 +26,8 @@ const mapStateToProps = (state, props) => {
         databases:            getDatabasesSorted(state),
         hasSampleDataset:     hasSampleDataset(state),
         engines:              MetabaseSettings.get('engines'),
-        adds:                 state.admin.databases.adds,
-        deletes:              state.admin.databases.deletes
+        deletes:              getDeletes(state),
+        deletionError:        getDeletionError(state)
     }
 }
 
@@ -38,7 +40,9 @@ export default class DatabaseList extends Component {
     static propTypes = {
         databases: PropTypes.array,
         hasSampleDataset: PropTypes.bool,
-        engines: PropTypes.object
+        engines: PropTypes.object,
+        deletes: PropTypes.array,
+        deletionError: PropTypes.object
     };
 
     componentWillMount() {
@@ -52,7 +56,7 @@ export default class DatabaseList extends Component {
     }
 
     render() {
-        let { databases, hasSampleDataset, created, engines } = this.props;
+        let { databases, hasSampleDataset, created, engines, deletionError } = this.props;
 
         return (
             <div className="wrapper">
@@ -60,6 +64,11 @@ export default class DatabaseList extends Component {
                     <Link to="/admin/databases/create" className="Button Button--primary float-right">Add database</Link>
                     <h2 className="PageTitle">Databases</h2>
                 </section>
+                { deletionError &&
+                    <section>
+                        <FormMessage formError={deletionError} />
+                    </section>
+                }
                 <section>
                     <table className="ContentTable">
                         <thead>
@@ -70,22 +79,6 @@ export default class DatabaseList extends Component {
                             </tr>
                         </thead>
                         <tbody>
-                            { this.props.adds.map((database) =>
-                                <tr
-                                    key={database.name}
-                                    className={'disabled'}
-                                >
-                                    <td>
-                                        <Link to={"/admin/databases/" + database.id} className="text-bold link">
-                                            {database.name}
-                                        </Link>
-                                    </td>
-                                    <td>
-                                        {engines && engines[database.engine] ? engines[database.engine]['driver-name'] : database.engine}
-                                    </td>
-                                    <td className="text-right">Adding...</td>
-                                </tr>
-                            ) }
                             { databases ?
                                 [ databases.map(database => {
                                     const isDeleting = this.props.deletes.indexOf(database.id) !== -1

--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -14,8 +14,15 @@ const SELECT_ENGINE = "metabase/admin/databases/SELECT_ENGINE";
 export const FETCH_DATABASES = "metabase/admin/databases/FETCH_DATABASES";
 export const INITIALIZE_DATABASE = "metabase/admin/databases/INITIALIZE_DATABASE";
 const ADD_SAMPLE_DATASET = "metabase/admin/databases/ADD_SAMPLE_DATASET";
-export const SAVE_DATABASE = "metabase/admin/databases/SAVE_DATABASE";
+export const UPDATE_DATABASE = 'metabase/admin/databases/UPDATE_DATABASE'
+export const UPDATE_DATABASE_STARTED = 'metabase/admin/databases/UPDATE_DATABASE_STARTED'
+export const UPDATE_DATABASE_FAILED = 'metabase/admin/databases/UPDATE_DATABASE_FAILED'
+export const CREATE_DATABASE = 'metabase/admin/databases/CREATE_DATABASE'
+export const CREATE_DATABASE_STARTED = 'metabase/admin/databases/CREATE_DATABASE_STARTED'
+export const CREATE_DATABASE_FAILED = 'metabase/admin/databases/CREATE_DATABASE_FAILED'
 export const DELETE_DATABASE = "metabase/admin/databases/DELETE_DATABASE";
+export const DELETE_DATABASE_STARTED = 'metabase/admin/databases/DELETE_DATABASE_STARTED'
+export const DELETE_DATABASE_FAILED = "metabase/admin/databases/DELETE_DATABASE_FAILED";
 const SYNC_DATABASE = "metabase/admin/databases/SYNC_DATABASE";
 
 export const reset = createAction(RESET);
@@ -73,70 +80,69 @@ export const addSampleDataset = createThunkAction(ADD_SAMPLE_DATASET, function()
     };
 });
 
-export const START_ADD_DATABASE = 'metabase/admin/databases/START_ADD_DATABASE'
-const startAddDatabase = createAction(START_ADD_DATABASE)
-
-// saveDatabase
-export const saveDatabase = createThunkAction(SAVE_DATABASE, function(database, details) {
-    return async function(dispatch, getState) {
-        let savedDatabase, formState;
-
+export const createDatabase = function (database) {
+    return async function (dispatch, getState) {
         try {
-            //$scope.$broadcast("form:reset");
-            database.details = details;
-            if (database.id) {
-                //$scope.$broadcast("form:api-success", "Successfully saved!");
-                savedDatabase = await MetabaseApi.db_update(database);
-                MetabaseAnalytics.trackEvent("Databases", "Update", database.engine);
-            } else {
-                //$scope.$broadcast("form:api-success", "Successfully created!");
-                //$scope.$emit("database:created", new_database);
-                dispatch(push('/admin/databases'))
-                dispatch(startAddDatabase(database))
-                savedDatabase = await MetabaseApi.db_create(database);
-                MetabaseAnalytics.trackEvent("Databases", "Create", database.engine);
+            dispatch.action(CREATE_DATABASE_STARTED, { database })
+            const createdDatabase = await MetabaseApi.db_create(database);
+            MetabaseAnalytics.trackEvent("Databases", "Create", database.engine);
 
-                // update the db metadata already here because otherwise there will be a gap between "Adding..." status
-                // and seeing the db that was just added
-                await dispatch(fetchDatabases())
-                dispatch(push('/admin/databases?created='+savedDatabase.id));
-            }
-
-            // this object format is what FormMessage expects:
-            formState = { formSuccess: { data: { message: "Successfully saved!" }}};
-
+            // update the db metadata already here because otherwise there will be a gap between "Adding..." status
+            // and seeing the db that was just added
+            await dispatch(fetchDatabases())
+            dispatch(push('/admin/databases?created=' + createdDatabase.id));
+            dispatch.action(CREATE_DATABASE, { database: createdDatabase })
         } catch (error) {
-            //$scope.$broadcast("form:api-error", error);
-            console.error("error saving database", error);
-            MetabaseAnalytics.trackEvent("Databases", database.id ? "Update Failed" : "Create Failed", database.engine);
-            formState = { formError: error };
-        }
-
-        return {
-            database: savedDatabase,
-            formState
+            console.error("error creating a database", error);
+            MetabaseAnalytics.trackEvent("Databases", "Create Failed", database.engine);
+            dispatch.action(CREATE_DATABASE_FAILED, { database, error })
         }
     };
-});
+}
 
-const START_DELETE_DATABASE = 'metabase/admin/databases/START_DELETE_DATABASE'
-const startDeleteDatabase = createAction(START_DELETE_DATABASE)
-
-
-// deleteDatabase
-export const deleteDatabase = createThunkAction(DELETE_DATABASE, function(databaseId, redirect=true) {
+export const updateDatabase = function(database) {
     return async function(dispatch, getState) {
         try {
-            dispatch(startDeleteDatabase(databaseId))
+            dispatch.action(UPDATE_DATABASE_STARTED, { database })
+            const savedDatabase = await MetabaseApi.db_update(database);
+            MetabaseAnalytics.trackEvent("Databases", "Update", database.engine);
+
+            dispatch.action(UPDATE_DATABASE, { database: savedDatabase })
+        } catch (error) {
+            MetabaseAnalytics.trackEvent("Databases", "Update Failed", database.engine);
+            dispatch.action(UPDATE_DATABASE_FAILED, { error });
+        }
+    };
+};
+
+// NOTE Atte Keinänen 7/26/17: Original monolithic saveDatabase was broken out to smaller actions
+// but `saveDatabase` action creator is still left here for keeping the interface for React components unchanged
+export const saveDatabase = function(database, details) {
+    return async function(dispatch, getState) {
+        database.details = details;
+        const isUnsavedDatabase = !database.id
+        if (isUnsavedDatabase) {
+            dispatch(createDatabase(database))
+        } else {
+            dispatch(updateDatabase(database))
+        }
+    };
+};
+
+export const deleteDatabase = function(databaseId, isDetailView = true) {
+    return async function(dispatch, getState) {
+        try {
+            dispatch.action(DELETE_DATABASE_STARTED, { databaseId })
             dispatch(push('/admin/databases/'));
             await MetabaseApi.db_delete({"dbId": databaseId});
-            MetabaseAnalytics.trackEvent("Databases", "Delete", redirect ? "Using Detail" : "Using List");
-            return databaseId;
+            MetabaseAnalytics.trackEvent("Databases", "Delete", isDetailView ? "Using Detail" : "Using List");
+            dispatch.action(DELETE_DATABASE, { databaseId })
         } catch(error) {
             console.log('error deleting database', error);
+            dispatch.action(DELETE_DATABASE_FAILED, { databaseId, error })
         }
     };
-});
+}
 
 // syncDatabase
 export const syncDatabase = createThunkAction(SYNC_DATABASE, function(databaseId) {
@@ -157,45 +163,44 @@ export const syncDatabase = createThunkAction(SYNC_DATABASE, function(databaseId
 const databases = handleActions({
     [FETCH_DATABASES]: { next: (state, { payload }) => payload },
     [ADD_SAMPLE_DATASET]: { next: (state, { payload }) => payload ? [...state, payload] : state },
-    [DELETE_DATABASE]: { next: (state, { payload }) => payload ? _.reject(state, (d) => d.id === payload) : state }
+    [DELETE_DATABASE]: (state, { payload: { databaseId} }) =>
+        databaseId ? _.reject(state, (d) => d.id === databaseId) : state
 }, null);
 
 const editingDatabase = handleActions({
     [RESET]: { next: () => null },
     [INITIALIZE_DATABASE]: { next: (state, { payload }) => payload },
-    [SAVE_DATABASE]: { next: (state, { payload }) => payload.database || state },
+    [UPDATE_DATABASE]: { next: (state, { payload }) => payload.database || state },
     [DELETE_DATABASE]: { next: (state, { payload }) => null },
     [SELECT_ENGINE]: { next: (state, { payload }) => ({...state, engine: payload }) }
 }, null);
 
-const adds = handleActions({
-    [START_ADD_DATABASE]: {
-        next: (state, { payload }) => state.concat([payload])
-    },
-    [SAVE_DATABASE]: {
-        next: (state, { payload }) => state.filter((db) => db.name !== payload.database.name)
-    }
-}, []);
-
 const deletes = handleActions({
-    [START_DELETE_DATABASE]: {
-        next: (state, { payload }) => state.concat([payload])
-    },
-    [DELETE_DATABASE]: {
-        next: (state, { payload }) => state.filter((dbId) => dbId !== payload)
-    }
+    [DELETE_DATABASE_STARTED]: (state, { payload: { databaseId } }) => state.concat([databaseId]),
+    [DELETE_DATABASE_FAILED]: (state, { payload: { databaseId, error } }) => state.filter((dbId) => dbId !== databaseId),
+    [DELETE_DATABASE]: (state, { payload: { databaseId } }) => state.filter((dbId) => dbId !== databaseId)
 }, []);
 
-const DEFAULT_FORM_STATE = { formSuccess: null, formError: null };
+const deletionError = handleActions({
+    [DELETE_DATABASE_FAILED]: (state, { payload: { error } }) => error,
+}, null)
+
+const DEFAULT_FORM_STATE = { formSuccess: null, formError: null, isSubmitting: false };
 const formState = handleActions({
     [RESET]: { next: () => DEFAULT_FORM_STATE },
-    [SAVE_DATABASE]: { next: (state, { payload }) => payload.formState }
+    [CREATE_DATABASE_STARTED]: () => ({ isSubmitting: true }),
+    // not necessarily needed as the page is immediately redirected after db creation
+    [CREATE_DATABASE]: () => ({ formSuccess: { data: { message: "Successfully created!" } } }),
+    [CREATE_DATABASE_FAILED]: (state, { payload: { error } }) => ({ formError: error }),
+    [UPDATE_DATABASE_STARTED]: () => ({ isSubmitting: true }),
+    [UPDATE_DATABASE]: () => ({ formSuccess: { data: { message: "Successfully saved!" } } }),
+    [UPDATE_DATABASE_FAILED]: (state, { payload: { error } }) => ({ formError: error }),
 }, DEFAULT_FORM_STATE);
 
 export default combineReducers({
     databases,
     editingDatabase,
+    deletionError,
     formState,
-    adds,
     deletes
 });

--- a/frontend/src/metabase/admin/databases/selectors.js
+++ b/frontend/src/metabase/admin/databases/selectors.js
@@ -21,3 +21,6 @@ export const hasSampleDataset = createSelector(
 // Database Edit
 export const getEditingDatabase   = state => state.admin.databases.editingDatabase;
 export const getFormState         = state => state.admin.databases.formState;
+
+export const getDeletes           = state => state.admin.databases.deletes;
+export const getDeletionError     = state => state.admin.databases.deletionError;

--- a/frontend/src/metabase/components/DatabaseDetailsForm.jsx
+++ b/frontend/src/metabase/components/DatabaseDetailsForm.jsx
@@ -48,7 +48,8 @@ export default class DatabaseDetailsForm extends Component {
         formError: PropTypes.object,
         hiddenFields: PropTypes.object,
         submitButtonText: PropTypes.string.isRequired,
-        submitFn: PropTypes.func.isRequired
+        submitFn: PropTypes.func.isRequired,
+        submitting: PropTypes.boolean
     };
 
     validateForm() {
@@ -250,7 +251,7 @@ export default class DatabaseDetailsForm extends Component {
     }
 
     render() {
-        let { engine, engines, formError, formSuccess, hiddenFields, submitButtonText } = this.props;
+        let { engine, engines, formError, formSuccess, hiddenFields, submitButtonText, submitting } = this.props;
         let { valid } = this.state;
 
         let fields = [
@@ -278,8 +279,8 @@ export default class DatabaseDetailsForm extends Component {
                 </div>
 
                 <div className="Form-actions">
-                    <button className={cx("Button", {"Button--primary": valid})} disabled={!valid}>
-                        {submitButtonText}
+                    <button className={cx("Button", {"Button--primary": valid})} disabled={!valid || submitting}>
+                        {submitting ? "Saving..." : submitButtonText}
                     </button>
                     <FormMessage formError={formError} formSuccess={formSuccess}></FormMessage>
                 </div>

--- a/frontend/src/metabase/components/form/FormMessage.jsx
+++ b/frontend/src/metabase/components/form/FormMessage.jsx
@@ -1,9 +1,10 @@
 import React, { Component } from "react";
 import cx from "classnames";
 
+export const SERVER_ERROR_MESSAGE = "Server error encountered";
+export const UNKNOWN_ERROR_MESSAGE = "Unknown error encountered";
 
 export default class FormMessage extends Component {
-
     render() {
         let { className, formError, formSuccess, message } = this.props;
 
@@ -12,9 +13,9 @@ export default class FormMessage extends Component {
                 if (formError.data && formError.data.message) {
                     message = formError.data.message;
                 } else if (formError.status >= 400) {
-                    message = "Server error encountered";
+                    message = SERVER_ERROR_MESSAGE;
                 } else {
-                    message = "Unknown error encountered";
+                    message = UNKNOWN_ERROR_MESSAGE;
                 }
             } else if (formSuccess && formSuccess.data.message) {
                 message = formSuccess.data.message;


### PR DESCRIPTION
I tried to fix #3347 in #5523 by using similar non-blocking logic for db creation as what we have have for db deletion. That turned out to be a misguided decision. If the db creation fails (for instance because of invalid credentials), the form values user has entered are lost and user has to re-enter them.

That is unacceptable user experience so instead of having complicated non-blocking logic I reverted those changes and simply disable the save button and show "Saving..." when DB creation is in progress.

Other changes:
- Non-blocking database deletion (#5432) didn't display any error on db removal failure so I fixed that
- More extensive tests for the database admin section, including failure scenarios in db creation, updating and deletion
- Refactored the Redux actions of database section; they are now more atomic and easier to understand