### PR TITLE
Add a noop `-init-driver` function to `metabase.driver.google`

### DIFF
--- a/src/metabase/driver/google.clj
+++ b/src/metabase/driver/google.clj
@@ -90,3 +90,8 @@
                     (.setTransport http-transport)))
       (.setAccessToken  access-token)
       (.setRefreshToken refresh-token))))
+
+(defn -init-driver
+  "Nothing to init as this is code used by the google drivers, but is not a driver itself"
+  []
+  true)


### PR DESCRIPTION
A warning is currently shown as we assume that namespace is a
driver. It's used by driver code but is not itself a driver. Added a
noop function so it won't output that warning.