### PR TITLE
Add timezone "Europe/Istanbul"

### DIFF
--- a/src/metabase/models/common.clj
+++ b/src/metabase/models/common.clj
@@ -69,6 +69,7 @@
    "Europe/Berlin"
    "Europe/Brussels"
    "Europe/Helsinki"
+   "Europe/Istanbul"
    "Europe/London"
    "Europe/Minsk"
    "Europe/Moscow"


### PR DESCRIPTION
I've added it as per the old discussion in #1751. I don't know if adding it here is enough for the support. So please guide me if not.

Probably there should be more timezones added to here, since timezones are political matters rather than geographical. Regards.

###### TODO 
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
