### PR TITLE
i18n(es_ES) initial version

### DIFF
--- a/locales/es.po
+++ b/locales/es.po
@@ -1,0 +1,136 @@
+# #-#-#-#-#  metabase-backend.pot (metabase)  #-#-#-#-#
+# Spanish Spain translations for metabase package.
+# Copyright (C) 2017 Metabase <docs@metabase.com>
+# This file is distributed under the same license as the metabase package.
+# Joe Bordes <joe@tsolucio.com>, 2017.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: metabase\n"
+"Report-Msgid-Bugs-To: docs@metabase.com\n"
+"POT-Creation-Date: 2017-08-21 21:54+0200\n"
+"PO-Revision-Date: 2017-10-07 21:17+0200\n"
+"Last-Translator: Joe Bordes <joe@tsolucio.com>\n"
+"Language-Team: \n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"#-#-#-#-#  metabase-frontend.pot  #-#-#-#-#\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"#-#-#-#-#  metabase-backend.pot (metabase)  #-#-#-#-#\n"
+
+#: frontend/src/metabase/home/components/Activity.jsx:131
+msgid "Hello World!"
+msgstr "Hola Mundo!"
+
+#: frontend/src/metabase/home/components/Activity.jsx:132
+msgid "Metabase is up and running."
+msgstr "Metabase está preparado y en marcha."
+
+#: frontend/src/metabase/home/components/Activity.jsx:176
+msgid "removed the filter {item.details.name}"
+msgstr "se ha eliminado el filtro {item.details.name}"
+
+#: frontend/src/metabase/home/components/Activity.jsx:179
+msgid "joined!"
+msgstr "unido!"
+
+#: frontend/src/metabase/home/components/NextStep.jsx:31
+msgid "Setup Tip"
+msgstr "Consejo de Configuración"
+
+#: frontend/src/metabase/home/components/NextStep.jsx:32
+msgid "View all"
+msgstr "Ver todo"
+
+#: frontend/src/metabase/home/components/RecentViews.jsx:38
+msgid "Recently Viewed"
+msgstr "Recientes"
+
+#: frontend/src/metabase/home/components/RecentViews.jsx:60
+msgid "You haven't looked at any dashboards or questions recently"
+msgstr "No has visto ningún cuadro de mando ni pregunta recientemente"
+
+#: frontend/src/metabase/home/containers/HomepageApp.jsx:93
+msgid "Activity"
+msgstr "Actividad"
+
+#: frontend/src/metabase/lib/greeting.js:2
+msgid "Hey there"
+msgstr "Hola"
+
+#: frontend/src/metabase/lib/greeting.js:3
+#: frontend/src/metabase/lib/greeting.js:25
+msgid "How's it going"
+msgstr "¿Cómo va?"
+
+#: frontend/src/metabase/lib/greeting.js:4
+msgid "Howdy"
+msgstr "Hola"
+
+#: frontend/src/metabase/lib/greeting.js:5
+msgid "Greetings"
+msgstr "Saludos"
+
+#: frontend/src/metabase/lib/greeting.js:6
+msgid "Good to see you"
+msgstr "Me alegro de verte"
+
+#: frontend/src/metabase/lib/greeting.js:10
+msgid "What do you want to know?"
+msgstr "¿Qué quieres saber?"
+
+#: frontend/src/metabase/lib/greeting.js:11
+msgid "What's on your mind?"
+msgstr "¿Qué estás buscando?"
+
+#: frontend/src/metabase/lib/greeting.js:12
+msgid "What do you want to find out?"
+msgstr "¿Qué quieres averiguar?"
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:129
+msgid "Dashboards"
+msgstr "Cuadros de Mando"
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:132
+msgid "Questions"
+msgstr "Preguntas"
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:135
+msgid "Pulses"
+msgstr "Latidos"
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:138
+msgid "Data Reference"
+msgstr "Referencia de Datos"
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:142
+msgid "New Question"
+msgstr "Nueva Pregunta"
+
+#: src/metabase/api/setup.clj
+msgid "Add a database"
+msgstr "Añadir una base de datos"
+
+#: src/metabase/api/setup.clj
+msgid "Get connected"
+msgstr "Conectar"
+
+#: src/metabase/api/setup.clj
+msgid "Connect to your data so your whole team can start to explore."
+msgstr "Conéctate con tus datos para que todo el equipo pueda comenzar a explorar."
+
+#. This is the very first log message that will get printed.
+#. It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
+#. It shows up a solid 10-15 seconds before the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
+#: src/metabase/util.clj
+msgid "Loading {0}..."
+msgstr "Cargando {0}..."
+
+#. This is the very first log message that will get printed.
+#. It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
+#. It shows up a solid 10-15 seconds before the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
+#: src/metabase/util.clj
+msgid "Metabase"
+msgstr "Metabase"


### PR DESCRIPTION
I know it is early for this but I thought it may be useful for you to be able to change to another language and I wanted to ask about the language file name.

I looked through the c3po documentation but couldn't see where it defines the language codes to use for the translation. From what I get we could use any letters.

I just want to make sure there is defined support for the different language regions. For example, ES Spain (which is the file in this PR), ES Argentina or ES Mexico, just to name a few. The same issue can appear in German, with de_DE and de_AT, among others.

I think the correct way to go is to use the [ISO 3166 3 letter code](https://www.iso.org/iso-3166-country-codes.html)

https://www.iso.org/obp/ui
