### PR TITLE
Fix a top level data/id call

### DIFF
--- a/test/metabase/models/on_demand_test.clj
+++ b/test/metabase/models/on_demand_test.clj
@@ -142,7 +142,7 @@
 ;;; |                                                   DASHBOARDS                                                   |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(def ^:private basic-mbql-query
+(defn- basic-mbql-query []
   {:database (data/id)
    :type     :query
    :query    {:source_table (data/id :venues)
@@ -157,7 +157,7 @@
     {:parameter_mappings (parameter-mappings-for-card-and-field card-or-id field-or-id)}))
 
 (defn- do-with-updated-fields-for-dashboard {:style/indent 1} [options & [f]]
-  (do-with-updated-fields-for-card (merge {:card {:dataset_query basic-mbql-query}}
+  (do-with-updated-fields-for-card (merge {:card {:dataset_query (basic-mbql-query)}}
                                           options)
     (fn [objects]
       (tt/with-temp Dashboard [dash]


### PR DESCRIPTION
There's a def of a data structure that contains a data/id call. This
can be a problem if the database hasn't been initialized yet. This
commit wraps it in a thunk to ensure it happens when the test run, not
when the code is compiled.
