### PR TITLE
Code cleanup: fix some *VERY* long lines of code :shower:

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
   :description "Metabase Community Edition"
   :url "http://metabase.com/"
   :min-lein-version "2.5.0"
-  :aliases {"bikeshed" ["bikeshed" "--max-line-length" "240"]
+  :aliases {"bikeshed" ["bikeshed" "--max-line-length" "195"]
             "check-reflection-warnings" ["with-profile" "+reflection-warnings" "check"]
             "test" ["with-profile" "+expectations" "expectations"]
             "generate-sample-dataset" ["with-profile" "+generate-sample-dataset" "run"]

--- a/sample_dataset/metabase/sample_dataset/generate.clj
+++ b/sample_dataset/metabase/sample_dataset/generate.clj
@@ -323,43 +323,68 @@
 (def ^:private ^:const metabase-metadata
   {:orders   {:description "This is a confirmed order for a product from a user."
               :columns     {:created_at {:description "The date and time an order was submitted."}
-                            :id         {:description "This is a unique ID for the product. It is also called the “Invoice number” or “Confirmation number” in customer facing emails and screens."}
-                            :product_id {:description "The product ID. This is an internal identifier for the product, NOT the SKU."}
-                            :subtotal   {:description "The raw, pre-tax cost of the order. Note that this might be different in the future from the product price due to promotions, credits, etc."}
-                            :tax        {:description (str "This is the amount of local and federal taxes that are collected on the purchase. Note that other governmental fees "
-                                                           "on some products are not included here, but instead are accounted for in the subtotal.")}
+                            :id         {:description (str "This is a unique ID for the product. It is also called "
+                                                           "the “Invoice number” or “Confirmation number” in "
+                                                           "customer facing emails and screens.")}
+                            :product_id {:description (str "The product ID. This is an internal identifier for the "
+                                                           "product, NOT the SKU.")}
+                            :subtotal   {:description (str "The raw, pre-tax cost of the order. Note that this might "
+                                                           "be different in the future from the product price due to "
+                                                           "promotions, credits, etc.")}
+                            :tax        {:description (str "This is the amount of local and federal taxes that are "
+                                                           "collected on the purchase. Note that other governmental "
+                                                           "fees on some products are not included here, but instead "
+                                                           "are accounted for in the subtotal.")}
                             :total      {:description "The total billed amount."}
-                            :user_id    {:description (str "The id of the user who made this order. Note that in some cases where an order was created on behalf "
-                                                           "of a customer who phoned the order in, this might be the employee who handled the request.")}}}
+                            :user_id    {:description (str "The id of the user who made this order. Note that in some "
+                                                           "cases where an order was created on behalf of a customer "
+                                                           "who phoned the order in, this might be the employee who "
+                                                           "handled the request.")}}}
    :people {:description "This is a user account. Note that employees and customer support staff will have accounts."
             :columns     {:address    {:description "The street address of the account’s billing address"}
                           :birth_date {:description "The date of birth of the user"}
                           :city       {:description "The city of the account’s billing address"}
-                          :created_at {:description "The date the user record was created. Also referred to as the user’s \"join date\""}
+                          :created_at {:description (str "The date the user record was created. Also referred to as "
+                                                         "the user’s \"join date\"")}
                           :email      {:description "The contact email for the account."}
                           :id         {:description "A unique identifier given to each user."}
-                          :latitude   {:description "This is the latitude of the user on sign-up. It might be updated in the future to the last seen location."}
-                          :longitude  {:description "This is the longitude of the user on sign-up. It might be updated in the future to the last seen location."}
+                          :latitude   {:description (str "This is the latitude of the user on sign-up. It might be "
+                                                         "updated in the future to the last seen location.")}
+                          :longitude  {:description (str "This is the longitude of the user on sign-up. It might be "
+                                                         "updated in the future to the last seen location.")}
                           :name       {:description "The name of the user who owns an account"}
-                          :password   {:description "This is the salted password of the user. It should not be visible"}
-                          :source     {:description "The channel through which we acquired this user. Valid values include: Affiliate, Facebook, Google, Organic and Twitter"}
+                          :password   {:description (str "This is the salted password of the user. It should not be "
+                                                         "visible")}
+                          :source     {:description (str "The channel through which we acquired this user. Valid "
+                                                         "values include: Affiliate, Facebook, Google, Organic and "
+                                                         "Twitter")}
                           :state      {:description "The state or province of the account’s billing address"}
                           :zip        {:description  "The postal code of the account’s billing address"
                                        :special_type "type/ZipCode"}}}
    :products {:description "This is our product catalog. It includes all products ever sold by the Sample Company."
-              :columns      {:category   {:description "The type of product, valid values include: Doohicky, Gadget, Gizmo and Widget"}
+              :columns      {:category   {:description (str "The type of product, valid values include: Doohicky, "
+                                                            "Gadget, Gizmo and Widget")}
                              :created_at {:description "The date the product was added to our catalog."}
-                             :ean        {:description "The international article number. A 13 digit number uniquely identifying the product."}
-                             :id         {:description "The numerical product number. Only used internally. All external communication should use the title or EAN."}
-                             :price      {:description "The list price of the product. Note that this is not always the price the product sold for due to discounts, promotions, etc."}
-                             :rating     {:description "The average rating users have given the product. This ranges from 1 - 5"}
-                             :title      {:description "The name of the product as it should be displayed to customers."}
+                             :ean        {:description (str "The international article number. A 13 digit number "
+                                                            "uniquely identifying the product.")}
+                             :id         {:description (str "The numerical product number. Only used internally. All "
+                                                            "external communication should use the title or EAN.")}
+                             :price      {:description (str "The list price of the product. Note that this is not "
+                                                            "always the price the product sold for due to discounts, "
+                                                            "promotions, etc.")}
+                             :rating     {:description (str "The average rating users have given the product. This "
+                                                            "ranges from 1 - 5")}
+                             :title      {:description (str "The name of the product as it should be displayed to "
+                                                            "customers.")}
                              :vendor     {:description "The source of the product."}}}
-   :reviews  {:description "These are reviews our customers have left on products. Note that these are not tied to orders so it is possible people have reviewed products they did not purchase from us."
+   :reviews  {:description (str "These are reviews our customers have left on products. Note that these are not tied "
+                                "to orders so it is possible people have reviewed products they did not purchase "
+                                "from us.")
               :columns     {:body       {:description  "The review the user left. Limited to 2000 characters."
                                          :special_type "type/Description"}
                             :created_at {:description "The day and time a review was written by a user."}
-                            :id         {:description "A unique internal identifier for the review. Should not be used externally."}
+                            :id         {:description (str "A unique internal identifier for the review. Should not "
+                                                           "be used externally.")}
                             :product_id {:description "The product the review was for"}
                             :rating     {:description "The rating (on a scale of 1-5) the user left."}
                             :reviewer   {:description "The user who left the review"}}}})
@@ -372,8 +397,10 @@
    (io/delete-file (str filename ".mv.db") :silently)
    (io/delete-file (str filename ".trace.db") :silently)
    (println "Creating db...")
-   (let [db (dbspec/h2 {:db (format "file:%s;UNDO_LOG=0;CACHE_SIZE=131072;QUERY_CACHE_SIZE=128;COMPRESS=TRUE;MULTI_THREADED=TRUE;MVCC=TRUE;DEFRAG_ALWAYS=TRUE;MAX_COMPACT_TIME=5000;ANALYZE_AUTO=100"
-                                    filename)})]
+   (let [db (dbspec/h2 {:db (str (format "file:%s;" filename)
+                                 "UNDO_LOG=0;CACHE_SIZE=131072;QUERY_CACHE_SIZE=128;COMPRESS=TRUE;"
+                                 "MULTI_THREADED=TRUE;MVCC=TRUE;DEFRAG_ALWAYS=TRUE;MAX_COMPACT_TIME=5000;"
+                                 "ANALYZE_AUTO=100")})]
      (doseq [[table-name field->type] (seq tables)]
        (jdbc/execute! db [(create-table-sql table-name field->type)]))
 

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -260,7 +260,7 @@
 
 ;;; ------------------------------------------------------------ POST /api/database ------------------------------------------------------------
 
-(defn- invalid-connection-response [field m]
+(defn- invalid-connection-response {:style/indent 1} [field m]
   ;; work with the new {:field error-message} format but be backwards-compatible with the UI as it exists right now
   {:valid   false
    field    m
@@ -274,11 +274,24 @@
           details (assoc details :engine engine)]
       (try
         (cond
-          (driver/can-connect-with-details? engine details :rethrow-exceptions) nil
-          (and host port (u/host-port-up? host port))                           (invalid-connection-response :dbname (format "Connection to '%s:%d' successful, but could not connect to DB." host port))
-          (and host (u/host-up? host))                                          (invalid-connection-response :port   (format "Connection to '%s' successful, but port %d is invalid." port))
-          host                                                                  (invalid-connection-response :host   (format "'%s' is not reachable" host))
-          :else                                                                 (invalid-connection-response :db     "Unable to connect to database."))
+          (driver/can-connect-with-details? engine details :rethrow-exceptions)
+          nil
+
+          (and host port (u/host-port-up? host port))
+          (invalid-connection-response :dbname
+            (format "Connection to '%s:%d' successful, but could not connect to DB." host port))
+
+          (and host (u/host-up? host))
+          (invalid-connection-response :port
+            (format "Connection to '%s' successful, but port %d is invalid." port))
+
+          host
+          (invalid-connection-response :host
+            (format "'%s' is not reachable" host))
+
+          :else
+          (invalid-connection-response :db
+            "Unable to connect to database."))
         (catch Throwable e
           (invalid-connection-response :dbname (.getMessage e)))))))
 

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -26,7 +26,8 @@
   ;; Hopefully this is a good balance between
   ;; 1. Not doing too many DB calls
   ;; 2. Not running out of mem
-  ;; 3. Not fetching too many results for things like mark-json-field! which will fail after the first result that isn't valid JSON
+  ;; 3. Not fetching too many results for things like mark-json-field! which will fail after the first result that
+  ;;    isn't valid JSON
   500)
 
 (def ^:const connection-error-messages
@@ -42,28 +43,30 @@
    :username-or-password-incorrect     "Looks like the username or password is incorrect."})
 
 (defprotocol IDriver
-  "Methods that Metabase drivers must implement. Methods marked *OPTIONAL* have default implementations in `IDriverDefaultsMixin`.
-   Drivers should also implement `getName` form `clojure.lang.Named`, so we can call `name` on them:
+  "Methods that Metabase drivers must implement. Methods marked *OPTIONAL* have default implementations in
+   `IDriverDefaultsMixin`. Drivers should also implement `getName` form `clojure.lang.Named`, so we can call `name` on
+    them:
 
      (name (PostgresDriver.)) -> \"PostgreSQL\"
 
    This name should be a \"nice-name\" that we'll display to the user."
 
   (can-connect? ^Boolean [this, ^java.util.Map details-map]
-    "Check whether we can connect to a `Database` with DETAILS-MAP and perform a simple query. For example, a SQL database might
-     try running a query like `SELECT 1;`. This function should return `true` or `false`.")
+    "Check whether we can connect to a `Database` with DETAILS-MAP and perform a simple query. For example, a SQL
+     database might try running a query like `SELECT 1;`. This function should return `true` or `false`.")
 
   (date-interval [this, ^Keyword unit, ^Number amount]
-    "*OPTIONAL* Return an driver-appropriate representation of a moment relative to the current moment in time. By default, this returns an `Timestamp` by calling
-     `metabase.util/relative-date`; but when possible drivers should return a native form so we can be sure the correct timezone is applied. For example, SQL drivers should
-     return a HoneySQL form to call the appropriate SQL fns:
+    "*OPTIONAL* Return an driver-appropriate representation of a moment relative to the current moment in time. By
+     default, this returns an `Timestamp` by calling `metabase.util/relative-date`; but when possible drivers should
+     return a native form so we can be sure the correct timezone is applied. For example, SQL drivers should return a
+     HoneySQL form to call the appropriate SQL fns:
 
        (date-interval (PostgresDriver.) :month 1) -> (hsql/call :+ :%now (hsql/raw \"INTERVAL '1 month'\"))")
 
   (describe-database ^java.util.Map [this, ^DatabaseInstance database]
-    "Return a map containing information that describes all of the schema settings in DATABASE, most notably a set of tables.
-     It is expected that this function will be peformant and avoid draining meaningful resources of the database.
-     Results should match the `DatabaseMetadata` schema.")
+    "Return a map containing information that describes all of the schema settings in DATABASE, most notably a set of
+     tables. It is expected that this function will be peformant and avoid draining meaningful resources of the
+     database. Results should match the `DatabaseMetadata` schema.")
 
   (describe-table ^java.util.Map [this, ^DatabaseInstance database, ^TableInstance table]
     "Return a map containing information that describes the physical schema of TABLE.
@@ -76,8 +79,8 @@
 
   (details-fields ^clojure.lang.Sequential [this]
     "A vector of maps that contain information about connection properties that should
-     be exposed to the user for databases that will use this driver. This information is used to build the UI for editing
-     a `Database` `details` map, and for validating it on the Backend. It should include things like `host`,
+     be exposed to the user for databases that will use this driver. This information is used to build the UI for
+     editing a `Database` `details` map, and for validating it on the Backend. It should include things like `host`,
      `port`, and other driver-specific parameters. Each field information map should have the following properties:
 
    *  `:name`
@@ -94,13 +97,14 @@
 
    *  `:default` *(OPTIONAL)*
 
-       A default value for this field if the user hasn't set an explicit value. This is shown in the UI as a placeholder.
+       A default value for this field if the user hasn't set an explicit value. This is shown in the UI as a
+       placeholder.
 
    *  `:placeholder` *(OPTIONAL)*
 
-      Placeholder value to show in the UI if user hasn't set an explicit value. Similar to `:default`, but this value is
-      *not* saved to `:details` if no explicit value is set. Since `:default` values are also shown as placeholders, you
-      cannot specify both `:default` and `:placeholder`.
+      Placeholder value to show in the UI if user hasn't set an explicit value. Similar to `:default`, but this value
+      is *not* saved to `:details` if no explicit value is set. Since `:default` values are also shown as
+      placeholders, you cannot specify both `:default` and `:placeholder`.
 
    *  `:required` *(OPTIONAL)*
 
@@ -123,44 +127,52 @@
                     [2 \"Rasta Can\"]]}")
 
   (features ^java.util.Set [this]
-    "*OPTIONAL*. A set of keyword names of optional features supported by this driver, such as `:foreign-keys`. Valid features are:
+    "*OPTIONAL*. A set of keyword names of optional features supported by this driver, such as `:foreign-keys`. Valid
+     features are:
 
   *  `:foreign-keys` - Does this database support foreign key relationships?
   *  `:nested-fields` - Does this database support nested fields (e.g. Mongo)?
   *  `:set-timezone` - Does this driver support setting a timezone for the query?
-  *  `:basic-aggregations` - Does the driver support *basic* aggregations like `:count` and `:sum`? (Currently, everything besides standard deviation is considered \"basic\"; only GA doesn't support this).
-  *  `:standard-deviation-aggregations` - Does this driver support [standard deviation aggregations](https://github.com/metabase/metabase/wiki/Query-Language-'98#stddev-aggregation)?
-  *  `:expressions` - Does this driver support [expressions](https://github.com/metabase/metabase/wiki/Query-Language-'98#expressions) (e.g. adding the values of 2 columns together)?
+  *  `:basic-aggregations` - Does the driver support *basic* aggregations like `:count` and `:sum`? (Currently,
+      everything besides standard deviation is considered \"basic\"; only GA doesn't support this).
+  *  `:standard-deviation-aggregations` - Does this driver support standard deviation aggregations?
+  *  `:expressions` - Does this driver support expressions? (e.g. adding the values of 2 columns together)?
   *  `:dynamic-schema` -  Does this Database have no fixed definitions of schemas? (e.g. Mongo)
   *  `:native-parameters` - Does the driver support parameter substitution on native queries?
-  *  `:expression-aggregations` - Does the driver support using expressions inside aggregations? e.g. something like \"sum(x) + count(y)\" or \"avg(x + y)\"
-  *  `:nested-queries` - Does the driver support using a query as the `:source-query` of another MBQL query? Examples are CTEs or subselects in SQL queries.")
+  *  `:expression-aggregations` - Does the driver support using expressions inside aggregations? e.g. something like
+      \"sum(x) + count(y)\" or \"avg(x + y)\"
+  *  `:nested-queries` - Does the driver support using a query as the `:source-query` of another MBQL query? Examples
+      are CTEs or subselects in SQL queries.")
 
   (field-values-lazy-seq ^clojure.lang.Sequential [this, ^FieldInstance field]
     "Return a lazy sequence of all values of FIELD.
      This is used to implement some methods of the database sync process which require rows of data during execution.
 
   The lazy sequence should not return more than `max-sync-lazy-seq-results`, which is currently `10000`.
-  For drivers that provide a chunked implementation, a recommended chunk size is `field-values-lazy-seq-chunk-size`, which is currently `500`.")
+  For drivers that provide a chunked implementation, a recommended chunk size is `field-values-lazy-seq-chunk-size`,
+  which is currently `500`.")
 
   (format-custom-field-name ^String [this, ^String custom-field-name]
-    "*OPTIONAL*. Return the custom name passed via an MBQL `:named` clause so it matches the way it is returned in the results.
-     This is used by the post-processing annotation stage to find the correct metadata to include with fields in the results.
-     The default implementation is `identity`, meaning the resulting field will have exactly the same name as passed to the `:named` clause.
-     Certain drivers like Redshift always lowercase these names, so this method is provided for those situations.")
+    "*OPTIONAL*. Return the custom name passed via an MBQL `:named` clause so it matches the way it is returned in the
+     results. This is used by the post-processing annotation stage to find the correct metadata to include with fields
+     in the results. The default implementation is `identity`, meaning the resulting field will have exactly the same
+     name as passed to the `:named` clause. Certain drivers like Redshift always lowercase these names, so this method
+     is provided for those situations.")
 
   (humanize-connection-error-message ^String [this, ^String message]
     "*OPTIONAL*. Return a humanized (user-facing) version of an connection error message string.
-     Generic error messages are provided in the constant `connection-error-messages`; return one of these whenever possible.")
+     Generic error messages are provided in the constant `connection-error-messages`; return one of these whenever
+     possible.")
 
   (mbql->native ^java.util.Map [this, ^java.util.Map query]
     "Transpile an MBQL structured query into the appropriate native query form.
 
-  The input QUERY will be a [fully-expanded MBQL query](https://github.com/metabase/metabase/wiki/Expanded-Queries) with
-  all the necessary pieces of information to build a properly formatted native query for the given database.
+  The input QUERY will be a [fully-expanded MBQL query](https://github.com/metabase/metabase/wiki/Expanded-Queries)
+  with all the necessary pieces of information to build a properly formatted native query for the given database.
 
-  If the underlying query language supports remarks or comments, the driver should use `query->remark` to generate an appropriate message and include that in an appropriate place;
-  alternatively a driver might directly include the query's `:info` dictionary if the underlying language is JSON-based.
+  If the underlying query language supports remarks or comments, the driver should use `query->remark` to generate an
+  appropriate message and include that in an appropriate place; alternatively a driver might directly include the
+  query's `:info` dictionary if the underlying language is JSON-based.
 
   The result of this function will be passed directly into calls to `execute-query`.
 
@@ -174,28 +186,31 @@
      the event that the driver was doing some caching or connection pooling.")
 
   (process-query-in-context [this, ^clojure.lang.IFn qp]
-    "*OPTIONAL*. Similar to `sync-in-context`, but for running queries rather than syncing. This should be used to do things like open DB connections
-     that need to remain open for the duration of post-processing. This function follows a middleware pattern and is injected into the QP
-     middleware stack immediately after the Query Expander; in other words, it will receive the expanded query.
-     See the Mongo and H2 drivers for examples of how this is intended to be used.
+    "*OPTIONAL*. Similar to `sync-in-context`, but for running queries rather than syncing. This should be used to do
+     things like open DB connections that need to remain open for the duration of post-processing. This function
+     follows a middleware pattern and is injected into the QP middleware stack immediately after the Query Expander;
+     in other words, it will receive the expanded query. See the Mongo and H2 drivers for examples of how this is
+     intended to be used.
 
        (defn process-query-in-context [driver qp]
          (fn [query]
            (qp query)))")
 
   (sync-in-context [this, ^DatabaseInstance database, ^clojure.lang.IFn f]
-    "*OPTIONAL*. Drivers may provide this function if they need to do special setup before a sync operation such as `sync-database!`. The sync
-     operation itself is encapsulated as the lambda F, which must be called with no arguments.
+    "*OPTIONAL*. Drivers may provide this function if they need to do special setup before a sync operation such as
+     `sync-database!`. The sync operation itself is encapsulated as the lambda F, which must be called with no
+     arguments.
 
        (defn sync-in-context [driver database f]
          (with-connection [_ database]
            (f)))")
 
   (table-rows-seq ^clojure.lang.Sequential [this, ^DatabaseInstance database, ^java.util.Map table]
-    "*OPTIONAL*. Return a sequence of *all* the rows in a given TABLE, which is guaranteed to have at least `:name` and `:schema` keys.
-     (It is guaranteed too satisfy the `DatabaseMetadataTable` schema in `metabase.sync.interface`.)
-     Currently, this is only used for iterating over the values in a `_metabase_metadata` table. As such, the results are not expected to be returned lazily.
-     There is no expectation that the results be returned in any given order."))
+    "*OPTIONAL*. Return a sequence of *all* the rows in a given TABLE, which is guaranteed to have at least `:name`
+     and `:schema` keys. (It is guaranteed too satisfy the `DatabaseMetadataTable` schema in
+     `metabase.sync.interface`.) Currently, this is only used for iterating over the values in a `_metabase_metadata`
+     table. As such, the results are not expected to be returned lazily. There is no expectation that the results be
+     returned in any given order."))
 
 
 (def IDriverDefaultsMixin
@@ -243,8 +258,8 @@
     (log/warn (format "No -init-driver function found for '%s'" (name ns-symb)))))
 
 (defn find-and-load-drivers!
-  "Search Classpath for namespaces that start with `metabase.driver.`, then `require` them and look for the `driver-init`
-   function which provides a uniform way for Driver initialization to be done."
+  "Search Classpath for namespaces that start with `metabase.driver.`, then `require` them and look for the
+   `driver-init` function which provides a uniform way for Driver initialization to be done."
   []
   (doseq [ns-symb @u/metabase-namespace-symbols
           :when   (re-matches #"^metabase\.driver\.[a-z0-9_]+$" (name ns-symb))]

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -38,7 +38,8 @@
 
 (def ^:private ^:const abandonment-context
   {:heading      "We’d love your feedback."
-   :callToAction "It looks like Metabase wasn’t quite a match for you. Would you mind taking a fast 5 question survey to help the Metabase team understand why and make things better in the future?"
+   :callToAction (str "It looks like Metabase wasn’t quite a match for you. Would you mind taking a fast 5 question "
+                      "survey to help the Metabase team understand why and make things better in the future?")
    :link         "http://www.metabase.com/feedback/inactive"})
 
 (def ^:private ^:const follow-up-context
@@ -71,8 +72,8 @@
 
 (defn- all-admin-recipients
   "Return a sequence of email addresses for all Admin users.
-   The first recipient will be the site admin (or oldest admin if unset), which is the address that should be used in `mailto` links
-   (e.g., for the new user to email with any questions)."
+   The first recipient will be the site admin (or oldest admin if unset), which is the address that should be used in
+   `mailto` links (e.g., for the new user to email with any questions)."
   []
   (concat (when-let [admin-email (public-settings/admin-email)]
             [admin-email])
@@ -120,7 +121,8 @@
       :message-type :html
       :message      message-body)))
 
-;; TODO - I didn't write these function and I don't know what it's for / what it's supposed to be doing. If this is determined add appropriate documentation
+;; TODO - I didn't write these function and I don't know what it's for / what it's supposed to be doing. If this is
+;; determined add appropriate documentation
 
 (defn- model-name->url-fn [model]
   (case model

--- a/src/metabase/query_processor/interface.clj
+++ b/src/metabase/query_processor/interface.clj
@@ -158,8 +158,9 @@
   [unit]
   (contains? relative-datetime-value-units (keyword unit)))
 
-;; TODO - maybe we should figure out some way to have the schema validate that the driver supports field literals, like we do for some of the other clauses.
-;; Ideally we'd do that in a more generic way (perhaps in expand, we could make the clauses specify required feature metadata and have that get checked automatically?)
+;; TODO - maybe we should figure out some way to have the schema validate that the driver supports field literals,
+;; like we do for some of the other clauses. Ideally we'd do that in a more generic way (perhaps in expand, we could
+;; make the clauses specify required feature metadata and have that get checked automatically?)
 (s/defrecord FieldLiteral [field-name    :- su/NonBlankString
                            base-type     :- su/FieldType]
   clojure.lang.Named
@@ -198,9 +199,10 @@
 
 ;; Replace Field IDs with these during first pass
 (s/defrecord FieldPlaceholder [field-id            :- su/IntGreaterThanZero
-                               fk-field-id         :- (s/maybe (s/constrained su/IntGreaterThanZero
-                                                                              (fn [_] (or (assert-driver-supports :foreign-keys) true)) ; assert-driver-supports will throw Exception if driver is bound
-                                                                              "foreign-keys is not supported by this driver."))         ; and driver does not support foreign keys
+                               fk-field-id         :- (s/maybe (s/constrained
+                                                                su/IntGreaterThanZero
+                                                                (fn [_] (or (assert-driver-supports :foreign-keys) true)) ; assert-driver-supports will throw Exception if driver is bound
+                                                                "foreign-keys is not supported by this driver."))         ; and driver does not support foreign keys
                                datetime-unit       :- (s/maybe DatetimeFieldUnit)
                                remapped-from       :- (s/maybe s/Str)
                                remapped-to         :- (s/maybe s/Str)

--- a/src/metabase/sample_data.clj
+++ b/src/metabase/sample_data.clj
@@ -1,4 +1,6 @@
 (ns metabase.sample-data
+  "Code for adding the Sample Dataset to our Databases, and updating its details if needed (for example, if the JAR is
+   moved, we'll need to update the details so we have the new path to the file.)"
   (:require [clojure.java.io :as io]
             [clojure.string :as s]
             [clojure.tools.logging :as log]
@@ -15,8 +17,10 @@
   (let [resource (io/resource sample-dataset-filename)]
     (when-not resource
       (throw (Exception. (format "Can't load sample dataset: the DB file '%s' can't be found." sample-dataset-filename))))
+    ;; to connect to an H2 DB inside a JAR just replace file: with zip: (this doesn't do anything when running from
+    ;; `lein`, which has no `file:` prefix)
     {:db (-> (.getPath resource)
-             (s/replace #"^file:" "zip:")           ; to connect to an H2 DB inside a JAR just replace file: with zip: (this doesn't do anything when running from `lein`, which has no `file:` prefix)
+             (s/replace #"^file:" "zip:")
              (s/replace #"\.mv\.db$" "")            ; strip the .mv.db suffix from the path
              (s/replace #"%20" " ")                 ; for some reason the path can get URL-encoded and replace spaces with `%20`; this breaks things so switch them back to spaces
              (str ";USER=GUEST;PASSWORD=guest"))})) ; specify the GUEST user account created for the DB

--- a/src/metabase/util/infer_spaces.clj
+++ b/src/metabase/util/infer_spaces.clj
@@ -1,5 +1,6 @@
 (ns metabase.util.infer-spaces
-  "Logic for automatically inferring where spaces should go in table names. Ported from ported from https://stackoverflow.com/questions/8870261/how-to-split-text-without-spaces-into-list-of-words/11642687#11642687."
+  "Logic for automatically inferring where spaces should go in table names.
+   Ported from https://stackoverflow.com/questions/8870261/how-to-split-text-without-spaces-into-list-of-words/11642687#11642687."
   (:require [clojure.java.io :as io]
             [clojure.string :as s])
   (:import java.lang.Math))
@@ -32,7 +33,9 @@
 (defn- best-match
   [i s cost]
   (let [candidates (reverse (subvec cost (max 0 (- i max-word)) i))]
-    (apply min-key first (map-indexed (fn [k c] [(+ c (get word-cost (subs s (- i k 1) i) 9e9999)) (inc k)]) candidates))))
+    (apply min-key first (map-indexed (fn [k c]
+                                        [(+ c (get word-cost (subs s (- i k 1) i) 9e9999)) (inc k)])
+                                      candidates))))
 
 ;;     # Build the cost array.
 ;;     cost = [0]

--- a/test/metabase/api/preview_embed_test.clj
+++ b/test/metabase/api/preview_embed_test.clj
@@ -7,9 +7,10 @@
             [metabase.util :as u]
             [toucan.util.test :as tt]))
 
-;;; ------------------------------------------------------------ GET /api/preview_embed/card/:token ------------------------------------------------------------
+;;; GET /api/preview_embed/card/:token
 
-(defn- card-url [card & [additional-token-params]] (str "preview_embed/card/" (embed-test/card-token card (merge {:_embedding_params {}} additional-token-params))))
+(defn- card-url [card & [additional-token-params]]
+  (str "preview_embed/card/" (embed-test/card-token card (merge {:_embedding_params {}} additional-token-params))))
 
 ;; it should be possible to use this endpoint successfully if all the conditions are met
 (expect
@@ -53,7 +54,7 @@
                                                                                   :params            {:c 100}}))))))
 
 
-;;; ------------------------------------------------------------ GET /api/preview_embed/card/:token/query ------------------------------------------------------------
+;;; GET /api/preview_embed/card/:token/query
 
 (defn- card-query-url [card & [additional-token-params]]
   (str "preview_embed/card/"
@@ -153,9 +154,11 @@
       ((test-users/user->client :crowberto) :get 200 (str (card-query-url card {:_embedding_params {:abc "enabled"}}) "?abc=200")))))
 
 
-;;; ------------------------------------------------------------ GET /api/preview_embed/dashboard/:token ------------------------------------------------------------
+;;; GET /api/preview_embed/dashboard/:token
 
-(defn- dashboard-url [dashboard & [additional-token-params]] (str "preview_embed/dashboard/" (embed-test/dash-token dashboard (merge {:_embedding_params {}} additional-token-params))))
+(defn- dashboard-url [dashboard & [additional-token-params]]
+  (str "preview_embed/dashboard/" (embed-test/dash-token dashboard (merge {:_embedding_params {}}
+                                                                          additional-token-params))))
 
 ;; it should be possible to call this endpoint successfully...
 (expect
@@ -196,13 +199,17 @@
                                                 {:slug "c", :name "c", :type "date"}
                                                 {:slug "d", :name "d", :type "date"}]}]
       (:parameters ((test-users/user->client :crowberto) :get 200 (dashboard-url dash {:params            {:c 100},
-                                                                                       :_embedding_params {:a "locked", :b "disabled", :c "enabled", :d "enabled"}}))))))
+                                                                                       :_embedding_params {:a "locked"
+                                                                                                           :b "disabled"
+                                                                                                           :c "enabled"
+                                                                                                           :d "enabled"}}))))))
 
 
-;;; ------------------------------------------------------------ GET /api/preview_embed/dashboard/:token/dashcard/:dashcard-id/card/:card-id ------------------------------------------------------------
+;;; GET /api/preview_embed/dashboard/:token/dashcard/:dashcard-id/card/:card-id
 
 (defn- dashcard-url {:style/indent 1} [dashcard & [additional-token-params]]
-  (str "preview_embed/dashboard/" (embed-test/dash-token (:dashboard_id dashcard) (merge {:_embedding_params {}} additional-token-params))
+  (str "preview_embed/dashboard/" (embed-test/dash-token (:dashboard_id dashcard) (merge {:_embedding_params {}}
+                                                                                         additional-token-params))
        "/dashcard/" (u/get-id dashcard)
        "/card/" (:card_id dashcard)))
 

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -22,7 +22,9 @@
   (:import java.io.ByteArrayInputStream
            java.util.UUID))
 
-;;; ------------------------------------------------------------ Helper Fns ------------------------------------------------------------
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                                   HELPER FNS                                                   |
+;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defn count-of-venues-card []
   {:dataset_query {:database (data/id)
@@ -62,7 +64,9 @@
 
 
 
-;;; ------------------------------------------------------------ GET /api/public/card/:uuid ------------------------------------------------------------
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                           GET /api/public/card/:uuid                                           |
+;;; +----------------------------------------------------------------------------------------------------------------+
 
 ;; Check that we *cannot* fetch a PublicCard if the setting is disabled
 (expect
@@ -111,7 +115,9 @@
         (update-in [(data/id :categories :name) :values] count))))
 
 
-;;; ------------------------------------------------------------ GET /api/public/card/:uuid/query (and JSON/CSV/XSLX versions)  ------------------------------------------------------------
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                         GET /api/public/card/:uuid/query (and JSON/CSV/XSLX versions)                          |
+;;; +----------------------------------------------------------------------------------------------------------------+
 
 ;; Check that we *cannot* execute a PublicCard if the setting is disabled
 (expect
@@ -174,7 +180,9 @@
               [:json_query :parameters]))))
 
 
-;;; ------------------------------------------------------------ GET /api/public/dashboard/:uuid ------------------------------------------------------------
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                        GET /api/public/dashboard/:uuid                                         |
+;;; +----------------------------------------------------------------------------------------------------------------+
 
 ;; Check that we *cannot* fetch PublicDashboard if setting is disabled
 (expect
@@ -211,7 +219,9 @@
       (fetch-public-dashboard dash))))
 
 
-;;; ------------------------------------------------------------ GET /api/public/dashboard/:uuid/card/:card-id ------------------------------------------------------------
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                 GET /api/public/dashboard/:uuid/card/:card-id                                  |
+;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defn- dashcard-url-path [dash card]
   (str "public/dashboard/" (:public_uuid dash) "/card/" (u/get-id card)))
@@ -281,7 +291,9 @@
           (qp-test/rows (http/client :get 200 (dashcard-url-path dash card-2))))))))
 
 
