### PR TITLE
Keep QP schema validation exception sizes reasonable

### DIFF
--- a/src/metabase/query_processor/middleware/catch_exceptions.clj
+++ b/src/metabase/query_processor/middleware/catch_exceptions.clj
@@ -23,7 +23,7 @@
                                 (dissoc :database :driver)
                                 u/ignore-exceptions))}
          (when-let [data (ex-data e)]
-           {:ex-data data})
+           {:ex-data (dissoc data :schema)})
          additional-info))
 
 (defn- explain-schema-validation-error


### PR DESCRIPTION
Fixes #5978. Includes test