### PR TITLE
fix component guide info file regex

### DIFF
--- a/frontend/src/metabase/internal/lib/components-webpack.js
+++ b/frontend/src/metabase/internal/lib/components-webpack.js
@@ -2,7 +2,7 @@
 const req = require.context(
     "metabase/components",
     true,
-    /^(.*\.info\.(js$))[^.]*$/igm
+    /^(.*\.info\.(js$))[^.]*$/im
 );
 
 export default req.keys().map(key => req(key));


### PR DESCRIPTION
Our use of `g` in our require.context call that loads up our component examples was causing nothing to render and logging this
```sh
WARNING in ./frontend/src/metabase/internal/lib/components-webpack.js
7:10-85 Critical dependency: Contexts can't use RegExps with the 'g' or 'y' flags.
 @ ./frontend/src/metabase/internal/lib/components-webpack.js
 @ ./frontend/src/metabase/internal/components/ComponentsApp.jsx
 @ ./frontend/src/metabase/internal/routes.js
 @ ./frontend/src/metabase/routes.jsx
 @ ./frontend/src/metabase/app-main.js
 @ multi (webpack)-dev-server/client?http://localhost:8080 webpack/hot/dev-server ./app-main.js
```

Problem noted here https://github.com/webpack/webpack/issues/5750 