### PR TITLE
Clean up `.scroll-show` class

### DIFF
--- a/frontend/src/metabase/css/core/scroll.css
+++ b/frontend/src/metabase/css/core/scroll.css
@@ -3,7 +3,7 @@
 
 .scroll-show::-webkit-scrollbar {
     width: 15px;
-    height: 18px;
+    min-height: 10px;
 }
 
 .scroll-show--hover::-webkit-scrollbar {
@@ -13,12 +13,7 @@
     display: inherit;
 }
 
-.scroll-show--horizontal::-webkit-scrollbar {
-    height: 6px;
-}
-
 .scroll-show::-webkit-scrollbar-thumb {
-    height: 6px;
     border: 4px solid transparent;
     border-radius: 7px;
     background-clip: padding-box;

--- a/frontend/src/metabase/query_builder/components/filters/FilterList.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterList.jsx
@@ -55,7 +55,7 @@ export default class FilterList extends Component {
     render() {
         const { query, filters, tableMetadata } = this.props;
         return (
-            <div className="Query-filterList scroll-x scroll-show scroll-show--horizontal">
+            <div className="Query-filterList scroll-x scroll-show">
                 {filters.map((filter, index) =>
                     <FilterWidget
                         key={index}

--- a/frontend/src/metabase/visualizations/components/TableSimple.jsx
+++ b/frontend/src/metabase/visualizations/components/TableSimple.jsx
@@ -92,7 +92,7 @@ export default class TableSimple extends Component {
         return (
             <div className={cx(this.props.className, "relative flex flex-column")}>
                 <div className="flex-full relative">
-                    <div className="absolute top bottom left right scroll-x scroll-show scroll-show--horizontal scroll-show--hover" style={{ overflowY: "hidden" }}>
+                    <div className="absolute top bottom left right scroll-x scroll-show scroll-show--hover" style={{ overflowY: "hidden" }}>
                         <table className={cx(styles.Table, styles.TableSimple, 'fullscreen-normal-text', 'fullscreen-night-text')}>
                             <thead ref="header">
                                 <tr>


### PR DESCRIPTION
Cleans up some redundant declarations and overrides that were causing the .scroll-show class to run into display issues when used on horizontal scrolls.

Fixes #5470. 