### PR TITLE
Make sure to require clj namespaces before we import their classes

### DIFF
--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -15,6 +15,7 @@
             [metabase.models
              [field :as field]
              [table :as table]]
+            metabase.query-processor.interface
             [metabase.util
              [honeysql-extensions :as hx]
              [ssh :as ssh]])

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -19,7 +19,8 @@
   (:import clojure.lang.Keyword
            [java.sql PreparedStatement ResultSet ResultSetMetaData SQLException]
            [java.util Calendar TimeZone]
-           [metabase.query_processor.interface AgFieldRef BinnedField DateTimeField DateTimeValue Expression ExpressionRef Field FieldLiteral RelativeDateTimeValue Value]))
+           [metabase.query_processor.interface AgFieldRef BinnedField DateTimeField DateTimeValue Expression
+            ExpressionRef Field FieldLiteral RelativeDateTimeValue Value]))
 
 (def ^:dynamic *query*
   "The outer query currently being processed."

--- a/src/metabase/models/params.clj
+++ b/src/metabase/models/params.clj
@@ -1,6 +1,7 @@
 (ns metabase.models.params
   "Utility functions for dealing with parameters for Dashboards and Cards."
   (:require [metabase.query-processor.middleware.expand :as ql]
+            metabase.query-processor.interface
             [metabase.util :as u]
             [toucan.db :as db])
   (:import metabase.query_processor.interface.FieldPlaceholder))

--- a/test_resources/log4j.properties
+++ b/test_resources/log4j.properties
@@ -1,4 +1,4 @@
-log4j.rootLogger=WARN, console
+log4j.rootLogger=ERROR, console
 
 # log to the console
 log4j.appender.console=org.apache.log4j.ConsoleAppender
@@ -15,12 +15,7 @@ log4j.appender.file.layout=org.apache.log4j.PatternLayout
 log4j.appender.file.layout.ConversionPattern=%d [%t] %-5p%c - %m%n
 
 # customizations to logging by package
-log4j.logger.com.mchange=ERROR
-log4j.logger.org.eclipse.jetty.server.HttpChannel=ERROR
 log4j.logger.metabase=ERROR
 log4j.logger.metabase.test-setup=INFO
-log4j.logger.metabase.sync=DEBUG
-log4j.logger.metabase.task.sync-databases=INFO
 log4j.logger.metabase.test.data.datasets=INFO
-log4j.logger.metabase.test.data=DEBUG
-log4j.logger.metabase.util.encryption=INFO
+log4j.logger.metabase.test.data=INFO


### PR DESCRIPTION
Very important! We need to make sure we require any Clojure namespace that defines classes before we try to import those classes. If the namespace hasn't been loaded, the class doesn't exist yet. So if we don't remember to require we are depending on having some other, previously loaded, namespace do it for us. 

Should fix #6277