### PR TITLE
Use JodaTime to parse datetime strings

### DIFF
--- a/bin/docker/run_metabase.sh
+++ b/bin/docker/run_metabase.sh
@@ -117,7 +117,6 @@ JAVA_OPTS="${JAVA_OPTS} -XX:+CMSClassUnloadingEnabled"              # These two 
 JAVA_OPTS="${JAVA_OPTS} -XX:+UseConcMarkSweepGC"
 JAVA_OPTS="${JAVA_OPTS} -server"
 JAVA_OPTS="${JAVA_OPTS} --add-opens=java.base/java.net=ALL-UNNAMED" # needed for Java 9 to allow dynamic classpath additions -- see https://github.com/tobias/dynapath
-JAVA_OPTS="${JAVA_OPTS} --add-modules=java.xml.bind"                # needed for Java 9 (Oracle VM only) because java.xml.bind is no longer on SE classpath by default since it's EE
 
 if [ ! -z "$JAVA_TIMEZONE" ]; then
     JAVA_OPTS="${JAVA_OPTS} -Duser.timezone=${JAVA_TIMEZONE}"

--- a/bin/start
+++ b/bin/start
@@ -103,7 +103,6 @@ JAVA_OPTS="$JAVA_OPTS -XX:+IgnoreUnrecognizedVMOptions"           # Don't barf i
 JAVA_OPTS="$JAVA_OPTS -Djava.awt.headless=true"                   # don't try to start AWT. Not sure this does anything but better safe than wasting memory
 JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8"                      # Use UTF-8
 JAVA_OPTS="$JAVA_OPTS --add-opens=java.base/java.net=ALL-UNNAMED" # Allow dynamically adding JARs to classpath (Java 9)
-JAVA_OPTS="$JAVA_OPTS --add-modules=java.xml.bind"                # Enable access to java.xml.bind module (Java 9)
 
 echo "Using these JAVA_OPTS: ${JAVA_OPTS}"
 

--- a/frontend/test/__runner__/backend.js
+++ b/frontend/test/__runner__/backend.js
@@ -52,7 +52,6 @@ export const BackendResource = createSharedResource("BackendResource", {
                                             "-XX:+CMSClassUnloadingEnabled",        // (Java 7) Allow GC to collect classes. Clojure makes lots of one-off dynamic classes
                                             "-XX:+UseConcMarkSweepGC",              // (Java 7) Use Concurrent Mark & Sweep GC which allows classes to be GC'ed
                                             "-Djava.awt.headless=true",             // when running on macOS prevent little Java icon from popping up in Dock
-                                            "--add-modules=java.xml.bind",          // Tell Java 9 we want to use java.xml stuff
                                             "-jar", "target/uberjar/metabase.jar"], {
                 env: {
                     MB_DB_FILE: server.dbFile,

--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
                   :exclusions [org.clojure/clojure
                                org.clojure/clojurescript]]            ; fixed length queue implementation, used in log buffering
                  [amalloy/ring-gzip-middleware "0.1.3"]               ; Ring middleware to GZIP responses if client can handle it
-                 [aleph "0.4.3"]                                      ; Async HTTP library; WebSockets
+                 [aleph "0.4.5-alpha2"]                               ; Async HTTP library; WebSockets
                  [bigml/histogram "4.1.3"]                            ; Streaming one-pass Histogram data structure
                  [buddy/buddy-core "1.2.0"]                           ; various cryptograhpic functions
                  [buddy/buddy-sign "1.5.0"]                           ; JSON Web Tokens; High-Level message signing library
@@ -115,7 +115,6 @@
              "-XX:+CMSClassUnloadingEnabled"                          ; let Clojure's dynamically generated temporary classes be GC'ed from PermGen
              "-XX:+UseConcMarkSweepGC"                                ; Concurrent Mark Sweep GC needs to be used for Class Unloading (above)
              "--add-opens=java.base/java.net=ALL-UNNAMED"             ; let Java 9 dynamically add to classpath -- see https://github.com/tobias/dynapath#note-on-java-9
-             "--add-modules=java.xml.bind"                            ; tell Java 9 (Oracle VM only) to add java.xml.bind to classpath. No longer on it by default. See https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j
              "-Djava.awt.headless=true"]                              ; prevent Java icon from randomly popping up in dock when running `lein ring server`
   :javac-options ["-target" "1.7", "-source" "1.7"]
   :uberjar-name "metabase.jar"

--- a/src/metabase/driver/bigquery.clj
+++ b/src/metabase/driver/bigquery.clj
@@ -132,17 +132,16 @@
 
 (defn- parse-timestamp-str [s]
   ;; Timestamp strings either come back as ISO-8601 strings or Unix timestamps in µs, e.g. "1.3963104E9"
-  (try (u/->Timestamp s)
-       (catch IllegalArgumentException _
-         ;; If parsing as ISO-8601 fails parse as a double then convert to ms
-         ;; Add the appropriate number of milliseconds to the number to convert it to the local timezone.
-         ;; We do this because the dates come back in UTC but we want the grouping to match the local time (HUH?)
-         ;; This gives us the same results as the other `has-questionable-timezone-support?` drivers
-         ;; Not sure if this is actually desirable, but if it's not, it probably means all of those other drivers are
-         ;; doing it wrong
-         (u/->Timestamp (- (* (Double/parseDouble s) 1000)
-                           (.getDSTSavings default-timezone)
-                           (.getRawOffset  default-timezone))))))
+  (or
+   (u/->Timestamp s)
+   ;; If parsing as ISO-8601 fails parse as a double then convert to ms. Add the appropriate number of milliseconds to
+   ;; the number to convert it to the local timezone. We do this because the dates come back in UTC but we want the
+   ;; grouping to match the local time (HUH?) This gives us the same results as the other
+   ;; `has-questionable-timezone-support?` drivers. Not sure if this is actually desirable, but if it's not, it
+   ;; probably means all of those other drivers are doing it wrong
+   (u/->Timestamp (- (* (Double/parseDouble s) 1000)
+                     (.getDSTSavings default-timezone)
+                     (.getRawOffset  default-timezone)))))
 
 (def ^:private type->parser
   "Functions that should be used to coerce string values in responses to the appropriate type for their column."

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -23,7 +23,6 @@
            [java.sql SQLException Timestamp]
            [java.text Normalizer Normalizer$Form]
            [java.util Calendar Date TimeZone]
-           javax.xml.bind.DatatypeConverter
            org.joda.time.DateTime
            org.joda.time.format.DateTimeFormatter))
 
