### PR TITLE
Ensure aggregation expressions have base_type included

### DIFF
--- a/src/metabase/query_processor/annotate.clj
+++ b/src/metabase/query_processor/annotate.clj
@@ -169,7 +169,8 @@
          ;; hardcoding these types is fine; In the future when we extend Expressions to handle more functionality
          ;; we'll want to introduce logic that associates a return type with a given expression. But this will work
          ;; for the purposes of a patch release.
-         (when (instance? ExpressionRef ag-field)
+         (when (or (instance? ExpressionRef ag-field)
+                   (instance? Expression ag-field))
            {:base-type    :type/Float
             :special-type :type/Number})))
 

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -97,3 +97,13 @@
             (ql/expressions {:x (ql/* $price 2.0)})
             (ql/aggregation (ql/count))
             (ql/breakout (ql/expression :x))))))
+
+;; Custom aggregation expressions should include their type
+(datasets/expect-with-engines (engines-that-support :expressions)
+  #{{:name "CATEGORY_ID" :base_type :type/Integer}
+    {:name "x" :base_type :type/Float}}
+  (set (map #(select-keys % [:name :base_type])
+            (-> (data/run-query venues
+                  (ql/aggregation (ql/named (ql/sum (ql/* $price -1)) "x"))
+                  (ql/breakout $category_id))
+                (get-in [:data :cols])))))


### PR DESCRIPTION
This bug appears when an aggregate expression has a nested
expression. Previously it was only looking for an expression reference
and not a full expression.

Fixes #6363