### PR TITLE
Add backend code to auto include CSVs on rows alerts

### DIFF
--- a/frontend/src/metabase-lib/lib/Alert.js
+++ b/frontend/src/metabase-lib/lib/Alert.js
@@ -29,10 +29,7 @@ export const getDefaultAlert = (question, user) => {
     };
 
     return {
-        card: {
-            id: question.id(),
-            include_csv: alertType === ALERT_TYPE_ROWS
-        },
+        card: { id: question.id() },
         channels: [defaultEmailChannel],
         ...typeDependentAlertFields
     };

--- a/src/metabase/api/alert.clj
+++ b/src/metabase/api/alert.clj
@@ -107,6 +107,11 @@
     (doseq [recipient (non-creator-recipients alert)]
       (messages/send-you-were-added-alert-email! alert recipient @api/*current-user*))))
 
+(defn- maybe-include-csv [card alert-condition]
+  (if (= "rows" alert-condition)
+    (assoc card :include_csv true)
+    card))
+
 (api/defendpoint POST "/"
   "Create a new alert (`Pulse`)"
   [:as {{:keys [alert_condition card channels alert_first_only alert_above_goal] :as req} :body}]
@@ -116,10 +121,11 @@
    card              su/Map
    channels          (su/non-empty [su/Map])}
   (pulse-api/check-card-read-permissions [card])
-  (let [new-alert (api/check-500
+  (let [alert-card (-> card (maybe-include-csv alert_condition) pulse/create-card-ref)
+        new-alert (api/check-500
                    (-> req
                        only-alert-keys
-                       (pulse/create-alert! api/*current-user-id* (pulse/create-card-ref card) channels)))]
+                       (pulse/create-alert! api/*current-user-id* alert-card channels)))]
 
     (notify-new-alert-created! new-alert)
 

--- a/test/metabase/api/alert_test.clj
+++ b/test/metabase/api/alert_test.clj
@@ -156,6 +156,7 @@
 ;; Check creation of a new rows alert with email notification
 (tt/expect-with-temp [Card [card1 {:name "My question"}]]
   [(-> (default-alert card1)
+       (assoc-in [:card :include_csv] true)
        (update-in [:channels 0] merge {:schedule_hour 12, :schedule_type "daily", :recipients []}))
    (rasta-new-alert-email {"has any results" true})]
   (with-alert-setup
@@ -182,6 +183,7 @@
 (tt/expect-with-temp [Card [card1 {:name "My question"}]]
   [(-> (default-alert card1)
        (assoc :creator (user-details :crowberto))
+       (assoc-in [:card :include_csv] true)
        (update-in [:channels 0] merge {:schedule_hour 12, :schedule_type "daily", :recipients (set (map recipient-details [:rasta :crowberto]))}))
    (merge (et/email-to :crowberto {:subject "You setup an alert",
                                    :body {"https://metabase.com/testmb" true,


### PR DESCRIPTION
Previously this was done by the frontend, including boolean that
enables it. This moves the logic to the backend.
