### PR TITLE
Bump node version to 8.4.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
     version:
       openjdk7
   node:
-    version: 4.4.7
+    version: 8.4.0
   services:
     - docker
 dependencies:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/metabase/metabase",
   "license": "private",
   "engines": {
-    "node": "4.4.7",
+    "node": "8.4.0",
     "npm": "2.15.9"
   },
   "dependencies": {


### PR DESCRIPTION
Yarn 1.0.0 has been released and it doesn't appear to work with the
version of node we current have configured (4.4.7). Bumping to 8.4.0
to get the build green again.
