### PR TITLE
 Add a MySQL date parser that can handle abbreviated offsets [ci drivers] 

### DIFF
--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -296,7 +296,7 @@
   "Takes a clj-time date formatter `DATE-FORMATTER` and a native query
   for the current time. Returns a function that executes the query and
   parses the date returned preserving it's timezone"
-  [date-formatter native-query]
+  [native-query date-formatter]
   (fn [driver database]
     (let [settings (when-let [report-tz (report-timezone-if-supported driver)]
                      {:settings {:report-timezone report-tz}})

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -292,11 +292,19 @@
   [date-format-str]
   (.withOffsetParsed ^DateTimeFormatter (tformat/formatter date-format-str)))
 
+(defn- first-successful-parse
+  "Attempt to parse `time-str` with each of `date-formatters`, returning the first successful parse. If there are no
+  successful parses throws the exception that the last formatter threw."
+  [date-formatters time-str]
+  (or (some #(u/ignore-exceptions (tformat/parse % time-str)) date-formatters)
+      (doseq [formatter (reverse date-formatters)]
+        (tformat/parse formatter time-str))))
+
 (defn make-current-db-time-fn
   "Takes a clj-time date formatter `DATE-FORMATTER` and a native query
   for the current time. Returns a function that executes the query and
   parses the date returned preserving it's timezone"
-  [native-query date-formatter]
+  [native-query date-formatter & more-date-formatters]
   (fn [driver database]
     (let [settings (when-let [report-tz (report-timezone-if-supported driver)]
                      {:settings {:report-timezone report-tz}})
@@ -311,7 +319,7 @@
                          (format "Error querying database '%s' for current time" (:name database)) e))))]
       (try
         (when time-str
-          (tformat/parse date-formatter time-str))
+          (first-successful-parse (cons date-formatter more-date-formatters) time-str))
         (catch Exception e
           (throw
            (Exception.

--- a/src/metabase/driver/bigquery.clj
+++ b/src/metabase/driver/bigquery.clj
@@ -534,7 +534,7 @@
                                                              #{:foreign-keys})))
           :format-custom-field-name (u/drop-first-arg format-custom-field-name)
           :mbql->native             (u/drop-first-arg mbql->native)
-          :current-db-time          (driver/make-current-db-time-fn bigquery-date-formatter bigquery-db-time-query)}))
+          :current-db-time          (driver/make-current-db-time-fn  bigquery-db-time-query bigquery-date-formatter)}))
 
 (defn -init-driver
   "Register the BigQuery driver"

--- a/src/metabase/driver/crate.clj
+++ b/src/metabase/driver/crate.clj
@@ -110,7 +110,7 @@
                                          :display-name "Hosts"
                                          :default      "localhost:5432/"}])
           :features        (comp (u/rpartial disj :foreign-keys) sql/features)
-          :current-db-time (driver/make-current-db-time-fn crate-date-formatter crate-db-time-query)})
+          :current-db-time (driver/make-current-db-time-fn crate-db-time-query crate-date-formatter)})
   sql/ISQLDriver
   (merge (sql/ISQLDriverDefaultsMixin)
          {:connection-details->spec  (u/drop-first-arg connection-details->spec)

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -222,7 +222,7 @@
                                                            :required     true}])
           :humanize-connection-error-message (u/drop-first-arg humanize-connection-error-message)
           :process-query-in-context          (u/drop-first-arg process-query-in-context)
-          :current-db-time                   (driver/make-current-db-time-fn h2-date-formatter h2-db-time-query)})
+          :current-db-time                   (driver/make-current-db-time-fn h2-db-time-query h2-date-formatter)})
 
   sql/ISQLDriver
   (merge (sql/ISQLDriverDefaultsMixin)

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -216,6 +216,11 @@
 (def ^:private mysql-date-formatter
   (driver/create-db-time-formatter "yyyy-MM-dd HH:mm:ss.SSSSSS zzz"))
 
+(def ^:private mysql-offset-date-formatter
+  "In some timezones, MySQL doesn't return a timezone description but rather a truncated offset, such as '-02'. That
+  offset will fail to parse using a regular formatter"
+  (driver/create-db-time-formatter "yyyy-MM-dd HH:mm:ss.SSSSSS Z"))
+
 (def ^:private mysql-db-time-query
   "select CONCAT(DATE_FORMAT(current_timestamp, '%Y-%m-%d %H:%i:%S.%f' ), ' ', @@system_time_zone)")
 
@@ -252,7 +257,7 @@
                                                              :display-name "Additional JDBC connection string options"
                                                              :placeholder  "tinyInt1isBit=false"}]))
           :humanize-connection-error-message (u/drop-first-arg humanize-connection-error-message)
-          :current-db-time                   (driver/make-current-db-time-fn mysql-db-time-query mysql-date-formatter)})
+          :current-db-time                   (driver/make-current-db-time-fn mysql-db-time-query mysql-date-formatter mysql-offset-date-formatter)})
 
   sql/ISQLDriver
   (merge (sql/ISQLDriverDefaultsMixin)

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -252,7 +252,7 @@
                                                              :display-name "Additional JDBC connection string options"
                                                              :placeholder  "tinyInt1isBit=false"}]))
           :humanize-connection-error-message (u/drop-first-arg humanize-connection-error-message)
