### PR TITLE
Fix date bucketing with Druid grouped timeseries queries

### DIFF
--- a/src/metabase/driver/druid/query_processor.clj
+++ b/src/metabase/driver/druid/query_processor.clj
@@ -720,14 +720,31 @@
 
 (defmulti ^:private post-process query-type-dispatch-fn)
 
-(defmethod post-process ::select  [_ results] (->> results first :result :events (map :event)))
-(defmethod post-process ::total   [_ results] (map :result results))
-(defmethod post-process ::topN    [_ results] (-> results first :result))
-(defmethod post-process ::groupBy [_ results] (map :event results))
+(defn- post-process-map [projections results]
+  {:projections projections
+   :results     results})
 
-(defmethod post-process ::timeseries [_ results]
-  (for [event results]
-    (conj {:timestamp (:timestamp event)} (:result event))))
+(defmethod post-process ::select  [_ projections results]
+  (->> results
+       first
+       :result
+       :events
+       (map :event)
+       (post-process-map projections)))
+
+(defmethod post-process ::total   [_ projections results]
+  (post-process-map projections (map :result results)))
+
+(defmethod post-process ::topN    [_ projections results]
+  (post-process-map projections (-> results first :result)))
+
+(defmethod post-process ::groupBy [_ projections results]
+  (post-process-map projections (map :event results)))
+
+(defmethod post-process ::timeseries [_ projections results]
+  (post-process-map (conj projections :timestamp)
+                    (for [event results]
+                      (conj {:timestamp (:timestamp event)} (:result event)))))
 
 (defn post-process-native
   "Post-process the results of a *native* Druid query.
@@ -778,24 +795,25 @@
   "Execute a query for a Druid DB."
   [do-query {database :database, {:keys [query query-type mbql? projections]} :native}]
   {:pre [database query]}
-  (let [details    (:details database)
-        query      (if (string? query)
-                     (json/parse-string query keyword)
-                     query)
-        query-type (or query-type (keyword "metabase.driver.druid.query-processor" (name (:queryType query))))
-        results     (->> query
-                         (do-query details)
-                         (post-process query-type))
-        columns    (if mbql?
-                     (->> projections
-                          remove-bonus-keys
-                          vec)
-                     (keys (first results)))
-        getters    (columns->getter-fns columns)]
+  (let [details       (:details database)
+        query         (if (string? query)
+                        (json/parse-string query keyword)
+                        query)
+        query-type    (or query-type (keyword "metabase.driver.druid.query-processor" (name (:queryType query))))
+        post-proc-map (->> query
+                           (do-query details)
+                           (post-process query-type projections))
+        columns       (if mbql?
+                        (->> post-proc-map
+                             :projections
+                             remove-bonus-keys
+                             vec)
+                        (-> post-proc-map :results first keys))
+        getters       (columns->getter-fns columns)]
     ;; rename any occurances of `:timestamp___int` to `:timestamp` in the results so the user doesn't know about our behind-the-scenes conversion
     ;; and apply any other post-processing on the value such as parsing some units to int and rounding up approximate cardinality values.
     {:columns   (vec (replace {:timestamp___int :timestamp :distinct___count :count} columns))
-     :rows      (for [row results]
+     :rows      (for [row (:results post-proc-map)]
                   (for [getter getters]
                     (getter row)))
      :annotate? mbql?}))

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -7,7 +7,9 @@
              [driver :as driver]
              [http-client :as http]
              [middleware :as middleware]
+             [query-processor-test :as qpt]
              [sync :as sync]
+             [timeseries-query-processor-test :as timeseries-qp-test]
              [util :as u]]
             [metabase.api.table :as table-api]
             [metabase.models
@@ -27,10 +29,7 @@
             [toucan
              [db :as db]
              [hydrate :as hydrate]]
-            [toucan.util.test :as tt]
-            [metabase.query-processor-test :as qpt]
-            [metabase.timeseries-query-processor-test :as timeseries-qp-test]
-            [metabase.test.data.datasets :as datasets :refer [*driver* *engine*]]))
+            [toucan.util.test :as tt]))
 
 ;; ## /api/org/* AUTHENTICATION Tests
 ;; We assume that all endpoints for a given context are enforced by the same middleware, so we don't run the same

--- a/test/metabase/timeseries_query_processor_test.clj
+++ b/test/metabase/timeseries_query_processor_test.clj
@@ -595,6 +595,23 @@
           (ql/breakout (ql/datetime-field $timestamp :month))
           (ql/limit 5))))
 
+;; This test is similar to the above query but doesn't use a limit
+;; clause which causes the query to be a grouped timeseries query
+;; rather than a topN query. The dates below are formatted incorrectly
+;; due to https://github.com/metabase/metabase/issues/5969.
+(expect-with-timeseries-dbs
+  {:columns ["timestamp" "count"]
+   :rows [["2013-01-01T00:00:00.000Z" 8]
+          ["2013-02-01T00:00:00.000Z" 11]
+          ["2013-03-01T00:00:00.000Z" 21]
+          ["2013-04-01T00:00:00.000Z" 26]
+          ["2013-05-01T00:00:00.000Z" 23]]}
+  (-> (data/run-query checkins
+        (ql/aggregation (ql/count))
+        (ql/breakout (ql/datetime-field $timestamp :month)))
+      data
+      (update :rows #(take 5 %))))
+
 ;;; date bucketing - month-of-year
 (expect-with-timeseries-dbs
   {:columns ["timestamp" "count"]


### PR DESCRIPTION
The timestamp field was getting added after the results were returned
and not getting added to the list of expected projections. This PR
adds that which causes the bucketed fields to be returned correctly.

Fixes #5933