### PR TITLE
UUIDs for anonymous stats.

### DIFF
--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -11,8 +11,7 @@
             [metabase.util.password :as password]
             [puppetlabs.i18n.core :refer [tru]]
             [toucan.db :as db])
-  (:import java.util.Locale
-           java.util.TimeZone))
+  (:import [java.util Locale TimeZone UUID]))
 
 (defsetting check-for-updates
   (tru "Identify when new versions of Metabase are available.")
@@ -29,8 +28,18 @@
   :default "Metabase")
 
 (defsetting site-uuid
-  (tru "The identifier for this instance of Metabase.")
-  :default (str (java.util.UUID/randomUUID)))
+  ;; Don't i18n this docstring because it's not user-facing! :)
+  "Unique identifier used for this instance of Metabase. This is set once and only once the first time it is fetched via
+  its magic getter. Nice!"
+  :internal? true
+  :setter    (fn [& _]
+               (throw (UnsupportedOperationException. "site-uuid is automatically generated. Don't try to change it!")))
+  ;; magic getter will either fetch value from DB, or if no value exists, set the value to a random UUID.
+  :getter    (fn []
+               (or (setting/get-string :site-uuid)
+                   (let [value (str (UUID/randomUUID))]
+                     (setting/set-string! :site-uuid value)
+                     value))))
 
 ;; This value is *guaranteed* to never have a trailing slash :D
 ;; It will also prepend `http://` to the URL if there's not protocol when it comes in

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -28,6 +28,10 @@
   (tru "The name used for this instance of Metabase.")
   :default "Metabase")
 
+(defsetting site-uuid
+  (tru "The identifier for this instance of Metabase.")
+  :default (str (java.util.UUID/randomUUID)))
+
 ;; This value is *guaranteed* to never have a trailing slash :D
 ;; It will also prepend `http://` to the URL if there's not protocol when it comes in
 (defsetting site-url

--- a/src/metabase/util/stats.clj
+++ b/src/metabase/util/stats.clj
@@ -50,10 +50,6 @@
 
 (def ^:private ^:const ^String metabase-usage-url "https://xuq0fbkk0j.execute-api.us-east-1.amazonaws.com/prod")
 
-(def ^:private ^Integer anonymous-id
-  "Generate an anonymous id. Don't worry too much about hash collisions or localhost cases, etc.
-   The goal is to be able to get a rough sense for how many different hosts are throwing a specific error/event."
-  (hash (str (java.net.InetAddress/getLocalHost))))
 
 (defn- bin-micro-number
   "Return really small bin number. Assumes positive inputs."
@@ -374,7 +370,7 @@
   "generate a map of the usage stats for this instance"
   []
   (merge (instance-settings)
-         {:uuid anonymous-id, :timestamp (Date.)}
+         {:uuid (public-settings/site-uuid) :timestamp (Date.)}
          {:stats {:cache      (cache-metrics)
                   :collection (collection-metrics)
                   :dashboard  (dashboard-metrics)


### PR DESCRIPTION
The current UUIDs aren't stable, and make it hard for us to know how well we're doing. Specifically, there's no way to calculate retention metrics. 

@camsaul I'm misusing settings for this. Any advice on how to do this better?