### PR TITLE
Remove ^:always-validate metadata

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -218,14 +218,14 @@
 ;; As a basic step to make sure the Metadata is valid we'll also pass a simple checksum and have the frontend pass it back to us.
 ;; See the QP `results-metadata` middleware namespace for more details
 
-(s/defn ^:private ^:always-validate result-metadata-for-query :- results-metadata/ResultsMetadata
+(s/defn ^:private result-metadata-for-query :- results-metadata/ResultsMetadata
   "Fetch the results metadata for a QUERY by running the query and seeing what the QP gives us in return.
    This is obviously a bit wasteful so hopefully we can avoid having to do this."
   [query]
   (binding [qpi/*disable-qp-logging* true]
     (get-in (qp/process-query query) [:data :results_metadata :columns])))
 
-(s/defn ^:private ^:always-validate result-metadata :- (s/maybe results-metadata/ResultsMetadata)
+(s/defn ^:private result-metadata :- (s/maybe results-metadata/ResultsMetadata)
   "Get the right results metadata for this CARD. We'll check to see whether the METADATA passed in seems valid;
    otherwise we'll run the query ourselves to get the right values."
   [query metadata checksum]

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -162,7 +162,7 @@
        "Map of expanded schedule maps")
     "value must be a valid map of schedule maps for a DB."))
 
-(s/defn ^:private ^:always-validate expanded-schedules [db :- DatabaseInstance]
+(s/defn ^:private expanded-schedules [db :- DatabaseInstance]
   {:cache_field_values (cron-util/cron-string->schedule-map (:cache_field_values_schedule db))
    :metadata_sync      (cron-util/cron-string->schedule-map (:metadata_sync_schedule db))})
 
@@ -322,7 +322,7 @@
                             (:name field)))]
     (contains? driver-props "ssl")))
 
-(s/defn ^:private ^:always-validate test-connection-details :- su/Map
+(s/defn ^:private test-connection-details :- su/Map
   "Try a making a connection to database ENGINE with DETAILS.
    Tries twice: once with SSL, and a second time without if the first fails.
    If either attempt is successful, returns the details used to successfully connect.
@@ -348,7 +348,7 @@
   {(s/optional-key :metadata_sync_schedule)      cron-util/CronScheduleString
    (s/optional-key :cache_field_values_schedule) cron-util/CronScheduleString})
 
-(s/defn ^:always-validate schedule-map->cron-strings :- CronSchedulesMap
+(s/defn schedule-map->cron-strings :- CronSchedulesMap
   "Convert a map of `:schedules` as passed in by the frontend to a map of cron strings with the approriate keys for
    Database. This map can then be merged directly inserted into the DB, or merged with a map of other columns to
    insert/update."

--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -83,7 +83,7 @@
        (or (not (string? v))
            (not (str/blank? v)))))
 
-(s/defn ^:private ^:always-validate validate-params
+(s/defn ^:private validate-params
   "Validate that the TOKEN-PARAMS passed in the JWT and the USER-PARAMS (passed as part of the URL) are allowed, and that ones that
    are required are specified by checking them against a Card or Dashboard's OBJECT-EMBEDDING-PARAMS (the object's value of
    `:embedding_params`). Throws a 400 if any of the checks fail. If all checks are successful, returns a merged parameters map."
@@ -104,7 +104,7 @@
         :when (not (contains? params-to-remove (keyword (:slug param))))]
     param))
 
-(s/defn ^:private ^:always-validate remove-locked-and-disabled-params
+(s/defn ^:private remove-locked-and-disabled-params
   "Remove the `:parameters` for DASHBOARD-OR-CARD that listed as `disabled` or `locked` in the EMBEDDING-PARAMS whitelist,
    or not present in the whitelist. This is done so the frontend doesn't display widgets for params the user can't set."
   [dashboard-or-card, embedding-params :- su/EmbeddingParams]

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -417,7 +417,7 @@
   10000)
 
 ;; TODO - move this to the metadata-queries namespace or something like that instead
-(s/defn ^:always-validate ^{:style/indent 1} table-rows-sample :- (s/maybe si/TableSample)
+(s/defn ^{:style/indent 1} table-rows-sample :- (s/maybe si/TableSample)
   "Run a basic MBQL query to fetch a sample of rows belonging to a Table."
   [table :- si/TableInstance, fields :- [si/FieldInstance]]
   (let [results ((resolve 'metabase.query-processor/process-query)

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -114,20 +114,20 @@
   (into {} (for [[group-id perms] (group-by :group_id (db/select 'Permissions))]
              {group-id (set (map :object perms))})))
 
-(s/defn ^:private ^:always-validate perms-type-for-collection :- CollectionPermissions
+(s/defn ^:private perms-type-for-collection :- CollectionPermissions
   [permissions-set collection-id]
   (cond
     (perms/set-has-full-permissions? permissions-set (perms/collection-readwrite-path collection-id)) :write
     (perms/set-has-full-permissions? permissions-set (perms/collection-read-path collection-id))      :read
     :else                                                                                             :none))
 
-(s/defn ^:private ^:always-validate group-permissions-graph :- GroupPermissionsGraph
+(s/defn ^:private group-permissions-graph :- GroupPermissionsGraph
   "Return the permissions graph for a single group having PERMISSIONS-SET."
   [permissions-set collection-ids]
   (into {} (for [collection-id collection-ids]
              {collection-id (perms-type-for-collection permissions-set collection-id)})))
 
-(s/defn ^:always-validate graph :- PermissionsGraph
+(s/defn graph :- PermissionsGraph
   "Fetch a graph representing the current permissions status for every group and all permissioned collections.
    This works just like the function of the same name in `metabase.models.permissions`; see also the documentation for that function."
   []
@@ -140,7 +140,7 @@
 
 ;;; ---------------------------------------- Update Graph ----------------------------------------
 
-(s/defn ^:private ^:always-validate update-collection-permissions! [group-id :- su/IntGreaterThanZero, collection-id :- su/IntGreaterThanZero, new-collection-perms :- CollectionPermissions]
+(s/defn ^:private update-collection-permissions! [group-id :- su/IntGreaterThanZero, collection-id :- su/IntGreaterThanZero, new-collection-perms :- CollectionPermissions]
   ;; remove whatever entry is already there (if any) and add a new entry if applicable
   (perms/revoke-collection-permissions! group-id collection-id)
   (case new-collection-perms
@@ -148,7 +148,7 @@
     :read  (perms/grant-collection-read-permissions! group-id collection-id)
     :none  nil))
 
-(s/defn ^:private ^:always-validate update-group-permissions! [group-id :- su/IntGreaterThanZero, new-group-perms :- GroupPermissionsGraph]
+(s/defn ^:private update-group-permissions! [group-id :- su/IntGreaterThanZero, new-group-perms :- GroupPermissionsGraph]
   (doseq [[collection-id new-perms] new-group-perms]
     (update-collection-permissions! group-id collection-id new-perms)))
 
@@ -163,7 +163,7 @@
       :after   new
       :user_id *current-user-id*)))
 
-(s/defn ^:always-validate update-graph!
+(s/defn update-graph!
   "Update the collections permissions graph.
    This works just like the function of the same name in `metabase.models.permissions`, but for `Collections`;
    refer to that function's extensive documentation to get a sense for how this works."

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -67,7 +67,7 @@
 (defonce ^:private registered-settings
   (atom {}))
 
-(s/defn ^:private ^:always-validate resolve-setting :- SettingDefinition
+(s/defn ^:private resolve-setting :- SettingDefinition
   [setting-or-name]
   (if (map? setting-or-name)
     setting-or-name
@@ -209,7 +209,7 @@
                    "\nAssuming Setting already exists in DB and updating existing value.")
          (update-setting! setting-name new-value))))
 
-(s/defn ^:always-validate set-string!
+(s/defn set-string!
   "Set string value of SETTING-OR-NAME. A `nil` or empty NEW-VALUE can be passed to unset (i.e., delete)
    SETTING-OR-NAME."
   [setting-or-name, new-value :- (s/maybe s/Str)]

--- a/src/metabase/public_settings/metastore.clj
+++ b/src/metabase/public_settings/metastore.clj
@@ -34,7 +34,7 @@
 
 (def ^:private ^:const fetch-token-status-timeout-ms 10000) ; 10 seconds
 
-(s/defn ^:private ^:always-validate fetch-token-status :- {:valid s/Bool, :status su/NonBlankString}
+(s/defn ^:private fetch-token-status :- {:valid s/Bool, :status su/NonBlankString}
   "Fetch info about the validity of TOKEN from the MetaStore. "
   [token :- ValidToken]
   (try

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -255,7 +255,7 @@
                        *allow-queries-with-no-executor-id*))
                  "executed-by cannot be nil unless *allow-queries-with-no-executor-id* is true"))
 
-(s/defn ^:always-validate process-query-and-save-execution!
+(s/defn process-query-and-save-execution!
   "Process and run a json based dataset query and return results.
 
   Takes 2 arguments:

--- a/src/metabase/query_processor/middleware/expand.clj
+++ b/src/metabase/query_processor/middleware/expand.clj
@@ -19,7 +19,7 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 ;; TODO - check that there's a matching :aggregation clause in the query ?
-(s/defn ^:ql ^:always-validate aggregate-field :- AgFieldRef
+(s/defn ^:ql aggregate-field :- AgFieldRef
   "Aggregate field referece, e.g. for use in an `order-by` clause.
 
      (query (aggregate (count))
@@ -27,7 +27,7 @@
   [index :- s/Int]
   (i/map->AgFieldRef {:index index}))
 
-(s/defn ^:ql ^:always-validate field-id :- i/AnyField
+(s/defn ^:ql field-id :- i/AnyField
   "Create a generic reference to a `Field` with ID."
   [id]
   ;; If for some reason we were passed a field literal (e.g. [field-id [field-literal ...]])
@@ -39,7 +39,7 @@
       id)
     (i/map->FieldPlaceholder {:field-id id})))
 
-(s/defn ^:private ^:always-validate field :- i/AnyField
+(s/defn ^:private field :- i/AnyField
   "Generic reference to a `Field`. F can be an integer Field ID, or various other forms like `fk->` or `aggregation`."
   [f]
   (if (integer? f)
@@ -47,20 +47,20 @@
         (field-id f))
     f))
 
-(s/defn ^:ql ^:always-validate field-literal :- FieldLiteral
+(s/defn ^:ql field-literal :- FieldLiteral
   "Generic reference to a Field by FIELD-NAME. This is intended for use when using nested queries so as to allow one to refer to the fields coming back from
    the source query."
   [field-name :- su/KeywordOrString, field-type :- su/KeywordOrString]
   (i/map->FieldLiteral {:field-name (u/keyword->qualified-name field-name), :base-type (keyword field-type)}))
 
-(s/defn ^:ql ^:always-validate named :- i/Aggregation
+(s/defn ^:ql named :- i/Aggregation
   "Specify a CUSTOM-NAME to use for a top-level AGGREGATION-OR-EXPRESSION in the results.
    (This will probably be extended to support Fields in the future, but for now, only the `:aggregation` clause is supported.)"
   {:added "0.22.0"}
   [aggregation-or-expression :- i/Aggregation, custom-name :- su/NonBlankString]
   (assoc aggregation-or-expression :custom-name custom-name))
 
-(s/defn ^:ql ^:always-validate datetime-field :- i/AnyField
+(s/defn ^:ql datetime-field :- i/AnyField
   "Reference to a `DateTimeField`. This is just a `Field` reference with an associated datetime UNIT."
   ([f _ unit]
    (log/warn (u/format-color 'yellow (str "The syntax for datetime-field has changed in MBQL '98. [:datetime-field <field> :as <unit>] is deprecated. "
@@ -74,7 +74,7 @@
      ;; (:datetime-unit f)          f
      :else                       (assoc (field f) :datetime-unit (qputil/normalize-token unit)))))
 
-(s/defn ^:ql ^:always-validate fk-> :- FieldPlaceholder
+(s/defn ^:ql fk-> :- FieldPlaceholder
   "Reference to a `Field` that belongs to another `Table`. DEST-FIELD-ID is the ID of this Field, and FK-FIELD-ID is the ID of the foreign key field
    belonging to the *source table* we should use to perform the join.
 
@@ -96,7 +96,7 @@
                                    (:unit f)
                                    (:unit v))))
 
-(s/defn ^:private ^:always-validate value :- i/AnyValue
+(s/defn ^:private value :- i/AnyValue
   "Literal value. F is the `Field` it relates to, and V is `nil`, or a boolean, string, numerical, or datetime value."
   [f v]
   (cond
@@ -109,7 +109,7 @@
     (instance? FieldLiteral f)          (i/map->Value {:value v, :field f})
     :else                               (i/map->ValuePlaceholder {:field-placeholder (field f), :value v})))
 
-(s/defn ^:private ^:always-validate field-or-value
+(s/defn ^:private field-or-value
   "Use instead of `value` when something may be either a field or a value."
   [f v]
 
@@ -118,7 +118,7 @@
     v
     (value f v)))
 
-(s/defn ^:ql ^:always-validate relative-datetime :- RelativeDatetime
+(s/defn ^:ql relative-datetime :- RelativeDatetime
   "Value that represents a point in time relative to each moment the query is ran, e.g. \"today\" or \"1 year ago\".
 
    With `:current` as the only arg, refer to the current point in time; otherwise N is some number and UNIT is a unit like `:day` or `:year`.
@@ -131,7 +131,7 @@
                                                                    :day                        ; give :unit a default value so we can simplify the schema a bit and require a :unit
                                                                    (qputil/normalize-token unit))})))
 
-(s/defn ^:ql ^:always-validate expression :- ExpressionRef
+(s/defn ^:ql expression :- ExpressionRef
   {:added "0.17.0"}
   [expression-name :- su/KeywordOrString]
   (i/strict-map->ExpressionRef {:expression-name (name expression-name)}))
@@ -151,7 +151,7 @@
     ;; otherwise if it's not an Expression it's a Field
     (field f)))
 
-(s/defn ^:private ^:always-validate ag-with-field :- i/Aggregation [ag-type f]
+(s/defn ^:private ag-with-field :- i/Aggregation [ag-type f]
   (i/map->AggregationWithField {:aggregation-type ag-type, :field (field-or-expression f)}))
 
 (def ^:ql ^{:arglists '([f])} avg      "Aggregation clause. Return the average value of F."                (partial ag-with-field :avg))
@@ -168,12 +168,12 @@
   (i/assert-driver-supports :standard-deviation-aggregations)
   (ag-with-field :stddev f))
 
-(s/defn ^:ql ^:always-validate count :- i/Aggregation
+(s/defn ^:ql count :- i/Aggregation
   "Aggregation clause. Return total row count (e.g., `COUNT(*)`). If F is specified, only count rows where F is non-null (e.g. `COUNT(f)`)."
   ([]  (i/map->AggregationWithoutField {:aggregation-type :count}))
   ([f] (ag-with-field :count f)))
 
-(s/defn ^:ql ^:always-validate cum-count :- i/Aggregation
+(s/defn ^:ql cum-count :- i/Aggregation
   "Aggregation clause. Return the cumulative row count (presumably broken out in some way)."
   []
   (i/map->AggregationWithoutField {:aggregation-type :cumulative-count}))
@@ -183,7 +183,7 @@
   []
   (log/warn (u/format-color 'yellow "Specifying :rows as the aggregation type is deprecated in MBQL '98. This is the default behavior, so you don't need to specify it.")))
 
-(s/defn ^:ql ^:always-validate aggregation
+(s/defn ^:ql aggregation
   "Specify the aggregation to be performed for this query.
 
      (aggregation {} (count 100))
@@ -213,7 +213,7 @@
 
 ;;; ## breakout & fields
 
-(s/defn ^:ql ^:always-validate binning-strategy :- FieldPlaceholder
+(s/defn ^:ql binning-strategy :- FieldPlaceholder
   "Reference to a `BinnedField`. This is just a `Field` reference with an associated `STRATEGY-NAME` and `STRATEGY-PARAM`"
   ([f strategy-name & [strategy-param]]
    (let [strategy (qputil/normalize-token strategy-name)
@@ -229,7 +229,7 @@
 
 ;;; ## filter
 
-(s/defn ^:private ^:always-validate compound-filter :- i/Filter
+(s/defn ^:private compound-filter :- i/Filter
   ([compound-type, subclause :- i/Filter]
    (log/warn (u/format-color 'yellow "You shouldn't specify an %s filter with only one subclause." compound-type))
    subclause)
@@ -240,7 +240,7 @@
 (def ^:ql ^{:arglists '([& subclauses])} and "Filter subclause. Return results that satisfy *all* SUBCLAUSES." (partial compound-filter :and))
 (def ^:ql ^{:arglists '([& subclauses])} or  "Filter subclause. Return results that satisfy *any* of the SUBCLAUSES." (partial compound-filter :or))
 
-(s/defn ^:private ^:always-validate equality-filter :- i/Filter
+(s/defn ^:private equality-filter :- i/Filter
   ([filter-type _ f v]
    (i/map->EqualityFilter {:filter-type filter-type, :field (field f), :value (field-or-value f v)}))
   ([filter-type compound-fn f v & more]
@@ -264,7 +264,7 @@
 (defn ^:ql is-null  "Filter subclause. Return results where F is `nil`."     [f] (=  f nil)) ; TODO - Should we deprecate these? They're syntactic sugar, and not particualarly useful.
 (defn ^:ql not-null "Filter subclause. Return results where F is not `nil`." [f] (!= f nil)) ; not-null is doubly unnecessary since you could just use `not` instead.
 
-(s/defn ^:private ^:always-validate comparison-filter :- ComparisonFilter [filter-type f v]
+(s/defn ^:private comparison-filter :- ComparisonFilter [filter-type f v]
   (i/map->ComparisonFilter {:filter-type filter-type, :field (field f), :value (value f v)}))
 
 (def ^:ql ^{:arglists '([f v])} <  "Filter subclause. Return results where F is less than V. V must be orderable, i.e. a number or datetime."                (partial comparison-filter :<))
@@ -272,26 +272,26 @@
 (def ^:ql ^{:arglists '([f v])} >  "Filter subclause. Return results where F is greater than V. V must be orderable, i.e. a number or datetime."             (partial comparison-filter :>))
 (def ^:ql ^{:arglists '([f v])} >= "Filter subclause. Return results where F is greater than or equal to V. V must be orderable, i.e. a number or datetime." (partial comparison-filter :>=))
 
-(s/defn ^:ql ^:always-validate between :- BetweenFilter
+(s/defn ^:ql between :- BetweenFilter
   "Filter subclause. Return results where F is between MIN and MAX. MIN and MAX must be orderable, i.e. numbers or datetimes.
    This behaves like SQL `BETWEEN`, i.e. MIN and MAX are inclusive."
   [f min-val max-val]
   (i/map->BetweenFilter {:filter-type :between, :field (field f), :min-val (value f min-val), :max-val (value f max-val)}))
 
-(s/defn ^:ql ^:always-validate inside :- CompoundFilter
+(s/defn ^:ql inside :- CompoundFilter
   "Filter subclause for geo bounding. Return results where LAT-FIELD and LON-FIELD are between some set of bounding values."
   [lat-field lon-field lat-max lon-min lat-min lon-max]
   (and (between lat-field lat-min lat-max)
        (between lon-field lon-min lon-max)))
 
-(s/defn ^:private ^:always-validate string-filter :- StringFilter [filter-type f s]
+(s/defn ^:private string-filter :- StringFilter [filter-type f s]
   (i/map->StringFilter {:filter-type filter-type, :field (field f), :value (value f s)}))
 
 (def ^:ql ^{:arglists '([f s])} starts-with "Filter subclause. Return results where F starts with the string S."    (partial string-filter :starts-with))
 (def ^:ql ^{:arglists '([f s])} contains    "Filter subclause. Return results where F contains the string S."       (partial string-filter :contains))
 (def ^:ql ^{:arglists '([f s])} ends-with   "Filter subclause. Return results where F ends with with the string S." (partial string-filter :ends-with))
 
-(s/defn ^:ql ^:always-validate not :- i/Filter
+(s/defn ^:ql not :- i/Filter
   "Filter subclause. Return results that do *not* satisfy SUBCLAUSE.
 
    For the sake of simplifying driver implementation, `not` automatically translates its argument to a simpler, logically equivalent form whenever possible:
@@ -320,7 +320,7 @@
 
 (def ^:ql ^{:arglists '([f s]), :added "0.15.0"} does-not-contain "Filter subclause. Return results where F does not start with the string S." (comp not contains))
 
-(s/defn ^:ql ^:always-validate time-interval :- i/Filter
+(s/defn ^:ql time-interval :- i/Filter
   "Filter subclause. Syntactic sugar for specifying a specific time interval.
 
     ;; return rows where datetime Field 100's value is in the current day
@@ -341,7 +341,7 @@
         (core/> n  1) (between f (value f (relative-datetime  1 unit))
                                  (value f (relative-datetime  n unit)))))))
 
-(s/defn ^:ql ^:always-validate filter
+(s/defn ^:ql filter
   "Filter the results returned by the query.
 
      (filter {} := 100 true) ; return rows where Field 100 == true"
@@ -350,7 +350,7 @@
     (assoc query :filter filter-map)
     query))
 
-(s/defn ^:ql ^:always-validate limit
+(s/defn ^:ql limit
   "Limit the number of results returned by the query.
 
      (limit {} 10)"
@@ -362,7 +362,7 @@
 
 ;;; ## order-by
 
-(s/defn ^:private ^:always-validate order-by-subclause :- i/OrderBy
+(s/defn ^:private order-by-subclause :- i/OrderBy
   [direction :- i/OrderByDirection, f]
   ;; it's not particularly useful to sort datetime fields with the default `:day` bucketing,
   ;; so specifiy `:default` bucketing to prevent the default of `:day` from being set during resolution.
@@ -386,7 +386,7 @@
      (order-by {} (desc 100))"
   (partial order-by-subclause :descending))
 
-(s/defn ^:private ^:always-validate maybe-parse-order-by-subclause :- i/OrderBy
+(s/defn ^:private maybe-parse-order-by-subclause :- i/OrderBy
   [subclause]
   (cond
     (map? subclause)    subclause ; already parsed by `asc` or `desc`
@@ -407,7 +407,7 @@
 
 ;;; ## page
 
-(s/defn ^:ql ^:always-validate page
+(s/defn ^:ql page
   "Specify which 'page' of results to fetch (offset and limit the results).
 
      (page {} {:page 1, :items 20}) ; fetch first 20 rows"
@@ -418,7 +418,7 @@
 
 ;;; ## source-table
 
-(s/defn ^:ql ^:always-validate source-table
+(s/defn ^:ql source-table
   "Specify the ID of the table to query.
    Queries must specify *either* `:source-table` or `:source-query`.
 
@@ -428,7 +428,7 @@
 
 (declare expand-inner)
 
-(s/defn ^:ql ^:always-validate source-query
+(s/defn ^:ql source-query
   "Specify a query to use as the source for this query (e.g., as a `SUBSELECT`).
    Queries must specify *either* `:source-table` or `:source-query`.
 
@@ -443,13 +443,13 @@
 
 ;;; ## calculated columns
 
-(s/defn ^:ql ^:always-validate expressions
+(s/defn ^:ql expressions
   "Top-level clause. Add additional calculated fields to a query."
   {:added "0.17.0"}
   [query, m :- {s/Keyword Expression}]
   (assoc query :expressions m))
 
-(s/defn ^:private ^:always-validate expression-fn :- Expression
+(s/defn ^:private expression-fn :- Expression
   [k :- s/Keyword, & args]
   (i/map->Expression {:operator k, :args (vec (for [arg args]
                                                 (if (number? arg)
@@ -491,7 +491,7 @@
     (core/or (token->ql-fn token)
              (throw (Exception. (str "Illegal clause (no matching fn found): " token))))))
 
-(s/defn ^:always-validate expand-ql-sexpr
+(s/defn expand-ql-sexpr
   "Expand a QL bracketed S-expression by dispatching to the appropriate `^:ql` function. If SEXPR is not a QL
    S-expression (the first item isn't a token), it is returned as-is.
 
@@ -511,7 +511,7 @@
         :else           x))
 
 
-(s/defn ^:always-validate expand-inner :- i/Query
+(s/defn expand-inner :- i/Query
   "Expand an inner query map."
   [inner-query :- (s/pred map?)]
   (loop [query {}, [[clause-name arg] & more] (seq inner-query)]

--- a/src/metabase/query_processor/middleware/parameters/sql.clj
+++ b/src/metabase/query_processor/middleware/parameters/sql.clj
@@ -121,7 +121,7 @@
 ;;                                   :target ["\dimension"\ ["\template-tag"\ "\checkin_date"\]]
 ;;                                   :value  "\2015-01-01~2016-09-01"\}}}
 
-(s/defn ^:private ^:always-validate param-with-target
+(s/defn ^:private param-with-target
   "Return the param in PARAMS with a matching TARGET. TARGET is something like:
 
      [:dimension [:template-tag <param-name>]] ; for Dimensions (Field Filters)
@@ -138,7 +138,7 @@
 
 ;;; Dimension Params (Field Filters) (e.g. WHERE {{x}})
 
-(s/defn ^:private ^:always-validate default-value-for-dimension :- (s/maybe DimensionValue)
+(s/defn ^:private default-value-for-dimension :- (s/maybe DimensionValue)
   "Return the default value for a Dimension (Field Filter) param defined by the map TAG, if one is set."
   [tag :- TagParam]
   (when-let [default (:default tag)]
@@ -146,11 +146,11 @@
      :target ["dimension" ["template-tag" (:name tag)]]
      :value  default}))
 
-(s/defn ^:private ^:always-validate dimension->field-id :- su/IntGreaterThanZero
+(s/defn ^:private dimension->field-id :- su/IntGreaterThanZero
   [dimension]
   (:field-id (ql/expand-ql-sexpr dimension)))
 
-(s/defn ^:private ^:always-validate dimension-value-for-tag :- (s/maybe Dimension)
+(s/defn ^:private dimension-value-for-tag :- (s/maybe Dimension)
   "Return the \"Dimension\" value of a param, if applicable. \"Dimension\" here means what is called a \"Field
   Filter\" in the Native Query Editor."
   [tag :- TagParam, params :- (s/maybe [DimensionValue])]
@@ -166,11 +166,11 @@
 
 ;;; Non-Dimension Params (e.g. WHERE x = {{x}})
 
-(s/defn ^:private ^:always-validate param-value-for-tag [tag :- TagParam, params :- (s/maybe [DimensionValue])]
+(s/defn ^:private param-value-for-tag [tag :- TagParam, params :- (s/maybe [DimensionValue])]
   (when (not= (:type tag) "dimension")
     (:value (param-with-target params ["variable" ["template-tag" (:name tag)]]))))
 
-(s/defn ^:private ^:always-validate default-value-for-tag
+(s/defn ^:private default-value-for-tag
   "Return the `:default` value for a param if no explicit values were passsed. This only applies to non-Dimension
    (non-Field Filter) params. Default values for Dimension (Field Filter) params are handled above in
    `default-value-for-dimension`."
@@ -182,13 +182,13 @@
 
 ;;; Parsing Values
 
-(s/defn ^:private ^:always-validate parse-number :- s/Num
+(s/defn ^:private parse-number :- s/Num
   "Parse a string like `1` or `2.0` into a valid number. Done mostly to keep people from passing in
    things that aren't numbers, like SQL identifiers."
   [s :- s/Str]
   (.parse (NumberFormat/getInstance) ^String s))
 
-(s/defn ^:private ^:always-validate value->number :- (s/cond-pre s/Num CommaSeparatedNumbers)
+(s/defn ^:private value->number :- (s/cond-pre s/Num CommaSeparatedNumbers)
   "Parse a 'numeric' param value. Normally this returns an integer or floating-point number,
    but as a somewhat undocumented feature it also accepts comma-separated lists of numbers. This was a side-effect of
    the old parameter code that unquestioningly substituted any parameter passed in as a number directly into the SQL.
@@ -212,7 +212,7 @@
         ;; otherwise just return the single number
         (first parts)))))
 
-(s/defn ^:private ^:always-validate parse-value-for-type :- ParamValue
+(s/defn ^:private parse-value-for-type :- ParamValue
   [param-type value]
   (cond
     (instance? NoValue value)                        value
@@ -222,7 +222,7 @@
          (= (get-in value [:param :type]) "number")) (update-in value [:param :value] value->number)
     :else                                            value))
 
-(s/defn ^:private ^:always-validate value-for-tag :- ParamValue
+(s/defn ^:private value-for-tag :- ParamValue
   "Given a map TAG (a value in the `:template_tags` dictionary) return the corresponding value from the PARAMS
    sequence. The VALUE is something that can be compiled to SQL via `->replacement-snippet-info`."
   [tag :- TagParam, params :- (s/maybe [DimensionValue])]
@@ -232,7 +232,7 @@
                                         ;; TODO - what if value is specified but is `nil`?
                                         (NoValue.))))
 
-(s/defn ^:private ^:always-validate query->params-map :- ParamValues
+(s/defn ^:private query->params-map :- ParamValues
   "Extract parameters info from QUERY. Return a map of parameter name -> value.
 
      (query->params-map some-query)
@@ -272,15 +272,15 @@
 (defn- date-param-type?          [param-type] (str/starts-with? param-type "date/"))
 
 ;; for relative dates convert the param to a `DateRange` record type and call `->replacement-snippet-info` on it
-(s/defn ^:private ^:always-validate relative-date-dimension-value->replacement-snippet-info :- ParamSnippetInfo
+(s/defn ^:private relative-date-dimension-value->replacement-snippet-info :- ParamSnippetInfo
   [value]
   (->replacement-snippet-info (map->DateRange (date-params/date-string->range value *timezone*)))) ; TODO - get timezone from query dict
 
-(s/defn ^:private ^:always-validate dimension-value->equals-clause-sql :- ParamSnippetInfo
+(s/defn ^:private dimension-value->equals-clause-sql :- ParamSnippetInfo
   [value]
   (update (->replacement-snippet-info value) :replacement-snippet (partial str "= ")))
 
-(s/defn ^:private ^:always-validate dimension->replacement-snippet-info :- ParamSnippetInfo
+(s/defn ^:private dimension->replacement-snippet-info :- ParamSnippetInfo
   "Return `[replacement-snippet & prepared-statement-args]` appropriate for a DIMENSION parameter."
   [{param-type :type, value :value} :- DimensionValue]
   (cond
@@ -288,14 +288,14 @@
     (date-param-type? param-type)          (dimension-value->equals-clause-sql (map->Date {:s value}))     ; convert all other dates to `= <date>`
     :else                                  (dimension-value->equals-clause-sql value)))                    ; convert everything else to `= <value>`
 
-(s/defn ^:private ^:always-validate honeysql->replacement-snippet-info :- ParamSnippetInfo
+(s/defn ^:private honeysql->replacement-snippet-info :- ParamSnippetInfo
   "Convert X to a replacement snippet info map by passing it to HoneySQL's `format` function."
   [x]
   (let [[snippet & args] (hsql/format x, :quoting ((resolve 'metabase.driver.generic-sql/quote-style) *driver*))]
     {:replacement-snippet     snippet
      :prepared-statement-args args}))
 
-(s/defn ^:private ^:always-validate field->identifier :- su/NonBlankString
+(s/defn ^:private field->identifier :- su/NonBlankString
   "Return an approprate snippet to represent this FIELD in SQL given its param type.
    For non-date Fields, this is just a quoted identifier; for dates, the SQL includes appropriately bucketing based on
    the PARAM-TYPE."
@@ -306,7 +306,7 @@
                                               identifier)))
       :replacement-snippet))
 
-(s/defn ^:private ^:always-validate combine-replacement-snippet-maps :- ParamSnippetInfo
+(s/defn ^:private combine-replacement-snippet-maps :- ParamSnippetInfo
   "Combine multiple REPLACEMENT-SNIPPET-MAPS into a single map using a SQL `AND` clause."
   [replacement-snippet-maps :- [ParamSnippetInfo]]
   {:replacement-snippet     (str \( (str/join " AND " (map :replacement-snippet replacement-snippet-maps)) \))
@@ -371,14 +371,14 @@
 ;;     :optional-snippet "AND timestamp < {{timestamp}}"      ; portion of the snippet inside [[optional]] brackets, or `nil` if the snippet isn't optional
 ;;     :variable-snippet "{{timestamp}}"}                     ; portion of the snippet referencing the variable itself, e.g. {{x}}
 
-(s/defn ^:private ^:always-validate param-snippet->param-name :- s/Keyword
+(s/defn ^:private param-snippet->param-name :- s/Keyword
   "Return the keyword name of the param being referenced inside PARAM-SNIPPET.
 
      (param-snippet->param-name \"{{x}}\") -> :x"
   [param-snippet :- su/NonBlankString]
   (keyword (second (re-find #"\{\{\s*(\w+)\s*\}\}" param-snippet))))
 
-(s/defn ^:private ^:always-validate sql->params-snippets-info :- [ParamSnippetInfo]
+(s/defn ^:private sql->params-snippets-info :- [ParamSnippetInfo]
   "Return a sequence of maps containing information about the param snippets found by paring SQL."
   [sql :- su/NonBlankString]
   (for [[param-snippet optional-replacement-snippet] (re-seq #"(?:\[\[(.+?)\]\])|(?:\{\{\s*\w+\s*\}\})" sql)]
@@ -407,7 +407,7 @@
 ;; (Basically these functions take `:param-key`, `:optional-snippet`, and `:variable-snippet` from the Query Parsing stage and the info from the other stages
 ;; to add the appropriate info for `:replacement-snippet` and `:prepared-statement-args`.)
 
-(s/defn ^:private ^:always-validate snippet-value :- ParamValue
+(s/defn ^:private snippet-value :- ParamValue
   "Fetch the value from PARAM-KEY->VALUE for SNIPPET-INFO.
    If no value is specified, return `NoValue` if the snippet is optional; otherwise throw an Exception."
   [{:keys [param-key optional-snippet]} :- ParamSnippetInfo, param-key->value :- ParamValues]
@@ -418,7 +418,7 @@
       (throw (ex-info (format "Unable to substitute '%s': param not specified.\nFound: %s" param-key (keys param-key->value))
                {:status-code 400})))))
 
-(s/defn ^:private ^:always-validate handle-optional-snippet :- ParamSnippetInfo
+(s/defn ^:private handle-optional-snippet :- ParamSnippetInfo
   "Create the approprate `:replacement-snippet` for PARAM, combining the value of REPLACEMENT-SNIPPET from the Param->SQL Substitution phase
    with the OPTIONAL-SNIPPET, if any."
   [{:keys [variable-snippet optional-snippet replacement-snippet prepared-statement-args], :as snippet-info} :- ParamSnippetInfo]
@@ -433,7 +433,7 @@
                                (apply concat (repeat occurances prepared-statement-args))
                                prepared-statement-args)))
 
-(s/defn ^:private ^:always-validate add-replacement-snippet-info :- [ParamSnippetInfo]
+(s/defn ^:private add-replacement-snippet-info :- [ParamSnippetInfo]
   "Add `:replacement-snippet` and `:prepared-statement-args` info to the maps in PARAMS-SNIPPETS-INFO by looking at
    PARAM-KEY->VALUE and using the Param->SQL substituion functions."
   [params-snippets-info :- [ParamSnippetInfo], param-key->value :- ParamValues]
@@ -450,12 +450,12 @@
 ;; These functions take the information about parameters from the Params Details List functions and then convert the
 ;; original SQL Query into a SQL query with appropriate subtitutions and a sequence of prepared statement args
 
-(s/defn ^:private ^:always-validate substitute-one
+(s/defn ^:private substitute-one
   [sql :- su/NonBlankString, {:keys [original-snippet replacement-snippet]} :- ParamSnippetInfo]
   (str/replace-first sql original-snippet replacement-snippet))
 
 
-(s/defn ^:private ^:always-validate substitute :- {:query su/NonBlankString, :params [s/Any]}
+(s/defn ^:private substitute :- {:query su/NonBlankString, :params [s/Any]}
   "Using the PARAM-SNIPPET-INFO built from the stages above, replace the snippets in SQL and return a vector of
    `[sql & prepared-statement-params]`."
   {:style/indent 1}
@@ -474,7 +474,7 @@
 ;;; |                                            PUTTING IT ALL TOGETHER                                             |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(s/defn ^:private ^:always-validate expand-query-params
+(s/defn ^:private expand-query-params
   [{sql :query, :as native}, param-key->value :- ParamValues]
   (merge native (when-let [param-snippets-info (seq (add-replacement-snippet-info (sql->params-snippets-info sql) param-key->value))]
                   (substitute sql param-snippets-info))))

--- a/src/metabase/query_processor/middleware/results_metadata.clj
+++ b/src/metabase/query_processor/middleware/results_metadata.clj
@@ -33,7 +33,7 @@
                                       "Valid array of results column metadata maps")
     "value must be an array of valid results column metadata maps."))
 
-(s/defn ^:private ^:always-validate results->column-metadata :- (s/maybe ResultsMetadata)
+(s/defn ^:private results->column-metadata :- (s/maybe ResultsMetadata)
   "Return the desired storage format for the column metadata coming back from RESULTS, or `nil` if no columns were returned."
   [results]
   ;; rarely certain queries will return columns with no names, for example `SELECT COUNT(*)` in SQL Server seems to come back with no name

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -46,7 +46,7 @@
 ;; to do that but it ended up breaking a few things that wrongly assume different clauses will always use a certain case (e.g. SQL `:template_tags`). Fixing
 ;; all of that is out-of-scope for the nested queries PR but should possibly be revisited in the future.
 
-(s/defn ^:always-validate normalize-token :- s/Keyword
+(s/defn normalize-token :- s/Keyword
   "Convert a string or keyword in various cases (`lisp-case`, `snake_case`, or `SCREAMING_SNAKE_CASE`) to a lisp-cased keyword."
   [token :- su/KeywordOrString]
   (-> (name token)

--- a/src/metabase/sync.clj
+++ b/src/metabase/sync.clj
@@ -16,7 +16,7 @@
             [schema.core :as s]
             [metabase.sync.util :as sync-util]))
 
-(s/defn ^:always-validate sync-database!
+(s/defn sync-database!
   "Perform all the different sync operations synchronously for DATABASE.
    This is considered a 'full sync' in that all the different sync operations are performed at the same time.
    Please note that this function is *not* what is called by the scheduled tasks. Those call different steps
@@ -32,7 +32,7 @@
     (field-values/update-field-values! database)))
 
 
-(s/defn ^:always-validate sync-table!
+(s/defn sync-table!
   "Perform all the different sync operations synchronously for a given TABLE."
   [table :- i/TableInstance]
   (sync-metadata/sync-table-metadata! table)

--- a/src/metabase/sync/analyze.clj
+++ b/src/metabase/sync/analyze.clj
@@ -55,7 +55,7 @@
 ;; `last_analyzed` is not `nil`.
 
 
-(s/defn ^:private ^:always-validate update-fields-last-analyzed!
+(s/defn ^:private update-fields-last-analyzed!
   "Update the `last_analyzed` date for all the recently re-fingerprinted/re-classified Fields in TABLE."
   [table :- i/TableInstance]
   ;; The WHERE portion of this query should match up with that of `classify/fields-to-classify`
@@ -65,7 +65,7 @@
     :last_analyzed (u/new-sql-timestamp)))
 
 
-(s/defn ^:always-validate analyze-table!
+(s/defn analyze-table!
   "Perform in-depth analysis for a TABLE."
   [table :- i/TableInstance]
   (table-row-count/update-row-count! table)
@@ -74,7 +74,7 @@
   (update-fields-last-analyzed! table))
 
 
-(s/defn ^:always-validate analyze-db!
+(s/defn analyze-db!
   "Perform in-depth analysis on the data for all Tables in a given DATABASE.
    This is dependent on what each database driver supports, but includes things like cardinality testing and table row
    counting. This also updates the `:last_analyzed` value for each affected Field."

--- a/src/metabase/sync/analyze/classifiers/category.clj
+++ b/src/metabase/sync/analyze/classifiers/category.clj
@@ -9,12 +9,12 @@
             [schema.core :as s]))
 
 
-(s/defn ^:private ^:always-validate cannot-be-category? :- s/Bool
+(s/defn ^:private cannot-be-category? :- s/Bool
   [base-type :- su/FieldType]
   (or (isa? base-type :type/DateTime)
       (isa? base-type :type/Collection)))
 
-(s/defn ^:always-validate infer-is-category :- (s/maybe i/FieldInstance)
+(s/defn infer-is-category :- (s/maybe i/FieldInstance)
   "Classifier that attempts to determine whether FIELD ought to be marked as a Category based on its distinct count."
   [field :- i/FieldInstance, fingerprint :- (s/maybe i/Fingerprint)]
   (when-not (:special_type field)

--- a/src/metabase/sync/analyze/classifiers/name.clj
+++ b/src/metabase/sync/analyze/classifiers/name.clj
@@ -69,7 +69,7 @@
     (assert (isa? special-type :type/*))))
 
 
-(s/defn ^:private ^:always-validate special-type-for-name-and-base-type :- (s/maybe su/FieldType)
+(s/defn ^:private special-type-for-name-and-base-type :- (s/maybe su/FieldType)
   "If `name` and `base-type` matches a known pattern, return the `special_type` we should assign to it."
   [field-name :- su/NonBlankString, base-type :- su/FieldType]
   (or (when (= "id" (str/lower-case field-name)) :type/PK)
@@ -79,7 +79,7 @@
                 special-type))
             pattern+base-types+special-type)))
 
-(s/defn ^:always-validate infer-special-type :- (s/maybe i/FieldInstance)
+(s/defn infer-special-type :- (s/maybe i/FieldInstance)
   "Classifer that infers the special type of a FIELD based on its name and base type."
   [field :- i/FieldInstance, _ :- (s/maybe i/Fingerprint)]
   (when-let [inferred-special-type (special-type-for-name-and-base-type (:name field) (:base_type field))]

--- a/src/metabase/sync/analyze/classifiers/no_preview_display.clj
+++ b/src/metabase/sync/analyze/classifiers/no_preview_display.clj
@@ -9,7 +9,7 @@
   "Fields whose values' average length is greater than this amount should be marked as `preview_display = false`."
   50)
 
-(s/defn ^:always-validate infer-no-preview-display :- (s/maybe i/FieldInstance)
+(s/defn infer-no-preview-display :- (s/maybe i/FieldInstance)
   "Classifier that determines whether FIELD should be marked 'No Preview Display'.
    If FIELD is textual and its average length is too great, mark it so it isn't displayed in the UI."
   [field :- i/FieldInstance, fingerprint :- (s/maybe i/Fingerprint)]

--- a/src/metabase/sync/analyze/classifiers/text_fingerprint.clj
+++ b/src/metabase/sync/analyze/classifiers/text_fingerprint.clj
@@ -13,7 +13,7 @@
    should be given the corresponding special type (such as `:type/Email`)."
   0.95)
 
-(s/defn ^:private ^:always-validate percent-key-below-threshold? :- s/Bool
+(s/defn ^:private percent-key-below-threshold? :- s/Bool
   "Is the value of PERCENT-KEY inside TEXT-FINGERPRINT above the `percent-valid-threshold`?"
   [text-fingerprint :- i/TextFingerprint, percent-key :- s/Keyword]
   (boolean
@@ -28,7 +28,7 @@
    :percent-url   :type/URL
    :percent-email :type/Email})
 
-(s/defn ^:private ^:always-validate infer-special-type-for-text-fingerprint :- (s/maybe su/FieldType)
+(s/defn ^:private infer-special-type-for-text-fingerprint :- (s/maybe su/FieldType)
   "Check various percentages inside the TEXT-FINGERPRINT and return the corresponding special type to mark the Field as if the percent passes the threshold."
   [text-fingerprint :- i/TextFingerprint]
   (some (fn [[percent-key special-type]]
@@ -37,7 +37,7 @@
         (seq percent-key->special-type)))
 
 
-(s/defn ^:always-validate infer-special-type :- (s/maybe i/FieldInstance)
+(s/defn infer-special-type :- (s/maybe i/FieldInstance)
   "Do classification for `:type/Text` Fields with a valid `TextFingerprint`.
    Currently this only checks the various recorded percentages, but this is subject to change in the future."
   [field :- i/FieldInstance, fingerprint :- (s/maybe i/Fingerprint)]

--- a/src/metabase/sync/analyze/classify.clj
+++ b/src/metabase/sync/analyze/classify.clj
@@ -39,7 +39,7 @@
   "Columns of Field that classifiers are allowed to set."
   #{:special_type :preview_display})
 
-(s/defn ^:private ^:always-validate save-field-updates!
+(s/defn ^:private save-field-updates!
   "Save the updates in UPDATED-FIELD."
   [original-field :- i/FieldInstance, updated-field :- i/FieldInstance]
   (let [[_ values-to-set] (data/diff original-field updated-field)]
@@ -64,7 +64,7 @@
    no-preview-display/infer-no-preview-display
    text-fingerprint/infer-special-type])
 
-(s/defn ^:private ^:always-validate run-classifiers :- i/FieldInstance
+(s/defn ^:private run-classifiers :- i/FieldInstance
   "Run all the available `classifiers` against FIELD and FINGERPRINT, and return the resulting FIELD with changes
    decided upon by the classifiers."
   [field :- i/FieldInstance, fingerprint :- (s/maybe i/Fingerprint)]
@@ -77,7 +77,7 @@
              more))))
 
 
-(s/defn ^:private ^:always-validate classify!
+(s/defn ^:private classify!
   "Run various classifiers on FIELD and its FINGERPRINT, and save any detected changes."
   ([field :- i/FieldInstance]
    (classify! field (or (:fingerprint field)
@@ -93,7 +93,7 @@
 ;;; |                                        CLASSIFYING ALL FIELDS IN A TABLE                                         |
 ;;; +------------------------------------------------------------------------------------------------------------------+
 
-(s/defn ^:private ^:always-validate fields-to-classify :- (s/maybe [i/FieldInstance])
+(s/defn ^:private fields-to-classify :- (s/maybe [i/FieldInstance])
   "Return a sequences of Fields belonging to TABLE for which we should attempt to determine special type.
    This should include Fields that have the latest fingerprint, but have not yet *completed* analysis."
   [table :- i/TableInstance]
@@ -102,7 +102,7 @@
          :fingerprint_version i/latest-fingerprint-version
          :last_analyzed       nil)))
 
-(s/defn ^:always-validate classify-fields!
+(s/defn classify-fields!
   "Run various classifiers on the appropriate FIELDS in a TABLE that have not been previously analyzed.
    These do things like inferring (and setting) the special types and preview display status for Fields
    belonging to TABLE."

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -18,7 +18,7 @@
             [schema.core :as s]
             [toucan.db :as db]))
 
-(s/defn ^:private ^:always-validate type-specific-fingerprint :- (s/maybe i/TypeSpecificFingerprint)
+(s/defn ^:private type-specific-fingerprint :- (s/maybe i/TypeSpecificFingerprint)
   "Return type-specific fingerprint info for FIELD AND. a FieldSample of Values if it has an elligible base type"
   [field :- i/FieldInstance, values :- i/FieldSample]
   (condp #(isa? %2 %1) (:base_type field)
@@ -26,7 +26,7 @@
     :type/Number {:type/Number (number/number-fingerprint values)}
     nil))
 
-(s/defn ^:private ^:always-validate fingerprint :- i/Fingerprint
+(s/defn ^:private fingerprint :- i/Fingerprint
   "Generate a 'fingerprint' from a FieldSample of VALUES."
   [field :- i/FieldInstance, values :- i/FieldSample]
   (merge
@@ -36,7 +36,7 @@
      {:type type-specific-fingerprint})))
 
 
-(s/defn ^:private ^:always-validate save-fingerprint!
+(s/defn ^:private save-fingerprint!
   [field :- i/FieldInstance, fingerprint :- i/Fingerprint]
   ;; don't bother saving fingerprint if it's completely empty
   (when (seq fingerprint)
@@ -49,7 +49,7 @@
       :fingerprint_version i/latest-fingerprint-version
       :last_analyzed       nil)))
 
-(s/defn ^:private ^:always-validate fingerprint-table!
+(s/defn ^:private fingerprint-table!
   [table :- i/TableInstance, fields :- [i/FieldInstance]]
   (doseq [[field sample] (sample/sample-fields table fields)]
     (when sample
@@ -78,7 +78,7 @@
 ;;        (fingerprint_version < 2 AND
 ;;         base_type IN ("type/Text", "type/SerializedJSON")))
 
-(s/defn ^:private ^:always-validate base-types->descendants :- #{su/FieldTypeKeywordOrString}
+(s/defn ^:private base-types->descendants :- #{su/FieldTypeKeywordOrString}
   "Given a set of BASE-TYPES return an expanded set that includes those base types as well as all of their
    descendants. These types are converted to strings so HoneySQL doesn't confuse them for columns."
   [base-types :- #{su/FieldType}]
@@ -107,7 +107,7 @@
 ;;
 ;; This way we can also completely omit adding clauses for versions that have been "eclipsed" by others.
 ;; This would keep the SQL query from growing boundlessly as new fingerprint versions are added
-(s/defn ^:private ^:always-validate versions-clauses :- [s/Any]
+(s/defn ^:private versions-clauses :- [s/Any]
   []
   ;; keep track of all the base types (including descendants) for each version, starting from most recent
   (let [versions+base-types (reverse (sort-by first (seq i/fingerprint-version->types-that-should-be-re-fingerprinted)))
@@ -124,7 +124,7 @@
          [:< :fingerprint_version version]
          [:in :base_type not-yet-seen]]))))
 
-(s/defn ^:private ^:always-validate honeysql-for-fields-that-need-fingerprint-updating :- {:where s/Any}
+(s/defn ^:private honeysql-for-fields-that-need-fingerprint-updating :- {:where s/Any}
   "Return appropriate WHERE clause for all the Fields whose Fingerprint needs to be re-calculated."
   ([]
    {:where [:and
@@ -141,7 +141,7 @@
 ;;; |                                      FINGERPRINTING ALL FIELDS IN A TABLE                                      |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(s/defn ^:private ^:always-validate fields-to-fingerprint :- (s/maybe [i/FieldInstance])
+(s/defn ^:private fields-to-fingerprint :- (s/maybe [i/FieldInstance])
   "Return a sequences of Fields belonging to TABLE for which we should generate (and save) fingerprints.
    This should include NEW fields that are active and visibile."
   [table :- i/TableInstance]
@@ -149,7 +149,7 @@
          (honeysql-for-fields-that-need-fingerprint-updating table))))
 
 ;; TODO - `fingerprint-fields!` and `fingerprint-table!` should probably have their names switched
-(s/defn ^:always-validate fingerprint-fields!
+(s/defn fingerprint-fields!
   "Generate and save fingerprints for all the Fields in TABLE that have not been previously analyzed."
   [table :- i/TableInstance]
   (when-let [fields (fields-to-fingerprint table)]

--- a/src/metabase/sync/analyze/fingerprint/global.clj
+++ b/src/metabase/sync/analyze/fingerprint/global.clj
@@ -3,7 +3,7 @@
   (:require [metabase.sync.interface :as i]
             [schema.core :as s]))
 
-(s/defn ^:always-validate global-fingerprint :- i/GlobalFingerprint
+(s/defn global-fingerprint :- i/GlobalFingerprint
   "Generate a fingerprint of global information for Fields of all types."
   [values :- i/FieldSample]
   ;; TODO - this logic isn't as nice as the old logic that actually called the DB

--- a/src/metabase/sync/analyze/fingerprint/number.clj
+++ b/src/metabase/sync/analyze/fingerprint/number.clj
@@ -4,7 +4,7 @@
             [metabase.sync.interface :as i]
             [schema.core :as s]))
 
-(s/defn ^:always-validate number-fingerprint :- i/NumberFingerprint
+(s/defn number-fingerprint :- i/NumberFingerprint
   "Generate a fingerprint containing information about values that belong to a `:type/Number` Field."
   [values :- i/FieldSample]
   {:min (apply min values)

--- a/src/metabase/sync/analyze/fingerprint/sample.clj
+++ b/src/metabase/sync/analyze/fingerprint/sample.clj
@@ -9,13 +9,13 @@
             [metabase.sync.interface :as i]
             [schema.core :as s]))
 
-(s/defn ^:private ^:always-validate basic-sample :- (s/maybe i/TableSample)
+(s/defn ^:private basic-sample :- (s/maybe i/TableSample)
   "Procure a sequence of table rows, up to `max-sample-rows` (10,000 at the time of this writing), for
    use in the fingerprinting sub-stage of analysis. Returns `nil` if no rows are available."
   [table :- i/TableInstance, fields :- [i/FieldInstance]]
   (seq (driver/table-rows-sample table fields)))
 
-(s/defn ^:private ^:always-validate table-sample->field-sample :- (s/maybe i/FieldSample)
+(s/defn ^:private table-sample->field-sample :- (s/maybe i/FieldSample)
   "Fetch a sample for the Field whose values are at INDEX in the TABLE-SAMPLE.
    Filters out `nil` values; returns `nil` if a non-empty sample cannot be obtained."
   [table-sample :- i/TableSample, i :- s/Int]
@@ -24,7 +24,7 @@
        (filter (complement nil?))
        seq))
 
-(s/defn ^:always-validate sample-fields :- [(s/pair i/FieldInstance "Field", (s/maybe i/FieldSample) "FieldSample")]
+(s/defn sample-fields :- [(s/pair i/FieldInstance "Field", (s/maybe i/FieldSample) "FieldSample")]
   "Fetch samples for a series of FIELDS. Returns tuples of Field and sample.
    This may return `nil` if the sample could not be fetched for some other reason."
   [table :- i/TableInstance, fields :- [i/FieldInstance]]

--- a/src/metabase/sync/analyze/fingerprint/text.clj
+++ b/src/metabase/sync/analyze/fingerprint/text.clj
@@ -5,7 +5,7 @@
             [metabase.util :as u]
             [schema.core :as s]))
 
-(s/defn ^:private ^:always-validate average-length :- (s/constrained Double #(>= % 0))
+(s/defn ^:private average-length :- (s/constrained Double #(>= % 0))
   "Return the average length of VALUES."
   [values :- i/FieldSample]
   (let [total-length (reduce + (for [value values]
@@ -13,7 +13,7 @@
     (/ (double total-length)
        (double (count values)))))
 
-(s/defn ^:private ^:always-validate percent-satisfying-predicate :- i/Percent
+(s/defn ^:private percent-satisfying-predicate :- i/Percent
   "Return the percentage of VALUES that satisfy PRED."
   [pred :- (s/pred fn?), values :- i/FieldSample]
   (let [total-count    (count values)
@@ -30,7 +30,7 @@
      (or (map? parsed-json)
          (sequential? parsed-json)))))
 
-(s/defn ^:always-validate text-fingerprint :- i/TextFingerprint
+(s/defn text-fingerprint :- i/TextFingerprint
   "Generate a fingerprint containing information about values that belong to a `:type/Text` Field."
   [values :- i/FieldSample]
   {:percent-json   (percent-satisfying-predicate valid-serialized-json? values)

--- a/src/metabase/sync/analyze/table_row_count.clj
+++ b/src/metabase/sync/analyze/table_row_count.clj
@@ -10,13 +10,13 @@
             [schema.core :as s]
             [toucan.db :as db]))
 
-(s/defn ^:private ^:always-validate table-row-count :- (s/maybe s/Int)
+(s/defn ^:private table-row-count :- (s/maybe s/Int)
   "Determine the count of rows in TABLE by running a simple structured MBQL query."
   [table :- i/TableInstance]
   (sync-util/with-error-handling (format "Unable to determine row count for %s" (sync-util/name-for-logging table))
     (queries/table-row-count table)))
 
-(s/defn ^:always-validate update-row-count!
+(s/defn update-row-count!
   "Update the cached row count (`rows`) for a single TABLE."
   [table :- i/TableInstance]
   (sync-util/with-error-handling (format "Error setting table row count for %s" (sync-util/name-for-logging table))

--- a/src/metabase/sync/fetch_metadata.clj
+++ b/src/metabase/sync/fetch_metadata.clj
@@ -7,24 +7,24 @@
             [schema.core :as s])
   (:import [org.joda.time DateTime]))
 
-(s/defn ^:always-validate db-metadata :- i/DatabaseMetadata
+(s/defn db-metadata :- i/DatabaseMetadata
   "Get basic Metadata about a DATABASE and its Tables. Doesn't include information about the Fields."
   [database :- i/DatabaseInstance]
   (driver/describe-database (driver/->driver database) database))
 
-(s/defn ^:always-validate table-metadata :- i/TableMetadata
+(s/defn table-metadata :- i/TableMetadata
   "Get more detailed information about a TABLE belonging to DATABASE. Includes information about the Fields."
   [database :- i/DatabaseInstance, table :- i/TableInstance]
   (driver/describe-table (driver/->driver database) database table))
 
-(s/defn ^:always-validate fk-metadata :- i/FKMetadata
+(s/defn fk-metadata :- i/FKMetadata
   "Get information about the foreign keys belonging to TABLE."
   [database :- i/DatabaseInstance, table :- i/TableInstance]
   (let [driver (driver/->driver database)]
     (when (driver/driver-supports? driver :foreign-keys)
       (driver/describe-table-fks driver database table))))
 
-(s/defn ^:always-validate db-timezone :- i/TimeZoneId
+(s/defn db-timezone :- i/TimeZoneId
   [database :- i/DatabaseInstance]
   (let [db-time  ^DateTime (driver/current-db-time (driver/->driver database) database)]
     (-> db-time .getChronology .getZone .getID)))

--- a/src/metabase/sync/field_values.clj
+++ b/src/metabase/sync/field_values.clj
@@ -11,19 +11,19 @@
             [schema.core :as s]
             [toucan.db :as db]))
 
-(s/defn ^:private ^:always-validate clear-field-values-for-field! [field :- i/FieldInstance]
+(s/defn ^:private clear-field-values-for-field! [field :- i/FieldInstance]
   (when (db/exists? FieldValues :field_id (u/get-id field))
     (log/debug (format "Based on type info, %s should no longer have field values.\n" (sync-util/name-for-logging field))
                (format "(base type: %s, special type: %s, visibility type: %s)\n" (:base_type field) (:special_type field) (:visibility_type field))
                "Deleting FieldValues...")
     (db/delete! FieldValues :field_id (u/get-id field))))
 
-(s/defn ^:private ^:always-validate update-field-values-for-field! [field :- i/FieldInstance]
+(s/defn ^:private update-field-values-for-field! [field :- i/FieldInstance]
   (log/debug (u/format-color 'green "Looking into updating FieldValues for %s" (sync-util/name-for-logging field)))
   (field-values/create-or-update-field-values! field))
 
 
-(s/defn ^:always-validate update-field-values-for-table!
+(s/defn update-field-values-for-table!
   "Update the cached FieldValues for all Fields (as needed) for TABLE."
   [table :- i/TableInstance]
   (doseq [field (db/select Field :table_id (u/get-id table), :active true, :visibility_type "normal")]
@@ -33,7 +33,7 @@
         (clear-field-values-for-field! field)))))
 
 
-(s/defn ^:always-validate update-field-values!
+(s/defn update-field-values!
   "Update the cached FieldValues (distinct values for categories and certain other fields that are shown
    in widgets like filters) for the Tables in DATABASE (as needed)."
   [database :- i/DatabaseInstance]

--- a/src/metabase/sync/sync_metadata.clj
+++ b/src/metabase/sync/sync_metadata.clj
@@ -17,7 +17,7 @@
              [tables :as sync-tables]]
             [schema.core :as s]))
 
-(s/defn ^:always-validate sync-db-metadata!
+(s/defn sync-db-metadata!
   "Sync the metadata for a Metabase DATABASE. This makes sure child Table & Field objects are synchronized."
   [database :- i/DatabaseInstance]
   (sync-util/sync-operation :sync-metadata database (format "Sync metadata for %s" (sync-util/name-for-logging database))

--- a/src/metabase/sync/sync_metadata/fks.clj
+++ b/src/metabase/sync/sync_metadata/fks.clj
@@ -19,7 +19,7 @@
    :dest-table   i/TableInstance
    :dest-field   i/FieldInstance})
 
-(s/defn ^:private ^:always-validate fetch-fk-relationship-objects :- (s/maybe FKRelationshipObjects)
+(s/defn ^:private fetch-fk-relationship-objects :- (s/maybe FKRelationshipObjects)
   "Fetch the Metabase objects (Tables and Fields) that are relevant to a foreign key relationship described by FK."
   [database :- i/DatabaseInstance, table :- i/TableInstance, fk :- i/FKMetadataEntry]
   (when-let [source-field (db/select-one Field
@@ -45,7 +45,7 @@
          :dest-field   dest-field}))))
 
 
-(s/defn ^:private ^:always-validate mark-fk!
+(s/defn ^:private mark-fk!
   [database :- i/DatabaseInstance, table :- i/TableInstance, fk :- i/FKMetadataEntry]
   (when-let [{:keys [source-field dest-table dest-field]} (fetch-fk-relationship-objects database table fk)]
     (log/info (u/format-color 'cyan "Marking foreign key from %s %s -> %s %s"
@@ -58,7 +58,7 @@
       :fk_target_field_id (u/get-id dest-field))))
 
 
-(s/defn ^:always-validate sync-fks-for-table!
+(s/defn sync-fks-for-table!
   "Sync the foreign keys for a specific TABLE."
   ([table :- i/TableInstance]
    (sync-fks-for-table! (table/database table) table))
@@ -67,7 +67,7 @@
      (doseq [fk (fetch-metadata/fk-metadata database table)]
        (mark-fk! database table fk)))))
 
-(s/defn ^:always-validate sync-fks!
+(s/defn sync-fks!
   "Sync the foreign keys in a DATABASE. This sets appropriate values for relevant Fields in the Metabase application DB
    based on values from the `FKMetadata` returned by `describe-table-fks`."
   [database :- i/DatabaseInstance]

--- a/src/metabase/sync/sync_metadata/metabase_metadata.clj
+++ b/src/metabase/sync/sync_metadata/metabase_metadata.clj
@@ -28,7 +28,7 @@
    :field-name (s/maybe su/NonBlankString)
    :k          s/Keyword})
 
-(s/defn ^:private ^:always-validate parse-keypath :- KeypathComponents
+(s/defn ^:private parse-keypath :- KeypathComponents
   "Parse a KEYPATH into components for easy use."
   ;; TODO: this does not support schemas in dbs :(
   [keypath :- su/NonBlankString]
@@ -40,7 +40,7 @@
      :field-name (when third-part second-part)
      :k          (keyword (or third-part second-part))}))
 
-(s/defn ^:private ^:always-validate set-property! :- s/Bool
+(s/defn ^:private set-property! :- s/Bool
   "Set a property for a Field or Table in DATABASE. Returns `true` if a property was successfully set."
   [database :- i/DatabaseInstance, {:keys [table-name field-name k]} :- KeypathComponents, value]
   (boolean
@@ -58,7 +58,7 @@
          (db/update! Table table-id
            k value))))))
 
-(s/defn ^:private ^:always-validate sync-metabase-metadata-table!
+(s/defn ^:private sync-metabase-metadata-table!
   "Databases may include a table named `_metabase_metadata` (case-insentive) which includes descriptions or other metadata about the `Tables` and `Fields`
    it contains. This table is *not* synced normally, i.e. a Metabase `Table` is not created for it. Instead, *this* function is called, which reads the data it
    contains and updates the relevant Metabase objects.
@@ -80,12 +80,12 @@
           (log/error (u/format-color 'red "Error syncing _metabase_metadata: no matching keypath: %s" keypath))))))
 
 
-(s/defn ^:always-validate is-metabase-metadata-table? :- s/Bool
+(s/defn is-metabase-metadata-table? :- s/Bool
   "Is this TABLE the special `_metabase_metadata` table?"
   [table :- i/DatabaseMetadataTable]
   (= "_metabase_metadata" (str/lower-case (:name table))))
 
-(s/defn ^:always-validate sync-metabase-metadata!
+(s/defn sync-metabase-metadata!
   "Sync the `_metabase_metadata` table, a special table with Metabase metadata, if present.
    This table contains information about type information, descriptions, and other properties that
    should be set for Metabase objects like Tables and Fields."

--- a/src/metabase/sync/sync_metadata/tables.clj
+++ b/src/metabase/sync/sync_metadata/tables.clj
@@ -72,7 +72,7 @@
     ;; Lobos
     #"^lobos_migrations$"})
 
-(s/defn ^:private ^:always-validate is-crufty-table? :- s/Bool
+(s/defn ^:private is-crufty-table? :- s/Bool
   "Should we give newly created TABLE a `visibility_type` of `:cruft`?"
   [table :- i/DatabaseMetadataTable]
   (boolean (some #(re-find % (str/lower-case (:name table))) crufty-table-patterns)))
@@ -82,7 +82,7 @@
 
 ;; TODO - should we make this logic case-insensitive like it is for fields?
 
-(s/defn ^:private ^:always-validate create-or-reactivate-tables!
+(s/defn ^:private create-or-reactivate-tables!
   "Create NEW-TABLES for database, or if they already exist, mark them as active."
   [database :- i/DatabaseInstance, new-tables :- #{i/DatabaseMetadataTable}]
   (log/info "Found new tables:"
@@ -108,7 +108,7 @@
                            :cruft)))))
 
 
-(s/defn ^:private ^:always-validate retire-tables!
+(s/defn ^:private retire-tables!
   "Mark any OLD-TABLES belonging to DATABASE as inactive."
   [database :- i/DatabaseInstance, old-tables :- #{i/DatabaseMetadataTable}]
   (log/info "Marking tables as inactive:"
@@ -121,14 +121,14 @@
       :active false)))
 
 
-(s/defn ^:private ^:always-validate db-metadata :- #{i/DatabaseMetadataTable}
+(s/defn ^:private db-metadata :- #{i/DatabaseMetadataTable}
   "Return information about DATABASE by calling its driver's implementation of `describe-database`."
   [database :- i/DatabaseInstance]
   (set (for [table (:tables (fetch-metadata/db-metadata database))
              :when (not (metabase-metadata/is-metabase-metadata-table? table))]
          table)))
 
-(s/defn ^:private ^:always-validate our-metadata :- #{i/DatabaseMetadataTable}
+(s/defn ^:private our-metadata :- #{i/DatabaseMetadataTable}
   "Return information about what Tables we have for this DB in the Metabase application DB."
   [database :- i/DatabaseInstance]
   (set (map (partial into {})
@@ -136,7 +136,7 @@
               :db_id  (u/get-id database)
               :active true))))
 
-(s/defn ^:always-validate sync-tables!
+(s/defn sync-tables!
   "Sync the Tables recorded in the Metabase application database with the ones obtained by calling DATABASE's driver's implementation of `describe-database`."
   [database :- i/DatabaseInstance]
   ;; determine what's changed between what info we have and what's in the DB

--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -72,13 +72,13 @@
 ;;; |                                               SCHEDULING/DELETING TASKS                                                |
 ;;; +------------------------------------------------------------------------------------------------------------------------+
 
-(s/defn ^:always-validate schedule-task!
+(s/defn schedule-task!
   "Add a given job and trigger to our scheduler."
   [job :- JobDetail, trigger :- Trigger]
   (when-let [scheduler (scheduler)]
     (qs/schedule scheduler job trigger)))
 
-(s/defn ^:always-validate delete-task!
+(s/defn delete-task!
   "delete a task from the scheduler"
   [job-key :- JobKey, trigger-key :- TriggerKey]
   (when-let [scheduler (scheduler)]

--- a/src/metabase/task/sync_databases.clj
+++ b/src/metabase/task/sync_databases.clj
@@ -24,7 +24,7 @@
 ;;; |                                                       JOB LOGIC                                                        |
 ;;; +------------------------------------------------------------------------------------------------------------------------+
 
-(s/defn ^:private ^:always-validate job-context->database :- DatabaseInstance
+(s/defn ^:private job-context->database :- DatabaseInstance
   "Get the Database referred to in JOB-CONTEXT. Guaranteed to return a valid Database."
   [job-context]
   (Database (u/get-id (get (qc/from-job-data job-context) "db-id"))))
@@ -67,27 +67,27 @@
 
 ;; These getter functions are not strictly neccesary but are provided primarily so we can get some extra validation by using them
 
-(s/defn ^:private ^:always-validate job-key :- JobKey
+(s/defn ^:private job-key :- JobKey
   "Return an appropriate string key for the job described by TASK-INFO for DATABASE-OR-ID."
   [database :- DatabaseInstance, task-info :- TaskInfo]
   (jobs/key (format "metabase.task.%s.job.%d" (name (:key task-info)) (u/get-id database))))
 
-(s/defn ^:private ^:always-validate trigger-key :- TriggerKey
+(s/defn ^:private trigger-key :- TriggerKey
   "Return an appropriate string key for the trigger for TASK-INFO and DATABASE-OR-ID."
   [database :- DatabaseInstance, task-info :- TaskInfo]
   (triggers/key (format "metabase.task.%s.trigger.%d" (name (:key task-info)) (u/get-id database))))
 
-(s/defn ^:private ^:always-validate cron-schedule :- cron-util/CronScheduleString
+(s/defn ^:private cron-schedule :- cron-util/CronScheduleString
   "Fetch the appropriate cron schedule string for DATABASE and TASK-INFO."
   [database :- DatabaseInstance, task-info :- TaskInfo]
   (get database (:db-schedule-column task-info)))
 
-(s/defn ^:private ^:always-validate job-class :- Class
+(s/defn ^:private job-class :- Class
   "Get the Job class for TASK-INFO."
   [task-info :- TaskInfo]
   (:job-class task-info))
 
-(s/defn ^:private ^:always-validate description :- s/Str
+(s/defn ^:private description :- s/Str
   "Return an appropriate description string for a job/trigger for Database described by TASK-INFO."
   [database :- DatabaseInstance, task-info :- TaskInfo]
   (format "%s Database %d" (name (:key task-info)) (u/get-id database)))
@@ -97,7 +97,7 @@
 ;;; |                                                DELETING TASKS FOR A DB                                                 |
 ;;; +------------------------------------------------------------------------------------------------------------------------+
 
-(s/defn ^:private ^:always-validate delete-task!
+(s/defn ^:private delete-task!
   "Cancel a single sync job for DATABASE-OR-ID and TASK-INFO."
   [database :- DatabaseInstance, task-info :- TaskInfo]
   (let [job-key     (job-key database task-info)
@@ -105,7 +105,7 @@
     (log/debug (u/format-color 'red "Unscheduling task for Database %d: job: %s; trigger: %s" (u/get-id database) (.getName job-key) (.getName trigger-key)))
     (task/delete-task! job-key trigger-key)))
 
-(s/defn ^:always-validate unschedule-tasks-for-db!
+(s/defn unschedule-tasks-for-db!
   "Cancel *all* scheduled sync and FieldValues caching tassks for DATABASE-OR-ID."
   [database :- DatabaseInstance]
   (doseq [task-info task-infos]
@@ -116,7 +116,7 @@
 ;;; |                                             (RE)SCHEDULING TASKS FOR A DB                                              |
 ;;; +------------------------------------------------------------------------------------------------------------------------+
 
-(s/defn ^:private ^:always-validate job :- JobDetail
+(s/defn ^:private job :- JobDetail
   "Build a Quartz Job for DATABASE and TASK-INFO."
   [database :- DatabaseInstance, task-info :- TaskInfo]
   (jobs/build
@@ -125,7 +125,7 @@
    (jobs/using-job-data {"db-id" (u/get-id database)})
    (jobs/with-identity (job-key database task-info))))
 
-(s/defn ^:private ^:always-validate trigger :- CronTrigger
+(s/defn ^:private trigger :- CronTrigger
   "Build a Quartz Trigger for DATABASE and TASK-INFO."
   [database :- DatabaseInstance, task-info :- TaskInfo]
   (triggers/build
@@ -139,7 +139,7 @@
       (cron/with-misfire-handling-instruction-do-nothing)))))
 
 
-(s/defn ^:private ^:always-validate schedule-task-for-db!
+(s/defn ^:private schedule-task-for-db!
   "Schedule a new Quartz job for DATABASE and TASK-INFO."
   [database :- DatabaseInstance, task-info :- TaskInfo]
   (let [job     (job database task-info)
@@ -148,7 +148,7 @@
     (task/schedule-task! job trigger)))
 
 
-(s/defn ^:always-validate schedule-tasks-for-db!
+(s/defn schedule-tasks-for-db!
   "Schedule all the different sync jobs we have for DATABASE.
    Unschedules any existing jobs."
   [database :- DatabaseInstance]

--- a/src/metabase/util/cron.clj
+++ b/src/metabase/util/cron.clj
@@ -42,7 +42,7 @@
 ;;; |                                          SCHEDULE MAP -> CRON STRING                                           |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(s/defn ^:private ^:always-validate cron-string :- CronScheduleString
+(s/defn ^:private cron-string :- CronScheduleString
   "Build a cron string from key-value pair parts."
   {:style/indent 0}
   [{:keys [seconds minutes hours day-of-month month day-of-week year]}]
@@ -77,7 +77,7 @@
                       "mid"   "15"
                       "last"  "L"))))
 
-(s/defn ^:always-validate ^{:style/indent 0} schedule-map->cron-string :- CronScheduleString
+(s/defn ^{:style/indent 0} schedule-map->cron-string :- CronScheduleString
   "Convert the frontend schedule map into a cron string."
   [{day-of-week :schedule_day, frame :schedule_frame, hour :schedule_hour, schedule-type :schedule_type} :- ScheduleMap]
   (cron-string (case (keyword schedule-type)
@@ -132,7 +132,7 @@
     :else                                         "hourly"))
 
 
-(s/defn ^:always-validate ^{:style/indent 0} cron-string->schedule-map :- ScheduleMap
+(s/defn ^{:style/indent 0} cron-string->schedule-map :- ScheduleMap
   "Convert a normal CRON-STRING into the expanded ScheduleMap format used by the frontend."
   [cron-string :- CronScheduleString]
   (let [[_ _ hours day-of-month _ day-of-week _] (str/split cron-string #"\s+")]

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -99,7 +99,7 @@
   `(ql/query (ql/source-table (id ~(keyword table)))
              ~@(map (partial $->id (keyword table)) forms)))
 
-(s/defn ^:always-validate wrap-inner-query
+(s/defn wrap-inner-query
   "Wrap inner QUERY with `:database` ID and other 'outer query' kvs. DB ID is fetched by looking up the Database for the query's `:source-table`."
   {:style/indent 0}
   [query :- qi/Query]
@@ -107,7 +107,7 @@
    :type     :query
    :query    query})
 
-(s/defn ^:always-validate run-query*
+(s/defn run-query*
   "Call `driver/process-query` on expanded inner QUERY, looking up the `Database` ID for the `source-table.`
 
      (run-query* (query (source-table 5) ...))"


### PR DESCRIPTION
This was just the following one-liner

```
find . -name '*.clj' -type f -exec perl -p -i -e 's/\^:always-validate\s//g' {} \;
```