### PR TITLE
Change logging level to INFO

### DIFF
--- a/resources/log4j.properties
+++ b/resources/log4j.properties
@@ -17,13 +17,13 @@ log4j.appender.file.layout.ConversionPattern=%d [%t] %-5p%c - %m%n
 log4j.appender.metabase=metabase.logger.Appender
 
 # customizations to logging by package
-log4j.logger.metabase.driver=DEBUG
-log4j.logger.metabase.middleware=DEBUG
-log4j.logger.metabase.models.permissions=DEBUG
-log4j.logger.metabase.query-processor.permissions=DEBUG
-log4j.logger.metabase.query-processor=DEBUG
+log4j.logger.metabase.driver=INFO
+log4j.logger.metabase.middleware=INFO
+log4j.logger.metabase.models.permissions=INFO
+log4j.logger.metabase.query-processor.permissions=INFO
+log4j.logger.metabase.query-processor=INFO
 log4j.logger.metabase.sync=DEBUG
-log4j.logger.metabase.models.field-values=DEBUG
+log4j.logger.metabase.models.field-values=INFO
 log4j.logger.metabase=INFO
 # c3p0 connection pools tend to log useless warnings way too often; only log actual errors
 log4j.logger.com.mchange=ERROR


### PR DESCRIPTION
I found an excessive amount of objects being allocated due to logging. We have quite a bit of logging that first pretty-prints data structures. The pretty printing is what is creating so many objects. Testing locally, I found over 30% of all objects being allocated, were allocated for logging. I don't have as firm specifics around wall clock time, but it appears to be roughly 15% faster with INFO level logging vs. DEBUG logging. Changing the logging level to INFO fixes this. The logging macro won't execute the pretty printing body unless DEBUG logging is enabled.

Users can opt in to slower debug-level logging if desired by following our instructions [here](https://github.com/metabase/metabase/blob/master/docs/operations-guide/start.md#configuring-logging-level).