### PR TITLE
Don't add in_public_dashboard status to (empty) Cards of text-only DashCards

### DIFF
--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -64,7 +64,8 @@
                                          (map :id)
                                          set))]
     (for [card cards]
-      (assoc card :in_public_dashboard (contains? public-dashboard-card-ids (u/get-id card))))))
+      (when (some? card) ; card may be `nil` here if it comes from a text-only Dashcard
+        (assoc card :in_public_dashboard (contains? public-dashboard-card-ids (u/get-id card)))))))
 
 
 ;;; ---------------------------------------------- Permissions Checking ----------------------------------------------

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -36,7 +36,9 @@
         (some? public-uuid))
    ;; if Dashboard is already hydrated no need to do it a second time
    (let [cards (or (dashcards->cards (:ordered_cards dashboard))
-                   (dashcards->cards (-> (db/select [DashboardCard :id :card_id], :dashboard_id (u/get-id dashboard))
+                   (dashcards->cards (-> (db/select [DashboardCard :id :card_id]
+                                           :dashboard_id (u/get-id dashboard)
+                                           :card_id      [:not= nil]) ; skip text-only Cards
                                          (hydrate [:card :in_public_dashboard] :series))))]
      (or (empty? cards)
          (some i/can-read? cards)))))


### PR DESCRIPTION
Fix an issue with the way we optimize permissions checking for public Dashboards that happen to have a text-only DashCard