### PR TITLE
Collections cleanup

### DIFF
--- a/frontend/src/metabase/questions/components/ExpandingSearchField.jsx
+++ b/frontend/src/metabase/questions/components/ExpandingSearchField.jsx
@@ -71,24 +71,24 @@ export default class ExpandingSearchField extends Component {
             <div
                 className={cx(
                     className,
-                    'bordered border-dark flex align-center pr2 transition-border',
+                    'bordered border-grey-1 flex align-center pr2 transition-border',
                     { 'border-brand' : active }
                 )}
                 onClick={this.setActive}
                 style={{borderRadius: 99}}
             >
                 <Icon
-                    className={cx('ml2', { 'text-brand': active })}
+                    className={cx('ml2 text-grey-3', { 'text-brand': active })}
                     name="search"
                 />
                 <Motion
-                    style={{width: active ? spring(450) : spring(250) }}
+                    style={{width: active ? spring(400) : spring(200) }}
                 >
                     { interpolatingStyle =>
                         <input
                             ref={(search) => this.searchInput = search}
-                            className="input text-bold borderless"
-                            placeholder="Search for a question..."
+                            className="input borderless text-bold"
+                            placeholder="Search for a question"
                             style={Object.assign({}, interpolatingStyle, { fontSize: '1em'})}
                             onFocus={() => this.setState({ active: true })}
                             onBlur={() => this.setState({ active: false })}

--- a/frontend/src/metabase/questions/components/ExpandingSearchField.jsx
+++ b/frontend/src/metabase/questions/components/ExpandingSearchField.jsx
@@ -82,7 +82,7 @@ export default class ExpandingSearchField extends Component {
                     name="search"
                 />
                 <Motion
-                    style={{width: active ? spring(400) : spring(200) }}
+                    style={{width: active ? spring(450) : spring(250) }}
                 >
                     { interpolatingStyle =>
                         <input

--- a/frontend/src/metabase/questions/containers/QuestionIndex.jsx
+++ b/frontend/src/metabase/questions/containers/QuestionIndex.jsx
@@ -62,7 +62,7 @@ export const QuestionIndexHeader = ({questions, collections, isAdmin, onSearch})
     return (
         <div className="flex align-center pt4 pb2">
 
-          { showSearch &&
+          { showSearch && hasCollections &&
           <ExpandingSearchField onSearch={onSearch}/>
           }
 
@@ -132,7 +132,7 @@ export class QuestionIndex extends Component {
 
                 { showNoSavedQuestionsState && <NoSavedQuestionsState /> }
 
-                <div className={cx({ "hide": !showEntityList })}>
+                <div className={cx("pt4", { "hide": !showEntityList })}>
                     {/* EntityList loads `questions` according to the query specified in the url query string */}
                     <EntityList
                         entityType="cards"

--- a/frontend/src/metabase/questions/containers/QuestionIndex.jsx
+++ b/frontend/src/metabase/questions/containers/QuestionIndex.jsx
@@ -5,7 +5,6 @@ import cx from "classnames";
 
 import Icon from "metabase/components/Icon";
 import Button from "metabase/components/Button";
-import TitleAndDescription from "metabase/components/TitleAndDescription";
 
 import ExpandingSearchField from "../components/ExpandingSearchField";
 import CollectionActions from "../components/CollectionActions";

--- a/frontend/src/metabase/questions/containers/QuestionIndex.jsx
+++ b/frontend/src/metabase/questions/containers/QuestionIndex.jsx
@@ -59,14 +59,14 @@ export const QuestionIndexHeader = ({questions, collections, isAdmin, onSearch})
     const showSearch = hasCollections || hasQuestionsWithoutCollection;
     const showSetPermissionsLink = isAdmin && hasCollections;
 
-    return (<div className="flex align-center pt4 pb2">
-        <TitleAndDescription title={ hasCollections ? "Collections of Questions" : "Saved Questions" }/>
+    return (
+        <div className="flex align-center pt4 pb2">
+
+          { showSearch &&
+          <ExpandingSearchField onSearch={onSearch}/>
+          }
 
         <div className="flex align-center ml-auto">
-            { showSearch &&
-            <ExpandingSearchField className="mr2" onSearch={onSearch}/>
-            }
-
             <CollectionActions>
                 { showSetPermissionsLink &&
                 <Link to="/collections/permissions">
@@ -78,7 +78,8 @@ export const QuestionIndexHeader = ({questions, collections, isAdmin, onSearch})
                 </Link>
             </CollectionActions>
         </div>
-    </div>);
+    </div>
+    );
 };
 
 const mapStateToProps = (state, props) => ({
@@ -112,7 +113,6 @@ export class QuestionIndex extends Component {
 
         const hasEntityListSectionQuery = !!(location.query && location.query.f);
         const showEntityList = hasQuestionsWithoutCollection || hasEntityListSectionQuery;
-        const showEverythingElseTitle = showEntityList && hasCollections;
 
         return (
             <div className={cx("relative px4", {"full-height flex flex-column bg-slate-extra-light": showNoSavedQuestionsState})}>
@@ -132,8 +132,6 @@ export class QuestionIndex extends Component {
 
                 { showNoSavedQuestionsState && <NoSavedQuestionsState /> }
 
-                { showEverythingElseTitle && <h2 className="mt2 mb2">Everything Else</h2> }
-
                 <div className={cx({ "hide": !showEntityList })}>
                     {/* EntityList loads `questions` according to the query specified in the url query string */}
                     <EntityList
@@ -152,4 +150,3 @@ export class QuestionIndex extends Component {
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(QuestionIndex);
-

--- a/frontend/src/metabase/questions/containers/SearchResults.jsx
+++ b/frontend/src/metabase/questions/containers/SearchResults.jsx
@@ -25,19 +25,22 @@ class SearchResults extends Component {
     render () {
         const { totalCount } = this.props;
         return (
+          <div className="pt4">
+            <div className="flex align-center border-bottom">
+                <div className="pl4 pb4">
+                  <ExpandingSearchField
+                      active
+                      defaultValue={this.props.location.query.q}
+                      onSearch={this.props.search}
+                  />
+                </div>
+            </div>
             <div className="px4 pt3">
                 <div className="flex align-center mb3">
                     <HeaderWithBack name={totalCount != null ?
                         `${totalCount} ${inflect("result", totalCount)}` :
                         "Search results"}
                     />
-                    <div className="ml-auto flex align-center">
-                        <ExpandingSearchField
-                            active
-                            defaultValue={this.props.location.query.q}
-                            onSearch={this.props.search}
-                        />
-                    </div>
                 </div>
                 <EntityList
                     entityType="cards"
@@ -46,6 +49,7 @@ class SearchResults extends Component {
                     defaultEmptyState="No matching questions found"
                 />
             </div>
+          </div>
         );
     }
 }


### PR DESCRIPTION
A few small changes to make the /questions/ page look nicer:
- get rid of "collections of questions" header (I think it's unnecessary)
- move search box to top-left so that it's not cramping the action icons, and restyle its colors a little to look better.
- hide the search box if no collections exist/are visible — it's redundant in conjunction with the filter box.
- change the layout of the search results page slightly to correspond with the search box move
- get rid of confusing "everything else" heading. might still need to add a horizontal rule/divider above the uncategorized questions list.

