### PR TITLE
i18n inflection

### DIFF
--- a/frontend/src/metabase-lib/lib/Dimension.js
+++ b/frontend/src/metabase-lib/lib/Dimension.js
@@ -1,8 +1,9 @@
 import React from "react";
+import { t, ngettext, msgid } from "c-3po";
 
 import Icon from "metabase/components/Icon";
 
-import { stripId, inflect } from "metabase/lib/formatting";
+import { stripId } from "metabase/lib/formatting";
 import Query_DEPRECATED from "metabase/lib/query";
 import { mbqlEq } from "metabase/lib/query/util";
 import _ from "underscore";
@@ -492,13 +493,14 @@ export class BinnedDimension extends FieldDimension {
 
   subTriggerDisplayName(): string {
     if (this._args[0] === "num-bins") {
-      return `${this._args[1]} ${inflect("bins", this._args[1])}`;
+      const n = this._args[1];
+      return ngettext(msgid`${n} bin`, `${n} bins`, n);
     } else if (this._args[0] === "bin-width") {
       const binWidth = this._args[1];
       const units = this.field().isCoordinate() ? "°" : "";
       return `${binWidth}${units}`;
     } else {
-      return "Auto binned";
+      return t`Auto binned`;
     }
   }
 

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx
@@ -1,8 +1,7 @@
 import React, { Component } from "react";
 
 import Icon from "metabase/components/Icon.jsx";
-import { t } from "c-3po";
-import { inflect } from "metabase/lib/formatting";
+import { t, ngettext, msgid } from "c-3po";
 
 import _ from "underscore";
 import cx from "classnames";
@@ -49,7 +48,9 @@ export default class MetadataSchemaList extends Component {
         </div>
         <ul className="AdminList-items">
           <li className="AdminList-section">
-            {filteredSchemas.length} {inflect("schema", filteredSchemas.length)}
+            {(n => ngettext(msgid`${n} schema`, `${n} schemas`, n))(
+              filteredSchemas.length,
+            )}
           </li>
           {filteredSchemas.map(schema => (
             <li key={schema.name}>

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx
@@ -3,8 +3,9 @@ import PropTypes from "prop-types";
 
 import ProgressBar from "metabase/components/ProgressBar.jsx";
 import Icon from "metabase/components/Icon.jsx";
-import { t } from "c-3po";
-import { inflect } from "metabase/lib/formatting";
+
+import { t, ngettext, msgid } from "c-3po";
+
 import { normal } from "metabase/lib/colors";
 
 import _ from "underscore";
@@ -82,16 +83,19 @@ export default class MetadataTableList extends Component {
     if (queryableTables.length > 0) {
       queryableTablesHeader = (
         <li className="AdminList-section">
-          {queryableTables.length} {t`Queryable`}{" "}
-          {inflect("Table", queryableTables.length)}
+          {(n =>
+            ngettext(msgid`${n} Queryable Table`, `${n} Queryable Tables`, n))(
+            queryableTables.length,
+          )}
         </li>
       );
     }
     if (hiddenTables.length > 0) {
       hiddenTablesHeader = (
         <li className="AdminList-section">
-          {hiddenTables.length} {t`Hidden`}{" "}
-          {inflect("Table", hiddenTables.length)}
+          {(n => ngettext(msgid`${n} Hidden Table`, `${n} Hidden Tables`, n))(
+            hiddenTables.length,
+          )}
         </li>
       );
     }

--- a/frontend/src/metabase/admin/people/components/GroupSummary.jsx
+++ b/frontend/src/metabase/admin/people/components/GroupSummary.jsx
@@ -1,8 +1,7 @@
 import React from "react";
 
 import _ from "underscore";
-import { t } from "c-3po";
-import { inflect } from "metabase/lib/formatting";
+import { t, ngettext, msgid } from "c-3po";
 import { isAdminGroup, isDefaultGroup } from "metabase/lib/groups";
 
 const GroupSummary = ({ groups, selectedGroups }) => {
@@ -14,14 +13,12 @@ const GroupSummary = ({ groups, selectedGroups }) => {
     return (
       <span>
         <span className="text-purple">{t`Admin`}</span>
-        {otherGroups.length > 0 && " and "}
+        {otherGroups.length > 0 && " " + t`and` + " "}
         {otherGroups.length > 0 && (
           <span className="text-brand">
-            {otherGroups.length +
-              " " +
-              t`other` +
-              " " +
-              inflect("group", otherGroups.length)}
+            {(n => ngettext(msgid`${n} other group`, `${n} other groups`, n))(
+              otherGroups.length,
+            )}
           </span>
         )}
       </span>
@@ -31,7 +28,9 @@ const GroupSummary = ({ groups, selectedGroups }) => {
   } else if (otherGroups.length > 1) {
     return (
       <span className="text-brand">
-        {otherGroups.length + " " + inflect("group", otherGroups.length)}
+        {(n => ngettext(msgid`${n} other group`, `${n} other groups`, n))(
+          otherGroups.length,
+        )}
       </span>
     );
   } else {

--- a/frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 
-import { inflect } from "metabase/lib/formatting";
-import { t } from "c-3po";
+import { t, ngettext, msgid } from "c-3po";
 import Tooltip from "metabase/components/Tooltip";
 
 const GroupName = ({ group }) => (
@@ -25,9 +24,9 @@ const TableAccessChange = ({ tables, verb, color }) => {
         <span>
           <span className={color}>
             {" " +
-              tableNames.length +
-              " " +
-              inflect("table", tableNames.length)}
+              (n => ngettext(msgid`${n} table`, `${n} tables`, n))(
+                tableNames.length,
+              )}
           </span>
         </span>
       </Tooltip>

--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -5,6 +5,7 @@ import inflection from "inflection";
 import moment from "moment";
 import Humanize from "humanize-plus";
 import React from "react";
+import { ngettext, msgid } from "c-3po";
 
 import ExternalLink from "metabase/components/ExternalLink.jsx";
 
@@ -441,10 +442,10 @@ export function humanize(...args) {
 export function duration(milliseconds: number) {
   if (milliseconds < 60000) {
     let seconds = Math.round(milliseconds / 1000);
-    return seconds + " " + inflect("second", seconds);
+    return ngettext(msgid`${seconds} second`, `${seconds} seconds`, seconds);
   } else {
     let minutes = Math.round(milliseconds / 1000 / 60);
-    return minutes + " " + inflect("minute", minutes);
+    return ngettext(msgid`${minutes} minute`, `${minutes} minutes`, minutes);
   }
 }
 

--- a/frontend/src/metabase/lib/i18n-debug.js
+++ b/frontend/src/metabase/lib/i18n-debug.js
@@ -25,18 +25,25 @@ const SPECIAL_STRINGS = new Set([
   "Max",
 ]);
 
+const obfuscateString = string => {
+  if (SPECIAL_STRINGS.has(string)) {
+    return string.toUpperCase();
+  } else {
+    // divide by 2 because Unicode `FULL BLOCK` is quite wide
+    return new Array(Math.ceil(string.length / 2) + 1).join("█");
+  }
+};
+
 export function enableTranslatedStringReplacement() {
   const c3po = require("c-3po");
   const _t = c3po.t;
   const _jt = c3po.jt;
+  const _ngettext = c3po.ngettext;
   c3po.t = (...args) => {
-    const string = _t(...args);
-    if (SPECIAL_STRINGS.has(string)) {
-      return string.toUpperCase();
-    } else {
-      // divide by 2 because Unicode `FULL BLOCK` is quite wide
-      return new Array(Math.ceil(string.length / 2) + 1).join("█");
-    }
+    return obfuscateString(_t(...args));
+  };
+  c3po.ngettext = (...args) => {
+    return obfuscateString(_ngettext(...args));
   };
   // eslint-disable-next-line react/display-name
   c3po.jt = (...args) => {

--- a/frontend/src/metabase/pulse/components/PulseEdit.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEdit.jsx
@@ -2,7 +2,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Link } from "react-router";
-import { t, jt } from "c-3po";
+import { t, jt, ngettext, msgid } from "c-3po";
 
 import PulseEditName from "./PulseEditName.jsx";
 import PulseEditCards from "./PulseEditCards.jsx";
@@ -20,7 +20,6 @@ import { pulseIsValid, cleanPulse, emailIsEnabled } from "metabase/lib/pulse";
 
 import _ from "underscore";
 import cx from "classnames";
-import { inflect } from "inflection";
 
 export default class PulseEdit extends Component {
   constructor(props) {
@@ -88,7 +87,9 @@ export default class PulseEdit extends Component {
           <span key={index}>
             {jt`This pulse will no longer be emailed to ${(
               <strong>
-                {c.recipients.length} {inflect(t`address`, c.recipients.length)}
+                {(n => ngettext(msgid`${n} address`, `${n} addresses`, n))(
+                  c.recipients.length,
+                )}
               </strong>
             )} ${<strong>{c.schedule_type}</strong>}`}.
           </span>

--- a/frontend/src/metabase/pulse/components/PulseListChannel.jsx
+++ b/frontend/src/metabase/pulse/components/PulseListChannel.jsx
@@ -1,11 +1,10 @@
 /* eslint "react/prop-types": "warn" */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { t } from "c-3po";
+import { t, ngettext, msgid } from "c-3po";
 
 import Icon from "metabase/components/Icon.jsx";
 
-import { inflect } from "inflection";
 import _ from "underscore";
 
 export default class PulseListChannel extends Component {
@@ -56,9 +55,9 @@ export default class PulseListChannel extends Component {
     let channelSchedule = channel.schedule_type;
     let channelTarget =
       channel.recipients &&
-      channel.recipients.length +
-        " " +
-        inflect("people", channel.recipients.length);
+      (n => ngettext(msgid`${n} person`, `${n} people`, n))(
+        channel.recipients.length,
+      );
 
     if (channel.channel_type === "email") {
       channelIcon = "mail";

--- a/frontend/src/metabase/qb/components/drill/UnderlyingRecordsDrill.jsx
+++ b/frontend/src/metabase/qb/components/drill/UnderlyingRecordsDrill.jsx
@@ -1,9 +1,10 @@
 /* @flow */
 
+import { ngettext, msgid } from "c-3po";
 import { inflect } from "metabase/lib/formatting";
 
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
-import { t } from "c-3po";
+
 import type {
   ClickAction,
   ClickActionProps,
@@ -23,14 +24,16 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
   // the metric value should be the number of rows that will be displayed
   const count = typeof clicked.value === "number" ? clicked.value : 2;
 
+  const inflectedTableName = inflect(query.table().display_name, count);
   return [
     {
       name: "underlying-records",
       section: "records",
-      title: t`View ${inflect(t`these`, count, t`this`, t`these`)} ${inflect(
-        query.table().display_name,
+      title: ngettext(
+        msgid`View this ${inflectedTableName}`,
+        `View these ${inflectedTableName}`,
         count,
-      )}`,
+      ),
       question: () => question.drillUnderlyingRecords(dimensions),
     },
   ];

--- a/frontend/src/metabase/query_builder/components/AlertModals.jsx
+++ b/frontend/src/metabase/query_builder/components/AlertModals.jsx
@@ -1,19 +1,33 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import { t, jt } from "c-3po";
+import { t, jt, ngettext, msgid } from "c-3po";
+import _ from "underscore";
+import cxs from "cxs";
 
+// components
 import Button from "metabase/components/Button";
 import SchedulePicker from "metabase/components/SchedulePicker";
-import { createAlert, deleteAlert, updateAlert } from "metabase/alert/alert";
 import ModalContent from "metabase/components/ModalContent";
+import DeleteModalWithConfirm from "metabase/components/DeleteModalWithConfirm";
+import ModalWithTrigger from "metabase/components/ModalWithTrigger";
+import Radio from "metabase/components/Radio";
+import Icon from "metabase/components/Icon";
+import ChannelSetupModal from "metabase/components/ChannelSetupModal";
+import ButtonWithStatus from "metabase/components/ButtonWithStatus";
+import PulseEditChannels from "metabase/pulse/components/PulseEditChannels";
+import RetinaImage from "react-retina-image";
+
+// actions
+import { createAlert, deleteAlert, updateAlert } from "metabase/alert/alert";
+import { apiUpdateQuestion } from "metabase/query_builder/actions";
+import { fetchPulseFormInput, fetchUsers } from "metabase/pulse/actions";
+
+// selectors
 import { getUser, getUserIsAdmin } from "metabase/selectors/user";
 import {
   getQuestion,
   getVisualizationSettings,
 } from "metabase/query_builder/selectors";
-import _ from "underscore";
-import PulseEditChannels from "metabase/pulse/components/PulseEditChannels";
-import { fetchPulseFormInput, fetchUsers } from "metabase/pulse/actions";
 import {
   formInputSelector,
   hasConfiguredAnyChannelSelector,
@@ -21,25 +35,19 @@ import {
   hasLoadedChannelInfoSelector,
   userListSelector,
 } from "metabase/pulse/selectors";
-import DeleteModalWithConfirm from "metabase/components/DeleteModalWithConfirm";
-import ModalWithTrigger from "metabase/components/ModalWithTrigger";
-import { inflect } from "metabase/lib/formatting";
+
+// lib
 import {
   ALERT_TYPE_PROGRESS_BAR_GOAL,
   ALERT_TYPE_ROWS,
   ALERT_TYPE_TIMESERIES_GOAL,
   getDefaultAlert,
 } from "metabase-lib/lib/Alert";
-import type { AlertType } from "metabase-lib/lib/Alert";
-import Radio from "metabase/components/Radio";
-import RetinaImage from "react-retina-image";
-import Icon from "metabase/components/Icon";
 import MetabaseCookies from "metabase/lib/cookies";
-import cxs from "cxs";
-import ChannelSetupModal from "metabase/components/ChannelSetupModal";
-import ButtonWithStatus from "metabase/components/ButtonWithStatus";
-import { apiUpdateQuestion } from "metabase/query_builder/actions";
 import MetabaseAnalytics from "metabase/lib/analytics";
+
+// types
+import type { AlertType } from "metabase-lib/lib/Alert";
 
 const getScheduleFromChannel = channel =>
   _.pick(
@@ -362,7 +370,9 @@ export class DeleteAlertSection extends Component {
         c.channel_type === "email" ? (
           <span>{jt`This alert will no longer be emailed to ${(
             <strong>
-              {c.recipients.length} {inflect("address", c.recipients.length)}
+              {(n => ngettext(msgid`${n} address`, `${n} addresses`, n))(
+                c.recipients.length,
+              )}
             </strong>
           )}.`}</span>
         ) : c.channel_type === "slack" ? (

--- a/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
@@ -2,7 +2,7 @@
 
 import React, { Component } from "react";
 import { Link } from "react-router";
-import { t, jt } from "c-3po";
+import { t, jt, ngettext, msgid } from "c-3po";
 import LoadingSpinner from "metabase/components/LoadingSpinner.jsx";
 import Tooltip from "metabase/components/Tooltip";
 import Icon from "metabase/components/Icon";
@@ -18,7 +18,7 @@ import Warnings from "./Warnings.jsx";
 import QueryDownloadWidget from "./QueryDownloadWidget.jsx";
 import QuestionEmbedWidget from "../containers/QuestionEmbedWidget";
 
-import { formatNumber, inflect, duration } from "metabase/lib/formatting";
+import { formatNumber, duration } from "metabase/lib/formatting";
 import Utils from "metabase/lib/utils";
 import MetabaseSettings from "metabase/lib/settings";
 import * as Urls from "metabase/lib/urls";
@@ -137,6 +137,8 @@ export default class QueryVisualization extends Component {
       !isObjectDetail &&
       question.display() === "table"
     ) {
+      const countString = formatNumber(result.row_count);
+      const rowsString = ngettext(msgid`row`, `rows`, result.row_count);
       messages.push({
         icon: "table2",
         message: (
@@ -144,11 +146,9 @@ export default class QueryVisualization extends Component {
           <div className="ShownRowCount">
             {result.data.rows_truncated != null
               ? jt`Showing first ${(
-                  <strong>{formatNumber(result.row_count)}</strong>
-                )} ${inflect(t`row`, result.data.rows.length)}`
-              : jt`Showing ${(
-                  <strong>{formatNumber(result.row_count)}</strong>
-                )} ${inflect(t`row`, result.data.rows.length)}`}
+                  <strong>{countString}</strong>
+                )} ${rowsString}`
+              : jt`Showing ${<strong>{countString}</strong>} ${rowsString}`}
           </div>
         ),
       });

--- a/frontend/src/metabase/query_builder/components/dataref/MainPane.jsx
+++ b/frontend/src/metabase/query_builder/components/dataref/MainPane.jsx
@@ -1,10 +1,9 @@
 /* eslint "react/prop-types": "warn" */
 import React from "react";
 import PropTypes from "prop-types";
-import { t } from "c-3po";
+import { t, ngettext, msgid } from "c-3po";
 import { isQueryable } from "metabase/lib/table";
 
-import inflection from "inflection";
 import cx from "classnames";
 
 const MainPane = ({ databases, show }) => (
@@ -22,9 +21,9 @@ const MainPane = ({ databases, show }) => (
               <div className="my2">
                 <h2 className="inline-block">{database.name}</h2>
                 <span className="ml1">
-                  {database.tables.length +
-                    " " +
-                    inflection.inflect("table", database.tables.length)}
+                  {(n => ngettext(msgid`${n} table`, `${n} tables`, n))(
+                    database.tables.length,
+                  )}
                 </span>
               </div>
               <ul>

--- a/frontend/src/metabase/query_builder/components/dataref/TablePane.jsx
+++ b/frontend/src/metabase/query_builder/components/dataref/TablePane.jsx
@@ -2,14 +2,17 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { t } from "c-3po";
+import cx from "classnames";
+
+// components
 import QueryButton from "metabase/components/QueryButton.jsx";
+import Expandable from "metabase/components/Expandable.jsx";
+
+// lib
 import { createCard } from "metabase/lib/card";
 import { createQuery } from "metabase/lib/query";
 import { foreignKeyCountsByOriginTable } from "metabase/lib/schema_metadata";
-import inflection from "inflection";
-import cx from "classnames";
-
-import Expandable from "metabase/components/Expandable.jsx";
+import { inflect } from "metabase/lib/formatting";
 
 export default class TablePane extends Component {
   constructor(props, context) {
@@ -93,7 +96,7 @@ export default class TablePane extends Component {
           onClick={this.showPane.bind(null, name)}
         >
           <span className="DataReference-paneCount">{count}</span>
-          <span>{inflection.inflect(name, count)}</span>
+          <span>{inflect(name, count)}</span>
         </a>
       ));
 

--- a/frontend/src/metabase/questions/containers/SearchResults.jsx
+++ b/frontend/src/metabase/questions/containers/SearchResults.jsx
@@ -1,12 +1,10 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import { t } from "c-3po";
+import { t, ngettext, msgid } from "c-3po";
 import HeaderWithBack from "metabase/components/HeaderWithBack";
 
 import ExpandingSearchField from "../components/ExpandingSearchField";
 import EntityList from "./EntityList";
-
-import { inflect } from "metabase/lib/formatting";
 
 import { getTotalCount } from "../selectors";
 import { search } from "../questions";
@@ -40,7 +38,11 @@ class SearchResults extends Component {
             <HeaderWithBack
               name={
                 totalCount != null
-                  ? `${totalCount} ${inflect("result", totalCount)}`
+                  ? ngettext(
+                      msgid`${totalCount} result`,
+                      `${totalCount} results`,
+                      totalCount,
+                    )
                   : t`Search results`
               }
             />

--- a/frontend/src/metabase/questions/questions.js
+++ b/frontend/src/metabase/questions/questions.js
@@ -1,25 +1,30 @@
+import React from "react";
+import { Link } from "react-router";
+import { push, replace } from "react-router-redux";
+import { t, ngettext, msgid } from "c-3po";
+import { normalize, schema } from "normalizr";
+import { getIn, assocIn, updateIn, chain } from "icepick";
+import _ from "underscore";
+
+// actions
 import {
   createAction,
   createThunkAction,
   mergeEntities,
   momentifyArraysTimestamps,
 } from "metabase/lib/redux";
+import { setRequestState } from "metabase/redux/requests";
+import { addUndo } from "metabase/redux/undo";
+import { SET_COLLECTION_ARCHIVED } from "./collections";
 
-import { normalize, schema } from "normalizr";
-import { getIn, assocIn, updateIn, chain } from "icepick";
-import _ from "underscore";
+// selectors
+import { getVisibleEntities, getSelectedEntities } from "./selectors";
 
-import { inflect } from "metabase/lib/formatting";
+// lib
 import MetabaseAnalytics from "metabase/lib/analytics";
 import * as Urls from "metabase/lib/urls";
 
-import { push, replace } from "react-router-redux";
-import { setRequestState } from "metabase/redux/requests";
-import { addUndo } from "metabase/redux/undo";
-
-import { getVisibleEntities, getSelectedEntities } from "./selectors";
-
-import { SET_COLLECTION_ARCHIVED } from "./collections";
+import { CardApi, CollectionsApi } from "metabase/services";
 
 const label = new schema.Entity("labels");
 const collection = new schema.Entity("collections");
@@ -27,8 +32,6 @@ const card = new schema.Entity("cards", {
   labels: [label],
   // collection: collection
 });
-
-import { CardApi, CollectionsApi } from "metabase/services";
 
 export const LOAD_ENTITIES = "metabase/questions/LOAD_ENTITIES";
 const SET_SEARCH_TEXT = "metabase/questions/SET_SEARCH_TEXT";
@@ -110,9 +113,6 @@ export const setFavorited = createThunkAction(
   },
 );
 
-import React from "react";
-import { Link } from "react-router";
-import { t } from "c-3po";
 function createUndo(type, actions, collection) {
   return {
     type: type,
@@ -121,11 +121,10 @@ function createUndo(type, actions, collection) {
     message: undo => (
       <div className="flex flex-column">
         <div>
-          {inflect(
-            null,
+          {ngettext(
+            msgid`${undo.count} question was ${type}`,
+            `${undo.count} questions were ${type}`,
             undo.count,
-            t`${undo.count} question was ${type}`,
-            t`${undo.count} questions were ${type}`,
           )}
           {undo.count === 1 &&
             collection && (

--- a/frontend/src/metabase/visualizations/lib/errors.js
+++ b/frontend/src/metabase/visualizations/lib/errors.js
@@ -1,14 +1,14 @@
 /* @flow */
 
-import { inflect } from "metabase/lib/formatting";
-import { t } from "c-3po";
+import { t, ngettext, msgid } from "c-3po";
 // NOTE: extending Error with Babel requires babel-plugin-transform-builtin-extend
 
 export class MinColumnsError extends Error {
   constructor(minColumns: number, actualColumns: number) {
     super(
-      t`Doh! The data from your query doesn't fit the chosen display choice. This visualization requires at least ${actualColumns} ${inflect(
-        "column",
+      t`Doh! The data from your query doesn't fit the chosen display choice. This visualization requires at least ${actualColumns} ${ngettext(
+        msgid`column`,
+        `columns`,
         actualColumns,
       )} of data.`,
     );
@@ -18,8 +18,9 @@ export class MinColumnsError extends Error {
 export class MinRowsError extends Error {
   constructor(minRows: number, actualRows: number) {
     super(
-      t`No dice. We have ${actualRows} data ${inflect(
-        "point",
+      t`No dice. We have ${actualRows} data ${ngettext(
+        msgid`point`,
+        `points`,
         actualRows,
       )} to show and that's not enough for this visualization.`,
     );


### PR DESCRIPTION
Part of #6781

This uses `c-3po`'s `ngettext`, described here: https://c-3po.js.org/ngettext.html

Alternatively we can use the existing `inflect` method in `metabase/lib/formatting`, which we already do in a couple places: https://github.com/metabase/metabase/blob/c033fd6d210d75c3373a09695a28cbbc7eac7227/frontend/src/metabase/questions/questions.js#L83

I think the main advantage of `ngettext` is it gives a hint to translators in the `.po` files:

```
msgid "${ n } time clicked"
msgid_plural "${ n } times clicked"
```

However I don't think it supports JSX like `inflect` + `jt` would.

Any opinions, @salsakran @kdoh?