### PR TITLE
Add clarifier about time series in x-ray settings

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsXrayForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsXrayForm.jsx
@@ -34,6 +34,10 @@ const SettingsXrayForm = ({ settings, elements, updateSetting }) => {
                 <p className="m0 text-paragraph">
                     If you're having performance issues related to x-ray usage you can cap how expensive x-rays are allowed to be.
                 </p>
+                <p className="text-paragraph">
+                  <em><strong>Note:</strong> "Extended" is required for viewing time series x-rays.</em>
+                </p>
+
                 <ol className="mt4">
                     { Object.keys(COSTS).map(key => {
                         const cost = COSTS[key]


### PR DESCRIPTION
Make it clearer that the Extended setting has to be on in order for time series x-rays to be made available.

![screen shot 2017-09-19 at 3 43 01 pm](https://user-images.githubusercontent.com/2223916/30618958-a90ecca8-9d51-11e7-839d-ee9c7f0bbed9.png)