### PR TITLE
Use jest spies / timers & remove sinon

### DIFF
--- a/frontend/test/components/Logs.unit.spec.js
+++ b/frontend/test/components/Logs.unit.spec.js
@@ -1,29 +1,20 @@
 import React from 'react'
 import Logs from '../../src/metabase/components/Logs'
 import { mount } from 'enzyme'
-import sinon from 'sinon'
 
 import { UtilApi } from 'metabase/services'
 
 describe('Logs', () => {
     describe('log fetching', () => {
-        let timer
-
-        beforeEach(() => {
-            timer = sinon.useFakeTimers()
-        })
-
-        afterEach(() => {
-            timer.restore()
-        })
 
         it('should call UtilApi.logs after 1 second', () => {
+            jest.useFakeTimers()
             const wrapper = mount(<Logs />)
-            const utilSpy = sinon.spy(UtilApi, "logs")
+            const utilSpy = jest.spyOn(UtilApi, "logs")
 
             expect(wrapper.state().logs.length).toEqual(0)
-            timer.tick(1001)
-            expect(utilSpy.called).toEqual(true)
+            jest.runTimersToTime(1001)
+            expect(utilSpy).toHaveBeenCalled()
         })
     })
 })

--- a/frontend/test/components/StepIndicators.unit.spec.js
+++ b/frontend/test/components/StepIndicators.unit.spec.js
@@ -2,7 +2,6 @@ import { click } from "__support__/enzyme_utils";
 
 import React from 'react'
 import { shallow } from 'enzyme'
-import sinon from 'sinon'
 
 import { normal } from 'metabase/lib/colors'
 
@@ -25,14 +24,14 @@ describe('Step indicators', () => {
 
     describe('goToStep', () => {
         it('should call goToStep with the proper number when a step is clicked', () => {
-            const goToStep = sinon.spy()
+            const goToStep = jest.fn()
             const wrapper = shallow(
                 <StepIndicators steps={steps} goToStep={goToStep} currentStep={1} />
             )
 
             const targetIndicator = wrapper.find('li').first()
             click(targetIndicator);
-            expect(goToStep.calledWith(1)).toEqual(true)
+            expect(goToStep).toHaveBeenCalledWith(1)
         })
     })
 })

--- a/frontend/test/home/NewUserOnboardingModal.unit.spec.js
+++ b/frontend/test/home/NewUserOnboardingModal.unit.spec.js
@@ -2,7 +2,6 @@ import { click } from "__support__/enzyme_utils";
 
 import React from 'react'
 import { shallow } from 'enzyme'
-import sinon from 'sinon'
 import NewUserOnboardingModal from '../../src/metabase/home/components/NewUserOnboardingModal'
 
 describe('new user onboarding modal', () => {
@@ -19,7 +18,7 @@ describe('new user onboarding modal', () => {
         })
 
         it('should close if on the last step', () => {
-            const onClose = sinon.spy()
+            const onClose = jest.fn()
             const wrapper = shallow(
                 <NewUserOnboardingModal onClose={onClose} />
             )
@@ -29,7 +28,7 @@ describe('new user onboarding modal', () => {
             const nextButton = wrapper.find('a')
             expect(nextButton.text()).toEqual('Let\'s go')
             click(nextButton);
-            expect(onClose.called).toEqual(true)
+            expect(onClose.mock.calls.length).toEqual(1)
         })
     })
 })

--- a/frontend/test/query_builder/NewQueryOptions.unit.spec.js
+++ b/frontend/test/query_builder/NewQueryOptions.unit.spec.js
@@ -1,8 +1,6 @@
 import React from 'react'
 import { mount } from 'enzyme'
 
-import sinon from 'sinon'
-
 import { NewQueryOptions } from 'metabase/new_query/containers/NewQueryOptions'
 
 import NewQueryOption from "metabase/new_query/components/NewQueryOption";
