### PR TITLE
Fix bug causing test email pulses to fail

### DIFF
--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -143,7 +143,7 @@
   "Polymorphoic function for creating notifications. This logic is different for pulse type (i.e. alert vs. pulse) and
   channel_type (i.e. email vs. slack)"
   (fn [pulse _ {:keys [channel_type] :as channel}]
-    [(alert-or-pulse pulse) channel_type]))
+    [(alert-or-pulse pulse) (keyword channel_type)]))
 
 (defmethod create-notification [:pulse :email]
   [{:keys [id name] :as pulse} results {:keys [recipients] :as channel}]
@@ -184,6 +184,11 @@
   {:channel-id channel-id
    :message (str "Alert: " (first-question-name pulse))
    :attachments (create-slack-attachment-data results)})
+
+(defmethod create-notification :default
+  [_ _ {:keys [channel_type] :as channel}]
+  (let [^String ex-msg (tru "Unrecognized channel type {0}" (pr-str channel_type))]
+    (throw (UnsupportedOperationException. ex-msg))))
 
 (defmulti ^:private send-notification!
   "Invokes the side-affecty function for sending emails/slacks depending on the notification type"


### PR DESCRIPTION
When test pulses are sent out their channel_types are strings not
keywords which caused the multimethod lookup in the pulse code to
fail. This commit adds a unit test that covers our pulse test
capability and ensures channel_type fields are keywords before
invoking the multimethod.

Fixes #6465

After merge this needs to be cherry-picked to the release-0.27.0 branch to be included in the next 0.27.0 RC release.