### PR TITLE
Add timezones to pulse rendering

### DIFF
--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -280,6 +280,15 @@
   [driver feature]
   (contains? (features driver) feature))
 
+(defn report-timezone-if-supported
+  "Returns the report-timezone if `DRIVER` supports setting it's
+  timezone and a report-timezone has been specified by the user"
+  [driver]
+  (when (driver-supports? driver :set-timezone)
+    (let [report-tz (report-timezone)]
+      (when-not (empty? report-tz)
+        report-tz))))
+
 (defn class->base-type
   "Return the `Field.base_type` that corresponds to a given class returned by the DB.
    This is used to infer the types of results that come back from native queries."

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -196,24 +196,6 @@
   (current-db-time ^DateTime [this ^DatabaseInstance database]
     "Returns the current time and timezone from the perspective of `DATABASE`."))
 
-(defn create-db-time-formatter
-  "Creates a date formatter from `DATE-FORMAT-STR` that will preserve
-  the offset/timezone information. Results of this are threadsafe and
-  can safely be def'd"
-  [date-format-str]
-  (.withOffsetParsed ^DateTimeFormatter (tformat/formatter date-format-str)))
-
-(defn make-current-db-time-fn
-  "Takes a clj-time date formatter `DATE-FORMATTER` and a native query
-  for the current time. Returns a function that executes the query and
-  parses the date returned preserving it's timezone"
-  [date-formatter native-query]
-  (fn [driver database]
-    (some->> (execute-query driver {:database database, :native {:query native-query}})
-             :rows
-             ffirst
-             (tformat/parse date-formatter))))
-
 (def IDriverDefaultsMixin
   "Default implementations of `IDriver` methods marked *OPTIONAL*."
   {:date-interval                     (u/drop-first-arg u/relative-date)
@@ -288,6 +270,39 @@
     (let [report-tz (report-timezone)]
       (when-not (empty? report-tz)
         report-tz))))
