### PR TITLE
Fix ACE Editor autocomplete

### DIFF
--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -195,12 +195,8 @@ export default class NativeQueryEditor extends Component {
 
         aceLanguageTools.addCompleter({
             getCompletions: async (editor, session, pos, prefix, callback) => {
-                if (prefix.length < 2) {
-                    callback(null, []);
-                    return;
-                }
                 try {
-                    // HACK: call this.props.autocompleteResultsFn rathern than caching the prop since it might change
+                    // HACK: call this.props.autocompleteResultsFn rather than caching the prop since it might change
                     let results = await this.props.autocompleteResultsFn(prefix);
                     // transform results of the API call into what ACE expects
                     let js_results = results.map(function(result) {


### PR DESCRIPTION
I figured out what's going on here. I'm guessing the logic in ACE Editor itself must have changed. When autocomplete has an opportunity to happen, a function is called with a callback. We're supposed to figure out our autocomplete results and then pass them back to the callback.

Since time immemorial, we just returned an empty set of autocomplete results when the word it asked us to auto-complete was less than 2 characters long, to minimize the number of possible matches before calling the API. It seems in newer versions of the ACE Editor it is now doing some optimization and assuming that if there were no auto-complete results for a single character (e.g. `c`), then there would be no results for something that started with that character (e.g. `core_`). This is not how it used to work, I can promise you :D

The good news is that since ACE is better about optimizing the times it calls the autocomplete function it means we don't have to do so much optimization ourselves. Removing our code that returned an empty set of results for single-character prefixes fixes autocomplete behavior without and noticeable increase in the number of API calls made or their duration.