### PR TITLE
Chart options buttons back to left

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -152,12 +152,12 @@ class ChartSettings extends Component {
                 </div>
                 <div className="pt1">
                     { !_.isEqual(this.state.settings, {}) &&
-                        <a className="Button Button--danger float-left" onClick={this.onResetSettings} data-metabase-event="Chart Settings;Reset">Reset to defaults</a>
+                        <a className="Button Button--danger float-right" onClick={this.onResetSettings} data-metabase-event="Chart Settings;Reset">Reset to defaults</a>
                     }
 
-                    <div className="float-right">
-                      <a className="Button" onClick={onClose} data-metabase-event="Chart Settings;Cancel">Cancel</a>
+                    <div className="float-left">
                       <a className="Button Button--primary ml2" onClick={() => this.onDone()} data-metabase-event="Chart Settings;Done">Done</a>
+                      <a className="Button ml2" onClick={onClose} data-metabase-event="Chart Settings;Cancel">Cancel</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This breaks the convention of the modals style guide, but after using the RC for a few days, I grew to hate the placement of these specific buttons on the chart settings modal, for a couple of reasons:

- there are 3 buttons, and one of them is a "destructive" one, which is an exception case
- the actual dropdown options themselves are on the far left, making it feel more natural to go straight down to click Done. I thought about moving the column of options to the right and the chart preview to the left, but because the gear button to open the modal in the first place is in the top-left, it felt annoying to have to move the mouse that much.

![screen shot 2017-09-05 at 11 39 53 am](https://user-images.githubusercontent.com/2223916/30076792-f7bc8e5e-922e-11e7-9f33-0901550dae5e.png)
