### PR TITLE
Remove extraneous dependencies introduces with feature extraction

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -61,7 +61,8 @@
                  [hiccup "1.0.5"]                                     ; HTML templating
                  [honeysql "0.8.2"]                                   ; Transform Clojure data structures to SQL
                  [kixi/stats "0.3.8"                                  ; Various statistic measures implemented as transducers
-                  :exclusions [org.clojure/test.check]]
+                  :exclusions [org.clojure/test.check                 ; test.check and AVL trees are used in kixi.stats.random. Remove exlusion if using.
+                               org.clojure/data.avl]]
                  [log4j/log4j "1.2.17"                                ; logging framework
                   :exclusions [javax.mail/mail
                                javax.jms/jms

--- a/project.clj
+++ b/project.clj
@@ -75,7 +75,8 @@
                   :exclusions [org.slf4j/slf4j-api]]
                  [net.sourceforge.jtds/jtds "1.3.1"]                  ; Open Source SQL Server driver
                  [com.clearspring.analytics/stream "2.9.5"            ; Various sketching algorithms
-                  :exclusions [org.slf4j/slf4j-api]]
+                  :exclusions [org.slf4j/slf4j-api
+                               it.unimi.dsi/fastutil]]
                  [org.clojars.pntblnk/clj-ldap "0.0.12"]              ; LDAP client
                  [org.liquibase/liquibase-core "3.5.3"]               ; migration management (Java lib)
                  [org.slf4j/slf4j-log4j12 "1.7.25"]                   ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time

--- a/project.clj
+++ b/project.clj
@@ -43,6 +43,7 @@
                                net.sourceforge.nekohtml/nekohtml
                                ring/ring-core]]
                  [com.draines/postal "2.0.2"]                         ; SMTP library
+                 [com.github.brandtg/stl-java "0.1.1"]                ; STL decomposition
                  [com.google.apis/google-api-services-analytics       ; Google Analytics Java Client Library
                   "v3-rev139-1.22.0"]
                  [com.google.apis/google-api-services-bigquery        ; Google BigQuery Java Client Library
@@ -87,9 +88,6 @@
                  [ring/ring-jetty-adapter "1.6.0"]                    ; Ring adapter using Jetty webserver (used to run a Ring server for unit tests)
                  [ring/ring-json "0.4.0"]                             ; Ring middleware for reading/writing JSON automatically
                  [stencil "0.5.0"]                                    ; Mustache templates for Clojure
-                 [tide "0.3.0-SNAPSHOT"                               ; Various algorithms for working with timeseries
-                  :exclusions [com.github.davidmoten/fastdtw
-                               org.slf4j/slf4j-simple]]
                  [toucan "1.0.3"                                      ; Model layer, hydration, and DB utilities
                   :exclusions [honeysql]]]
   :repositories [["bintray" "https://dl.bintray.com/crate/crate"]]    ; Repo for Crate JDBC driver

--- a/project.clj
+++ b/project.clj
@@ -59,7 +59,8 @@
                  [environ "1.1.0"]                                    ; easy environment management
                  [hiccup "1.0.5"]                                     ; HTML templating
                  [honeysql "0.8.2"]                                   ; Transform Clojure data structures to SQL
-                 [kixi/stats "0.3.8"]                                 ; Various statistic measures implemented as transducers
+                 [kixi/stats "0.3.8"                                  ; Various statistic measures implemented as transducers
+                  :exclusions [org.clojure/test.check]]
                  [log4j/log4j "1.2.17"                                ; logging framework
                   :exclusions [javax.mail/mail
                                javax.jms/jms
@@ -71,7 +72,8 @@
                  [net.sf.cssbox/cssbox "4.12"                         ; HTML / CSS rendering
                   :exclusions [org.slf4j/slf4j-api]]
                  [net.sourceforge.jtds/jtds "1.3.1"]                  ; Open Source SQL Server driver
-                 [com.clearspring.analytics/stream "2.9.5"]           ; Various sketching algorithms
+                 [com.clearspring.analytics/stream "2.9.5"            ; Various sketching algorithms
+                  :exclusions [org.slf4j/slf4j-api]]
                  [org.clojars.pntblnk/clj-ldap "0.0.12"]              ; LDAP client
                  [org.liquibase/liquibase-core "3.5.3"]               ; migration management (Java lib)
                  [org.slf4j/slf4j-log4j12 "1.7.25"]                   ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
@@ -85,7 +87,9 @@
                  [ring/ring-jetty-adapter "1.6.0"]                    ; Ring adapter using Jetty webserver (used to run a Ring server for unit tests)
                  [ring/ring-json "0.4.0"]                             ; Ring middleware for reading/writing JSON automatically
                  [stencil "0.5.0"]                                    ; Mustache templates for Clojure
-                 [tide "0.1.0-SNAPSHOT"]                              ; Various algorithms for working with timeseries
+                 [tide "0.3.0-SNAPSHOT"                               ; Various algorithms for working with timeseries
+                  :exclusions [com.github.davidmoten/fastdtw
+                               org.slf4j/slf4j-simple]]
                  [toucan "1.0.3"                                      ; Model layer, hydration, and DB utilities
                   :exclusions [honeysql]]]
   :repositories [["bintray" "https://dl.bintray.com/crate/crate"]]    ; Repo for Crate JDBC driver

--- a/src/metabase/fingerprinting/fingerprinters.clj
+++ b/src/metabase/fingerprinting/fingerprinters.clj
@@ -13,10 +13,10 @@
             [medley.core :as m]
             [metabase.fingerprinting
              [histogram :as h]
-             [costs :as costs]]
+             [costs :as costs]
+             [stl :as stl]]
             [metabase.util :as u]            ;;;; temp!
