### PR TITLE
Add missing comments for when migrations were added

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -3847,6 +3847,7 @@ databaseChangeLog:
   - changeSet:
       id: 67
       author: attekei
+      comment: 'Added 0.27.0'
       changes:
         - createTable:
             tableName: computation_job
@@ -3930,6 +3931,7 @@ databaseChangeLog:
   - changeSet:
     - id: 68
     - author: sbelak
+    - comment: 'Added 0.27.0'
     - changes:
       - addColumn:
             tableName: computation_job


### PR DESCRIPTION
Lately we've been adding comments to migrations to note the version they were added to help debug issues with them, but it looks like the last two migrations are missing that info. Go ahead and add it.

It also looks like we didn't add comments about the purpose of the new columns in these migrations which is always a nice-to-have (we've added them for every migration for the last year or so), and I'm not eager to get out of that habit (I think it's helpful for contributors to help get a sense of how our application DB works) but since those would require new checksums I'll leave that as a project to do at a later date.
