### PR TITLE
Fix docstring checker crashes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -125,7 +125,7 @@
                                 #"^metabase\.http-client$"]}
   :profiles {:dev {:dependencies [[expectations "2.2.0-beta2"]              ; unit tests
                                   [ring/ring-mock "0.3.0"]]           ; Library to create mock Ring requests for unit tests
-                   :plugins [[docstring-checker "1.0.0"]              ; Check that all public vars have docstrings. Run with 'lein docstring-checker'
+                   :plugins [[docstring-checker "1.0.2"]              ; Check that all public vars have docstrings. Run with 'lein docstring-checker'
                              [jonase/eastwood "0.2.3"
                               :exclusions [org.clojure/clojure]]      ; Linting
                              [lein-bikeshed "0.4.1"]                  ; Linting

--- a/test/metabase/models/on_demand_test.clj
+++ b/test/metabase/models/on_demand_test.clj
@@ -24,7 +24,7 @@
       (f updated-field-names)
       @updated-field-names)))
 
-(def ^:private basic-native-query
+(defn- basic-native-query []
   {:database (data/id)
    :type     "native"
    :native   {:query "SELECT AVG(SUBTOTAL) AS \"Average Price\"\nFROM ORDERS"}})
@@ -99,7 +99,7 @@
   #{"New Field"}
   ;; create a Card with non-parameterized query
   (do-with-updated-fields-for-card {:db    {:is_on_demand true}
-                                    :card  {:dataset_query basic-native-query}
+                                    :card  {:dataset_query (basic-native-query)}
                                     :field {:name "New Field"}}
     (fn [{:keys [table field card]}]
       ;; now change the query to one that references our Field in a on-demand DB. Field should have updated values
@@ -120,7 +120,7 @@
   #{}
   ;; create a Card with non-parameterized query
   (do-with-updated-fields-for-card {:db   {:is_on_demand false}
-                                    :card {:dataset_query basic-native-query}}
+                                    :card {:dataset_query (basic-native-query)}}
     (fn [{:keys [field card]}]
       ;; now change the query to one that references a Field. Field should not get values since DB is not On-Demand
       (db/update! Card (u/get-id card)


### PR DESCRIPTION
The docstring checker linter had an issue where it loaded all the namespaces in a project (even ones where we told it not to enforce the linting rules, i.e. our tests), and some of our tests had code that accidentally triggered DB migrations when the namespace was loaded. This lead to a situation where the docstring checker could fail because DB migrations failed if the DB was in a bad state. The docstring checker, of course, should not be running DB migrations at all.

I fixed the upstream issue and deployed a new version of the plugin already, so this PR updates our dependency version and fixes the test in question as well.