### PR TITLE
Update 10-pulses.md

### DIFF
--- a/docs/users-guide/10-pulses.md
+++ b/docs/users-guide/10-pulses.md
@@ -23,15 +23,15 @@ When you select a saved question, Metabase will show you a preview of how it’l
 #### Attaching a .csv or .xls with results
 You can also optionally include the results of a saved question in an emailed pulse as a .csv or .xls file attachment. Just click the paperclip icon on an included saved question to add the attachment. Click the paperclip again to remove the attachment.
 
-![Attach button](images/pulses/attach-button.png)
+![Attach button](images/pulses/attachments/attach-button.png)
 
 Choose between a .csv or .xls file by clicking on the text buttons:
 
-![Attached](images/pulses/attached.png)
+![Attached](images/pulses/attachments/attached.png)
 
 Your attachments will be included in your emailed pulse just like a regular email attachment:
 
-![Email attachment](images/pulses/email.png)
+![Email attachment](images/pulses/attachments/email.png)
 
 #### Limitations
 Currently, there are a few restrictions on what kinds of saved questions you can put into a pulse:


### PR DESCRIPTION
Attach them attachment images 📎

Fixes broken image links on the pulses page under [Attaching a .csv or .xls with results](https://metabase.com/docs/latest/users-guide/10-pulses.html#attaching-a-csv-or-xls-with-results)
