### PR TITLE
Automagic filters [WIP]

### DIFF
--- a/src/metabase/api/automagic_dashboards.clj
+++ b/src/metabase/api/automagic_dashboards.clj
@@ -3,7 +3,8 @@
             [metabase.api.common :as api]
             [metabase.automagic-dashboards
              [core :as magic]
-             [comparison :as magic.comparison]]
+             [comparison :as magic.comparison]
+             [filters :as magic.filters]]
             [metabase.models
              [dashboard :refer [Dashboard]]
              [segment :refer [Segment]]
@@ -32,5 +33,11 @@
   [(:id (magic.comparison/comparison-dashboard (Dashboard dashboard-id)
                                                (Segment left-id)
                                                (Segment right-id)))])
+
+(api/defendpoint GET "/filters/:dashboard-id"
+  "Add filters to dashboard."
+  [dashboard-id]
+  (magic.filters/add-filters! (Dashboard dashboard-id))
+  "Done")
 
 (api/define-routes)

--- a/src/metabase/automagic_dashboards/filters.clj
+++ b/src/metabase/automagic_dashboards/filters.clj
@@ -1,0 +1,94 @@
+(ns metabase.automagic-dashboards.filters
+  (:require [clojure.string :as str]
+            [metabase.models
+             [card :refer [Card]]
+             [dashboard :as dashboard :refer [Dashboard]]
+             [dashboard-card :refer [DashboardCard]]
+             [field :refer [Field]]]
+            [schema.core :as s]
+            [toucan.db :as db]))
+
+(def ^:private FieldIdForm
+  [(s/one (s/constrained (s/either s/Str s/Keyword)
+                         (comp #{"field-id" "fk->"} str/lower-case name))
+          "head")
+   s/Any])
+
+(defn- collect-field-references
+  [card]
+  (->> card
+       :dataset_query
+       :query
+       ((juxt :breakout :fields))
+       (tree-seq sequential? identity)
+       (remove (s/checker FieldIdForm))))
+
+(defn- candidates-for-filtering
+  [cards]
+  (->> cards
+       (mapcat collect-field-references)
+       distinct
+       (map (comp Field last))
+       distinct
+       (filter (fn [{:keys [base_type special_type]}]
+                 (or (isa? base_type :type/DateTime)
+                     (isa? special_type :type/Category))))))
+
+(defn- find-fk
+  [from-table to-field]
+  (->> (db/select [Field :id :fk_target_field_id]
+         :fk_target_field_id [:not= nil]
+         :table_id from-table)
+       (filter (comp #{(:table_id to-field)} :table_id Field :fk_target_field_id))
+       (map :id)))
+
+(defn- filter-for-card
+  [card field]
+  (when-let [field-reference (if (= (:table_id card) (:table_id field))
+                               [:field-id (:id field)]
+                               (let [fk (find-fk (:table_id card) field)]
+                                 ;; Bail out if there are multiple FKs from the
+                                 ;; same table.
+                                 (when (= (count fk) 1)
+                                   [:fk-> (first fk) (:id field)])))]
+    [:dimension field-reference]))
+
+(defn- add-filter
+  [dashcard filter-id field]
+  (if-let [target (-> dashcard :card_id Card (filter-for-card field))]
+    (update dashcard :parameter_mappings conj
+            {:parameter_id filter-id
+             :card_id      (:card_id dashcard)
+             :target       target})
+    dashcard))
+
+(defn- filter-type
+  [{:keys [base_type special_type]}]
+  (cond
+    (isa? base_type :type/DateTime)    "date/all-options"
+    (isa? special_type :type/State)    "location/state"
+    (isa? special_type :type/Country)  "location/country"
+    (isa? special_type :type/Category) "category"))
+
+(defn add-filters!
+  [dashboard]
+  (let [dashcards (db/select DashboardCard :dashboard_id (:id dashboard))
+        [parameters dashcards]
+        (->> dashcards
+             (keep (comp Card :card_id))
+             candidates-for-filtering
+             (reduce
+              (fn [[parameters dashcards] candidate]
+                (let [filter-id     (-> candidate hash str)
+                      dashcards-new (keep #(add-filter % filter-id candidate)
+                                          dashcards)]
+                  [(cond-> parameters
+                     (not= dashcards dashcards-new)
+                     (conj {:id   filter-id
+                            :type (filter-type candidate)
+                            :name (:display_name candidate)
+                            :slug (:name candidate)}))
+                   dashcards-new]))
+              [(:parameters dashboard) dashcards]))]
+    (dashboard/update-dashcards! dashboard dashcards)
+    (db/update! Dashboard (:id dashboard) :parameters parameters)))

--- a/src/metabase/types.clj
+++ b/src/metabase/types.clj
@@ -127,6 +127,7 @@
 (derive :type/State :type/Category)
 (derive :type/Country :type/Category)
 (derive :type/Name :type/Category)
+(derive :type/Title :type/Category)
 
 (derive :type/User :type/*)
 (derive :type/Author :type/User)


### PR DESCRIPTION
Automagically adds filters to a dashboard. 

We extract all categories and date-times used in cards contained in the given dashboard and create filters for them.

```
GET /automagic-dashboards/filters/:dashboard-id
```
Note, this call mutates the original dashboard.

<img width="1276" alt="screenshot 2018-02-02 12 35 23" src="https://user-images.githubusercontent.com/178038/35753701-9e1e7de6-0815-11e8-972c-84d08860995b.png">
 

## Current limitations:

* Only works with GUI queries
* Skips dimensions in adjoined tables that are linked to by multiple FKs (this seems solvable for most cases).
* Doesn't pickup GA dimensions (also seems to be affected by #6769).