### PR TITLE
Change Druid queries so that their weeks start on Sunday [ci drivers]

### DIFF
--- a/src/metabase/driver/druid/query_processor.clj
+++ b/src/metabase/driver/druid/query_processor.clj
@@ -370,16 +370,22 @@
     :year            (extract:timeFormat "yyyy")))
 
 (defn- unit->granularity [unit]
-  {:type     "period"
-   :period   (case unit
-               :minute  "PT1M"
-               :hour    "PT1H"
-               :day     "P1D"
-               :week    "P1W"
-               :month   "P1M"
-               :quarter "P3M"
-               :year    "P1Y")
-   :timeZone (get-timezone-id)})
+  (conj {:type     "period"
+         :period   (case unit
+                     :minute  "PT1M"
+                     :hour    "PT1H"
+                     :day     "P1D"
+                     :week    "P1W"
+                     :month   "P1M"
+                     :quarter "P3M"
+                     :year    "P1Y")
+         :timeZone (get-timezone-id)}
+        ;; Druid uses Monday for the start of its weekly calculations. Metabase uses Sundays. When grouping by week,
+        ;; the origin keypair will use the date specified as it's start of the week. The below date is the first
+        ;; Sunday after Epoch. The date itself isn't significant, it just uses it to figure out what day it should
+        ;; start from.
+        (when (= :week unit)
+          {:origin "1970-01-04T00:00:00Z"})))
 
 (def ^:private ^:const units-that-need-post-processing-int-parsing
   "`extract:timeFormat` always returns a string; there are cases where we'd like to return an integer instead, such as `:day-of-month`.

--- a/test/metabase/driver/druid_test.clj
+++ b/test/metabase/driver/druid_test.clj
@@ -137,6 +137,16 @@
 (defmacro ^:private druid-query-returning-rows {:style/indent 0} [& body]
   `(rows (druid-query ~@body)))
 
+;; Count the number of events in the given week. Metabase uses Sunday as the start of the week, Druid by default will
+;; use Monday.All of the below events should happen in one week. Using Druid's default grouping, 3 of the events would
+;; have counted for the previous week
+(expect-with-engine :druid
+  [["2015-10-04T00:00:00.000Z" 9]]
+  (druid-query-returning-rows
+    (ql/filter (ql/between (ql/datetime-field $timestamp :day) "2015-10-04" "2015-10-10"))
+    (ql/aggregation (ql/count $id))
+    (ql/breakout (ql/datetime-field $timestamp :week))))
+
 ;; sum, *
 (expect-with-engine :druid
   [["1" 110688.0]


### PR DESCRIPTION
By default Druid weeks start on Monday, but the rest of Metabase
expects that the weeks start on Sunday. This commit adds an `origin`
clause to `week` granularity queries which will force Sunday as the
start of the week.

Fixes #6047