### PR TITLE
clean up EditReferenceHeader and Detail inputs

### DIFF
--- a/frontend/src/metabase/reference/components/Detail.jsx
+++ b/frontend/src/metabase/reference/components/Detail.jsx
@@ -21,7 +21,7 @@ const Detail = ({ name, description, placeholder, subtitleClass, url, icon, isEd
                     <textarea
                         className={S.detailTextarea}
                         placeholder={placeholder}
-                        {...field}
+                        onChange={field.onChange}
                         //FIXME: use initialValues from redux forms instead of default value
                         // to allow for reinitializing on cancel (see GettingStartedGuide.jsx)
                         defaultValue={description}

--- a/frontend/src/metabase/reference/components/EditableReferenceHeader.jsx
+++ b/frontend/src/metabase/reference/components/EditableReferenceHeader.jsx
@@ -10,6 +10,7 @@ import E from "metabase/reference/components/EditButton.css";
 
 import IconBorder from "metabase/components/IconBorder.jsx";
 import Icon from "metabase/components/Icon.jsx";
+import Input from "metabase/components/Input.jsx";
 import Ellipsified from "metabase/components/Ellipsified.jsx";
 import EditButton from "metabase/reference/components/EditButton.jsx";
 
@@ -54,21 +55,19 @@ const EditableReferenceHeader = ({
                 style={isEditing && name === 'Details' ? {alignItems: "flex-start"} : {}}
             >
                 { isEditing && name === 'Details' ?
-                    hasDisplayName ?
-                        <input
+                        <Input
                             className={S.headerTextInput}
                             type="text"
                             placeholder={entity.name}
-                            {...displayNameFormField}
-                            defaultValue={entity.display_name}
-                        /> :
-                        <input
-                            className={S.headerTextInput}
-                            type="text"
-                            placeholder={entity.name}
-                            {...nameFormField}
-                            defaultValue={entity.name}
-                        /> :
+                            onChange={
+                                hasDisplayName ? displayNameFormField.onChange : nameFormField.onChange
+                            }
+                            defaultValue={
+                                hasDisplayName ? entity.display_name : entity.name
+                            }
+
+                        />
+                        :
                     [
                         <Ellipsified
                             key="1"


### PR DESCRIPTION
Fixes #5717. Something about all the junk that was being added on to the inputs due to the use of the spread operator here was nuking the values of the form fields (my guess is `initialValue=""`).  So instead of just blindly passing every part of the object I moved over to explicitly referencing things that we care about, specifically `onChange` which I think we should be doing in all cases.

@attekei I could use a double check to see if we need to explicitly add any other props, but this seems to fix the problem @mazameli found.
