### PR TITLE
Data Reference: add missing hidden filter for multi-schema case

### DIFF
--- a/frontend/src/metabase/reference/databases/TableList.jsx
+++ b/frontend/src/metabase/reference/databases/TableList.jsx
@@ -70,6 +70,7 @@ export const separateTablesBySchema = (
     .sort((table1, table2) => table1.schema > table2.schema ? 1 :
         table1.schema === table2.schema ? 0 : -1
     )
+    .filter(isQueryable)
     .map((table, index, sortedTables) => {
         if (!table || !table.id || !table.name) {
             return;


### PR DESCRIPTION
- same filter as on the single-schema case (line 127/128)
- without filter, hidden tables are shown in data reference for databases with multiple schemas
- with filter, hidden tables are hidden in the data reference for databases with multiple schemas



###### TODO 
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
