### PR TITLE
X-rays for unsaved timeseries questions

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -361,7 +361,7 @@ export default class Question {
             this.isDirtyComparedTo(originalQuestion);
 
         return isDirty
-            ? Urls.question(null, this._serializeForUrl())
+            ? Urls.question(null, this.getUrlHash())
             : Urls.question(this.id(), "");
     }
 
@@ -454,19 +454,17 @@ export default class Question {
                 return false;
             }
         } else {
-            const origCardSerialized = originalQuestion._serializeForUrl({
+            const origCardSerialized = originalQuestion.getUrlHash({
                 includeOriginalCardId: false
             });
-            const currentCardSerialized = this._serializeForUrl({
+            const currentCardSerialized = this.getUrlHash({
                 includeOriginalCardId: false
             });
             return currentCardSerialized !== origCardSerialized;
         }
     }
 
-    // Internal methods
-
-    _serializeForUrl({ includeOriginalCardId = true } = {}) {
+    getUrlHash({ includeOriginalCardId = true } = {}) {
         // TODO Atte Keinänen 5/31/17: Remove code mutation and unnecessary copying
         const dataset_query = Utils.copy(this._card.dataset_query);
         if (dataset_query.query) {
@@ -488,5 +486,9 @@ export default class Question {
         };
 
         return Card_DEPRECATED.utf8_to_b64url(JSON.stringify(cardCopy));
+    }
+
+    static deserializeUrlHash(urlHash) {
+        return Card_DEPRECATED.deserializeCardFromUrl(urlHash)
     }
 }

--- a/frontend/src/metabase/qb/components/actions/XRayCard.jsx
+++ b/frontend/src/metabase/qb/components/actions/XRayCard.jsx
@@ -9,16 +9,21 @@ import { t } from "c-3po";
 export default ({ question, settings }: ClickActionProps): ClickAction[] => {
     // currently time series xrays require the maximum fidelity
     if (
-        question.card().id &&
         settings["enable_xrays"] &&
         settings["xray_max_cost"] === "extended"
     ) {
+        const cardId = question.card().id
+        const isSavedQuestion = !!cardId
+
+        const url = () =>
+            isSavedQuestion ? `/xray/card/${cardId}/extended` : `/xray/card/extended#` + question.getUrlHash()
+
         return [
             {
                 name: "xray-card",
                 title: t`X-ray this question`,
                 icon: "beaker",
-                url: () => `/xray/card/${question.card().id}/extended`
+                url
             }
         ];
     } else {

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -256,6 +256,7 @@ export const getRoutes = (store) =>
                     <Route path="table/:tableId/:cost" component={TableXRay} />
                     <Route path="field/:fieldId/:cost" component={FieldXRay} />
                     <Route path="card/:cardId/:cost" component={CardXRay} />
+                    <Route path="card/:cost" component={CardXRay} />
                     <Route path="compare/:modelTypePlural/:modelId1/:modelId2/:cost" component={SharedTypeComparisonXRay} />
                     <Route path="compare/:modelType1/:modelId1/:modelType2/:modelId2/:cost" component={TwoTypesComparisonXRay} />
                 </Route>

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -168,6 +168,7 @@ export const XRayApi = {
     table_xray:                  GET("/api/x-ray/table/:tableId"),
     segment_xray:                GET("/api/x-ray/segment/:segmentId"),
     card_xray:                   GET("/api/x-ray/card/:cardId"),
+    unsaved_card_xray:          POST("/api/x-ray/query"),
 
     compare_shared_type:         GET("/api/x-ray/compare/:modelTypePlural/:modelId1/:modelId2"),
     compare_two_types:           GET("/api/x-ray/compare/:modelType1/:modelId1/:modelType2/:modelId2"),


### PR DESCRIPTION
Adds support for unsaved question xrays. So far we've only supported timeseries questions so that restriction applies to this PR as well; we might want to loosen that criterion separately.

Uses  `POST /api/x-ray/query` endpoint which @sbelak had implemented earlier.

I wanted to keep unsaved question xrays and native question xrays in separate PRs so native question xrays are coming up next and will automagically support both saved and unsaved questions.

TODO:
- [ ] Ask for UX help; for instance I'm not sure what should be the page title for unsaved questions
- [ ] Fix the failing integration test