### PR TITLE
Mac App isn't an installer, it's a disk image [ci skip]

### DIFF
--- a/docs/operations-guide/running-the-metabase-mac-app.md
+++ b/docs/operations-guide/running-the-metabase-mac-app.md
@@ -1,10 +1,12 @@
 # Running the Metabase Mac Application
 
-The Mac Application is the easiest way to setup Metabase locally on Mac OS X for personal use.  Note that currently the Mac Application is not setup for shared use, so some Metabase features which involve the rest of your team won't be possible.
+The Mac Application is the easiest way to setup Metabase locally on macOS for personal use.
+Note that currently the Mac Application is not setup for shared use, so some Metabase features which involve the rest of your team won't be possible.
 
 ### Installing the Mac Application
 
-Start off by downloading the [Metabase Mac Application](http://www.metabase.com/start/mac.html) if you haven't done so already.  Once the download is complete go ahead and double click the file to open the installer.  You should see something like this:
+Start off by downloading the [Metabase Mac Application](http://www.metabase.com/start/mac.html) if you haven't done so already.
+Once the download is complete go ahead and double click the file to open it up. You should see something like this:
 
 ![macinstaller](images/MacInstaller.png)
 
@@ -27,7 +29,7 @@ Now that you’ve installed Metabase, it’s time to [set it up and connect it t
 
 ### The application database
 
-The application database lives on your filesystem, at 
+The application database lives on your filesystem, at
 `~/Library/Application Support/Metabase/metabase.db.h2.db`
 
 If you want to delete it, back it up, or replace it with an old backup, shut down the application and then delete, copy or replace the file.


### PR DESCRIPTION
There was a second place we said the word "installer" in reference to our Mac App. Let's make there be zero places.

Fixes #6302