### PR TITLE
Add clearCheckSums to `migrate force`

### DIFF
--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -181,6 +181,7 @@
    without rolling back the entirety of changes that were made. (If a single statement in a transaction fails you
    can't do anything futher until you clear the error state by doing something like calling `.rollback`.)"
   [conn, ^Liquibase liquibase]
+  (.clearCheckSums liquibase)
   (when (has-unrun-migrations? liquibase)
     (doseq [line (migrations-lines liquibase)]
       (log/info line)


### PR DESCRIPTION
Now whenever running migrate force, it will remove the MD5 checksums
in the databasechangelog table and recalculate them. This is mostly
useful for developers running code from several different branches.
