### PR TITLE
[Support]String date, 'YYYYMMDDHHmm' etc..., [Added]i18n for graph date(x-axis)

### DIFF
--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -12,7 +12,7 @@ import { isDate, isNumber, isCoordinate, isLatitude, isLongitude } from "metabas
 import { isa, TYPE } from "metabase/lib/types";
 import { parseTimestamp,parseTime } from "metabase/lib/time";
 import { rangeForValue } from "metabase/lib/dataset";
-import { getFriendlyName } from "metabase/visualizations/lib/utils";
+import { getFriendlyName, getUserBrowserLanguage } from "metabase/visualizations/lib/utils";
 import { decimalCount } from "metabase/visualizations/lib/numeric";
 
 import type { Column, Value } from "metabase/meta/types/Dataset";
@@ -145,12 +145,14 @@ export function formatTimeWithUnit(value: Value, unit: DatetimeUnit, options: Fo
     if (!m.isValid()) {
         return String(value);
     }
+    // date displayed in the graph is optimized by the user's browser language. if it can not be acquired, default: 'en'.
+    m.locale(getUserBrowserLanguage())
 
     switch (unit) {
         case "hour": // 12 AM - January 1, 2015
             return formatMajorMinor(m.format("h A"), m.format("MMMM D, YYYY"), options);
         case "day": // January 1, 2015
-            return m.format("MMMM D, YYYY");
+            return m.format("LL");
         case "week": // 1st - 2015
             if (options.type === "tooltip") {
                 // tooltip show range like "January 1 - 7, 2017"
@@ -277,7 +279,7 @@ export function formatValue(value: Value, options: FormattingOptions = {}) {
     } else if (column && column.unit != null) {
         return formatTimeWithUnit(value, column.unit, options);
     } else if (isDate(column) || moment.isDate(value) || moment.isMoment(value) || moment(value, ["YYYY-MM-DD'T'HH:mm:ss.SSSZ"], true).isValid()) {
-        return parseTimestamp(value, column && column.unit).format("LLLL");
+        return parseTimestamp(value, column && column.unit).locale(getUserBrowserLanguage()).format("LLLL");
     } else if (typeof value === "string") {
         return formatStringFallback(value, options);
     } else if (typeof value === "number") {

--- a/frontend/src/metabase/lib/time.js
+++ b/frontend/src/metabase/lib/time.js
@@ -11,7 +11,7 @@ export function parseTimestamp(value, unit) {
         // workaround for https://github.com/metabase/metabase/issues/1992
         return moment().year(value).startOf("year");
     } else {
-        return moment.utc(value);
+        return moment.utc(value, ["YYYY-MM-DD'T'HH:mm:ss.SSSZ"]);
     }
 }
 

--- a/frontend/src/metabase/visualizations/lib/utils.js
+++ b/frontend/src/metabase/visualizations/lib/utils.js
@@ -301,3 +301,10 @@ export function getCardAfterVisualizationClick(nextCard, previousCard) {
         };
     }
 }
+export function getUserBrowserLanguage() {
+    return (window.navigator.languages && window.navigator.languages[0]) ||
+        window.navigator.language ||
+        window.navigator.userLanguage ||
+        window.navigator.browserLanguage ||
+        'en';
+}


### PR DESCRIPTION
Hi, I implemented two suggestions. I think metabase users will be more comfortable.
Could you please check? :)

----


<img width="600" alt="_2018-02-06_17_20_46" src="https://user-images.githubusercontent.com/12589846/35849566-67844d4e-0b65-11e8-8bad-8213eef0a605.png">
<img width="600" alt="_2018-02-06_17_01_44" src="https://user-images.githubusercontent.com/12589846/35849565-675ce8da-0b65-11e8-9cc2-921015adf1ac.png">



# Supported String date, 'YYYYMMDDHHmm' etc...

[Support]
'YYYYMMDDHHmmss'
'YYYYMMDDHHmm'
'YYYYMMDDHH'
etc...

Before change, X-axis is separated in days.
With this change, the X-axis can be separated by hours, minutes, and seconds. **Google Analytics's "[Ga:datehourminute](https://developers.google.com/analytics/devguides/reporting/core/dimsmets#view=detail&group=time&jump=ga_datehourminute)" will be correctly available in graph.**

# Added i18n for graph date(X-axis)

In non-English-speaking countries, we do not use the 'en' 'LLLL' format, so we can not easily see it.
changed it to optimize to the user's browser language using locale of moment.js.

locale('en'): "Thursday, January 1, 2015 12:00 PM"
locale('ja'): "2015年1月1日午前12時0分 木曜日"

----



###### TODO 
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
