### PR TITLE
Refactor pulse sending and add tests

### DIFF
--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -212,7 +212,7 @@
           :logoFooter   true}
          (random-quote-context)))
 
-(defn render-message-body
+(defn- render-message-body
   [message-template message-context images]
   (vec (cons {:type "text/html; charset=utf-8" :content (stencil/render-file message-template message-context)}
              (map write-image-content images))))

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -212,6 +212,11 @@
           :logoFooter   true}
          (random-quote-context)))
 
+(defn render-message-body
+  [message-template message-context images]
+  (vec (cons {:type "text/html; charset=utf-8" :content (stencil/render-file message-template message-context)}
+             (map write-image-content images))))
+
 (defn render-pulse-email
   "Take a pulse object and list of results, returns an array of attachment objects for an email"
   [timezone pulse results]
@@ -219,8 +224,5 @@
         body         (binding [render/*include-title* true
                                render/*render-img-fn* (partial render-image images)]
                        (vec (cons :div (for [result results]
-                                         (render/render-pulse-section timezone result)))))
-        message-body (stencil/render-file "metabase/email/pulse"
-                       (pulse-context body pulse))]
-    (vec (cons {:type "text/html; charset=utf-8" :content message-body}
-               (mapv write-image-content (seq @images))))))
+                                         (render/render-pulse-section timezone result)))))]
+    (render-message-body "metabase/email/pulse" (pulse-context body pulse) (seq @images))))

--- a/src/metabase/metabot.clj
+++ b/src/metabase/metabot.clj
@@ -129,7 +129,7 @@
      (do
        (with-metabot-permissions
          (read-check Card card-id))
-       (do-async (let [attachments (pulse/create-and-upload-slack-attachments! [(pulse/execute-card card-id, :context :metabot)])]
+       (do-async (let [attachments (pulse/create-and-upload-slack-attachments! (pulse/create-slack-attachment-data [(pulse/execute-card card-id, :context :metabot)]))]
                    (slack/post-chat-message! *channel-id*
                                              nil
                                              attachments)))

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -63,7 +63,9 @@
     :message-type message-type
     :message      message))
 
-(defn create-slack-attachment-data [card-results]
+(defn create-slack-attachment-data
+  "Returns a seq of slack attachment data structures, used in `create-and-upload-slack-attachments!`"
+  [card-results]
   (let [{channel-id :id} (slack/files-channel)]
     (for [{{card-id :id, card-name :name, :as card} :card, result :result} card-results]
       {:title      card-name

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -44,40 +44,57 @@
                                  (System/getProperty "user.timezone"))]
     (TimeZone/getTimeZone timezone-str)))
 
-(defn- send-email-pulse!
-  "Send a `Pulse` email given a list of card results to render and a list of recipients to send to."
-  [{:keys [id name] :as pulse} results recipients]
+(defn- create-email-notification [{:keys [id name] :as pulse} results recipients]
   (log/debug (format "Sending Pulse (%d: %s) via Channel :email" id name))
   (let [email-subject    (str "Pulse: " name)
         email-recipients (filterv u/is-email? (map :email recipients))
         timezone         (-> results first :card defaulted-timezone)]
-    (email/send-message!
-      :subject      email-subject
-      :recipients   email-recipients
-      :message-type :attachments
-      :message      (messages/render-pulse-email timezone pulse results))))
+    {:subject      email-subject
+     :recipients   email-recipients
+     :message-type :attachments
+     :message      (messages/render-pulse-email timezone pulse results)}))
+
+(defn- send-email-pulse!
+  "Send a `Pulse` email given a list of card results to render and a list of recipients to send to."
+  [{:keys [subject recipients message-type message]}]
+  (email/send-message!
+    :subject      subject
+    :recipients   recipients
+    :message-type message-type
+    :message      message))
+
+(defn create-slack-attachment-data [card-results]
+  (let [{channel-id :id} (slack/files-channel)]
+    (for [{{card-id :id, card-name :name, :as card} :card, result :result} card-results]
+      {:title      card-name
+       :attachment-bytes-thunk (fn [] (render/render-pulse-card-to-png (defaulted-timezone card) card result))
+       :title_link (urls/card-url card-id)
+       :attachment-name "image.png"
+       :channel-id channel-id
+       :fallback   card-name})))
+
+(defn- create-slack-notification [pulse results channel-id]
+  (log/debug (u/format-color 'cyan "Sending Pulse (%d: %s) via Slack" (:id pulse) (:name pulse)))
+  {:channel-id channel-id
+   :message (str "Pulse: " (:name pulse))
+   :attachments (create-slack-attachment-data results)})
 
 (defn create-and-upload-slack-attachments!
   "Create an attachment in Slack for a given Card by rendering its result into an image and uploading it."
-  [card-results]
-  (let [{channel-id :id} (slack/files-channel)]
-    (doall (for [{{card-id :id, card-name :name, :as card} :card, result :result} card-results]
-             (let [image-byte-array (render/render-pulse-card-to-png (defaulted-timezone card) card result)
-                   slack-file-url   (slack/upload-file! image-byte-array "image.png" channel-id)]
-               {:title      card-name
-                :title_link (urls/card-url card-id)
-                :image_url  slack-file-url
-                :fallback   card-name})))))
+  [attachments]
+  (doall
+   (for [{:keys [attachment-bytes-thunk attachment-name channel-id] :as attachment-data} attachments]
+     (let [slack-file-url (slack/upload-file! (attachment-bytes-thunk) attachment-name channel-id)]
+       (-> attachment-data
+           (select-keys [:title :title_link :fallback])
+           (assoc :image_url slack-file-url))))))
 
 (defn- send-slack-pulse!
   "Post a `Pulse` to a slack channel given a list of card results to render and details about the slack destination."
-  [pulse results channel-id]
+  [{:keys [channel-id message attachments]}]
   {:pre [(string? channel-id)]}
-  (log/debug (u/format-color 'cyan "Sending Pulse (%d: %s) via Slack" (:id pulse) (:name pulse)))
-  (let [attachments (create-and-upload-slack-attachments! results)]
-    (slack/post-chat-message! channel-id
-                              (str "Pulse: " (:name pulse))
-                              attachments)))
+  (let [attachments (create-and-upload-slack-attachments! attachments)]
+    (slack/post-chat-message! channel-id message attachments)))
 
 (defn- is-card-empty?
   "Check if the card is empty"
@@ -93,6 +110,26 @@
   [results]
   (every? is-card-empty? results))
 
+(defn- pulse->notifications [{:keys [cards channel-ids], :as pulse}]
+  (let [results     (for [card  cards
+                          :let  [result (execute-card (:id card), :pulse-id (:id pulse))] ; Pulse ID may be `nil` if the Pulse isn't saved yet
+                          :when result] ; some cards may return empty results, e.g. if the card has been archived
+                      result)
+        channel-ids (or channel-ids (mapv :id (:channels pulse)))]
+    (when-not (and (:skip_if_empty pulse) (are-all-cards-empty? results))
+      (for [channel-id channel-ids
+            :let [{:keys [channel_type details recipients]} (some #(when (= channel-id (:id %)) %)
+                                                                  (:channels pulse))]]
+          (case (keyword channel_type)
+            :email (create-email-notification pulse results recipients)
+            :slack (create-slack-notification pulse results (:channel details)))))))
+
+(defn- send-notifications! [notifications]
+  (doseq [notification notifications]
+    (if (contains? notification :channel-id)
+      (send-slack-pulse! notification)
+      (send-email-pulse! notification))))
+
 (defn send-pulse!
   "Execute and Send a `Pulse`, optionally specifying the specific `PulseChannels`.  This includes running each
    `PulseCard`, formatting the results, and sending the results to any specified destination.
@@ -102,15 +139,4 @@
        (send-pulse! pulse :channel-ids [312])    Send only to Channel with :id = 312"
   [{:keys [cards], :as pulse} & {:keys [channel-ids]}]
   {:pre [(map? pulse) (every? map? cards) (every? :id cards)]}
-  (let [results     (for [card  cards
-                          :let  [result (execute-card (:id card), :pulse-id (:id pulse))] ; Pulse ID may be `nil` if the Pulse isn't saved yet
-                          :when result]                                                   ; some cards may return empty results, e.g. if the card has been archived
-                      result)
-        channel-ids (or channel-ids (mapv :id (:channels pulse)))]
-    (when-not (and (:skip_if_empty pulse) (are-all-cards-empty? results))
-      (doseq [channel-id channel-ids]
-        (let [{:keys [channel_type details recipients]} (some #(when (= channel-id (:id %)) %)
-                                                              (:channels pulse))]
-          (condp = (keyword channel_type)
-            :email (send-email-pulse! pulse results recipients)
-            :slack (send-slack-pulse! pulse results (:channel details))))))))
+  (send-notifications! (pulse->notifications (merge pulse (when channel-ids {:channel-ids channel-ids})))))

--- a/test/metabase/pulse_test.clj
+++ b/test/metabase/pulse_test.clj
@@ -1,0 +1,170 @@
+(ns metabase.pulse-test
+  (:require [expectations :refer :all]
+            [metabase.models
+             [card :refer [Card]]
+             [pulse :refer [Pulse retrieve-pulse]]
+             [pulse-card :refer [PulseCard]]
+             [pulse-channel :refer [PulseChannel]]
+             [pulse-channel-recipient :refer [PulseChannelRecipient]]]
+            [metabase.pulse :refer :all]
+            [metabase.test.data :as data]
+            [metabase.test.data
+             [dataset-definitions :as defs]
+             [users :as users]]
+            [toucan.util.test :as tt]))
+
+(defn- email-body? [{message-type :type content :content}]
+  (and (= "text/html; charset=utf-8" message-type)
+       (string? content)
+       (.startsWith content "<html>")))
+
+(defn- attachment? [{message-type :type content-type :content-type content :content}]
+  (and (= :inline message-type)
+       (= "image/png" content-type)
+       (instance? java.io.File content)))
+
+(defn- checkins-query [query-map]
+  {:dataset_query {:database (data/id)
+                   :type     :query
+                   :query (merge {:source_table (data/id :checkins)
+                                  :aggregation [["count"]]}
+                                 query-map)}})
+
+(defn- rasta-id []
+  (users/user->id :rasta))
+
+(defmacro ^:private test-setup
+  "Macro that ensures test-data is present and disables sending of notifications"
+  [& body]
+  `(data/with-db (data/get-or-create-database! defs/test-data)
+     (with-redefs [metabase.pulse/send-notifications! identity]
+       ~@body)))
+
+;; Basic test, 1 card, 1 receipient
+(expect
+  [true
+   {:subject "Pulse: Pulse Name"
+    :recipients [(:email (users/fetch-user :rasta))]
+    :message-type :attachments}
+   2
+   true
+   true]
+  (test-setup
+   (tt/with-temp* [Card                 [{card-id :id}  (checkins-query {:breakout [["datetime-field" (data/id :checkins :date) "hour"]]})]
+                   Pulse                [{pulse-id :id} {:name "Pulse Name"
+                                                         :skip_if_empty false}]
+                   PulseCard             [_             {:pulse_id pulse-id
+                                                         :card_id  card-id
+                                                         :position 0}]
+                   PulseChannel          [{pc-id :id}   {:pulse_id pulse-id}]
+                   PulseChannelRecipient [_             {:user_id (rasta-id)
+                                                         :pulse_channel_id pc-id}]]
+     (let [[result & no-more-results] (send-pulse! (retrieve-pulse pulse-id))]
+       [(empty? no-more-results)
+        (select-keys result [:subject :recipients :message-type])
+        (count (:message result))
+        (email-body? (first (:message result)))
+        (attachment? (second (:message result)))]))))
+
+;; Pulse should be sent to two receipients
+(expect
+  [true
+   {:subject "Pulse: Pulse Name"
+    :recipients (set (map (comp :email users/fetch-user) [:rasta :crowberto]))
+    :message-type :attachments}
+   2
+   true
+   true]
+  (test-setup
+   (tt/with-temp* [Card                 [{card-id :id}  (checkins-query {:breakout [["datetime-field" (data/id :checkins :date) "hour"]]})]
+                   Pulse                [{pulse-id :id} {:name "Pulse Name"
+                                                         :skip_if_empty false}]
+                   PulseCard             [_             {:pulse_id pulse-id
+                                                         :card_id  card-id
+                                                         :position 0}]
+                   PulseChannel          [{pc-id :id}   {:pulse_id pulse-id}]
+                   PulseChannelRecipient [_             {:user_id (rasta-id)
+                                                         :pulse_channel_id pc-id}]
+                   PulseChannelRecipient [_             {:user_id (users/user->id :crowberto)
+                                                         :pulse_channel_id pc-id}]]
+     (let [[result & no-more-results] (send-pulse! (retrieve-pulse pulse-id))]
+       [(empty? no-more-results)
+        (-> result
+            (select-keys [:subject :recipients :message-type])
+            (update :recipients set))
+        (count (:message result))
+        (email-body? (first (:message result)))
+        (attachment? (second (:message result)))]))))
+
+;; 1 pulse that has 2 cards, should contain two attachments
+(expect
+  [true
+   {:subject "Pulse: Pulse Name"
+    :recipients [(:email (users/fetch-user :rasta))]
+    :message-type :attachments}
+   3
+   true
+   true]
+  (test-setup
+   (tt/with-temp* [Card                 [{card-id-1 :id}  (checkins-query {:breakout [["datetime-field" (data/id :checkins :date) "hour"]]})]
+                   Card                 [{card-id-2 :id}  (checkins-query {:breakout [["datetime-field" (data/id :checkins :date) "day-of-week"]]})]
+                   Pulse                [{pulse-id :id} {:name "Pulse Name"
+                                                         :skip_if_empty false}]
+                   PulseCard             [_             {:pulse_id pulse-id
+                                                         :card_id  card-id-1
+                                                         :position 0}]
+                   PulseCard             [_             {:pulse_id pulse-id
+                                                         :card_id  card-id-2
+                                                         :position 1}]
+                   PulseChannel          [{pc-id :id}   {:pulse_id pulse-id}]
+                   PulseChannelRecipient [_             {:user_id (rasta-id)
+                                                         :pulse_channel_id pc-id}]]
+     (let [[result & no-more-results] (send-pulse! (retrieve-pulse pulse-id))]
+       [(empty? no-more-results)
+        (select-keys result [:subject :recipients :message-type])
+        (count (:message result))
+        (email-body? (first (:message result)))
+        (attachment? (second (:message result)))]))))
+
+;; Pulse where the card has no results, but skip_if_empty is false, so should still send
+(expect
+  [true
+   {:subject      "Pulse: Pulse Name"
+    :recipients   [(:email (users/fetch-user :rasta))]
+    :message-type :attachments}
+   2
+   true
+   true]
+  (test-setup
+   (tt/with-temp* [Card                  [{card-id :id}  (checkins-query {:filter   [">",["field-id" (data/id :checkins :date)],"2017-10-24"]
+                                                                          :breakout [["datetime-field" ["field-id" (data/id :checkins :date)] "hour"]]})]
+                   Pulse                 [{pulse-id :id} {:name          "Pulse Name"
+                                                          :skip_if_empty false}]
+                   PulseCard             [pulse-card     {:pulse_id pulse-id
+                                                          :card_id  card-id
+                                                          :position 0}]
+                   PulseChannel          [{pc-id :id}    {:pulse_id pulse-id}]
+                   PulseChannelRecipient [_              {:user_id          (rasta-id)
+                                                          :pulse_channel_id pc-id}]]
+     (let [[result & no-more-results] (send-pulse! (retrieve-pulse pulse-id))]
+       [(empty? no-more-results)
+        (select-keys result [:subject :recipients :message-type])
+        (count (:message result))
+        (email-body? (first (:message result)))
+        (attachment? (second (:message result)))]))))
+
+;; Pulse where the card has no results, skip_if_empty is true, so no pulse should be sent
+(expect
+  nil
+  (test-setup
+   (tt/with-temp* [Card                  [{card-id :id}  (checkins-query {:filter   [">",["field-id" (data/id :checkins :date)],"2017-10-24"]
+                                                                          :breakout [["datetime-field" ["field-id" (data/id :checkins :date)] "hour"]]})]
+                   Pulse                 [{pulse-id :id} {:name          "Pulse Name"
+                                                          :skip_if_empty true}]
+                   PulseCard             [pulse-card     {:pulse_id pulse-id
+                                                          :card_id  card-id
+                                                          :position 0}]
+                   PulseChannel          [{pc-id :id}    {:pulse_id pulse-id}]
+                   PulseChannelRecipient [_              {:user_id          (rasta-id)
+                                                          :pulse_channel_id pc-id}]]
+     (send-pulse! (retrieve-pulse pulse-id)))))


### PR DESCRIPTION
This PR has two goals. The first is to get some pulse tests in place as most of the pulse code has no test coverage. Next this PR is making some of the functions more generic as they will be shared by the upcoming alerts work.

There should be no change in behavior for this PR.