### PR TITLE
Add support for sending alert emails via a background thread

### DIFF
--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -444,7 +444,8 @@
           (rasta-alert-not-working {"the question was archived by Rasta Toucan" true}))
    nil]
   (et/with-fake-inbox
-    ((user->client :rasta) :put 200 (str "card/" card-id) {:archived true})
+    (et/with-expected-messages 2
+      ((user->client :rasta) :put 200 (str "card/" card-id) {:archived true}))
     [(et/regex-email-bodies #"the question was archived by Rasta Toucan")
      (Pulse pulse-id)]))
 
@@ -468,7 +469,8 @@
 
    nil]
   (et/with-fake-inbox
-    ((user->client :rasta) :put 200 (str "card/" card-id) {:display :line})
+    (et/with-expected-messages 2
+      ((user->client :rasta) :put 200 (str "card/" card-id) {:display :line}))
     [(et/regex-email-bodies #"the question was edited by Rasta Toucan")
      (Pulse pulse-id)]))
 
@@ -488,7 +490,8 @@
   [(rasta-alert-not-working {"the question was edited by Rasta Toucan" true})
    nil]
   (et/with-fake-inbox
-    ((user->client :rasta) :put 200 (str "card/" card-id) {:display :table})
+    (et/with-expected-messages 1
+      ((user->client :rasta) :put 200 (str "card/" card-id) {:display :table}))
     [(et/regex-email-bodies #"the question was edited by Rasta Toucan")
      (Pulse pulse-id)]))
 
@@ -532,7 +535,8 @@
   [(rasta-alert-not-working {"the question was edited by Rasta Toucan" true})
    nil]
   (et/with-fake-inbox
-    ((user->client :rasta) :put 200 (str "card/" card-id) {:visualization_settings {:something "else"}})
+    (et/with-expected-messages 1
+      ((user->client :rasta) :put 200 (str "card/" card-id) {:visualization_settings {:something "else"}}))
     [(et/regex-email-bodies #"the question was edited by Rasta Toucan")
      (Pulse pulse-id)]))
 
@@ -556,9 +560,10 @@
   [(rasta-alert-not-working {"the question was edited by Crowberto Corv" true})
    nil]
   (et/with-fake-inbox
-    ((user->client :crowberto) :put 200 (str "card/" card-id) {:dataset_query (assoc-in (mbql-count-query database-id table-id)
-                                                                                        [:query :breakout] [["datetime-field" (data/id :checkins :date) "hour"]
-                                                                                                            ["datetime-field" (data/id :checkins :date) "second"]])})
+    (et/with-expected-messages 1
+      ((user->client :crowberto) :put 200 (str "card/" card-id) {:dataset_query (assoc-in (mbql-count-query database-id table-id)
+                                                                                          [:query :breakout] [["datetime-field" (data/id :checkins :date) "hour"]
+                                                                                                              ["datetime-field" (data/id :checkins :date) "second"]])}))
     [(et/regex-email-bodies #"the question was edited by Crowberto Corv")
      (Pulse pulse-id)]))
 

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -139,7 +139,8 @@
                            :body {"the question was archived by Crowberto Corv" true}}]}
    nil]
   (et/with-fake-inbox
-    ((user->client :crowberto) :put 200 (str "collection/" collection-id)
-     {:name "My Beautiful Collection", :color "#ABCDEF", :archived true})
+    (et/with-expected-messages 2
+      ((user->client :crowberto) :put 200 (str "collection/" collection-id)
+       {:name "My Beautiful Collection", :color "#ABCDEF", :archived true}))
     [(et/regex-email-bodies #"the question was archived by Crowberto Corv")
      (Pulse pulse-id)]))

--- a/test/metabase/task/send_pulses_test.clj
+++ b/test/metabase/task/send_pulses_test.clj
@@ -33,5 +33,6 @@
                 :body    {"My Question Name.*has results" true}})
   (et/with-fake-inbox
     (data/with-db (data/get-or-create-database! defs/test-data)
-      (#'metabase.task.send-pulses/send-pulses! 0 "fri" :first :first)
+      (et/with-expected-messages 1
+        (#'metabase.task.send-pulses/send-pulses! 0 "fri" :first :first))
       (et/regex-email-bodies #"My Question Name.*has results"))))


### PR DESCRIPTION
Previously notifications of alert lifecycles (i.e. subscribing to an
alert, or being removed from an alert) was happening on the HTTP
request thread. When the SMTP server was slow, this would slow down
the response and thus the UI. This instead returns immediately and
connects to the SMTP server via a background thread separately from
the HTTP request thread.