### PR TITLE
don't collect test coverage in watch mode

### DIFF
--- a/jest.unit.conf.json
+++ b/jest.unit.conf.json
@@ -21,7 +21,6 @@
     "ga": {},
     "document": {}
   },
-  "collectCoverage": true,
   "coverageDirectory": "./",
   "coverageReporters": ["text", "json-summary"],
   "collectCoverageFrom": ["frontend/src/**/*.js", "frontend/src/**/*.jsx"]

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "test": "yarn run test-integrated && yarn run test-unit && yarn run test-karma",
     "test-integrated": "babel-node ./frontend/test/__runner__/run_integrated_tests.js",
     "test-integrated-watch": "babel-node ./frontend/test/__runner__/run_integrated_tests.js --watch",
-    "test-unit": "jest --maxWorkers=10 --config jest.unit.conf.json",
+    "test-unit": "jest --maxWorkers=10 --config jest.unit.conf.json --coverage",
     "test-unit-watch": "jest --maxWorkers=10 --config jest.unit.conf.json --watch",
     "test-karma": "karma start frontend/test/karma.conf.js --single-run",
     "test-karma-watch": "karma start frontend/test/karma.conf.js --auto-watch --reporters nyan",


### PR DESCRIPTION
The FE code coverage reports we added in #6313 are great, but because we added `collectCoverage: true`  to the unit test config file they were also being generated on every run while in watch mode, which makes TDD basically impossible.

Instead of globally configuring that and having it happen on any unit test jest run, I figured we should explicitly add the flag on the command that gets run in CI, so `--coverage` gets added in that case and in other cases things work as before.