### PR TITLE
Async test fix race condition, part III

### DIFF
--- a/src/metabase/feature_extraction/async.clj
+++ b/src/metabase/feature_extraction/async.clj
@@ -73,8 +73,8 @@
    Uses the same logic as `metabase.api.card`."
   [{:keys [created_at ended_at]}]
   (let [duration (time-delta-seconds created_at ended_at)
-        ttl     (* duration (public-settings/query-caching-ttl-ratio))
-        age     (time-delta-seconds ended_at (java.util.Date.))]
+        ttl      (* duration (public-settings/query-caching-ttl-ratio))
+        age      (time-delta-seconds ended_at (java.util.Date.))]
     (<= age ttl)))
 
 (defn- cached-job
@@ -82,8 +82,7 @@
   (when (public-settings/enable-query-caching)
     (let [job (db/select-one ComputationJob
                 :context (json/encode ctx)
-                :status  [:not= "error"]
-                {:order-by [[:ended_at :desc]]})]
+                :status  [:not= "error"])]
       (when (some-> job fresh?)
         job))))
 

--- a/src/metabase/feature_extraction/async.clj
+++ b/src/metabase/feature_extraction/async.clj
@@ -23,8 +23,19 @@
   "Has the computation job been canceled?"
   (comp some? #{:canceled} :status))
 
+(defn result
+  "Get result of an asynchronous computation job."
+  [job]
+  (if (done? job)
+    (if-let [result (db/select-one ComputationJobResult :job_id (:id job))]
+      {:status     (:status job)
+       :result     (:payload result)
+       :created-at (:created_at result)}
+      {:status :result-not-available})
+    {:status (:status job)}))
+
 (defn- save-result
-  [{:keys [id]} payload]
+  [{:keys [id] :as job} payload callback]
   (when-not (future-cancelled? (@running-jobs id))
     (db/transaction
       (db/insert! ComputationJobResult
@@ -33,13 +44,15 @@
         :payload    payload)
       (db/update! ComputationJob id
         :status   :done
-        :ended_at (u/new-sql-timestamp))))
+        :ended_at (u/new-sql-timestamp)))
+    (when callback
+      (callback job payload)))
   (swap! running-jobs dissoc id)
   (log/info (format "Async job %s done." id))
   payload)
 
 (defn- save-error
-  [{:keys [id]} error]
+  [{:keys [id] :as job} error callback]
   (let [error (Throwable->map error)]
     (when-not (future-cancelled? (@running-jobs id))
       (log/warn (format "Async job %s encountered an error:\n%s." id error))
@@ -50,7 +63,9 @@
           :payload    error)
         (db/update! ComputationJob id
           :status :error
-          :ended_at (u/new-sql-timestamp))))
+          :ended_at (u/new-sql-timestamp)))
+      (when callback
+        (callback job error)))
     (swap! running-jobs dissoc id)
     error))
 
@@ -88,12 +103,16 @@
 
 (defn compute
   "Compute closure `f` in context `ctx` asynchronously. Returns id of the
-   associated computation job.
+   associated computation job. Optionally takes a callback function `callback`
+   that will be called on compleation with 2 arguments: the ComputationJob object
+   and the result.
 
    Will return cached result if query caching is enabled and a job with identical
    context has successfully run within TTL."
-  [ctx f]
-  (or (-> ctx cached-job :id)
+  [ctx f & [callback]]
+  (or (when-let [job (cached-job ctx)]
+        (callback job (:result (result job)))
+        (:id job))
       (let [{:keys [id] :as job} (db/insert! ComputationJob
                                    :creator_id api/*current-user-id*
                                    :status     :running
@@ -102,9 +121,9 @@
         (log/info (format "Async job %s started." id))
         (swap! running-jobs assoc id (future
                                        (try
-                                         (save-result job (f))
+                                         (save-result job (f) callback)
                                          (catch Throwable e
-                                           (save-error job e)))))
+                                           (save-error job e callback)))))
         id)))
 
 (defmacro with-async
@@ -120,17 +139,6 @@
                  :bindings (quote ~bindings)
                  :closure  (zipmap (quote ~binding-vars) ~binding-vars)}
                 (fn [] ~@body)))))
-
-(defn result
-  "Get result of an asynchronous computation job."
-  [job]
-  (if (done? job)
-    (if-let [result (db/select-one ComputationJobResult :job_id (:id job))]
-      {:status     (:status job)
-       :result     (:payload result)
-       :created-at (:created_at result)}
-      {:status :result-not-available})
-    {:status (:status job)}))
 
 (defn running-jobs-user
   "Get all running jobs for a given user."

--- a/test/metabase/test/async.clj
+++ b/test/metabase/test/async.clj
@@ -32,5 +32,10 @@
 (defn result!
   "Blocking version of async/result."
   [job-id]
-  (while-with-timeout (not (@job-done? job-id)))
+  (while-with-timeout (or (not (@job-done? job-id))
+                          (-> job-id
+                              ComputationJob
+                              async/result
+                              (find :result)
+                              nil?)))
   (async/result (ComputationJob job-id)))

--- a/test/metabase/test/async.clj
+++ b/test/metabase/test/async.clj
@@ -27,7 +27,8 @@
               deref                  ; var
               deref                  ; atom
               (get job-id))]
-    (if (and f (not (future-cancelled? f)))
+    (if (and f (not (or (future-cancelled? f)
+                        (future-done? f))))
       {:result     @f
        :status     (-> job-id ComputationJob :status)
        :created-at (u/new-sql-timestamp)}


### PR DESCRIPTION
Reduced the number of MB DB reads as that seem to cause issues for very short-lived jobs without the benefit of a TCP/IP roundtrip. 
