### PR TITLE
Fix table corner radius visual artifact

### DIFF
--- a/frontend/src/metabase/visualizations/components/TableInteractive.css
+++ b/frontend/src/metabase/visualizations/components/TableInteractive.css
@@ -1,10 +1,22 @@
+:root {
+    --table-border-radius: 6px;
+}
+
 .TableInteractive {
-  border-radius: 6px;
+  border-radius: var(--table-border-radius);
   overflow: hidden;
 }
 
 .TableInteractive-headerCellData {
   font-weight: 700;
+}
+
+.TableInteractive-headerCellData.TableInteractive-cellWrapper--firstColumn {
+  border-top-left-radius: var(--table-border-radius);
+}
+
+.TableInteractive-headerCellData.TableInteractive-cellWrapper--lastColumn {
+  border-top-right-radius: var(--table-border-radius);
 }
 
 .TableInteractive-headerCellData .Icon {
@@ -77,4 +89,3 @@
   background-color: var(--brand-color);
   color: white;
 }
-

--- a/frontend/src/metabase/visualizations/components/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive.jsx
@@ -227,6 +227,7 @@ export default class TableInteractive extends Component {
                 key={key} style={style}
                 className={cx("TableInteractive-cellWrapper", {
                     "TableInteractive-cellWrapper--firstColumn": columnIndex === 0,
+                    "TableInteractive-cellWrapper--lastColumn": columnIndex === cols.length - 1,
                     "cursor-pointer": isClickable,
                     "justify-end": isColumnRightAligned(column),
                     "link": isClickable && isID(column)
@@ -281,6 +282,7 @@ export default class TableInteractive extends Component {
                 style={{ ...style, overflow: "visible" /* ensure resize handle is visible */ }}
                 className={cx("TableInteractive-cellWrapper TableInteractive-headerCellData", {
                     "TableInteractive-cellWrapper--firstColumn": columnIndex === 0,
+                    "TableInteractive-cellWrapper--lastColumn": columnIndex === cols.length - 1,
                     "TableInteractive-headerCellData--sorted": isSorted,
                     "cursor-pointer": isClickable,
                     "justify-end": isRightAligned


### PR DESCRIPTION
Fixes this:

<img width="270" alt="screen shot 2017-12-29 at 4 26 15 pm" src="https://user-images.githubusercontent.com/18193/34432731-17b2d872-ecb5-11e7-8275-7993d133a78a.png">

like this:

<img width="186" alt="screen shot 2017-12-29 at 4 29 12 pm" src="https://user-images.githubusercontent.com/18193/34432777-73fe92a6-ecb5-11e7-8b63-cb4004fbb3fe.png">

  That bottom border is slightly bothersome still, though.