### PR TITLE
Downgrade SQLite driver, again :unamused: [ci drivers]

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -73,7 +73,7 @@
                  [org.liquibase/liquibase-core "3.5.3"]               ; migration management (Java lib)
                  [org.slf4j/slf4j-log4j12 "1.7.25"]                   ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
                  [org.yaml/snakeyaml "1.18"]                          ; YAML parser (required by liquibase)
-                 [org.xerial/sqlite-jdbc "3.16.1"]                    ; SQLite driver
+                 [org.xerial/sqlite-jdbc "3.8.11.2"]                  ; SQLite driver. !!!!! DO NOT UPGRADE THIS! THINGS WILL BREAK! SEE https://github.com/metabase/metabase/issues/3753 !!!!!
                  [postgresql "9.3-1102.jdbc41"]                       ; Postgres driver
                  [io.crate/crate-jdbc "2.1.6"]                        ; Crate JDBC driver
                  [prismatic/schema "1.1.5"]                           ; Data schema declaration and validation library


### PR DESCRIPTION
Apparently I erroneously assumed the SQLite driver was finally safe to update again and did so before we shipped 24. A few people ran into this issue (I think it may only affect people on Java 7?) so reverting back to the version of the SQLite driver before people started having problems

Fixes #3753