-;;; ------------------------------------------------------------ Check that parameter information comes back with Dashboard ------------------------------------------------------------
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                           Check that parameter information comes back with Dashboard                           |
+;;; +----------------------------------------------------------------------------------------------------------------+
 
 ;; double-check that the Field has FieldValues
 (expect
@@ -297,7 +309,8 @@
   (db/update! Dashboard (u/get-id dashboard) :parameters [{:name "Price", :type "category", :slug "price"}]))
 
 (defn- add-dimension-param-mapping-to-dashcard! [dashcard card dimension]
-  (db/update! DashboardCard (u/get-id dashcard) :parameter_mappings [{:card_id (u/get-id card), :target ["dimension" dimension]}]))
+  (db/update! DashboardCard (u/get-id dashcard)
+    :parameter_mappings [{:card_id (u/get-id card), :target ["dimension" dimension]}]))
 
 (defn- GET-param-values [dashboard]
   (tu/with-temporary-setting-values [enable-public-sharing true]
@@ -307,7 +320,11 @@
 (expect
   (price-param-values)
   (with-temp-public-dashboard-and-card [dash card dashcard]
-    (db/update! Card (u/get-id card) :dataset_query {:native {:template_tags {:price {:name "price", :display_name "Price", :type "dimension", :dimension ["field-id" (data/id :venues :price)]}}}})
+    (db/update! Card (u/get-id card)
+      :dataset_query {:native {:template_tags {:price {:name         "price"
+                                                       :display_name "Price"
+                                                       :type         "dimension"
+                                                       :dimension    ["field-id" (data/id :venues :price)]}}}})
     (add-price-param-to-dashboard! dash)
     (add-dimension-param-mapping-to-dashcard! dashcard card ["template-tag" "price"])
     (GET-param-values dash)))

--- a/test/metabase/api/setting_test.clj
+++ b/test/metabase/api/setting_test.clj
@@ -15,10 +15,20 @@
 ;; ## GET /api/setting
 ;; Check that we can fetch all Settings for Org
 (expect
- [{:key "test-setting-1", :value nil,     :is_env_setting true,  :env_name "MB_TEST_SETTING_1", :description "Test setting - this only shows up in dev (1)", :default "Using $MB_TEST_SETTING_1"}
-  {:key "test-setting-2", :value "FANCY", :is_env_setting false, :env_name "MB_TEST_SETTING_2", :description "Test setting - this only shows up in dev (2)", :default "[Default Value]"}]
- (do (set-settings! nil "FANCY")
-     (fetch-test-settings)))
+  [{:key            "test-setting-1"
+    :value          nil
+    :is_env_setting true
+    :env_name       "MB_TEST_SETTING_1"
+    :description    "Test setting - this only shows up in dev (1)"
+    :default        "Using $MB_TEST_SETTING_1"}
+   {:key            "test-setting-2"
+    :value          "FANCY"
+    :is_env_setting false
+    :env_name       "MB_TEST_SETTING_2"
+    :description    "Test setting - this only shows up in dev (2)"
+    :default        "[Default Value]"}]
+  (do (set-settings! nil "FANCY")
+      (fetch-test-settings)))
 
 ;; Check that non-superusers are denied access
 (expect "You don't have permissions to do that."

--- a/test/metabase/driver/bigquery_test.clj
+++ b/test/metabase/driver/bigquery_test.clj
@@ -16,13 +16,17 @@
 (expect-with-engine :bigquery
   [[100]
    [99]]
-  (get-in (qp/process-query {:native   {:query "SELECT [test_data.venues.id] FROM [test_data.venues] ORDER BY [test_data.venues.id] DESC LIMIT 2;"}
+  (get-in (qp/process-query {:native   {:query (str "SELECT [test_data.venues.id]\n"
+                                                    "FROM [test_data.venues]\n"
+                                                    "ORDER BY [test_data.venues.id] DESC\n"
+                                                    "LIMIT 2;")}
                              :type     :native
                              :database (data/id)})
           [:data :rows]))
 
 
-;; make sure that BigQuery native queries maintain the column ordering specified in the SQL -- post-processing ordering shouldn't apply (Issue #2821)
+;; make sure that BigQuery native queries maintain the column ordering specified in the SQL -- post-processing
+;; ordering shouldn't apply (Issue #2821)
 (expect-with-engine :bigquery
   {:columns ["venue_id" "user_id" "checkins_id"],
    :cols    (mapv #(merge col-defaults %)
@@ -30,9 +34,11 @@
                    {:name "user_id",     :display_name  "User ID",    :base_type :type/Integer}
                    {:name "checkins_id", :display_name "Checkins ID", :base_type :type/Integer}])}
 
-  (select-keys (:data (qp/process-query {:native   {:query "SELECT [test_data.checkins.venue_id] AS [venue_id], [test_data.checkins.user_id] AS [user_id], [test_data.checkins.id] AS [checkins_id]
-                                                            FROM [test_data.checkins]
-                                                            LIMIT 2"}
+  (select-keys (:data (qp/process-query {:native   {:query (str "SELECT [test_data.checkins.venue_id] AS [venue_id],"
+                                                                "  [test_data.checkins.user_id] AS [user_id], "
+                                                                "  [test_data.checkins.id] AS [checkins_id]\n"
+                                                                "FROM [test_data.checkins]\n"
+                                                                "LIMIT 2\n")}
                                          :type     :native
                                          :database (data/id)}))
                [:cols :columns]))

--- a/test/metabase/driver/mongo_test.clj
+++ b/test/metabase/driver/mongo_test.clj
@@ -171,7 +171,7 @@
             (ql/filter (ql/= $bird_id "abcdefabcdefabcdefabcdef"))))))
 
 
-;;; ------------------------------------------------------------ Test that we can handle native queries with "ISODate(...)" and "ObjectId(...) forms (#3741, #4448) ------------------------------------------------------------
+;; Test that we can handle native queries with "ISODate(...)" and "ObjectId(...) forms (#3741, #4448)
 (tu/resolve-private-vars metabase.driver.mongo.query-processor
   maybe-decode-fncall decode-fncalls encode-fncalls)
 

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -150,7 +150,8 @@
    [[(hsql/raw "'192.168.1.1'::inet")]
     [(hsql/raw "'10.4.4.15'::inet")]]])
 
-;; Filtering by inet columns should add the appropriate SQL cast, e.g. `cast('192.168.1.1' AS inet)` (otherwise this wouldn't work)
+;; Filtering by inet columns should add the appropriate SQL cast, e.g. `cast('192.168.1.1' AS inet)` (otherwise this
+;; wouldn't work)
 (expect-with-engine :postgres
   [[1]]
   (rows (data/dataset metabase.driver.postgres-test/ip-addresses
@@ -210,7 +211,8 @@
       (tt/with-temp Database [database {:engine :postgres, :details (assoc details :dbname "fdw_test")}]
         (driver/describe-database pg-driver database)))))
 
-;; make sure that if a view is dropped and recreated that the original Table object is marked active rather than a new one being created (#3331)
+;; make sure that if a view is dropped and recreated that the original Table object is marked active rather than a new
+;; one being created (#3331)
 (expect-with-engine :postgres
   [{:name "angry_birds", :active true}]
   (let [details (i/database->connection-details pg-driver :db {:database-name "dropped_views_test"})
@@ -261,7 +263,8 @@
   "America/Chicago"
   (get-timezone-with-report-timezone "America/Chicago"))
 
-;; ok, check that if we try to put in a fake timezone that the query still reëxecutes without a custom timezone. This should give us the same result as if we didn't try to set a timezone at all
+;; ok, check that if we try to put in a fake timezone that the query still reëxecutes without a custom timezone. This
+;; should give us the same result as if we didn't try to set a timezone at all
 (expect-with-engine :postgres
   (get-timezone-with-report-timezone nil)
   (get-timezone-with-report-timezone "Crunk Burger"))

--- a/test/metabase/permissions_test.clj
+++ b/test/metabase/permissions_test.clj
@@ -31,7 +31,7 @@
 ;; lucky, member of All Users, Ops
 
 
-;;; ------------------------------------------------------------ Ops Group ------------------------------------------------------------
+;;; Ops Group
 
 ;; ops group is a group with only one member: lucky
 (def ^:dynamic *ops-group*)
@@ -48,7 +48,7 @@
         (f)))))
 
 
-;;; ------------------------------------------------------------ DBs, Tables, & Fields ------------------------------------------------------------
+;;; DBs, Tables, & Fields
 
 (def db-details
   (delay (db/select-one [Database :details :engine] :id (data/id))))
@@ -109,7 +109,7 @@
                         (f)))))
 
 
-;;; ------------------------------------------------------------ Cards ------------------------------------------------------------
+;;; Cards
 
 (defn- count-card [db table-name card-name]
   (let [table (table db table-name)]
@@ -175,7 +175,7 @@
         (f)))))
 
 
