### PR TITLE
Don't try to expand GA gaid: 'metrics'

### DIFF
--- a/src/metabase/query_processor/middleware/expand_macros.clj
+++ b/src/metabase/query_processor/middleware/expand_macros.clj
@@ -76,7 +76,7 @@
   [[_ id]]
   (boolean
    (when ((some-fn string? keyword?) id)
-     (re-find #"^ga:" (name id)))))
+     (re-find #"^ga(id)?:" (name id)))))
 
 (defn- metric? [aggregation]
   (and (is-clause? #{:metric} aggregation)

--- a/test/metabase/query_processor/middleware/expand_macros_test.clj
+++ b/test/metabase/query_processor/middleware/expand_macros_test.clj
@@ -184,3 +184,7 @@
 (expect
   {:query {:aggregation [[:metric :ga:users]]}}
   (#'expand-macros/expand-metrics-and-segments {:query {:aggregation [[:metric :ga:users]]}}))
+
+(expect
+  {:query {:aggregation [[:metric :gaid:users]]}}
+  (#'expand-macros/expand-metrics-and-segments {:query {:aggregation [[:metric :gaid:users]]}}))


### PR DESCRIPTION
As @dhinus noted on Friday my fix in #6414 worked for `ga:` "Metrics" but not `gaid:` ones. This PR fixes that oversight. Includes test. Fixes #6104