### PR TITLE
Fix public dash rendering

### DIFF
--- a/frontend/src/metabase/public/components/EmbedFrame.jsx
+++ b/frontend/src/metabase/public/components/EmbedFrame.jsx
@@ -58,9 +58,13 @@ export default class EmbedFrame extends Component {
                     this.setState({ innerScroll: false })
                 }
             }
+
+            // Make iframe-resizer avaliable to the embed
+            // We only care about contentWindow so require that minified file
+
             // $FlowFixMe: flow doesn't know about require.ensure
             require.ensure([], (require) => {
-                require('iframe-resizer')
+                require('iframe-resizer/js/iframeResizer.contentWindow.min.js')
             });
         }
     }

--- a/frontend/src/metabase/public/components/EmbedFrame.jsx
+++ b/frontend/src/metabase/public/components/EmbedFrame.jsx
@@ -74,7 +74,7 @@ export default class EmbedFrame extends Component {
 
             // Make iframe-resizer avaliable to the embed
             // We only care about contentWindow so require that minified file
-            // $FlowFixMe: flow doesn't know about require.ensure
+
             require.ensure([], (require) => {
                 require('iframe-resizer/js/iframeResizer.contentWindow.min.js')
             });

--- a/frontend/src/metabase/public/components/EmbedFrame.jsx
+++ b/frontend/src/metabase/public/components/EmbedFrame.jsx
@@ -59,9 +59,21 @@ export default class EmbedFrame extends Component {
                 }
             }
 
+
+            // FIXME: Crimes
+            // This is needed so the FE test framework which runs in node
+            // without the avaliability of require.ensure skips over this part
+            // which is for external purposes only.
+            //
+            // Ideally that should happen in the test config, but it doesn't
+            // seem to want to play nice when messing with require
+            if(typeof require.ensure !== "function") {
+                // $FlowFixMe: flow doesn't seem to like returning false here
+                return false
+            }
+
             // Make iframe-resizer avaliable to the embed
             // We only care about contentWindow so require that minified file
-
             // $FlowFixMe: flow doesn't know about require.ensure
             require.ensure([], (require) => {
                 require('iframe-resizer/js/iframeResizer.contentWindow.min.js')

--- a/frontend/src/metabase/public/components/EmbedFrame.jsx
+++ b/frontend/src/metabase/public/components/EmbedFrame.jsx
@@ -46,6 +46,8 @@ export default class EmbedFrame extends Component {
     }
 
     componentWillMount() {
+        // Make iFrameResizer avaliable so that embed users can
+        // have their embeds autosize to their content
         if (window.iFrameResizer) {
             console.error("iFrameResizer resizer already defined.")
         } else {
@@ -57,8 +59,8 @@ export default class EmbedFrame extends Component {
                 }
             }
             // $FlowFixMe: flow doesn't know about require.ensure
-            require.ensure && require.ensure([], () => {
-                require("iframe-resizer/js/iframeResizer.contentWindow.js")
+            require.ensure([], (require) => {
+                require('iframe-resizer')
             });
         }
     }

--- a/frontend/test/__support__/integrated_tests.js
+++ b/frontend/test/__support__/integrated_tests.js
@@ -10,7 +10,7 @@ import "./mocks";
 
 import { format as urlFormat } from "url";
 import api from "metabase/lib/api";
-import { CardApi, SessionApi } from "metabase/services";
+import { CardApi, DashboardApi, SessionApi } from "metabase/services";
 import { METABASE_SESSION_COOKIE } from "metabase/lib/cookies";
 import normalReducers from 'metabase/reducers-main';
 import publicReducers from 'metabase/reducers-public';
@@ -337,6 +337,11 @@ export const createSavedQuestion = async (unsavedQuestion) => {
     const savedQuestion = unsavedQuestion.setCard(savedCard);
     savedQuestion._card = { ...savedQuestion._card, original_card_id: savedQuestion.id() }
     return savedQuestion
+}
+
+export const createDashboard = async (details) => {
+    let savedDashboard = await DashboardApi.create(details)
+    return savedDashboard
 }
 
 /**

--- a/frontend/test/__support__/mocks.js
+++ b/frontend/test/__support__/mocks.js
@@ -53,9 +53,6 @@ const testRemoveEventListener = jest.fn((event, listener) => {
     eventListeners[event] = (eventListeners[event] || []).filter(l => l !== listener)
 })
 
-global.require = () => {}
-global.require.ensure = (deps, cb) => cb(global.require);
-
 global.document.addEventListener = testAddEventListener
 global.window.addEventListener = testAddEventListener
 global.document.removeEventListener = testRemoveEventListener

--- a/frontend/test/__support__/mocks.js
+++ b/frontend/test/__support__/mocks.js
@@ -53,6 +53,9 @@ const testRemoveEventListener = jest.fn((event, listener) => {
     eventListeners[event] = (eventListeners[event] || []).filter(l => l !== listener)
 })
 
+global.require = () => {}
+global.require.ensure = (deps, cb) => cb(global.require);
+
 global.document.addEventListener = testAddEventListener
 global.window.addEventListener = testAddEventListener
 global.document.removeEventListener = testRemoveEventListener

--- a/frontend/test/public/public.integ.spec.js
+++ b/frontend/test/public/public.integ.spec.js
@@ -1,0 +1,64 @@
+import { mount } from 'enzyme'
+
+import {
+    createDashboard,
+    createTestStore,
+    useSharedAdminLogin
+} from "__support__/integrated_tests";
+
+import { FETCH_DASHBOARD } from "metabase/dashboard/dashboard";
+
+import * as Urls from "metabase/lib/urls";
+
+import { DashboardApi, SettingsApi } from "metabase/services";
+
+describe('public pages', () => {
+    beforeAll(async () => {
+        // needed to create the public dash
+        useSharedAdminLogin()
+    })
+
+    describe('public dashboards', () => {
+        let dashboard, store, publicDash
+
+        beforeAll(async () => {
+            store = await createTestStore()
+
+            // enable public sharing
+            await SettingsApi.put({ key: 'enable-public-sharing', value: true })
+
+            // create a dashboard
+            dashboard = await createDashboard({
+                name: 'Test public dash',
+                description: 'A dashboard for testing public things'
+            })
+
+            // create the public link for that dashboard
+            publicDash = await DashboardApi.createPublicLink({ id: dashboard.id })
+
+        })
+
+        it('should be possible to view a public dashboard', async () => {
+            store.pushPath(Urls.publicDashboard(publicDash.uuid));
+
+            const app = mount(store.getAppContainer());
+
+            await store.waitForActions([FETCH_DASHBOARD])
+
+            const headerText = app.find('.EmbedFrame-header .h4').text()
+
+            expect(headerText).toEqual('Test public dash')
+        })
+
+        afterAll(async () => {
+            // archive the dash so we don't impact other tests
+            await DashboardApi.update({
+                id: dashboard.id,
+                archived: true
+            })
+            // do some cleanup so that we don't impact other tests
+            await SettingsApi.put({ key: 'enable-public-sharing', value: false })
+        })
+    })
+
+})


### PR DESCRIPTION
Investigation into #6352. 

I decided to start by adding a test to create and visit a public dashboard. Strangely though, this is passing when I'd expect it to fail.

@attekei Could this be due to some difference between the Jest environment and the browser environment?

~~That aside, my gut says that a recent change in our webpack config has caused the public app to no longer be able to locate `iframe-resizer.` I'm wondering if the change in #6159 to create a vendor bundle is causing it to be excluded since it's dynamically required.~~