@@ -48,6 +47,8 @@
   (->Timestamp ^java.sql.Timestamp [this]
     "Coerce this object to a `java.sql.Timestamp`. Strings are parsed as ISO-8601."))
 
+(declare str->date-time)
+
 (extend-protocol ITimestampCoercible
   nil       (->Timestamp [_]
               nil)
@@ -62,7 +63,7 @@
               (->Timestamp (.getTime this)))
   ;; Strings are expected to be in ISO-8601 format. `YYYY-MM-DD` strings *are* valid ISO-8601 dates.
   String    (->Timestamp [this]
-              (->Timestamp (DatatypeConverter/parseDateTime this)))
+              (->Timestamp (str->date-time this)))
   DateTime  (->Timestamp [this]
               (->Timestamp (.getMillis this))))
 
@@ -251,7 +252,7 @@
   (let [year    (date-extract :year date timezone-id)
         quarter (date-extract :quarter-of-year date timezone-id)
         month   (- (* 3 quarter) 2)]
-    (format "%d-%02d-01ZZ" year month)))
+    (format "%d-%02d-01'T'ZZ" year month)))
 
 (defn date-trunc
   "Truncate DATE to UNIT. DATE defaults to now.
@@ -267,11 +268,11 @@
      ;; For minute and hour truncation timezone should not be taken into account
      :minute  (trunc-with-floor date (* 60 1000))
      :hour    (trunc-with-floor date (* 60 60 1000))
-     :day     (trunc-with-format "yyyy-MM-ddZZ" date timezone-id)
-     :week    (trunc-with-format "yyyy-MM-ddZZ" (->first-day-of-week date timezone-id) timezone-id)
-     :month   (trunc-with-format "yyyy-MM-01ZZ" date timezone-id)
+     :day     (trunc-with-format "yyyy-MM-dd'T'ZZ" date timezone-id)
+     :week    (trunc-with-format "yyyy-MM-dd'T'ZZ" (->first-day-of-week date timezone-id) timezone-id)
+     :month   (trunc-with-format "yyyy-MM-01'T'ZZ" date timezone-id)
      :quarter (trunc-with-format (format-string-for-quarter date timezone-id) date timezone-id)
-     :year    (trunc-with-format "yyyy-01-01ZZ" date timezone-id))))
+     :year    (trunc-with-format "yyyy-01-01'T'ZZ" date timezone-id))))
 
 
 (defn date-trunc-or-extract


### PR DESCRIPTION
Remove our only direct usage of `javax.xml.bind.DatatypeConverter`. Once a new version of `aleph` is released with the changes from https://github.com/ztellman/aleph/pull/337 we can officially stop requiring usage of the `--add-modules=java.xml.bind` for people using Java 9