### PR TITLE
In new question flow, apply appropriate filter and breakout for metrics automatically

### DIFF
--- a/frontend/src/metabase/new_query/containers/MetricSearch.jsx
+++ b/frontend/src/metabase/new_query/containers/MetricSearch.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { fetchMetrics, fetchDatabasesWithMetadata } from "metabase/redux/metadata";
+import { fetchMetrics, fetchDatabases } from "metabase/redux/metadata";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import EntitySearch from "metabase/containers/EntitySearch";
 import { getMetadata, getMetadataFetched } from "metabase/selectors/metadata";
@@ -21,7 +21,7 @@ const mapStateToProps = state => ({
 })
 const mapDispatchToProps = {
     fetchMetrics,
-    fetchDatabasesWithMetadata,
+    fetchDatabases,
     resetQuery
 }
 
@@ -40,9 +40,7 @@ export default class MetricSearch extends Component {
     }
 
     componentDidMount() {
-        // load metadata for all tables for the automatic application of a filter;
-        // THIS IS EXPERIMENTAL AND PROBABLY TOO HEAVY APPROACH FOR PRODUCTION!
-        this.props.fetchDatabasesWithMetadata()
+        this.props.fetchDatabases() // load databases if not loaded yet
         this.props.fetchMetrics(true) // metrics may change more often so always reload them
         this.props.resetQuery();
 

--- a/frontend/src/metabase/new_query/containers/MetricSearch.jsx
+++ b/frontend/src/metabase/new_query/containers/MetricSearch.jsx
@@ -28,7 +28,7 @@ const mapDispatchToProps = {
 @connect(mapStateToProps, mapDispatchToProps)
 export default class MetricSearch extends Component {
     props: {
-        getUrlForQuery: (StructuredQuery) => void,
+        getUrlForMetric: (StructuredQuery) => void,
         backButtonUrl: string,
 
         query: StructuredQuery,
@@ -48,24 +48,8 @@ export default class MetricSearch extends Component {
 
     }
 
-    getQueryForMetric = (metric: Metric) => {
-        const queryWithoutFilter = this.props.query
-            .setDatabase(metric.table.db)
-            .setTable(metric.table)
-            .addAggregation(metric.aggregationClause())
-
-        const dateField = metric.table.fields.find((field) => field.isDate())
-
-        if (dateField) {
-            const dateFilter = ["time-interval", dateField.dimension().mbql(), -365, "day"]
-            return queryWithoutFilter.addFilter(dateFilter).addBreakout(dateField.getDefaultBreakout())
-        } else {
-            return queryWithoutFilter;
-        }
-    }
-
     getUrlForMetric = (metric: Metric) => {
-        return this.props.getUrlForQuery(this.getQueryForMetric(metric))
+        return this.props.getUrlForMetric(metric)
     }
 
     render() {

--- a/frontend/src/metabase/new_query/containers/MetricSearch.jsx
+++ b/frontend/src/metabase/new_query/containers/MetricSearch.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { fetchMetrics, fetchDatabases } from "metabase/redux/metadata";
+import { fetchMetrics, fetchDatabasesWithMetadata } from "metabase/redux/metadata";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import EntitySearch from "metabase/containers/EntitySearch";
 import { getMetadata, getMetadataFetched } from "metabase/selectors/metadata";
@@ -21,7 +21,7 @@ const mapStateToProps = state => ({
 })
 const mapDispatchToProps = {
     fetchMetrics,
-    fetchDatabases,
+    fetchDatabasesWithMetadata,
     resetQuery
 }
 
@@ -40,18 +40,32 @@ export default class MetricSearch extends Component {
     }
 
     componentDidMount() {
-        this.props.fetchDatabases() // load databases if not loaded yet
+        // load metadata for all tables for the automatic application of a filter;
+        // THIS IS EXPERIMENTAL AND PROBABLY TOO HEAVY APPROACH FOR PRODUCTION!
+        this.props.fetchDatabasesWithMetadata()
         this.props.fetchMetrics(true) // metrics may change more often so always reload them
         this.props.resetQuery();
+
     }
 
-    getUrlForMetric = (metric: Metric) => {
-        const updatedQuery = this.props.query
+    getQueryForMetric = (metric: Metric) => {
+        const queryWithoutFilter = this.props.query
             .setDatabase(metric.table.db)
             .setTable(metric.table)
             .addAggregation(metric.aggregationClause())
 
-        return this.props.getUrlForQuery(updatedQuery);
+        const dateField = metric.table.fields.find((field) => field.isDate())
+
+        if (dateField) {
+            const dateFilter = ["time-interval", dateField.dimension().mbql(), -365, "day"]
+            return queryWithoutFilter.addFilter(dateFilter).addBreakout(dateField.getDefaultBreakout())
+        } else {
+            return queryWithoutFilter;
+        }
+    }
+
+    getUrlForMetric = (metric: Metric) => {
+        return this.props.getUrlForQuery(this.getQueryForMetric(metric))
     }
 
     render() {

--- a/frontend/src/metabase/new_query/router_wrappers.js
+++ b/frontend/src/metabase/new_query/router_wrappers.js
@@ -29,7 +29,9 @@ export class NewQuestionStart extends Component {
 @withBackground('bg-slate-extra-light')
 export class NewQuestionMetricSearch extends Component {
     getUrlForQuery = (query) => {
-        return query.question().getUrl()
+        return query.question()
+            .setDisplay(query.breakouts().length > 0 ? "line" : "scalar")
+            .getUrl()
     }
 
     render() {

--- a/frontend/src/metabase/new_query/router_wrappers.js
+++ b/frontend/src/metabase/new_query/router_wrappers.js
@@ -52,7 +52,9 @@ export class NewQuestionFromMetric extends Component {
         }
 
         const tableId = this.props.metadata.metrics[metricId].table_id
-        if (!metadataBeforeInit.tables[tableId]) {
+        if (!metadataBeforeInit.tables[tableId] ||
+            !metadataBeforeInit.tables[tableId].fields ||
+            !metadataBeforeInit.tables[tableId].fields.length) {
             await this.props.fetchTableMetadata(tableId)
         }
 

--- a/frontend/src/metabase/redux/metadata.js
+++ b/frontend/src/metabase/redux/metadata.js
@@ -38,6 +38,27 @@ export const fetchMetrics = createThunkAction(FETCH_METRICS, (reload = false) =>
     };
 });
 
+export const FETCH_METRIC = "metabase/metadata/FETCH_METRIC";
+export const fetchMetric = createThunkAction(FETCH_METRIC, (metricId, reload = false) => {
+    return async (dispatch, getState) => {
+        const requestStatePath = ["metadata", "metrics", metricId];
+        const existingStatePath = ["metadata", "metrics"]
+        const getData = async () => {
+            const metric = await MetricApi.get({ metricId });
+            return normalize([metric], [MetricSchema]);
+        };
+
+        return await fetchData({
+            dispatch,
+            getState,
+            requestStatePath,
+            existingStatePath,
+            getData,
+            reload
+        });
+    };
+});
+
 const UPDATE_METRIC = "metabase/metadata/UPDATE_METRIC";
 export const updateMetric = createThunkAction(UPDATE_METRIC, function(metric) {
     return async (dispatch, getState) => {

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -42,7 +42,7 @@ import SetupApp from "metabase/setup/containers/SetupApp.jsx";
 import UserSettingsApp from "metabase/user/containers/UserSettingsApp.jsx";
 
 // new question
-import { NewQuestionStart, NewQuestionMetricSearch } from "metabase/new_query/router_wrappers";
+import { NewQuestionStart, NewQuestionMetricSearch, NewQuestionFromMetric } from "metabase/new_query/router_wrappers";
 
 // admin containers
 import DatabaseListApp from "metabase/admin/databases/containers/DatabaseListApp.jsx";
@@ -201,6 +201,7 @@ export const getRoutes = (store) =>
                     <Route path="new" title="New Question">
                         <IndexRoute component={NewQuestionStart} />
                         <Route path="metric" title="Metrics" component={NewQuestionMetricSearch} />
+                        <Route path="metric/:metricId" component={NewQuestionFromMetric} />
                     </Route>
                 </Route>
                 <Route path="/question/:cardId" component={QueryBuilder} />

--- a/frontend/test/home/HomepageApp.integ.spec.js
+++ b/frontend/test/home/HomepageApp.integ.spec.js
@@ -73,8 +73,6 @@ describe("HomepageApp", () => {
             // eslint-disable-next-line no-irregular-whitespace
             expect(activityItems.at(2).text()).toMatch(/You saved a question about Orders/);
             expect(activityStories.at(2).text()).toMatch(new RegExp(unsavedOrderCountQuestion.displayName()));
-
-
         });
         it("shows successfully open QB for a metric when clicking the metric name", async () => {
             const store = await createTestStore()


### PR DESCRIPTION
Wanted to create a separate PR for this, earlier this was part of https://github.com/metabase/metabase/pull/5997.

---

Currently this has one potential performance problem that we need to solve if we want to merge this to production. A brief description of the problem:
- List items in Metrics search view are question links which contain the hashed questions.
- We want that clicking the link opens the question with breakouts/filters applied
- The problem is that in order to generate the link, we have to know which breakouts/filters to apply. We want to choose the fields for breakouts/filters so we have to know the fields for generating the links.
- The current solution is that we fetch the detailed metadata for every single table so that we can be sure that we have fields available when we need them.

Just realized that the fix is maybe pretty simple – just load the detailed metadata for those tables that have metrics attached. If there are metrics in >10 tables then the page load might be a little slow but probably still tolerable?