-            [redux.core :as redux]
-            [tide.stl :as stl])
+            [redux.core :as redux])
   (:import com.clearspring.analytics.stream.cardinality.HyperLogLogPlus))
 
 (def ^:private ^:const percentiles (range 0 1 0.1))
@@ -329,10 +329,7 @@
                  :week  52
                  :day   365)]
     (when (>= (count ts) (* 2 period))
-      (select-keys (stl/decompose period {:periodic? true
-                                          :robust?   true}
-                                  ts)
-                   [:trend :seasonal :residual]))))
+      (select-keys (stl/decompose period ts) [:trend :seasonal :residual]))))
 
 (defmethod fingerprinter [DateTime Num]
   [{:keys [max-cost resolution query]} field]

--- a/src/metabase/fingerprinting/fingerprinters.clj
+++ b/src/metabase/fingerprinting/fingerprinters.clj
@@ -16,7 +16,7 @@
              [costs :as costs]]
             [metabase.util :as u]            ;;;; temp!
             [redux.core :as redux]
-            [tide.core :as tide])
+            [tide.stl :as stl])
   (:import com.clearspring.analytics.stream.cardinality.HyperLogLogPlus))
 
 (def ^:private ^:const percentiles (range 0 1 0.1))
@@ -329,7 +329,10 @@
                  :week  52
                  :day   365)]
     (when (>= (count ts) (* 2 period))
-      (select-keys (tide/decompose period ts) [:trend :seasonal :reminder]))))
+      (select-keys (stl/decompose period {:periodic? true
+                                          :robust?   true}
+                                  ts)
+                   [:trend :seasonal :residual]))))
 
 (defmethod fingerprinter [DateTime Num]
   [{:keys [max-cost resolution query]} field]

--- a/src/metabase/fingerprinting/stl.clj
+++ b/src/metabase/fingerprinting/stl.clj
@@ -29,9 +29,10 @@
                   (fn
                     ([] (.getConfig decomposer))
                     ([_]
-                     (let [^StlResult decomposition (.decompose decomposer
-                                                                xs
-                                                                (preprocess ys))]
+                     (let [^StlResult decomposition (.decompose
+                                                     ^StlDecomposition decomposer
+                                                     xs
+                                                     (preprocess ys))]
                        {:trend    (postprocess (.getTrend decomposition))
                         :seasonal (postprocess (.getSeasonal decomposition))
                         :residual (postprocess (.getRemainder decomposition))

--- a/src/metabase/fingerprinting/stl.clj
+++ b/src/metabase/fingerprinting/stl.clj
@@ -4,37 +4,42 @@
   (:import (com.github.brandtg.stl StlDecomposition StlResult StlConfig)))
 
 (def ^:private setters
-  {:inner-loop-passes           (memfn setNumberOfInnerLoopPasses n)
-   :robustness-iterations       (memfn setNumberOfRobustnessIterations n)
-   :trend-bandwidth             (memfn setTrendComponentBandwidth bw)
-   :seasonal-bandwidth          (memfn setSeasonalComponentBandwidth bw)
-   :loess-robustness-iterations (memfn setLoessRobustnessIterations n)
-   :periodic?                   (memfn setPeriodic periodic?)})
+  {:inner-loop-passes           (memfn ^StlConfig setNumberOfInnerLoopPasses n)
+   :robustness-iterations       (memfn ^StlConfig setNumberOfRobustnessIterations n)
+   :trend-bandwidth             (memfn ^StlConfig setTrendComponentBandwidth bw)
+   :seasonal-bandwidth          (memfn ^StlConfig setSeasonalComponentBandwidth bw)
+   :loess-robustness-iterations (memfn ^StlConfig setLoessRobustnessIterations n)
+   :periodic?                   (memfn ^StlConfig setPeriodic periodic?)})
 
 (defn decompose
   "Decompose time series into trend, seasonal component, and residual."
   ([period ts]
    (decompose period {} ts))
   ([period opts ts]
-   (let [xs                           (map first ts)
-         ys                           (map second ts)
-         preprocess                   (if-let [transform (:transform opts)]
-                                        (partial map transform)
-                                        identity)
-         postprocess                  (if-let [transform (:reverse-transform opts)]
-                                        (partial map transform)
-                                        vec)
-         ^StlDecomposition decomposer (StlDecomposition. period)
-         _                            (reduce-kv (fn [^StlConfig config k v]
-                                                   (when-let [setter (setters k)]
-                                                     (setter config v))
-                                                   config)
-                                                 (.getConfig decomposer)
-                                                 (merge {:inner-loop-passes 100}
-                                                        opts))
-         ^StlResult decomposition     (.decompose decomposer xs (preprocess ys))]
-     {:trend    (postprocess (.getTrend decomposition))
-      :seasonal (postprocess (.getSeasonal decomposition))
-      :residual (postprocess (.getRemainder decomposition))
-      :xs       xs
-      :ys       ys})))
+   (let [xs          (map first ts)
+         ys          (map second ts)
+         preprocess  (if-let [transform (:transform opts)]
+                       (partial map transform)
+                       identity)
+         postprocess (if-let [transform (:reverse-transform opts)]
+                       (partial map transform)
+                       vec)]
+     (transduce identity
+                (let [^StlDecomposition decomposer (StlDecomposition. period)]
+                  (fn
+                    ([] (.getConfig decomposer))
+                    ([_]
+                     (let [^StlResult decomposition (.decompose decomposer
+                                                                xs
+                                                                (preprocess ys))]
+                       {:trend    (postprocess (.getTrend decomposition))
+                        :seasonal (postprocess (.getSeasonal decomposition))
+                        :residual (postprocess (.getRemainder decomposition))
+                        :xs       xs
+                        :ys       ys}))
+                    ([^StlConfig config [k v]]
+                     (when-let [setter (setters k)]
+                       (setter config v))
+                     config)))
+                (merge {:inner-loop-passes 100}
+                       opts)))))

--- a/src/metabase/fingerprinting/stl.clj
+++ b/src/metabase/fingerprinting/stl.clj
@@ -1,0 +1,40 @@
+(ns metabase.fingerprinting.stl
+  "Seasonal-Trend Decomposition
+  https://www.wessa.net/download/stl.pdf"
+  (:import com.github.brandtg.stl.StlDecomposition))
+
+(def ^:private setters
+  {:inner-loop-passes           (memfn setNumberOfInnerLoopPasses n)
+   :robustness-iterations       (memfn setNumberOfRobustnessIterations n)
+   :trend-bandwidth             (memfn setTrendComponentBandwidth bw)
+   :seasonal-bandwidth          (memfn setSeasonalComponentBandwidth bw)
+   :loess-robustness-iterations (memfn setLoessRobustnessIterations n)
+   :periodic?                   (memfn setPeriodic periodic?)})
+
+(defn decompose
+  "Decompose time series into trend, seasonal component, and residual."
+  ([period ts]
+   (decompose period {} ts))
+  ([period opts ts]
+   (let [xs            (map first ts)
+         ys            (map second ts)
+         preprocess    (if-let [transform (:transform opts)]
+                         (partial map transform)
+                         identity)
+         postprocess   (if-let [transform (:reverse-transform opts)]
+                         (partial map transform)
+                         vec)
+         decomposer    (StlDecomposition. period)
+         _             (reduce-kv (fn [config k v]
+                                    (when-let [setter (setters k)]
+                                      (setter config v))
+                                    config)
+                                  (.getConfig decomposer)
+                                  (merge {:inner-loop-passes 100}
+                                         opts))
+         decomposition (.decompose decomposer xs (preprocess ys))]
+     {:trend    (postprocess (.getTrend decomposition))
+      :seasonal (postprocess (.getSeasonal decomposition))
+      :residual (postprocess (.getRemainder decomposition))
+      :xs       xs
+      :ys       ys})))

--- a/src/metabase/fingerprinting/stl.clj
+++ b/src/metabase/fingerprinting/stl.clj
@@ -30,9 +30,9 @@
                     ([] (.getConfig decomposer))
                     ([_]
                      (let [^StlResult decomposition (.decompose
-                                                     ^StlDecomposition decomposer
-                                                     xs
-                                                     (preprocess ys))]
+                                                     decomposer
+                                                     (double-array xs)
+                                                     (double-array (preprocess ys)))]
                        {:trend    (postprocess (.getTrend decomposition))
                         :seasonal (postprocess (.getSeasonal decomposition))
                         :residual (postprocess (.getRemainder decomposition))


### PR DESCRIPTION
Fix for #5711 

Shaves about 3MB (10%) from the uberjar (built using lein uberjar).

Removes the need for Java 1.8 (downside: we're back to the old STL algorithm :( ).

What's left all seems reasonably measured (there's probably a better way but just summing up the sizes of all the added JARs, feature extraction now adds < 1MB). 