### PR TITLE
Tweak Mac App build script for Xcode 8 [Don't merge yet]

### DIFF
--- a/OSX/exportOptions.plist
+++ b/OSX/exportOptions.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>method</key>
+	<string>developer-id</string>
+        <key>teamID</key>
+        <string>BR27ZJK7WW</string>
+</dict>
+</plist>

--- a/bin/osx-release
+++ b/bin/osx-release
@@ -21,6 +21,7 @@ Readonly my $release_notes   => artifact('release-notes.html');
 Readonly my $dmg             => artifact('Metabase.dmg');
 
 Readonly my $xcode_project   => get_file_or_die('OSX/Metabase.xcodeproj');
+Readonly my $export_options  => get_file_or_die('OSX/exportOptions.plist');
 
 # Get the version saved in the CFBundle, e.g. '0.11.3.1'
 sub version {
@@ -82,9 +83,9 @@ sub build {
     # Ok, now create the Metabase.app artifact
     system('xcodebuild',
            '-exportArchive',
-           '-exportFormat', 'APP',
+           '-exportOptionsPlist', $export_options,
            '-archivePath', $xcarchive,
-           '-exportPath', $app) == 0 or die $!;
+           '-exportPath', OSX_ARTIFACTS_DIR) == 0 or die $!;
 
     # Ok, we can remove the .xcarchive file now
     remove_tree($xcarchive);


### PR DESCRIPTION
Apparently Apple changed how `xcodebuild` works in Xcode 8 because they wanted everyone to have the joy of dealing with broken build scripts. 

Hold off on merging this until I can double-check that this doesn't break building with my ancient computer still running Yosemite/Xcode 7 