### PR TITLE
Drop frontend build step, always run integrated tests in CI

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -52,23 +52,8 @@ node-5() {
     run_step yarn run flow
 }
 node-6() {
-    if is_enabled "jar" || is_enabled "e2e" || is_enabled "screenshots"; then
-        run_step ./bin/build version frontend-fast sample-dataset uberjar
-    fi
-
-    # NOTE Atte Keinänen 6/23/17: Reuse the existing E2E infra for running integrated tests (they require the prebuild jar too)
-    if is_enabled "e2e"; then
-        run_step yarn run test-integrated
-    fi
-
-    # TODO Atte Keinänen 6/22/17: Disabled due to Sauce problems, all tests will be converted to use Jest and Enzyme
-    # if is_enabled "e2e" || is_enabled "compare_screenshots"; then
-    #     USE_SAUCE=true \
-    #         run_step yarn run test-e2e
-    # fi
-    # if is_enabled "screenshots"; then
-    #     run_step node_modules/.bin/babel-node ./bin/compare-screenshots
-    # fi
+    run_step ./bin/build version sample-dataset uberjar
+    run_step yarn run test-integrated
 }
 
 


### PR DESCRIPTION
Speeds up the CircleCI container 6 by dropping the `frontend-fast` build step which added 3-5 minutes to the total build time. We don't need any compiled frontend assets in the integrated tests as opposed to old e2e tests.

Now integration tests aren't any slower than other tests (the frontend lints and unit tests take approximately the same time) so I also enabled integration tests by default for all CircleCI builds. This means that using `[ci e2e]` becomes obsolete.