### PR TITLE
Round ticks in stacked normalized charts

### DIFF
--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -200,8 +200,10 @@ export function applyChartYAxis(chart, settings, series, yExtent, axisName) {
 
     if (axis.setting("axis_enabled")) {
         // special case for normalized stacked charts
+        // for normalized stacked charts the y-axis is a percentage number. In Javascript, 0.07 * 100.0 = 7.000000000000001 (try it) so we
+        // round that number to get something nice like "7". Then we append "%" to get a nice tick like "7%"
         if (settings["stackable.stack_type"] === "normalized") {
-            axis.axis().tickFormat(value => (value * 100) + "%");
+            axis.axis().tickFormat(value => Math.round(value * 100) + "%");
         }
         chart.renderHorizontalGridLines(true);
         adjustTicksIfNeeded(axis.axis(), chart.height(), MIN_PIXELS_PER_TICK.y);


### PR DESCRIPTION
In Javascript, 0.07 * 100.0 = 7.000000000000001. Fun!

Make sure we round our y-axis ticks for stacked normalized charts. Fixes #3959

(Btw these sorts of fixes are much easier now that the code is better-organized)

### BEFORE

![before](https://user-images.githubusercontent.com/1455846/32073346-91de2dba-ba4a-11e7-8eb3-ff34deaf8df6.PNG)

### AFTER

![after](https://user-images.githubusercontent.com/1455846/32073349-944d1660-ba4a-11e7-8fc3-14fe3305b241.PNG)