-;;; ------------------------------------------------------------ Dashboards ------------------------------------------------------------
+;;; Dashboards
 
 (def ^:dynamic *dash:db1-all*)
 (def ^:dynamic *dash:db2-all*)
@@ -218,7 +218,7 @@
         (f)))))
 
 
-;;; ------------------------------------------------------------ Pulses ------------------------------------------------------------
+;;; Pulses
 
 (def ^:dynamic *pulse:all*)
 (def ^:dynamic *pulse:db1-all*)
@@ -297,7 +297,7 @@
         (f)))))
 
 
-;;; ------------------------------------------------------------ Metrics ------------------------------------------------------------
+;;; Metrics
 
 (def ^:dynamic *metric:db1-venues-count*)
 (def ^:dynamic *metric:db2-venues-count*)
@@ -326,7 +326,7 @@
                 *metric:db2-users-count*  db2-users-count]
         (f)))))
 
-;;; ------------------------------------------------------------ Segments ------------------------------------------------------------
+;;; Segments
 
 (def ^:dynamic *segment:db1-expensive-venues*)
 (def ^:dynamic *segment:db2-expensive-venues*)
@@ -365,7 +365,7 @@
                 *segment:db2-todays-users*     db2-todays-users]
         (f)))))
 
-;;; ------------------------------------------------------------ with everything! ------------------------------------------------------------
+;;; with everything!
 
 
 (defn -do-with-test-data [f]
@@ -389,11 +389,11 @@
        ~actual)))
 
 
