### PR TITLE
Major Mac App Improvements

### DIFF
--- a/OSX/Metabase.xcodeproj/project.pbxproj
+++ b/OSX/Metabase.xcodeproj/project.pbxproj
@@ -537,6 +537,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -569,6 +570,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
+				VALID_ARCHS = x86_64;
 			};
 			name = Debug;
 		};
@@ -576,6 +578,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -601,7 +604,9 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
+				VALID_ARCHS = x86_64;
 			};
 			name = Release;
 		};

--- a/OSX/Metabase/Backend/AppDelegate.h
+++ b/OSX/Metabase/Backend/AppDelegate.h
@@ -14,4 +14,7 @@
 
 @property (readonly) NSUInteger port;
 
+- (void)stopMetabaseTask;
+- (void)startMetabaseTask;
+
 @end

--- a/OSX/Metabase/Backend/MetabaseTask.h
+++ b/OSX/Metabase/Backend/MetabaseTask.h
@@ -16,6 +16,10 @@
 
 - (void)launch;
 
+/// Remove the task termination handler that pops up the 'Task died unexpectedly' alert.
+/// For cases when we want to kill the Metabase task without freaking the user out, e.g. for Reset Password
+- (void)disableTerminationAlert;
+
 - (NSUInteger)port;
 
 @end

--- a/OSX/Metabase/Backend/MetabaseTask.m
+++ b/OSX/Metabase/Backend/MetabaseTask.m
@@ -11,7 +11,10 @@
 @interface MetabaseTask ()
 
 @property (nonatomic) NSUInteger port;
+@property (nonatomic, strong) NSMutableArray *lastMessages; ///< 10 most recently logged messages.
+
 @end
+
 
 @implementation MetabaseTask
 
@@ -34,6 +37,12 @@
 	regex = [NSRegularExpression regularExpressionWithPattern:@"\\[\\d+m" options:0 error:nil];
 	message = [regex stringByReplacingMatchesInString:message options:0 range:NSMakeRange(0, message.length) withTemplate:@""];
 	
+
+    // add the message to the recently logged messages. If we now have more than 5 remove the oldest
+    [self.lastMessages addObject:message];
+    if (self.lastMessages.count > 10) [self.lastMessages removeObjectAtIndex:0];
+    
+    // log the message the normal way as well
 	NSLog(@"%@", message);
 }
 
@@ -63,7 +72,7 @@
 		
 		self.task				= [[NSTask alloc] init];
 		self.task.launchPath	= JREPath();
