### PR TITLE
Date dimension options should apply to unix timestamps

### DIFF
--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -165,7 +165,8 @@
   (let [{min_value :min, max_value :max} (get-in fingerprint [:type :type/Number])
         [default-option all-options] (cond
 
-                                       (isa? base_type :type/DateTime)
+                                       (or (isa? base_type :type/DateTime)
+                                           (isa? special_type :type/DateTime))
                                        [date-default-index datetime-dimension-indexes]
 
                                        (and min_value max_value


### PR DESCRIPTION
They have a base_type of numeric but a special type of DateTime. This
adds the check for special type when associating dimension options to
a field.

Fixes #5876

