### PR TITLE
Fix SQLite test failure with date parameters [ci drivers]

### DIFF
--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -277,7 +277,8 @@
             :expression-aggregations
             :native-parameters
             :nested-queries
-            :binning}
+            :binning
+            :native-query-params}
     (set-timezone-sql driver) (conj :set-timezone)))
 
 

--- a/test/metabase/driver/druid_test.clj
+++ b/test/metabase/driver/druid_test.clj
@@ -102,7 +102,8 @@
                                    {:name "venue_price", :display_name "Venue Price"}
                                    {:name "venue_name",  :display_name "Venue Name"}
                                    {:name "count",       :display_name "Count", :base_type :type/Integer}])
-               :native_form {:query native-query-1}}}
+               :native_form {:query native-query-1
+                             :parms []}}}
   (process-native-query native-query-1))
 
 


### PR DESCRIPTION
This commit fixes a test failure with SQLite where the latest SQL
template changes weren't calling the driver-specific
`prepare-sql-param` function to ensure the SQL params are formatted
correctly for that database.