### PR TITLE
Ensure collection_id is included in series dashcards

### DIFF
--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -68,7 +68,7 @@
 (defn ^:hydrate series
   "Return the `Cards` associated as additional series on this `DashboardCard`."
   [{:keys [id]}]
-  (db/select [Card :id :name :description :display :dataset_query :visualization_settings]
+  (db/select [Card :id :name :description :display :dataset_query :visualization_settings :collection_id]
     (mdb/join [Card :id] [DashboardCardSeries :card_id])
     (db/qualify DashboardCardSeries :dashboardcard_id) id
     {:order-by [[(db/qualify DashboardCardSeries :position) :asc]]}))


### PR DESCRIPTION
Hydrating series dashcards wasn't including the related collection
id. The collection id is one way in which permissions are
checked. This would manifest itself in the user having access to
something they shouldn't. As an example, if a dashboard had a single
card that was part of a collection the user wouldn't have access to,
and the user attempted to access it, they would get a 403. If a second
card was added and that card contained multiple (i.e. a series) due to
this bug, the second card wouldn't have a collection_id and thus we'd
assume the user has access to it. The permissions checking on the
dashboard only checks whether or not the user has access to at least
one card in the dashboard, thus giving user access to the dashboard.

Fixes #5266
