### PR TITLE
Fix randomly failing segment test

### DIFF
--- a/test/metabase/api/segment_test.clj
+++ b/test/metabase/api/segment_test.clj
@@ -363,9 +363,9 @@
 
 
 ;;; GET /api/segement/
-(tt/expect-with-temp [Segment [segment-1]
-                      Segment [segment-2]
-                      Segment [_          {:is_active false}]] ; inactive segments shouldn't show up
+(tt/expect-with-temp [Segment [segment-1 {:name "Segment 1"}]
+                      Segment [segment-2 {:name "Segment 2"}]
+                      Segment [_         {:is_active false}]] ; inactive segments shouldn't show up
   (tu/mappify (hydrate [segment-1
                         segment-2] :creator))
   ((user->client :rasta) :get 200 "segment/"))


### PR DESCRIPTION
Sometimes the test would fail because the segments would be out-of-order. The endpoint returns them sorted by name but they both had the same name.