-;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
-;;; |                                                                          QUERY BUILDER                                                                         |
-;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                                 QUERY BUILDER                                                  |
+;;; +----------------------------------------------------------------------------------------------------------------+
 
-;;; ------------------------------------------------------------ GET /api/database?include_tables=true (Visible DBs + Tables) ------------------------------------------------------------
+;;; GET /api/database?include_tables=true (Visible DBs + Tables)
 
 (defn- GET-database [username]
   (vec (for [db    ((test-users/user->client username) :get 200 "database", :include_tables true)
@@ -418,7 +418,7 @@
   (GET-database :lucky))
 
 
-;;; ------------------------------------------------------------ GET /api/table/:id/query_metadata ------------------------------------------------------------
+;;; GET /api/table/:id/query_metadata
 
 (defn- GET-table-query-metadata [username db table-name]
   (not= ((test-users/user->client username) :get (format "table/%d/query_metadata" (u/get-id (table db table-name))))
@@ -449,7 +449,7 @@
 (expect-with-test-data true  (GET-table-query-metadata :lucky *db2* :venues))
 
 
-;;; ------------------------------------------------------------ POST /api/dataset (SQL query) ------------------------------------------------------------
+;;; POST /api/dataset (SQL query)
 
 (defn- sql-query [username db]
   (let [results ((test-users/user->client username) :post "dataset"
@@ -466,17 +466,18 @@
 (expect-with-test-data [[100]] (sql-query :rasta *db1*))
 (expect-with-test-data [[100]] (sql-query :lucky *db1*))
 
-;; Only Admin should be able to ask SQL questions against DB 2. Error message is slightly different for Rasta & Lucky because Rasta has no permissions whatsoever for DB 2 while Lucky has partial perms
+;; Only Admin should be able to ask SQL questions against DB 2. Error message is slightly different for Rasta & Lucky
+;; because Rasta has no permissions whatsoever for DB 2 while Lucky has partial perms
 (expect-with-test-data [[100]] (sql-query :crowberto *db2*))
 (expect-with-test-data "You don't have permissions to do that." (sql-query :rasta *db2*))
 (expect-with-test-data #"You do not have read permissions for /db/\d+/native/\." (sql-query :lucky *db2*))
 
 
-;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
-;;; |                                                                         SAVED QUESTIONS                                                                        |
-;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                                SAVED QUESTIONS                                                 |
+;;; +----------------------------------------------------------------------------------------------------------------+
 
-;;; ------------------------------------------------------------ GET /api/card (Visible Cards) ------------------------------------------------------------
+;;; GET /api/card (Visible Cards)
 
 (defn- GET-card [username]
   (vec (for [card  ((test-users/user->client username) :get 200 "card")
@@ -514,7 +515,7 @@
   (GET-card :lucky))
 
 
-;;; ------------------------------------------------------------ GET /api/card/:id ------------------------------------------------------------
+;;; GET /api/card/:id
 
 ;; just return true/false based on whether they were allowed to see the card
 (defn- GET-card-id [username card]
@@ -552,11 +553,11 @@
 (expect-with-test-data true  (GET-card-id :lucky *card:db2-sql-count-of-users*))
 
 
-;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
-;;; |                                                                           DASHBOARDS                                                                           |
-;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                                   DASHBOARDS                                                   |
+;;; +----------------------------------------------------------------------------------------------------------------+
 
-;;; ------------------------------------------------------------ GET /api/dashboard (Visible Dashboards) ------------------------------------------------------------
+;;; GET /api/dashboard (Visible Dashboards)
 
 (defn- GET-dashboard [username]
   (vec (for [dashboard ((test-users/user->client username) :get 200 "dashboard")
@@ -584,7 +585,7 @@
   (GET-dashboard :lucky))
 
 
-;;; ------------------------------------------------------------ GET /api/dashboard/:id  ------------------------------------------------------------
+;;; GET /api/dashboard/:id
 
 (defn- GET-dashboard-id [username dashboard]
   (not= ((test-users/user->client username) :get (str "dashboard/" (u/get-id dashboard)))
@@ -603,11 +604,11 @@
 (expect-with-test-data false (GET-dashboard-id :lucky *dash:db2-public*))
 
 
-;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
-;;; |                                                                             PULSES                                                                             |
-;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                                     PULSES                                                     |
+;;; +----------------------------------------------------------------------------------------------------------------+
 
-;;; ------------------------------------------------------------ GET /api/pulse ------------------------------------------------------------
+;;; GET /api/pulse
 
 (defn- GET-pulse [username]
   (vec (for [pulse ((test-users/user->client username) :get 200 "pulse")
@@ -637,7 +638,7 @@
   (GET-pulse :lucky))
 
 
-;;; ------------------------------------------------------------ GET /api/pulse/:id ------------------------------------------------------------
+;;; GET /api/pulse/:id
 
 (defn- GET-pulse-id [username pulse]
   (not= ((test-users/user->client username) :get (str "pulse/" (u/get-id pulse)))
@@ -665,11 +666,11 @@
 (expect-with-test-data false (GET-pulse-id :lucky *pulse:db2-restricted*))
 
 
-;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
-;;; |                                                                         DATA REFERENCE                                                                         |
-;;; +----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                                 DATA REFERENCE                                                 |
+;;; +----------------------------------------------------------------------------------------------------------------+
 
-;;; ------------------------------------------------------------ GET /api/metric (Visible Metrics) ------------------------------------------------------------
+;;; GET /api/metric (Visible Metrics)
 
 (defn- GET-metric [username]
   (vec (for [metric ((test-users/user->client username) :get 200 "metric")
@@ -695,7 +696,7 @@
   (GET-metric :lucky))
 
 
-;;; ------------------------------------------------------------ GET /api/segment (Visible Segments) ------------------------------------------------------------
+;;; GET /api/segment (Visible Segments)
 
 (defn- GET-segment [username]
   (vec (for [segment ((test-users/user->client username) :get 200 "segment")
@@ -721,7 +722,7 @@
   (GET-segment :lucky))
 
 
-;;; ------------------------------------------------------------ GET /api/database/:id/metadata (Visible Tables) ------------------------------------------------------------
+;;; GET /api/database/:id/metadata (Visible Tables)
 
 (defn- GET-database-id-metadata [username db]
   (let [db ((test-users/user->client username) :get (format "database/%d/metadata" (u/get-id db)))]

--- a/test/metabase/query_processor/expand_resolve_test.clj
+++ b/test/metabase/query_processor/expand_resolve_test.clj
@@ -144,29 +144,39 @@
                                   :name   "VENUES"
                                   :id     true}
                    :filter       {:filter-type :=
-                                  :field       (merge field-defaults
-                                                      {:field-id           true
-                                                       :fk-field-id        (id :venues :category_id)
-                                                       :field-name         "NAME"
-                                                       :field-display-name "Name"
-                                                       :base-type          :type/Text
-                                                       :special-type       :type/Name
-                                                       :table-id           (id :categories)
-                                                       :table-name         "CATEGORIES__via__CATEGORY_ID"
-                                                       :values             category-field-values
-                                                       :fingerprint        {:global {:distinct-count 75}, :type {:type/Text {:percent-json 0.0, :percent-url 0.0, :percent-email 0.0, :average-length 8.333333333333334}}}})
+                                  :field       (merge
+                                                field-defaults
+                                                {:field-id           true
+                                                 :fk-field-id        (id :venues :category_id)
+                                                 :field-name         "NAME"
+                                                 :field-display-name "Name"
+                                                 :base-type          :type/Text
+                                                 :special-type       :type/Name
+                                                 :table-id           (id :categories)
+                                                 :table-name         "CATEGORIES__via__CATEGORY_ID"
+                                                 :values             category-field-values
+                                                 :fingerprint        {:global {:distinct-count 75}
+                                                                      :type   {:type/Text {:percent-json   0.0
+                                                                                           :percent-url    0.0
+                                                                                           :percent-email  0.0
+                                                                                           :average-length 8.333333333333334}}}})
                                   :value       {:value "abc"
-                                                :field (merge field-defaults
-                                                              {:field-id           true
-                                                               :fk-field-id        (id :venues :category_id)
-                                                               :field-name         "NAME"
-                                                               :field-display-name "Name"
-                                                               :base-type          :type/Text
-                                                               :special-type       :type/Name
-                                                               :table-id           (id :categories)
-                                                               :table-name         "CATEGORIES__via__CATEGORY_ID"
-                                                               :values             category-field-values
-                                                               :fingerprint        {:global {:distinct-count 75}, :type {:type/Text {:percent-json 0.0, :percent-url 0.0, :percent-email 0.0, :average-length 8.333333333333334}}}})}}
+                                                :field (merge
+                                                        field-defaults
+                                                        {:field-id           true
+                                                         :fk-field-id        (id :venues :category_id)
+                                                         :field-name         "NAME"
+                                                         :field-display-name "Name"
+                                                         :base-type          :type/Text
+                                                         :special-type       :type/Name
+                                                         :table-id           (id :categories)
+                                                         :table-name         "CATEGORIES__via__CATEGORY_ID"
+                                                         :values             category-field-values
+                                                         :fingerprint        {:global {:distinct-count 75}
+                                                                              :type   {:type/Text {:percent-json   0.0
+                                                                                                   :percent-url    0.0
+                                                                                                   :percent-email  0.0
+                                                                                                   :average-length 8.333333333333334}}}})}}
                    :join-tables  [{:source-field {:field-id   true
                                                   :field-name "CATEGORY_ID"}
                                    :pk-field     {:field-id   true


### PR DESCRIPTION
Previously we have a hard line-width limit, enforced by a linter, of 240 characters. (I picked this because it was basically what would fit on my screen given the window configurations I usually use in Emacs.) That was, and always has been, IMO, way too loosey-goosey. So I dropped the hard limit down to 200 characters and cleaned up lines that were excessively long.

Personally I think it's nice to keep our LOC around 120 characters wide, solely because that's the limit in GitHub before it cuts off code. But that's just my personal style preference (as of this week), and, at any rate, I don't have all day to reformat old code. So this can be considered a step towards making things look nicer.