### PR TITLE
Make fill-timeseries work on not evenly spaced data

### DIFF
--- a/src/metabase/feature_extraction/feature_extractors.clj
+++ b/src/metabase/feature_extraction/feature_extractors.clj
@@ -398,15 +398,7 @@
     (fn [{:keys [series linear-regression]}]
       (let [resolution (infer-resolution query series)
             series     (if resolution
-                         (fill-timeseries (case resolution
-                                            :month   (t/months 1)
-                                            :quarter (t/months 3)
-                                            :year    (t/years 1)
-                                            :week    (t/weeks 1)
-                                            :day     (t/days 1)
-                                            :hour    (t/hours 1)
-                                            :minute  (t/minutes 1))
-                                          series)
+                         (fill-timeseries resolution series)
                          series)]
         (merge {:resolution             resolution
                 :series                 series

--- a/test/metabase/feature_extraction/async_test.clj
+++ b/test/metabase/feature_extraction/async_test.clj
@@ -10,12 +10,12 @@
     (done? (ComputationJob job-id))))
 
 (expect
-  [true false false]
-  (let [job-id (compute (gensym) #(loop [] (Thread/sleep 100) (recur)))]
+  [true :canceled false]
+  (let [job-id (compute (gensym) #(loop [] (Thread/sleep 100) (recur)))
+        r? (running? (ComputationJob job-id))]
     (Thread/sleep 100)
-    (let [r? (running? (ComputationJob job-id))]
-      (cancel (ComputationJob job-id))
-      [r? (done? (ComputationJob job-id)) (running? (ComputationJob job-id))])))
+    (cancel (ComputationJob job-id))
+    [r? (:status (ComputationJob job-id)) (running? (ComputationJob job-id))]))
 
 (expect
   {:status :done

--- a/test/metabase/feature_extraction/feature_extractors_test.clj
+++ b/test/metabase/feature_extraction/feature_extractors_test.clj
@@ -78,7 +78,7 @@
    [(make-timestamp 2016 11) 0]
    [(make-timestamp 2016 12) 0]
    [(make-timestamp 2017 1) 25]]
-  (#'fe/fill-timeseries (t/months 1) [[(make-timestamp 2016 1 12 34) 12]
+  (#'fe/fill-timeseries (t/months 1) [[(make-timestamp 2016 1 12 4) 12]
                                      [(make-timestamp 2016 3 0 2) 4]
                                       [(make-timestamp 2017 1) 25]]))
 

--- a/test/metabase/feature_extraction/feature_extractors_test.clj
+++ b/test/metabase/feature_extraction/feature_extractors_test.clj
@@ -78,8 +78,8 @@
    [(make-timestamp 2016 11) 0]
    [(make-timestamp 2016 12) 0]
    [(make-timestamp 2017 1) 25]]
-  (#'fe/fill-timeseries (t/months 1) [[(make-timestamp 2016 1) 12]
-                                     [(make-timestamp 2016 3) 4]
+  (#'fe/fill-timeseries (t/months 1) [[(make-timestamp 2016 1 12 34) 12]
+                                     [(make-timestamp 2016 3 0 2) 4]
                                       [(make-timestamp 2017 1) 25]]))
 
 (expect

--- a/test/metabase/feature_extraction/feature_extractors_test.clj
+++ b/test/metabase/feature_extraction/feature_extractors_test.clj
@@ -79,7 +79,7 @@
    [(make-timestamp 2016 12) 0]
    [(make-timestamp 2017 1) 25]]
   (#'fe/fill-timeseries (t/months 1) [[(make-timestamp 2016 1 12 4) 12]
-                                     [(make-timestamp 2016 3 0 2) 4]
+                                     [(make-timestamp 2016 3 2 2) 4]
                                       [(make-timestamp 2017 1) 25]]))
 
 (expect

--- a/test/metabase/feature_extraction/feature_extractors_test.clj
+++ b/test/metabase/feature_extraction/feature_extractors_test.clj
@@ -78,9 +78,9 @@
    [(make-timestamp 2016 11) 0]
    [(make-timestamp 2016 12) 0]
    [(make-timestamp 2017 1) 25]]
-  (#'fe/fill-timeseries (t/months 1) [[(make-timestamp 2016 1 12 4) 12]
-                                     [(make-timestamp 2016 3 2 2) 4]
-                                      [(make-timestamp 2017 1) 25]]))
+  (#'fe/fill-timeseries :month [[(make-timestamp 2016 1 12 4) 12]
+                                [(make-timestamp 2016 3 2 2) 4]
+                                [(make-timestamp 2017 1) 25]]))
 
 (expect
   [2

--- a/test/metabase/test/async.clj
+++ b/test/metabase/test/async.clj
@@ -9,10 +9,12 @@
   "Retries fetching job results until `max-retries` times."
   [user job-id]
   (loop [tries 1]
-    (let [{:keys [status result]} ((user->client user) :get 200 (str "async/" job-id))]
+    (let [{:keys [status result] :as response}
+          ((user->client user) :get 200 (str "async/" job-id))]
       (cond
         (= "done" status)     result
-        (> tries max-retries) (throw (ex-info "Timeout. Max retries exceeded."))
+        (> tries max-retries) (throw (ex-info "Timeout. Max retries exceeded."
+                                       response))
         :else                 (do
                                 (log/info (format "Waiting for computation to finish. Retry: %" tries))
                                 (Thread/sleep (* 100 tries))

--- a/test/metabase/test/async.clj
+++ b/test/metabase/test/async.clj
@@ -12,10 +12,10 @@
     (let [{:keys [status result] :as response}
           ((user->client user) :get 200 (str "async/" job-id))]
       (cond
-        (= status "done") result
-        (= status "error") (throw (ex-info "Error encountered." result))
-        (> tries max-retries) (throw (ex-info "Timeout. Max retries exceeded."
-                                       response))
+        (= status "done")     result
+        (= status "error")    (throw (ex-info (str "Error encountered.\n" result)
+                                       result))
+        (> tries max-retries) (throw (ex-info "Timeout. Max retries exceeded." {}))
         :else                 (do
                                 (log/info (format "Waiting for computation to finish. Retry: %" tries))
                                 (Thread/sleep (* 100 tries))

--- a/test/metabase/test/async.clj
+++ b/test/metabase/test/async.clj
@@ -12,7 +12,8 @@
     (let [{:keys [status result] :as response}
           ((user->client user) :get 200 (str "async/" job-id))]
       (cond
-        (#{"done" "error"} status) result
+        (= status "done") result
+        (= status "error") (throw (ex-info "Error encountered." result))
         (> tries max-retries) (throw (ex-info "Timeout. Max retries exceeded."
                                        response))
         :else                 (do

--- a/test/metabase/test/async.clj
+++ b/test/metabase/test/async.clj
@@ -12,7 +12,7 @@
     (let [{:keys [status result] :as response}
           ((user->client user) :get 200 (str "async/" job-id))]
       (cond
-        (= "done" status)     result
+        (#{"done" "error"} status) result
         (> tries max-retries) (throw (ex-info "Timeout. Max retries exceeded."
                                        response))
         :else                 (do


### PR DESCRIPTION
Fixes #6270

Change fill-timeseries algorithm to be more robust and not assume evenly spaced (eg. rounded to 00:00:00 1st of the month) data.

Also fixes an annoying async intermittent test failure.

