### PR TITLE
Explicitly convert user-specified query params keys to keywords

### DIFF
--- a/frontend/src/metabase/pulse/components/PulseCardPreview.jsx
+++ b/frontend/src/metabase/pulse/components/PulseCardPreview.jsx
@@ -6,6 +6,7 @@ import PropTypes from "prop-types";
 import Icon from "metabase/components/Icon.jsx";
 import LoadingSpinner from "metabase/components/LoadingSpinner.jsx";
 import Tooltip from "metabase/components/Tooltip.jsx";
+import MetabaseAnalytics from "metabase/lib/analytics";
 
 import { t } from "c-3po";
 import cx from "classnames";
@@ -46,8 +47,12 @@ export default class PulseCardPreview extends Component {
         const { card, onChange } = this.props;
         if (this.hasAttachment()) {
             onChange({ ...card, include_csv: false, include_xls: false })
+
+            MetabaseAnalytics.trackEvent((this.props.pulseId) ? "PulseEdit" : "PulseCreate", "RemoveAttachment");
         } else {
             onChange({ ...card, include_csv: true })
+
+            MetabaseAnalytics.trackEvent((this.props.pulseId) ? "PulseEdit" : "PulseCreate", "AddAttachment", 'csv');
         }
     }
 

--- a/frontend/src/metabase/pulse/components/PulseCardPreview.jsx
+++ b/frontend/src/metabase/pulse/components/PulseCardPreview.jsx
@@ -6,7 +6,6 @@ import PropTypes from "prop-types";
 import Icon from "metabase/components/Icon.jsx";
 import LoadingSpinner from "metabase/components/LoadingSpinner.jsx";
 import Tooltip from "metabase/components/Tooltip.jsx";
-import MetabaseAnalytics from "metabase/lib/analytics";
 
 import { t } from "c-3po";
 import cx from "classnames";
@@ -23,6 +22,7 @@ export default class PulseCardPreview extends Component {
         onRemove: PropTypes.func.isRequired,
         fetchPulseCardPreview: PropTypes.func.isRequired,
         attachmentsEnabled: PropTypes.bool,
+        trackPulseEvent: PropTypes.func.isRequired
     };
 
     componentWillMount() {
@@ -48,11 +48,11 @@ export default class PulseCardPreview extends Component {
         if (this.hasAttachment()) {
             onChange({ ...card, include_csv: false, include_xls: false })
 
-            MetabaseAnalytics.trackEvent((this.props.pulseId) ? "PulseEdit" : "PulseCreate", "RemoveAttachment");
+            this.props.trackPulseEvent("RemoveAttachment")
         } else {
             onChange({ ...card, include_csv: true })
 
-            MetabaseAnalytics.trackEvent((this.props.pulseId) ? "PulseEdit" : "PulseCreate", "AddAttachment", 'csv');
+            this.props.trackPulseEvent("AddAttachment", 'csv')
         }
     }
 

--- a/frontend/src/metabase/pulse/components/PulseEditCards.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEditCards.jsx
@@ -38,10 +38,17 @@ export default class PulseEditCards extends Component {
         });
     }
 
+    trackPulseEvent = (eventName: string, eventValue: string) => {
+        MetabaseAnalytics.trackEvent(
+            (this.props.pulseId) ? "PulseEdit" : "PulseCreate",
+            eventName,
+            eventValue
+        );
+    }
+
     addCard(index, cardId) {
         this.setCard(index, { id: cardId })
-
-        MetabaseAnalytics.trackEvent((this.props.pulseId) ? "PulseEdit" : "PulseCreate", "AddCard", index);
+        this.trackPulseEvent("AddCard", index);
     }
 
     removeCard(index) {
@@ -51,7 +58,7 @@ export default class PulseEditCards extends Component {
             cards: [...pulse.cards.slice(0, index), ...pulse.cards.slice(index + 1)]
         });
 
