### PR TITLE
New Question flow copy tweaks

### DIFF
--- a/frontend/src/metabase/new_query/components/NewQueryOption.jsx
+++ b/frontend/src/metabase/new_query/components/NewQueryOption.jsx
@@ -40,7 +40,9 @@ export default class NewQueryOption extends Component {
                </div>
                <div className="text-normal mt2 mb2 text-paragraph" style={{lineHeight: "1.25em"}}>
                    <h2 className={cx("transition-all", {"text-brand": hover})}>{title}</h2>
-                   <p className={"text-grey-4 text-small"}>{description}</p>
+                   <div className="flex layout-centered">
+                     <p style={{maxWidth: 300}} className={"text-grey-4 text-small"}>{description}</p>
+                   </div>
                </div>
            </Link>
        );

--- a/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
+++ b/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
@@ -132,7 +132,7 @@ export class NewQueryOptions extends Component {
                                 <li className="Grid-cell">
                                     <NewQueryOption
                                         image="/app/img/list_illustration"
-                                        title="Segments"
+                                        title="Tables"
                                         description="Explore tables and see what’s going on underneath your charts."
                                         width={180}
                                         to={segmentSearchUrl}
@@ -144,7 +144,7 @@ export class NewQueryOptions extends Component {
                                 <NewQueryOption
                                     image="/app/img/query_builder_illustration"
                                     title={ showCustomInsteadOfNewQuestionText ? "Custom" : "New question"}
-                                    description="Use the simple query builder to see trends, lists of things, or to create your own metrics."
+                                    description="Use the simple question builder to see trends, lists of things, or to create your own metrics."
                                     width={180}
                                     to={this.getGuiQueryUrl}
                                 />
@@ -153,8 +153,8 @@ export class NewQueryOptions extends Component {
                                 <li className="Grid-cell">
                                     <NewQueryOption
                                         image="/app/img/sql_illustration"
-                                        title="SQL"
-                                        description="For more complicated questions, you can write your own SQL."
+                                        title="Native query"
+                                        description="For more complicated questions, you can write your own SQL or native query."
                                         to={this.getNativeQueryUrl}
                                     />
                                 </li>


### PR DESCRIPTION
Changed `Segments` to `Tables`, and `SQL` to `Native query`

For this PR to really be true, the `Tables` option will of course need to include all tables. Doing that will raise a couple issues:
1. Do we visually distinguish or separate saved segments from raw tables in the list(s)? Maybe they're grouped with their parent table somehow?
2. We'll need to remove the `Table` view-by option on the left, presumably. Probably also the `Created by` option.