### PR TITLE
Move db.spec/redshift -> driver/redshift/connection-details->spec

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -88,7 +88,7 @@ install-vertica() {
 }
 
 install-presto() {
-    docker run --detach --publish 8080:8080 wiill/presto-mb-ci
+    docker run --detach --publish 8080:8080 metabase/presto-mb-ci
     sleep 10
 }
 

--- a/src/metabase/db/spec.clj
+++ b/src/metabase/db/spec.clj
@@ -38,15 +38,3 @@
           :subname (str "//" host ":" port "/" db)
           :delimiters "`"}
          (dissoc opts :host :port :db)))
-
-(defn redshift
-  "Create a database specification for a redshift database. Opts should include
-  keys for :db, :user, and :password. You can also optionally set host and
-  port."
-  [{:keys [host port db]
-    :as opts}]
-  (merge {:classname "com.amazon.redshift.jdbc.Driver" ; must be in classpath
-          :subprotocol "redshift"
-          :subname (str "//" host ":" port "/" db "?OpenSourceSubProtocolOverride=false")
-          :ssl true}
-         (dissoc opts :host :port :db)))

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -83,13 +83,13 @@
     :inet :type/IPAddress
     nil))
 
-(def ^:const ssl-params
+(def ^:private ^:const ssl-params
   "Params to include in the JDBC connection spec for an SSL connection."
   {:ssl        true
    :sslmode    "require"
    :sslfactory "org.postgresql.ssl.NonValidatingFactory"})  ; HACK Why enable SSL if we disable certificate validation?
 
-(def ^:const disable-ssl-params
+(def ^:private ^:const disable-ssl-params
   "Params to include in the JDBC connection spec to disable SSL."
   {:sslmode "disable"})
 

--- a/src/metabase/driver/redshift.clj
+++ b/src/metabase/driver/redshift.clj
@@ -7,7 +7,6 @@
              [config :as config]
              [driver :as driver]
              [util :as u]]
-            [metabase.db.spec :as dbspec]
             [metabase.driver
              [generic-sql :as sql]
              [postgres :as postgres]]
@@ -15,8 +14,17 @@
              [honeysql-extensions :as hx]
              [ssh :as ssh]]))
 
-(defn- connection-details->spec [details]
-  (dbspec/redshift details))
+(defn- connection-details->spec
+  "Create a database specification for a redshift database. Opts should include
+  keys for :db, :user, and :password. You can also optionally set host and
+  port."
+  [{:keys [host port db],
+    :as opts}]
+  (merge {:classname "com.amazon.redshift.jdbc.Driver" ; must be in classpath
+          :subprotocol "redshift"
+          :subname (str "//" host ":" port "/" db "?OpenSourceSubProtocolOverride=false")
+          :ssl true}
+         (dissoc opts :host :port :db)))
 
 (defn- date-interval [unit amount]
   (hsql/call :+ :%getdate (hsql/raw (format "INTERVAL '%d %s'" (int amount) (name unit)))))


### PR DESCRIPTION
Follow-on to #6019.

Explanation is taken from a comment there:

> [...] the only reason we have this "spec" namespace is because the code here is used for application DB connections as well. See my note at the top of the namespace:
>
```clojure
(ns metabase.db.spec
  "Functions for creating JDBC DB specs for a given engine.
   Only databases that are supported as application DBs should have functions in this namespace;
   otherwise, similar functions are only needed by drivers, and belong in those namespaces.")
```
>
>The "spec" stuff is basically just a copy of the [Korma functions](https://github.com/korma/Korma/blob/master/src/korma/db.clj#L190) that did the same thing that I pulled over when we switched from Korma to HoneySQL. (Korma does substantially more than HoneySQL out-of-the-box, so during the transition I had to manually replicate the missing pieces of functionality, such as the C3P0 connection pools. That's also how [Toucan](https://github.com/metabase/toucan) got it's start.)
>
>So we would probably be best served by moving this `redshift` function into `driver/redshift` and renaming it something like `db-details->spec`. See the other JDBC-based drivers for examples