### PR TITLE
SQL driver simplification: remove need for prepare-value protocol method 

### DIFF
--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -98,15 +98,10 @@
 
   The default implementation is `identity`.
 
-  NOTE - This method is only used for parameters in raw SQL queries. It's not needed for MBQL queries because other
-  functions like `prepare-value` are used for similar purposes; at some point in the future, we might be able to
-  combine them into a single method used in both places.")
-
-  (prepare-value [this, ^Value value]
-    "*OPTIONAL*. Prepare a value (e.g. a `String` or `Integer`) that will be used in a HoneySQL form. By default, this
-     returns VALUE's `:value` as-is, which is eventually passed as a parameter in a prepared statement. Drivers such
-     as BigQuery that don't support prepared statements can skip this behavior by returning a HoneySQL `raw` form
-     instead, or other drivers can perform custom type conversion as appropriate.")
+  NOTE - This method is only used for parameters in raw SQL queries. It's not needed for MBQL queries because
+  the multimethod `metabase.driver.generic-sql.query-processor/->honeysql` provides an opportunity for drivers to do
+  type conversions as needed. In the future we may simplify a bit and combine them into a single method used in both
+  places.")
 
   (quote-style ^clojure.lang.Keyword [this]
     "*OPTIONAL*. Return the quoting style that should be used by [HoneySQL](https://github.com/jkk/honeysql) when
@@ -407,7 +402,6 @@
    :field->identifier    (u/drop-first-arg (comp (partial apply hsql/qualify) field/qualified-name-components))
    :field->alias         (u/drop-first-arg name)
    :prepare-sql-param    (u/drop-first-arg identity)
-   :prepare-value        (u/drop-first-arg :value)
    :quote-style          (constantly :ansi)
    :set-timezone-sql     (constantly nil)
    :stddev-fn            (constantly :STDDEV)})

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -18,7 +18,7 @@
             [metabase.util.honeysql-extensions :as hx])
   (:import clojure.lang.Keyword
            [java.sql PreparedStatement ResultSet ResultSetMetaData SQLException]
-           [java.util Calendar TimeZone]
+           [java.util Calendar Date TimeZone]
            [metabase.query_processor.interface AgFieldRef BinnedField DateTimeField DateTimeValue Expression
             ExpressionRef Field FieldLiteral RelativeDateTimeValue Value]))
 
@@ -32,8 +32,6 @@
   Each nested query increments this counter by 1."
   0)
 
-(defn- driver [] {:pre [(map? *query*)]} (:driver *query*))
-
 ;; register the function "distinct-count" with HoneySQL
 ;; (hsql/format :%distinct-count.x) -> "count(distinct x)"
 (defmethod hformat/fn-handler "distinct-count" [_ field]
@@ -44,15 +42,15 @@
 
 (defn- qualified-alias
   "Convert the given `FIELD` to a stringified alias"
-  [field]
+  [driver field]
   (some->> field
-           (sql/field->alias (driver))
+           (sql/field->alias driver)
            hx/qualify-and-escape-dots))
 
 (defn as
   "Generate a FORM `AS` FIELD alias using the name information of FIELD."
-  [form field]
-  (if-let [alias (qualified-alias field)]
+  [driver form field]
+  (if-let [alias (qualified-alias driver field)]
     [form alias]
     form))
 
@@ -74,84 +72,83 @@
      (nth (:aggregation query) index)
      (recur index (:source-query query) (dec aggregation-level)))))
 
-;; TODO - maybe this fn should be called `->honeysql` instead.
-(defprotocol ^:private IGenericSQLFormattable
-  (formatted [this]
-    "Return an appropriate HoneySQL form for an object."))
 
