### PR TITLE
Reduce number of Jest test runner worker threads

### DIFF
--- a/frontend/test/metabase-lib/Mode.unit.spec.js
+++ b/frontend/test/metabase-lib/Mode.unit.spec.js
@@ -22,7 +22,7 @@ describe("Mode", () => {
         .mode();
 
     describe("forQuestion(question)", () => {
-        it("with structured query question", () => {
+        describe("with structured query question", () => {
             // testbed for generative testing? see http://leebyron.com/testcheck-js
 
             it("returns `segment` mode with raw data", () => {});
@@ -39,11 +39,11 @@ describe("Mode", () => {
             it("returns `default` mode with >=0 aggregations and >=3 breakouts", () => {});
             it("returns `default` mode with >=1 aggregations and >=1 breakouts when first neither date or category", () => {});
         });
-        it("with native query question", () => {
+        describe("with native query question", () => {
             it("returns `NativeMode` for empty query", () => {});
             it("returns `NativeMode` for query with query text", () => {});
         });
-        it("with oddly constructed query", () => {
+        describe("with oddly constructed query", () => {
             it("should throw an error", () => {
                 // this is not the actual behavior atm (it returns DefaultMode)
             });

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "test": "yarn run test-integrated && yarn run test-unit && yarn run test-karma",
     "test-integrated": "babel-node ./frontend/test/__runner__/run_integrated_tests.js",
     "test-integrated-watch": "babel-node ./frontend/test/__runner__/run_integrated_tests.js --watch",
-    "test-unit": "jest --maxWorkers=10 --config jest.unit.conf.json --coverage",
+    "test-unit": "jest --maxWorkers=8 --config jest.unit.conf.json --coverage",
     "test-unit-watch": "jest --maxWorkers=10 --config jest.unit.conf.json --watch",
     "test-unit-update-snapshot": "jest --maxWorkers=10 --config jest.unit.conf.json --updateSnapshot",
     "test-karma": "karma start frontend/test/karma.conf.js --single-run",


### PR DESCRIPTION
Upgrading Jest did not improve the memory usage enough to keep us under the Circle 4GB limit. This PR now just lowers the number of worker threads.

Original (now out of date) PR description:

[Jest 21](https://github.com/facebook/jest/issues/3292) is supposed to include some memory enhancements. Our tests occasionally fail in Circle due to memory issues specifically when running the Jest tests. Upgrading to hopefully avoid those memory issues.

Attempted to upgrade to the latest Jest (v22.1.4) but hit a lot of test failures. This upgrade caused a few failures,but they were pretty easy to fix.


Fixes #6790
