### PR TITLE
Move google utilities out of the driver namespace

### DIFF
--- a/src/metabase/driver/bigquery.clj
+++ b/src/metabase/driver/bigquery.clj
@@ -12,8 +12,7 @@
              [driver :as driver]
              [util :as u]]
             [metabase.driver
-             [generic-sql :as sql]
-             [google :as google]]
+             [generic-sql :as sql]]
             [metabase.driver.generic-sql.query-processor :as sqlqp]
             [metabase.driver.generic-sql.util.unprepare :as unprepare]
             [metabase.models
@@ -21,7 +20,10 @@
              [field :as field]
              [table :as table]]
             [metabase.query-processor.util :as qputil]
-            [metabase.util.honeysql-extensions :as hx]
+            [metabase.util
+             [google :as google]
+             [honeysql-extensions :as hx]]
+
             [toucan.db :as db])
   (:import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
            [com.google.api.services.bigquery Bigquery Bigquery$Builder BigqueryScopes]

--- a/src/metabase/driver/googleanalytics.clj
+++ b/src/metabase/driver/googleanalytics.clj
@@ -4,9 +4,9 @@
             [metabase
              [driver :as driver]
              [util :as u]]
-            [metabase.driver.google :as google]
             [metabase.driver.googleanalytics.query-processor :as qp]
-            [metabase.models.database :refer [Database]])
+            [metabase.models.database :refer [Database]]
+            [metabase.util.google :as google])
   (:import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
            [com.google.api.services.analytics Analytics Analytics$Builder Analytics$Data$Ga$Get AnalyticsScopes]
            [com.google.api.services.analytics.model Column Columns Profile Profiles Webproperties Webproperty]

--- a/src/metabase/util/google.clj
+++ b/src/metabase/util/google.clj
@@ -1,4 +1,4 @@
-(ns metabase.driver.google
+(ns metabase.util.google
   "Shared logic for various Google drivers, including BigQuery and Google Analytics."
   (:require [clojure.tools.logging :as log]
             [metabase

--- a/test/metabase/test/data/bigquery.clj
+++ b/test/metabase/test/data/bigquery.clj
@@ -3,13 +3,13 @@
             [environ.core :refer [env]]
             [medley.core :as m]
             [metabase.driver
-             [bigquery :as bigquery]
-             [google :as google]]
+             [bigquery :as bigquery]]
             [metabase.test.data
              [datasets :as datasets]
              [interface :as i]]
             [metabase.test.util :refer [resolve-private-vars]]
-            [metabase.util :as u])
+            [metabase.util :as u]
+            [metabase.util.google :as google])
   (:import com.google.api.client.util.DateTime
            com.google.api.services.bigquery.Bigquery
            [com.google.api.services.bigquery.model Dataset DatasetReference QueryRequest Table


### PR DESCRIPTION
The metabase.driver.google namespace isn't a driver but rather a set
of utilities used by the Google Analytics and Bigquery driver. When we
try to load the google namespace as a driver it results in a warning
that there is no `-init-driver` function. It's harmless, but not
necessary. This commit moves the code to a utility namespace which
will not try to load it as a driver.
