### PR TITLE
Wrap link URLs within map popups

### DIFF
--- a/frontend/src/metabase/css/core/link.css
+++ b/frontend/src/metabase/css/core/link.css
@@ -17,6 +17,9 @@
 .link--nohover:hover {
   text-decoration: none;
 }
+.link--wrappable {
+  word-break: break-all;
+}
 
 .expand-clickable {
   display: inline-block;

--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -209,7 +209,7 @@ const URL_WHITELIST_REGEX = /^(https?|mailto):\/*(?:[^:@]+(?::[^@]+)?@)?(?:[^\s:
 export function formatUrl(value: Value, { jsx }: FormattingOptions = {}) {
     const url = String(value);
     if (jsx && URL_WHITELIST_REGEX.test(url)) {
-        return <ExternalLink href={url}>{url}</ExternalLink>;
+        return <ExternalLink className="link link--wrappable" href={url}>{url}</ExternalLink>;
     } else {
         return url;
     }


### PR DESCRIPTION
### Problem
When a dataset includes a URL and you map it, the URL can break outside the layout of the popup.

![screen shot 2017-09-13 at 12 57 04 pm](https://user-images.githubusercontent.com/17760/30398514-92930578-9885-11e7-92ca-c8e369a58c18.png)

### Solution
This PR adds a `word-break: break-all` to the styling of those links. We add a `.link--wrappable` variant and apply that to any use of `formatUrl`.  `formatUrl` is likely the best place for this since it can only render a full `url`. Any place where Metabase does that in the future will likely benefit from this fix. 

![screen shot 2017-09-13 at 12 58 35 pm](https://user-images.githubusercontent.com/17760/30398686-25c5c074-9886-11e7-91e8-5a54d8cd0bcc.png)

Feel free to recommend another approach. This is breaking some of our dashboards at Hoodline, so let me know if there's a simpler/better fix. Thanks!