### PR TITLE
Fix GuiBuild Expand width calculation - sortLimitSection

### DIFF
--- a/frontend/src/metabase/query_builder/components/ExtendedOptions.jsx
+++ b/frontend/src/metabase/query_builder/components/ExtendedOptions.jsx
@@ -43,6 +43,7 @@ export default class ExtendedOptions extends Component {
         features: PropTypes.object.isRequired,
         datasetQuery: PropTypes.object.isRequired,
         tableMetadata: PropTypes.object,
+        setSortLimitSectionRef: PropTypes.func,
         setDatasetQuery: PropTypes.func.isRequired
     };
 
@@ -178,13 +179,13 @@ export default class ExtendedOptions extends Component {
     }
 
     render() {
-        const { features } = this.props;
+        const { features, setSortLimitSectionRef } = this.props;
         if (!features.sort && !features.limit) return null;
 
         const onClick = this.props.tableMetadata ? () => this.setState({isOpen: true}) : null;
 
         return (
-            <div className="GuiBuilder-section GuiBuilder-sort-limit flex align-center">
+            <div className="GuiBuilder-section GuiBuilder-sort-limit flex align-center" ref={setSortLimitSectionRef}>
                 <span className={cx("EllipsisButton no-decoration text-grey-1 px1", {"cursor-pointer": onClick})} onClick={onClick}>…</span>
                 {this.renderPopover()}
                 {this.renderExpressionWidget()}

--- a/frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx
@@ -86,6 +86,11 @@ export default class GuiQueryEditor extends Component {
         supportMultipleAggregations: true
     };
 
+    constructor(props, context) {
+        super(props, context);
+        this.setSortLimitSectionRef = this.setSortLimitSectionRef.bind(this);
+    }
+
     renderAdd(text: ?string, onClick: ?(() => void), targetRefName?: string) {
         let className = "AddButton text-grey-2 text-bold flex align-center text-grey-4-hover cursor-pointer no-decoration transition-color";
         if (onClick) {
@@ -339,6 +344,10 @@ export default class GuiQueryEditor extends Component {
         );
     }
 
+    setSortLimitSectionRef(sortLimitSection) {
+        this.refs.sortLimitSection = sortLimitSection;
+    }
+
     componentDidUpdate() {
         const guiBuilder = ReactDOM.findDOMNode(this.refs.guiBuilder);
         if (!guiBuilder) {
@@ -378,6 +387,7 @@ export default class GuiQueryEditor extends Component {
                     <div className="flex-full"></div>
                     {this.props.children}
                     <ExtendedOptions
+                        setSortLimitSectionRef={this.setSortLimitSectionRef}
                         {...this.props}
                     />
                 </div>


### PR DESCRIPTION
`sortLimitSection`

Fix GuiBuild Expand width calculation base on 

[https://github.com/metabase/metabase/blob/master/frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx#L349](https://github.com/metabase/metabase/blob/master/frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx#L349)

###### TODO 
-  [ ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
