### PR TITLE
Add a deprecation warning for JDK 7

### DIFF
--- a/docs/operations-guide/start.md
+++ b/docs/operations-guide/start.md
@@ -13,6 +13,7 @@
 *  [Handling Timezones](#handling-timezones-in-metabase)
 *  [Configuring Emoji Logging](#configuring-emoji-logging)
 *  [How to setup monitoring via JMX](#monitoring-via-jmx)
+*  [A word on Java versions](#java-versions)
 
 # Installing and Running Metabase
 
@@ -327,3 +328,27 @@ The easiest way to get started customizing logging would be to use a copy of def
 # [Monitoring via JMX](enable-jmx.md)
 
 Diagnosing performance related issues can be a challenge. Luckily the JVM ships with tools that can help diagnose many common issues. Enabling JMX and using a tool like VisualVM can help diagnose issues related to running out of memory, a hung Metabase instance and slow response times. See [Monitoring via JMX](enable-jmx.md) for more information on setting this up.
+
+# Java Versions
+
+Metabase will run on Java version 7 or greater, but Java 8 is the easiest and most common chioce. Java 7 was End of Life'd by Oracle in April of 2015 and as such, *Metabase support for Java 7 has been deprecated*. Users are encouraged to upgrade to Java 8 as we will drop support for Java 7 in a future release. For more information on installing/upgrading a Windows or macOS system, see the [Oracle installation instructions](https://docs.oracle.com/javase/8/docs/technotes/guides/install/install_overview.html). Linux users likely find OpenJDK easier to install/upgrade, more information is available on [the OpenJDK install page](http://openjdk.java.net/install/).
+
+## Running on Java 7
+
+Running Metabase on Java version 7 requires additional arguments to the Java invocation:
+
+    java -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:MaxPermSize=256m -jar metabase.jar
+
+Note that these extra arguments are not required on Java 8. *Support for Java 7 has been deprecated and users are encouraged to upgrade*.
+
+## Running on Java 8
+
+Running on Java 8 is the easiest path to running Metabase. There are no additional parameters required, if launching from a Jar the below invocation will work:
+
+    java -jar metabase.jar
+
+## Running on Java 9
+
+Java version 9 has introduced a new module system that places some additional restrictions on class loading. Metabase (and it's dependencies) still rely on the old behavior. Metabase runs on Java 9, but requires an additional argument to work around these changes in the module system:
+
+    java --add-opens=java.base/java.net=ALL-UNNAMED -jar metabase.jar

--- a/docs/troubleshooting-guide/running.md
+++ b/docs/troubleshooting-guide/running.md
@@ -14,7 +14,7 @@ or one like
 
 If this happens, setting a few JVM options should fix your issue:
 
-    java -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:MaxPermSize=256m -jar target/uberjar/metabase.jar
+    java -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:MaxPermSize=256m -jar metabase.jar
 
 You can also pass JVM arguments by setting the environment variable `JAVA_TOOL_OPTIONS`, e.g.
 


### PR DESCRIPTION
This PR starts the conversation around how/what we need to mark/warn for deprecation of JDK 7. We'll need to make doc changes to call this out as well. I'm not exactly sure what needs to be changed where, but we can use this as a starting point.
