### PR TITLE
Fix issues with `type/PK` + `type/DateTime`  fields

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -311,10 +311,16 @@ export default class Question {
     drillPK(field: Field, value: Value): ?Question {
         const query = this.query();
         if (query instanceof StructuredQuery) {
+            // NOTE: if it's a date we need to use a datetime-field with "default"
+            // unit otherwise it will be bucketed by day
+            let fieldRef = ["field-id", field.id];
+            if (field.isDate()) {
+              fieldRef = ["datetime-field", fieldRef, "default"]
+            }
             return query
                 .reset()
                 .setTable(field.table)
-                .addFilter(["=", ["field-id", field.id], value])
+                .addFilter(["=", fieldRef, value])
                 .question();
         }
     }

--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -315,7 +315,7 @@ export default class Question {
             // unit otherwise it will be bucketed by day
             let fieldRef = ["field-id", field.id];
             if (field.isDate()) {
-              fieldRef = ["datetime-field", fieldRef, "default"]
+                fieldRef = ["datetime-field", fieldRef, "default"];
             }
             return query
                 .reset()

--- a/frontend/src/metabase/meta/types/Dataset.js
+++ b/frontend/src/metabase/meta/types/Dataset.js
@@ -34,5 +34,6 @@ export type DatasetData = {
 
 export type Dataset = {
     data: DatasetData,
-    json_query: DatasetQuery
+    json_query: DatasetQuery,
+    row_count: number
 };

--- a/frontend/src/metabase/qb/lib/modes.js
+++ b/frontend/src/metabase/qb/lib/modes.js
@@ -64,9 +64,10 @@ export function getMode(
                         // uniqueness guarentee normally provided by primary key
                         // but if we're explicitly using the "default" unit then
                         // consider it a PK again
-                        (!isDate(field) || (
-                          Q_DEPRECATED.isDatetimeField(filter[1]) &&
-                          Q_DEPRECATED.getDatetimeUnit(filter[1]) === "default"))
+                        (!isDate(field) ||
+                            (Q_DEPRECATED.isDatetimeField(filter[1]) &&
+                                Q_DEPRECATED.getDatetimeUnit(filter[1]) ===
+                                    "default"))
                     ) {
                         return true;
                     }
@@ -74,7 +75,10 @@ export function getMode(
                 return false;
             };
             // if we know row count isn't 1 don't show ObjectMode
-            if (_.any(filters, isPKFilter) && (!result || result.row_count === 1)) {
+            if (
+                _.any(filters, isPKFilter) &&
+                (!result || result.row_count === 1)
+            ) {
                 return ObjectMode;
             } else {
                 return SegmentMode;

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -99,8 +99,8 @@ import { getMode as getMode_ } from "metabase/qb/lib/modes";
 import { getAlerts } from "metabase/alert/selectors";
 
 export const getMode = createSelector(
-    [getLastRunCard, getTableMetadata],
-    (card, tableMetadata) => getMode_(card, tableMetadata)
+    [getLastRunCard, getTableMetadata, getQueryResult],
+    (card, tableMetadata, result) => getMode_(card, tableMetadata, result)
 )
 
 export const getIsObjectDetail = createSelector(

--- a/frontend/test/metabase-lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/Question.unit.spec.js
@@ -537,7 +537,7 @@ describe("Question", () => {
 
             it("returns the correct query for a PK detail drill-through if the column is also a DateTime", () => {
                 // temporarily set the field's special_type to PK
-                cmetadata.fields[ORDERS_CREATED_DATE_FIELD_ID].special_type = "type/PK";
+                metadata.fields[ORDERS_CREATED_DATE_FIELD_ID].special_type = "type/PK";
 
                 const drilledQuestion = question.drillPK(
                     metadata.fields[ORDERS_CREATED_DATE_FIELD_ID],

--- a/frontend/test/metabase-lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/Question.unit.spec.js
@@ -531,6 +531,39 @@ describe("Question", () => {
                         filter: ["=", ["field-id", ORDERS_PK_FIELD_ID], 1]
                     }
                 });
+
+                expect(drilledQuestion.mode().name()).toBe("object")
+            });
+
+            it("returns the correct query for a PK detail drill-through if the column is also a DateTime", () => {
+                // temporarily set the field's special_type to PK
+                cmetadata.fields[ORDERS_CREATED_DATE_FIELD_ID].special_type = "type/PK";
+
+                const drilledQuestion = question.drillPK(
+                    metadata.fields[ORDERS_CREATED_DATE_FIELD_ID],
+                    "2013-01-19T15:00:00.000+07:00"
+                );
+
+                expect(drilledQuestion.canRun()).toBe(true);
+
+                // if I actually call the .query() method below, this blows up garbage collection =/
+                expect(drilledQuestion._card.dataset_query).toEqual({
+                    type: "query",
+                    database: DATABASE_ID,
+                    query: {
+                        source_table: ORDERS_TABLE_ID,
+                        filter: [
+                          "=",
+                          ["datetime-field", ["field-id", ORDERS_CREATED_DATE_FIELD_ID], "default"],
+                          "2013-01-19T15:00:00.000+07:00"
+                        ]
+                    }
+                });
+
+                expect(drilledQuestion.mode().name()).toBe("object")
+
+                // restore the special_type
+                metadata.fields[ORDERS_CREATED_DATE_FIELD_ID].special_type = null;
             });
         });
     });

--- a/src/metabase/driver/druid/query_processor.clj
+++ b/src/metabase/driver/druid/query_processor.clj
@@ -586,6 +586,12 @@
 
 (defn- parse-filter-subclause:intervals [{:keys [filter-type field value] :as filter}]
   (when (instance? DateTimeField field)
+    ;; since the `make-intervals` and `add-date-time-units` stuff below need to have a concrete bucketing unit go
+    ;; ahead and assume `:milliseconds` if `:default` was specified, because `:milliseconds` is the smallest
+    ;; resolution Druid lets you use. Futhermore since we're making date ranges anyways chosing the smallest option
+    ;; will let you get fine-grained access if you want it, but not change the results for larger ranges (e.g. 'June
+    ;; 2018' is the same whether you specify milliseconds or not; but 'the first millisecond of June 1st, 2018' needs
+    ;; to include milliseconds by definition.)
     (let [value (update-in value [:field :unit] (fn [unit]
                                                   (if (= unit :default)
                                                     :millisecond

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -188,14 +188,15 @@
   (^java.sql.Timestamp [unit amount date]
    (let [cal               (->Calendar date)
          [unit multiplier] (case unit
-                             :second  [Calendar/SECOND 1]
-                             :minute  [Calendar/MINUTE 1]
-                             :hour    [Calendar/HOUR   1]
-                             :day     [Calendar/DATE   1]
-                             :week    [Calendar/DATE   7]
-                             :month   [Calendar/MONTH  1]
-                             :quarter [Calendar/MONTH  3]
-                             :year    [Calendar/YEAR   1])]
+                             :millisecond [Calendar/MILLISECOND 1]
+                             :second      [Calendar/SECOND      1]
+                             :minute      [Calendar/MINUTE      1]
+                             :hour        [Calendar/HOUR        1]
+                             :day         [Calendar/DATE        1]
+                             :week        [Calendar/DATE        7]
+                             :month       [Calendar/MONTH       1]
+                             :quarter     [Calendar/MONTH       3]
+                             :year        [Calendar/YEAR        1])]
      (.set cal unit (+ (.get cal unit)
                        (* amount multiplier)))
      (->Timestamp cal))))
@@ -266,13 +267,15 @@
   (^java.sql.Timestamp [unit date timezone-id]
    (case unit
      ;; For minute and hour truncation timezone should not be taken into account
-     :minute  (trunc-with-floor date (* 60 1000))
-     :hour    (trunc-with-floor date (* 60 60 1000))
-     :day     (trunc-with-format "yyyy-MM-dd'T'ZZ" date timezone-id)
-     :week    (trunc-with-format "yyyy-MM-dd'T'ZZ" (->first-day-of-week date timezone-id) timezone-id)
-     :month   (trunc-with-format "yyyy-MM-01'T'ZZ" date timezone-id)
-     :quarter (trunc-with-format (format-string-for-quarter date timezone-id) date timezone-id)
-     :year    (trunc-with-format "yyyy-01-01'T'ZZ" date timezone-id))))
+     :millisecond (trunc-with-floor date 1)
+     :second      (trunc-with-floor date 1000)
+     :minute      (trunc-with-floor date (* 60 1000))
+     :hour        (trunc-with-floor date (* 60 60 1000))
+     :day         (trunc-with-format "yyyy-MM-dd'T'ZZ" date timezone-id)
+     :week        (trunc-with-format "yyyy-MM-dd'T'ZZ" (->first-day-of-week date timezone-id) timezone-id)
+     :month       (trunc-with-format "yyyy-MM-01'T'ZZ" date timezone-id)
+     :quarter     (trunc-with-format (format-string-for-quarter date timezone-id) date timezone-id)
+     :year        (trunc-with-format "yyyy-01-01'T'ZZ" date timezone-id))))
 
 
 (defn date-trunc-or-extract


### PR DESCRIPTION
- [x] if drilling into a `type/PK` + `type/DateTime` field use `["datetime-field", ..., "default"]` to disable implicit bucketing by day
- [x] `getMode` shouldn't detect `type/PK` + `type/DateTime` fields as PKs (and thus `ObjectMode`) unless `["datetime-field", ..., "default"]` is used
- [x] `getMode` shouldn't return `ObjectMode` if results have more than one row.
- [x] tests

Resolves #6290
Builds on #6724