### PR TITLE
provide `crate` database user as default

### DIFF
--- a/src/metabase/driver/crate.clj
+++ b/src/metabase/driver/crate.clj
@@ -48,7 +48,8 @@
     :as   details}]
   (merge {:classname   "io.crate.client.jdbc.CrateDriver" ; must be in classpath
           :subprotocol "crate"
-          :subname     (str "//" hosts "/")}
+          :subname     (str "//" hosts)
+          :user        "crate"}
          (dissoc details :hosts)))
 
 (defn- can-connect? [details]
@@ -107,7 +108,7 @@
           :describe-table  describe-table
           :details-fields  (constantly [{:name         "hosts"
                                          :display-name "Hosts"
-                                         :default      "localhost:5432"}])
+                                         :default      "localhost:5432/"}])
           :features        (comp (u/rpartial disj :foreign-keys) sql/features)
           :current-db-time (driver/make-current-db-time-fn crate-date-formatter crate-db-time-query)})
   sql/ISQLDriver

--- a/test/metabase/test/data/crate.clj
+++ b/test/metabase/test/data/crate.clj
@@ -51,7 +51,8 @@
       (insert! rows))))
 
 (def ^:private database->connection-details
-  (constantly {:hosts "localhost:5200"}))
+  (constantly {:hosts "localhost:5200/"
+               :user  "crate"}))
 
 (extend CrateDriver
   generic/IGenericSQLTestExtensions


### PR DESCRIPTION
Since Version >= 2.0 CrateDB supports Host-Based-Authentication which
is enabled by default. It requires a user to trust the authentication.
User `crate` is the default superuser.
