### PR TITLE
Rewrite async tests to not use sleep

### DIFF
--- a/test/metabase/api/async_test.clj
+++ b/test/metabase/api/async_test.clj
@@ -14,8 +14,8 @@
 (expect
   true
   (let [client (user->client :rasta)
-        job-id (:job-id (client :get 200 (str "x-ray/field/" (id :venues :price))))
-        _      (result! job-id)]
+        job-id (:job-id (client :get 200 (str "x-ray/field/" (id :venues :price))))]
+    (result! job-id)
     (-> (client :get 200 (str "async/" job-id))
         :result
         (contains? :features))))

--- a/test/metabase/api/x_ray_test.clj
+++ b/test/metabase/api/x_ray_test.clj
@@ -17,8 +17,8 @@
 (defn- async-call
   [method endpoint & args]
   (let [client (user->client :rasta)
-        job-id (:job-id (apply client method 200 endpoint args))
-        _      (result! job-id)]
+        job-id (:job-id (apply client method 200 endpoint args))]
+    (result! job-id)
     (:result (client :get 200 (str "async/" job-id)))))
 
 (expect

--- a/test/metabase/api/x_ray_test.clj
+++ b/test/metabase/api/x_ray_test.clj
@@ -16,9 +16,10 @@
 
 (defn- async-call
   [method endpoint & args]
-  (->> (apply (user->client :rasta) method 200 endpoint args)
-       :job-id
-       (call-with-retries :rasta)))
+  (let [client (user->client :rasta)
+        job-id (:job-id (apply client method 200 endpoint args))
+        _      (result! job-id)]
+    (:result (client :get 200 (str "async/" job-id)))))
 
 (expect
   100.0

--- a/test/metabase/feature_extraction/async_test.clj
+++ b/test/metabase/feature_extraction/async_test.clj
@@ -6,8 +6,8 @@
 
 (expect
   true
-  (let [job-id (compute (gensym) (constantly 42))
-        _      (result! job-id)]
+  (let [job-id (compute (gensym) (constantly 42))]
+    (result! job-id)
     (done? (ComputationJob job-id))))
 
 (expect

--- a/test/metabase/feature_extraction/async_test.clj
+++ b/test/metabase/feature_extraction/async_test.clj
@@ -2,7 +2,7 @@
   (:require [expectations :refer :all]
             [metabase.feature-extraction.async :refer :all]
             [metabase.models.computation-job :refer [ComputationJob]]
-            [metabase.test.async :refer [result!]]))
+            [metabase.test.async :refer :all]))
 
 (expect
   true
@@ -12,7 +12,9 @@
 
 (expect
   [true :canceled false]
-  (let [job-id (compute (gensym) #(do (while (not (Thread/interrupted))) 42))
+  (let [job-id (compute (gensym) #(do
+                                    (while-with-timeout (not (Thread/interrupted)))
+                                    42))
         r?     (running? (ComputationJob job-id))]
     (cancel (ComputationJob job-id))
     [r? (:status (ComputationJob job-id)) (running? (ComputationJob job-id))]))

--- a/test/metabase/feature_extraction/feature_extractors_test.clj
+++ b/test/metabase/feature_extraction/feature_extractors_test.clj
@@ -83,7 +83,7 @@
       t.coerce/to-sql-time))
 
 (def ^:private numbers [0.1 0.4 0.2 nil 0.5 0.3 0.51 0.55 0.22 0.0])
-(def ^:private ints [0 nil Long/MAX_VALUE Long/MIN_VALUE 5 -100])
+(def ^:private integers [0 nil Long/MAX_VALUE Long/MIN_VALUE 5 -100])
 (def ^:private datetimes [(make-sql-timestamp 2015 6 1)
                           nil
                           (make-sql-timestamp 2015 6 1)
@@ -107,7 +107,7 @@
    (var-get #'fe/Text)
    nil]
   [(-> (->features {:base_type :type/Number} numbers) :type)
-   (-> (->features {:base_type :type/Number} ints) :type)
+   (-> (->features {:base_type :type/Number} integers) :type)
    (-> (->features {:base_type :type/DateTime} datetimes) :type)
    (-> (->features {:base_type :type/Text
                     :special_type :type/Category}

--- a/test/metabase/middleware_test.clj
+++ b/test/metabase/middleware_test.clj
@@ -247,8 +247,6 @@
 ;; test that handler is killed when connection closes
 ;; Note: this closing over state is a dirty hack and the whole test should be
 ;; rewritten.
-(def test-slow-handler-state1 (atom :unset))
-(def test-slow-handler-state2 (atom :unset))
 
 (defn- test-slow-handler [state]
   (fn [_]
@@ -274,9 +272,9 @@
 ;; In this first test we will close the connection before the test handler gets to change the state
 (expect
   [:initial-state true]
-  (start-and-maybe-kill-test-request test-slow-handler-state1 true))
+  (start-and-maybe-kill-test-request (atom :unset) true))
 
 ;; and to make sure this test actually works, run the same test again and let it change the state.
 (expect
   :ran-to-compleation
-  (start-and-maybe-kill-test-request test-slow-handler-state2 false))
+  (start-and-maybe-kill-test-request (atom :unset) false))

--- a/test/metabase/middleware_test.clj
+++ b/test/metabase/middleware_test.clj
@@ -13,6 +13,7 @@
             [metabase.api.common :refer [*current-user* *current-user-id*]]
             [metabase.models.session :refer [Session]]
             [metabase.test.data.users :refer :all]
+            [metabase.test.async :refer [while-with-timeout]]
             [ring.mock.request :as mock]
             [ring.util.response :as resp]
             [toucan.db :as db]
@@ -264,7 +265,7 @@
                                           (GET (str "/" path) [] (middleware/streaming-json-response
                                                                   (test-slow-handler state))))]
       (let  [reader (io/input-stream (str "http://localhost:" (config/config-int :mb-jetty-port) "/" path))]
-        (while (= :initial-state @state))
+        (while-with-timeout (= :initial-state @state))
         (when kill?
           (.close reader))
         (Thread/sleep 10000)))) ;; this is long enough to ensure that the handler has run to completion if it was not killed.

--- a/test/metabase/test/async.clj
+++ b/test/metabase/test/async.clj
@@ -6,5 +6,9 @@
 (defn result!
   "Blocking version of async/result."
   [job-id]
-  @((deref (deref #'async/running-jobs)) job-id)
+  (-> #'async/running-jobs
+      deref          ; var
+      deref          ; atom
+      (get job-id)
+      deref)         ; future
   (async/result (ComputationJob job-id)))

--- a/test/metabase/test/async.clj
+++ b/test/metabase/test/async.clj
@@ -1,6 +1,7 @@
 (ns metabase.test.async
   "Utilities for testing async API endpoints."
-  (:require [metabase.feature-extraction.async :as async]
+  (:require [clojure.tools.logging :as log]
+            [metabase.feature-extraction.async :as async]
             [metabase.models.computation-job :refer [ComputationJob]]))
 
 (defn result!
@@ -12,3 +13,17 @@
       (get job-id)
       deref)         ; future
   (async/result (ComputationJob job-id)))
+
+(def ^:dynamic *max-while-runtime*
+  "Maximal time in milliseconds `while-with-timeout` runs."
+  10000000)
+
+(defmacro while-with-timeout
+  "Like while except it runs a maximum of `*max-while-runtime*` milliseconds."
+  [test & body]
+  `(let [start# (System/currentTimeMillis)]
+     (while (and ~test
+                 (< (- (System/currentTimeMillis) start#) *max-while-runtime*))
+       ~@body)
+     (when (>= (- (System/currentTimeMillis) start#) *max-while-runtime*)
+       (log/warn "While loop terminated due to exceeded max runtime."))))


### PR DESCRIPTION
It seems these were causing some issues so I've turned them to blocking calls utilizing the underlying features.