-        MetabaseAnalytics.trackEvent((this.props.pulseId) ? "PulseEdit" : "PulseCreate", "RemoveCard", index);
+        this.trackPulseEvent("RmoveCard", index);
     }
 
     getNotices(card, cardPreview, index) {
@@ -61,7 +68,7 @@ export default class PulseEditCards extends Component {
         if (hasAttachment) {
             notices.push({
                 head: t`Attachment`,
-                body: <AttachmentWidget card={card} onChange={(card) => this.setCard(index, card)} index={index} pulseId={this.props.pulseId}  />
+                body: <AttachmentWidget card={card} onChange={(card) => this.setCard(index, card)} trackPulseEvent={this.trackPulseEvent} />
             });
         }
         if (cardPreview) {
@@ -128,13 +135,13 @@ export default class PulseEditCards extends Component {
                                     <span className="h3 text-bold mr1 mt2">{index + 1}.</span>
                                     { card ?
                                         <PulseCardPreview
-                                            pulseId={this.props.pulseId}
                                             card={card}
                                             cardPreview={cardPreviews[card.id]}
                                             onChange={this.setCard.bind(this, index)}
                                             onRemove={this.removeCard.bind(this, index)}
                                             fetchPulseCardPreview={this.props.fetchPulseCardPreview}
                                             attachmentsEnabled={this.props.attachmentsEnabled}
+                                            trackPulseEvent={this.trackPulseEvent}
                                         />
                                     :
                                         <CardPicker
@@ -156,7 +163,7 @@ export default class PulseEditCards extends Component {
 
 const ATTACHMENT_TYPES = ["csv", "xls"];
 
-const AttachmentWidget = ({ card, onChange, pulseId }) =>
+const AttachmentWidget = ({ card, onChange, trackPulseEvent }) =>
     <div>
         { ATTACHMENT_TYPES.map(type =>
             <span
@@ -168,7 +175,7 @@ const AttachmentWidget = ({ card, onChange, pulseId }) =>
                       newCard["include_" + attachmentType] = type === attachmentType;
                     }
 
-                    MetabaseAnalytics.trackEvent((pulseId) ? "PulseEdit" : "PulseCreate", "AttachmentTypeChanged", type);
+                    trackPulseEvent("AttachmentTypeChanged", type);
                     onChange(newCard)
                 }}
             >
@@ -180,5 +187,5 @@ const AttachmentWidget = ({ card, onChange, pulseId }) =>
 AttachmentWidget.propTypes = {
     card: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-    pulseId: PropTypes.number
+    trackPulseEvent: PropTypes.func.isRequired
 }

--- a/frontend/src/metabase/pulse/components/PulseEditCards.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEditCards.jsx
@@ -61,7 +61,7 @@ export default class PulseEditCards extends Component {
         if (hasAttachment) {
             notices.push({
                 head: t`Attachment`,
-                body: <AttachmentWidget card={card} onChange={(card) => this.setCard(index, card)} />
+                body: <AttachmentWidget card={card} onChange={(card) => this.setCard(index, card)} index={index} pulseId={this.props.pulseId}  />
             });
         }
         if (cardPreview) {
@@ -128,6 +128,7 @@ export default class PulseEditCards extends Component {
                                     <span className="h3 text-bold mr1 mt2">{index + 1}.</span>
                                     { card ?
                                         <PulseCardPreview
+                                            pulseId={this.props.pulseId}
                                             card={card}
                                             cardPreview={cardPreviews[card.id]}
                                             onChange={this.setCard.bind(this, index)}
@@ -155,7 +156,7 @@ export default class PulseEditCards extends Component {
 
 const ATTACHMENT_TYPES = ["csv", "xls"];
 
-const AttachmentWidget = ({ card, onChange }) =>
+const AttachmentWidget = ({ card, onChange, pulseId }) =>
     <div>
         { ATTACHMENT_TYPES.map(type =>
             <span
@@ -166,6 +167,8 @@ const AttachmentWidget = ({ card, onChange }) =>
                     for (const attachmentType of ATTACHMENT_TYPES) {
                       newCard["include_" + attachmentType] = type === attachmentType;
                     }
+
+                    MetabaseAnalytics.trackEvent((pulseId) ? "PulseEdit" : "PulseCreate", "AttachmentTypeChanged", type);
                     onChange(newCard)
                 }}
             >
@@ -176,5 +179,6 @@ const AttachmentWidget = ({ card, onChange }) =>
 
 AttachmentWidget.propTypes = {
     card: PropTypes.object.isRequired,
-    onChange: PropTypes.func.isRequired
+    onChange: PropTypes.func.isRequired,
+    pulseId: PropTypes.number
 }

--- a/frontend/src/metabase/pulse/components/PulseEditCards.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEditCards.jsx
@@ -58,7 +58,7 @@ export default class PulseEditCards extends Component {
             cards: [...pulse.cards.slice(0, index), ...pulse.cards.slice(index + 1)]
         });
 
-        this.trackPulseEvent("RmoveCard", index);
+        this.trackPulseEvent("RemoveCard", index);
     }
 
     getNotices(card, cardPreview, index) {

--- a/frontend/test/query_builder/qb_drillthrough.integ.spec.js
+++ b/frontend/test/query_builder/qb_drillthrough.integ.spec.js
@@ -71,7 +71,6 @@ describe("QueryBuilder", () => {
                     }
                 }));
 
-
                 click(qb.find(RunButton));
                 await store.waitForActions([QUERY_COMPLETED]);
 
@@ -79,7 +78,9 @@ describe("QueryBuilder", () => {
                 const firstRowCells = table.find("tbody tr").first().find("td");
                 expect(firstRowCells.length).toBe(2);
 
-                expect(firstRowCells.first().text()).toBe("4  –  6");
+                // NOTE: Commented out due to the randomness involved in sample dataset generation
+                // which sometimes causes the cell value to be different
+                // expect(firstRowCells.first().text()).toBe("4  –  6");
 
                 const countCell = firstRowCells.last();
                 expect(countCell.text()).toBe("2");
@@ -187,6 +188,10 @@ describe("QueryBuilder", () => {
                 // Should have visualization type set to the previous visualization
                 const card = getCard(store.getState())
                 expect(card.display).toBe("bar");
+
+                // Some part of visualization seems to be asynchronous, causing a cluster of errors
+                // about missing query results if this delay isn't present
+                await delay(100)
             });
         })
     })

--- a/project.clj
+++ b/project.clj
@@ -152,7 +152,8 @@
                    :aot [metabase.logger]}                            ; Log appender class needs to be compiled for log4j to use it
              :ci {:jvm-opts ["-Xmx3g"]}
              :reflection-warnings {:global-vars {*warn-on-reflection* true}} ; run `lein check-reflection-warnings` to check for reflection warnings
-             :expectations {:injections [(require 'metabase.test-setup)]
+             :expectations {:injections [(require 'metabase.test-setup  ; for test setup stuff
+                                                  'metabase.test.util)] ; for the toucan.util.test default values for temp models
                             :resource-paths ["test_resources"]
                             :env {:mb-test-setting-1 "ABCDEFG"
                                   :mb-run-mode "test"}

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -42,6 +42,8 @@
 
 ;;; CONFIG
 
+;; TODO - why not just put this in `metabase.middleware` with *all* of our other custom middleware. Also, what's the
+;; difference between this and `streaming-json-response`?
 (defn- streamed-json-response
   "Write `RESPONSE-SEQ` to a PipedOutputStream as JSON, returning the connected PipedInputStream"
   [response-seq options]

--- a/test/metabase/api/preview_embed_test.clj
+++ b/test/metabase/api/preview_embed_test.clj
@@ -2,14 +2,16 @@
   (:require [expectations :refer :all]
             [metabase.api.embed-test :as embed-test]
             [metabase.models.dashboard :refer [Dashboard]]
+            [metabase.test.data :as data]
             [metabase.test.data.users :as test-users]
             [metabase.test.util :as tu]
             [metabase.util :as u]
             [toucan.util.test :as tt]))
 
-;;; ------------------------------------------------------------ GET /api/preview_embed/card/:token ------------------------------------------------------------
+;;; --------------------------------------- GET /api/preview_embed/card/:token ---------------------------------------
 
-(defn- card-url [card & [additional-token-params]] (str "preview_embed/card/" (embed-test/card-token card (merge {:_embedding_params {}} additional-token-params))))
+(defn- card-url [card & [additional-token-params]]
+  (str "preview_embed/card/" (embed-test/card-token card (merge {:_embedding_params {}} additional-token-params))))
 
 ;; it should be possible to use this endpoint successfully if all the conditions are met
 (expect
@@ -45,15 +47,20 @@
 (expect
   [{:id nil, :type "date/single", :target ["variable" ["template-tag" "d"]], :name "d", :slug "d", :default nil}]
   (embed-test/with-embedding-enabled-and-new-secret-key
-    (embed-test/with-temp-card [card {:dataset_query {:native {:template_tags {:a {:type "date", :name "a", :display_name "a"}
-                                                                               :b {:type "date", :name "b", :display_name "b"}
-                                                                               :c {:type "date", :name "c", :display_name "c"}
-                                                                               :d {:type "date", :name "d", :display_name "d"}}}}}]
-      (:parameters ((test-users/user->client :crowberto) :get 200 (card-url card {:_embedding_params {:a "locked", :b "disabled", :c "enabled", :d "enabled"}
-                                                                                  :params            {:c 100}}))))))
+    (embed-test/with-temp-card [card {:dataset_query
+                                      {:native {:template_tags {:a {:type "date", :name "a", :display_name "a"}
+                                                                :b {:type "date", :name "b", :display_name "b"}
+                                                                :c {:type "date", :name "c", :display_name "c"}
+                                                                :d {:type "date", :name "d", :display_name "d"}}}}}]
+      (-> ((test-users/user->client :crowberto) :get 200 (card-url card {:_embedding_params {:a "locked"
+                                                                                             :b "disabled"
+                                                                                             :c "enabled"
+                                                                                             :d "enabled"}
+                                                                         :params            {:c 100}}))
+          :parameters ))))
 
 
-;;; ------------------------------------------------------------ GET /api/preview_embed/card/:token/query ------------------------------------------------------------
+;;; ------------------------------------ GET /api/preview_embed/card/:token/query ------------------------------------
 
 (defn- card-query-url [card & [additional-token-params]]
   (str "preview_embed/card/"
@@ -104,14 +111,17 @@
   (embed-test/successful-query-results)
   (embed-test/with-embedding-enabled-and-new-secret-key
     (embed-test/with-temp-card [card]
-      ((test-users/user->client :crowberto) :get 200 (card-query-url card {:_embedding_params {:abc "locked"}, :params {:abc 100}})))))
+      ((test-users/user->client :crowberto) :get 200 (card-query-url card {:_embedding_params {:abc "locked"}
+                                                                           :params            {:abc 100}})))))
 
 ;; if `:locked` parameter is present in URL params, request should fail
 (expect
   "You can only specify a value for :abc in the JWT."
   (embed-test/with-embedding-enabled-and-new-secret-key
     (embed-test/with-temp-card [card]
-      ((test-users/user->client :crowberto) :get 400 (str (card-query-url card {:_embedding_params {:abc "locked"}, :params {:abc 100}}) "?abc=200")))))
+      ((test-users/user->client :crowberto) :get 400 (str (card-query-url card {:_embedding_params {:abc "locked"}
+                                                                                :params            {:abc 100}})
+                                                          "?abc=200")))))
 
 ;;; DISABLED params
 
@@ -120,14 +130,16 @@
   "You're not allowed to specify a value for :abc."
   (embed-test/with-embedding-enabled-and-new-secret-key
     (embed-test/with-temp-card [card]
-      ((test-users/user->client :crowberto) :get 400 (card-query-url card {:_embedding_params {:abc "disabled"}, :params {:abc 100}})))))
+      ((test-users/user->client :crowberto) :get 400 (card-query-url card {:_embedding_params {:abc "disabled"}
+                                                                           :params            {:abc 100}})))))
 
 ;; If a `:disabled` param is passed in the URL the request should fail
 (expect
   "You're not allowed to specify a value for :abc."
   (embed-test/with-embedding-enabled-and-new-secret-key
     (embed-test/with-temp-card [card]
-      ((test-users/user->client :crowberto) :get 400 (str (card-query-url card {:_embedding_params {:abc "disabled"}}) "?abc=200")))))
+      ((test-users/user->client :crowberto) :get 400 (str (card-query-url card {:_embedding_params {:abc "disabled"}})
+                                                          "?abc=200")))))
 
 ;;; ENABLED params
 
