### PR TITLE
Fix issue with scalar pulses returning timezones

### DIFF
--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -32,11 +32,15 @@
         (catch Throwable t
           (log/warn (format "Error running card query (%n)" card-id) t))))))
 
+(defn- database-id [card]
+  (or (:database_id card)
+      (get-in card [:database_query :database])))
+
 (s/defn defaulted-timezone :- TimeZone
   "Returns the timezone for the given `CARD`. Either the report
   timezone (if applicable) or the JVM timezone."
   [card :- Card]
-  (let [^String timezone-str (or (-> card :database_id driver/database-id->driver driver/report-timezone-if-supported)
+  (let [^String timezone-str (or (some-> card database-id driver/database-id->driver driver/report-timezone-if-supported)
                                  (System/getProperty "user.timezone"))]
     (TimeZone/getTimeZone timezone-str)))
 

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -352,7 +352,7 @@
 (defn- render:scalar
   [timezone card {:keys [cols rows]}]
   [:div {:style (style scalar-style)}
-   (-> rows first first (format-cell timezone (first cols)) h)])
+   (h (format-cell timezone (ffirst rows) (first cols)))])
 
 (defn- render-sparkline-to-png
   "Takes two arrays of numbers between 0 and 1 and plots them as a sparkline"


### PR DESCRIPTION
This commit fixes a format-cell argument order issue that would cause
the timezone object to be returned instead of the data being
formatted.

While investigating this I found that the database_id isn't being
populated and so we are erroring out while trying to lookup the report
timezone. This commit will look in the database_query map if
database_id isn't found on the card.

