### PR TITLE
Have Utils.isEmpty() cast its arg to String()

### DIFF
--- a/frontend/src/metabase/lib/utils.js
+++ b/frontend/src/metabase/lib/utils.js
@@ -37,6 +37,7 @@ var MetabaseUtils = {
     },
 
     isEmpty: function(str) {
+        if (str != null) str = String(str); // make sure 'str' is actually a string
         return (str == null || 0 === str.length || str.match(/^\s+$/) != null);
     },
 


### PR DESCRIPTION
We have a function that's supposed to check whether a *string* is "empty". People were doing things with it like calling `Utils.isEmpty(true)`. That makes tons of sense! (not)

Rather than break such questionable code in other places by making sure the `str` argument actually is a String, I coded defensively, as I'm afraid one must do in these sorts of places, and just had the function cast its arg to a String.

Fixes #6422