### PR TITLE
Relax defsetting precondition for descriptions

### DIFF
--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -378,7 +378,7 @@
                      clear the values of the Setting.)"
   {:style/indent 1}
   [setting-symb description & {:as options}]
-  {:pre [(symbol? setting-symb) (string? description)]}
+  {:pre [(symbol? setting-symb)]}
   `(let [setting# (register-setting! (assoc ~options
                                        :name ~(keyword setting-symb)
                                        :description ~description))]

--- a/test/metabase/models/setting_test.clj
+++ b/test/metabase/models/setting_test.clj
@@ -2,6 +2,7 @@
   (:require [expectations :refer :all]
             [metabase.models.setting :as setting :refer [defsetting Setting]]
             [metabase.test.util :refer :all]
+            [puppetlabs.i18n.core :refer [tru]]
             [toucan.db :as db]))
 
 ;; ## TEST SETTINGS DEFINITIONS
@@ -16,11 +17,11 @@
   "Test setting - this only shows up in dev (2)"
   :default "[Default Value]")
 
-(defsetting test-boolean-setting
+(defsetting ^:private test-boolean-setting
   "Test setting - this only shows up in dev (3)"
   :type :boolean)
 
-(defsetting test-json-setting
+(defsetting ^:private test-json-setting
   "Test setting - this only shows up in dev (4)"
   :type :json)
 
@@ -180,6 +181,16 @@
       (for [setting (setting/all)
             :when   (re-find #"^test-setting-\d$" (name (:key setting)))]
         setting)))
+
+(defsetting ^:private test-i18n-setting
+  (tru "Test setting - with i18n"))
+
+;; Validate setting description with i18n string
+(expect
+  ["Test setting - with i18n"]
+  (for [{:keys [key description]} (setting/all)
+        :when (= :test-i18n-setting key)]
+    description))
 
 
 ;;; ------------------------------------------------------------ BOOLEAN SETTINGS ------------------------------------------------------------


### PR DESCRIPTION
Previously the code would only allow a string literal for a
description. This poses problems for i18n strings, i.e. `(tru "my
string")`, which evaluates to a string, but at macro expansion time is
not a string. This removes that precondition. The string is still
validated at runtime via schema.