### PR TITLE
Change download button tooltip and menu label

### DIFF
--- a/frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx
@@ -18,14 +18,14 @@ const EXPORT_FORMATS = ["csv", "xlsx", "json"];
 const QueryDownloadWidget = ({ className, card, result, uuid, token }) =>
     <PopoverWithTrigger
         triggerElement={
-            <Tooltip tooltip="Download">
+            <Tooltip tooltip="Download full results">
                 <Icon title="Download this data" name="downarrow" size={16} />
             </Tooltip>
         }
         triggerClasses={cx(className, "text-brand-hover")}
     >
         <div className="p2" style={{ maxWidth: 320 }}>
-            <h4>Download</h4>
+            <h4>Download full results</h4>
             { result.data.rows_truncated != null &&
                 <FieldSet className="my2 text-gold border-gold" legend="Warning">
                     <div className="my1">Your answer has a large number of rows so it could take awhile to download.</div>


### PR DESCRIPTION
A poor man's fix for #5657. Just trying to clarify that the downloaded file might differ from the viewable results in terms of rows.

![screen shot 2017-08-02 at 1 00 35 pm](https://user-images.githubusercontent.com/2223916/28896529-a77f31a6-7791-11e7-8240-7a645d490909.png)

![screen shot 2017-08-02 at 1 00 38 pm](https://user-images.githubusercontent.com/2223916/28896534-a9923b82-7791-11e7-969a-32f61867d137.png)


Resolves #5657