### PR TITLE
Add empty commit hint to Heroku upgrade instructions

### DIFF
--- a/docs/operations-guide/running-metabase-on-heroku.md
+++ b/docs/operations-guide/running-metabase-on-heroku.md
@@ -68,3 +68,10 @@ git push -f heroku master
 ```
 
 * Wait for the deploy to finish
+
+* If there have been no new changes to the metabase-deploy repository, you will need to add an empty commit. This triggers Heroku to re-deploy the code, fetching the newest version of Metabase in the process.
+
+```bash
+git commit --allow-empty -m "empty commit"
+git push -f heroku master
+```


### PR DESCRIPTION
Since the metabase-deploy repo seems to no longer get updated, the instructions listed here won't work anymore. Unfortunately Heroku does not offer re-deployments. Adding an empty commit and pushing fixes the problem.



###### TODO 
-  [ ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
