### PR TITLE
Fix for upstream issue 5648

### DIFF
--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -26,7 +26,6 @@ import { open, shouldOpenInBlankWindow } from "metabase/lib/dom";
 import { formatSQL } from "metabase/lib/formatting";
 import Query, { createQuery } from "metabase/lib/query";
 import { syncQueryFields, getExistingFields } from "metabase/lib/dataset";
-import { isPK } from "metabase/lib/types";
 import Utils from "metabase/lib/utils";
 import { getEngineNativeType, formatJsonQuery } from "metabase/lib/engine";
 import { defer } from "metabase/lib/promise";

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -1357,7 +1357,7 @@ export const followForeignKey = createThunkAction(FOLLOW_FOREIGN_KEY, fk => {
     // extract the value we will use to filter our new query
     let originValue;
     for (let i = 0; i < queryResult.data.cols.length; i++) {
-      if (isPK(queryResult.data.cols[i].special_type)) {
+      if (queryResult.data.cols[i].id == fk.destination.id) {
         originValue = queryResult.data.rows[0][i];
       }
     }
@@ -1387,10 +1387,10 @@ export const loadObjectDetailFKReferences = createThunkAction(
       const { qb: { card, tableForeignKeys } } = getState();
       const queryResult = getFirstQueryResult(getState());
 
-      function getObjectDetailIdValue(data) {
+      function getObjectDetailIdValue(data, fk) {
         for (let i = 0; i < data.cols.length; i++) {
           let coldef = data.cols[i];
-          if (isPK(coldef.special_type)) {
+          if (coldef.id == fk.destination.id) {
             return data.rows[0][i];
           }
         }
@@ -1403,7 +1403,7 @@ export const loadObjectDetailFKReferences = createThunkAction(
         fkQuery.query.aggregation = ["count"];
         fkQuery.query.filter = [
           "and",
-          ["=", fk.origin.id, getObjectDetailIdValue(queryResult.data)],
+          ["=", fk.origin.id, getObjectDetailIdValue(queryResult.data, fk)],
         ];
 
         let info = { status: 0, value: null };


### PR DESCRIPTION
Simple fix for [issue #5648](https://github.com/metabase/metabase/issues/5648).

Instead of looking for the first primary key in the destination table, this looks for the column which matches the relationship specified by the foreign key; as far as I can tell, this is more robust and allows for a situation which wasn't explicitly disallowed, but wasn't actually supported completely before -- accurate relationship counting and drill-through on tables with more than one entity key.

Since the target column id is known, it makes sense to use that to match a column instead of grabbing the first thing that is a primary key.

###### TODO 
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
