### PR TITLE
Fix Druid test so it passes with 0.11.0 [ci drivers]

### DIFF
--- a/test/metabase/driver/druid_test.clj
+++ b/test/metabase/driver/druid_test.clj
@@ -64,17 +64,17 @@
          (sort-by first)
          (take 5))))
 
-(def ^:const ^:private ^String native-query-1
+(def ^:private ^String native-query-1
   (json/generate-string
     {:intervals   ["1900-01-01/2100-01-01"]
      :granularity :all
      :queryType   :select
      :pagingSpec  {:threshold 2}
      :dataSource  :checkins
-     :dimensions  [:venue_price
-                   :venue_name
+     :dimensions  [:id
                    :user_name
-                   :id]
+                   :venue_price
+                   :venue_name]
      :metrics     [:count]}))
 
 (defn- process-native-query [query]
@@ -107,7 +107,7 @@
 
 
 ;; make sure we can run a native :timeseries query. This was throwing an Exception -- see #3409
-(def ^:const ^:private ^String native-query-2
+(def ^:private ^String native-query-2
   (json/generate-string
     {:intervals    ["1900-01-01/2100-01-01"]
      :granularity  {:type     :period


### PR DESCRIPTION
Apparently Druid 0.11.0 actually pays attention to the order you put columns in in the `:dimensions` clause and returns them that way as opposed to sorting them by the famous ????? method. So specify the correct order here so this test will pass on our old 0.9.3 server as well as our new 0.11.0 server.