### PR TITLE
Get ALL WebProperties visible to this connection,

### DIFF
--- a/src/metabase/driver/googleanalytics.clj
+++ b/src/metabase/driver/googleanalytics.clj
@@ -39,8 +39,8 @@
   "Return a set of tuples of `Webproperty` and `Profile` for DATABASE."
   [{{:keys [account-id]} :details, :as database}]
   (let [client (database->client database)]
-    (set (for [^Webproperty property (.getItems (fetch-properties client account-id))
-               ^Profile     profile  (.getItems (fetch-profiles client account-id (.getId property)))]
+    (set (for [^Webproperty property (.getItems (fetch-properties client "~all"))
+               ^Profile     profile  (.getItems (fetch-profiles client (.getAccountId property) (.getId property)))]
            [property profile]))))
 
 (defn- profile-ids


### PR DESCRIPTION
#6468 

This changes the behavior of the `properties+profiles` function to look at all Webproperties and Profiles 
that the given AccountID has access to, not just that account itself.

###### TODO 
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
