### PR TITLE
Fix bug in ordering by an aggregate expression [ci drivers]

### DIFF
--- a/src/metabase/driver/bigquery.clj
+++ b/src/metabase/driver/bigquery.clj
@@ -23,7 +23,9 @@
             [metabase.models
              [database :refer [Database]]
              [field :as field]]
-            [metabase.query-processor.util :as qputil]
+            [metabase.query-processor
+             [annotate :as annotate]
+             [util :as qputil]]
             [metabase.util.honeysql-extensions :as hx]
             [toucan.db :as db])
   (:import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
@@ -32,7 +34,7 @@
             TableList TableList$Tables TableReference TableRow TableSchema]
            java.sql.Time
            [java.util Collections Date]
-           [metabase.query_processor.interface DateTimeValue TimeValue Value]))
+           [metabase.query_processor.interface AggregationWithField AggregationWithoutField DateTimeValue Expression TimeValue Value]))
 
 (defrecord BigQueryDriver []
   clojure.lang.Named
@@ -300,12 +302,48 @@
      :rows    (for [row rows]
                 (mapv row columns))}))
 
+;; From the dox: Fields must contain only letters, numbers, and underscores, start with a letter or underscore, and be
+;; at most 128 characters long.
+(defn- format-custom-field-name ^String [^String custom-field-name]
+  (let [replaced-str (-> (str/trim custom-field-name)
+                         (str/replace #"[^\w\d_]" "_")
+                         (str/replace #"(^\d)" "_$1"))]
+    (subs replaced-str 0 (min 128 (count replaced-str)))))
+
+(defn- agg-or-exp? [x]
+  (or (instance? Expression x)
+      (instance? AggregationWithField x)
+      (instance? AggregationWithoutField x)))
+
+(defn- bg-aggregate-name [aggregate]
+  (-> aggregate annotate/aggregation-name format-custom-field-name))
+
+(defn- pre-alias-aggregations
+  "Expressions are not allowed in the order by clauses of a BQ query. To sort by a custom expression, that custom
+  expression must be aliased from the order by. This code will find the aggregations and give them a name if they
+  don't already have one. This name can then be used in the order by if one is present."
+  [query]
+  (let [aliases (atom {})]
+    (walk/postwalk (fn [maybe-agg]
+                     (if-let [exp-name (and (agg-or-exp? maybe-agg)
+                                            (bg-aggregate-name maybe-agg))]
+                       (if-let [usage-count (get @aliases exp-name)]
+                         (let [new-custom-name (str exp-name "_" (inc usage-count))]
+                           (swap! aliases assoc
+                                  exp-name (inc usage-count)
+                                  new-custom-name 1)
+                           (assoc maybe-agg :custom-name new-custom-name))
+                         (do
+                           (swap! aliases assoc exp-name 1)
+                           (assoc maybe-agg :custom-name exp-name)))
+                       maybe-agg))
+                   query)))
+
 (defn- mbql->native [{{{:keys [dataset-id]} :details, :as database} :database, {{table-name :name} :source-table} :query, :as outer-query}]
   {:pre [(map? database) (seq dataset-id) (seq table-name)]}
-  (binding [sqlqp/*query* outer-query]
-    (let [honeysql-form (honeysql-form outer-query)
-          sql           (honeysql-form->sql honeysql-form)]
-      {:query      sql
+  (let [aliased-query (pre-alias-aggregations outer-query)]
+    (binding [sqlqp/*query* aliased-query]
+      {:query      (-> aliased-query honeysql-form honeysql-form->sql)
        :table-name table-name
        :mbql?      true})))
 
@@ -341,18 +379,25 @@
        (sqlqp/->honeysql driver)
        hx/->time))
 
-(defn- field->alias [{:keys [^String schema-name, ^String field-name, ^String table-name, ^Integer index, field], :as this}]
+(defn- field->alias [driver {:keys [^String schema-name, ^String field-name, ^String table-name, ^Integer index, field], :as this}]
   {:pre [(map? this) (or field
                          index
                          (and (seq schema-name) (seq field-name) (seq table-name))
                          (log/error "Don't know how to alias: " this))]}
   (cond
-    field (recur field) ; type/DateTime
-    index (name (let [{{aggregations :aggregation} :query} sqlqp/*query*
-                      {ag-type :aggregation-type}          (nth aggregations index)]
-                  (if (= ag-type :distinct)
-                    :count
-                    ag-type)))
+    field (recur driver field) ; type/DateTime
+    index (let [{{aggregations :aggregation} :query} sqlqp/*query*
+                {ag-type :aggregation-type :as agg}  (nth aggregations index)]
+            (cond
+              (= ag-type :distinct)
+              "count"
+
+              (instance? Expression agg)
+              (:custom-name agg)
+
+              :else
+              (name ag-type)))
+
     :else (str schema-name \. table-name \. field-name)))
 
 ;; TODO - Making 2 DB calls for each field to fetch its dataset is inefficient and makes me cry, but this method is
@@ -362,91 +407,13 @@
         dataset (:dataset-id (db/select-one-field :details Database, :id db-id))]
     (hsql/raw (apply format "[%s.%s.%s]" dataset (field/qualified-name-components field)))))
 
-;; We have to override the default SQL implementations of breakout and order-by because BigQuery propogates casting
-;; functions in SELECT
-;; BAD:
-;; SELECT msec_to_timestamp([sad_toucan_incidents.incidents.timestamp]) AS [sad_toucan_incidents.incidents.timestamp],
-;;       count(*) AS [count]
-;; FROM [sad_toucan_incidents.incidents]
-;; GROUP BY msec_to_timestamp([sad_toucan_incidents.incidents.timestamp])
-;; ORDER BY msec_to_timestamp([sad_toucan_incidents.incidents.timestamp]) ASC
-;; LIMIT 10
-;;
-;; GOOD:
-;; SELECT msec_to_timestamp([sad_toucan_incidents.incidents.timestamp]) AS [sad_toucan_incidents.incidents.timestamp],
-;;        count(*) AS [count]
-;; FROM [sad_toucan_incidents.incidents]
-;; GROUP BY [sad_toucan_incidents.incidents.timestamp]
-;; ORDER BY [sad_toucan_incidents.incidents.timestamp] ASC
-;; LIMIT 10
-
-(defn- deduplicate-aliases
-  "Given a sequence of aliases, return a sequence where duplicate aliases have been appropriately suffixed.
-
-     (deduplicate-aliases [\"sum\" \"count\" \"sum\" \"avg\" \"sum\" \"min\"])
-     ;; -> [\"sum\" \"count\" \"sum_2\" \"avg\" \"sum_3\" \"min\"]"
-  [aliases]
-  (loop [acc [], alias->use-count {}, [alias & more, :as aliases] aliases]
-    (let [use-count (get alias->use-count alias)]
-      (cond
-        (empty? aliases) acc
-        (not alias)      (recur (conj acc alias) alias->use-count more)
-        (not use-count)  (recur (conj acc alias) (assoc alias->use-count alias 1) more)
-        :else            (let [new-count (inc use-count)
-                               new-alias (str alias "_" new-count)]
-                           (recur (conj acc new-alias) (assoc alias->use-count alias new-count, new-alias 1) more))))))
-
-(defn- select-subclauses->aliases
-  "Return a vector of aliases used in HoneySQL SELECT-SUBCLAUSES.
-   (For clauses that aren't aliased, `nil` is returned as a placeholder)."
-  [select-subclauses]
-  (for [subclause select-subclauses]
-    (when (and (vector? subclause)
-               (= 2 (count subclause)))
-      (second subclause))))
-
-(defn update-select-subclause-aliases
-  "Given a vector of HoneySQL SELECT-SUBCLAUSES and a vector of equal length of NEW-ALIASES,
-   return a new vector with combining the original `SELECT` subclauses with the new aliases.
-
-   Subclauses that are not aliased are not modified; they are given a placeholder of `nil` in the NEW-ALIASES vector.
-
-     (update-select-subclause-aliases [[:user_id \"user_id\"] :venue_id]
-                                      [\"user_id_2\" nil])
-     ;; -> [[:user_id \"user_id_2\"] :venue_id]"
-  [select-subclauses new-aliases]
-  (for [[subclause new-alias] (partition 2 (interleave select-subclauses new-aliases))]
-    (if-not new-alias
-      subclause
-      [(first subclause) new-alias])))
-
-(defn- deduplicate-select-aliases
-  "Replace duplicate aliases in SELECT-SUBCLAUSES with appropriately suffixed aliases.
-
-  BigQuery doesn't allow duplicate aliases in `SELECT` statements; a statement like `SELECT sum(x) AS sum, sum(y) AS
-  sum` is invalid. (See #4089) To work around this, we'll modify the HoneySQL aliases to make sure the same one isn't
-  used twice by suffixing duplicates appropriately.
-  (We'll generate SQL like `SELECT sum(x) AS sum, sum(y) AS sum_2` instead.)"
-  [select-subclauses]
-  (let [aliases (select-subclauses->aliases select-subclauses)
-        deduped (deduplicate-aliases aliases)]
-    (update-select-subclause-aliases select-subclauses deduped)))
-
-(defn- apply-aggregation
-  "BigQuery's implementation of `apply-aggregation` just hands off to the normal Generic SQL implementation, but calls
-  `deduplicate-select-aliases` on the results."
-  [driver honeysql-form query]
-  (-> (sqlqp/apply-aggregation driver honeysql-form query)
-      (update :select deduplicate-select-aliases)))
-
-
-(defn- field->breakout-identifier [field]
-  (hsql/raw (str \[ (field->alias field) \])))
+(defn- field->breakout-identifier [driver field]
+  (hsql/raw (str \[ (field->alias driver field) \])))
 
 (defn- apply-breakout [driver honeysql-form {breakout-fields :breakout, fields-fields :fields}]
   (-> honeysql-form
       ;; Group by all the breakout fields
-      ((partial apply h/group)  (map field->breakout-identifier breakout-fields))
+      ((partial apply h/group)  (map #(field->breakout-identifier driver %) breakout-fields))
       ;; Add fields form only for fields that weren't specified in :fields clause -- we don't want to include it
       ;; twice, or HoneySQL will barf
       ((partial apply h/merge-select) (for [field breakout-fields
@@ -465,24 +432,17 @@
         (recur honeysql-form more)
         honeysql-form))))
 
-(defn- apply-order-by [honeysql-form {subclauses :order-by}]
+(defn- apply-order-by [driver honeysql-form {subclauses :order-by}]
   (loop [honeysql-form honeysql-form, [{:keys [field direction]} & more] subclauses]
-    (let [honeysql-form (h/merge-order-by honeysql-form [(field->breakout-identifier field) (case direction
-                                                                                              :ascending  :asc
-                                                                                              :descending :desc)])]
+    (let [honeysql-form (h/merge-order-by honeysql-form [(field->breakout-identifier driver field) (case direction
+                                                                                                     :ascending  :asc
+                                                                                                     :descending :desc)])]
       (if (seq more)
         (recur honeysql-form more)
         honeysql-form))))
 
 (defn- string-length-fn [field-key]
   (hsql/call :length field-key))
-
-;; From the dox: Fields must contain only letters, numbers, and underscores, start with a letter or underscore, and be
-;; at most 128 characters long.
-(defn- format-custom-field-name ^String [^String custom-field-name]
-  (str/join (take 128 (-> (str/trim custom-field-name)
-                        (str/replace #"[^\w\d_]" "_")
-                        (str/replace #"(^\d)" "_$1")))))
 
 (defn- date-interval [driver unit amount]
   (sqlqp/->honeysql driver (u/relative-date unit amount)))
@@ -497,16 +457,15 @@
 (u/strict-extend BigQueryDriver
   sql/ISQLDriver
   (merge (sql/ISQLDriverDefaultsMixin)
-         {:apply-aggregation         apply-aggregation
-          :apply-breakout            apply-breakout
+         {:apply-breakout            apply-breakout
           :apply-join-tables         (u/drop-first-arg apply-join-tables)
-          :apply-order-by            (u/drop-first-arg apply-order-by)
+          :apply-order-by            apply-order-by
           ;; these two are actually not applicable since we don't use JDBC
           :column->base-type         (constantly nil)
           :connection-details->spec  (constantly nil)
           :current-datetime-fn       (constantly :%current_timestamp)
           :date                      (u/drop-first-arg date)
-          :field->alias              (u/drop-first-arg field->alias)
+          :field->alias              field->alias
           :field->identifier         (u/drop-first-arg field->identifier)
           ;; we want identifiers quoted [like].[this] initially (we have to convert them to [like.this] before
           ;; executing)

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -151,7 +151,7 @@
       (->honeysql driver field))))
 
 ;; TODO - can't we just roll this into the ->honeysql method for `expression`?
-(defn- expression-aggregation->honeysql
+(defn expression-aggregation->honeysql
   "Generate the HoneySQL form for an expression aggregation."
   [driver expression]
   (->honeysql driver

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -129,36 +129,6 @@
         (hx/* bin-width)
         (hx/+ min-value))))
 
-;; e.g. the ["aggregation" 0] fields we allow in order-by
-(defmethod ->honeysql [Object AgFieldRef]
-  [_ {index :index}]
-  (let [{:keys [aggregation-type]} (aggregation-at-index index)]
-    ;; For some arcane reason we name the results of a distinct aggregation "count",
-    ;; everything else is named the same as the aggregation
-    (if (= aggregation-type :distinct)
-      :count
-      aggregation-type)))
-
-(defmethod ->honeysql [Object Value]
-  [driver {:keys [value]}]
-  (->honeysql driver value))
-
-(defmethod ->honeysql [Object DateTimeValue]
-  [driver {{unit :unit} :field, value :value}]
-  (sql/date driver unit (->honeysql driver value)))
-
-(defmethod ->honeysql [Object RelativeDateTimeValue]
-  [driver {:keys [amount unit], {field-unit :unit} :field}]
-  (sql/date driver field-unit (if (zero? amount)
-                                (sql/current-datetime-fn driver)
-                                (driver/date-interval driver unit amount))))
-
-(defmethod ->honeysql [Object TimeValue]
-  [driver  {:keys [value]}]
-  (->honeysql driver value))
-
-;;; ## Clause Handlers
-
 (defn- aggregation->honeysql
   "Generate the HoneySQL form for an aggregation."
   [driver aggregation-type field]
@@ -192,6 +162,42 @@
                   (number? arg)           arg
                   (:aggregation-type arg) (aggregation->honeysql driver (:aggregation-type arg) (:field arg))
                   (:operator arg)         (expression-aggregation->honeysql driver arg)))))))
+
+;; e.g. the ["aggregation" 0] fields we allow in order-by
+(defmethod ->honeysql [Object AgFieldRef]
+  [driver {index :index}]
+  (let [{:keys [aggregation-type] :as aggregation} (aggregation-at-index index)]
+    (cond
+      ;; For some arcane reason we name the results of a distinct aggregation "count",
+      ;; everything else is named the same as the aggregation
+      (= aggregation-type :distinct)
+      :count
+
+      (instance? Expression aggregation)
+      (expression-aggregation->honeysql driver aggregation)
+
+      :else
+      aggregation-type)))
+
+(defmethod ->honeysql [Object Value]
+  [driver {:keys [value]}]
+  (->honeysql driver value))
+
+(defmethod ->honeysql [Object DateTimeValue]
+  [driver {{unit :unit} :field, value :value}]
+  (sql/date driver unit (->honeysql driver value)))
+
+(defmethod ->honeysql [Object RelativeDateTimeValue]
+  [driver {:keys [amount unit], {field-unit :unit} :field}]
+  (sql/date driver field-unit (if (zero? amount)
+                                (sql/current-datetime-fn driver)
+                                (driver/date-interval driver unit amount))))
+
+(defmethod ->honeysql [Object TimeValue]
+  [driver  {:keys [value]}]
+  (->honeysql driver value))
+
+;;; ## Clause Handlers
 
 (defn- apply-expression-aggregation [driver honeysql-form expression]
   (h/merge-select honeysql-form [(expression-aggregation->honeysql driver expression)

--- a/test/metabase/query_processor_test/expression_aggregations_test.clj
+++ b/test/metabase/query_processor_test/expression_aggregations_test.clj
@@ -150,6 +150,15 @@
             (ql/aggregation (ql/+ 1 (ql/count)))
             (ql/breakout $price)))))
 
+;; Sorting by an un-named aggregate expression
+(datasets/expect-with-engines (engines-that-support :expression-aggregations)
+  [[1 2] [2 2] [12 2] [4 4] [7 4] [10 4] [11 4] [8 8]]
+  (format-rows-by [int int]
+    (rows (data/run-query users
+            (ql/aggregation (ql/* (ql/count) 2))
+            (ql/breakout (ql/datetime-field $last_login :month-of-year))
+            (ql/order-by (ql/asc (ql/aggregation 0)))))))
+
 ;; aggregation with math inside the aggregation :scream_cat:
 (datasets/expect-with-engines (engines-that-support :expression-aggregations)
   [[1  44]


### PR DESCRIPTION
When ordering by a non-aliased aggregate expression, the order by
clause wouldn't resolve correctly. This resulted in a null value in the
order by which would then have no affect on the order of the
results. The AgFieldRef wasn't able to handle an expression in the
order-by.

Fixes #5943
