### PR TITLE
Save Card read_permissions

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -4020,3 +4020,14 @@ databaseChangeLog:
                   remarks: 'True if a XLS of the data should be included for this pulse card'
                   constraints:
                     nullable: false
+  - changeSet:
+      id: 75
+      author: camsaul
+      comment: 'Added 0.28.2'
+      changes:
+        - addColumn:
+            tableName: report_card
+            columns:
+              name: read_permissions
+              type: text
+              remarks: 'Permissions required to view this Card and run its query.'

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -55,7 +55,9 @@
    native (e.g. SQL) queries. Will be one of `:write`, `:read`, or `:none`."
   [dbs]
   (for [db dbs]
-    (let [user-has-perms? (fn [path-fn] (perms/set-has-full-permissions? @api/*current-user-permissions-set* (path-fn (u/get-id db))))]
+    (let [user-has-perms? (fn [path-fn]
+                            (perms/set-has-full-permissions? @api/*current-user-permissions-set*
+                                                             (path-fn (u/get-id db))))]
       (assoc db :native_permissions (cond
                                       (user-has-perms? perms/native-readwrite-path) :write
                                       (user-has-perms? perms/native-read-path)      :read
@@ -103,7 +105,8 @@
 (defn- source-query-cards
   "Fetch the Cards that can be used as source queries (e.g. presented as virtual tables)."
   []
-  (as-> (db/select [Card :name :description :database_id :dataset_query :id :collection_id :result_metadata]
+  (as-> (db/select [Card :name :description :database_id :dataset_query :id :collection_id :result_metadata
+                    :read_permissions]
           :result_metadata [:not= nil] :archived false
           {:order-by [[:%lower.name :asc]]}) <>
     (filter card-database-supports-nested-queries? <>)
@@ -142,7 +145,9 @@
       include-cards?  add-virtual-tables-for-saved-cards)))
 
 (api/defendpoint GET "/"
-  "Fetch all `Databases`."
+  "Fetch all `Databases`. `include_tables` means we should hydrate the Tables belonging to each DB. `include_cards` here
+  means we should also include virtual Table entries for saved Questions, e.g. so we can easily use them as source
+  Tables in queries. Default for both is `false`."
   [include_tables include_cards]
   {include_tables (s/maybe su/BooleanString)
    include_cards  (s/maybe su/BooleanString)}

--- a/src/metabase/models/common.clj
+++ b/src/metabase/models/common.clj
@@ -1,6 +1,6 @@
 (ns metabase.models.common)
 
-(def ^:const timezones
+(def timezones
   "The different timezones supported by Metabase.
    Presented as options for the `report-timezone` Setting in the admin panel."
   ["Africa/Algiers"

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -32,6 +32,12 @@
   :in  json-in
   :out json-out)
 
+;; json-set is just like json but calls `set` on it when coming out of the DB. Intended for storing things like a
+;; permissions set
+(models/add-type! :json-set
+  :in  json-in
+  :out #(when % (set (json-out %))))
+
 (models/add-type! :clob
   :in  identity
   :out u/jdbc-clob->str)

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -213,9 +213,10 @@
             :database_id            database-id ; these should be inferred automatically
             :table_id               table-id
             :labels                 []
-            :can_write              true,
-            :dashboard_count        0,
+            :can_write              true
+            :dashboard_count        0
             :collection             nil
+            :read_permissions       [(format "/db/%d/schema//table/%d/" database-id table-id)]
             :creator                (match-$ (fetch-user :rasta)
                                       {:common_name  "Rasta Toucan"
                                        :is_superuser false
@@ -295,6 +296,7 @@
                                        :id           $})
             :updated_at             $
             :dataset_query          $
+            :read_permissions       [(format "/db/%d/schema//table/%d/" database-id table-id)]
             :id                     $
             :display                "table"
             :visualization_settings {}

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -133,6 +133,7 @@
                                                            :display                "table"
                                                            :query_type             nil
                                                            :dataset_query          {}
+                                                           :read_permissions       []
                                                            :visualization_settings {}
                                                            :query_average_duration nil
                                                            :in_public_dashboard    false

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -139,10 +139,12 @@
   [{:id nil, :type "date/single", :target ["variable" ["template-tag" "d"]], :name "d", :slug "d", :default nil}]
   (with-embedding-enabled-and-new-secret-key
     (with-temp-card [card {:enable_embedding true
-                           :dataset_query    {:native {:template_tags {:a {:type "date", :name "a", :display_name "a"}
-                                                                       :b {:type "date", :name "b", :display_name "b"}
-                                                                       :c {:type "date", :name "c", :display_name "c"}
-                                                                       :d {:type "date", :name "d", :display_name "d"}}}}
+                           :dataset_query    {:database (data/id)
+                                              :type     :native
+                                              :native   {:template_tags {:a {:type "date", :name "a", :display_name "a"}
+                                                                         :b {:type "date", :name "b", :display_name "b"}
+                                                                         :c {:type "date", :name "c", :display_name "c"}
+                                                                         :d {:type "date", :name "d", :display_name "d"}}}}
                            :embedding_params {:a "locked", :b "disabled", :c "enabled", :d "enabled"}}]
       (:parameters (http/client :get 200 (card-url card {:params {:c 100}}))))))
 

--- a/test/metabase/api/preview_embed_test.clj
+++ b/test/metabase/api/preview_embed_test.clj
@@ -48,10 +48,12 @@
   [{:id nil, :type "date/single", :target ["variable" ["template-tag" "d"]], :name "d", :slug "d", :default nil}]
   (embed-test/with-embedding-enabled-and-new-secret-key
     (embed-test/with-temp-card [card {:dataset_query
-                                      {:native {:template_tags {:a {:type "date", :name "a", :display_name "a"}
-                                                                :b {:type "date", :name "b", :display_name "b"}
-                                                                :c {:type "date", :name "c", :display_name "c"}
-                                                                :d {:type "date", :name "d", :display_name "d"}}}}}]
+                                      {:database (data/id)
+                                       :type     :native
+                                       :native   {:template_tags {:a {:type "date", :name "a", :display_name "a"}
+                                                                  :b {:type "date", :name "b", :display_name "b"}
+                                                                  :c {:type "date", :name "c", :display_name "c"}
+                                                                  :d {:type "date", :name "d", :display_name "d"}}}}}]
       (-> ((test-users/user->client :crowberto) :get 200 (card-url card {:_embedding_params {:a "locked"
                                                                                              :b "disabled"
                                                                                              :c "enabled"

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -53,7 +53,9 @@
 (defn- add-card-to-dashboard! [card dashboard]
   (db/insert! DashboardCard :dashboard_id (u/get-id dashboard), :card_id (u/get-id card)))
 
-(defmacro with-temp-public-dashboard-and-card {:style/indent 1} [[dashboard-binding card-binding & [dashcard-binding]] & body]
+(defmacro ^:private with-temp-public-dashboard-and-card
+  {:style/indent 1}
+  [[dashboard-binding card-binding & [dashcard-binding]] & body]
   `(with-temp-public-dashboard [dash#]
      (with-temp-public-card [card#]
        (let [~dashboard-binding        dash#
@@ -98,18 +100,20 @@
   {(data/id :categories :name) {:values                75
                                 :human_readable_values {}
                                 :field_id              (data/id :categories :name)}}
-  (tt/with-temp Card [card {:dataset_query {:type   :native
-                                            :native {:query         (str "SELECT COUNT(*) "
-                                                                         "FROM venues "
-                                                                         "LEFT JOIN categories ON venues.category_id = categories.id "
-                                                                         "WHERE {{category}}")
-                                                     :collection    "CATEGORIES"
-                                                     :template_tags {:category {:name         "category"
-                                                                                :display_name "Category"
-                                                                                :type         "dimension"
-                                                                                :dimension    ["field-id" (data/id :categories :name)]
-                                                                                :widget_type  "category"
-                                                                                :required     true}}}}}]
+  (tt/with-temp Card [card {:dataset_query
+                            {:database (data/id)
+                             :type     :native
+                             :native   {:query         (str "SELECT COUNT(*) "
+                                                            "FROM venues "
+                                                            "LEFT JOIN categories ON venues.category_id = categories.id "
+                                                            "WHERE {{category}}")
+                                        :collection    "CATEGORIES"
+                                        :template_tags {:category {:name         "category"
+                                                                   :display_name "Category"
+                                                                   :type         "dimension"
+                                                                   :dimension    ["field-id" (data/id :categories :name)]
+                                                                   :widget_type  "category"
+                                                                   :required     true}}}}}]
     (-> (:param_values (#'public-api/public-card :id (u/get-id card)))
         (update-in [(data/id :categories :name) :values] count))))
 
@@ -313,7 +317,9 @@
   (tu/with-temporary-setting-values [enable-public-sharing true]
     (with-temp-public-dashboard-and-card [dash card]
       (with-temp-public-card [card-2]
-        (tt/with-temp DashboardCardSeries [_ {:dashboardcard_id (db/select-one-id DashboardCard :card_id (u/get-id card), :dashboard_id (u/get-id dash))
+        (tt/with-temp DashboardCardSeries [_ {:dashboardcard_id (db/select-one-id DashboardCard
+                                                                  :card_id      (u/get-id card)
+                                                                  :dashboard_id (u/get-id dash))
                                               :card_id          (u/get-id card-2)}]
           (qp-test/rows (http/client :get 200 (dashcard-url-path dash card-2))))))))
 
@@ -334,7 +340,8 @@
   (db/update! Dashboard (u/get-id dashboard) :parameters [{:name "Price", :type "category", :slug "price"}]))
 
 (defn- add-dimension-param-mapping-to-dashcard! [dashcard card dimension]
-  (db/update! DashboardCard (u/get-id dashcard) :parameter_mappings [{:card_id (u/get-id card), :target ["dimension" dimension]}]))
+  (db/update! DashboardCard (u/get-id dashcard) :parameter_mappings [{:card_id (u/get-id card)
+                                                                      :target  ["dimension" dimension]}]))
 
 (defn- GET-param-values [dashboard]
   (tu/with-temporary-setting-values [enable-public-sharing true]
@@ -344,7 +351,13 @@
 (expect
   (price-param-values)
   (with-temp-public-dashboard-and-card [dash card dashcard]
-    (db/update! Card (u/get-id card) :dataset_query {:native {:template_tags {:price {:name "price", :display_name "Price", :type "dimension", :dimension ["field-id" (data/id :venues :price)]}}}})
+    (db/update! Card (u/get-id card)
+      :dataset_query {:database (data/id)
+                      :type     :native
+                      :native   {:template_tags {:price {:name         "price"
+                                                         :display_name "Price"
+                                                         :type         "dimension"
+                                                         :dimension    ["field-id" (data/id :venues :price)]}}}})
     (add-price-param-to-dashboard! dash)
     (add-dimension-param-mapping-to-dashcard! dashcard card ["template-tag" "price"])
     (GET-param-values dash)))

--- a/test/metabase/events/revision_test.clj
+++ b/test/metabase/events/revision_test.clj
@@ -33,6 +33,7 @@
    :creator_id             (:creator_id card)
    :database_id            (id)
    :dataset_query          (:dataset_query card)
+   :read_permissions       (vec (:read_permissions card))
    :description            nil
    :display                "table"
    :enable_embedding       false


### PR DESCRIPTION
Fixes #6889

The underlying problem is that calculating read permissions for a Card is expensive. We need to parse the query and lookup the Tables/Fields it references and do things like expand segment/metric "macros" to get a full picture of the permissions required to view a Card and run its query. Previously we cached these permissions sets for six hours which reduced the DB load somewhat, but this was only helpful when the cache wasn't expired.

In the case of #6889 when the cache was expired hitting `GET /api/database?include_cards=true` fetched every Card from the DB so they could be included in the metadata as "Saved Questions". Calculating the permissions for each Card would require a DB query or two so hundreds or thousands of Cards would result in the endpoints doing hundreds or thousands of DB calls.

As a solution I added a new column to Card, `read_permissions`, to save pre-calculated permissions since they are so expensive to calculate. Whenever saving a new Card or updating an existing one these permissions are automatically updated, meaning they can be read by the DB and perms-checked without any additional DB calls in the future. 

After some thought about the best way to populate these columns for the first time for existing Cards, I went ahead and added a data migration to do so upon launch. This might take a minute or two to run on launch for instances with thousands of Cards, but that is the same amount of time it would have added to the slow endpoints anyways. After the migration is finished the previously slow API calls will be back to doing ~4 DB calls, making dreams come true.

Instead of doing a data migration I also considered the following approaches, but decided not to go with them due to the downsides mentioned:
* populate `read_permissions` for each Card that didn't yet have them the first time they are calculated *synchronously*. I decided against this approach because it could turn a 1000-DB-call API call into a 1500-DB-call API call.
*  populate `read_permissions` columns *asynchronously* the first time they are calculated. Decided against this because I wasn't sure if spinning up a new `future` for each Card would really be a good idea. It might be possible with some magic to batch all this work together into a single future and then run them all in the background one at a time. Either way, there is a potential downside that another API request could come along and schedule duplicate work.
