### PR TITLE
Switch from the PostgreSQL driver to Redshift [ci drivers]

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -82,7 +82,7 @@
                  [org.slf4j/slf4j-log4j12 "1.7.25"]                   ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
                  [org.yaml/snakeyaml "1.18"]                          ; YAML parser (required by liquibase)
                  [org.xerial/sqlite-jdbc "3.16.1"]                    ; SQLite driver
-                 [postgresql "9.3-1102.jdbc41"]                       ; Postgres driver
+                 [org.postgresql/postgresql "42.1.4.jre7"]            ; Postgres driver
                  [io.crate/crate-jdbc "2.1.6"]                        ; Crate JDBC driver
                  [prismatic/schema "1.1.5"]                           ; Data schema declaration and validation library
                  [redux "0.1.4"]                                      ; Utility functions for building and composing transducers

--- a/project.clj
+++ b/project.clj
@@ -91,8 +91,10 @@
                  [ring/ring-json "0.4.0"]                             ; Ring middleware for reading/writing JSON automatically
                  [stencil "0.5.0"]                                    ; Mustache templates for Clojure
                  [toucan "1.0.3"                                      ; Model layer, hydration, and DB utilities
-                  :exclusions [honeysql]]]
-  :repositories [["bintray" "https://dl.bintray.com/crate/crate"]]    ; Repo for Crate JDBC driver
+                  :exclusions [honeysql]]
+                 [com.amazon.redshift/redshift-jdbc41 "1.2.8.1005"]]  ; Redshift JDBC driver
+  :repositories [["bintray" "https://dl.bintray.com/crate/crate"]
+                 ["redshift" "http://redshift-maven-repository.s3-website-us-east-1.amazonaws.com/release"]] ; Repo for Crate JDBC driver
   :plugins [[lein-environ "1.1.0"]                                    ; easy access to environment variables
             [lein-ring "0.11.0"                                       ; start the HTTP server with 'lein ring server'
              :exclusions [org.clojure/clojure]]]                      ; TODO - should this be a dev dependency ?

--- a/src/metabase/db/spec.clj
+++ b/src/metabase/db/spec.clj
@@ -38,3 +38,15 @@
           :subname (str "//" host ":" port "/" db)
           :delimiters "`"}
          (dissoc opts :host :port :db)))
+
+(defn redshift
+  "Create a database specification for a redshift database. Opts should include
+  keys for :db, :user, and :password. You can also optionally set host and
+  port."
+  [{:keys [host port db]
+    :as opts}]
+  (merge {:classname "com.amazon.redshift.jdbc.Driver" ; must be in classpath
+          :subprotocol "redshift"
+          :subname (str "//" host ":" port "/" db)
+          :ssl true}
+         (dissoc opts :host :port :db)))

--- a/src/metabase/db/spec.clj
+++ b/src/metabase/db/spec.clj
@@ -23,7 +23,7 @@
     :as opts}]
   (merge {:classname "org.postgresql.Driver" ; must be in classpath
           :subprotocol "postgresql"
-          :subname (str "//" host ":" port "/" db)}
+          :subname (str "//" host ":" port "/" db "?OpenSourceSubProtocolOverride=true")}
          (dissoc opts :host :port :db)))
 
 (defn mysql
@@ -47,6 +47,6 @@
     :as opts}]
   (merge {:classname "com.amazon.redshift.jdbc.Driver" ; must be in classpath
           :subprotocol "redshift"
-          :subname (str "//" host ":" port "/" db)
+          :subname (str "//" host ":" port "/" db "?OpenSourceSubProtocolOverride=false")
           :ssl true}
          (dissoc opts :host :port :db)))

--- a/src/metabase/driver/redshift.clj
+++ b/src/metabase/driver/redshift.clj
@@ -16,7 +16,7 @@
              [ssh :as ssh]]))
 
 (defn- connection-details->spec [details]
-  (dbspec/postgres (merge details postgres/ssl-params))) ; always connect to redshift over SSL
+  (dbspec/redshift details))
 
 (defn- date-interval [unit amount]
   (hsql/call :+ :%getdate (hsql/raw (format "INTERVAL '%d %s'" (int amount) (name unit)))))

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -33,7 +33,7 @@
   {:user        "camsaul"
    :classname   "org.postgresql.Driver"
    :subprotocol "postgresql"
-   :subname     "//localhost:5432/bird_sightings"
+   :subname     "//localhost:5432/bird_sightings?OpenSourceSubProtocolOverride=true"
    :sslmode     "disable"}
   (sql/connection-details->spec pg-driver {:ssl    false
                                            :host   "localhost"
@@ -49,7 +49,7 @@
    :subprotocol "postgresql"
    :user        "camsaul"
    :sslfactory  "org.postgresql.ssl.NonValidatingFactory"
-   :subname     "//localhost:5432/bird_sightings"}
+   :subname     "//localhost:5432/bird_sightings?OpenSourceSubProtocolOverride=true"}
   (sql/connection-details->spec pg-driver {:ssl    true
                                            :host   "localhost"
                                            :port   5432
@@ -268,7 +268,7 @@
 
 ;; make sure connection details w/ extra params work as expected
 (expect
-  "//localhost:5432/cool?prepareThreshold=0"
+  "//localhost:5432/cool?OpenSourceSubProtocolOverride=true&prepareThreshold=0"
   (:subname (sql/connection-details->spec pg-driver {:host               "localhost"
                                                      :port               "5432"
                                                      :dbname             "cool"

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -155,9 +155,13 @@
    (:id (db)))
 
   ([table-name]
+   ;; Ensure the database has been created
+   (db)
    (get-table-id-or-explode (id) table-name))
 
   ([table-name field-name & nested-field-names]
+   ;; Ensure the database has been created
+   (db)
    (let [table-id (id table-name)]
      (loop [parent-id (get-field-id-or-explode table-id field-name), [nested-field-name & more] nested-field-names]
        (if-not nested-field-name


### PR DESCRIPTION
Previously we were using the PostgreSQL driver for connecting to
Redshift. Newer versions of PostgreSQL require newer drivers that are
no longer compatible with Redshift which has prevented us from
upgrading. By switching to the AWS Redshift driver, we can upgrade the
PostgreSQL driver independently.
