### PR TITLE
Map Druid datetime :default -> :millisecond

### DIFF
--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -188,14 +188,15 @@
   (^java.sql.Timestamp [unit amount date]
    (let [cal               (->Calendar date)
          [unit multiplier] (case unit
-                             :second  [Calendar/SECOND 1]
-                             :minute  [Calendar/MINUTE 1]
-                             :hour    [Calendar/HOUR   1]
-                             :day     [Calendar/DATE   1]
-                             :week    [Calendar/DATE   7]
-                             :month   [Calendar/MONTH  1]
-                             :quarter [Calendar/MONTH  3]
-                             :year    [Calendar/YEAR   1])]
+                             :millisecond [Calendar/MILLISECOND 1]
+                             :second      [Calendar/SECOND      1]
+                             :minute      [Calendar/MINUTE      1]
+                             :hour        [Calendar/HOUR        1]
+                             :day         [Calendar/DATE        1]
+                             :week        [Calendar/DATE        7]
+                             :month       [Calendar/MONTH       1]
+                             :quarter     [Calendar/MONTH       3]
+                             :year        [Calendar/YEAR        1])]
      (.set cal unit (+ (.get cal unit)
                        (* amount multiplier)))
      (->Timestamp cal))))
@@ -266,13 +267,15 @@
   (^java.sql.Timestamp [unit date timezone-id]
    (case unit
      ;; For minute and hour truncation timezone should not be taken into account
-     :minute  (trunc-with-floor date (* 60 1000))
-     :hour    (trunc-with-floor date (* 60 60 1000))
-     :day     (trunc-with-format "yyyy-MM-dd'T'ZZ" date timezone-id)
-     :week    (trunc-with-format "yyyy-MM-dd'T'ZZ" (->first-day-of-week date timezone-id) timezone-id)
-     :month   (trunc-with-format "yyyy-MM-01'T'ZZ" date timezone-id)
-     :quarter (trunc-with-format (format-string-for-quarter date timezone-id) date timezone-id)
-     :year    (trunc-with-format "yyyy-01-01'T'ZZ" date timezone-id))))
+     :millisecond (trunc-with-floor date 1)
+     :second      (trunc-with-floor date 1000)
+     :minute      (trunc-with-floor date (* 60 1000))
+     :hour        (trunc-with-floor date (* 60 60 1000))
+     :day         (trunc-with-format "yyyy-MM-dd'T'ZZ" date timezone-id)
+     :week        (trunc-with-format "yyyy-MM-dd'T'ZZ" (->first-day-of-week date timezone-id) timezone-id)
+     :month       (trunc-with-format "yyyy-MM-01'T'ZZ" date timezone-id)
+     :quarter     (trunc-with-format (format-string-for-quarter date timezone-id) date timezone-id)
+     :year        (trunc-with-format "yyyy-01-01'T'ZZ" date timezone-id))))
 
 
 (defn date-trunc-or-extract


### PR DESCRIPTION
@tlrobinson please try this out and let me know if it fixes your issues with filtering by datetimes with `:default` with Druid. It generates a correct clause now to make sure the datetime you want matches the same millisecond but I'm not sure that will actually give us the correct result so give it a go.

(Druid does not support filtering with `=` the way SQL does; instead you have to give it a date range to filter by. So we're specifying a date range of a single millisecond to match a specific record. Not sure if that is going to work.)