### PR TITLE
Deal with GA's new enable API requirements

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -47,9 +47,9 @@
                  [com.draines/postal "2.0.2"]                         ; SMTP library
                  [com.github.brandtg/stl-java "0.1.1"]                ; STL decomposition
                  [com.google.apis/google-api-services-analytics       ; Google Analytics Java Client Library
-                  "v3-rev139-1.22.0"]
+                  "v3-rev142-1.23.0"]
                  [com.google.apis/google-api-services-bigquery        ; Google BigQuery Java Client Library
-                  "v2-rev342-1.22.0"]
+                   "v2-rev368-1.23.0"]
                  [com.jcraft/jsch "0.1.54"]                           ; SSH client for tunnels
                  [com.h2database/h2 "1.4.194"]                        ; embedded SQL database
                  [com.mattbertolini/liquibase-slf4j "2.0.0"]          ; Java Migrations lib

--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -5,8 +5,7 @@
              [email :as email]
              [events :as events]
              [public-settings :as public-settings]
-             [setup :as setup]
-             [util :as u]]
+             [setup :as setup]]
             [metabase.api
              [common :as api]
              [database :as database-api :refer [DBEngineString]]]
@@ -16,7 +15,7 @@
              [session :refer [Session]]
              [user :as user :refer [User]]]
             [metabase.util.schema :as su]
-            [puppetlabs.i18n.core :as i18n :refer [tru]]
+            [puppetlabs.i18n.core :refer [tru]]
             [schema.core :as s]
             [toucan.db :as db]))
 


### PR DESCRIPTION
Fixes #6644.

Did two things to deal with the issue:
*  Provide a link in the admin DB details page so people know to head to the GA API access page and can do so
*  If they forget to do so, GA give people a readable error message instead of a ton of garbage with tiny nuggets of wisdom inside.

Both fixes above are visible in the screenshot below:

![screen shot 2018-01-10 at 2 12 17 pm](https://user-images.githubusercontent.com/1455846/34798365-9b0024f0-f610-11e7-962f-84ad8de29d35.png)

