### PR TITLE
Change the min node version from 8.4.0->6.7.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
     version:
       openjdk7
   node:
-    version: 8.4.0
+    version: 6.7.0
   services:
     - docker
 dependencies:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/metabase/metabase",
   "license": "private",
   "engines": {
-    "node": "8.4.0",
+    "node": ">=6.7.0",
     "npm": "2.15.9"
   },
   "dependencies": {


### PR DESCRIPTION
Our docker containers currently building with the Alphine system
nodejs package (6.7.0) so this lowers our minimum version to that in
packages.json and changes the circle config to use that same version