### PR TITLE
Allow whitespace in params in native query builder

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/NativeQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/NativeQuery.js
@@ -201,7 +201,7 @@ export default class NativeQuery extends AtomicQuery {
             // a variable name can optionally end with :start or :end which is not considered part of the actual variable name
             // expected pattern is like mustache templates, so we are looking for something like {{category}} or {{date:start}}
             // anything that doesn't match our rule is ignored, so {{&foo!}} would simply be ignored
-            let match, re = /\{\{([A-Za-z0-9_]+?)\}\}/g;
+            let match, re = /\{\{\s*([A-Za-z0-9_]+?)\s*\}\}/g;
             while ((match = re.exec(queryText)) != null) {
                 tags.push(match[1]);
             }


### PR DESCRIPTION
Fixes #5954 

@mazameli give this a try when you get a chance