### PR TITLE
Set the min height to 3 cells for tables

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Table.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.jsx
@@ -36,7 +36,7 @@ export default class Table extends Component {
     static identifier = "table";
     static iconName = "table";
 
-    static minSize = { width: 4, height: 4 };
+    static minSize = { width: 4, height: 3 };
 
     static isSensible(cols, rows) {
         return true;


### PR DESCRIPTION
Implements #5156.
Sets the minimum height to 3 cells for table cards. Under that, it doesn't display well, even for tables with a single line.

###### TODO 
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
