### PR TITLE
CI build stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ bin/release/aws-eb/metabase-aws-eb.zip
 *.po~
 /locales/metabase-*.pot
 /stats.json
+coverage-summary.json

--- a/bin/ci
+++ b/bin/ci
@@ -44,6 +44,11 @@ node-4() {
     run_step lein bikeshed
     run_step lein docstring-checker
     run_step ./bin/reflection-linter
+
+    # build the frontend, jar, and record the sizes
+    run_step ./bin/build version frontend sample-dataset uberjar
+    report-frontend-size
+    report-uberjar-size
 }
 node-5() {
     run_step lein eastwood
@@ -54,9 +59,7 @@ node-5() {
     run_step yarn run test-karma
 }
 node-6() {
-    run_step ./bin/build version frontend-fast sample-dataset uberjar
-    report-frontend-size
-    report-uberjar-size
+    run_step ./bin/build version sample-dataset uberjar
     run_step yarn run test-integrated
 }
 

--- a/bin/ci
+++ b/bin/ci
@@ -50,13 +50,34 @@ node-5() {
     run_step yarn run lint
     run_step yarn run flow
     run_step yarn run test-unit
+    report-frontend-coverage
     run_step yarn run test-karma
 }
 node-6() {
-    run_step ./bin/build version sample-dataset uberjar
+    run_step ./bin/build version frontend-fast sample-dataset uberjar
+    report-frontend-size
+    report-uberjar-size
     run_step yarn run test-integrated
 }
 
+report() {
+  timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  name="$1"
+  value="$2"
+  if ! [ -z ${STATS_DB+x} ]; then
+    psql "$STATS_DB" -c "INSERT INTO build_stats (timestamp, name, value, build_number, node_index, branch, hash) VALUES ('$timestamp', '$name', $value, $CIRCLE_BUILD_NUM, $CIRCLE_NODE_INDEX, '$CIRCLE_BRANCH', '$CIRCLE_SHA1');" > /dev/null
+  fi
+}
+
+report-frontend-coverage() {
+  report "frontend-coverage" $(node -e "console.log(require('./coverage-summary.json').total.lines.pct)")
+}
+report-frontend-size() {
+  report "frontend-size" "$(wc -c < resources/frontend_client/app/dist/app-main.bundle.js)"
+}
+report-uberjar-size() {
+  report "uberjar-size" "$(wc -c < target/uberjar/metabase.jar)"
+}
 
 install-crate() {
     sudo add-apt-repository ppa:crate/stable -y
@@ -123,6 +144,8 @@ run_step() {
     wait $! || status=$?
     elapsed=$(expr $(date +%s) - $start || true)
     summary="${summary}status=$status time=$elapsed command=$@\n"
+    report "run-status \"$*\"" "$status"
+    report "run-time \"$*\"" "$elapsed"
     return $status
 }
 
@@ -139,6 +162,10 @@ summary() {
 trap summary EXIT
 
 fail_fast() {
+  if [ -z ${CIRCLE_NODE_TOTAL+x} ]; then
+    return 0
+  fi
+
   echo -e "========================================"
   echo -e "Failing fast! Stopping other nodes..."
   # Touch a file to differentiate between a local failure and a
@@ -160,6 +187,10 @@ exit_early() {
 }
 
 trap exit_early SIGUSR1
+
+if [ -z ${CIRCLE_BUILD_NUM+x} ]; then
+    export CIRCLE_BUILD_NUM="-1"
+fi
 
 if [ -z ${CIRCLE_SHA1+x} ]; then
     export CIRCLE_SHA1="$(git rev-parse HEAD)"
@@ -184,7 +215,8 @@ if [ -z ${CIRCLE_NODE_INDEX+x} ]; then
     # If CIRCLE_NODE_INDEX isn't set, read node numbers from the args
     # Useful for testing locally.
     for i in "$@"; do
-        node-$i
+      export CIRCLE_NODE_INDEX="$i"
+      node-$i
     done
 else
     # Normal mode on CircleCI

--- a/bin/ci
+++ b/bin/ci
@@ -76,7 +76,12 @@ report() {
 }
 
 report-frontend-coverage() {
-  report "frontend-coverage" $(node -e "console.log(require('./coverage-summary.json').total.lines.pct)")
+  report "frontend-coverage-lines" $(node -e "console.log(require('./coverage-summary.json').total.lines.pct)")
+  report "frontend-coverage-functions" $(node -e "console.log(require('./coverage-summary.json').total.functions.pct)")
+  report "frontend-coverage-branches" $(node -e "console.log(require('./coverage-summary.json').total.branches.pct)")
+  report "frontend-coverage-statements" $(node -e "console.log(require('./coverage-summary.json').total.statements.pct)")
+
+  report "frontend-loc" $(node -e "console.log(require('./coverage-summary.json').total.lines.total)")
 }
 report-frontend-size() {
   report "frontend-size" "$(wc -c < resources/frontend_client/app/dist/app-main.bundle.js)"

--- a/bin/ci
+++ b/bin/ci
@@ -11,6 +11,8 @@ node-0() {
     MB_MYSQL_TEST_USER=ubuntu run_step lein-test
 }
 node-1() {
+    run_step lein docstring-checker
+
     is_enabled "drivers" && export ENGINES="h2,sqlserver,oracle" || export ENGINES="h2"
     if is_engine_enabled "oracle"; then
         run_step install-oracle
@@ -19,6 +21,8 @@ node-1() {
         run_step lein-test
 }
 node-2() {
+    run_step lein bikeshed
+
     is_enabled "drivers" && export ENGINES="h2,postgres,sqlite,presto" || export ENGINES="h2"
     if is_engine_enabled "crate"; then
         run_step install-crate
@@ -31,6 +35,9 @@ node-2() {
         run_step lein-test
 }
 node-3() {
+    run_step yarn run lint
+    run_step yarn run flow
+
     is_enabled "drivers" && export ENGINES="h2,redshift,druid,vertica" || export ENGINES="h2"
     if is_engine_enabled "vertica"; then
         run_step install-vertica
@@ -41,22 +48,18 @@ node-3() {
     fi
 }
 node-4() {
-    run_step lein bikeshed
-    run_step lein docstring-checker
     run_step ./bin/reflection-linter
 
-    # build the frontend, jar, and record the sizes
     run_step ./bin/build version frontend sample-dataset uberjar
     report-frontend-size
     report-uberjar-size
 }
 node-5() {
     run_step lein eastwood
-    run_step yarn run lint
-    run_step yarn run flow
+
+    run_step yarn run test-karma
     run_step yarn run test-unit
     report-frontend-coverage
-    run_step yarn run test-karma
 }
 node-6() {
     run_step ./bin/build version sample-dataset uberjar

--- a/jest.unit.conf.json
+++ b/jest.unit.conf.json
@@ -20,5 +20,8 @@
     "ace": {},
     "ga": {},
     "document": {}
-  }
+  },
+  "collectCoverage": true,
+  "coverageDirectory": "./",
+  "coverageReporters": ["text", "json-summary"]
 }

--- a/jest.unit.conf.json
+++ b/jest.unit.conf.json
@@ -23,5 +23,6 @@
   },
   "collectCoverage": true,
   "coverageDirectory": "./",
-  "coverageReporters": ["text", "json-summary"]
+  "coverageReporters": ["text", "json-summary"],
+  "collectCoverageFrom": ["frontend/src/**/*.js", "frontend/src/**/*.jsx"]
 }


### PR DESCRIPTION
Collects stats from CI builds:

* each step's duration
* each step's exit status code
* frontend code coverage percentage
* frontend size
* jar size

I had to re-enable frontend building in node 6 to get accurate sizes. It was also kind of nice being able to pull a fully built jar from the build artifacts. However, that's probably going to slow down builds, so we might need to disable it or use a different approach.