### PR TITLE
Fix GuiBuild Expand width calculation - groupedBySection

### DIFF
--- a/frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx
@@ -332,7 +332,7 @@ export default class GuiQueryEditor extends Component {
         }
 
         return (
-            <div className="GuiBuilder-section GuiBuilder-groupedBy flex align-center px1" ref="viewSection">
+            <div className="GuiBuilder-section GuiBuilder-groupedBy flex align-center px1" ref="groupedBySection">
                 <span className="GuiBuilder-section-label Query-label">Grouped By</span>
                 {this.renderBreakouts()}
             </div>


### PR DESCRIPTION
`groupedBySection`

Fix GuiBuild Expand width calculation base on [https://github.com/metabase/metabase/blob/master/frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx#L349](https://github.com/metabase/metabase/blob/master/frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx#L349)



###### TODO 
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