@@ -136,26 +148,32 @@
   "You can't specify a value for :abc if it's already set in the JWT."
   (embed-test/with-embedding-enabled-and-new-secret-key
     (embed-test/with-temp-card [card]
-      ((test-users/user->client :crowberto) :get 400 (str (card-query-url card {:_embedding_params {:abc "enabled"}, :params {:abc 100}}) "?abc=200")))))
+      ((test-users/user->client :crowberto) :get 400 (str (card-query-url card {:_embedding_params {:abc "enabled"}
+                                                                                :params            {:abc 100}})
+                                                          "?abc=200")))))
 
 ;; If an `:enabled` param is present in the JWT, that's ok
 (expect
   (embed-test/successful-query-results)
   (embed-test/with-embedding-enabled-and-new-secret-key
     (embed-test/with-temp-card [card]
-      ((test-users/user->client :crowberto) :get 200 (card-query-url card {:_embedding_params {:abc "enabled"}, :params {:abc "enabled"}})))))
+      ((test-users/user->client :crowberto) :get 200 (card-query-url card {:_embedding_params {:abc "enabled"}
+                                                                           :params            {:abc "enabled"}})))))
 
 ;; If an `:enabled` param is present in URL params but *not* the JWT, that's ok
 (expect
   (embed-test/successful-query-results)
   (embed-test/with-embedding-enabled-and-new-secret-key
     (embed-test/with-temp-card [card]
-      ((test-users/user->client :crowberto) :get 200 (str (card-query-url card {:_embedding_params {:abc "enabled"}}) "?abc=200")))))
+      ((test-users/user->client :crowberto) :get 200 (str (card-query-url card {:_embedding_params {:abc "enabled"}})
+                                                          "?abc=200")))))
 
 
-;;; ------------------------------------------------------------ GET /api/preview_embed/dashboard/:token ------------------------------------------------------------
+;;; ------------------------------------ GET /api/preview_embed/dashboard/:token -------------------------------------
 
