### PR TITLE
Fix broken urls in field detail data reference page

### DIFF
--- a/frontend/src/metabase/reference/databases/FieldDetail.jsx
+++ b/frontend/src/metabase/reference/databases/FieldDetail.jsx
@@ -36,7 +36,7 @@ import * as metadataActions from 'metabase/redux/metadata';
 import * as actions from 'metabase/reference/reference';
 
 
-const interestingQuestions = (database, table, field) => {
+const interestingQuestions = (database, table, field, metadata) => {
     return [
         {
             text: `Number of ${table.display_name} grouped by ${field.display_name}`,
@@ -46,7 +46,8 @@ const interestingQuestions = (database, table, field) => {
                 tableId: table.id,
                 fieldId: field.id,
                 getCount: true,
-                visualization: 'bar'
+                visualization: 'bar',
+                metadata
             })
         },
         {
@@ -57,7 +58,8 @@ const interestingQuestions = (database, table, field) => {
                 tableId: table.id,
                 fieldId: field.id,
                 getCount: true,
-                visualization: 'pie'
+                visualization: 'pie',
+                metadata
             })
         },
         {
@@ -66,7 +68,8 @@ const interestingQuestions = (database, table, field) => {
             link: getQuestionUrl({
                 dbId: database.id,
                 tableId: table.id,
-                fieldId: field.id
+                fieldId: field.id,
+                metadata
             })
         }
     ]
@@ -128,6 +131,7 @@ export default class FieldDetail extends Component {
         loading: PropTypes.bool,
         loadingError: PropTypes.object,
         submitting: PropTypes.bool,
+        metadata: PropTypes.object
     };
 
     render() {
@@ -146,6 +150,7 @@ export default class FieldDetail extends Component {
             handleSubmit,
             resetForm,
             submitting,
+            metadata
         } = this.props;
 
         const onSubmit = handleSubmit(async (fields) =>
@@ -226,7 +231,7 @@ export default class FieldDetail extends Component {
                             </li>
 
 
-                            { !isEditing && 
+                            { !isEditing &&
                                 <li className="relative">
                                     <Detail
                                         id="base_type"
@@ -246,7 +251,16 @@ export default class FieldDetail extends Component {
                                 </li>
                             { !isEditing &&
                                 <li className="relative">
-                                    <UsefulQuestions questions={interestingQuestions(this.props.database, this.props.table, this.props.field)} />
+                                    <UsefulQuestions
+                                        questions={
+                                            interestingQuestions(
+                                                this.props.database,
+                                                this.props.table,
+                                                this.props.field,
+                                                metadata
+                                            )
+                                        }
+                                    />
                                 </li>
                             }
 

--- a/frontend/src/metabase/reference/databases/FieldDetailContainer.jsx
+++ b/frontend/src/metabase/reference/databases/FieldDetailContainer.jsx
@@ -9,6 +9,7 @@ import FieldDetail from "metabase/reference/databases/FieldDetail.jsx"
 
 import * as metadataActions from 'metabase/redux/metadata';
 import * as actions from 'metabase/reference/reference';
+import { getMetadata } from "metabase/selectors/metadata";
 
 import {
     getDatabase,
@@ -23,7 +24,8 @@ const mapStateToProps = (state, props) => ({
     table: getTable(state, props),    
     field: getField(state, props),    
     databaseId: getDatabaseId(state, props),
-    isEditing: getIsEditing(state, props)
+    isEditing: getIsEditing(state, props),
+    metadata: getMetadata(state, props)
 });
 
 const mapDispatchToProps = {
@@ -40,7 +42,8 @@ export default class FieldDetailContainer extends Component {
         databaseId: PropTypes.number.isRequired,
         table: PropTypes.object.isRequired,
         field: PropTypes.object.isRequired,
-        isEditing: PropTypes.bool
+        isEditing: PropTypes.bool,
+        metadata: PropTypes.object
     };
 
     async fetchContainerData(){

--- a/frontend/src/metabase/reference/databases/databases.integ.spec.js
+++ b/frontend/src/metabase/reference/databases/databases.integ.spec.js
@@ -1,6 +1,7 @@
 import {
     login,
-    createTestStore
+    createTestStore,
+    clickRouterLink
 } from "metabase/__support__/integrated_tests";
 
 import React from 'react';
@@ -28,6 +29,10 @@ import List from "metabase/components/List.jsx";
 import ListItem from "metabase/components/ListItem.jsx";
 import ReferenceHeader from "../components/ReferenceHeader.jsx";
 import AdminAwareEmptyState from "metabase/components/AdminAwareEmptyState.jsx";
+import UsefulQuestions from "metabase/reference/components/UsefulQuestions";
+import QueryButton from "metabase/components/QueryButton";
+import { INITIALIZE_QB, QUERY_COMPLETED } from "metabase/query_builder/actions";
+import { getQuestion } from "metabase/query_builder/selectors";
 
 describe("The Reference Section", () => {
     // Test data
@@ -85,7 +90,7 @@ describe("The Reference Section", () => {
             const store = await createTestStore()
             store.pushPath("/reference/databases/1");
             mount(store.connectContainer(<DatabaseDetailContainer />));
-            await store.waitForActions([FETCH_DATABASE_METADATA])
+            await store.waitForActions([FETCH_DATABASE_METADATA, END_LOADING])
 
         })
         
@@ -94,7 +99,7 @@ describe("The Reference Section", () => {
             const store = await createTestStore()
             store.pushPath("/reference/databases/1/tables");
             mount(store.connectContainer(<TableListContainer />));
-            await store.waitForActions([FETCH_DATABASE_METADATA])
+            await store.waitForActions([FETCH_DATABASE_METADATA, END_LOADING])
         })
         // table detail
 
@@ -102,33 +107,33 @@ describe("The Reference Section", () => {
             const store = await createTestStore()
             store.pushPath("/reference/databases/1/tables/1");
             mount(store.connectContainer(<TableDetailContainer />));
-            await store.waitForActions([FETCH_DATABASE_METADATA])
+            await store.waitForActions([FETCH_DATABASE_METADATA, END_LOADING])
         })
 
        it("should see the Reviews table", async  () => {
             const store = await createTestStore()
             store.pushPath("/reference/databases/1/tables/2");
             mount(store.connectContainer(<TableDetailContainer />));
-            await store.waitForActions([FETCH_DATABASE_METADATA])
+            await store.waitForActions([FETCH_DATABASE_METADATA, END_LOADING])
         })
        it("should see the Products table", async  () => {
             const store = await createTestStore()
             store.pushPath("/reference/databases/1/tables/3");
             mount(store.connectContainer(<TableDetailContainer />));
-            await store.waitForActions([FETCH_DATABASE_METADATA])
+            await store.waitForActions([FETCH_DATABASE_METADATA, END_LOADING])
         })
        it("should see the People table", async  () => {
             const store = await createTestStore()
             store.pushPath("/reference/databases/1/tables/4");
             mount(store.connectContainer(<TableDetailContainer />));
-            await store.waitForActions([FETCH_DATABASE_METADATA])
+            await store.waitForActions([FETCH_DATABASE_METADATA, END_LOADING])
         })
         // field list
        it("should see the fields for the orders table", async  () => {
             const store = await createTestStore()
             store.pushPath("/reference/databases/1/tables/1/fields");
             mount(store.connectContainer(<FieldListContainer />));
-            await store.waitForActions([FETCH_DATABASE_METADATA])
+            await store.waitForActions([FETCH_DATABASE_METADATA, END_LOADING])
 
         })
        it("should see the questions for the orders tables", async  () => {
@@ -136,7 +141,7 @@ describe("The Reference Section", () => {
             const store = await createTestStore()
             store.pushPath("/reference/databases/1/tables/1/questions");
             mount(store.connectContainer(<TableQuestionsContainer />));
-            await store.waitForActions([FETCH_DATABASE_METADATA])
+            await store.waitForActions([FETCH_DATABASE_METADATA, END_LOADING])
             
             var card = await CardApi.create(cardDef)
 
@@ -151,16 +156,36 @@ describe("The Reference Section", () => {
             const store = await createTestStore()
             store.pushPath("/reference/databases/1/tables/1/fields/1");
             mount(store.connectContainer(<FieldDetailContainer />));
-            await store.waitForActions([FETCH_DATABASE_METADATA])
+            await store.waitForActions([FETCH_DATABASE_METADATA, END_LOADING])
+        })
+
+        it("should let you open a potentially useful question for created_at field without errors", async () => {
+            const store = await createTestStore()
+            store.pushPath("/reference/databases/1/tables/1/fields/1");
+
+            const app = mount(store.getAppContainer());
+
+            await store.waitForActions([FETCH_DATABASE_METADATA, END_LOADING])
+            const fieldDetails = app.find(FieldDetailContainer);
+            expect(fieldDetails.length).toBe(1);
+
+            const usefulQuestionLink = fieldDetails.find(UsefulQuestions).find(QueryButton).first().find("a");
+            expect(usefulQuestionLink.text()).toBe("Number of Orders grouped by Created At")
+            clickRouterLink(usefulQuestionLink);
+
+            await store.waitForActions([INITIALIZE_QB, QUERY_COMPLETED]);
+
+            const qbQuery = getQuestion(store.getState()).query();
+
+            // the granularity/subdimension should be applied correctly to the breakout
+            expect(qbQuery.breakouts()).toEqual([["datetime-field", ["field-id", 1], "day"]]);
         })
 
        it("should see the orders id field", async () => {
             const store = await createTestStore()
             store.pushPath("/reference/databases/1/tables/1/fields/25");
             mount(store.connectContainer(<FieldDetailContainer />));
-            await store.waitForActions([FETCH_DATABASE_METADATA])
+            await store.waitForActions([FETCH_DATABASE_METADATA, END_LOADING])
         })
     });
-
-
 });

--- a/frontend/src/metabase/reference/metrics/metrics.integ.spec.js
+++ b/frontend/src/metabase/reference/metrics/metrics.integ.spec.js
@@ -105,15 +105,19 @@ describe("The Reference Section", () => {
 
             it("Should see a newly asked question in its questions list", async () => {
                     var card = await CardApi.create(metricCardDef)
-
                     expect(card.name).toBe(metricCardDef.name);
-                    // see that there is a new question on the metric's questions page
-                    const store = await createTestStore()    
-                    store.pushPath("/reference/metrics/"+metricIds[0]+'/questions');
-                    mount(store.connectContainer(<MetricQuestionsContainer />));
-                    await store.waitForActions([FETCH_METRICS, FETCH_METRIC_TABLE])
-                    
-                    await CardApi.delete({cardId: card.id})
+
+                    try {
+                        // see that there is a new question on the metric's questions page
+                        const store = await createTestStore()
+
+                        store.pushPath("/reference/metrics/"+metricIds[0]+'/questions');
+                        mount(store.connectContainer(<MetricQuestionsContainer />));
+                        await store.waitForActions([FETCH_METRICS, FETCH_METRIC_TABLE])
+                    } finally {
+                        // even if the code above results in an exception, try to delete the question
+                        await CardApi.delete({cardId: card.id})
+                    }
             })
 
                        


### PR DESCRIPTION
Fixes #5055. This was caused because the subdimension/bucketing (like "Day" or "Week of year") was missing from the question url in case of date breakout. Luckily I already had added the logic for inferring the default subdimension to `getQuestion` for one other data reference page so this PR is only about passing it the metadata parameter it needs for dimension stuff.