### PR TITLE
Remove auto-guessing of timeseries

### DIFF
--- a/frontend/src/metabase/visualizations/lib/timeseries.js
+++ b/frontend/src/metabase/visualizations/lib/timeseries.js
@@ -19,8 +19,9 @@ const TIMESERIES_UNITS = new Set([
 // investigate the response from a dataset query and determine if the dimension is a timeseries
 export function dimensionIsTimeseries({ cols, rows }, i = 0) {
     return (
-        (isDate(cols[i]) && (cols[i].unit == null || TIMESERIES_UNITS.has(cols[i].unit))) ||
-        moment(rows[0] && rows[0][i], moment.ISO_8601).isValid()
+        // (isDate(cols[i]) && (cols[i].unit == null || TIMESERIES_UNITS.has(cols[i].unit))) ||
+        // moment(rows[0] && rows[0][i], moment.ISO_8601).isValid()
+        false
     );
 }
 


### PR DESCRIPTION
It's heavy-handed, but it works. Something is very broken with auto detection of time series -- I've got part numbers where the visualization breaks depending if a date-looking part is the first entry returned. This avoids that, and I haven't seen a downside yet.

I don't expect this to be merged, but I'm using it on my install, and I suspect there is other type work being done..

###### TODO 
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).