-(defn- dashboard-url [dashboard & [additional-token-params]] (str "preview_embed/dashboard/" (embed-test/dash-token dashboard (merge {:_embedding_params {}} additional-token-params))))
+(defn- dashboard-url {:style/indent 1} [dashboard & [additional-token-params]]
+  (str "preview_embed/dashboard/" (embed-test/dash-token dashboard (merge {:_embedding_params {}}
+                                                                          additional-token-params))))
 
 ;; it should be possible to call this endpoint successfully...
 (expect
@@ -195,14 +213,19 @@
                                                 {:slug "b", :name "b", :type "date"}
                                                 {:slug "c", :name "c", :type "date"}
                                                 {:slug "d", :name "d", :type "date"}]}]
-      (:parameters ((test-users/user->client :crowberto) :get 200 (dashboard-url dash {:params            {:c 100},
-                                                                                       :_embedding_params {:a "locked", :b "disabled", :c "enabled", :d "enabled"}}))))))
+      (:parameters ((test-users/user->client :crowberto) :get 200 (dashboard-url dash
+                                                                    {:params            {:c 100},
+                                                                     :_embedding_params {:a "locked"
+                                                                                         :b "disabled"
+                                                                                         :c "enabled"
+                                                                                         :d "enabled"}}))))))
 
 
-;;; ------------------------------------------------------------ GET /api/preview_embed/dashboard/:token/dashcard/:dashcard-id/card/:card-id ------------------------------------------------------------
+;;; ------------------ GET /api/preview_embed/dashboard/:token/dashcard/:dashcard-id/card/:card-id -------------------
 
 (defn- dashcard-url {:style/indent 1} [dashcard & [additional-token-params]]
-  (str "preview_embed/dashboard/" (embed-test/dash-token (:dashboard_id dashcard) (merge {:_embedding_params {}} additional-token-params))
+  (str "preview_embed/dashboard/" (embed-test/dash-token (:dashboard_id dashcard) (merge {:_embedding_params {}}
+                                                                                         additional-token-params))
        "/dashcard/" (u/get-id dashcard)
        "/card/" (:card_id dashcard)))
 
@@ -277,7 +300,8 @@
   "You're not allowed to specify a value for :abc."
   (embed-test/with-embedding-enabled-and-new-secret-key
     (embed-test/with-temp-dashcard [dashcard]
-      ((test-users/user->client :crowberto) :get 400 (str (dashcard-url dashcard {:_embedding_params {:abc "disabled"}}) "?abc=200")))))
+      ((test-users/user->client :crowberto) :get 400 (str (dashcard-url dashcard {:_embedding_params {:abc "disabled"}})
+                                                          "?abc=200")))))
 
 ;;; ENABLED params
 
