### PR TITLE
Improve `/database/:id/fields` response time

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -268,13 +268,14 @@
                                           :table_id        [:in (db/select-field :id Table, :db_id id)]
                                           :visibility_type [:not-in ["sensitive" "retired"]])
                                         (hydrate :table)))]
-    (for [{:keys [id display_name table base_type special_type]} fields]
-      {:id           id
-       :name         display_name
-       :base_type    base_type
-       :special_type special_type
-       :table_name   (:display_name table)
-       :schema       (:schema table)})))
+    (api/piped-json-stream
+     (for [{:keys [id display_name table base_type special_type]} fields]
+       {:id           id
+        :name         display_name
+        :base_type    base_type
+        :special_type special_type
+        :table_name   (:display_name table)
+        :schema       (:schema table)}))))
 
 
 ;;; ----------------------------------------- GET /api/database/:id/idfields -----------------------------------------


### PR DESCRIPTION
This PR makes two small changes to the `/database/:id/fields` API call. The first is using the `generate-stream` function from Cheshire, rather than using `generate-string`. This avoids holding the entire string representation of the fields response in memory before returning it. Very rough benchmarking looks like it consumes about half the memory as the previous solution. This would eventually get GC'd anyway, but that takes CPU cycles to, so if you create less garbage, you clean less garbage, it's faster.

The second part switches to a `java.io.PipedInputStream` and `java.io.PipedOutputStream`. This will allow streaming JSON responses to the client. Although the total response time is roughly the same, we can return the response initially and the client can parse the response as it is received. With the test schema I have locally, I went from roughly a 70s wait for the initial response (4s to receive the data) to 28s waiting for the response (46s receiving).