### PR TITLE
Don't update state in SQL editor variable pane on every text change

### DIFF
--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
@@ -3,6 +3,7 @@
 import React, { Component } from "react";
 
 import Toggle from "metabase/components/Toggle.jsx";
+import Input from "metabase/components/Input.jsx";
 import Select, { Option } from "metabase/components/Select.jsx";
 import ParameterValueWidget from "metabase/parameters/components/ParameterValueWidget.jsx";
 
@@ -100,11 +101,11 @@ export default class TagEditorParam extends Component {
 
                 <div className="pb1">
                     <h5 className="pb1 text-normal">Filter label</h5>
-                    <input
+                    <Input
                         type="text"
                         value={tag.display_name}
                         className="AdminSelect p1 text-bold text-grey-4 bordered border-med rounded full"
-                        onChange={(e) => this.setParameterAttribute("display_name", e.target.value)}
+                        onBlurChange={(e) => this.setParameterAttribute("display_name", e.target.value)}
                     />
                 </div>
 


### PR DESCRIPTION
Ok, so this was one of the easiest fixes ever. Basically we were just using a plain `<input>` to edit the display name of variables in the native query editor and binding the `onChange` property to a function to update the value. That function updated the state of the component which reset the cursor to the end of the input box every time you triggered an `onChange` event. Needless to say, this was hella inconvenient. Fixed by switching to an `<Input>` component and binding `onBlurChange` instead.

Fixes #3231