### PR TITLE
Have ./bin/osx-setup use getcwd() to figure out where ./bin/build is

### DIFF
--- a/bin/osx-setup
+++ b/bin/osx-setup
@@ -21,11 +21,13 @@ use constant UBERJAR_DEST => getcwd() . '/OSX/Resources/metabase.jar';
 use constant RESET_PW_SRC => getcwd() . '/reset-password-artifacts/reset-password/reset-password.jar';
 use constant RESET_PW_DEST => getcwd() . '/OSX/Resources/reset-password.jar';
 
+use constant BUILD_SCRIPT => getcwd() . '/bin/build';
+
 # Copy the JRE if needed
 (rcopy(JRE_HOME, JRE_DEST) or die $!) unless -d JRE_DEST;
 
 # Build jars if needed
-(system('./bin/build') or die $!) unless -f UBERJAR_SRC;
+(system(BUILD_SCRIPT) or die $!) unless -f UBERJAR_SRC;
 (system('lein', 'with-profile', 'reset-password', 'jar') or die $!) unless -f RESET_PW_SRC;
 
 # Copy jars over


### PR DESCRIPTION
Sometimes running `./bin/osx-setup` (script that copies JVM and whatnot into the relevant locations in the `OSX/` folder) fails because it tries to call `./bin/build` but can't figure out where it is. Minor tweak to determine the path by calling `getcwd()` like we do for the other targets in the script
