### PR TITLE
Compare email 'to` as a set, not a vector

### DIFF
--- a/test/metabase/api/alert_test.clj
+++ b/test/metabase/api/alert_test.clj
@@ -193,18 +193,19 @@
                                        "confirmation that your alert" false}))]
 
   (with-alert-setup
-    [(-> ((alert-client :crowberto) :post 200 "alert"
-          {:card              {:id (:id card1)}
-           :alert_condition   "rows"
-           :alert_first_only  false
-           :channels          [{:enabled       true
-                                :channel_type  "email"
-                                :schedule_type "daily"
-                                :schedule_hour 12
-                                :schedule_day  nil
-                                :details       {:emails nil}
-                                :recipients    (mapv fetch-user [:crowberto :rasta])}]})
-         setify-recipient-emails)
+    [(et/with-expected-messages 2
+       (-> ((alert-client :crowberto) :post 200 "alert"
+            {:card              {:id (:id card1)}
+             :alert_condition   "rows"
+             :alert_first_only  false
+             :channels          [{:enabled       true
+                                  :channel_type  "email"
+                                  :schedule_type "daily"
+                                  :schedule_hour 12
+                                  :schedule_day  nil
+                                  :details       {:emails nil}
+                                  :recipients    (mapv fetch-user [:crowberto :rasta])}]})
+           setify-recipient-emails))
      (et/regex-email-bodies #"https://metabase.com/testmb"
                             #"now getting alerts"
                             #"confirmation that your alert"

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -116,10 +116,10 @@
 ;; Archiving a collection should delete any alerts associated with questions in the collection
 (tt/expect-with-temp [Collection            [{collection-id :id}]
                       Card                  [{card-id :id :as card} {:collection_id collection-id}]
-                      Pulse                 [{pulse-id :id} {:alert_condition   "rows"
-                                                             :alert_first_only  false
-                                                             :creator_id        (user->id :rasta)
-                                                             :name              "Original Alert Name"}]
+                      Pulse                 [{pulse-id :id} {:alert_condition  "rows"
+                                                             :alert_first_only false
+                                                             :creator_id       (user->id :rasta)
+                                                             :name             "Original Alert Name"}]
 
                       PulseCard             [_              {:pulse_id pulse-id
                                                              :card_id  card-id
@@ -129,14 +129,11 @@
                                                              :pulse_channel_id pc-id}]
                       PulseChannelRecipient [{pcr-id-2 :id} {:user_id          (user->id :rasta)
                                                              :pulse_channel_id pc-id}]]
-  [{"crowberto@metabase.com" [{:from "notifications@metabase.com",
-                               :to ["crowberto@metabase.com"],
-                               :subject "One of your alerts has stopped working",
-                               :body {"the question was archived by Crowberto Corv" true}}],
-    "rasta@metabase.com" [{:from "notifications@metabase.com",
-                           :to ["rasta@metabase.com"],
-                           :subject "One of your alerts has stopped working",
-                           :body {"the question was archived by Crowberto Corv" true}}]}
+
+  [(merge (et/email-to :crowberto {:subject "One of your alerts has stopped working",
+                                   :body    {"the question was archived by Crowberto Corv" true}})
+          (et/email-to :rasta {:subject "One of your alerts has stopped working",
+                               :body    {"the question was archived by Crowberto Corv" true}}))
    nil]
   (et/with-fake-inbox
     (et/with-expected-messages 2

--- a/test/metabase/pulse_test.clj
+++ b/test/metabase/pulse_test.clj
@@ -102,7 +102,7 @@
                                                             :pulse_channel_id pc-id}]]
   (into {} (map (fn [user-kwd]
                   (et/email-to user-kwd {:subject "Pulse: Pulse Name",
-                                         :to ["rasta@metabase.com" "crowberto@metabase.com"]
+                                         :to #{"rasta@metabase.com" "crowberto@metabase.com"}
                                          :body [{"Pulse Name" true}
                                                 png-attachment]}))
                 [:rasta :crowberto]))


### PR DESCRIPTION
Some databases have the email addresses in a different order causing
CI to fail. This commit converts the `:to` vector to a set so order
doesn't matter.

