### PR TITLE
Add mapping for Postgres CITEXT type

### DIFF
--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -26,6 +26,7 @@
    :bytea         :type/*    ; byte array
    :cidr          :type/Text ; IPv4/IPv6 network address
    :circle        :type/*
+   :citext        :type/Text ; case-insensitive text
    :date          :type/Date
    :decimal       :type/Decimal
    :float4        :type/Float


### PR DESCRIPTION
Add mapping for `citext` (case-insensitive text) which is a fairly common postgres extension to enable.

Fixes #6172
