### PR TITLE
Add MB_DB_CONNECTION_TIMEOUT_MS env var; fix log colorization on Windows

### DIFF
--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -9,7 +9,7 @@
   "Are we running on a Windows machine?"
   (s/includes? (s/lower-case (System/getProperty "os.name")) "win"))
 
-(def ^:private ^:const app-defaults
+(def ^:private app-defaults
   "Global application defaults"
   {:mb-run-mode            "prod"
    ;; DB Settings

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -2,6 +2,7 @@
   (:require [clj-time.format :as tformat]
             [clojure.tools.logging :as log]
             [medley.core :as m]
+            [metabase.config :as config]
             [metabase.models
              [database :refer [Database]]
              [setting :refer [defsetting]]]
@@ -360,10 +361,11 @@
 
 
 ;; ## Implementation-Agnostic Driver API
-
-(def ^:private ^:const can-connect-timeout-ms
-  "Consider `can-connect?`/`can-connect-with-details?` to have failed after this many milliseconds."
-  5000)
+(def ^:private can-connect-timeout-ms
+  "Consider `can-connect?`/`can-connect-with-details?` to have failed after this many milliseconds.
+   By default, this is 5 seconds. You can configure this value by setting the env var `MB_DB_CONNECTION_TIMEOUT_MS`."
+  (or (config/config-int :mb-db-connection-timeout-ms)
+      5000))
 
 (defn can-connect-with-details?
   "Check whether we can connect to a database with ENGINE and DETAILS-MAP and perform a basic query


### PR DESCRIPTION
As requested in #3912.