### PR TITLE
Time datatype support

### DIFF
--- a/frontend/src/metabase-lib/lib/metadata/Field.js
+++ b/frontend/src/metabase-lib/lib/metadata/Field.js
@@ -8,6 +8,7 @@ import { FieldIDDimension } from "../Dimension";
 import { getFieldValues } from "metabase/lib/query/field";
 import {
     isDate,
+    isTime,
     isNumber,
     isNumeric,
     isBoolean,
@@ -40,6 +41,9 @@ export default class Field extends Base {
 
     isDate() {
         return isDate(this);
+    }
+    isTime() {
+        return isTime(this);
     }
     isNumber() {
         return isNumber(this);

--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -10,7 +10,7 @@ import ExternalLink from "metabase/components/ExternalLink.jsx";
 
 import { isDate, isNumber, isCoordinate, isLatitude, isLongitude } from "metabase/lib/schema_metadata";
 import { isa, TYPE } from "metabase/lib/types";
-import { parseTimestamp } from "metabase/lib/time";
+import { parseTimestamp,parseTime } from "metabase/lib/time";
 import { rangeForValue } from "metabase/lib/dataset";
 import { getFriendlyName } from "metabase/visualizations/lib/utils";
 import { decimalCount } from "metabase/visualizations/lib/numeric";
@@ -191,6 +191,15 @@ export function formatTimeWithUnit(value: Value, unit: DatetimeUnit, options: Fo
     }
 }
 
+export function formatTimeValue(value: Value) {
+    let m = parseTime(value);
+    if (!m.isValid()){
+        return String(value);
+    } else {
+        return m.format("LT");
+    }
+}
+
 // https://github.com/angular/angular.js/blob/v1.6.3/src/ng/directive/input.js#L27
 const EMAIL_WHITELIST_REGEX = /^(?=.{1,254}$)(?=.{1,64}@)[-!#$%&'*+/0-9=?A-Z^_`a-z{|}~]+(\.[-!#$%&'*+/0-9=?A-Z^_`a-z{|}~]+)*@[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$/;
 
@@ -263,6 +272,8 @@ export function formatValue(value: Value, options: FormattingOptions = {}) {
         return formatUrl(value, options);
     } else if (column && isa(column.special_type, TYPE.Email)) {
         return formatEmail(value, options);
+    } else if (column && isa(column.base_type, TYPE.Time)) {
+        return formatTimeValue(value);
     } else if (column && column.unit != null) {
         return formatTimeWithUnit(value, column.unit, options);
     } else if (isDate(column) || moment.isDate(value) || moment.isMoment(value) || moment(value, ["YYYY-MM-DD'T'HH:mm:ss.SSSZ"], true).isValid()) {

--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -119,6 +119,8 @@ export const isNumericBaseType = (field) => isa(field && field.base_type, TYPE.N
 // ZipCode, ID, etc derive from Number but should not be formatted as numbers
 export const isNumber = (field) => field && isNumericBaseType(field) && (field.special_type == null || field.special_type === TYPE.Number);
 
+export const isTime         = (field) => isa(field && field.base_type, TYPE.Time);
+
 export const isAddress      = (field) => isa(field && field.special_type, TYPE.Address);
 export const isState        = (field) => isa(field && field.special_type, TYPE.State);
 export const isCountry      = (field) => isa(field && field.special_type, TYPE.Country);

--- a/frontend/src/metabase/lib/time.js
+++ b/frontend/src/metabase/lib/time.js
@@ -14,3 +14,13 @@ export function parseTimestamp(value, unit) {
         return moment.utc(value);
     }
 }
+
+export function parseTime(value) {
+    if (moment.isMoment(value)) {
+        return value;
+    } else if (typeof value === "string"){
+        return moment(value, ["HH:mm:SS.sssZZ", "HH:mm:SS.sss", "HH:mm:SS.sss", "HH:mm:SS", "HH:mm"])
+    } else {
+        return moment.utc(value);
+    }
+}

--- a/frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx
@@ -7,6 +7,7 @@ import FieldList from "../FieldList.jsx";
 import OperatorSelector from "./OperatorSelector.jsx";
 import FilterOptions from "./FilterOptions";
 import DatePicker from "./pickers/DatePicker.jsx";
+import TimePicker from "./pickers/TimePicker.jsx";
 import NumberPicker from "./pickers/NumberPicker.jsx";
 import SelectPicker from "./pickers/SelectPicker.jsx";
 import TextPicker from "./pickers/TextPicker.jsx";
@@ -14,7 +15,7 @@ import TextPicker from "./pickers/TextPicker.jsx";
 import Icon from "metabase/components/Icon.jsx";
 
 import Query from "metabase/lib/query";
-import { isDate } from "metabase/lib/schema_metadata";
+import { isDate, isTime } from "metabase/lib/schema_metadata";
 import { formatField, singularize } from "metabase/lib/formatting";
 
 import cx from "classnames";
@@ -276,7 +277,13 @@ export default class FilterPopover extends Component {
                         <h3 className="mx1">-</h3>
                         <h3 className="text-default">{formatField(field)}</h3>
                     </div>
-                    { isDate(field) ?
+                    { isTime(field) ?
+                        <TimePicker
+                            className="mt1 border-top"
+                            filter={filter}
+                            onFilterChange={this.setFilter}
+                        />
+                    : isDate(field) ?
                         <DatePicker
                             className="mt1 border-top"
                             filter={filter}

--- a/frontend/src/metabase/query_builder/components/filters/FilterWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterWidget.jsx
@@ -67,7 +67,7 @@ export default class FilterWidget extends Component {
         // $FlowFixMe: not understanding maxDisplayValues is provided by defaultProps
         if (operator && operator.multi && values.length > maxDisplayValues) {
             formattedValues = [values.length + " selections"];
-        } else if (dimension.field().isDate()) {
+        } else if (dimension.field().isDate() && !dimension.field().isTime()) {
             formattedValues = generateTimeFilterValuesDescriptions(filter);
         } else {
             // TODO Atte Keinänen 7/16/17: Move formatValue to metabase-lib

--- a/frontend/src/metabase/query_builder/components/filters/pickers/HoursMinutesInput.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/HoursMinutesInput.jsx
@@ -1,0 +1,40 @@
+import React from "react";
+
+import NumericInput from "./NumericInput";
+import Icon from "metabase/components/Icon";
+
+import cx from "classnames";
+
+const HoursMinutesInput = ({ hours, minutes, onChangeHours, onChangeMinutes, onClear }) =>
+    <div className="flex align-center">
+        <NumericInput
+            className="input"
+            style={{ height: 36 }}
+            size={2}
+            maxLength={2}
+            value={(hours % 12) === 0 ? "12" : String(hours % 12)}
+            onChange={(value) => onChangeHours((hours >= 12 ? 12 : 0) + value) }
+        />
+        <span className="px1">:</span>
+        <NumericInput
+            className="input"
+            style={{ height: 36 }}
+            size={2}
+            maxLength={2}
+            value={(minutes < 10 ? "0" : "") + minutes}
+            onChange={(value) => onChangeMinutes(value) }
+        />
+        <div className="flex align-center pl1">
+            <span className={cx("text-purple-hover mr1", { "text-purple": hours < 12, "cursor-pointer": hours >= 12 })} onClick={hours >= 12 ? () => onChangeHours(hours - 12) : null}>AM</span>
+            <span className={cx("text-purple-hover mr1", { "text-purple": hours >= 12, "cursor-pointer": hours < 12 })} onClick={hours < 12 ? () => onChangeHours(hours + 12) : null}>PM</span>
+        </div>
+        { onClear &&
+            <Icon
+                className="text-grey-2 cursor-pointer text-grey-4-hover ml-auto"
+                name="close"
+                onClick={onClear}
+            />
+        }
+    </div>
+
+export default HoursMinutesInput;

--- a/frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx
@@ -8,7 +8,7 @@ import Input from "metabase/components/Input";
 import Icon from "metabase/components/Icon";
 import ExpandingContent from "metabase/components/ExpandingContent";
 import Tooltip from "metabase/components/Tooltip";
-import NumericInput from "./NumericInput.jsx";
+import HoursMinutesInput from "./HoursMinutesInput";
 
 import moment from "moment";
 import cx from "classnames";
@@ -146,8 +146,8 @@ export default class SpecificDatePicker extends Component {
                                 Add a time
                             </div>
                             :
-                            <HoursMinutes
-                                clear={() => this.onChange(date, null, null)}
+                            <HoursMinutesInput
+                                onClear={() => this.onChange(date, null, null)}
                                 hours={hours}
                                 minutes={minutes}
                                 onChangeHours={hours => this.onChange(date, hours, minutes)}
@@ -160,31 +160,3 @@ export default class SpecificDatePicker extends Component {
         )
     }
 }
-
-const HoursMinutes = ({ hours, minutes, onChangeHours, onChangeMinutes, clear }) =>
-    <div className="flex align-center">
-        <NumericInput
-            className="input"
-            size={2}
-            maxLength={2}
-            value={(hours % 12) === 0 ? "12" : String(hours % 12)}
-            onChange={(value) => onChangeHours((hours >= 12 ? 12 : 0) + value) }
-        />
-        <span className="px1">:</span>
-        <NumericInput
-            className="input"
-            size={2}
-            maxLength={2}
-            value={minutes}
-            onChange={(value) => onChangeMinutes(value) }
-        />
-        <div className="flex align-center pl1">
-            <span className={cx("text-purple-hover mr1", { "text-purple": hours < 12, "cursor-pointer": hours >= 12 })} onClick={hours >= 12 ? () => onChangeHours(hours - 12) : null}>AM</span>
-            <span className={cx("text-purple-hover mr1", { "text-purple": hours >= 12, "cursor-pointer": hours < 12 })} onClick={hours < 12 ? () => onChangeHours(hours + 12) : null}>PM</span>
-        </div>
-        <Icon
-            className="text-grey-2 cursor-pointer text-grey-4-hover ml-auto"
-            name="close"
-            onClick={() => clear() }
-        />
-    </div>

--- a/frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { t } from 'c-3po';
+
+import DatePicker, { getDateTimeFieldTarget } from "./DatePicker";
+import HoursMinutesInput from "./HoursMinutesInput";
+import { mbqlEq } from "metabase/lib/query/util";
+import { parseTime } from "metabase/lib/time";
+
+const TimeInput = ({ value, onChange }) => {
+    const time = parseTime(value);
+    return (
+      <HoursMinutesInput
+        hours={time.hour()}
+        minutes={time.minute()}
+        onChangeHours={(hours) => onChange(time.hour(hours).format("HH:mm:00.000"))}
+        onChangeMinutes={(minutes) => onChange(time.minute(minutes).format("HH:mm:00.000"))}
+      />
+    );
+}
+
+const SingleTimePicker = ({ filter, onFilterChange }) =>
+  <div className="mx2 mb2">
+    <TimeInput value={getTime(filter[2])} onChange={(time) => onFilterChange([filter[0], filter[1], time])} />
+  </div>
+
+SingleTimePicker.horizontalLayout = true;
+
+const MultiTimePicker = ({ filter, onFilterChange }) =>
+  <div className="flex align-center justify-between mx2 mb1" style={{ minWidth: 480 }}>
+    <TimeInput value={getTime(filter[2])} onChange={(time) => onFilterChange([filter[0], filter[1], ...sortTimes(time, filter[3])])} />
+    <span className="h3">and</span>
+    <TimeInput value={getTime(filter[3])} onChange={(time) => onFilterChange([filter[0], filter[1], ...sortTimes(filter[2], time)])} />
+  </div>
+
+const sortTimes = (a, b) => {
+    console.log(parseTime(a).isAfter(parseTime(b)))
+    return parseTime(a).isAfter(parseTime(b)) ? [b, a] : [a, b];
+}
+
+const getTime = (value) => {
+    if (typeof value === "string" && /^\d+:\d+(:\d+(.\d+(\+\d+:\d+)?)?)?$/.test(value)) {
+      return value;
+    } else {
+      return "00:00:00.000+00:00"
+    }
+}
+
+export const TIME_OPERATORS: Operator[] = [
+  {
+      name: "before",
+      displayName: t`Before`,
+      init: (filter) =>  ["<", getDateTimeFieldTarget(filter[1]), getTime(filter[2])],
+      test: ([op]) => op === "<",
+      widget: SingleTimePicker,
+  },
+  {
+      name: "after",
+      displayName: t`After`,
+      init: (filter) => [">", getDateTimeFieldTarget(filter[1]), getTime(filter[2])],
+      test: ([op]) => op === ">",
+      widget: SingleTimePicker,
+  },
+  {
+      name: "between",
+      displayName: t`Between`,
+      init: (filter) => ["BETWEEN", getDateTimeFieldTarget(filter[1]), getTime(filter[2]), getTime(filter[3])],
+      test: ([op]) => mbqlEq(op, "between"),
+      widget: MultiTimePicker,
+  },
+]
+
+const TimePicker = (props) =>
+  <DatePicker {...props} operators={TIME_OPERATORS} />
+
+export default TimePicker;

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -166,12 +166,18 @@
 (defn- supports-numeric-binning? [driver]
   (and driver (contains? (driver/features driver) :binning)))
 
+(defn- supports-date-binning?
+  "Time fields don't support binning, returns true if it's a DateTime field and not a time field"
+  [{:keys [base_type special_type]}]
+  (and (or (isa? base_type :type/DateTime)
+           (isa? special_type :type/DateTime))
+       (not (isa? base_type :type/Time))))
+
 (defn- assoc-field-dimension-options [driver {:keys [base_type special_type fingerprint] :as field}]
   (let [{min_value :min, max_value :max} (get-in fingerprint [:type :type/Number])
         [default-option all-options] (cond
 
-                                       (or (isa? base_type :type/DateTime)
-                                           (isa? special_type :type/DateTime))
+                                       (supports-date-binning? field)
                                        [date-default-index datetime-dimension-indexes]
 
                                        (and min_value max_value

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -16,7 +16,8 @@
             [metabase.util
              [honeysql-extensions :as hx]
              [ssh :as ssh]])
-  (:import [java.util Date TimeZone]
+  (:import java.sql.Time
+           [java.util Date TimeZone]
            org.joda.time.format.DateTimeFormatter))
 
 (defrecord MySQLDriver []
@@ -147,6 +148,10 @@
       ;; otherwise if we don't have a report timezone we can continue to pass the object as-is, e.g. as a prepared
       ;; statement param
       date)))
+
+(defmethod sqlqp/->honeysql [MySQLDriver Time]
+  [_ time-value]
+  (hx/->time time-value))
 
 ;; Since MySQL doesn't have date_trunc() we fake it by formatting a date to an appropriate string and then converting
 ;; back to a date. See http://dev.mysql.com/doc/refman/5.6/en/date-and-time-functions.html#function_date-format for an

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -17,6 +17,7 @@
              [honeysql-extensions :as hx]
              [ssh :as ssh]])
   (:import java.util.UUID
+           java.sql.Time
            metabase.query_processor.interface.Value))
 
 (defrecord PostgresDriver []
@@ -198,6 +199,10 @@
       (isa? base-type :type/IPAddress)    (hx/cast :inet value)
       (isa? base-type :type/PostgresEnum) (hx/quoted-cast database-type value)
       :else                               (sqlqp/->honeysql driver value))))
+
+(defmethod sqlqp/->honeysql [PostgresDriver Time]
+  [driver time-value]
+  (hx/->time time-value))
 
 (defn- string-length-fn [field-key]
   (hsql/call :char_length (hx/cast :VARCHAR field-key)))

--- a/src/metabase/driver/presto.clj
+++ b/src/metabase/driver/presto.clj
@@ -1,6 +1,7 @@
 (ns metabase.driver.presto
   (:require [clj-http.client :as http]
             [clj-time
+             [coerce :as tcoerce]
              [core :as time]
              [format :as tformat]]
             [clojure
@@ -20,12 +21,13 @@
             [metabase.util
              [honeysql-extensions :as hx]
              [ssh :as ssh]])
-  (:import java.util.Date))
+  (:import java.sql.Time
+           java.util.Date
+           [metabase.query_processor.interface TimeValue]))
 
 (defrecord PrestoDriver []
   clojure.lang.Named
   (getName [_] "Presto"))
-
 
 ;;; Presto API helpers
 
@@ -56,10 +58,20 @@
 (def ^:private presto-date-time-formatter
   (u/->DateTimeFormatter "yyyy-MM-dd HH:mm:ss.SSS"))
 
+(defn- parse-presto-time
+  "Parsing time from presto using a specific formatter rather than the
+  utility functions as this will be called on each row returned, so
+  performance is important"
+  [time-str]
+  (->> time-str
+       (u/parse-date :hour-minute-second-ms)
+       tcoerce/to-long
+       Time.))
+
 (defn- field-type->parser [report-timezone field-type]
   (condp re-matches field-type
     #"decimal.*"                bigdec
-    #"time"                     (partial u/parse-date :hour-minute-second-ms)
+    #"time"                     parse-presto-time
     #"time with time zone"      parse-time-with-tz
     #"timestamp"                (partial u/parse-date
                                          (if-let [report-tz (and report-timezone
@@ -90,8 +102,9 @@
 
 (defn- execute-presto-query! [details query]
   (ssh/with-ssh-tunnel [details-with-tunnel details]
-    (let [{{:keys [columns data nextUri error]} :body} (http/post (details->uri details-with-tunnel "/v1/statement")
-                                                                  (assoc (details->request details-with-tunnel) :body query, :as :json))]
+    (let [{{:keys [columns data nextUri error]} :body :as foo} (http/post (details->uri details-with-tunnel "/v1/statement")
+                                                                          (assoc (details->request details-with-tunnel) :body query, :as :json))]
+
       (when error
         (throw (ex-info (or (:message error) "Error preparing query.") error)))
       (let [rows    (parse-presto-results (:report-timezone details) (or columns []) (or data []))
@@ -156,7 +169,8 @@
     #"varbinary.*" :type/*
     #"json"        :type/Text       ; TODO - this should probably be Dictionary or something
     #"date"        :type/Date
-    #"time.*"      :type/DateTime
+    #"time"        :type/Time
+    #"time.+"      :type/DateTime
     #"array"       :type/Array
     #"map"         :type/Dictionary
     #"row.*"       :type/*          ; TODO - again, but this time we supposedly have a schema
@@ -184,9 +198,27 @@
   [_ date]
   (hsql/call :from_iso8601_timestamp (hx/literal (u/date->iso-8601 date))))
 
+(def ^:private time-format (tformat/formatter "HH:mm:SS.SSS"))
+
+(defn- time->str
+  ([t]
+   (time->str t nil))
+  ([t tz-id]
+   (let [tz (time/time-zone-for-id tz-id)]
+     (tformat/unparse (tformat/with-zone time-format tz) (tcoerce/to-date-time t)))))
+
+(defmethod sqlqp/->honeysql [PrestoDriver TimeValue]
+  [_ {:keys [value timezone-id]}]
+  (hx/cast :time (time->str value timezone-id)))
+
+(defmethod sqlqp/->honeysql [PrestoDriver Time]
+  [_ {:keys [value]}]
+  (hx/->time (time->str value)))
+
 (defn- execute-query [{:keys [database settings], {sql :query, params :params} :native, :as outer-query}]
-  (let [sql                    (str "-- " (qputil/query->remark outer-query) "\n"
-                                          (unprepare/unprepare (cons sql params) :quote-escape "'", :iso-8601-fn :from_iso8601_timestamp))
+  (let [sql                    (str "-- "
+                                    (qputil/query->remark outer-query) "\n"
+                                    (unprepare/unprepare (cons sql params) :quote-escape "'", :iso-8601-fn :from_iso8601_timestamp))
         details                (merge (:details database) settings)
         {:keys [columns rows]} (execute-presto-query! details sql)
         columns                (for [[col name] (map vector columns (rename-duplicates (map :name columns)))]

--- a/src/metabase/driver/sqlserver.clj
+++ b/src/metabase/driver/sqlserver.clj
@@ -9,7 +9,8 @@
             [metabase.driver.generic-sql.query-processor :as sqlqp]
             [metabase.util
              [honeysql-extensions :as hx]
-             [ssh :as ssh]]))
+             [ssh :as ssh]])
+  (:import java.sql.Time))
 
 (defrecord SQLServerDriver []
   clojure.lang.Named
@@ -154,6 +155,10 @@
 (defmethod sqlqp/->honeysql [SQLServerDriver Boolean]
   [_ bool]
   (if bool 1 0))
+
+(defmethod sqlqp/->honeysql [SQLServerDriver Time]
+  [_ time-value]
+  (hx/->time time-value))
 
 (defn- string-length-fn [field-key]
   (hsql/call :len (hx/cast :VARCHAR field-key)))

--- a/src/metabase/query_processor/interface.clj
+++ b/src/metabase/query_processor/interface.clj
@@ -10,7 +10,7 @@
             [metabase.util.schema :as su]
             [schema.core :as s])
   (:import clojure.lang.Keyword
-           java.sql.Timestamp))
+           [java.sql Time Timestamp]))
 
 ;;; --------------------------------------------------- CONSTANTS ----------------------------------------------------
 
@@ -181,6 +181,15 @@
                             unit  :- DatetimeFieldUnit]
   clojure.lang.Named
   (getName [_] (name field)))
+
+;; TimeField is just a field wrapper that indicates string should be interpretted as a time
+(s/defrecord TimeField [field :- (s/cond-pre Field FieldLiteral)]
+  clojure.lang.Named
+  (getName [_] (name field)))
+
+(s/defrecord TimeValue [value       :- Time
+                        field       :- TimeField
+                        timezone-id :- (s/maybe String)])
 
 (def binning-strategies
   "Valid binning strategies for a `BinnedField`"

--- a/src/metabase/query_processor/middleware/format_rows.clj
+++ b/src/metabase/query_processor/middleware/format_rows.clj
@@ -7,12 +7,17 @@
   (let [timezone (or report-timezone (System/getProperty "user.timezone"))]
     (for [row rows]
       (for [v row]
-        (if (u/is-temporal? v)
-          ;; NOTE: if we don't have an explicit report-timezone then use the JVM timezone
-          ;;       this ensures alignment between the way dates are processed by JDBC and our returned data
-          ;;       GH issues: #2282, #2035
+        ;; NOTE: if we don't have an explicit report-timezone then use the JVM timezone
+        ;;       this ensures alignment between the way dates are processed by JDBC and our returned data
+        ;;       GH issues: #2282, #2035
+        (cond
+          (u/is-time? v)
+          (u/format-time v timezone)
+
+          (u/is-temporal? v)
           (u/->iso-8601-datetime v timezone)
-          v)))))
+
+          :else v)))))
 
 (defn format-rows
   "Format individual query result values as needed.  Ex: format temporal values as iso8601 strings w/ timezone."

--- a/src/metabase/util/honeysql_extensions.clj
+++ b/src/metabase/util/honeysql_extensions.clj
@@ -134,6 +134,7 @@
 (defn ->timestamp                "CAST X to a `timestamp`."                [x] (cast :timestamp x))
 (defn ->timestamp-with-time-zone "CAST X to a `timestamp with time zone`." [x] (cast "timestamp with time zone" x))
 (defn ->integer                  "CAST X to a `integer`."                  [x] (cast :integer x))
+(defn ->time                     "CAST X to a `time` datatype"             [x] (cast :time x))
 
 ;;; Random SQL fns. Not all DBs support all these!
 (def ^{:arglists '([& exprs])} floor   "SQL `floor` function."  (partial hsql/call :floor))

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -657,3 +657,9 @@
  (var-get #'table-api/datetime-dimension-indexes)
  (let [response ((user->client :rasta) :get 200 (format "table/%d/query_metadata" (data/id :checkins)))]
    (dimension-options-for-field response "date")))
+
+(qpt/expect-with-non-timeseries-dbs
+  []
+  (data/with-db (data/get-or-create-database! defs/test-data-with-time)
+    (let [response ((user->client :rasta) :get 200 (format "table/%d/query_metadata" (data/id :users)))]
+      (dimension-options-for-field response "last_login_time"))))

--- a/test/metabase/driver/mongo_test.clj
+++ b/test/metabase/driver/mongo_test.clj
@@ -177,11 +177,11 @@
 
 ;;; Check that we support Mongo BSON ID and can filter by it (#1367)
 (i/def-database-definition ^:private with-bson-ids
-  ["birds"
-   [{:field-name "name", :base-type :type/Text}
-    {:field-name "bird_id", :base-type :type/MongoBSONID}]
-   [["Rasta Toucan" (ObjectId. "012345678901234567890123")]
-    ["Lucky Pigeon" (ObjectId. "abcdefabcdefabcdefabcdef")]]])
+  [["birds"
+     [{:field-name "name", :base-type :type/Text}
+      {:field-name "bird_id", :base-type :type/MongoBSONID}]
+     [["Rasta Toucan" (ObjectId. "012345678901234567890123")]
+      ["Lucky Pigeon" (ObjectId. "abcdefabcdefabcdefabcdef")]]]])
 
 (datasets/expect-with-engine :mongo
   [[2 "Lucky Pigeon" (ObjectId. "abcdefabcdefabcdefabcdef")]]

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -24,9 +24,9 @@
 ;; MySQL allows 0000-00-00 dates, but JDBC does not; make sure that MySQL is converting them to NULL when returning
 ;; them like we asked
 (def-database-definition ^:private ^:const all-zero-dates
-  ["exciting-moments-in-history"
-   [{:field-name "moment", :base-type :type/DateTime}]
-   [["0000-00-00"]]])
+  [["exciting-moments-in-history"
+     [{:field-name "moment", :base-type :type/DateTime}]
+     [["0000-00-00"]]]])
 
 (expect-with-engine :mysql
   [[1 nil]]
@@ -52,12 +52,12 @@
 ;; correct additional options, we should be able to change that -- see
 ;; https://github.com/metabase/metabase/issues/3506
 (def-database-definition ^:private ^:const tiny-int-ones
-  ["number-of-cans"
-   [{:field-name "thing",          :base-type :type/Text}
-    {:field-name "number-of-cans", :base-type {:native "tinyint(1)"}}]
-   [["Six Pack"              6]
-    ["Toucan"                2]
-    ["Empty Vending Machine" 0]]])
+  [["number-of-cans"
+     [{:field-name "thing",          :base-type :type/Text}
+      {:field-name "number-of-cans", :base-type {:native "tinyint(1)"}}]
+     [["Six Pack"              6]
+      ["Toucan"                2]
+      ["Empty Vending Machine" 0]]]])
 
 (defn- db->fields [db]
   (let [table-ids (db/select-ids 'Table :db_id (u/get-id db))]

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -75,13 +75,13 @@
 
 ;;; # UUID Support
 (i/def-database-definition ^:private with-uuid
-  ["users"
-   [{:field-name "user_id", :base-type :type/UUID}]
-   [[#uuid "4f01dcfd-13f7-430c-8e6f-e505c0851027"]
-    [#uuid "4652b2e7-d940-4d55-a971-7e484566663e"]
-    [#uuid "da1d6ecc-e775-4008-b366-c38e7a2e8433"]
-    [#uuid "7a5ce4a2-0958-46e7-9685-1a4eaa3bd08a"]
-    [#uuid "84ed434e-80b4-41cf-9c88-e334427104ae"]]])
+  [["users"
+     [{:field-name "user_id", :base-type :type/UUID}]
+     [[#uuid "4f01dcfd-13f7-430c-8e6f-e505c0851027"]
+      [#uuid "4652b2e7-d940-4d55-a971-7e484566663e"]
+      [#uuid "da1d6ecc-e775-4008-b366-c38e7a2e8433"]
+      [#uuid "7a5ce4a2-0958-46e7-9685-1a4eaa3bd08a"]
+      [#uuid "84ed434e-80b4-41cf-9c88-e334427104ae"]]]])
 
 
 ;; Check that we can load a Postgres Database with a :type/UUID
@@ -112,11 +112,11 @@
 
 ;; Make sure that Tables / Fields with dots in their names get escaped properly
 (i/def-database-definition ^:private dots-in-names
-  ["objects.stuff"
-   [{:field-name "dotted.name", :base-type :type/Text}]
-   [["toucan_cage"]
-    ["four_loko"]
-    ["ouija_board"]]])
+  [["objects.stuff"
+     [{:field-name "dotted.name", :base-type :type/Text}]
+     [["toucan_cage"]
+      ["four_loko"]
+      ["ouija_board"]]]])
 
 (expect-with-engine :postgres
   {:columns ["id" "dotted.name"]
@@ -130,14 +130,14 @@
 
 ;; Make sure that duplicate column names (e.g. caused by using a FK) still return both columns
 (i/def-database-definition ^:private duplicate-names
-  ["birds"
-   [{:field-name "name", :base-type :type/Text}]
-   [["Rasta"]
-    ["Lucky"]]]
-  ["people"
-   [{:field-name "name", :base-type :type/Text}
-    {:field-name "bird_id", :base-type :type/Integer, :fk :birds}]
-   [["Cam" 1]]])
+  [["birds"
+     [{:field-name "name", :base-type :type/Text}]
+     [["Rasta"]
+      ["Lucky"]]]
+   ["people"
+    [{:field-name "name", :base-type :type/Text}
+     {:field-name "bird_id", :base-type :type/Integer, :fk :birds}]
+    [["Cam" 1]]]])
 
 (expect-with-engine :postgres
   {:columns ["name" "name_2"]
@@ -150,10 +150,10 @@
 
 ;;; Check support for `inet` columns
 (i/def-database-definition ^:private ip-addresses
-  ["addresses"
-   [{:field-name "ip", :base-type {:native "inet"}}]
-   [[(hsql/raw "'192.168.1.1'::inet")]
-    [(hsql/raw "'10.4.4.15'::inet")]]])
+  [["addresses"
+     [{:field-name "ip", :base-type {:native "inet"}}]
+     [[(hsql/raw "'192.168.1.1'::inet")]
+      [(hsql/raw "'10.4.4.15'::inet")]]]])
 
 ;; Filtering by inet columns should add the appropriate SQL cast, e.g. `cast('192.168.1.1' AS inet)` (otherwise this
 ;; wouldn't work)

--- a/test/metabase/driver/sqlserver_test.clj
+++ b/test/metabase/driver/sqlserver_test.clj
@@ -18,9 +18,9 @@
   (apply str (repeatedly 1000 (partial rand-nth [\A \G \C \T]))))
 
 (def-database-definition ^:private ^:const genetic-data
-  ["genetic-data"
-   [{:field-name "gene", :base-type {:native "VARCHAR(MAX)"}}]
-   [[a-gene]]])
+  [["genetic-data"
+     [{:field-name "gene", :base-type {:native "VARCHAR(MAX)"}}]
+     [[a-gene]]]])
 
 (expect-with-engine :sqlserver
   [[1 a-gene]]

--- a/test/metabase/query_processor/middleware/format_rows_test.clj
+++ b/test/metabase/query_processor/middleware/format_rows_test.clj
@@ -1,0 +1,57 @@
+(ns metabase.query-processor.middleware.format-rows-test
+  (:require [metabase.query-processor-test :as qpt]
+            [metabase.query-processor.middleware.expand :as ql]
+            [metabase.test
+             [data :as data]
+             [util :as tu]]
+            [metabase.test.data
+             [dataset-definitions :as defs]
+             [datasets :refer [*engine*]]]))
+
+(qpt/expect-with-non-timeseries-dbs-except #{:oracle :mongo :redshift :presto}
+  (if (= :sqlite *engine*)
+    [[1 "Plato Yeshua" "2014-04-01 00:00:00" "08:30:00"]
+     [2 "Felipinho Asklepios" "2014-12-05 00:00:00" "15:15:00"]
+     [3 "Kaneonuskatew Eiran" "2014-11-06 00:00:00" "16:15:00"]
+     [4 "Simcha Yan" "2014-01-01 00:00:00" "08:30:00"]
+     [5 "Quentin Sören" "2014-10-03 00:00:00" "17:30:00"]]
+
+    [[1 "Plato Yeshua" "2014-04-01T00:00:00.000Z" "08:30:00.000Z"]
+     [2 "Felipinho Asklepios" "2014-12-05T00:00:00.000Z" "15:15:00.000Z"]
+     [3 "Kaneonuskatew Eiran" "2014-11-06T00:00:00.000Z" "16:15:00.000Z"]
+     [4 "Simcha Yan" "2014-01-01T00:00:00.000Z" "08:30:00.000Z"]
+     [5 "Quentin Sören" "2014-10-03T00:00:00.000Z" "17:30:00.000Z"]])
+  (->> (data/with-db (data/get-or-create-database! defs/test-data-with-time)
+         (data/run-query users
+           (ql/order-by (ql/asc $id))
+           (ql/limit 5)))
+       qpt/rows))
+
+(qpt/expect-with-non-timeseries-dbs-except #{:oracle :mongo :redshift :presto}
+  (cond
+    (= :sqlite *engine*)
+    [[1 "Plato Yeshua" "2014-04-01 00:00:00" "08:30:00"]
+     [2 "Felipinho Asklepios" "2014-12-05 00:00:00" "15:15:00"]
+     [3 "Kaneonuskatew Eiran" "2014-11-06 00:00:00" "16:15:00"]
+     [4 "Simcha Yan" "2014-01-01 00:00:00" "08:30:00"]
+     [5 "Quentin Sören" "2014-10-03 00:00:00" "17:30:00"]]
+
+    (qpt/supports-report-timezone? *engine*)
+    [[1 "Plato Yeshua" "2014-04-01T00:00:00.000-07:00" "00:30:00.000-08:00"]
+     [2 "Felipinho Asklepios" "2014-12-05T00:00:00.000-08:00" "07:15:00.000-08:00"]
+     [3 "Kaneonuskatew Eiran" "2014-11-06T00:00:00.000-08:00" "08:15:00.000-08:00"]
+     [4 "Simcha Yan" "2014-01-01T00:00:00.000-08:00" "00:30:00.000-08:00"]
+     [5 "Quentin Sören" "2014-10-03T00:00:00.000-07:00" "09:30:00.000-08:00"]]
+
+    :else
+    [[1 "Plato Yeshua" "2014-04-01T00:00:00.000Z" "08:30:00.000Z"]
+     [2 "Felipinho Asklepios" "2014-12-05T00:00:00.000Z" "15:15:00.000Z"]
+     [3 "Kaneonuskatew Eiran" "2014-11-06T00:00:00.000Z" "16:15:00.000Z"]
+     [4 "Simcha Yan" "2014-01-01T00:00:00.000Z" "08:30:00.000Z"]
+     [5 "Quentin Sören" "2014-10-03T00:00:00.000Z" "17:30:00.000Z"]])
+  (tu/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
+    (->> (data/with-db (data/get-or-create-database! defs/test-data-with-time)
+           (data/run-query users
+             (ql/order-by (ql/asc $id))
+             (ql/limit 5)))
+         qpt/rows)))

--- a/test/metabase/query_processor_test/time_field_test.clj
+++ b/test/metabase/query_processor_test/time_field_test.clj
@@ -1,0 +1,102 @@
+(ns metabase.query-processor-test.time-field-test
+  (:require [metabase.query-processor-test :as qpt]
+            [metabase.query-processor.middleware.expand :as ql]
+            [metabase.test
+             [data :as data]
+             [util :as tu]]
+            [metabase.test.data
+             [dataset-definitions :as defs]
+             [datasets :refer [*engine*]]]))
+
+(defmacro ^:private time-query [& filter-clauses]
+  `(qpt/rows
+     (data/with-db (data/get-or-create-database! defs/test-data-with-time)
+       (data/run-query users
+         (ql/fields ~'$id ~'$name ~'$last_login_time)
+         (ql/order-by (ql/asc ~'$id))
+         ~@filter-clauses))))
+
+;; Basic between query on a time field
+(qpt/expect-with-non-timeseries-dbs-except #{:oracle :mongo :redshift}
+  (if (= :sqlite *engine*)
+    [[1 "Plato Yeshua" "08:30:00"]
+     [4 "Simcha Yan"   "08:30:00"]]
+
+    [[1 "Plato Yeshua" "08:30:00.000Z"]
+     [4 "Simcha Yan"   "08:30:00.000Z"]])
+  (time-query (ql/filter (ql/between $last_login_time
+                                     "08:00:00"
+                                     "09:00:00"))))
+
+;; Basic between query on a time field with milliseconds
+(qpt/expect-with-non-timeseries-dbs-except #{:oracle :mongo :redshift}
+  (if (= :sqlite *engine*)
+    [[1 "Plato Yeshua" "08:30:00"]
+     [4 "Simcha Yan"   "08:30:00"]]
+
+    [[1 "Plato Yeshua" "08:30:00.000Z"]
+     [4 "Simcha Yan"   "08:30:00.000Z"]])
+  (time-query (ql/filter (ql/between $last_login_time
+                                     "08:00:00.000"
+                                     "09:00:00.000"))))
+
+;; Basic > query with a time field
+(qpt/expect-with-non-timeseries-dbs-except #{:oracle :mongo :redshift}
+  (if (= :sqlite *engine*)
+    [[3 "Kaneonuskatew Eiran" "16:15:00"]
+     [5 "Quentin Sören" "17:30:00"]
+     [10 "Frans Hevel" "19:30:00"]]
+
+    [[3 "Kaneonuskatew Eiran" "16:15:00.000Z"]
+     [5 "Quentin Sören" "17:30:00.000Z"]
+     [10 "Frans Hevel" "19:30:00.000Z"]])
+  (time-query (ql/filter (ql/> $last_login_time "16:00:00.000Z"))))
+
+;; Basic query with an = filter on a time field
+(qpt/expect-with-non-timeseries-dbs-except #{:oracle :mongo :redshift}
+  (if (= :sqlite *engine*)
+    [[3 "Kaneonuskatew Eiran" "16:15:00"]]
+
+    [[3 "Kaneonuskatew Eiran" "16:15:00.000Z"]])
+  (time-query (ql/filter (ql/= $last_login_time "16:15:00.000Z"))))
+
+;; Query with a time filter and a report timezone
+(qpt/expect-with-non-timeseries-dbs-except #{:oracle :mongo :redshift}
+  (cond
+    (= :sqlite *engine*)
+    [[1 "Plato Yeshua" "08:30:00"]
+     [4 "Simcha Yan" "08:30:00"]]
+
+    ;; This is the correct "answer" to this query, though it doesn't
+    ;; pass through JDBC. The 08:00 is adjusted to UTC (16:00), which
+    ;; should yield the third item
+    (= :presto *engine*)
+    [[3 "Kaneonuskatew Eiran" "00:15:00.000-08:00"]]
+
+    ;; Best I can tell, MySQL's interpretation of this part of the
+    ;; JDBC is way off. This doesn't return results because it looks
+    ;; like it's basically double converting the time to
+    ;; America/Los_Angeles. What's getting sent to the database is
+    ;; 00:00 and 01:00 (which we have no data in that range). I think
+    ;; we'll need to switch to their new JDBC date code to get this
+    ;; fixed
+    (= :mysql *engine*)
+    []
+
+    ;; Databases like PostgreSQL ignore timezone information when
+    ;; using a time field, the result below is what happens when the
+    ;; 08:00 time is interpreted as UTC, then not adjusted to Pacific
+    ;; time by the DB
+    (qpt/supports-report-timezone? *engine*)
+    [[1 "Plato Yeshua" "00:30:00.000-08:00"]
+     [4 "Simcha Yan" "00:30:00.000-08:00"]]
+
+    :else
+    [[1 "Plato Yeshua" "08:30:00.000Z"]
+     [4 "Simcha Yan" "08:30:00.000Z"]])
+  (tu/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
+    (time-query (ql/filter (apply ql/between
+                                  $last_login_time
+                                  (if (qpt/supports-report-timezone? *engine*)
+                                    ["08:00:00" "09:00:00"]
+                                    ["08:00:00-00:00" "09:00:00-00:00"]))))))

--- a/test/metabase/sync/sync_metadata/tables_test.clj
+++ b/test/metabase/sync/sync_metadata/tables_test.clj
@@ -7,18 +7,18 @@
             [toucan.db :as db]))
 
 (i/def-database-definition ^:const ^:private db-with-some-cruft
-  ["acquired_toucans"
-   [{:field-name "species",              :base-type :type/Text}
-    {:field-name "cam_has_acquired_one", :base-type :type/Boolean}]
-   [["Toco"               false]
-    ["Chestnut-Mandibled" true]
-    ["Keel-billed"        false]
-    ["Channel-billed"     false]]]
-  ["south_migrationhistory"
-   [{:field-name "app_name",  :base-type :type/Text}
-    {:field-name "migration", :base-type :type/Text}]
-   [["main" "0001_initial"]
-    ["main" "0002_add_toucans"]]])
+  [["acquired_toucans"
+     [{:field-name "species",              :base-type :type/Text}
+      {:field-name "cam_has_acquired_one", :base-type :type/Boolean}]
+     [["Toco"               false]
+      ["Chestnut-Mandibled" true]
+      ["Keel-billed"        false]
+      ["Channel-billed"     false]]]
+   ["south_migrationhistory"
+    [{:field-name "app_name",  :base-type :type/Text}
+     {:field-name "migration", :base-type :type/Text}]
+    [["main" "0001_initial"]
+     ["main" "0002_add_toucans"]]]])
 
 ;; south_migrationhistory, being a CRUFTY table, should still be synced, but marked as such
 (expect

--- a/test/metabase/test/data/dataset_definitions.clj
+++ b/test/metabase/test/data/dataset_definitions.clj
@@ -1,36 +1,72 @@
 (ns metabase.test.data.dataset-definitions
   "Definitions of various datasets for use in tests with `with-temp-db`."
   (:require [clojure.tools.reader.edn :as edn]
-            [metabase.test.data.interface :refer [def-database-definition]]))
-
+            [metabase.test.data.interface :as di])
+  (:import java.sql.Time
+           java.util.Calendar))
 
 ;; ## Datasets
 
-(def ^:private ^:const edn-definitions-dir "./test/metabase/test/data/dataset_definitions/")
-
-;; TODO - move this to interface
-;; TODO - make rows be lazily loadable for DB definitions from a file
-(defmacro ^:private def-database-definition-edn [dbname]
-  `(def-database-definition ~dbname
-     ~@(edn/read-string (slurp (str edn-definitions-dir (name dbname) ".edn")))))
-
 ;; The O.G. "Test Database" dataset
-(def-database-definition-edn test-data)
+(di/def-database-definition-edn test-data)
 
 ;; Times when the Toucan cried
-(def-database-definition-edn sad-toucan-incidents)
+(di/def-database-definition-edn sad-toucan-incidents)
 
 ;; Places, times, and circumstances where Tupac was sighted
-(def-database-definition-edn tupac-sightings)
+(di/def-database-definition-edn tupac-sightings)
 
-(def-database-definition-edn geographical-tips)
+(di/def-database-definition-edn geographical-tips)
 
 ;; A very tiny dataset with a list of places and a booleans
-(def-database-definition-edn places-cam-likes)
+(di/def-database-definition-edn places-cam-likes)
 
 ;; A small dataset with users and a set of messages between them. Each message has *2* foreign keys to user --
 ;; sender and reciever -- allowing us to test situations where multiple joins for a *single* table should occur.
-(def-database-definition-edn avian-singles)
+(di/def-database-definition-edn avian-singles)
+
+(defn- date-only
+  "This function emulates a date only field as it would come from the
+  JDBC driver. The hour/minute/second/millisecond fields should be 0s"
+  [date]
+  (let [orig-cal (doto (Calendar/getInstance)
+                   (.setTime date))]
+    (-> (doto (Calendar/getInstance)
+          (.clear)
+          (.set Calendar/YEAR (.get orig-cal Calendar/YEAR))
+          (.set Calendar/MONTH (.get orig-cal Calendar/MONTH))
+          (.set Calendar/DAY_OF_MONTH (.get orig-cal Calendar/DAY_OF_MONTH)))
+        .getTime)))
+
+(defn- time-only
+  "This function will return a java.sql.Time object. To create a Time
+  object similar to what JDBC would return, the time needs to be
+  relative to epoch. As an example a time of 4:30 would be a Time
+  instance, but it's a subclass of Date, so it looks like
+  1970-01-01T04:30:00.000"
+  [date]
+  (let [orig-cal (doto (Calendar/getInstance)
+                   (.setTime date))]
+    (-> (doto (Calendar/getInstance)
+          (.clear)
+          (.set Calendar/HOUR_OF_DAY (.get orig-cal Calendar/HOUR_OF_DAY))
+          (.set Calendar/MINUTE (.get orig-cal Calendar/MINUTE))
+          (.set Calendar/SECOND (.get orig-cal Calendar/SECOND)))
+        .getTimeInMillis
+        Time.)))
+
+(di/def-database-definition test-data-with-time
+  (di/update-table-def "users"
+                       (fn [table-def]
+                         [(first table-def)
+                          {:field-name "last_login_date", :base-type :type/Date}
+                          {:field-name "last_login_time", :base-type :type/Time}
+                          (peek table-def)])
+                       (fn [rows]
+                         (mapv (fn [[username last-login password-text]]
+                                 [username (date-only last-login) (time-only last-login) password-text])
+                               rows))
+                       (di/slurp-edn-table-def "test-data")))
 
 (def test-data-map
   "Converts data from `test-data` to a map of maps like the following:

--- a/test/metabase/test/data/generic_sql.clj
+++ b/test/metabase/test/data/generic_sql.clj
@@ -171,7 +171,8 @@
                                 (:field-definitions tabledef))]
     (for [row (:rows tabledef)]
       (zipmap fields-for-insert (for [v row]
-                                  (if (instance? java.util.Date v)
+                                  (if (and (not (instance? java.sql.Time v))
+                                           (instance? java.util.Date v))
                                     (u/->Timestamp v)
                                     v))))))
 

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -4,6 +4,7 @@
    Objects that implement `IDriverTestExtensions` know how to load a `DatabaseDefinition` into an
    actual physical RDMS database. This functionality allows us to easily test with multiple datasets."
   (:require [clojure.string :as str]
+            [clojure.tools.reader.edn :as edn]
             [environ.core :refer [env]]
             [metabase
              [db :as db]
@@ -166,15 +167,36 @@
                                                            :table-definitions (mapv (partial apply create-table-definition)
                                                                                     table-name+field-definition-maps+rows)})))
 
+(def ^:private ^:const edn-definitions-dir "./test/metabase/test/data/dataset_definitions/")
+
+(defn slurp-edn-table-def [dbname]
+  (edn/read-string (slurp (str edn-definitions-dir dbname ".edn"))))
+
+(defn update-table-def
+  "Function useful for modifying a table definition before it's
+  applied. Will invoke `UPDATE-TABLE-DEF-FN` on the vector of column
+  definitions and `UPDATE-ROWS-FN` with the vector of rows in the
+  database definition. `TABLE-DEF` is the database
+  definition (typically used directly in a `def-database-definition`
+  invocation)."
+  [table-name-to-update update-table-def-fn update-rows-fn table-def]
+  (vec
+   (for [[table-name table-def rows] table-def
+         :when (= table-name table-name-to-update)]
+     [table-name
+      (update-table-def-fn table-def)
+      (update-rows-fn rows)])))
+
 (defmacro def-database-definition
   "Convenience for creating a new `DatabaseDefinition` named by the symbol DATASET-NAME."
-  [^clojure.lang.Symbol dataset-name & table-name+field-definition-maps+rows]
+  [^clojure.lang.Symbol dataset-name table-name+field-definition-maps+rows]
   {:pre [(symbol? dataset-name)]}
   `(def ~(vary-meta dataset-name assoc :tag DatabaseDefinition)
-     (create-database-definition ~(name dataset-name)
-       ~@table-name+field-definition-maps+rows)))
+     (apply create-database-definition ~(name dataset-name) ~table-name+field-definition-maps+rows)))
 
-
+(defmacro def-database-definition-edn [dbname]
+  `(def-database-definition ~dbname
+     ~(slurp-edn-table-def (name dbname))))
 
 ;;; ## Convenience + Helper Functions
 ;; TODO - should these go here, or in `metabase.test.data`?

--- a/test/metabase/test/data/presto.clj
+++ b/test/metabase/test/data/presto.clj
@@ -41,6 +41,7 @@
       :type/Text       "cast('' AS varchar(255))"
       :type/Date       "current_timestamp" ; this should probably be a date type, but the test data begs to differ
       :type/DateTime   "current_timestamp"
+      :type/Time       "cast(current_time as TIME)"
       "from_hex('00')") ; this might not be the best default ever
     ;; we were given a native type, map it back to a base-type and try again
     (field-base-type->dummy-value (#'presto/presto-type->base-type field-type))))
@@ -82,7 +83,6 @@
       (#'presto/execute-presto-query! details (create-table-sql dbdef tabledef))
       (doseq [batch batches]
         (#'presto/execute-presto-query! details (insert-sql dbdef tabledef batch))))))
-
 
 ;;; IDriverTestExtensions implementation
 

--- a/test/metabase/test/data/sqlite.clj
+++ b/test/metabase/test/data/sqlite.clj
@@ -27,9 +27,14 @@
   (fn [rows]
     (insert! (for [row rows]
                (into {} (for [[k v] row]
-                          [k (if-not (instance? java.util.Date v)
-                               v
-                               (hsql/call :datetime (hx/literal (u/date->iso-8601 v))))]))))))
+                          [k (cond
+                               (instance? java.sql.Time v)
+                               (hsql/call :time (hx/literal (u/format-time v "UTC")))
+
+                               (instance? java.util.Date v)
+                               (hsql/call :datetime (hx/literal (u/date->iso-8601 v)))
+
+                               :else v)]))))))
 
 (u/strict-extend SQLiteDriver
   generic/IGenericSQLTestExtensions


### PR DESCRIPTION
This PR adds support for Time datatypes on those databases that support them. `java.sql.Time` objects in Java are a subclass of `java.util.Date`, but have their year/month/day set to epoch. On some databases, lack of support for Time datatypes will maybe them look like all of the times took place on _1970-01-01_. On other databases (like BigQuery) this will cause errors.

This PR adds support for returning Time fields in query results and querying/filtering using time fields.

TODO:

- [x] - Add handling for Time objects in SQL databases that support them
- [x] - Add handling for Time objects in BigQuery
- [x] - Add handling for Time objects in Presto
- [x] - Add support for Time query parameters
- [x] - UI should use just a "time picker" for time fields 
 