### PR TITLE
Fix async-test transient failures

### DIFF
--- a/test/metabase/feature_extraction/async_test.clj
+++ b/test/metabase/feature_extraction/async_test.clj
@@ -5,7 +5,7 @@
             [metabase.test.async :refer :all]))
 
 ;; DISABLED due to constant failures 12/6/17. Fix soon!
-#_(expect
+(expect
     true
     (let [job-id (compute (gensym) (constantly 42))]
       (result! job-id)
@@ -27,7 +27,7 @@
       :result))
 
 ;; DISABLED due to constant failures 12/6/17. Fix soon!
-#_(expect
+(expect
   "foo"
   (-> (compute (gensym) #(throw (Throwable. "foo")))
       result!


### PR DESCRIPTION
Depending on the order in which the threads were running, we were
looking for the job in the running-jobs atom BEFORE we put the data in
the atom. If that happens, we might not ever update the job with the
correct status, it's also possible that we'll never remove the job
from the running-jobs atom, just depending on unlucky we are with the
ordering of the threads.

This commit introduces coordination between the code adding the new
data to the running-jobs atom and the work done by the job.