-          :current-db-time                   (driver/make-current-db-time-fn mysql-date-formatter mysql-db-time-query)})
+          :current-db-time                   (driver/make-current-db-time-fn mysql-db-time-query mysql-date-formatter)})
 
   sql/ISQLDriver
   (merge (sql/ISQLDriverDefaultsMixin)

--- a/src/metabase/driver/oracle.clj
+++ b/src/metabase/driver/oracle.clj
@@ -287,7 +287,7 @@
                                                              :placeholder  "*******"}]))
           :execute-query                     (comp remove-rownum-column sqlqp/execute-query)
           :humanize-connection-error-message (u/drop-first-arg humanize-connection-error-message)
-          :current-db-time                   (driver/make-current-db-time-fn oracle-date-formatter oracle-db-time-query)})
+          :current-db-time                   (driver/make-current-db-time-fn oracle-db-time-query oracle-date-formatter)})
 
   sql/ISQLDriver
   (merge (sql/ISQLDriverDefaultsMixin)

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -242,7 +242,7 @@
 (u/strict-extend PostgresDriver
   driver/IDriver
   (merge (sql/IDriverSQLDefaultsMixin)
-         {:current-db-time                   (driver/make-current-db-time-fn pg-date-formatter pg-db-time-query)
+         {:current-db-time                   (driver/make-current-db-time-fn pg-db-time-query pg-date-formatter)
           :date-interval                     (u/drop-first-arg date-interval)
           :describe-table                    describe-table
           :details-fields                    (constantly (ssh/with-tunnel-config

--- a/src/metabase/driver/presto.clj
+++ b/src/metabase/driver/presto.clj
@@ -308,7 +308,7 @@
                                                                       ;; during unit tests don't treat presto as having FK support
                                                                       #{:foreign-keys})))
           :humanize-connection-error-message (u/drop-first-arg humanize-connection-error-message)
-          :current-db-time                   (driver/make-current-db-time-fn presto-date-formatter presto-db-time-query)})
+          :current-db-time                   (driver/make-current-db-time-fn presto-db-time-query presto-date-formatter)})
 
   sql/ISQLDriver
   (merge (sql/ISQLDriverDefaultsMixin)

--- a/src/metabase/driver/redshift.clj
+++ b/src/metabase/driver/redshift.clj
@@ -103,7 +103,7 @@
                                                     :placeholder  "*******"
                                                     :required     true}]))
           :format-custom-field-name (u/drop-first-arg str/lower-case)
-          :current-db-time          (driver/make-current-db-time-fn redshift-date-formatter redshift-db-time-query)})
+          :current-db-time          (driver/make-current-db-time-fn redshift-db-time-query redshift-date-formatter)})
 
   sql/ISQLDriver
   (merge postgres/PostgresISQLDriverMixin

--- a/src/metabase/driver/sqlite.clj
+++ b/src/metabase/driver/sqlite.clj
@@ -178,7 +178,7 @@
                                              ;; the foreign key stuff in the tests.
                                              (when config/is-test?
                                                #{:foreign-keys})))
-          :current-db-time (driver/make-current-db-time-fn sqlite-date-formatter sqlite-db-time-query)})
+          :current-db-time (driver/make-current-db-time-fn sqlite-db-time-query sqlite-date-formatter)})
   sql/ISQLDriver
   (merge (sql/ISQLDriverDefaultsMixin)
          {:active-tables             sql/post-filtered-active-tables

--- a/src/metabase/driver/sqlserver.clj
+++ b/src/metabase/driver/sqlserver.clj
@@ -199,7 +199,7 @@
                                          {:name         "additional-options"
                                           :display-name "Additional JDBC connection string options"
                                           :placeholder  "trustServerCertificate=false"}]))
-          :current-db-time (driver/make-current-db-time-fn sqlserver-date-formatter sqlserver-db-time-query)})
+          :current-db-time (driver/make-current-db-time-fn sqlserver-db-time-query sqlserver-date-formatter)})
 
 
   sql/ISQLDriver

--- a/src/metabase/driver/vertica.clj
+++ b/src/metabase/driver/vertica.clj
@@ -141,7 +141,7 @@
                                             {:name         "additional-options"
                                              :display-name "Additional JDBC connection string options"
                                              :placeholder  "ConnectionLoadBalance=1"}]))
-          :current-db-time   (driver/make-current-db-time-fn vertica-date-formatter vertica-db-time-query)})
+          :current-db-time   (driver/make-current-db-time-fn vertica-db-time-query vertica-date-formatter)})
   sql/ISQLDriver
   (merge (sql/ISQLDriverDefaultsMixin)
          {:column->base-type         (u/drop-first-arg column->base-type)

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -87,6 +87,11 @@
   "America/Los_Angeles"
   (tu/db-timezone-id))
 
+(expect-with-engine :mysql
+  "-02:00"
+  (with-redefs [metabase.driver/execute-query (constantly {:rows [["2018-01-09 18:39:08.000000 -02"]]})]
+    (tu/db-timezone-id)))
+
 (expect (#'mysql/timezone-id->offset-str "US/Pacific")          "-08:00")
 (expect (#'mysql/timezone-id->offset-str "UTC")                 "+00:00")
 (expect (#'mysql/timezone-id->offset-str "America/Los_Angeles") "-08:00")


### PR DESCRIPTION
Dependong on what timezone you're in, the system_time_zone can be
returned as abbreviated timezone identifier like CST or it can return
an abbreviated offset like -02. This commit adds some special handling
for the offset case.
