### PR TITLE
Stream all JSON responses [ci drivers]

### DIFF
--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -351,14 +351,3 @@
     (check-404 object)
     (check (not (:archived object))
       [404 {:message "The object has been archived.", :error_code "archived"}])))
-
-(defn piped-json-stream
-  "Write `RESPONSE-SEQ` to a PipedOutputStream as JSON, returning the connected PipedInputStream"
-  [response-seq]
-  (rui/piped-input-stream
-   (fn [^OutputStream output-stream]
-     (with-open [output-writer   (OutputStreamWriter. ^OutputStream output-stream ^Charset StandardCharsets/UTF_8)
-                 buffered-writer (BufferedWriter. output-writer)]
-       (-> response-seq
-           (json/generate-stream buffered-writer)
-           (rr/content-type "application/json; charset=utf-8"))))))

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -269,14 +269,13 @@
                                           :table_id        [:in (db/select-field :id Table, :db_id id)]
                                           :visibility_type [:not-in ["sensitive" "retired"]])
                                         (hydrate :table)))]
-    (api/piped-json-stream
-     (for [{:keys [id display_name table base_type special_type]} fields]
-       {:id           id
-        :name         display_name
-        :base_type    base_type
-        :special_type special_type
-        :table_name   (:display_name table)
-        :schema       (:schema table)}))))
+    (for [{:keys [id display_name table base_type special_type]} fields]
+      {:id           id
+       :name         display_name
+       :base_type    base_type
+       :special_type special_type
+       :table_name   (:display_name table)
+       :schema       (:schema table)})))
 
 
 ;;; ----------------------------------------- GET /api/database/:id/idfields -----------------------------------------


### PR DESCRIPTION
This commit switches from `ring.middleware.json/wrap-json-response` to
a new function that will stream JSON responses. Before this change the
full JSON response was serialized to a String first, then written to
the response stream. This change will skip that step and write the
response to a PipedOutputStream directly.

This is the same approach that was used in the response for the
`/database/:id/fields` route, just generalized and applied to all
routes.