### PR TITLE
Consider the font-weight

### DIFF
--- a/frontend/src/metabase/components/NewsletterForm.jsx
+++ b/frontend/src/metabase/components/NewsletterForm.jsx
@@ -62,7 +62,7 @@ export default class NewsletterForm extends Component {
 
                 <div className="MB-Newsletter sm-float-right">
                     <div>
-                        <div style={{color: "#878E95"}} className="text-grey-4 text-strong h3 pb3">
+                        <div style={{color: "#878E95"}} className="text-grey-4 h3 pb3">
                             Get infrequent emails about new releases and feature updates.
                         </div>
 

--- a/frontend/src/metabase/css/components/form.css
+++ b/frontend/src/metabase/css/components/form.css
@@ -32,7 +32,7 @@
 .Form-field .Form-label {
     display: block;
     font-size: 0.85em;
-    font-weight: bold;
+    font-weight: 700;
     color: currentColor;
 }
 

--- a/frontend/src/metabase/css/core/base.css
+++ b/frontend/src/metabase/css/core/base.css
@@ -12,6 +12,7 @@ html {
 body {
     font-family: var(--default-font-family), "Helvetica Neue", Helvetica, sans-serif;
     font-size: var(--default-font-size);
+    font-weight: 400;
     color: var(--default-font-color);
     margin: 0;
     height: 100%; /* ensure the entire page will fill the window */

--- a/frontend/src/metabase/css/core/base.css
+++ b/frontend/src/metabase/css/core/base.css
@@ -13,13 +13,13 @@ body {
     font-family: var(--default-font-family), "Helvetica Neue", Helvetica, sans-serif;
     font-size: var(--default-font-size);
     font-weight: 400;
+    font-style: normal;
     color: var(--default-font-color);
     margin: 0;
     height: 100%; /* ensure the entire page will fill the window */
     display: flex;
     flex-direction: column;
 
-    text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 }

--- a/frontend/src/metabase/css/core/base.css
+++ b/frontend/src/metabase/css/core/base.css
@@ -10,7 +10,7 @@ html {
 }
 
 body {
-    font-family: var(--default-font-family), "Helvetica Neue", Helvetica, sans-serif;
+    font-family: var(--default-font-family), sans-serif;
     font-size: var(--default-font-size);
     font-weight: 400;
     font-style: normal;

--- a/frontend/src/metabase/css/core/headings.css
+++ b/frontend/src/metabase/css/core/headings.css
@@ -8,6 +8,7 @@ h3, .h3,
 h4, .h4,
 h5, .h5,
 h6, .h6 {
+  font-weight: 700;
   margin-top: var(--default-header-margin);
   margin-bottom: var(--default-header-margin);
 }

--- a/frontend/src/metabase/css/core/text.css
+++ b/frontend/src/metabase/css/core/text.css
@@ -73,7 +73,6 @@
 /* text weight */
 .text-light  { font-weight: 300; }
 .text-normal { font-weight: 400; }
-.text-strong { font-weight: 570; }
 .text-bold, :local(.text-bold)   { font-weight: 700; }
 
 /* text style */

--- a/frontend/src/metabase/nav/containers/Navbar.jsx
+++ b/frontend/src/metabase/nav/containers/Navbar.jsx
@@ -84,7 +84,7 @@ export default class Navbar extends Component {
                         <span className="NavItem-text ml1 hide sm-show text-bold">Metabase Admin</span>
                     </div>
 
-                    <ul className="sm-ml4 flex flex-full text-strong">
+                    <ul className="sm-ml4 flex flex-full">
                         <AdminNavItem name="Settings"    path="/admin/settings"     currentPath={this.props.path} />
                         <AdminNavItem name="People"      path="/admin/people"       currentPath={this.props.path} />
                         <AdminNavItem name="Data Model"  path="/admin/datamodel"    currentPath={this.props.path} />

--- a/frontend/src/metabase/query_builder/components/QueryHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryHeader.jsx
@@ -261,7 +261,7 @@ export default class QueryHeader extends Component {
                     buttonSections.push([
                         <button
                             key="recentlySaved"
-                            className="cursor-pointer bg-white text-success text-strong text-uppercase"
+                            className="cursor-pointer bg-white text-success text-bold text-uppercase"
                         >
                             <span>
                                 <Icon name='check' size={12} />

--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -58,7 +58,7 @@
                     document.body.appendChild(script);
                 }
                 loadScript('https://ajax.googleapis.com/ajax/libs/webfont/1.4.7/webfont.js', function () {
-                    WebFont.load({ google: { families: ["Lato:n3,n4,n9,i9"] } });
+                    WebFont.load({ google: { families: ["Lato:n3,n4,n7,n9,i9"] } });
                 });
                 var googleAuthClientID = window.MetabaseBootstrap.google_auth_client_id;
                 if (googleAuthClientID) {

--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -58,10 +58,11 @@
                     if (onload) script.onload = onload;
                     document.body.appendChild(script);
                 }
-                /* loadScript('https://ajax.googleapis.com/ajax/libs/webfont/1.4.7/webfont.js', function () {
-                    WebFont.load({ google: { families: ["Lato:n3,n4,n7,n9,i9"] } });
+                loadScript('https://ajax.googleapis.com/ajax/libs/webfont/1.4.7/webfont.js', function () {
+                    WebFont.load({ google: {
+                        families: ["Lato:300,400,700,900"] }
+                    });
                 });
-                */
                 var googleAuthClientID = window.MetabaseBootstrap.google_auth_client_id;
                 if (googleAuthClientID) {
                     loadScript('https://apis.google.com/js/api:client.js');

--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -6,7 +6,6 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, minimal-ui" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-        <link href="https://fonts.googleapis.com/css?family=Lato:300,400,700,900,900i" rel="stylesheet">
 
         {{{embed_code}}}
 

--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -6,6 +6,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, minimal-ui" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+        <link href="https://fonts.googleapis.com/css?family=Lato:300,400,700,900,900i" rel="stylesheet">
 
         {{{embed_code}}}
 
@@ -57,9 +58,10 @@
                     if (onload) script.onload = onload;
                     document.body.appendChild(script);
                 }
-                loadScript('https://ajax.googleapis.com/ajax/libs/webfont/1.4.7/webfont.js', function () {
+                /* loadScript('https://ajax.googleapis.com/ajax/libs/webfont/1.4.7/webfont.js', function () {
                     WebFont.load({ google: { families: ["Lato:n3,n4,n7,n9,i9"] } });
                 });
+                */
                 var googleAuthClientID = window.MetabaseBootstrap.google_auth_client_id;
                 if (googleAuthClientID) {
                     loadScript('https://apis.google.com/js/api:client.js');


### PR DESCRIPTION
Things get weird cosmically if you try and use font-weights you aren't actually loading when using web fonts.

Our [`text-bold` class](https://github.com/metabase/metabase/blob/master/frontend/src/metabase/css/core/text.css#L77), which we use a lot sets the font-weight to 700. But we weren't actually loading the normal bold font from Google Fonts. Chrome has done an admirable job for the most point of making things look bold enough that I don't think we noticed the mistake. 

I haven't been able to do comprehensive enough testing in various browsers yet to confirm if this will help with some of the text rendering issues we've seen and have been reported but explicitly referencing the font weights you're using can't be a bad thing.

As part of this I also removed an additional class `.text-strong` since it didn't seem different enough to warrant the additional weight down the pipe (not to mention there's no  Lato 570)