### PR TITLE
Don't set max heap size unless testing; only reload src/ for dev server

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -116,7 +116,8 @@
   :uberjar-name "metabase.jar"
   :ring {:handler metabase.core/app
          :init metabase.core/init!
-         :destroy metabase.core/destroy}
+         :destroy metabase.core/destroy
+         :reload-paths ["src"]}
   :eastwood {:exclude-namespaces [:test-paths
                                   metabase.driver.generic-sql]        ; ISQLDriver causes Eastwood to fail. Skip this ns until issue is fixed: https://github.com/jonase/eastwood/issues/191
              :add-linters [:unused-private-vars
@@ -142,16 +143,16 @@
                               :exclusions [org.clojure/clojure
                                            org.clojure/tools.namespace]]]
                    :env {:mb-run-mode "dev"}
-                   :jvm-opts ["-Dlogfile.path=target/log"
-                              "-Xms1024m"                             ; give JVM a decent heap size to start with
-                              "-Xmx2048m"]                            ; hard limit of 2GB so we stop hitting the 4GB container limit on CircleCI
+                   :jvm-opts ["-Dlogfile.path=target/log"]
                    :aot [metabase.logger]}                            ; Log appender class needs to be compiled for log4j to use it
              :reflection-warnings {:global-vars {*warn-on-reflection* true}} ; run `lein check-reflection-warnings` to check for reflection warnings
              :expectations {:injections [(require 'metabase.test-setup)]
                             :resource-paths ["test_resources"]
                             :env {:mb-test-setting-1 "ABCDEFG"
                                   :mb-run-mode "test"}
-                            :jvm-opts ["-Duser.timezone=UTC"
+                            :jvm-opts ["-Xms1024m"                    ; give JVM a decent heap size to start with
+                                       "-Xmx2048m"                    ; hard limit of 2GB so we stop hitting the 4GB container limit on CircleCI
+                                       "-Duser.timezone=UTC"
                                        "-Dmb.db.in.memory=true"
                                        "-Dmb.jetty.join=false"
                                        "-Dmb.jetty.port=3010"


### PR DESCRIPTION
This was making me so angrey not even a toucan could cheer me up.

Starting the dev server with `lein ring server` was taking 6-7+ minutes on my work box, which is overclocked to like 5 GHz and not slow. I shudder to even think about how long it would take on a laptop. **However, I have been able to reduce the start-up time to ~1 minute now!** 😱 

Figuring out what to do took a while and I tried many, many things. How I figured this out makes for an interesting (ish) story so here was my riveting journey (slash a reminder of what to do for next time we need to profile startup):

*  I assumed that we were running into slow loading in a namespace. So with a little bit of scriptery with `find -exec` I appended a `(log/info "Loaded <name of file>")` statement to the end of every Metabase Clojure file. After restarting I realized all the namespaces were loaded reasonably quickly so it turned out that initial theory was incorrect
*  Next I set the root logging level to `TRACE` to look for slowness in our dependencies. There was still an empty period of *5 minutes* or so with no log messages
*  Then I did the equivalent of [Objective-C method swizzling](http://nshipster.com/method-swizzling/) or [Emacs Lisp after-advice](https://www.gnu.org/software/emacs/manual/html_node/elisp/Advising-Functions.html) and swapped out `clojure.core/require` with a function that would log every single call made to it. The code for that looks like:

   ```clojure
   ;; using defonce since it's the easiest way here to make sure a block of code runs 
   ;; just once
   (defonce ^:private replace-require
     (let [original-fn @(resolve 'clojure.core 'require)]
       (intern 'clojure.core 'require
               (fn [& args]
                 (require 'clojure.core.logging)
                 (apply original-fn args)
                 (clojure.core.logging/info (cons 'require args))))
       nil))
   ```
   (put that in a namespace that gets loaded early like `metabase.util`.) Still no closer to finding the truth
*  Start looking at the GC for issues. Add Java options `-XX:+PrintGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps`. Finally I had some answers: the garbage collector was spending *5 minutes* doing a series of incremental minor collections to clean up the young generation and a few to clean up eden as well. This was getting filled and emptied repeatedly suggesting a *massive* number of temporary objects was being allocated
*  At that point I thought I might be able to tune the GC a little bit and reduce the number of collections happening. We were setting the max heap size to 2 GB so we didn't hit limits on CircleCI. I tweaked this so we only set it when running tests, but not for normal dev situations. My JVM picked a heap size of 16 GB which reduced the number of GC pauses but each pass ended up taking longer (the young generation was now much larger). So overall this had little effect.
*  I tried to get really crazy with tuning and see if it would even be possible to make things work nicely. At one point I had a heap size of 50 GB and a young generation size of 32 GB. Still no dice! Whoever was filling the memory managed to even fill that up.
*  Further tuning such as tweaking the GC used and number of threads for GC had little effect
*  At this point I gave up on trying to get ahead of the GC by allocating more memory so I decided to profile allocations during launch with [YourKit](https://www.yourkit.com/). For future reference add the JVM option below to make sure it automatically connects as soon as the JVM starts
   ```bash
   -agentpath:/Users/cam/yourkit/YourKit-Java-Profiler-2017.02.app/Contents/Resources/bin/mac/libyjpagent.jnilib
    ```
* After profiling I discovered that the *billions* of objects being allocated were basically all Clojure lazy sequences related to calls to `recur` in a `loop`. I traced that back to this function: https://github.com/ring-clojure/ring/blob/master/ring-devel/src/ring/middleware/reload.clj#L7
*  It took some time to figure out how that function gets called. We're using the [`lein-ring`](https://github.com/weavejester/lein-ring) middleware, which in turn depends on [`ring-server`](https://github.com/weavejester/ring-server), which in turn adds the `wrap-reload` middleware from [`ring`](https://github.com/ring-clojure/ring). Basically the middleware was running an infinite loop that would continuously try to reload any namespace that failed to load with an Exception, which seemed to be the source of the billions of objects.
*  After I figured out how that I worked I experimented with changing the `:reload-compile-errors?` option that gets passed to `wrap-reload` to prevent the insane loopery. Since there was no easy way to pass that I had to swap out the function similarly to what I did above with `require`. This had some effect but not quite as much as I had hoped
*  With a bit more debugging I realized it was also attempting to track all the files in `resources/` and `test/` for live reloading. That thankfully was easily configurable so I changed it to just track `src` and that had a **massive** effect on startup time. Wow! 😱 

So here we are. A couple minor changes to project.clj for a 5+ minute faster launch when doing development. Yay