### PR TITLE
Keep using --add-modules=java.xml.bind flag for SQLServer driver

### DIFF
--- a/bin/docker/run_metabase.sh
+++ b/bin/docker/run_metabase.sh
@@ -117,6 +117,7 @@ JAVA_OPTS="${JAVA_OPTS} -XX:+CMSClassUnloadingEnabled"              # These two 
 JAVA_OPTS="${JAVA_OPTS} -XX:+UseConcMarkSweepGC"
 JAVA_OPTS="${JAVA_OPTS} -server"
 JAVA_OPTS="${JAVA_OPTS} --add-opens=java.base/java.net=ALL-UNNAMED" # needed for Java 9 to allow dynamic classpath additions -- see https://github.com/tobias/dynapath
+JAVA_OPTS="${JAVA_OPTS} --add-modules=java.xml.bind"                # needed for Java 9 (Oracle VM only) because java.xml.bind is no longer on SE classpath by default since it's EE
 
 if [ ! -z "$JAVA_TIMEZONE" ]; then
     JAVA_OPTS="${JAVA_OPTS} -Duser.timezone=${JAVA_TIMEZONE}"

--- a/bin/start
+++ b/bin/start
@@ -103,6 +103,7 @@ JAVA_OPTS="$JAVA_OPTS -XX:+IgnoreUnrecognizedVMOptions"           # Don't barf i
 JAVA_OPTS="$JAVA_OPTS -Djava.awt.headless=true"                   # don't try to start AWT. Not sure this does anything but better safe than wasting memory
 JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8"                      # Use UTF-8
 JAVA_OPTS="$JAVA_OPTS --add-opens=java.base/java.net=ALL-UNNAMED" # Allow dynamically adding JARs to classpath (Java 9)
+JAVA_OPTS="$JAVA_OPTS --add-modules=java.xml.bind"                # Enable access to java.xml.bind module (Java 9)
 
 echo "Using these JAVA_OPTS: ${JAVA_OPTS}"
 

--- a/frontend/test/__runner__/backend.js
+++ b/frontend/test/__runner__/backend.js
@@ -52,6 +52,7 @@ export const BackendResource = createSharedResource("BackendResource", {
                                             "-XX:+CMSClassUnloadingEnabled",        // (Java 7) Allow GC to collect classes. Clojure makes lots of one-off dynamic classes
                                             "-XX:+UseConcMarkSweepGC",              // (Java 7) Use Concurrent Mark & Sweep GC which allows classes to be GC'ed
                                             "-Djava.awt.headless=true",             // when running on macOS prevent little Java icon from popping up in Dock
+                                            "--add-modules=java.xml.bind",          // Tell Java 9 we want to use java.xml stuff
                                             "-jar", "target/uberjar/metabase.jar"], {
                 env: {
                     MB_DB_FILE: server.dbFile,

--- a/project.clj
+++ b/project.clj
@@ -115,6 +115,7 @@
              "-XX:+CMSClassUnloadingEnabled"                          ; let Clojure's dynamically generated temporary classes be GC'ed from PermGen
              "-XX:+UseConcMarkSweepGC"                                ; Concurrent Mark Sweep GC needs to be used for Class Unloading (above)
              "--add-opens=java.base/java.net=ALL-UNNAMED"             ; let Java 9 dynamically add to classpath -- see https://github.com/tobias/dynapath#note-on-java-9
+             "--add-modules=java.xml.bind"                            ; tell Java 9 (Oracle VM only) to add java.xml.bind to classpath. No longer on it by default. See https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j
              "-Djava.awt.headless=true"]                              ; prevent Java icon from randomly popping up in dock when running `lein ring server`
   :javac-options ["-target" "1.7", "-source" "1.7"]
   :uberjar-name "metabase.jar"


### PR DESCRIPTION
Revert removal of these flags from #6577.

I found out a few minutes ago SQLServer still requires this flag with Java 9.