### PR TITLE
Card comparison and metrics groundwork

### DIFF
--- a/src/metabase/feature_extraction/feature_extractors.clj
+++ b/src/metabase/feature_extraction/feature_extractors.clj
@@ -226,7 +226,6 @@
     histogram-extractor
     cardinality-extractor
     (field-metadata-extractor field)
-    number-extractor
     (fn [{:keys [histogram histogram-categorical kurtosis skewness sum
                  sum-of-squares]}]
       (let [var    (h.impl/variance histogram)

--- a/src/metabase/feature_extraction/histogram.clj
+++ b/src/metabase/feature_extraction/histogram.clj
@@ -19,6 +19,16 @@
   ([^Histogram histogram] histogram)
   ([^Histogram histogram x] (impl/insert-categorical! histogram (when x 1) x)))
 
+(defn histogram-aggregated
+  "Transducer that summarizes preaggregated data with a histogram."
+  [fx fw]
+  (fn
+    ([] (impl/create))
+    ([^Histogram histogram] histogram)
+    ([^Histogram histogram e]
+     (let [x (fx e)]
+       (impl/insert-categorical! histogram (when x (fw e)) x)))))
+
 (def ^{:arglists '([^Histogram histogram])} categorical?
   "Returns true if given histogram holds categorical values."
   (comp (complement #{:none :unset}) impl/target-type))

--- a/test/metabase/feature_extraction/comparison_test.clj
+++ b/test/metabase/feature_extraction/comparison_test.clj
@@ -65,3 +65,19 @@
   (approximately 0.3 0.1)
   (:distance (features-distance {:foo 2.0 :bar [1 2 3] :baz false}
                                 {:foo 12 :bar [10.7 0.2 3] :baz false})))
+
+(expect
+  [nil
+   nil
+   nil
+   [[1] [10] [12]]
+   [[1 2] [10 11] [12 15]]
+   nil
+   [[1] [10 11] [12 15]]]
+  [(#'c/comparable-segment [[1 1]] [])
+   (#'c/comparable-segment [] [[1 1]])
+   (#'c/comparable-segment nil nil)
+   (#'c/comparable-segment [[1 10]] [[1 12]])
+   (#'c/comparable-segment [[1 10] [2 11]] [[1 12] [2 15]])
+   (#'c/comparable-segment [[1 10] [2 11]] [[1 12] [3 15]])
+   (#'c/comparable-segment [[1 10] [2 11] [3 14]] [[1 12] [2 15]])])

--- a/test/metabase/feature_extraction/comparison_test.clj
+++ b/test/metabase/feature_extraction/comparison_test.clj
@@ -28,7 +28,7 @@
    1
    1
    0
-   0.25
+   0.5
    0]
   (mapv :difference [(difference 1 2.0)
                      (difference 2.0 2.0)
@@ -38,7 +38,7 @@
                      (difference true false)
                      (difference false true)
                      (difference false false)
-                     (difference [1 0 1] [0 1 1])
+                     (difference [[1 1] [2 0] [3 1]] [[1 0] [2 1] [3 1]])
                      (difference nil nil)]))
 
 (expect
@@ -63,8 +63,8 @@
 
 (expect
   (approximately 0.3 0.1)
-  (:distance (features-distance {:foo 2.0 :bar [1 2 3] :baz false}
-                                {:foo 12 :bar [10.7 0.2 3] :baz false})))
+  (:distance (features-distance {:foo 2.0 :bar [[1 2] [2 3] [3 4]] :baz false}
+                                {:foo 12 :bar [[1 10.7] [2 0.2] [3 5]] :baz false})))
 
 (expect
   [nil
@@ -73,7 +73,7 @@
    [[1] [10] [12]]
    [[1 2] [10 11] [12 15]]
    nil
-   [[1] [10 11] [12 15]]]
+   [[1 2] [10 11] [12 15]]]
   [(#'c/comparable-segment [[1 1]] [])
    (#'c/comparable-segment [] [[1 1]])
    (#'c/comparable-segment nil nil)

--- a/test/metabase/feature_extraction/feature_extractors_test.clj
+++ b/test/metabase/feature_extraction/feature_extractors_test.clj
@@ -115,14 +115,6 @@
           vec)]))
 
 (expect
-  [{1 3 2 3 3 3 4 2}
-   {1 3 2 3 3 3 4 3}
-   {1 1 2 1 3 1 4 1}]
-  [(#'fe/quarter-frequencies (t/date-time 2015) (t/date-time 2017 9 12))
-   (#'fe/quarter-frequencies (t/date-time 2015) (t/date-time 2017 10))
-   (#'fe/quarter-frequencies (t/date-time 2015 5) (t/date-time 2016 2))])
-
-(expect
   [true false]
   [(roughly= 30 30.5 0.05)
    (roughly= 130 30.5 0.05)])
@@ -145,14 +137,6 @@
    (#'fe/infer-resolution nil [[(make-timestamp 2015 1) 1]
                                [(make-timestamp 2015 12) 2]
                                [(make-timestamp 2016 1) 0]])])
-
-(expect
-  [{1 3 2 3 3 3 4 3 5 3 6 3 7 3 8 3 9 2 10 2 11 2 12 2}
-   {1 1 2 1 5 1 6 1 7 1 8 1 9 1 10 1 11 1 12 1}
-   {5 1 6 1}]
-  [(#'fe/month-frequencies (t/date-time 2015) (t/date-time 2017 8 12))
-   (#'fe/month-frequencies (t/date-time 2015 5) (t/date-time 2016 2))
-   (#'fe/month-frequencies (t/date-time 2015 5 31) (t/date-time 2015 6 28))])
 
 (defn- make-sql-timestamp
   [& args]


### PR DESCRIPTION
* Adds sensible comparison for time series and aggregated queries. 
This introduces a slight change in the protocol. Now a single comparison dimension can have multiple features (previously it was only `:difference` and occasionally `:significant`, now comparison dimension has in addition `:correlation`, `:covariance`, `:deltas`)

* Refractor of existing feature extraction code so that metrics can be implemented/defined as a collection of ad-hoc queries/cards. 