### PR TITLE
Fix time datatype test failure on Oracle [ci drivers]

### DIFF
--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -658,7 +658,7 @@
  (let [response ((user->client :rasta) :get 200 (format "table/%d/query_metadata" (data/id :checkins)))]
    (dimension-options-for-field response "date")))
 
-(qpt/expect-with-non-timeseries-dbs
+(qpt/expect-with-non-timeseries-dbs-except #{:oracle :mongo :redshift}
   []
   (data/with-db (data/get-or-create-database! defs/test-data-with-time)
     (let [response ((user->client :rasta) :get 200 (format "table/%d/query_metadata" (data/id :users)))]


### PR DESCRIPTION
Oracle, mongo and redshift don't support the time datatype. A new test
covering dimension options for time fields was added, but included
those three databases in the test. This commit excludes them which
should make the test pass.