### PR TITLE
Don't use Postgres NonValidatingFactory [Proposal]

### DIFF
--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -85,9 +85,8 @@
 
 (def ^:private ^:const ssl-params
   "Params to include in the JDBC connection spec for an SSL connection."
-  {:ssl        true
-   :sslmode    "require"
-   :sslfactory "org.postgresql.ssl.NonValidatingFactory"})  ; HACK Why enable SSL if we disable certificate validation?
+  {:ssl     true
+   :sslmode "require"})
 
 (def ^:private ^:const disable-ssl-params
   "Params to include in the JDBC connection spec to disable SSL."


### PR DESCRIPTION
We've configured the Postgres driver to use [the `NonValidatingFactory`](https://jdbc.postgresql.org/documentation/publicapi/org/postgresql/ssl/NonValidatingFactory.html) for SSL cert validation. So while your connection will still be encrypted, we don't check if the certificate itself is valid, which is obviously less secure than if we did.

The only real benefit I think of using the `NonValidatingFactory` is that it makes connecting with self-signed certificates less of a hassle. But I think this should be opt-in (you can always add `?sslfactory=NonValidatingFactory` as additional JDBC connection params) rather than on for everybody by default. Or you could just [add your self-signed cert to your Java keystore](https://docs.oracle.com/javase/tutorial/security/toolsign/rstep2.html) which is a little more involved but a still a much better solution than just disabling cert validation entirely.

So opening this PR to discuss pros/cons of this security improvement. I don't know how many people this would potentially affect, so if we went forward with it, we could either let people know they need to change some settings if they're using a self-signed cert, or instead maybe just do this for new connections only.

Also FWIW we don't disable cert validation for other drivers so this would bring Postgres' behavior in line with others like MySQL