@@ -286,18 +310,47 @@
   "You can't specify a value for :abc if it's already set in the JWT."
   (embed-test/with-embedding-enabled-and-new-secret-key
     (embed-test/with-temp-dashcard [dashcard]
-      ((test-users/user->client :crowberto) :get 400 (str (dashcard-url dashcard {:_embedding_params {:abc "enabled"}, :params {:abc 100}}) "?abc=200")))))
+      ((test-users/user->client :crowberto) :get 400 (str (dashcard-url dashcard {:_embedding_params {:abc "enabled"}
+                                                                                  :params            {:abc 100}})
+                                                          "?abc=200")))))
 
 ;; If an `:enabled` param is present in the JWT, that's ok
 (expect
   (embed-test/successful-query-results)
   (embed-test/with-embedding-enabled-and-new-secret-key
     (embed-test/with-temp-dashcard [dashcard]
-      ((test-users/user->client :crowberto) :get 200 (dashcard-url dashcard {:_embedding_params {:abc "enabled"}, :params {:abc 100}})))))
+      ((test-users/user->client :crowberto) :get 200 (dashcard-url dashcard {:_embedding_params {:abc "enabled"}
+                                                                             :params            {:abc 100}})))))
 
 ;; If an `:enabled` param is present in URL params but *not* the JWT, that's ok
 (expect
   (embed-test/successful-query-results)
   (embed-test/with-embedding-enabled-and-new-secret-key
     (embed-test/with-temp-dashcard [dashcard]
-      ((test-users/user->client :crowberto) :get 200 (str (dashcard-url dashcard {:_embedding_params {:abc "enabled"}}) "?abc=200")))))
+      ((test-users/user->client :crowberto) :get 200 (str (dashcard-url dashcard {:_embedding_params {:abc "enabled"}})
+                                                          "?abc=200")))))
+
+;; Check that editable query params work correctly and keys get coverted from strings to keywords, even if they're
+;; something that our middleware doesn't normally assume is implicitly convertable to a keyword. See
+;; `ring.middleware.keyword-params/keyword-syntax?` (#6783)
+(expect
+  "completed"
+  (embed-test/with-embedding-enabled-and-new-secret-key
+    (embed-test/with-temp-card [card {:dataset_query
+                                      {:database (data/id)
+                                       :type     "native"
+                                       :native   {:query         (str "SELECT {{num_birds}} AS num_birds,"
+                                                                      "       {{2nd_date_seen}} AS 2nd_date_seen")
+                                                  :template_tags {:equipment        {:name         "num_birds"
+                                                                                     :display_name "Num Birds"
+                                                                                     :type         "number"}
+                                                                  :7_days_ending_on {:name         "2nd_date_seen",
+                                                                                     :display_name "Date Seen",
+                                                                                     :type         "date"}}}}}]
+      (-> (embed-test/with-temp-dashcard [dashcard {:dash {:enable_embedding true}}]
+            ((test-users/user->client :crowberto) :get 200 (str (dashcard-url dashcard
+                                                                  {:_embedding_params {:num_birds     :locked
+                                                                                       :2nd_date_seen :enabled}
+                                                                   :params            {:num_birds 2}})
+                                                                "?2nd_date_seen=2018-02-14")))
+          :status))))

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -10,7 +10,7 @@
             [toucan.db :as db])
   (:import clojure.lang.ExceptionInfo))
 