@@ -34,7 +32,7 @@ describe('New Query Options', () => {
         describe('with SQL access on a single DB', () => {
             it('should show the SQL option', (done) => {
 
-                sinon.spy(NewQueryOptions.prototype, 'determinePaths')
+                const spy = jest.spyOn(NewQueryOptions.prototype, 'determinePaths')
 
                 const wrapper = mount(
                     <NewQueryOptions
@@ -55,9 +53,14 @@ describe('New Query Options', () => {
                     />
                 )
 
-                setImmediate(() => {
-                    expect(NewQueryOptions.prototype.determinePaths.calledOnce).toEqual(true)
-                    expect(wrapper.find(NewQueryOption).length).toEqual(2)
+                process.nextTick(() => {
+                    try {
+                        expect(spy).toHaveBeenCalled()
+                        expect(wrapper.find(NewQueryOption).length).toEqual(2)
+
+                    } catch (e) {
+                        return done(e)
+                    }
                     done()
                 })
             })
@@ -65,7 +68,8 @@ describe('New Query Options', () => {
 
         describe('with no SQL access', () => {
             it('should redirect', (done) => {
-                const mockedPush = sinon.spy()
+
+                const mockedPush = jest.fn()
                 const mockQueryUrl = 'query'
 
                 mount(
@@ -91,9 +95,13 @@ describe('New Query Options', () => {
                     />
                 )
 
-                setImmediate(() => {
-                    expect(mockedPush.called).toEqual(true)
-                    expect(mockedPush.calledWith(mockQueryUrl)).toEqual(true)
+                process.nextTick(() => {
+                    try {
+                        expect(mockedPush.mock.calls.length).toEqual(1)
+                        expect(mockedPush).toHaveBeenCalledWith(mockQueryUrl)
+                    } catch (e) {
+                        return (done(e))
+                    }
                     done()
                 })
             })

--- a/package.json
+++ b/package.json
@@ -136,7 +136,6 @@
     "react-test-renderer": "^15.5.4",
     "sauce-connect-launcher": "^1.1.1",
     "selenium-webdriver": "^2.53.3",
-    "sinon": "^2.3.1",
     "style-loader": "^0.16.1",
     "unused-files-webpack-plugin": "^3.0.0",
     "webchauffeur": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2321,7 +2321,7 @@ diff@^1.3.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
 
-diff@^3.0.0, diff@^3.1.0, diff@^3.2.0:
+diff@^3.0.0, diff@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
@@ -3274,12 +3274,6 @@ form-data@~2.1.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
-
-formatio@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
-  dependencies:
-    samsam "1.x"
 
 forwarded@~0.1.0:
   version "0.1.0"
@@ -5130,10 +5124,6 @@ log4js@^0.6.31:
     readable-stream "~1.0.2"
     semver "~4.3.3"
 
-lolex@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
-
 longest-streak@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.1.tgz#42d291b5411e40365c00e63193497e2247316e35"
@@ -5425,10 +5415,6 @@ mz@^2.6.0:
 nan@^2.3.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
-
-native-promise-only@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -6023,12 +6009,6 @@ path-root@^0.1.1:
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
-
-path-to-regexp@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
-  dependencies:
-    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -7488,10 +7468,6 @@ safe-json-parse@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/safe-json-parse/-/safe-json-parse-1.0.1.tgz#3e76723e38dfdda13c9b1d29a1e07ffee4b30b57"
 
-samsam@1.x, samsam@^1.1.3:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.2.1.tgz#edd39093a3184370cb859243b2bdf255e7d8ea67"
-
 sane@~1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/sane/-/sane-1.5.0.tgz#a4adeae764d048621ecb27d5f9ecf513101939f3"
@@ -7652,19 +7628,6 @@ simple-swizzle@^0.2.2:
   resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
   dependencies:
     is-arrayish "^0.3.1"
-
-sinon@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-2.3.1.tgz#48c9c758b4d0bb86327486833f1c4298919ce9ee"
-  dependencies:
-    diff "^3.1.0"
-    formatio "1.2.0"
-    lolex "^1.6.0"
-    native-promise-only "^0.8.1"
-    path-to-regexp "^1.7.0"
-    samsam "^1.1.3"
-    text-encoding "0.6.4"
-    type-detect "^4.0.0"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -8092,10 +8055,6 @@ tether@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/tether/-/tether-1.4.0.tgz#0f9fa171f75bf58485d8149e94799d7ae74d1c1a"
 
-text-encoding@0.6.4:
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
-
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -8282,10 +8241,6 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
-
-type-detect@^4.0.0:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
 
 type-is@~1.6.14:
   version "1.6.15"


### PR DESCRIPTION
Figured there was no need to have an additional dependency / way of doing things when Jest has built in spy / timer functions. This converts the few places we were still using sinon to jest built-ins.