### PR TITLE
split up webpack config based on env [WIP]

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "webchauffeur": "^1.2.0",
     "webpack": "^3.8.1",
     "webpack-dev-server": "^2.9.1",
+    "webpack-merge": "^4.1.0",
     "webpack-postcss-tools": "^1.1.2"
   },
   "scripts": {
@@ -161,9 +162,9 @@
     "test-e2e": "JASMINE_CONFIG_PATH=./frontend/test/e2e/support/jasmine.json jasmine",
     "test-e2e-dev": "./frontend/test/e2e-with-persistent-browser.js",
     "test-e2e-sauce": "USE_SAUCE=true yarn run test-e2e",
-    "build": "webpack --bail",
-    "build-watch": "webpack --watch",
-    "build-hot": "NODE_ENV=hot webpack-dev-server --progress",
+    "build": "webpack --bail --config webpack.prod.js",
+    "build-watch": "webpack --config webpack.dev.js --watch",
+    "build-hot": "NODE_ENV=hot webpack-dev-server --progress --config webpack.dev.js",
     "build-stats": "webpack --json > stats.json",
     "start": "yarn run build && lein ring server",
     "precommit": "lint-staged",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -4,33 +4,30 @@
 require("babel-register");
 require("babel-polyfill");
 
-var webpack = require('webpack');
+const webpack = require('webpack');
 
-var ExtractTextPlugin = require('extract-text-webpack-plugin');
-var HtmlWebpackPlugin = require('html-webpack-plugin');
-var HtmlWebpackHarddiskPlugin = require('html-webpack-harddisk-plugin');
-var UnusedFilesWebpackPlugin = require("unused-files-webpack-plugin").default;
-var BannerWebpackPlugin = require('banner-webpack-plugin');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const HtmlWebpackHarddiskPlugin = require('html-webpack-harddisk-plugin');
+const UnusedFilesWebpackPlugin = require("unused-files-webpack-plugin").default;
+const BannerWebpackPlugin = require('banner-webpack-plugin');
 
-var fs = require('fs');
+const fs = require('fs');
 
-var chevrotain = require("chevrotain");
-var allTokens = require("./frontend/src/metabase/lib/expressions/tokens").allTokens;
-
-var SRC_PATH = __dirname + '/frontend/src/metabase';
-var LIB_SRC_PATH = __dirname + '/frontend/src/metabase-lib';
-var TEST_SUPPORT_PATH = __dirname + '/frontend/test/__support__';
-var BUILD_PATH = __dirname + '/resources/frontend_client';
+const SRC_PATH = __dirname + '/frontend/src/metabase';
+const LIB_SRC_PATH = __dirname + '/frontend/src/metabase-lib';
+const TEST_SUPPORT_PATH = __dirname + '/frontend/test/__support__';
+const BUILD_PATH = __dirname + '/resources/frontend_client';
 
 // default NODE_ENV to development
 var NODE_ENV = process.env["NODE_ENV"] || "development";
 
 // Babel:
-var BABEL_CONFIG = {
+const BABEL_CONFIG = {
     cacheDirectory: process.env.BABEL_DISABLE_CACHE ? null : ".babel_cache"
-};
+}
 
-var CSS_CONFIG = {
+const CSS_CONFIG = {
     localIdentName: NODE_ENV !== "production" ?
         "[name]__[local]___[hash:base64:5]" :
         "[hash:base64:5]",
@@ -38,7 +35,7 @@ var CSS_CONFIG = {
     importLoaders: 1
 }
 
-var config = module.exports = {
+const config = module.exports = {
     context: SRC_PATH,
 
     // output a bundle for the app JS and a bundle for styles
@@ -174,54 +171,7 @@ var config = module.exports = {
     ]
 };
 
-if (NODE_ENV === "hot") {
-    // suffixing with ".hot" allows us to run both `yarn run build-hot` and `yarn run test` or `yarn run test-watch` simultaneously
-    config.output.filename = "[name].hot.bundle.js?[hash]";
-
-    // point the publicPath (inlined in index.html by HtmlWebpackPlugin) to the hot-reloading server
-    config.output.publicPath = "http://localhost:8080/" + config.output.publicPath;
-
-    config.module.rules.unshift({
-        test: /\.jsx$/,
-        exclude: /node_modules/,
-        use: [
-            // NOTE Atte Keinänen 10/19/17: We are currently sticking to an old version of react-hot-loader
-            // because newer versions would require us to upgrade to react-router v4 and possibly deal with
-            // asynchronous route issues as well. See https://github.com/gaearon/react-hot-loader/issues/249
-            { loader: 'react-hot-loader' },
-            { loader: 'babel-loader', options: BABEL_CONFIG }
-        ]
-    });
-
-    // disable ExtractTextPlugin
-    config.module.rules[config.module.rules.length - 1].use = [
-        { loader: "style-loader" },
-        { loader: "css-loader", options: CSS_CONFIG },
-        { loader: "postcss-loader" }
-    ]
-
-    config.devServer = {
-        hot: true,
-        inline: true,
-        contentBase: "frontend",
-        headers: {
-            'Access-Control-Allow-Origin': '*'
-        }
-        // if webpack doesn't reload UI after code change in development
-        // watchOptions: {
-        //     aggregateTimeout: 300,
-        //     poll: 1000
-        // }
-        // if you want to reduce stats noise
-        // stats: 'minimal' // values: none, errors-only, minimal, normal, verbose
-    };
-
-    config.plugins.unshift(
-        new webpack.NoEmitOnErrorsPlugin(),
-        new webpack.NamedModulesPlugin(),
-        new webpack.HotModuleReplacementPlugin()
-    );
-}
+module.exports.BABEL_CONFIG = BABEL_CONFIG
 
 if (NODE_ENV !== "production") {
     // replace minified files with un-minified versions
@@ -233,25 +183,4 @@ if (NODE_ENV !== "production") {
         }
     }
 
-    // enable "cheap" source maps in hot or watch mode since re-build speed overhead is < 1 second
-    config.devtool = "cheap-module-source-map";
-
-    // works with breakpoints
-    // config.devtool = "inline-source-map"
-
-    // helps with source maps
-    config.output.devtoolModuleFilenameTemplate = '[absolute-resource-path]';
-    config.output.pathinfo = true;
-} else {
-    config.plugins.push(new webpack.optimize.UglifyJsPlugin({
-        mangle: {
-            // this is required to ensure we don't minify Chevrotain token identifiers
-            // https://github.com/SAP/chevrotain/tree/master/examples/parser/minification
-            except: allTokens.map(function(currTok) {
-                return chevrotain.tokenName(currTok);
-            })
-        }
-    }))
-
-    config.devtool = "source-map";
 }

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,0 +1,75 @@
+/* eslint-env node */
+/* eslint-disable import/no-commonjs */
+
+const webpack = require('webpack')
+const merge = require('webpack-merge')
+const common = require('./webpack.common.js')
+
+const BABEL_CONFIG = require('./webpack.common.js').BABEL_CONFIG
+
+module.exports = merge(common, {
+    devServer: {
+        hot: true,
+        inline: true,
+        contentBase: "frontend",
+        headers: {
+            'Access-Control-Allow-Origin': '*'
+        }
+        // if webpack doesn't reload UI after code change in development
+        // watchOptions: {
+        //     aggregateTimeout: 300,
+        //     poll: 1000
+        // }
+        // if you want to reduce stats noise
+        // stats: 'minimal' // values: none, errors-only, minimal, normal, verbose
+    },
+    devtool: 'inline-source-map',
+    module: {
+        rules: [
+            {
+                test: /\.jsx$/,
+                exclude: /node_modules/,
+                use: [
+                    // NOTE Atte Keinänen 10/19/17: We are currently sticking to an old version of react-hot-loader
+                    // because newer versions would require us to upgrade to react-router v4 and possibly deal with
+                    // asynchronous route issues as well. See https://github.com/gaearon/react-hot-loader/issues/249
+                    { loader: 'react-hot-loader' },
+                    { loader: 'babel-loader', options: BABEL_CONFIG }
+                ]
+
+            }
+        ]
+    },
+    output: {
+        devtoolModuleFilenameTemplate: '[absolute-resource-path]',
+
+        // suffixing with ".hot" allows us to run both `yarn run build-hot`
+        // and `yarn run test` or `yarn run test-watch` simultaneously
+        filename: '[name].hot.bundle.js?[hash]',
+
+        pathinfo: true,
+
+        // point the publicPath (inlined in index.html by HtmlWebpackPlugin)
+        // to the hot-reloading server
+        publicPath:  "http://localhost:8080/" + common.output.publicPath
+    },
+    plugins: [
+        new webpack.NoEmitOnErrorsPlugin(),
+        new webpack.NamedModulesPlugin(),
+        new webpack.HotModuleReplacementPlugin()
+    ]
+})
+
+/*
+    if (NODE_ENV === "hot") {
+        config.module.rules.unshift({
+        });
+
+        // disable ExtractTextPlugin
+        config.module.rules[config.module.rules.length - 1].use = [
+            { loader: "style-loader" },
+            { loader: "css-loader", options: CSS_CONFIG },
+            { loader: "postcss-loader" }
+        ]
+    }
+*/

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,0 +1,28 @@
+/* eslint-env node */
+/* eslint-disable import/no-commonjs */
+
+const merge = require('webpack-merge')
+const common = require('./webpack.common.js')
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
+
+const chevrotain = require("chevrotain");
+// tokens related to chevrotain
+const allTokens = require("./frontend/src/metabase/lib/expressions/tokens").allTokens;
+
+module.exports = merge(common, {
+    devtool: 'source-map',
+    plugins: [
+        new UglifyJsPlugin({
+            uglifyOptions: {
+                mangle: {
+                    // this is required to ensure we don't minify Chevrotain token identifiers
+                    // https://github.com/SAP/chevrotain/tree/master/examples/parser/minification
+                    except: allTokens.map(function(currTok) {
+                        return chevrotain.tokenName(currTok);
+                    })
+                }
+            }
+        })
+    ]
+})
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -1444,7 +1444,7 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
-brace-expansion@^1.1.7:
+brace-expansion@^1.0.0, brace-expansion@^1.1.7:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
   dependencies:
@@ -1605,6 +1605,10 @@ builtin-status-codes@^3.0.0:
 bytes@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-1.0.0.tgz#3569ede8ba34315fab99c3e92cb04c7220de1fa8"
+
+bytes@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.4.0.tgz#7d97196f9d5baf7f6935e25985549edd2a6c2339"
 
 bytes@3.0.0:
   version "3.0.0"
@@ -2150,7 +2154,7 @@ content-type-parser@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/content-type-parser/-/content-type-parser-1.0.1.tgz#c3e56988c53c65127fb46d4032a3a900246fdc94"
 
-content-type@~1.0.4:
+content-type@~1.0.2, content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
 
@@ -2507,6 +2511,12 @@ debug@2.3.3:
   dependencies:
     ms "0.7.2"
 
+debug@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
+  dependencies:
+    ms "0.7.2"
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.3, debug@^2.6.6, debug@^2.6.8, debug@~2.6.7:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -2607,7 +2617,7 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
-depd@1.1.1, depd@~1.1.1:
+depd@1.1.1, depd@~1.1.0, depd@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359"
 
@@ -4338,7 +4348,7 @@ http-deceiver@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/http-deceiver/-/http-deceiver-1.2.7.tgz#fa7168944ab9a519d337cb0bec7284dc3e723d87"
 
-http-errors@1.6.2, http-errors@~1.6.2:
+http-errors@1.6.2, http-errors@~1.6.1, http-errors@~1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.2.tgz#0a002cc85707192a7e7946ceedc11155f60ec736"
   dependencies:
@@ -4406,6 +4416,10 @@ icepick@^1.1.0:
 iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
+
+iconv-lite@0.4.15:
+  version "0.4.15"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
 
 iconv-lite@0.4.19, iconv-lite@~0.4.13:
   version "0.4.19"
@@ -4781,7 +4795,7 @@ is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
 
-is-regex@^1.0.4:
+is-regex@^1.0.3, is-regex@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
   dependencies:
@@ -7592,6 +7606,10 @@ qjobs@^1.1.4:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/qjobs/-/qjobs-1.1.5.tgz#659de9f2cf8dcc27a1481276f205377272382e73"
 
+qs@6.4.0, qs@~6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+
 qs@6.5.1, qs@^6.4.0, qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
@@ -7599,10 +7617,6 @@ qs@6.5.1, qs@^6.4.0, qs@~6.5.1:
 qs@~6.3.0:
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.2.tgz#e75bd5f6e268122a2a0e0bda630b2550c166502c"
-
-qs@~6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
 query-string@^4.1.0, query-string@^4.2.2:
   version "4.3.4"
@@ -7665,6 +7679,14 @@ raw-body@~1.1.0:
   dependencies:
     bytes "1"
     string_decoder "0.10"
+
+raw-body@~2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.2.0.tgz#994976cf6a5096a41162840492f0bdc5d6e7fb96"
+  dependencies:
+    bytes "2.4.0"
+    iconv-lite "0.4.15"
+    unpipe "1.0.0"
 
 rc@^1.1.7:
   version "1.2.2"
@@ -9431,7 +9453,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-is@~1.6.15:
+type-is@~1.6.14, type-is@~1.6.15:
   version "1.6.15"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.15.tgz#cab10fb4909e441c82842eafe1ad646c81804410"
   dependencies:
@@ -9892,6 +9914,12 @@ webpack-dev-server@^2.9.1:
     supports-color "^4.2.1"
     webpack-dev-middleware "^1.11.0"
     yargs "^6.6.0"
+
+webpack-merge@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.1.0.tgz#6ad72223b3e0b837e531e4597c199f909361511e"
+  dependencies:
+    lodash "^4.17.4"
 
 webpack-postcss-tools@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
While working on #6242 I started to get a little annoyed by our one massive webpack config file. Proposing we do [what they recommend in the guide](https://webpack.js.org/guides/production/) and split up our config so that it's a little clearer to understand what config modifications apply in what environments.

I think this might also help us feel more comfortable tweaking the config for dev to help speed things up because it'll help us know we're not accidentally busting things in the prod build, etc.

Wanted to get this up even though it's not finished so that I could get feedback from @attekei and others on the idea so that I don't bother finishing migrating this if we don't like the concept.

Questions:
- Do we like this?
- If we like it, how do we want to handle 'dev'? I'm pretty sure most of us consider the hot env "dev" these days so is it worth having a `webpack.hot.js` or just continue calling it 'dev'

ToDos
- [ ] get feedback on the approach
- [ ] finish splitting up the config
