### PR TITLE
Disable max-width for query filters

### DIFF
--- a/frontend/src/metabase/css/query_builder.css
+++ b/frontend/src/metabase/css/query_builder.css
@@ -68,7 +68,7 @@
 }
 
 .Query-filters {
-  max-width: 400px;
+  //max-width: 400px;
 }
 
 .Query-filterList {


### PR DESCRIPTION
If you add more than 3 filters, the filters will not be editable anymore, because the overflow content is hidden after 400px
Without the max width, the filters box grows with each added filter, which is the best solution.
Tested in the latest versions of firefox and google chrome.