### PR TITLE
Fix popover width for dual date picker

### DIFF
--- a/frontend/src/metabase/components/Calendar.css
+++ b/frontend/src/metabase/components/Calendar.css
@@ -1,7 +1,3 @@
-
-.Calendar {
-}
-
 .Calendar-week {
     display: flex;
 }

--- a/frontend/src/metabase/components/Calendar.jsx
+++ b/frontend/src/metabase/components/Calendar.jsx
@@ -139,7 +139,7 @@ export default class Calendar extends Component {
     renderCalender(current, side) {
         return (
             <div className={
-                cx("Calendar", { "Calendar--range": this.props.selected && this.props.selectedEnd })}>
+                cx("Calendar Grid-cell", { "Calendar--range": this.props.selected && this.props.selectedEnd })}>
                 {this.renderMonthHeader(current, side)}
                 {this.renderDayNames(current)}
                 {this.renderWeeks(current)}
@@ -151,10 +151,8 @@ export default class Calendar extends Component {
         const { current } = this.state;
         if (this.props.isDual) {
             return (
-                <div className="flex">
-                    <div className="mr3">
-                        {this.renderCalender(current, "left")}
-                    </div>
+                <div className="Grid Grid--1of2 Grid--gutters">
+                    {this.renderCalender(current, "left")}
                     {this.renderCalender(moment(current).add(1, "month"), "right")}
                 </div>
             )

--- a/frontend/src/metabase/components/Popover.css
+++ b/frontend/src/metabase/components/Popover.css
@@ -1,7 +1,3 @@
-:root {
-
-}
-
 /* afaik popover needs a positioning context to be able to calculate the transform */
 .PopoverContainer {
 	pointer-events: none;
@@ -19,6 +15,16 @@
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;
+  /* add a max-width so that long strings don't cause the popover to expand
+   * see issue #4930 */
+  max-width: 500px;
+}
+
+/* remove the max-width for date pickers so the dual date picker can fully
+ * expand as necessary - issue #5971
+ */
+.PopoverBody.DatePopover {
+  max-width: none;
 }
 
 .PopoverBody.PopoverBody--tooltip {

--- a/frontend/src/metabase/components/Popover.css
+++ b/frontend/src/metabase/components/Popover.css
@@ -19,7 +19,6 @@
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;
-  max-width: 500px;
 }
 
 .PopoverBody.PopoverBody--tooltip {

--- a/frontend/src/metabase/components/Popover.css
+++ b/frontend/src/metabase/components/Popover.css
@@ -20,10 +20,11 @@
   max-width: 500px;
 }
 
-/* remove the max-width for date pickers so the dual date picker can fully
+/* remove the max-width in cases where the popover content needs to expand
+ * initially added  for date pickers so the dual date picker can fully
  * expand as necessary - issue #5971
  */
-.PopoverBody.DatePopover {
+.PopoverBody.PopoverBody--autoWidth {
   max-width: none;
 }
 

--- a/frontend/src/metabase/components/Popover.jsx
+++ b/frontend/src/metabase/components/Popover.jsx
@@ -33,8 +33,14 @@ export default class Popover extends Component {
         hasArrow: PropTypes.bool,
         // target: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
         tetherOptions: PropTypes.object,
+        // used to prevent popovers from being taller than the screen
         sizeToFit: PropTypes.bool,
         pinInitialAttachment: PropTypes.bool,
+        // most popovers have a max-width to prevent them from being overly wide
+        // in the case their content is of an unexpected length
+        // noMaxWidth allows that to be overridden in cases where popovers should
+        // expand  alongside their contents contents
+        autoWidth: PropTypes.bool
     };
 
     static defaultProps = {
@@ -45,6 +51,7 @@ export default class Popover extends Component {
         targetOffsetX: 24,
         targetOffsetY: 5,
         sizeToFit: false,
+        autoWidth: false
     };
 
     _getPopoverElement() {
@@ -96,10 +103,22 @@ export default class Popover extends Component {
 
     _popoverComponent() {
         return (
-            <OnClickOutsideWrapper handleDismissal={this.handleDismissal} dismissOnEscape={this.props.dismissOnEscape} dismissOnClickOutside={this.props.dismissOnClickOutside}>
+            <OnClickOutsideWrapper
+                handleDismissal={this.handleDismissal}
+                dismissOnEscape={this.props.dismissOnEscape}
+                dismissOnClickOutside={this.props.dismissOnClickOutside}
+            >
                 <div
                     id={this.props.id}
-                    className={cx("PopoverBody", { "PopoverBody--withArrow": this.props.hasArrow }, this.props.className)}
+                    className={cx(
+                        "PopoverBody",
+                        {
+                            "PopoverBody--withArrow": this.props.hasArrow,
+                            "PopoverBody--autoWidth": this.props.autoWidth
+                        },
+                        // TODO kdoh 10/16/2017 we should eventually remove this
+                        this.props.className
+                    )}
                     style={this.props.style}
                 >
                     { typeof this.props.children === "function" ?

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -168,13 +168,15 @@ export default class ParameterValueWidget extends Component {
                 <PopoverWithTrigger
                     ref="valuePopover"
                     triggerElement={
-                    <div ref="trigger" className={cx(S.parameter, className, { [S.selected]: hasValue })}>
-                        { getParameterTypeIcon() }
-                        <div className="mr1 text-nowrap">{ hasValue ? Widget.format(value, values) : placeholderText }</div>
-                        { getWidgetStatusIcon() }
-                    </div>
-                }
+                        <div ref="trigger" className={cx(S.parameter, className, { [S.selected]: hasValue })}>
+                            { getParameterTypeIcon() }
+                            <div className="mr1 text-nowrap">{ hasValue ? Widget.format(value, values) : placeholderText }</div>
+                            { getWidgetStatusIcon() }
+                        </div>
+                    }
                     target={() => this.refs.trigger} // not sure why this is necessary
+                    // make sure the full date picker will expand to fit the dual calendars
+                    autoWidth={parameter.type === "date/all-options"}
                 >
                     <Widget value={value} values={values} setValue={setValue}
                             onClose={() => this.refs.valuePopover.close()}/>

--- a/frontend/src/metabase/qb/components/TimeseriesFilterWidget.jsx
+++ b/frontend/src/metabase/qb/components/TimeseriesFilterWidget.jsx
@@ -125,6 +125,7 @@ export default class TimeseriesFilterWidget extends Component {
                 triggerClasses={cx(className, "my2")}
                 ref={ref => this._popover = ref}
                 sizeToFit
+                className="DatePopover"
             >
                 <DatePicker
                     filter={this.state.filter}

--- a/frontend/src/metabase/qb/components/TimeseriesFilterWidget.jsx
+++ b/frontend/src/metabase/qb/components/TimeseriesFilterWidget.jsx
@@ -125,7 +125,8 @@ export default class TimeseriesFilterWidget extends Component {
                 triggerClasses={cx(className, "my2")}
                 ref={ref => this._popover = ref}
                 sizeToFit
-                className="DatePopover"
+                // accomodate dual calendar size
+                autoWidth={true}
             >
                 <DatePicker
                     filter={this.state.filter}

--- a/frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx
@@ -158,6 +158,7 @@ export default class GuiQueryEditor extends Component {
                         triggerClasses="flex align-center"
                         getTarget={() => this.refs.addFilterTarget}
                         horizontalAttachments={["left"]}
+                        autoWidth
                     >
                         <FilterPopover
                             isNew

--- a/frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx
@@ -261,6 +261,7 @@ export default class FilterPopover extends Component {
             return (
                 <div style={{
                     minWidth: 300,
+                    // $FlowFixMe
                     maxWidth: dimension.field().isDate() ? null : 500
                 }}>
                     <div className="FilterPopover-header text-grey-3 p1 mt1 flex align-center">

--- a/frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx
@@ -240,13 +240,13 @@ export default class FilterPopover extends Component {
     render() {
         const { query } = this.props;
         const { filter } = this.state;
-        const [operator, field] = filter;
-        if (operator === "SEGMENT" || field == undefined) {
+        const [operator, fieldRef] = filter;
+        if (operator === "SEGMENT" || fieldRef == undefined) {
             return (
                 <div className="FilterPopover">
                     <FieldList
                         className="text-purple"
-                        field={field}
+                        field={fieldRef}
                         fieldOptions={query.filterFieldOptions(filter)}
                         segmentOptions={query.filterSegmentOptions(filter)}
                         tableMetadata={query.table()}
@@ -256,11 +256,12 @@ export default class FilterPopover extends Component {
                 </div>
             );
         } else {
-            let { table, field } = Query.getFieldTarget(filter[1], query.table());
-
+            let { table, field } = Query.getFieldTarget(fieldRef, query.table());
+            const dimension = query.parseFieldReference(fieldRef);
             return (
                 <div style={{
-                    minWidth: 300
+                    minWidth: 300,
+                    maxWidth: dimension.field().isDate() ? null : 500
                 }}>
                     <div className="FilterPopover-header text-grey-3 p1 mt1 flex align-center">
                         <a className="cursor-pointer text-purple-hover transition-color flex align-center" onClick={this.clearField}>

--- a/frontend/src/metabase/query_builder/components/filters/FilterWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterWidget.jsx
@@ -127,11 +127,17 @@ export default class FilterWidget extends Component {
     renderPopover() {
         if (this.state.isOpen) {
             const { query, filter } = this.props;
+            const [, field,,] = filter;
+            const dimension = query.parseFieldReference(field);
             return (
                 <Popover
                     id="FilterPopover"
                     ref="filterPopover"
-                    className="FilterPopover"
+                    className={cx(
+                        'FilterPopover',
+                        // $FlowFixMe
+                        { 'DatePopover': dimension.field().isDate()
+                    })}
                     isInitiallyOpen={this.props.filter[1] === null}
                     onClose={this.close}
                     horizontalAttachments={["left"]}

--- a/frontend/src/metabase/query_builder/components/filters/FilterWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterWidget.jsx
@@ -142,7 +142,7 @@ export default class FilterWidget extends Component {
                         // should be allowed to auto size its width to accomodate
                         // the calendars
                         // $FlowFixMe
-                        dimension.field().isdate()
+                        dimension.field().isDate()
                     }
                 >
                     <FilterPopover

--- a/frontend/src/metabase/query_builder/components/filters/FilterWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterWidget.jsx
@@ -133,14 +133,17 @@ export default class FilterWidget extends Component {
                 <Popover
                     id="FilterPopover"
                     ref="filterPopover"
-                    className={cx(
-                        'FilterPopover',
-                        // $FlowFixMe
-                        { 'DatePopover': dimension.field().isDate()
-                    })}
+                    className="FilterPopover"
                     isInitiallyOpen={this.props.filter[1] === null}
                     onClose={this.close}
                     horizontalAttachments={["left"]}
+                    autoWidth={
+                        // If the field is a date field the filter popover
+                        // should be allowed to auto size its width to accomodate
+                        // the calendars
+                        // $FlowFixMe
+                        dimension.field().isdate()
+                    }
                 >
                     <FilterPopover
                         query={query}

--- a/frontend/src/metabase/query_builder/components/filters/FilterWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterWidget.jsx
@@ -127,8 +127,6 @@ export default class FilterWidget extends Component {
     renderPopover() {
         if (this.state.isOpen) {
             const { query, filter } = this.props;
-            const [, field,,] = filter;
-            const dimension = query.parseFieldReference(field);
             return (
                 <Popover
                     id="FilterPopover"
@@ -137,13 +135,7 @@ export default class FilterWidget extends Component {
                     isInitiallyOpen={this.props.filter[1] === null}
                     onClose={this.close}
                     horizontalAttachments={["left"]}
-                    autoWidth={
-                        // If the field is a date field the filter popover
-                        // should be allowed to auto size its width to accomodate
-                        // the calendars
-                        // $FlowFixMe
-                        dimension.field().isDate()
-                    }
+                    autoWidth
                 >
                     <FilterPopover
                         query={query}

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx
@@ -24,24 +24,32 @@ import type {
 } from "metabase/meta/types/Query";
 
 const SingleDatePicker = ({ filter: [op, field, value], onFilterChange, hideTimeSelectors }) =>
-    <SpecificDatePicker
-        value={value}
-        onChange={(value) => onFilterChange([op, field, value])}
-        hideTimeSelectors={hideTimeSelectors}
-        calendar />
+    <div className="mx2">
+        <SpecificDatePicker
+            value={value}
+            onChange={(value) => onFilterChange([op, field, value])}
+            hideTimeSelectors={hideTimeSelectors}
+            calendar
+        />
+    </div>
 
 const MultiDatePicker = ({ filter: [op, field, startValue, endValue], onFilterChange , hideTimeSelectors}) =>
     <div className="mx2 mb1">
-        <div className="flex">
-            <SpecificDatePicker
-                value={startValue}
-                hideTimeSelectors={hideTimeSelectors}
-                onChange={(value) => onFilterChange([op, field, value, endValue])}  />
-            <span className="mx2 mt2">&ndash;</span>
-            <SpecificDatePicker
-                value={endValue}
-                hideTimeSelectors={hideTimeSelectors}
-                onChange={(value) => onFilterChange([op, field, startValue, value])} />
+        <div className="Grid Grid--1of2 Grid--gutters">
+            <div className="Grid-cell">
+                <SpecificDatePicker
+                    value={startValue}
+                    hideTimeSelectors={hideTimeSelectors}
+                    onChange={(value) => onFilterChange([op, field, value, endValue])}
+                />
+            </div>
+            <div className="Grid-cell">
+                <SpecificDatePicker
+                    value={endValue}
+                    hideTimeSelectors={hideTimeSelectors}
+                    onChange={(value) => onFilterChange([op, field, startValue, value])}
+                />
+            </div>
         </div>
         <div className="Calendar--noContext">
             <Calendar

--- a/frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx
@@ -82,7 +82,7 @@ export default class SpecificDatePicker extends Component {
         }
 
         return (
-            <div className="px1">
+            <div>
                 <div className="flex align-center mb1">
                     <div className={cx('border-top border-bottom full border-left', { 'border-right': !calendar })}>
                         <Input


### PR DESCRIPTION
Fixes #5971 

Removes the max-width on the PopoverBody when the FilterWidget is working with dates. This max width was causing the cut off in dual calendar mode when using between filters.

Also moves to use our Grid system for calendar layout to make the calendar layout logic more explicit.