### PR TITLE
Better category classification

### DIFF
--- a/src/metabase/sync/analyze/classifiers/category.clj
+++ b/src/metabase/sync/analyze/classifiers/category.clj
@@ -18,6 +18,8 @@
   (and (nil? special_type)
        (or (isa? base_type :type/Integer)
            (isa? base_type :type/Text))
+       ;; Druid does not support group by on metrics so these should never be
+       ;; marked as category.
        (not= database_type "metric")))
 
 (s/defn infer-is-category :- (s/maybe i/FieldInstance)

--- a/src/metabase/sync/analyze/classifiers/category.clj
+++ b/src/metabase/sync/analyze/classifiers/category.clj
@@ -1,5 +1,5 @@
 (ns metabase.sync.analyze.classifiers.category
-  "Classifier that determines whether a Field should be marked as a `:type/Category` based on the number of distinct values it has."
+  "Classifier that determines whether a Field should be marked as a `:type/Category` based on its type and the number of distinct values it has."
   (:require [clojure.tools.logging :as log]
             [metabase.models.field-values :as field-values]
             [metabase.sync
@@ -9,22 +9,29 @@
             [schema.core :as s]))
 
 
-(s/defn ^:private cannot-be-category? :- s/Bool
-  [base-type :- su/FieldType]
-  (or (isa? base-type :type/DateTime)
-      (isa? base-type :type/Collection)))
+(def ^:const ^:Integer category-string-length-threshold
+  "Maximum average string length for a field to be considered a category."
+  20)
+
+(s/defn ^:private category-candidate? :- s/Bool
+  [{:keys [base_type special_type database_type]}]
+  (and (nil? special_type)
+       (or (isa? base_type :type/Integer)
+           (isa? base_type :type/Text))
+       (not= database_type "metric")))
 
 (s/defn infer-is-category :- (s/maybe i/FieldInstance)
   "Classifier that attempts to determine whether FIELD ought to be marked as a Category based on its distinct count."
   [field :- i/FieldInstance, fingerprint :- (s/maybe i/Fingerprint)]
-  (when-not (:special_type field)
-    (when fingerprint
-      (when-not (cannot-be-category? (:base_type field))
-        (when-let [distinct-count (get-in fingerprint [:global :distinct-count])]
-          (when (< distinct-count field-values/low-cardinality-threshold)
-            (log/debug (format "%s has %d distinct values. Since that is less than %d, we're marking it as a category."
-                               (sync-util/name-for-logging field)
-                               distinct-count
-                               field-values/low-cardinality-threshold))
-            (assoc field
-              :special_type :type/Category)))))))
+  (when (category-candidate? field)
+    (let [distinct-count (get-in fingerprint [:global :distinct-count])
+          average-length (-> field :type :type/Text :average-length)]
+      (when (and (some-> distinct-count (< field-values/low-cardinality-threshold))
+                 (or (nil? average-length)
+                     (<  average-length category-string-length-threshold)))
+        (log/debug (format "%s has %d distinct values. Since that is less than %d, we're marking it as a category."
+                           (sync-util/name-for-logging field)
+                           distinct-count
+                           field-values/low-cardinality-threshold))
+        (assoc field
+          :special_type :type/Category)))))

--- a/src/metabase/types.clj
+++ b/src/metabase/types.clj
@@ -123,9 +123,8 @@
 (derive :type/Name :type/Category)
 
 (derive :type/User :type/Field)
-(derive :type/Product :type/Field)
-
-(derive :type/Source :type/Field)
+(derive :type/Product :type/Category)
+(derive :type/Source :type/Category)
 
 ;;; ---------------------------------------------------- Util Fns ----------------------------------------------------
 


### PR DESCRIPTION
This makes category classification somewhat more stringent. Changes:
* category can only be an integer or text
* fields with `databaset_type` = "metric" (druid) are not eligible to be a category
* only text fields with average length < `category-string-length-threshold` (currently 20) are considered.

This should limit the most grievous overreaches.  

Note this is based off #6624 as it's a continuation of tweaks to the sync process to better support automagic dashboards (but the change is small enough that I can also rebase it if need be).