### PR TITLE
Render pulse even if pulse channel is missing `details` prop

### DIFF
--- a/frontend/src/metabase/lib/pulse.js
+++ b/frontend/src/metabase/lib/pulse.js
@@ -19,7 +19,7 @@ export function channelIsValid(channel, channelSpec) {
     }
     if (channelSpec.fields) {
         for (let field of channelSpec.fields) {
-            if (field.required && (channel.details[field.name] == null || channel.details[field.name] == "")) {
+            if (field.required && channel.details && (channel.details[field.name] == null || channel.details[field.name] == "")) {
                 return false;
             }
         }

--- a/frontend/src/metabase/pulse/components/PulseEdit.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEdit.jsx
@@ -84,7 +84,7 @@ export default class PulseEdit extends Component {
             c.channel_type === "email" ?
                 <span>This pulse will no longer be emailed to <strong>{c.recipients.length} {inflect("address", c.recipients.length)}</strong> <strong>{c.schedule_type}</strong>.</span>
             : c.channel_type === "slack" ?
-                <span>Slack channel <strong>{c.details.channel}</strong> will no longer get this pulse <strong>{c.schedule_type}</strong>.</span>
+                <span>Slack channel <strong>{c.details && c.details.channel}</strong> will no longer get this pulse <strong>{c.schedule_type}</strong>.</span>
             :
                 <span>Channel <strong>{c.channel_type}</strong> will no longer receive this pulse <strong>{c.schedule_type}</strong>.</span>
         );

--- a/frontend/src/metabase/pulse/components/PulseEditChannels.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEditChannels.jsx
@@ -155,10 +155,11 @@ export default class PulseEditChannels extends Component {
                         { field.type === "select" ?
                             <Select
                                 className="h4 text-bold bg-white"
-                                value={channel.details[field.name]}
+                                value={channel.details && channel.details[field.name]}
                                 options={field.options}
                                 optionNameFn={o => o}
                                 optionValueFn={o => o}
+                                // Address #5799 where `details` object is missing for some reason
                                 onChange={(o) => this.onChannelPropertyChange(index, "details", { ...channel.details, [field.name]: o })}
                             />
                         : null }

--- a/frontend/src/metabase/pulse/components/PulseListChannel.jsx
+++ b/frontend/src/metabase/pulse/components/PulseListChannel.jsx
@@ -56,7 +56,8 @@ export default class PulseListChannel extends Component {
         } else if (channel.channel_type === "slack") {
             channelIcon = "slack";
             channelVerb = "Slack'd";
-            channelTarget = channel.details.channel;
+            // Address #5799 where `details` object is missing for some reason
+            channelTarget = channel.details ? channel.details.channel : "No channel";
         }
 
         return (


### PR DESCRIPTION
Addresses #5799. I wasn't able to reproduce the original issue any other way than directly emptying the contents of `details` field in `pulse_channel` table for a Slack channel.