### PR TITLE
Fix wrong values in tooltips (#6401)

### DIFF
--- a/frontend/src/metabase/visualizations/lib/apply_tooltips.js
+++ b/frontend/src/metabase/visualizations/lib/apply_tooltips.js
@@ -83,20 +83,25 @@ function applyChartTooltips(chart, series, isStacked, isNormalized, isScalarSeri
                          const row        = (rowIndex != null) && seriesData.rows[rowIndex];
                          const rawRow     = row && row._origin && row._origin.row; // get the raw query result row
                          // make sure the row index we've determined with our formula above is correct. Check the
-                         // x/y axis values ("key" & "value") and make sure they match up with the row before pushing
-                         // extra data for the tooltip
+                         // x/y axis values ("key" & "value") and make sure they match up with the row before setting
+                         // the data for the tooltip
                          if (rawRow && row[0] === d.data.key && row[1] === d.data.value) {
-                             // loop over all the columns returned with the query
-                             for (let colIndex = 0; colIndex < rawCols.length; colIndex++) {
-                                 const col = rawCols[colIndex];
-                                 // skip over the x/y column since those will already be included
-                                 if (col === cols[0] || col === cols[1]) continue;
-                                 data.push({
+                             // rather than just append the additional values we'll just create a new `data` array.
+                             // simply appending the additional values would result in tooltips whose order switches
+                             // between different series.
+                             // Loop over *all* of the columns and create the new array
+                             data = rawCols.map((col, i) => {
+                                 // if this was one of the original x/y columns keep the original object because it
+                                 // may have the `isNormalized` tweak above.
+                                 if (col === data[0].col) return data[0];
+                                 if (col === data[1].col) return data[1];
+                                 // otherwise just create a new object for any other columns.
+                                 return {
                                      key: getFriendlyName(col),
-                                     value: rawRow[colIndex],
+                                     value: rawRow[i],
                                      col: col
-                                 });
-                             }
+                                 };
+                             });
                          }
                      }
 


### PR DESCRIPTION
This bug was caused by me misunderstanding what the variable `i` meant. It turns out it was some sort of internal index used by d3 rather than the index of the row we're displaying, e.g.:

```javascript
[Series 1]  i = 7   i = 8   i = 9  i = 10   i = 11
[Series 0]  i = 1   i = 2   i = 3  i = 4    i = 5
           [Row 0] [Row 1] [Row 2] [Row 3] [Row 4]
```

Making sure use the correct row index resulted in a simple fix for this issue, as seen below:

![screen shot 2017-12-18 at 5 58 52 pm](https://user-images.githubusercontent.com/1455846/34136955-230e5868-e41d-11e7-860d-4782e11b7ac0.png)
![screen shot 2017-12-18 at 5 58 46 pm](https://user-images.githubusercontent.com/1455846/34136956-232b437e-e41d-11e7-8f51-7e199c7d2af2.png)


Fixes #6401