### PR TITLE
Drop first and last period when x-raying timeseries [WIP]

### DIFF
--- a/src/metabase/feature_extraction/timeseries.clj
+++ b/src/metabase/feature_extraction/timeseries.clj
@@ -11,6 +11,7 @@
             [metabase.feature-extraction
              [histogram :as h]
              [math :as math]]
+            [net.cgrand.xforms :as x]
             [redux.core :as redux])
   (:import (com.github.brandtg.stl StlDecomposition StlResult StlConfig)))
 
@@ -177,3 +178,7 @@
          (math/outliers :eta)
          most-likely-breaks
          (map :x))))
+
+(def ^{:arglists '([series])} drop-incomplete-periods
+  "A Transducer that drops presumably incomplete first and last period."
+  (comp (drop 1) (x/drop-last 1)))

--- a/test/metabase/feature_extraction/feature_extractors_test.clj
+++ b/test/metabase/feature_extraction/feature_extractors_test.clj
@@ -127,7 +127,8 @@
                 {:base_type :type/Number}]
                [[(make-sql-timestamp 2015 6 1) 0]
                 [(make-sql-timestamp 2015 6 2) 1000000]
-                [(make-sql-timestamp 2015 6 3) Double/MAX_VALUE]])))
+                [(make-sql-timestamp 2015 6 3) Double/MAX_VALUE]
+                [(make-sql-timestamp 2015 6 4) -13]])))
 
 (expect
   [:some

--- a/test/metabase/feature_extraction/timeseries_test.clj
+++ b/test/metabase/feature_extraction/timeseries_test.clj
@@ -55,3 +55,27 @@
                                           (repeat 100 20))))
    (breaks 12 (map vector (range) (take 100 (cycle (range 10)))))
    (breaks 4 nil)])
+
+(expect
+  [[(t/date-time 2016 3) 4]
+   [(t/date-time 2016 4) 0]
+   [(t/date-time 2016 5) 0]
+   [(t/date-time 2016 6) 0]
+   [(t/date-time 2016 7) 0]
+   [(t/date-time 2016 8) 0]
+   [(t/date-time 2016 9) 0]
+   [(t/date-time 2016 10) 0]
+   [(t/date-time 2016 11) 0]]
+  (transduce drop-incomplete-periods
+             conj
+             [[(t/date-time 2016 2) 0]
+              [(t/date-time 2016 3) 4]
+              [(t/date-time 2016 4) 0]
+              [(t/date-time 2016 5) 0]
+              [(t/date-time 2016 6) 0]
+              [(t/date-time 2016 7) 0]
+              [(t/date-time 2016 8) 0]
+              [(t/date-time 2016 9) 0]
+              [(t/date-time 2016 10) 0]
+              [(t/date-time 2016 11) 0]
+              [(t/date-time 2016 12) 0]]))


### PR DESCRIPTION
First and last period tend to be incomplete. We can produce more intuitive and relevant results, if we skip them.