### PR TITLE
Query cancellation

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -103,7 +103,7 @@
   :repositories [["bintray" "https://dl.bintray.com/crate/crate"]     ; Repo for Crate JDBC driver
                  ["redshift" "https://s3.amazonaws.com/redshift-driver-downloads"]]
   :plugins [[lein-environ "1.1.0"]                                    ; easy access to environment variables
-            [lein-ring "0.11.0"                                       ; start the HTTP server with 'lein ring server'
+            [lein-ring "0.12.3"                                       ; start the HTTP server with 'lein ring server'
              :exclusions [org.clojure/clojure]]                       ; TODO - should this be a dev dependency ?
             [puppetlabs/i18n "0.8.0"]]                                ; i18n helpers
   :main ^:skip-aot metabase.core

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -669,5 +669,4 @@
   (api/check-embedding-enabled)
   (db/select [Card :name :id], :enable_embedding true, :archived false))
 
-(api/define-routes
-  (middleware/streaming-json-response (route-fn-name 'POST "/:card-id/query")))
+(api/define-routes)

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -59,8 +59,10 @@
     (api/read-check Database database))
   ;; add sensible constraints for results limits on our query
   (let [source-card-id (query->source-card-id query)]
-    (qp/process-query-and-save-execution! (assoc query :constraints default-query-constraints)
-      {:executed-by api/*current-user-id*, :context :ad-hoc, :card-id source-card-id, :nested? (boolean source-card-id)})))
+    (api/cancellable-json-response
+     (fn []
+       (qp/process-query-and-save-execution! (assoc query :constraints default-query-constraints)
+         {:executed-by api/*current-user-id*, :context :ad-hoc, :card-id source-card-id, :nested? (boolean source-card-id)})))))
 
 
 ;;; ----------------------------------- Downloading Query Results in Other Formats -----------------------------------
@@ -152,5 +154,4 @@
                 (query/average-execution-time-ms (qputil/query-hash (assoc query :constraints default-query-constraints)))
                 0)})
 
-(api/define-routes
-  (middleware/streaming-json-response (route-fn-name 'POST "/")))
+(api/define-routes)

--- a/src/metabase/driver/druid.clj
+++ b/src/metabase/driver/druid.clj
@@ -43,6 +43,7 @@
 
 (def ^:private ^{:arglists '([url & {:as options}])} GET  (partial do-request http/get))
 (def ^:private ^{:arglists '([url & {:as options}])} POST (partial do-request http/post))
+(def ^:private ^{:arglists '([url & {:as options}])} DELETE (partial do-request http/delete))
 
 
 ;;; ### Misc. Driver Fns
@@ -57,15 +58,39 @@
 (defn- do-query [details query]
   {:pre [(map? query)]}
   (ssh/with-ssh-tunnel [details-with-tunnel details]
-    (try (vec (POST (details->url details-with-tunnel "/druid/v2"), :body query))
-         (catch Throwable e
-           ;; try to extract the error
-           (let [message (or (u/ignore-exceptions
-                               (:error (json/parse-string (:body (:object (ex-data e))) keyword)))
-                             (.getMessage e))]
-             (log/error (u/format-color 'red "Error running query:\n%s" message))
-             ;; Re-throw a new exception with `message` set to the extracted message
-             (throw (Exception. message e)))))))
+    (try
+      (POST (details->url details-with-tunnel "/druid/v2"), :body query)
+      (catch Throwable e
+        ;; try to extract the error
+        (let [message (or (u/ignore-exceptions
+                            (:error (json/parse-string (:body (:object (ex-data e))) keyword)))
+                          (.getMessage e))]
+          (log/error (u/format-color 'red "Error running query:\n%s" message))
+          ;; Re-throw a new exception with `message` set to the extracted message
+          (throw (Exception. message e)))))))
+
+(defn- do-query-with-cancellation [details query]
+  (let [query-id  (get-in query [:context :queryId])
+        query-fut (future (do-query details query))]
+    (try
+      ;; Run the query in a future so that this thread will be interrupted, not the thread running the query (which is
+      ;; not interrupt aware)
+      @query-fut
+      (catch InterruptedException interrupted-ex
+        ;; The future has been cancelled, if we ahve a query id, try to cancel the query
+        (if-not query-id
+          (log/warn interrupted-ex "Client closed connection, no queryId found, can't cancel query")
+          (ssh/with-ssh-tunnel [details-with-tunnel details]
+            (log/warnf "Client closed connection, cancelling Druid queryId '%s'" query-id)
+            (try
+              ;; If we can't cancel the query, we don't want to hide the original exception, attempt to cancel, but if
+              ;; we can't, we should rethrow the InterruptedException, not an exception from the cancellation
+              (DELETE (details->url details-with-tunnel (format "/druid/v2/%s" query-id)))
+              (catch Exception cancel-ex
+                (log/warnf cancel-ex "Failed to cancel Druid query with queryId" query-id))
+              (finally
+                ;; Propogate the exception, will cause any other catch/finally clauses to fire
+                (throw interrupted-ex)))))))))
 
 
 ;;; ### Sync
@@ -134,7 +159,7 @@
                                              :display-name "Broker node port"
                                              :type         :integer
                                              :default      8082}]))
-          :execute-query     (fn [_ query] (qp/execute-query do-query query))
+          :execute-query     (fn [_ query] (qp/execute-query do-query-with-cancellation query))
           :features          (constantly #{:basic-aggregations :set-timezone :expression-aggregations})
           :mbql->native      (u/drop-first-arg qp/mbql->native)}))
 

--- a/src/metabase/driver/druid/query_processor.clj
+++ b/src/metabase/driver/druid/query_processor.clj
@@ -86,7 +86,8 @@
 (def ^:private ^:const query-type->default-query
   (let [defaults {:intervals   ["1900-01-01/2100-01-01"]
                   :granularity :all
-                  :context     {:timeout 60000}}]
+                  :context     {:timeout 60000
+                                :queryId (str (java.util.UUID/randomUUID))}}]
     {::select             (merge defaults {:queryType  :select
                                            :pagingSpec {:threshold i/absolute-max-results}})
      ::total              (merge defaults {:queryType :timeseries})

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -451,16 +451,46 @@
               (jdbc/set-parameter value stmt i)))
           (rest (range)) params)))
 
+(defmacro ^:private with-ensured-connection
+  "In many of the clojure.java.jdbc functions, it checks to see if there's already a connection open before opening a
+  new one. This macro checks to see if one is open, or will open a new one. Will bind the connection to `conn-sym`."
+  [conn-sym db & body]
+  `(let [db# ~db]
+     (if-let [~conn-sym (jdbc/db-find-connection db#)]
+       (do ~@body)
+       (with-open [~conn-sym (jdbc/get-connection db#)]
+         ~@body))))
+
+(defn- cancellable-run-query
+  "Runs `sql` in such a way that it can be interrupted via a `future-cancel`"
+  [db sql params opts]
+  (with-ensured-connection conn db
+    ;; This is normally done for us by java.jdbc as a result of our `jdbc/query` call
+    (with-open [^PreparedStatement stmt (jdbc/prepare-statement conn sql opts)]
+      ;; Need to run the query in another thread so that this thread can cancel it if need be
+      (try
+        (let [query-future (future (jdbc/query conn (into [stmt] params) opts))]
+          ;; This thread is interruptable because it's awaiting the other thread (the one actually running the
+          ;; query). Interrupting this thread means that the client has disconnected (or we're shutting down) and so
+          ;; we can give up on the query running in the future
+          @query-future)
+        (catch InterruptedException e
+          (log/warn e "Client closed connection, cancelling query")
+          ;; This is what does the real work of cancelling the query. We aren't checking the result of
+          ;; `query-future` but this will cause an exception to be thrown, saying the query has been cancelled.
+          (.cancel stmt)
+          (throw e))))))
+
 (defn- run-query
   "Run the query itself."
   [{sql :query, params :params, remark :remark} timezone connection]
   (let [sql              (str "-- " remark "\n" (hx/unescape-dots sql))
         statement        (into [sql] params)
-        [columns & rows] (jdbc/query connection statement {:identifiers    identity, :as-arrays? true
-                                                           :read-columns   (read-columns-with-date-handling timezone)
-                                                           :set-parameters (set-parameters-with-timezone timezone)})]
-    {:rows    (or rows [])
-     :columns columns}))
+        [columns & rows] (cancellable-run-query connection sql params {:identifiers    identity, :as-arrays? true
+                                                                       :read-columns   (read-columns-with-date-handling timezone)
+                                                                       :set-parameters (set-parameters-with-timezone timezone)})]
+       {:rows    (or rows [])
+        :columns columns}))
 
 (defn- exception->nice-error-message ^String [^SQLException e]
   (or (->> (.getMessage e)     ; error message comes back like 'Column "ZID" not found; SQL statement: ... [error-code]' sometimes

--- a/src/metabase/middleware.clj
+++ b/src/metabase/middleware.clj
@@ -1,10 +1,6 @@
 (ns metabase.middleware
   "Metabase-specific middleware functions & configuration."
-  (:require [cheshire
-             [core :as json]
-             [generate :refer [add-encoder encode-nil encode-str]]]
-            [clojure.core.async :as async]
-            [clojure.java.io :as io]
+  (:require [cheshire.generate :refer [add-encoder encode-nil encode-str]]
             [clojure.tools.logging :as log]
             [metabase
              [config :as config]
@@ -20,8 +16,6 @@
              [setting :refer [defsetting]]
              [user :as user :refer [User]]]
             monger.json
-            [ring.core.protocols :as protocols]
-            [ring.util.response :as response]
             [toucan
              [db :as db]
              [models :as models]])
@@ -366,74 +360,3 @@
            (handler request))
          (catch Throwable e
            {:status 400, :body (.getMessage e)}))))
-
-
-;;; --------------------------------------------------- STREAMING ----------------------------------------------------
-
-(def ^:private ^:const streaming-response-keep-alive-interval-ms
-  "Interval between sending newline characters to keep Heroku from terminating requests like queries that take a long
-  time to complete."
-  (* 1 1000))
-
-;; Handle ring response maps that contain a core.async chan in the :body key:
-;;
-;; {:status 200
-;;  :body (async/chan)}
-;;
-;; and send each string sent to that queue back to the browser as it arrives
-;; this avoids output buffering in the default stream handling which was not sending
-;; any responses until ~5k characters where in the queue.
-(extend-protocol protocols/StreamableResponseBody
-  clojure.core.async.impl.channels.ManyToManyChannel
-  (write-body-to-stream [output-queue _ ^OutputStream output-stream]
-    (log/debug (u/format-color 'green "starting streaming request"))
-    (with-open [out (io/writer output-stream)]
-      (loop [chunk (async/<!! output-queue)]
-        (when-not (= chunk ::EOF)
-          (.write out (str chunk))
-          (try
-            (.flush out)
-            (catch org.eclipse.jetty.io.EofException e
-              (log/info (u/format-color 'yellow "connection closed, canceling request %s" (type e)))
-              (async/close! output-queue)
-              (throw e)))
-          (recur (async/<!! output-queue)))))))
-
-(defn streaming-json-response
-  "This midelware assumes handlers fail early or return success Run the handler in a future and send newlines to keep
-  the connection open and help detect when the browser is no longer listening for the response. Waits for one second
-  to see if the handler responds immediately, If it does then there is no need to stream the response and it is sent
-  back directly. In cases where it takes longer than a second, assume the eventual result will be a success and start
-  sending newlines to keep the connection open."
-  [handler]
-  (fn [request]
-    (let [response            (future (handler request))
-          optimistic-response (deref response streaming-response-keep-alive-interval-ms ::no-immediate-response)]
-      (if (= optimistic-response ::no-immediate-response)
-        ;; if we didn't get a normal response in the first poling interval assume it's going to be slow
-        ;; and start sending keepalive packets.
-        (let [output (async/chan 1)]
-          ;; the output channel will be closed by the adapter when the incoming connection is closed.
-          (future
-            (loop []
-              (Thread/sleep streaming-response-keep-alive-interval-ms)
-              (when-not (realized? response)
-                (log/debug (u/format-color 'blue "Response not ready, writing one byte & sleeping..."))
-                ;; a newline padding character is used because it forces output flushing in jetty.
-                ;; if sending this character fails because the connection is closed, the chan will then close.
-                ;; Newlines are no-ops when reading JSON which this depends upon.
-                (when-not (async/>!! output "\n")
-                  (log/info (u/format-color 'yellow "canceled request %s" (future-cancel response)))
-                  (future-cancel response)) ;; try our best to kill the thread running the query.
-                (recur))))
-          (future
-            (try
-              ;; This is the part where we make this assume it's a JSON response we are sending.
-              (async/>!! output (json/encode (:body @response)))
-              (finally
-                (async/>!! output ::EOF)
-                (async/close! response))))
-          ;; here we assume a successful response will be written to the output channel.
-          (assoc (response/response output)
-            :content-type "applicaton/json"))
-          optimistic-response))))

--- a/test/metabase/api/common_test.clj
+++ b/test/metabase/api/common_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.api.common-test
-  (:require [expectations :refer :all]
-            [metabase.api.common :refer :all]
+  (:require [clojure.core.async :as async]
+            [expectations :refer :all]
+            [metabase.api.common :refer :all :as api]
             [metabase.api.common.internal :refer :all]
             [metabase.test.data :refer :all]
             [metabase.util.schema :as su]))
@@ -94,3 +95,86 @@
     (defendpoint GET "/:id" [id]
       {id su/IntGreaterThanZero}
       (select-one Card :id id))))
+
+(def ^:private long-timeout
+  ;; 2 minutes
+  (* 2 60000))
+
+(defn- take-with-timeout [response-chan]
+  (let [[response c] (async/alts!! [response-chan
+                                    ;; We should never reach this unless something is REALLY wrong
+                                    (async/timeout long-timeout)])]
+    (when (and (nil? response)
+               (not= c response-chan))
+      (throw (Exception. "Taking from streaming endpoint timed out!")))
+
+    response))
+
+(defn- wait-for-future-cancellation
+  "Once a client disconnects, the next heartbeat sent will result in an exception that should cancel the future. In
+  theory 1 keepalive-interval should be enough, but building in some wiggle room here for poor concurrency timing in
+  tests."
+  [fut]
+  (let [keepalive-interval (var-get #'api/streaming-response-keep-alive-interval-ms)
+        max-iterations     (long (/ long-timeout keepalive-interval))]
+    (loop [i 0]
+      (if (or (future-cancelled? fut) (> i max-iterations))
+        fut
+        (do
+          (Thread/sleep keepalive-interval)
+          (recur (inc i)))))))
+
+;; This simulates 2 keepalive-intervals followed by the query response
+(expect
+  [\newline \newline {:success true} false]
+  (let [send-response (promise)
+        {:keys [output-channel error-channel response-future]} (#'api/invoke-thunk-with-keepalive (fn [] @send-response))]
+    [(take-with-timeout output-channel)
+     (take-with-timeout output-channel)
+     (do
+       (deliver send-response {:success true})
+       (take-with-timeout output-channel))
+     (future-cancelled? response-future)]))
+
+;; This simulates an immediate query response
+(expect
+  [{:success true} false]
+  (let [{:keys [output-channel error-channel response-future]} (#'api/invoke-thunk-with-keepalive (fn [] {:success true}))]
+    [(take-with-timeout output-channel)
+     (future-cancelled? response-future)]))
+
+;; This simulates a closed connection from the client, should cancel the future
+(expect
+  [\newline \newline true]
+  (let [send-response (promise)
+        {:keys [output-channel error-channel response-future]} (#'api/invoke-thunk-with-keepalive (fn [] (Thread/sleep long-timeout)))]
+    [(take-with-timeout output-channel)
+     (take-with-timeout output-channel)
+     (do
+       (async/close! output-channel)
+       (future-cancelled? (wait-for-future-cancellation response-future)))]))
+
+;; When an immediate exception happens, we should know that via the error channel
+(expect
+  ;; Each channel should have the failure and then get closed
+  ["It failed" "It failed" nil nil]
+  (let [{:keys [output-channel error-channel response-future]} (#'api/invoke-thunk-with-keepalive (fn [] (throw (Exception. "It failed"))))]
+    [(.getMessage (take-with-timeout error-channel))
+     (.getMessage (take-with-timeout output-channel))
+     (async/<!! error-channel)
+     (async/<!! output-channel)]))
+
+;; This simulates a slow failure, we'll still get an exception, but the error channel is closed, so at this point
+;; we've assumed it would be a success, but it wasn't
+(expect
+  [\newline nil \newline "It failed" false]
+  (let [now-throw-exception (promise)
+        {:keys [output-channel error-channel response-future]} (#'api/invoke-thunk-with-keepalive
+                                                                (fn [] @now-throw-exception (throw (Exception. "It failed"))))]
+    [(take-with-timeout output-channel)
+     (take-with-timeout error-channel)
+     (take-with-timeout output-channel)
+     (do
+       (deliver now-throw-exception true)
+       (.getMessage (take-with-timeout output-channel)))
+     (future-cancelled? response-future)]))

--- a/test/metabase/query_processor_test/query_cancellation_test.clj
+++ b/test/metabase/query_processor_test/query_cancellation_test.clj
@@ -1,0 +1,54 @@
+(ns metabase.query-processor-test.query-cancellation-test
+  (:require [clojure.java.jdbc :as jdbc]
+            [expectations :refer :all]
+            [metabase.test.util :as tu]))
+
+(deftype FakePreparedStatement [called-cancel?]
+  java.sql.PreparedStatement
+  (cancel [_] (deliver called-cancel? true))
+  (close [_] true))
+
+(defn- make-fake-prep-stmt
+  "Returns `fake-value` whenenver the `sql` parameter returns a truthy value when passed to `use-fake-value?`"
+  [orig-make-prep-stmt use-fake-value? faked-value]
+  (fn [connection sql options]
+    (if (use-fake-value? sql)
+      faked-value
+      (orig-make-prep-stmt connection sql options))))
+
+(defn- fake-query
+  "Function to replace the `clojure.java.jdbc/query` function. Will invoke `call-on-query`, then `call-to-pause` whe
+  passed an instance of `FakePreparedStatement`"
+  [orig-jdbc-query call-on-query call-to-pause]
+  (fn
+    ([conn stmt+params]
+     (orig-jdbc-query conn stmt+params))
+    ([conn stmt+params opts]
+     (if (instance? FakePreparedStatement (first stmt+params))
+       (do
+         (call-on-query)
+         (call-to-pause))
+       (orig-jdbc-query conn stmt+params opts)))))
+
+(expect
+  [false ;; Ensure the query promise hasn't fired yet
+   false ;; Ensure the cancellation promise hasn't fired yet
+   true  ;; Was query called?
+   false ;; Cancel should not have been called yet
+   true  ;; Cancel should have been called now
+   true  ;; The paused query can proceed now
+   ]
+  (tu/call-with-paused-query
+   (fn [query-thunk called-query? called-cancel? pause-query]
+     (let [ ;; This fake prepared statement is cancellable like a prepared statement, but will allow us to tell the
+           ;; difference between our Prepared statement and the real thing
+           fake-prep-stmt             (->FakePreparedStatement called-cancel?)
+           ;; Much of the underlying plumbing of MB requires a working jdbc/query and jdbc/prepared-statement (such
+           ;; as queryies for the application database). Let binding the original versions of the functions allows
+           ;; us to delegate to them when it's not the query we're trying to test
+           orig-jdbc-query            jdbc/query
+           orig-prep-stmt             jdbc/prepare-statement]
+       (future
+         (with-redefs [jdbc/prepare-statement (make-fake-prep-stmt orig-prep-stmt (fn [table-name] (re-find #"CHECKINS" table-name)) fake-prep-stmt)
+                       jdbc/query             (fake-query orig-jdbc-query #(deliver called-query? true) #(deref pause-query))]
+           (query-thunk)))))))

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -27,8 +27,11 @@
              [setting :as setting]
              [table :refer [Table]]
              [user :refer [User]]]
+            [metabase.query-processor.middleware.expand :as ql]
             [metabase.test.data :as data]
-            [metabase.test.data.datasets :refer [*driver*]]
+            [metabase.test.data
+             [datasets :refer [*driver*]]
+             [dataset-definitions :as defs]]
             [toucan.db :as db]
             [toucan.util.test :as test])
   (:import java.util.TimeZone
@@ -478,3 +481,46 @@
      (finally
        (doseq [model# ~model-seq]
          (db/delete! model#)))))
+
+(defn call-with-paused-query
+  "This is a function to make testing query cancellation eaiser as it can be complex handling the multiple threads
+  needed to orchestrate a query cancellation.
+
+  This function takes `f` which is a function of 4 arguments:
+     - query-thunk - no-arg function that will invoke a query
+     - query promise - promise used to validate the query function was called
+     - cancel promise - promise used to validate a cancellation function was called
+     - pause query promise - promise used to hang the query function, allowing cancellation
+
+  This function returns a vector of booleans indicating the various statuses of the promises, useful for comparison
+  in an `expect`"
+  [f]
+  (data/with-db (data/get-or-create-database! defs/test-data)
+    (let [called-cancel?             (promise)
+          called-query?              (promise)
+          pause-query                (promise)
+          before-query-called-cancel (realized? called-cancel?)
+          before-query-called-query  (realized? called-query?)
+          query-thunk                (fn [] (data/run-query checkins
+                                              (ql/aggregation (ql/count))))
+          ;; When the query is ran via the datasets endpoint, it will run in a future. That future can be cancelled,
+          ;; which should cause an interrupt
+          query-future               (f query-thunk called-query? called-cancel? pause-query)]
+
+      ;; Make sure that we start out with our promises not having a value
+      [before-query-called-cancel
+       before-query-called-query
+       ;; The cancelled-query? and called-cancel? timeouts are very high and are really just intended to
+       ;; prevent the test from hanging indefinitely. It shouldn't be hit unless something is really wrong
+       (deref called-query? 120000 ::query-never-called)
+       ;; At this point in time, the query is blocked, waiting for `pause-query` do be delivered
+       (realized? called-cancel?)
+       (do
+         ;; If we cancel the future, it should throw an InterruptedException, which should call the cancel
+         ;; method on the prepared statement
+         (future-cancel query-future)
+         (deref called-cancel? 120000 ::cancel-never-called))
+       (do
+         ;; This releases the fake query function so it finishes
+         (deliver pause-query true)
+         true)])))


### PR DESCRIPTION
This PR adds query cancelling support to databases that support it. This is done via an interrupt on the thread that is running the query. If the driver allows query cancellation, that interrupt will cause the cancellation logic to run, then propagate the error. This interrupt is triggered by the backend realizing the that client is no longer connected which can happen if the user clicks `Cancel` or if they've closed the tab, broken the connection etc.

TODO
- [x] JDBC cancellation support
- [x] Druid cancellation support
- [x] Presto cancellation support
- [x] Unit tests ensuring the cancellation code gets invoked
- [x] Diagnose code loading issue with `lein ring server-headless`