-		self.task.environment	= @{@"MB_DB_FILE": [DBPath() stringByAppendingString:@";AUTO_SERVER=TRUE"],
+		self.task.environment	= @{@"MB_DB_FILE": DBPath(),
 									@"MB_PLUGINS_DIR": PluginsDirPath(),
 									@"MB_JETTY_PORT": @(self.port),
 									@"MB_CLIENT": @"OSX"};
@@ -74,9 +83,15 @@
 				
 		__weak MetabaseTask *weakSelf = self;
 		self.task.terminationHandler = ^(NSTask *task){
-			NSLog(@"\n\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Task terminated with exit code %d !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!", task.terminationStatus);
+			NSLog(@"\n\n!!!!! Task terminated with exit code %d !!!!!\n\n", task.terminationStatus);
+            
 			dispatch_async(dispatch_get_main_queue(), ^{
-				if ([[NSAlert alertWithMessageText:@"Fatal Error" defaultButton:@"Restart" alternateButton:@"Quit" otherButton:nil informativeTextWithFormat:@"The Metabase server terminated unexpectedly."] runModal] == NSAlertDefaultReturn) {
+				if ([[NSAlert alertWithMessageText:@"Fatal Error"
+                                     defaultButton:@"Restart"
+                                   alternateButton:@"Quit"
+                                       otherButton:nil
+                         informativeTextWithFormat:@"The Metabase server terminated unexpectedly.\n\nMessages:\n%@", [weakSelf.lastMessages componentsJoinedByString:@""]] // components should already have newline at end
+                     runModal] == NSAlertDefaultReturn) {
 					[weakSelf launch];
 				} else {
 					exit(task.terminationStatus);
@@ -94,6 +109,10 @@
 	_port = 0;
 }
 
+- (void)disableTerminationAlert {
+    self.task.terminationHandler = nil;
+}
+
 
 #pragma mark - Getters / Setters
 
@@ -104,6 +123,12 @@
 		NSLog(@"Using port %lu", _port);
 	}
 	return _port;
+}
+                        
+
+- (NSMutableArray *)lastMessages {
+    if (!_lastMessages) _lastMessages = [NSMutableArray array];
+    return _lastMessages;
 }
 
 @end

--- a/OSX/Metabase/Backend/ResetPasswordTask.m
+++ b/OSX/Metabase/Backend/ResetPasswordTask.m
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Metabase. All rights reserved.
 //
 
+#import "AppDelegate.h"
 #import "ResetPasswordTask.h"
 
 @interface ResetPasswordTask ()
@@ -19,28 +20,29 @@
 
 - (void)resetPasswordForEmailAddress:(NSString *)emailAddress success:(void (^)(NSString *))successBlock error:(void (^)(NSString *))errorBlock {
 	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+        // first, we need to stop the main Metabase task so we can access the DB
+        NSLog(@"Stopping Metabase task in order to reset password...");
+        [[AppDelegate instance] stopMetabaseTask];
+        
 		self.task = [[NSTask alloc] init];
 				
-		NSString *dbPath = [DBPath() stringByAppendingString:@";IFEXISTS=TRUE;AUTO_SERVER=TRUE"];
-		self.task.environment = @{@"MB_DB_FILE": dbPath, @"HOME": @"/Users/camsaul"};
-		
 		// time travelers from the future: this is hardcoded since I'm the only one who works on this. I give you permission to fix it - Cam
 		#define DEBUG_RUN_LEIN_TASK 0
 		
 		#if DEBUG_RUN_LEIN_TASK
-			self.task.environment			= @{@"MB_DB_FILE": dbPath};
+			self.task.environment			= @{@"MB_DB_FILE": DBPath()};
 			self.task.currentDirectoryPath	= @"/Users/cam/metabase";
 			self.task.launchPath			= @"/usr/local/bin/lein";
 			self.task.arguments				= @[@"run", @"reset-password", emailAddress];
-			NSLog(@"Launching ResetPasswordTask\nMB_DB_FILE='%@' lein run reset-password %@", dbPath, emailAddress);
+			NSLog(@"Launching ResetPasswordTask\nMB_DB_FILE='%@' lein run reset-password %@", DBPath(), emailAddress);
 		#else
-			self.task.environment	= @{@"MB_DB_FILE": dbPath};
+			self.task.environment	= @{@"MB_DB_FILE": DBPath()};
 			self.task.launchPath	= JREPath();
             self.task.arguments		= @[@"-Djava.awt.headless=true", // this prevents the extra java icon from popping up in the dock when running
                                         @"-Xverify:none",            // disable bytecode verification for faster launch speed, not really needed here since JAR is packaged as part of signed .app
                                         @"-jar", UberjarPath(),
                                         @"reset-password", emailAddress];
-			NSLog(@"Launching ResetPasswordTask\nMB_DB_FILE='%@' %@ -jar %@ reset-password %@", dbPath, JREPath(), UberjarPath(), emailAddress);
+			NSLog(@"Launching ResetPasswordTask\nMB_DB_FILE='%@' %@ -jar %@ reset-password %@", DBPath(), JREPath(), UberjarPath(), emailAddress);
 		#endif
 		
 		__weak ResetPasswordTask *weakSelf = self;
@@ -54,6 +56,10 @@
 				} else {
 					errorBlock(weakSelf.output.length ? weakSelf.output : @"An unknown error has occured.");
 				}
+                
+                // now restart the main Metabase task
+                NSLog(@"Reset password complete, restarting Metabase task...");
+                [[AppDelegate instance] startMetabaseTask];
 			});
 		};
 		

--- a/OSX/Metabase/Backend/TaskHealthChecker.h
+++ b/OSX/Metabase/Backend/TaskHealthChecker.h
@@ -8,17 +8,14 @@
 
 static NSString * const MetabaseTaskBecameHealthyNotification	= @"MetabaseTaskBecameHealthyNotification";
 static NSString * const MetabaseTaskBecameUnhealthyNotification = @"MetabaseTaskBecameUnhealthyNotification";
-static NSString * const MetabaseTaskTimedOutNotification		= @"MetabaseTaskTimedOutNotification";
 
 /// Manages the MetabaseTask (server) and restarts it if it gets unresponsive
 @interface TaskHealthChecker : NSObject
 
 @property () NSUInteger port;
 
+/// (re)start the health checker
 - (void)start;
 - (void)stop;
-- (void)resetTimeout;
-
-- (CFAbsoluteTime)lastCheckTime;
 
 @end


### PR DESCRIPTION
Most substantial reworking of the Mac App code since we launched.

*  Remove 60-second health-check timeout. This should fix issues where the Mac App would suddenly restart when loading heavy dashboards. Bugs: #5418 ,#4867, #2960. I also made sure more things are running on background threads which was probably the source of this issue
*  Rework reset password to kill the main Metabase task and restart when finished. This removes the need to run with the H2 database in `AUTO_SERVER` mode, which I believe was the underlying cause behind #6068.
*  Add error messages in the on-screen alert dialog when the app crashes unexpectedly. This should make debugging future Mac App issues much easier.
*  Other general cleanup to simplify the code a bit. (less moving parts)