### PR TITLE
Added timestamp formatting for druid select queries [ci drivers]

### DIFF
--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -1,6 +1,7 @@
 (ns metabase.test.util
   "Helper functions and macros for writing unit tests."
   (:require [cheshire.core :as json]
+            [clj-time.core :as time]
             [clojure.tools.logging :as log]
             [clojure.walk :as walk]
             [clojurewerkz.quartzite.scheduler :as qs]
@@ -28,7 +29,8 @@
             [metabase.test.data :as data]
             [metabase.test.data.datasets :refer [*driver*]]
             [toucan.util.test :as test])
-  (:import org.joda.time.DateTime
+  (:import java.util.TimeZone
+           [org.joda.time DateTime DateTimeZone]
            [org.quartz CronTrigger JobDetail JobKey Scheduler Trigger]))
 
 ;; ## match-$
@@ -418,3 +420,34 @@
         .getChronology
         .getZone
         .getID)))
+
+(defn call-with-jvm-tz
+  "Invokes the thunk `F` with the JVM timezone set to `DTZ`, puts the
+  various timezone settings back the way it found it when it exits."
+  [^DateTimeZone dtz f]
+  (let [orig-tz (TimeZone/getDefault)
+        orig-dtz (time/default-time-zone)
+        orig-tz-prop (System/getProperty "user.timezone")]
+    (try
+      ;; It looks like some DB drivers cache the timezone information
+      ;; when instantiated, this clears those to force them to reread
+      ;; that timezone value
+      (reset! @#'metabase.driver.generic-sql/database-id->connection-pool {})
+      ;; Used by JDBC, and most JVM things
+      (TimeZone/setDefault (.toTimeZone dtz))
+      ;; Needed as Joda time has a different default TZ
+      (DateTimeZone/setDefault dtz)
+      ;; We read the system property directly when formatting results, so this needs to be changed
+      (System/setProperty "user.timezone" (.getID dtz))
+      (f)
+      (finally
+        ;; We need to ensure we always put the timezones back the way
+        ;; we found them as it will cause test failures
+        (TimeZone/setDefault orig-tz)
+        (DateTimeZone/setDefault orig-dtz)
+        (System/setProperty "user.timezone" orig-tz-prop)))))
+
+(defmacro with-jvm-tz
+  "Invokes `BODY` with the JVM timezone set to `DTZ`"
+  [dtz & body]
+  `(call-with-jvm-tz ~dtz (fn [] ~@body)))


### PR DESCRIPTION
Druid select queries don't allow setting of a timezone. This commit
will parse the timestamps coming out of Druid and reformat them using
the user's report timezone or system timezone. This allows Druid
select queries to have similar timezone semantics to other supported
databases.

Fixes #3690