### PR TITLE
Infer spaces double to float

### DIFF
--- a/src/metabase/util/infer_spaces.clj
+++ b/src/metabase/util/infer_spaces.clj
@@ -20,7 +20,7 @@
   (let [log-count (Math/log (count words))]
     (into (sorted-map)
           (map-indexed (fn [idx word]
-                         [(hash word) (Math/log (* (inc idx) log-count))])
+                         [(hash word) (float (Math/log (* (inc idx) log-count)))])
                        words))))
 
 ;; # Build arrays for a cost lookup, assuming Zipf's law and cost = -math.log(probability).
@@ -35,9 +35,9 @@
     "Array of word hash values, ordered by that hash value"
     (int-array (keys sorted-words)))
 
-  (def ^:private ^"[D" word-cost
-    "Array of word cost doubles, ordered by the hash value for that word"
-    (double-array (vals sorted-words)))
+  (def ^:private ^"[F" word-cost
+    "Array of word cost floats, ordered by the hash value for that word"
+    (float-array (vals sorted-words)))
 
   ;; maxword = max(len(x) for x in words)
   (def ^:private max-word
@@ -97,7 +97,7 @@
   [input]
   (let [s (s/lower-case input)
         cost (build-cost-array s)]
-    (loop [i (double (count s))
+    (loop [i (float (count s))
            out []]
       (if-not (pos? i)
         (reverse out)

--- a/test/metabase/api/alert_test.clj
+++ b/test/metabase/api/alert_test.clj
@@ -577,7 +577,8 @@
   (with-alert-setup
    [(count ((user->client :rasta) :get 200 (format "alert/question/%d" card-id)))
     (do
-      ((user->client :rasta) :put 204 (format "alert/%d/unsubscribe" pulse-id))
+      (et/with-expected-messages 1
+        ((user->client :rasta) :put 204 (format "alert/%d/unsubscribe" pulse-id)))
       (count ((user->client :crowberto) :get 200 (format "alert/question/%d" card-id))))
     (et/regex-email-bodies #"https://metabase.com/testmb"
                            #"Foo")]))
@@ -602,7 +603,8 @@
   (with-alert-setup
    [(count ((user->client :rasta) :get 200 (format "alert/question/%d" card-id)))
     (do
-      ((user->client :rasta) :put 204 (format "alert/%d/unsubscribe" pulse-id))
+      (et/with-expected-messages 1
+        ((user->client :rasta) :put 204 (format "alert/%d/unsubscribe" pulse-id)))
       (count ((user->client :crowberto) :get 200 (format "alert/question/%d" card-id))))
     (et/regex-email-bodies #"https://metabase.com/testmb"
                            #"Foo")]))
@@ -627,7 +629,8 @@
   (with-alert-setup
    [(count ((user->client :rasta) :get 200 (format "alert/question/%d" card-id)))
     (do
-      ((user->client :rasta) :put 204 (format "alert/%d/unsubscribe" pulse-id))
+      (et/with-expected-messages 1
+        ((user->client :rasta) :put 204 (format "alert/%d/unsubscribe" pulse-id)))
       (count ((user->client :crowberto) :get 200 (format "alert/question/%d" card-id))))
     (et/regex-email-bodies #"https://metabase.com/testmb"
                            #"Foo")]))


### PR DESCRIPTION
This change will consume about half the memory that the previous
doubles consumed. The change in precision shouldn't affect the results
of word splitting.