### PR TITLE
Change the metabase.middleware default log level to DEBUG

### DIFF
--- a/resources/log4j.properties
+++ b/resources/log4j.properties
@@ -18,7 +18,7 @@ log4j.appender.metabase=metabase.logger.Appender
 
 # customizations to logging by package
 log4j.logger.metabase.driver=INFO
-log4j.logger.metabase.middleware=INFO
+log4j.logger.metabase.middleware=DEBUG
 log4j.logger.metabase.models.permissions=INFO
 log4j.logger.metabase.query-processor.permissions=INFO
 log4j.logger.metabase.query-processor=INFO


### PR DESCRIPTION
This will include API call timings by default.