### PR TITLE
Fix deploying to Heroku OOM issues [ci skip]

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: ./bin/start
+web: HEROKU=true ./bin/start

--- a/app.json
+++ b/app.json
@@ -5,7 +5,8 @@
     "business intelligence",
     "analytics",
     "dashboard",
-    "charting"
+    "charting",
+    "metabase"
   ],
   "website": "http://www.metabase.com/",
   "repository": "https://github.com/metabase/metabase",

--- a/bin/start
+++ b/bin/start
@@ -82,9 +82,29 @@ if [ ! -z "$RDS_HOSTNAME" ]; then
     export MB_DB_PORT=$RDS_PORT
 fi
 
-JAVA_OPTS="${JAVA_OPTS} -XX:+IgnoreUnrecognizedVMOptions"
-JAVA_OPTS="${JAVA_OPTS} -Dfile.encoding=UTF-8"
-JAVA_OPTS="${JAVA_OPTS} --add-opens=java.base/java.net=ALL-UNNAMED"
-JAVA_OPTS="${JAVA_OPTS} --add-modules=java.xml.bind"
+# Determine whether we're on Heroku on a free, hobby, or 1x dyno.
+#
+# We set $HEROKU in the Procfile; we know we're on a baby dyno if the process limit is 256 per user.
+#
+# On a baby dyno we need to override the $JAVA_OPTS and give it a slightly lower memory limit because Heroku tends to think
+# we can use more memory than we actually can. It defaults to giving us 300m but that still ends up going over the 512MB
+# limit for the dyno. Set a few other additional options to minimize memory usage as well.
+if [ -n "$HEROKU" ] && [ `ulimit -u` = 256 ]; then
+    JAVA_OPTS="$JAVA_OPTS -Xmx248m"                        # This seems to be the right amount that prevents the dyno from going over the quota
+    JAVA_OPTS="$JAVA_OPTS -XX:-UseGCOverheadLimit"         # Disable limit to amount of time spent in GC. Better slow than not working at all
+    JAVA_OPTS="$JAVA_OPTS -XX:+UseConcMarkSweepGC"         # ConcMarkSweepGC seems to cause less OOM issues in my testing on low-mem Heroku envs
+    JAVA_OPTS="$JAVA_OPTS -XX:+CMSClassUnloadingEnabled"   # Not 100% sure this does anything in Java 8 but if it does, we want to enable it
+    JAVA_OPTS="$JAVA_OPTS -XX:+UseCompressedOops"          # Use 32-bit pointers. Reduces memory usage and GC events
+    JAVA_OPTS="$JAVA_OPTS -XX:+UseCompressedClassPointers" # Same as above. See also http://blog.leneghan.com/2012/03/reducing-java-memory-usage-and-garbage.html
+fi
+
+# Other Java options
+JAVA_OPTS="$JAVA_OPTS -XX:+IgnoreUnrecognizedVMOptions"           # Don't barf if we see an option we don't understand (e.g. Java 9 option on Java 7/8)
+JAVA_OPTS="$JAVA_OPTS -Djava.awt.headless=true"                   # don't try to start AWT. Not sure this does anything but better safe than wasting memory
+JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8"                      # Use UTF-8
+JAVA_OPTS="$JAVA_OPTS --add-opens=java.base/java.net=ALL-UNNAMED" # Allow dynamically adding JARs to classpath (Java 9)
+JAVA_OPTS="$JAVA_OPTS --add-modules=java.xml.bind"                # Enable access to java.xml.bind module (Java 9)
+
+echo "Using these JAVA_OPTS: ${JAVA_OPTS}"
 
 exec java $JAVA_OPTS -jar ./target/uberjar/metabase.jar


### PR DESCRIPTION
After fixing the metabase-deploy repo I thought I'd give the "Deploy to Heroku" button a test to make sure things were working correctly. To my horror, they were not; the application was constantly running out of memory when Liquibase attempted to parse our "huge" migrations file. It seems like this is not a new issue: #3360, but it has certainly gotten worse over time as the migrations file has grown.

I tried every trick in the book to get things to work correctly without having to change anything in Metabase itself. After a few hours of experimenting I have found a set of JVM options that seems to resolve the issue. 

Corresponding PR for deploy repo: https://github.com/metabase/metabase-deploy/pull/18

It seems like sooner or later we'll have to split our migrations file into two or more files to resolve these memory issues, but this seems to be a short-term fix that works as we'd expect