### PR TITLE
Ga aggregation fix

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
@@ -229,9 +229,22 @@ export default class StructuredQuery extends AtomicQuery {
     /**
      * @returns an array of MBQL @type {Aggregation}s.
      */
-    aggregations(): Aggregation[] {
-        return Q.getAggregations(this.query());
-    }
+     aggregations(): Aggregation[] {
+
+      // if ga, restructure back to original non-native query structure
+      let aggregationList = Q.getAggregations(this.query());
+      if (aggregationList.length !== 0) {
+        if (aggregationList[0][1].includes('ga:')) {
+          let reformattedQueryList = aggregationList[0][1].split(", ");
+          let revertToOriginalAggregationFormat = []
+          for (let i = 0; i < reformattedQueryList.length; i ++){
+            revertToOriginalAggregationFormat.push([aggregationList[0][0], reformattedQueryList[i]])
+          }
+          return revertToOriginalAggregationFormat
+        }
+      }
+       return Q.getAggregations(this.query());
+   }
 
     /**
      * @returns an array of aggregation wrapper objects

--- a/frontend/src/metabase/lib/query/aggregation.js
+++ b/frontend/src/metabase/lib/query/aggregation.js
@@ -10,6 +10,12 @@ export function getAggregations(aggregation: ?AggregationClause): Aggregation[] 
     let aggregations: Aggregation[];
     if (Array.isArray(aggregation) && Array.isArray(aggregation[0])) {
         aggregations = (aggregation: any);
+
+        // If GA, then change format of aggregation
+        if (aggregations[0][1].includes('ga:')) {
+          aggregations = updateGAQuery(aggregations)
+        }
+
     } else if (Array.isArray(aggregation) && typeof aggregation[0] === "string") {
         // legacy
         aggregations = [(aggregation: any)];
@@ -27,6 +33,16 @@ function getAggregationClause(aggregations: Aggregation[]): ?AggregationClause {
     } else {
         return aggregations;
     }
+}
+
+function updateGAQuery(aggregations) {
+    let gaQuery = aggregations[0][1];
+    for (let i=1; i < aggregations.length; i ++) {
+      gaQuery += ", " + aggregations[i][1];
+    }
+
+    let gaAggregations = [aggregations[0][0], gaQuery]
+    return gaAggregations;
 }
 
 export function addAggregation(aggregation: ?AggregationClause, newAggregation: Aggregation): ?AggregationClause {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9503,19 +9503,7 @@ unherit@^1.0.4:
     inherits "^2.0.1"
     xtend "^4.0.1"
 
-unified@^6.0.0:
-  version "6.1.5"
-  resolved "https://registry.yarnpkg.com/unified/-/unified-6.1.5.tgz#716937872621a63135e62ced2f3ac6a063c6fb87"
-  dependencies:
-    bail "^1.0.0"
-    extend "^3.0.0"
-    is-plain-obj "^1.1.0"
-    trough "^1.0.0"
-    vfile "^2.0.0"
-    x-is-function "^1.0.4"
-    x-is-string "^0.1.0"
-
-unified@^6.1.5:
+unified@^6.0.0, unified@^6.1.5:
   version "6.1.6"
   resolved "https://registry.yarnpkg.com/unified/-/unified-6.1.6.tgz#5ea7f807a0898f1f8acdeefe5f25faa010cc42b1"
   dependencies:
@@ -9603,11 +9591,7 @@ unist-util-stringify-position@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.1.tgz#3ccbdc53679eed6ecf3777dd7f5e3229c1b6aa3c"
 
-unist-util-visit@^1.0.0, unist-util-visit@^1.0.1, unist-util-visit@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.1.3.tgz#ec268e731b9d277a79a5b5aa0643990e405d600b"
-
-unist-util-visit@^1.1.3:
+unist-util-visit@^1.0.0, unist-util-visit@^1.0.1, unist-util-visit@^1.1.0, unist-util-visit@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.2.0.tgz#9dc78d1f95cd242e865f7f93f327d3296bb9a718"
   dependencies:


### PR DESCRIPTION
**Bug Fix**
This is a bug fix for the following issues: [5756](https://github.com/metabase/metabase/issues/5756) and [4894](https://github.com/metabase/metabase/issues/4894). This allows a user to select multiple aggregations for GA and see the results displayed in a column. 

The problem was the structured query was not formatted correctly to send to GA, so only the first aggregation was being sent.  

**New bug**
However, another issue has arisen. You can now use multiple aggregations, but you cannot remove the aggregation one-by-one. The aggregations can be (all) deleted if you select to delete the first aggregation selection. 

The problem is that the aggregation value that is being used when the `x` is clicked is the aggregation that was reformatted for the GA request. Any help that you can suggest for me to fix this new bug would be greatly appreciated!

![google_analytics_broken_agg](https://user-images.githubusercontent.com/12179055/35177131-20b35d1a-fd32-11e7-9a2f-146961e48702.gif)


###### TODO 
-  [x ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
