### PR TITLE
Make purple button text white on hover instead of blue

### DIFF
--- a/frontend/src/metabase/css/components/buttons.css
+++ b/frontend/src/metabase/css/components/buttons.css
@@ -107,6 +107,7 @@
 }
 
 .Button--purple:hover {
+    color: white;
     background-color: #885AB1;
     border-color: #885AB1;
 }


### PR DESCRIPTION
Fixes #5846

<img width="323" alt="screen shot 2017-08-31 at 12 55 00 pm" src="https://user-images.githubusercontent.com/2223916/29942744-cb43c02c-8e4b-11e7-884d-f519faba16f3.png">

<img width="616" alt="screen shot 2017-08-31 at 12 54 43 pm" src="https://user-images.githubusercontent.com/2223916/29942745-cb452606-8e4b-11e7-9293-8be7700393f8.png">