+
+(defn create-db-time-formatter
+  "Creates a date formatter from `DATE-FORMAT-STR` that will preserve
+  the offset/timezone information. Results of this are threadsafe and
+  can safely be def'd"
+  [date-format-str]
+  (.withOffsetParsed ^DateTimeFormatter (tformat/formatter date-format-str)))
+
+(defn make-current-db-time-fn
+  "Takes a clj-time date formatter `DATE-FORMATTER` and a native query
+  for the current time. Returns a function that executes the query and
+  parses the date returned preserving it's timezone"
+  [date-formatter native-query]
+  (fn [driver database]
+    (let [settings (when-let [report-tz (report-timezone-if-supported driver)]
+                     {:settings {:report-timezone report-tz}})
+          time-str (try
+                     (->> (merge settings {:database database, :native {:query native-query}})
+                          (execute-query driver)
+                          :rows
+                          ffirst)
+                     (catch Exception e
+                       (throw
+                        (Exception.
+                         (format "Error querying database '%s' for current time" (:name database)) e))))]
+      (try
+        (when time-str
+          (tformat/parse date-formatter time-str))
+        (catch Exception e
+          (throw
+           (Exception.
+            (format "Unable to parse date string '%s' for database engine '%s'"
+                    time-str (-> database :engine name)) e)))))))
 
 (defn class->base-type
   "Return the `Field.base_type` that corresponds to a given class returned by the DB.

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -214,12 +214,12 @@
 
 (defn render-pulse-email
   "Take a pulse object and list of results, returns an array of attachment objects for an email"
-  [pulse results]
+  [timezone pulse results]
   (let [images       (atom {})
         body         (binding [render/*include-title* true
                                render/*render-img-fn* (partial render-image images)]
                        (vec (cons :div (for [result results]
-                                         (render/render-pulse-section result)))))
+                                         (render/render-pulse-section timezone result)))))
         message-body (stencil/render-file "metabase/email/pulse"
                        (pulse-context body pulse))]
     (vec (cons {:type "text/html; charset=utf-8" :content message-body}

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -2,6 +2,7 @@
   "Public API for sending Pulses."
   (:require [clojure.tools.logging :as log]
             [metabase
+             [driver :as driver]
              [email :as email]
              [query-processor :as qp]
              [util :as u]]
@@ -9,7 +10,9 @@
             [metabase.integrations.slack :as slack]
             [metabase.models.card :refer [Card]]
             [metabase.pulse.render :as render]
-            [metabase.util.urls :as urls]))
+            [metabase.util.urls :as urls]
+            [schema.core :as s])
+  (:import java.util.TimeZone))
 
 ;;; ## ---------------------------------------- PULSE SENDING ----------------------------------------
 
@@ -29,24 +32,33 @@
         (catch Throwable t
           (log/warn (format "Error running card query (%n)" card-id) t))))))
 
+(s/defn defaulted-timezone :- TimeZone
+  "Returns the timezone for the given `CARD`. Either the report
+  timezone (if applicable) or the JVM timezone."
+  [card :- Card]
+  (let [^String timezone-str (or (-> card :database_id driver/database-id->driver driver/report-timezone-if-supported)
+                                 (System/getProperty "user.timezone"))]
+    (TimeZone/getTimeZone timezone-str)))
+
 (defn- send-email-pulse!
   "Send a `Pulse` email given a list of card results to render and a list of recipients to send to."
   [{:keys [id name] :as pulse} results recipients]
   (log/debug (format "Sending Pulse (%d: %s) via Channel :email" id name))
   (let [email-subject    (str "Pulse: " name)
-        email-recipients (filterv u/is-email? (map :email recipients))]
+        email-recipients (filterv u/is-email? (map :email recipients))
+        timezone         (-> results first :card defaulted-timezone)]
     (email/send-message!
       :subject      email-subject
       :recipients   email-recipients
       :message-type :attachments
-      :message      (messages/render-pulse-email pulse results))))
+      :message      (messages/render-pulse-email timezone pulse results))))
 
 (defn create-and-upload-slack-attachments!
   "Create an attachment in Slack for a given Card by rendering its result into an image and uploading it."
   [card-results]
   (let [{channel-id :id} (slack/files-channel)]
     (doall (for [{{card-id :id, card-name :name, :as card} :card, result :result} card-results]
-             (let [image-byte-array (render/render-pulse-card-to-png card result)
+             (let [image-byte-array (render/render-pulse-card-to-png (defaulted-timezone card) card result)
                    slack-file-url   (slack/upload-file! image-byte-array "image.png" channel-id)]
                {:title      card-name
                 :title_link (urls/card-url card-id)

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -22,7 +22,8 @@
            [org.fit.cssbox.css CSSNorm DOMAnalyzer DOMAnalyzer$Origin]
            [org.fit.cssbox.io DefaultDOMSource StreamDocumentSource]
            org.fit.cssbox.layout.BrowserCanvas
-           org.fit.cssbox.misc.Base64Coder))
+           org.fit.cssbox.misc.Base64Coder
+           org.joda.time.DateTimeZone))
 
 ;; NOTE: hiccup does not escape content by default so be sure to use "h" to escape any user-controlled content :-/
 
@@ -104,24 +105,29 @@
   [n]
   (cl-format nil (if (integer? n) "~:d" "~,2f") n))
 
+(defn- reformat-timestamp [timezone old-format-timestamp new-format-string]
+  (f/unparse (f/with-zone (f/formatter new-format-string)
+               (DateTimeZone/forTimeZone timezone))
+             (u/str->date-time old-format-timestamp timezone)))
+
 (defn- format-timestamp
   "Formats timestamps with human friendly absolute dates based on the column :unit"
-  [timestamp col]
+  [timezone timestamp col]
   (case (:unit col)
-    :hour          (f/unparse (f/formatter "h a - MMM YYYY") (c/from-long timestamp))
-    :week          (str "Week " (f/unparse (f/formatter "w - YYYY") (c/from-long timestamp)))
-    :month         (f/unparse (f/formatter "MMMM YYYY") (c/from-long timestamp))
-    :quarter       (str "Q"
-                        (inc (int (/ (t/month (c/from-long timestamp))
-                                     3)))
-                        " - "
-                        (t/year (c/from-long timestamp)))
-    :year          (str timestamp)
-    :hour-of-day   (str timestamp) ; TODO: probably shouldn't even be showing sparkline for x-of-y groupings?
-    :day-of-week   (str timestamp)
-    :week-of-year  (str timestamp)
-    :month-of-year (str timestamp)
-    (f/unparse (f/formatter "MMM d, YYYY") (c/from-long timestamp))))
+    :hour          (reformat-timestamp timezone timestamp "h a - MMM YYYY")
+    :week          (str "Week " (reformat-timestamp timezone timestamp "w - YYYY"))
+    :month         (reformat-timestamp timezone timestamp "MMMM YYYY")
+    :quarter       (let [timestamp-obj (u/str->date-time timestamp timezone)]
+                     (str "Q"
+                          (inc (int (/ (t/month timestamp-obj)
+                                       3)))
+                          " - "
+                          (t/year timestamp-obj)))
+
+    (:year :hour-of-day :day-of-week :week-of-year :month-of-year); TODO: probably shouldn't even be showing sparkline for x-of-y groupings?
+    (str timestamp)
+
+    (reformat-timestamp timezone timestamp "MMM d, YYYY")))
 
 (def ^:private year  (comp t/year  t/now))
 (def ^:private month (comp t/month t/now))
@@ -138,30 +144,39 @@
 
 (defn- format-timestamp-relative
   "Formats timestamps with relative names (today, yesterday, this *, last *) based on column :unit, if possible, otherwie returns nil"
-  [timestamp, {:keys [unit]}]
-  (case unit
-    :day     (date->interval-name (c/from-long timestamp)     (t/date-midnight (year) (month) (day)) (t/days 1)   "Today"        "Yesterday")
-    :week    (date->interval-name (c/from-long timestamp)     (start-of-this-week)                   (t/weeks 1)  "This week"    "Last week")
-    :month   (date->interval-name (c/from-long timestamp)     (t/date-midnight (year) (month))       (t/months 1) "This month"   "Last month")
-    :quarter (date->interval-name (c/from-long timestamp)     (start-of-this-quarter)                (t/months 3) "This quarter" "Last quarter")
-    :year    (date->interval-name (t/date-midnight timestamp) (t/date-midnight (year))               (t/years 1)  "This year"    "Last year")
-    nil))
-
+  [timezone timestamp, {:keys [unit]}]
+  (let [parsed-timestamp (u/str->date-time timestamp timezone)]
+    (case unit
+      :day     (date->interval-name parsed-timestamp
+                                    (t/date-midnight (year) (month) (day))
+                                    (t/days 1) "Today" "Yesterday")
+      :week    (date->interval-name parsed-timestamp
+                                    (start-of-this-week)
+                                    (t/weeks 1) "This week" "Last week")
+      :month   (date->interval-name parsed-timestamp
+                                    (t/date-midnight (year) (month))
+                                    (t/months 1) "This month" "Last month")
+      :quarter (date->interval-name parsed-timestamp
+                                    (start-of-this-quarter)
+                                    (t/months 3) "This quarter" "Last quarter")
+      :year    (date->interval-name (t/date-midnight parsed-timestamp)
+                                    (t/date-midnight (year))
+                                    (t/years 1) "This year" "Last year")
+      nil)))
 
 (defn- format-timestamp-pair
   "Formats a pair of timestamps, using relative formatting for the first timestamps if possible and 'Previous :unit' for the second, otherwise absolute timestamps for both"
-  [[a b] col]
-  (if-let [a' (format-timestamp-relative a col)]
+  [timezone [a b] col]
+  (if-let [a' (format-timestamp-relative timezone a col)]
     [a' (str "Previous " (-> col :unit name))]
-    [(format-timestamp a col) (format-timestamp b col)]))
+    [(format-timestamp timezone a col) (format-timestamp timezone b col)]))
 
 (defn- format-cell
-  [value col]
+  [timezone value col]
   (cond
-    (datetime-field? col) (format-timestamp (.getTime ^Date (u/->Timestamp value)) col)
+    (datetime-field? col) (format-timestamp timezone value col)
     (and (number? value) (not (datetime-field? col))) (format-number value)
     :else (str value)))
-
 
 (defn- render-img-data-uri
   "Takes a PNG byte array and returns a Base64 encoded URI"
@@ -278,7 +293,7 @@
 
 (defn- query-results->row-seq
   "Returns a seq of stringified formatted rows that can be rendered into HTML"
-  [remapping-lookup cols rows bar-column max-value]
+  [timezone remapping-lookup cols rows bar-column max-value]
   (for [row rows]
     {:bar-width (when bar-column
                   ;; cast to double to avoid "Non-terminating decimal expansion" errors
@@ -289,17 +304,17 @@
                                        [(nth cols (get remapping-lookup (:name maybe-remapped-col)))
                                         (nth row (get remapping-lookup (:name maybe-remapped-col)))]
                                        [maybe-remapped-col maybe-remapped-row-cell])]]
-            (format-cell row-cell col))}))
+            (format-cell timezone row-cell col))}))
 
 (defn- prep-for-html-rendering
   "Convert the query results (`COLS` and `ROWS`) into a formatted seq
   of rows (list of strings) that can be rendered as HTML"
-  [cols rows bar-column max-value column-limit]
+  [timezone cols rows bar-column max-value column-limit]
   (let [remapping-lookup (create-remapping-lookup cols)
         limited-cols (take column-limit cols)]
     (cons
      (query-results->header-row remapping-lookup limited-cols bar-column)
-     (query-results->row-seq remapping-lookup limited-cols (take rows-limit rows) bar-column max-value))))
+     (query-results->row-seq timezone remapping-lookup limited-cols (take rows-limit rows) bar-column max-value))))
 
 (defn- render-truncation-warning
   [col-limit col-count row-limit row-count]
@@ -322,22 +337,22 @@
         " columns."])]))
 
 (defn- render:table
-  [card {:keys [cols rows] :as data}]
+  [timezone card {:keys [cols rows] :as data}]
   [:div
-   (render-table (prep-for-html-rendering cols rows nil nil cols-limit))
+   (render-table (prep-for-html-rendering timezone cols rows nil nil cols-limit))
    (render-truncation-warning cols-limit (count cols) rows-limit (count rows))])
 
 (defn- render:bar
-  [card {:keys [cols rows] :as data}]
+  [timezone card {:keys [cols rows] :as data}]
   (let [max-value (apply max (map second rows))]
     [:div
-     (render-table (prep-for-html-rendering cols rows second max-value 2))
+     (render-table (prep-for-html-rendering timezone cols rows second max-value 2))
      (render-truncation-warning 2 (count cols) rows-limit (count rows))]))
 
 (defn- render:scalar
-  [card {:keys [cols rows]}]
+  [timezone card {:keys [cols rows]}]
   [:div {:style (style scalar-style)}
-   (-> rows first first (format-cell (first cols)) h)])
+   (-> rows first first (format-cell timezone (first cols)) h)])
 
 (defn- render-sparkline-to-png
   "Takes two arrays of numbers between 0 and 1 and plots them as a sparkline"
@@ -369,7 +384,7 @@
     (.toByteArray os)))
 
 (defn- render:sparkline
-  [_ {:keys [rows cols]}]
+  [timezone card {:keys [rows cols]}]
   (let [ft-row (if (datetime-field? (first cols))
                  #(.getTime ^Date (u/->Timestamp %))
                  identity)
@@ -391,7 +406,7 @@
         ys'    (map #(/ (double (- % ymin)) yrange) ys) ; cast to double to avoid "Non-terminating decimal expansion" errors
         rows'  (reverse (take-last 2 rows))
         values (map (comp format-number second) rows')
-        labels (format-timestamp-pair (map first rows') (first cols))]
+        labels (format-timestamp-pair timezone (map first rows') (first cols))]
     [:div
      [:img {:style (style {:display :block
                            :width :100%})
@@ -454,7 +469,7 @@
 
 (defn render-pulse-card
   "Render a single CARD for a `Pulse` to Hiccup HTML. RESULT is the QP results."
-  [card {:keys [data error]}]
+  [timezone card {:keys [data error]}]
   [:a {:href   (card-href card)
        :target "_blank"
        :style  (style section-style
@@ -474,31 +489,31 @@
            [:img {:style (style {:width :16px})
                   :width 16
                   :src   (render-image-with-filename "frontend_client/app/assets/img/external_link.png")}])]]]])
-  (try
-    (when error
-      (throw (Exception. (str "Card has errors: " error))))
-    (case (detect-pulse-card-type card data)
-      :empty     (render:empty     card data)
-      :scalar    (render:scalar    card data)
-      :sparkline (render:sparkline card data)
-      :bar       (render:bar       card data)
-      :table     (render:table     card data)
-      [:div {:style (style font-style
-                           {:color       "#F9D45C"
-                            :font-weight 700})}
-       "We were unable to display this card." [:br] "Please view this card in Metabase."])
-    (catch Throwable e
-      (log/warn "Pulse card render error:" e)
-      [:div {:style (style font-style
-                           {:color       "#EF8C8C"
-                            :font-weight 700
-                            :padding     :16px})}
-       "An error occurred while displaying this card."]))])
+   (try
+     (when error
+       (throw (Exception. (str "Card has errors: " error))))
+     (case (detect-pulse-card-type card data)
+       :empty     (render:empty     card data)
+       :scalar    (render:scalar    timezone card data)
+       :sparkline (render:sparkline timezone card data)
+       :bar       (render:bar       timezone card data)
+       :table     (render:table     timezone card data)
+       [:div {:style (style font-style
+                            {:color       "#F9D45C"
+                             :font-weight 700})}
+        "We were unable to display this card." [:br] "Please view this card in Metabase."])
+     (catch Throwable e
+       (log/warn "Pulse card render error:" e)
+       [:div {:style (style font-style
+                            {:color       "#EF8C8C"
+                             :font-weight 700
+                             :padding     :16px})}
+        "An error occurred while displaying this card."]))])
 
 
 (defn render-pulse-section
   "Render a specific section of a Pulse, i.e. a single Card, to Hiccup HTML."
-  [{:keys [card result]}]
+  [timezone {:keys [card result]}]
   [:div {:style (style {:margin-top       :10px
                         :margin-bottom    :20px
                         :border           "1px solid #dddddd"
@@ -506,9 +521,9 @@
                         :background-color :white
                         :box-shadow       "0 1px 2px rgba(0, 0, 0, .08)"})}
    (binding [*include-title* true]
-     (render-pulse-card card result))])
+     (render-pulse-card timezone card result))])
 
 (defn render-pulse-card-to-png
   "Render a PULSE-CARD as a PNG. DATA is the `:data` from a QP result (I think...)"
-  ^bytes [pulse-card result]
-  (render-html-to-png (render-pulse-card pulse-card result) card-width))
+  ^bytes [timezone pulse-card result]
+  (render-html-to-png (render-pulse-card timezone pulse-card result) card-width))

--- a/src/metabase/query_processor/middleware/add_settings.clj
+++ b/src/metabase/query_processor/middleware/add_settings.clj
@@ -4,10 +4,7 @@
             [metabase.driver :as driver]))
 
 (defn- add-settings* [{:keys [driver] :as query}]
-  (let [settings {:report-timezone (when (driver/driver-supports? driver :set-timezone)
-                                     (let [report-tz (driver/report-timezone)]
-                                       (when-not (empty? report-tz)
-                                         report-tz)))}]
+  (let [settings {:report-timezone (driver/report-timezone-if-supported driver)}]
     (assoc query :settings (m/filter-vals (complement nil?) settings))))
 
 (defn add-settings

--- a/test/metabase/pulse/render_test.clj
+++ b/test/metabase/pulse/render_test.clj
@@ -1,11 +1,13 @@
 (ns metabase.pulse.render-test
-  (:require [clj-time.coerce :as c]
-            [expectations :refer :all]
+  (:require [expectations :refer :all]
             [hiccup.core :refer [html]]
             [metabase.pulse.render :refer :all]
-            [metabase.test.util :as tu]))
+            [metabase.test.util :as tu])
+  (:import java.util.TimeZone))
 
 (tu/resolve-private-vars metabase.pulse.render prep-for-html-rendering render-truncation-warning)
+
+(def pacific-tz (TimeZone/getTimeZone "America/Los_Angeles"))
 
 (def ^:private test-columns
   [{:name         "ID",
@@ -26,41 +28,41 @@
     :special_type nil}])
 
 (def ^:private test-data
-  [[1 34.0996 (c/from-string "2014-04-01T08:30:00.0000") "Stout Burgers & Beers"]
-   [2 34.0406 (c/from-string "2014-12-05T15:15:00.0000") "The Apple Pan"]
-   [3 34.0474 (c/from-string "2014-08-01T12:45:00.0000") "The Gorbals"]])
+  [[1 34.0996 "2014-04-01T08:30:00.0000" "Stout Burgers & Beers"]
+   [2 34.0406 "2014-12-05T15:15:00.0000" "The Apple Pan"]
+   [3 34.0474 "2014-08-01T12:45:00.0000" "The Gorbals"]])
 
 ;; Testing the format of headers
 (expect
   {:row ["ID" "LATITUDE" "LAST LOGIN" "NAME"]
    :bar-width nil}
-  (first (prep-for-html-rendering test-columns test-data nil nil (count test-columns))))
+  (first (prep-for-html-rendering pacific-tz test-columns test-data nil nil (count test-columns))))
 
 ;; When including a bar column, bar-width is 99%
 (expect
   {:row ["ID" "LATITUDE" "LAST LOGIN" "NAME"]
    :bar-width 99}
-  (first (prep-for-html-rendering test-columns test-data second 40.0 (count test-columns))))
+  (first (prep-for-html-rendering pacific-tz test-columns test-data second 40.0 (count test-columns))))
 
 ;; When there are too many columns, prep-for-html-rendering show narrow it
 (expect
   {:row ["ID" "LATITUDE"]
    :bar-width 99}
-  (first (prep-for-html-rendering test-columns test-data second 40.0 2)))
+  (first (prep-for-html-rendering pacific-tz test-columns test-data second 40.0 2)))
 
 ;; Basic test that result rows are formatted correctly (dates, floating point numbers etc)
 (expect
   [{:bar-width nil, :row ["1" "34.10" "Apr 1, 2014" "Stout Burgers & Beers"]}
    {:bar-width nil, :row ["2" "34.04" "Dec 5, 2014" "The Apple Pan"]}
    {:bar-width nil, :row ["3" "34.05" "Aug 1, 2014" "The Gorbals"]}]
-  (rest (prep-for-html-rendering test-columns test-data nil nil (count test-columns))))
+  (rest (prep-for-html-rendering pacific-tz test-columns test-data nil nil (count test-columns))))
 
 ;; Testing the bar-column, which is the % of this row relative to the max of that column
 (expect
   [{:bar-width (float 85.249),  :row ["1" "34.10" "Apr 1, 2014" "Stout Burgers & Beers"]}
    {:bar-width (float 85.1015), :row ["2" "34.04" "Dec 5, 2014" "The Apple Pan"]}
    {:bar-width (float 85.1185), :row ["3" "34.05" "Aug 1, 2014" "The Gorbals"]}]
-  (rest (prep-for-html-rendering test-columns test-data second 40 (count test-columns))))
+  (rest (prep-for-html-rendering pacific-tz test-columns test-data second 40 (count test-columns))))
 
 (defn- add-rating
   "Injects `RATING-OR-COL` and `DESCRIPTION-OR-COL` into `COLUMNS-OR-ROW`"
@@ -94,14 +96,14 @@
 (expect
   {:row ["ID" "LATITUDE" "RATING DESC" "LAST LOGIN" "NAME"]
    :bar-width nil}
-  (first (prep-for-html-rendering test-columns-with-remapping test-data-with-remapping nil nil (count test-columns-with-remapping))))
+  (first (prep-for-html-rendering pacific-tz test-columns-with-remapping test-data-with-remapping nil nil (count test-columns-with-remapping))))
 
 ;; Result rows should include only the remapped column value, not the original
 (expect
   [["1" "34.10" "Bad" "Apr 1, 2014" "Stout Burgers & Beers"]
    ["2" "34.04" "Ok" "Dec 5, 2014" "The Apple Pan"]
    ["3" "34.05" "Good" "Aug 1, 2014" "The Gorbals"]]
-  (map :row (rest (prep-for-html-rendering test-columns-with-remapping test-data-with-remapping nil nil (count test-columns-with-remapping)))))
+  (map :row (rest (prep-for-html-rendering pacific-tz test-columns-with-remapping test-data-with-remapping nil nil (count test-columns-with-remapping)))))
 
 ;; There should be no truncation warning if the number of rows/cols is fewer than the row/column limit
 (expect
@@ -130,4 +132,4 @@
   [{:bar-width nil, :row ["1" "34.10" "Apr 1, 2014" "Stout Burgers & Beers"]}
    {:bar-width nil, :row ["2" "34.04" "Dec 5, 2014" "The Apple Pan"]}
    {:bar-width nil, :row ["3" "34.05" "Aug 1, 2014" "The Gorbals"]}]
-  (rest (prep-for-html-rendering test-columns-with-date-special-type test-data nil nil (count test-columns))))
+  (rest (prep-for-html-rendering pacific-tz test-columns-with-date-special-type test-data nil nil (count test-columns))))


### PR DESCRIPTION
Previously pulses were always rendered with UTC time, this commit
changes that to use the report timezone (if available and applicable)
otherwise the JVM timezone (similar to how query results are
returned).

Fixes #3109