### PR TITLE
Webpack vendor bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ bin/release/aws-eb/metabase-aws-eb.zip
 /crate-*
 *.po~
 /locales/metabase-*.pot
+/stats.json

--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
     "build": "webpack --bail",
     "build-watch": "webpack --watch",
     "build-hot": "NODE_ENV=hot webpack-dev-server --progress",
+    "build-stats": "webpack --json > stats.json",
     "start": "yarn run build && lein ring server",
     "precommit": "lint-staged",
     "preinstall": "echo $npm_execpath | grep -q yarn || echo '\\033[0;33mSorry, npm is not supported. Please use Yarn (https://yarnpkg.com/).\\033[0m'",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -104,6 +104,12 @@ var config = module.exports = {
     },
 
     plugins: [
+        new webpack.optimize.CommonsChunkPlugin({
+            name: 'vendor',
+            minChunks (module) {
+                return module.context && module.context.indexOf('node_modules') >= 0
+            }
+        }),
         new UnusedFilesWebpackPlugin({
             globOptions: {
                 ignore: [
@@ -121,7 +127,7 @@ var config = module.exports = {
         new HtmlWebpackPlugin({
             filename: '../../index.html',
             chunksSortMode: 'manual',
-            chunks: ["styles", "app-main"],
+            chunks: ["vendor", "styles", "app-main"],
             template: __dirname + '/resources/frontend_client/index_template.html',
             inject: 'head',
             alwaysWriteToDisk: true,
@@ -129,7 +135,7 @@ var config = module.exports = {
         new HtmlWebpackPlugin({
             filename: '../../public.html',
             chunksSortMode: 'manual',
-            chunks: ["styles", "app-public"],
+            chunks: ["vendor", "styles", "app-public"],
             template: __dirname + '/resources/frontend_client/index_template.html',
             inject: 'head',
             alwaysWriteToDisk: true,
@@ -137,7 +143,7 @@ var config = module.exports = {
         new HtmlWebpackPlugin({
             filename: '../../embed.html',
             chunksSortMode: 'manual',
-            chunks: ["styles", "app-embed"],
+            chunks: ["vendor", "styles", "app-embed"],
             template: __dirname + '/resources/frontend_client/index_template.html',
             inject: 'head',
             alwaysWriteToDisk: true,


### PR DESCRIPTION
I started to get a bit peeved at our webpack build speeds while trying to work on mobile improvements and the fact that things often hadn't rebuilt in the time it takes to pick pick up an iPhone and refresh safari seemed like something we should be able to fix.

This splits out common non MB related dependencies in `node_modules` into its own bundle that can be shared. Significantly reduces the size of our `app-main`, `app-public` and `app-embed` bundles.

### Before:
```                                            Asset     Size  Chunks                    Chunk Names
         1.hot.bundle.js.map?74992da6f3a833efa5a1   110 kB       1  [emitted]         
             0.hot.bundle.js?74992da6f3a833efa5a1  31.9 kB       0  [emitted]         
             2.hot.bundle.js?74992da6f3a833efa5a1    73 kB       2  [emitted]         
      app-main.hot.bundle.js?74992da6f3a833efa5a1  14.1 MB       3  [emitted]  [big]  app-main
    app-public.hot.bundle.js?74992da6f3a833efa5a1   8.8 MB       4  [emitted]  [big]  app-public
     app-embed.hot.bundle.js?74992da6f3a833efa5a1   8.8 MB       5  [emitted]  [big]  app-embed
        styles.hot.bundle.js?74992da6f3a833efa5a1   536 kB       6  [emitted]  [big]  styles
         0.hot.bundle.js.map?74992da6f3a833efa5a1  40.8 kB       0  [emitted]         
             1.hot.bundle.js?74992da6f3a833efa5a1   106 kB       1  [emitted]         
         2.hot.bundle.js.map?74992da6f3a833efa5a1  62.2 kB       2  [emitted]         
  app-main.hot.bundle.js.map?74992da6f3a833efa5a1  11.8 MB       3  [emitted]  [big]  app-main
app-public.hot.bundle.js.map?74992da6f3a833efa5a1  8.38 MB       4  [emitted]  [big]  app-public
 app-embed.hot.bundle.js.map?74992da6f3a833efa5a1  8.38 MB       5  [emitted]  [big]  app-embed
    styles.hot.bundle.js.map?74992da6f3a833efa5a1   583 kB       6  [emitted]  [big]  styles
                                 ../../index.html  4.11 kB          [emitted]         
                                ../../public.html  4.11 kB          [emitted]         
                                 ../../embed.html  4.11 kB          [emitted]         
```
Initial build time: 60934ms

Rebuild time after file change:
Time: 9186ms
Time: 8878ms
Time: 8659ms

*Average: 8,907ms*

### After:
```                                            Asset     Size  Chunks                    Chunk Names
         1.hot.bundle.js.map?bb3caea14231f07b3d70   110 kB       1  [emitted]         
             0.hot.bundle.js?bb3caea14231f07b3d70  31.9 kB       0  [emitted]         
             2.hot.bundle.js?bb3caea14231f07b3d70    73 kB       2  [emitted]         
      app-main.hot.bundle.js?bb3caea14231f07b3d70  6.93 MB       3  [emitted]  [big]  app-main
    app-public.hot.bundle.js?bb3caea14231f07b3d70  2.69 MB       4  [emitted]  [big]  app-public
     app-embed.hot.bundle.js?bb3caea14231f07b3d70  2.69 MB       5  [emitted]  [big]  app-embed
        styles.hot.bundle.js?bb3caea14231f07b3d70   135 kB       6  [emitted]         styles
        vendor.hot.bundle.js?bb3caea14231f07b3d70  7.19 MB       7  [emitted]  [big]  vendor
         0.hot.bundle.js.map?bb3caea14231f07b3d70  40.8 kB       0  [emitted]         
             1.hot.bundle.js?bb3caea14231f07b3d70   106 kB       1  [emitted]         
         2.hot.bundle.js.map?bb3caea14231f07b3d70  62.2 kB       2  [emitted]         
  app-main.hot.bundle.js.map?bb3caea14231f07b3d70  4.03 MB       3  [emitted]  [big]  app-main
app-public.hot.bundle.js.map?bb3caea14231f07b3d70  1.68 MB       4  [emitted]  [big]  app-public
 app-embed.hot.bundle.js.map?bb3caea14231f07b3d70  1.68 MB       5  [emitted]  [big]  app-embed
    styles.hot.bundle.js.map?bb3caea14231f07b3d70   141 kB       6  [emitted]         styles
    vendor.hot.bundle.js.map?bb3caea14231f07b3d70  7.81 MB       7  [emitted]  [big]  vendor
                                 ../../index.html  4.23 kB          [emitted]         
                                ../../public.html  4.23 kB          [emitted]         
                                 ../../embed.html  4.23 kB          [emitted]
```
Initial build time: 58801ms

Rebuild time after file change:
Time: 6350ms
Time: 6325ms
Time: 6793ms

*Average: 6,489ms*

Also adds a script to `package.json` to generate stats on our webpack build. I figure this will be useful and might lead to some further optimizations. 