-;;; ------------------------------------------------------------ User Definitions ------------------------------------------------------------
+;;; ------------------------------------------------ User Definitions ------------------------------------------------
 
 ;; ## Test Users
 ;;
@@ -44,7 +44,7 @@
 (def ^:private ^:const usernames
   (set (keys user->info)))
 
-;;; ------------------------------------------------------------ Test User Fns ------------------------------------------------------------
+;;; ------------------------------------------------- Test User Fns --------------------------------------------------
 
 (defn- wait-for-initiailization
   "Wait up to MAX-WAIT-SECONDS (default: 30) for Metabase to finish initializing.
@@ -58,7 +58,8 @@
      (when-not (init-status/complete?)
        (when (<= max-wait-seconds 0)
          (throw (Exception. "Metabase still hasn't finished initializing.")))
-       (printf "Metabase is not yet initialized, waiting 1 second (max wait remaining: %d seconds)...\n" max-wait-seconds)
+       (println (format "Metabase is not yet initialized, waiting 1 second (max wait remaining: %d seconds)...\n"
+                        max-wait-seconds))
        (Thread/sleep 1000)
        (recur (dec max-wait-seconds))))))
 
@@ -130,7 +131,8 @@
   (or (@tokens username)
       (u/prog1 (http/authenticate (user->credentials username))
         (swap! tokens assoc username <>))
-      (throw (Exception. (format "Authentication failed for %s with credentials %s" username (user->credentials username))))))
+      (throw (Exception. (format "Authentication failed for %s with credentials %s"
+                                 username (user->credentials username))))))
 
 (defn- client-fn [username & args]
   (try
@@ -155,6 +157,7 @@
 
 (defn ^:deprecated delete-temp-users!
   "Delete all users besides the 4 persistent test users.
-   This is a HACK to work around tests that don't properly clean up after themselves; one day we should be able to remove this. (TODO)"
+  This is a HACK to work around tests that don't properly clean up after themselves; one day we should be able to
+  remove this. (TODO)"
   []
   (db/delete! User :id [:not-in (map user->id [:crowberto :lucky :rasta :trashbird])]))


### PR DESCRIPTION
So the core problem here was that our middleware that automatically converts the keys in the query parameters map only does so for keys that have "keyword syntax". This does *not* include param keys that start with a number. So by using a query param called `7_days_ending_on` for a locked param our user managed to break an edge case that may well never have been hit before.

Includes test.
Fixes #6783 