### PR TITLE
On export, format dates to not include times

### DIFF
--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -1,6 +1,9 @@
 (ns metabase.api.dataset-test
   "Unit tests for /api/dataset endpoints."
-  (:require [cheshire.generate :as generate]
+  (:require [cheshire
+             [core :as json]
+             [generate :as generate]]
+            [clojure.data.csv :as csv]
             [dk.ative.docjure.spreadsheet :as spreadsheet]
             [expectations :refer :all]
             [medley.core :as m]
@@ -153,3 +156,34 @@
                                                ["ABC"]])
        (spreadsheet/select-sheet "Results")
        (spreadsheet/select-columns {:A "Values"})))
+
+(defn- parse-and-sort-csv [response]
+  (sort-by
+   ;; ID in CSV is a string, parse it and sort it to get the first 5
+   (comp #(Integer/parseInt %) first)
+   ;; First row is the header
+   (rest (csv/read-csv response))))
+
+;; Date columns should be emitted without time
+(expect
+  [["1" "2014-04-07" "5" "12"]
+   ["2" "2014-09-18" "1" "31"]
+   ["3" "2014-09-15" "8" "56"]
+   ["4" "2014-03-11" "5" "4"]
+   ["5" "2013-05-05" "3" "49"]]
+  (let [result ((user->client :rasta) :post 200 "dataset/csv" :query
+                (json/generate-string (wrap-inner-query
+                                        (query checkins))))]
+    (take 5 (parse-and-sort-csv result))))
+
+;; DateTime fields are untouched when exported
+(expect
+  [["1" "Plato Yeshua" "2014-04-01T08:30:00.000Z"]
+   ["2" "Felipinho Asklepios" "2014-12-05T15:15:00.000Z"]
+   ["3" "Kaneonuskatew Eiran" "2014-11-06T16:15:00.000Z"]
+   ["4" "Simcha Yan" "2014-01-01T08:30:00.000Z"]
+   ["5" "Quentin Sören" "2014-10-03T17:30:00.000Z"]]
+  (let [result ((user->client :rasta) :post 200 "dataset/csv" :query
+                (json/generate-string (wrap-inner-query
+                                        (query users))))]
+    (take 5 (parse-and-sort-csv result))))


### PR DESCRIPTION
Currently all :type/DateTime values, including :type/Date values are
serialized as ISO timestamps, which includes the time and
timezone. This commit handles :type/Date fields differently, emitting
only the date (year, month and day).

Fixes #5828