### PR TITLE
Fix parameter mapper and action widget overflowing issues

### DIFF
--- a/frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx
@@ -111,6 +111,7 @@ export default class DashCardCardParameterMapper extends Component {
                 <PopoverWithTrigger
                     ref="popover"
                     triggerClasses={cx({ "disabled": disabled })}
+                    sizeToFit
                     triggerElement={
                         <Tooltip tooltip={tooltipText} verticalAttachments={["bottom", "top"]}>
                             {/* using div instead of button due to

--- a/frontend/src/metabase/query_builder/components/ActionsWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/ActionsWidget.jsx
@@ -168,7 +168,9 @@ export default class ActionsWidget extends Component {
                                 width: POPOVER_WIDTH,
                                 bottom: "50%",
                                 right: "50%",
-                                zIndex: -1
+                                zIndex: -1,
+                                maxHeight: "600px",
+                                overflow: "scroll"
                             }}
                         >
                             {PopoverComponent


### PR DESCRIPTION
Fixes both issues described in #5559.

First I tried something overly complicated for fixing the dashboard parameter mapper overflow issue but then I luckily found `sizeToFit` parameter of `Popover` component which solved the problem perfectly.