### PR TITLE
[Bug] Fix javascript JWT regexp check

### DIFF
--- a/frontend/src/metabase/lib/utils.js
+++ b/frontend/src/metabase/lib/utils.js
@@ -65,7 +65,7 @@ var MetabaseUtils = {
     },
 
     isJWT(string) {
-        return typeof string === "string" && /^[A-Za-z0-9]+\.[A-Za-z0-9]+\.[A-Za-z0-9_-]+$/.test(string);
+        return typeof string === "string" && /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(string);
     },
 
     validEmail: function(email) {

--- a/frontend/test/lib/utils.unit.spec.js
+++ b/frontend/test/lib/utils.unit.spec.js
@@ -79,6 +79,12 @@ describe('utils', () => {
             expect(MetabaseUtils.isEmpty(" ")).toEqual(true);
         });
     });
+
+    describe("isJWT", () => {
+        it("should allow for JWT tokens with dashes", () => {
+            expect(MetabaseUtils.isJWT("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXJhbXMiOnsicGFyYW0xIjoidGVzdCIsInBhcmFtMiI6ImFiIiwicGFyYW0zIjoiMjAwMC0wMC0wMFQwMDowMDowMCswMDowMCIsInBhcmFtNCI6Iu-8iO-8iSJ9LCJyZXNvdXJjZSI6eyJkYXNoYm9hcmQiOjB9fQ.wsNWliHJNwJBv_hx0sPo1EGY0nATdgEa31TM1AYotIA")).toEqual(true);
+        });
+    });
 });
 
 function shuffle(a) {


### PR DESCRIPTION
A JWT token may contain dashes `-` but the current regexp didn't account for it.

In such cases, the frontend would request the `/api/dashboard` instead of the `/embed/api/dashboard` and the result would be a `Not Found` message.

An example of a valid JWT with dashes: 
```
eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXJhbXMiOnsicGFyYW0xIjoidGVzdCIsInBhcmFtMiI6ImFiIiwicGFyYW0zIjoiMjAwMC0wMC0wMFQwMDowMDowMCswMDowMCIsInBhcmFtNCI6Iu-8iO-8iSJ9LCJyZXNvdXJjZSI6eyJkYXNoYm9hcmQiOjB9fQ.wsNWliHJNwJBv_hx0sPo1EGY0nATdgEa31TM1AYotIA
```
You can verify it in the debugger: https://jwt.io/

Also an example of another project using a similar regexp: https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/master/src/System.IdentityModel.Tokens.Jwt/JwtConstants.cs#L58

I think this may fix #6334 - at least the symptoms described in that issue are the same to those we were having. 

###### TODO

- [x] Sign the Contributor License Agreement
(unless it's a tiny documentation change).