### PR TITLE
 Remove HTTP connection closing tests 

### DIFF
--- a/test/metabase/middleware_test.clj
+++ b/test/metabase/middleware_test.clj
@@ -245,38 +245,3 @@
     (catch java.io.IOException e
       (.getMessage e))))
 )
-;; test that handler is killed when connection closes
-;; Note: this closing over state is a dirty hack and the whole test should be
-;; rewritten.
-
-(defn- test-slow-handler [state]
-  (fn [_]
-    (log/debug (u/format-color 'yellow "starting test-slow-handler"))
-    (reset! state :test-started)
-    (Thread/sleep 7000)  ;; this is somewhat long to make sure the keepalive polling has time to kill it.
-    (reset! state :ran-to-compleation)
-    (log/debug (u/format-color 'yellow "finished test-slow-handler"))
-    (resp/response {:success true})))
-
-(defn- start-and-maybe-kill-test-request [state kill?]
-  (reset! state :initial-state)
-  (let [path "test-slow-handler"]
-    (with-redefs [metabase.routes/routes (compojure.core/routes
-                                          (GET (str "/" path) [] (middleware/streaming-json-response
-                                                                  (test-slow-handler state))))]
-      (let  [reader (io/input-stream (str "http://localhost:" (config/config-int :mb-jetty-port) "/" path))]
-        (while-with-timeout (= :initial-state @state))
-        (when kill?
-          (.close reader))
-        (Thread/sleep 10000)))) ;; this is long enough to ensure that the handler has run to completion if it was not killed.
-  @state)
-
-;; In this first test we will close the connection before the test handler gets to change the state
-(expect
-  :test-started
-  (start-and-maybe-kill-test-request (atom :unset) true))
-
-;; and to make sure this test actually works, run the same test again and let it change the state.
-(expect
-  :ran-to-compleation
-  (start-and-maybe-kill-test-request (atom :unset) false))


### PR DESCRIPTION
These tests essentially cover Jetty's ability to notice a connection
has been closed and reap that connection by interrupting the thread
that our handler is running on. We don't set anything changing this
default behavior, we don't handle the InterruptedException. That
exception just gets bubbled up, and handled by Jetty.