-(extend-protocol IGenericSQLFormattable
-  nil                    (formatted [_] nil)
-  Number                 (formatted [this] this)
-  String                 (formatted [this] this)
-  Keyword                (formatted [this] this) ; HoneySQL fn calls and keywords (e.g. `:%count.*`) are
-  honeysql.types.SqlCall (formatted [this] this) ; already converted to HoneySQL so just return them as-is
+(defmulti ^{:doc          (str "Return an appropriate HoneySQL form for an object. Dispatches off both driver and object "
+                               "classes making this easy to override in any places needed for a given driver.")
+            :arglists     '([driver x])
+            :style/indent 1}
+  ->honeysql
+  (fn [driver x]
+    [(class driver) (class x)]))
 
-  Expression
-  (formatted [{:keys [operator args]}]
-    (apply (partial hsql/call operator)
-           (map formatted args)))
+(defmethod ->honeysql [Object nil]    [_ _]    nil)
+(defmethod ->honeysql [Object Object] [_ this] this)
 
-  ExpressionRef
-  (formatted [{:keys [expression-name]}]
-    ;; Unfortunately you can't just refer to the expression by name in other clauses like filter, but have to use the
-    ;; original formuala.
-    (formatted (expression-with-name expression-name)))
+(defmethod ->honeysql [Object Expression]
+  [driver {:keys [operator args]}]
+  (apply (partial hsql/call operator)
+         (map (partial ->honeysql driver) args)))
 
-  Field
-  (formatted [{:keys [schema-name table-name special-type field-name]}]
-    (let [field (keyword (hx/qualify-and-escape-dots schema-name table-name field-name))]
-      (cond
-        (isa? special-type :type/UNIXTimestampSeconds)      (sql/unix-timestamp->timestamp (driver) field :seconds)
-        (isa? special-type :type/UNIXTimestampMilliseconds) (sql/unix-timestamp->timestamp (driver) field :milliseconds)
-        :else                                               field)))
+(defmethod ->honeysql [Object ExpressionRef]
+  [driver {:keys [expression-name]}]
+  ;; Unfortunately you can't just refer to the expression by name in other clauses like filter, but have to use the
+  ;; original formula.
+  (->honeysql driver (expression-with-name expression-name)))
 
-  FieldLiteral
-  (formatted [{:keys [field-name]}]
-    (keyword (hx/escape-dots (name field-name))))
+(defmethod ->honeysql [Object Field]
+  [driver {:keys [schema-name table-name special-type field-name]}]
+  (let [field (keyword (hx/qualify-and-escape-dots schema-name table-name field-name))]
+    (cond
+      (isa? special-type :type/UNIXTimestampSeconds)      (sql/unix-timestamp->timestamp driver field :seconds)
+      (isa? special-type :type/UNIXTimestampMilliseconds) (sql/unix-timestamp->timestamp driver field :milliseconds)
+      :else                                               field)))
 
-  DateTimeField
-  (formatted [{unit :unit, field :field}]
-    (sql/date (driver) unit (formatted field)))
+(defmethod ->honeysql [Object FieldLiteral]
+  [driver {:keys [field-name]}]
+  (->honeysql driver (keyword (hx/escape-dots (name field-name)))))
 
-  BinnedField
-  (formatted [{:keys [bin-width min-value max-value field]}]
-    (let [formatted-field (formatted field)]
-      ;;
-      ;; Equation is | (value - min) |
-      ;;             | ------------- | * bin-width + min-value
-      ;;             |_  bin-width  _|
-      ;;
-      (-> formatted-field
-          (hx/- min-value)
-          (hx// bin-width)
-          hx/floor
-          (hx/* bin-width)
-          (hx/+ min-value))))
+(defmethod ->honeysql [Object DateTimeField]
+  [driver {unit :unit, field :field}]
+  (sql/date driver unit (->honeysql driver field)))
 
-  ;; e.g. the ["aggregation" 0] fields we allow in order-by
-  AgFieldRef
-  (formatted [{index :index}]
-    (let [{:keys [aggregation-type]} (aggregation-at-index index)]
-      ;; For some arcane reason we name the results of a distinct aggregation "count",
-      ;; everything else is named the same as the aggregation
-      (if (= aggregation-type :distinct)
-        :count
-        aggregation-type)))
+(defmethod ->honeysql [Object BinnedField]
+  [driver {:keys [bin-width min-value max-value field]}]
+  (let [honeysql-field-form (->honeysql driver field)]
+    ;;
+    ;; Equation is | (value - min) |
+    ;;             | ------------- | * bin-width + min-value
+    ;;             |_  bin-width  _|
+    ;;
+    (-> honeysql-field-form
+        (hx/- min-value)
+        (hx// bin-width)
+        hx/floor
+        (hx/* bin-width)
+        (hx/+ min-value))))
 
-  Value
-  (formatted [value] (sql/prepare-value (driver) value))
+;; e.g. the ["aggregation" 0] fields we allow in order-by
+(defmethod ->honeysql [Object AgFieldRef]
+  [_ {index :index}]
+  (let [{:keys [aggregation-type]} (aggregation-at-index index)]
+    ;; For some arcane reason we name the results of a distinct aggregation "count",
+    ;; everything else is named the same as the aggregation
+    (if (= aggregation-type :distinct)
+      :count
+      aggregation-type)))
 
-  DateTimeValue
-  (formatted [{{unit :unit} :field, :as value}]
-    (sql/date (driver) unit (sql/prepare-value (driver) value)))
+(defmethod ->honeysql [Object Value]
+  [driver {:keys [value]}]
+  (->honeysql driver value))
 
-  RelativeDateTimeValue
-  (formatted [{:keys [amount unit], {field-unit :unit} :field}]
-    (sql/date (driver) field-unit (if (zero? amount)
-                                    (sql/current-datetime-fn (driver))
-                                    (driver/date-interval (driver) unit amount)))))
+(defmethod ->honeysql [Object DateTimeValue]
+  [driver {{unit :unit} :field, value :value}]
+  (sql/date driver unit (->honeysql driver value)))
 
-
+(defmethod ->honeysql [Object RelativeDateTimeValue]
+  [driver {:keys [amount unit], {field-unit :unit} :field}]
+  (sql/date driver field-unit (if (zero? amount)
+                                (sql/current-datetime-fn driver)
+                                (driver/date-interval driver unit amount))))
 
 
 ;;; ## Clause Handlers
@@ -175,17 +172,20 @@
                  :sum      :sum
                  :min      :min
                  :max      :max)
-      (formatted field))))
+      (->honeysql driver field))))
 
+;; TODO - can't we just roll this into the ->honeysql method for `expression`?
 (defn- expression-aggregation->honeysql
   "Generate the HoneySQL form for an expression aggregation."
   [driver expression]
-  (formatted (update expression :args (fn [args]
-                                        (for [arg args]
-                                          (cond
-                                            (number? arg)           arg
-                                            (:aggregation-type arg) (aggregation->honeysql driver (:aggregation-type arg) (:field arg))
-                                            (:operator arg)         (expression-aggregation->honeysql driver arg)))))))
+  (->honeysql driver
+    (update expression :args
+            (fn [args]
+              (for [arg args]
+                (cond
+                  (number? arg)           arg
+                  (:aggregation-type arg) (aggregation->honeysql driver (:aggregation-type arg) (:field arg))
+                  (:operator arg)         (expression-aggregation->honeysql driver arg)))))))
 
 (defn- apply-expression-aggregation [driver honeysql-form expression]
   (h/merge-select honeysql-form [(expression-aggregation->honeysql driver expression)
@@ -208,50 +208,50 @@
 
 (defn apply-breakout
   "Apply a `breakout` clause to HONEYSQL-FORM. Default implementation of `apply-breakout` for SQL drivers."
-  [_ honeysql-form {breakout-fields :breakout, fields-fields :fields :as query}]
+  [driver honeysql-form {breakout-fields :breakout, fields-fields :fields :as query}]
   (as-> honeysql-form new-hsql
     (apply h/merge-select new-hsql (for [field breakout-fields
                                          :when (not (contains? (set fields-fields) field))]
-                                     (as (formatted field) field)))
-    (apply h/group new-hsql (map formatted breakout-fields))))
+                                     (as driver (->honeysql driver field) field)))
+    (apply h/group new-hsql (map (partial ->honeysql driver) breakout-fields))))
 
 (defn apply-fields
   "Apply a `fields` clause to HONEYSQL-FORM. Default implementation of `apply-fields` for SQL drivers."
-  [_ honeysql-form {fields :fields}]
+  [driver honeysql-form {fields :fields}]
   (apply h/merge-select honeysql-form (for [field fields]
-                                        (as (formatted field) field))))
+                                        (as driver (->honeysql driver field) field))))
 
 (defn filter-subclause->predicate
   "Given a filter SUBCLAUSE, return a HoneySQL filter predicate form for use in HoneySQL `where`."
-  [{:keys [filter-type field value], :as filter}]
+  [driver {:keys [filter-type field value], :as filter}]
   {:pre [(map? filter) field]}
-  (let [field (formatted field)]
+  (let [field (->honeysql driver field)]
     (case          filter-type
-      :between     [:between field (formatted (:min-val filter)) (formatted (:max-val filter))]
-      :starts-with [:like    field (formatted (update value :value (fn [s] (str    s \%)))) ]
-      :contains    [:like    field (formatted (update value :value (fn [s] (str \% s \%))))]
-      :ends-with   [:like    field (formatted (update value :value (fn [s] (str \% s))))]
-      :>           [:>       field (formatted value)]
-      :<           [:<       field (formatted value)]
-      :>=          [:>=      field (formatted value)]
-      :<=          [:<=      field (formatted value)]
-      :=           [:=       field (formatted value)]
-      :!=          [:not=    field (formatted value)])))
+      :between     [:between field (->honeysql driver (:min-val filter)) (->honeysql driver (:max-val filter))]
+      :starts-with [:like    field (->honeysql driver (update value :value (fn [s] (str    s \%)))) ]
+      :contains    [:like    field (->honeysql driver (update value :value (fn [s] (str \% s \%))))]
+      :ends-with   [:like    field (->honeysql driver (update value :value (fn [s] (str \% s))))]
+      :>           [:>       field (->honeysql driver value)]
+      :<           [:<       field (->honeysql driver value)]
+      :>=          [:>=      field (->honeysql driver value)]
+      :<=          [:<=      field (->honeysql driver value)]
+      :=           [:=       field (->honeysql driver value)]
+      :!=          [:not=    field (->honeysql driver value)])))
 
 (defn filter-clause->predicate
   "Given a filter CLAUSE, return a HoneySQL filter predicate form for use in HoneySQL `where`.
    If this is a compound clause then we call `filter-subclause->predicate` on all of the subclauses."
-  [{:keys [compound-type subclause subclauses], :as clause}]
+  [driver {:keys [compound-type subclause subclauses], :as clause}]
   (case compound-type
-    :and (apply vector :and (map filter-clause->predicate subclauses))
-    :or  (apply vector :or  (map filter-clause->predicate subclauses))
-    :not [:not (filter-subclause->predicate subclause)]
-    nil  (filter-subclause->predicate clause)))
+    :and (apply vector :and (map (partial filter-clause->predicate driver) subclauses))
+    :or  (apply vector :or  (map (partial filter-clause->predicate driver) subclauses))
+    :not [:not (filter-subclause->predicate driver subclause)]
+    nil  (filter-subclause->predicate driver clause)))
 
 (defn apply-filter
   "Apply a `filter` clause to HONEYSQL-FORM. Default implementation of `apply-filter` for SQL drivers."
-  [_ honeysql-form {clause :filter}]
-  (h/where honeysql-form (filter-clause->predicate clause)))
+  [driver honeysql-form {clause :filter}]
+  (h/where honeysql-form (filter-clause->predicate driver clause)))
 
 (defn apply-join-tables
   "Apply expanded query `join-tables` clause to HONEYSQL-FORM. Default implementation of `apply-join-tables` for SQL drivers."
@@ -272,12 +272,12 @@
 
 (defn apply-order-by
   "Apply `order-by` clause to HONEYSQL-FORM. Default implementation of `apply-order-by` for SQL drivers."
-  [_ honeysql-form {subclauses :order-by breakout-fields :breakout}]
+  [driver honeysql-form {subclauses :order-by breakout-fields :breakout}]
   (let [[{:keys [special-type] :as first-breakout-field}] breakout-fields]
     (loop [honeysql-form honeysql-form, [{:keys [field direction]} & more] subclauses]
-      (let [honeysql-form (h/merge-order-by honeysql-form [(formatted field) (case direction
-                                                                               :ascending  :asc
-                                                                               :descending :desc)])]
+      (let [honeysql-form (h/merge-order-by honeysql-form [(->honeysql driver field) (case direction
+                                                                                       :ascending  :asc
+                                                                                       :descending :desc)])]
         (if (seq more)
           (recur honeysql-form more)
           honeysql-form)))))

--- a/src/metabase/driver/presto.clj
+++ b/src/metabase/driver/presto.clj
@@ -14,13 +14,18 @@
              [driver :as driver]
              [util :as u]]
             [metabase.driver.generic-sql :as sql]
+            [metabase.driver.generic-sql.query-processor :as sqlqp]
             [metabase.driver.generic-sql.util.unprepare :as unprepare]
             [metabase.query-processor.util :as qputil]
             [metabase.util
              [honeysql-extensions :as hx]
              [ssh :as ssh]])
-  (:import java.util.Date
-           [metabase.query_processor.interface DateTimeValue Value]))
+  (:import java.util.Date))
+
+(defrecord PrestoDriver []
+  clojure.lang.Named
+  (getName [_] "Presto"))
+
 
 ;;; Presto API helpers
 
@@ -167,17 +172,17 @@
                      :database-type type
                      :base-type     (presto-type->base-type type)}))}))
 
-(defprotocol ^:private IPrepareValue
-  (^:private prepare-value [this]))
-(extend-protocol IPrepareValue
-  nil           (prepare-value [_] nil)
-  DateTimeValue (prepare-value [{:keys [value]}] (prepare-value value))
-  Value         (prepare-value [{:keys [value]}] (prepare-value value))
-  String        (prepare-value [this] (hx/literal (str/replace this "'" "''")))
-  Boolean       (prepare-value [this] (hsql/raw (if this "TRUE" "FALSE")))
-  Date          (prepare-value [this] (hsql/call :from_iso8601_timestamp (hx/literal (u/date->iso-8601 this))))
-  Number        (prepare-value [this] this)
-  Object        (prepare-value [this] (throw (Exception. (format "Don't know how to prepare value %s %s" (class this) this)))))
+(defmethod sqlqp/->honeysql [PrestoDriver String]
+  [_ s]
+  (hx/literal (str/replace s "'" "''")))
+
+(defmethod sqlqp/->honeysql [PrestoDriver Boolean]
+  [_ bool]
+  (hsql/raw (if bool "TRUE" "FALSE")))
+
+(defmethod sqlqp/->honeysql [PrestoDriver Date]
+  [_ date]
+  (hsql/call :from_iso8601_timestamp (hx/literal (u/date->iso-8601 date))))
 
 (defn- execute-query [{:keys [database settings], {sql :query, params :params} :native, :as outer-query}]
   (let [sql                    (str "-- " (qputil/query->remark outer-query) "\n"
@@ -256,10 +261,6 @@
 
 ;;; Driver implementation
 
-(defrecord PrestoDriver []
-  clojure.lang.Named
-  (getName [_] "Presto"))
-
 (def ^:private presto-date-formatter (driver/create-db-time-formatter "yyyy-MM-dd'T'HH:mm:ss.SSSZ"))
 (def ^:private presto-db-time-query "select to_iso8601(current_timestamp)")
 
@@ -317,7 +318,6 @@
           :current-datetime-fn       (constantly :%now)
           :date                      (u/drop-first-arg date)
           :excluded-schemas          (constantly #{"information_schema"})
-          :prepare-value             (u/drop-first-arg prepare-value)
           :quote-style               (constantly :ansi)
           :stddev-fn                 (constantly :stddev_samp)
           :string-length-fn          (u/drop-first-arg string-length-fn)

--- a/src/metabase/query_processor/interface.clj
+++ b/src/metabase/query_processor/interface.clj
@@ -5,10 +5,10 @@
   (:require [metabase.models
              [dimension :as dim]
              [field :as field]]
+            [metabase.sync.interface :as i]
             [metabase.util :as u]
             [metabase.util.schema :as su]
-            [schema.core :as s]
-            [metabase.sync.interface :as i])
+            [schema.core :as s])
   (:import clojure.lang.Keyword
            java.sql.Timestamp))
 
@@ -26,7 +26,8 @@
 
 (def ^:dynamic ^Boolean *disable-qp-logging*
   "Should we disable logging for the QP? (e.g., during sync we probably want to turn it off to keep logs less
-  cluttered)." false)
+  cluttered)."
+  false)
 
 
 (def ^:dynamic *driver*

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -17,6 +17,7 @@
              [database :refer [Database]]
              [field :refer [Field]]
              [table :refer [Table]]]
+            [metabase.query-processor.interface :as qpi]
             [metabase.query-processor.middleware.expand :as ql]
             [metabase.sync.sync-metadata :as sync-metadata]
             [metabase.test
@@ -375,11 +376,11 @@
                   (db/select [Field :name :database_type :base_type] :table_id table-id)))))))
 
 
-;; check that values for enum types get wrapped in appropriate CAST() fn calls in prepare-value
+;; check that values for enum types get wrapped in appropriate CAST() fn calls in `->honeysql`
 (expect-with-engine :postgres
   {:name :cast, :args ["toucan" (keyword "bird type")]}
-  (#'postgres/prepare-value {:field {:database-type "bird type", :base-type :type/PostgresEnum}
-                             :value "toucan"}))
+  (sqlqp/->honeysql pg-driver (qpi/map->Value {:field {:database-type "bird type", :base-type :type/PostgresEnum}
+                                               :value "toucan"})))
 
 ;; End-to-end check: make sure everything works as expected when we run an actual query
 (expect-with-engine :postgres

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -828,8 +828,9 @@
      [{:field-name "timestamp"
        :base-type  :type/DateTime}]
      (vec (for [i (range -15 15)]
-            ;; Create timestamps using relative dates (e.g. `DATEADD(second, -195, GETUTCDATE())` instead of generating `java.sql.Timestamps` here so
-            ;; they'll be in the DB's native timezone. Some DBs refuse to use the same timezone we're running the tests from *cough* SQL Server *cough*
+            ;; Create timestamps using relative dates (e.g. `DATEADD(second, -195, GETUTCDATE())` instead of
+            ;; generating `java.sql.Timestamps` here so they'll be in the DB's native timezone. Some DBs refuse to use
+            ;; the same timezone we're running the tests from *cough* SQL Server *cough*
             [(u/prog1 (driver/date-interval *driver* :second (* i interval-seconds))
                (assert <>))]))]))
 

--- a/test/metabase/test/data/generic_sql.clj
+++ b/test/metabase/test/data/generic_sql.clj
@@ -8,6 +8,7 @@
              [helpers :as h]]
             [medley.core :as m]
             [metabase.driver.generic-sql :as sql]
+            [metabase.driver.generic-sql.query-processor :as sqlqp]
             [metabase.test.data.interface :as i]
             [metabase.util :as u]
             [metabase.util.honeysql-extensions :as hx])
@@ -15,7 +16,7 @@
            java.sql.SQLException
            [metabase.test.data.interface DatabaseDefinition FieldDefinition TableDefinition]))
 
-;;; ------------------------------------- IGenericDatasetLoader + default impls --------------------------------------
+;;; ----------------------------------- IGenericSQLTestExtensions + default impls ------------------------------------
 
 (defprotocol IGenericSQLTestExtensions
   "Methods for loading `DatabaseDefinition` in a SQL database.
@@ -211,7 +212,7 @@
         columns     (keys (first rows))
         values      (for [row rows]
                       (for [value (map row columns)]
-                        (sql/prepare-value driver {:value value})))
+                        (sqlqp/->honeysql driver value)))
         hsql-form   (-> (apply h/columns (for [column columns]
                                            (hx/qualify-and-escape-dots (prepare-key column))))
                         (h/insert-into (prepare-key table-name))


### PR DESCRIPTION
Make the Generic SQL QP function responsible for converting various things to HoneySQL forms a multimethod that dispatches off of driver and value class. This eliminates the need for a seperate `prepare-value` method in `ISQLDriver` which simplifies the code significantly