### PR TITLE
Java 9 test fix

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -11,7 +11,7 @@ node-0() {
     MB_MYSQL_TEST_USER=ubuntu run_step lein-test
 }
 node-1() {
-    run_step lein docstring-checker
+    run_step lein with-profile +ci docstring-checker
 
     is_enabled "drivers" && export ENGINES="h2,sqlserver,oracle" || export ENGINES="h2"
     if is_engine_enabled "oracle"; then
@@ -21,7 +21,7 @@ node-1() {
         run_step lein-test
 }
 node-2() {
-    run_step lein bikeshed
+    run_step lein with-profile +ci bikeshed
 
     is_enabled "drivers" && export ENGINES="h2,postgres,sqlite,presto" || export ENGINES="h2"
     if is_engine_enabled "crate"; then
@@ -55,7 +55,7 @@ node-4() {
     report-uberjar-size
 }
 node-5() {
-    run_step lein eastwood
+    run_step lein with-profile +ci eastwood
 
     run_step yarn run test-karma
     run_step yarn run test-unit
@@ -125,7 +125,7 @@ install-presto() {
 }
 
 lein-test() {
-    lein test
+    lein with-profile +ci test
 }
 
 if [ -z ${CIRCLE_BRANCH_REGEX+x} ]; then

--- a/bin/reflection-linter
+++ b/bin/reflection-linter
@@ -2,7 +2,7 @@
 
 echo -e "\e[1;34mChecking for reflection warnings. This may take a few minutes, so sit tight...\e[0m"
 
-warnings=`lein check-reflection-warnings 2>&1 | grep Reflection | grep metabase | uniq`
+warnings=`lein with-profile +ci check-reflection-warnings 2>&1 | grep Reflection | grep metabase | uniq`
 
 if [ ! -z "$warnings" ]; then
     echo -e "\e[1;31mYour code has cased introduced some reflection warnings.\e[0m 😞"

--- a/frontend/src/metabase/containers/EntitySearch.jsx
+++ b/frontend/src/metabase/containers/EntitySearch.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 import { push, replace } from "react-router-redux";
 import _ from "underscore";
 import cx from "classnames";
+import { t } from 'c-3po'
 
 import SearchHeader from "metabase/components/SearchHeader";
 import DirectionalButton from "metabase/components/DirectionalButton";

--- a/project.clj
+++ b/project.clj
@@ -149,13 +149,13 @@
                    :env {:mb-run-mode "dev"}
                    :jvm-opts ["-Dlogfile.path=target/log"]
                    :aot [metabase.logger]}                            ; Log appender class needs to be compiled for log4j to use it
+             :ci {:jvm-opts ["-Xmx3g"]}
              :reflection-warnings {:global-vars {*warn-on-reflection* true}} ; run `lein check-reflection-warnings` to check for reflection warnings
              :expectations {:injections [(require 'metabase.test-setup)]
                             :resource-paths ["test_resources"]
                             :env {:mb-test-setting-1 "ABCDEFG"
                                   :mb-run-mode "test"}
                             :jvm-opts ["-Xms1024m"                    ; give JVM a decent heap size to start with
-                                       "-Xmx2048m"                    ; hard limit of 2GB so we stop hitting the 4GB container limit on CircleCI
                                        "-Duser.timezone=UTC"
                                        "-Dmb.db.in.memory=true"
                                        "-Dmb.jetty.join=false"

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -768,15 +768,15 @@
 (def metabase-namespace-symbols
   "Delay to a vector of symbols of all Metabase namespaces, excluding test namespaces.
    This is intended for use by various routines that load related namespaces, such as task and events initialization.
-   Using `ns-find/find-namespaces` is fairly slow, and can take as much as half a second to iterate over the thousand or so
-   namespaces that are part of the Metabase project; use this instead for a massive performance increase."
-  ;; Actually we can go ahead and start doing this in the background once the app launches while other stuff is loading, so use a future here
-  ;; This would be faster when running the *JAR* if we just did it at compile-time and made it ^:const, but that would inhibit the "plugin system"
-  ;; from loading "plugin" namespaces at launch if they're on the classpath
-  (future (vec (for [ns-symb (ns-find/find-namespaces (classpath/system-classpath))
-                     :when   (and (.startsWith (name ns-symb) "metabase.")
-                                  (not (.contains (name ns-symb) "test")))]
-                 ns-symb))))
+   Using `ns-find/find-namespaces` is fairly slow, and can take as much as half a second to iterate over the thousand
+   or so namespaces that are part of the Metabase project; use this instead for a massive performance increase."
+  ;; We want to give JARs in the ./plugins directory a chance to load. At one point we have this as a future so it
+  ;; start looking for things in the background while other stuff is happening but that meant plugins couldn't
+  ;; introduce new Metabase namespaces such as drivers.
+  (delay (vec (for [ns-symb (ns-find/find-namespaces (classpath/system-classpath))
+                    :when   (and (.startsWith (name ns-symb) "metabase.")
+                                 (not (.contains (name ns-symb) "test")))]
+                ns-symb))))
 
 (def ^:const ^java.util.regex.Pattern uuid-regex
   "A regular expression for matching canonical string representations of UUIDs."

--- a/test/metabase/cmd/load_from_h2_test.clj
+++ b/test/metabase/cmd/load_from_h2_test.clj
@@ -1,8 +1,7 @@
 (ns metabase.cmd.load-from-h2-test
-  (:require [clojure.java.classpath :as classpath]
-            [clojure.tools.namespace.find :as ns-find]
-            [expectations :refer :all]
+  (:require [expectations :refer :all]
             metabase.cmd.load-from-h2
+            [metabase.util :as u]
             [toucan.models :as models]))
 
 ;; Check to make sure we're migrating all of our entities.
@@ -19,7 +18,7 @@
     "QueryExecution"})
 
 (defn- all-model-names []
-  (set (for [ns       (ns-find/find-namespaces (classpath/classpath))
+  (set (for [ns       @u/metabase-namespace-symbols
              :when    (or (re-find #"^metabase\.models\." (name ns))
                           (= (name ns) "metabase.db.migrations"))
              :when    (not (re-find #"test" (name ns)))


### PR DESCRIPTION
Fix a backend test that was failing on Java 9 due to differences in working ways to introspect namespaces on the classpath. 

Incorporate fix for plugins not being able to define custom MB namespaces from #5282