### PR TITLE
Add type information to expression columns

### DIFF
--- a/src/metabase/query_processor/annotate.clj
+++ b/src/metabase/query_processor/annotate.clj
@@ -69,7 +69,10 @@
        :field-display-name (humanization/name->human-readable-name (:field-name this)))]
 
     metabase.query_processor.interface.ExpressionRef
-    [(assoc this :field-display-name (:expression-name this))]
+    [(assoc this
+       :field-display-name (:expression-name this)
+       :base-type          :type/Float
+       :special-type       :type/Number)]
 
     ;; for every value in a map in the query we'll descend into the map and find all the fields contained therein and mark the key as each field's source.
     ;; e.g. if we descend into the `:breakout` columns for a query each field returned will get a `:source` of `:breakout`


### PR DESCRIPTION
Expressions aren't columns, but they have an entry in the cols
property which currently doesn't have type info. This adds that which
allows it to be used as the Y-axis in graphs.

Fixes #3952
