### PR TITLE
Fix typo in developers guide

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -196,7 +196,7 @@ You can also skim through [`__support__/integrated_tests.js`](https://github.com
 
 Unit tests are focused around isolated parts of business logic. 
 
-Integration tests use an enforced file naming convention `<test-suite-name>.unit.js` to separate them from integration tests.
+Unit tests use an enforced file naming convention `<test-suite-name>.unit.js` to separate them from integration tests.
 
 ```
 yarn run jest-test # Run all tests at once


### PR DESCRIPTION
In [Jest Unit tests section](https://github.com/metabase/metabase/blob/master/docs/developers-guide.md#jest-unit-tests)
It should say
"**Unit** tests use an enforced file naming..."