### PR TITLE
Add no-case-sensitivity-string-filter-options feature for SQLite 

### DIFF
--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -143,12 +143,16 @@
       everything besides standard deviation is considered \"basic\"; only GA doesn't support this).
   *  `:standard-deviation-aggregations` - Does this driver support standard deviation aggregations?
   *  `:expressions` - Does this driver support expressions (e.g. adding the values of 2 columns together)?
-  *  `:dynamic-schema` -  Does this Database have no fixed definitions of schemas? (e.g. Mongo)
   *  `:native-parameters` - Does the driver support parameter substitution on native queries?
   *  `:expression-aggregations` - Does the driver support using expressions inside aggregations? e.g. something like
       \"sum(x) + count(y)\" or \"avg(x + y)\"
   *  `:nested-queries` - Does the driver support using a query as the `:source-query` of another MBQL query? Examples
-      are CTEs or subselects in SQL queries.")
+      are CTEs or subselects in SQL queries.
+  *  `:no-case-sensitivity-string-filter-options` - An anti-feature: does this driver not let you specify whether or not
+      our string search filter clauses (`:contains`, `:starts-with`, and `:ends-with`, collectively the equivalent of
+      SQL `LIKE` are case-senstive or not? This informs whether we should present you with the 'Case Sensitive' checkbox
+      in the UI. At the time of this writing SQLite, SQLServer, and MySQL have this 'feature' -- `LIKE` clauses are
+      always case-insensitive.")
 
   (format-custom-field-name ^String [this, ^String custom-field-name]
     "*OPTIONAL*. Return the custom name passed via an MBQL `:named` clause so it matches the way it is returned in the

--- a/src/metabase/driver/mongo.clj
+++ b/src/metabase/driver/mongo.clj
@@ -205,7 +205,7 @@
                                                              :display-name "Additional Mongo connection string options"
                                                              :placeholder  "readPreference=nearest&replicaSet=test"}]))
           :execute-query                     (u/drop-first-arg qp/execute-query)
-          :features                          (constantly #{:basic-aggregations :dynamic-schema :nested-fields})
+          :features                          (constantly #{:basic-aggregations :nested-fields})
           :humanize-connection-error-message (u/drop-first-arg humanize-connection-error-message)
           :mbql->native                      (u/drop-first-arg qp/mbql->native)
           :process-query-in-context          (u/drop-first-arg process-query-in-context)

--- a/src/metabase/driver/sqlserver.clj
+++ b/src/metabase/driver/sqlserver.clj
@@ -169,56 +169,62 @@
 
 (u/strict-extend SQLServerDriver
   driver/IDriver
-  (merge (sql/IDriverSQLDefaultsMixin)
-         {:date-interval  (u/drop-first-arg date-interval)
-          :details-fields (constantly (ssh/with-tunnel-config
-                                        [{:name         "host"
-                                          :display-name "Host"
-                                          :default      "localhost"}
-                                         {:name         "port"
-                                          :display-name "Port"
-                                          :type         :integer
-                                          :default      1433}
-                                         {:name         "db"
-                                          :display-name "Database name"
-                                          :placeholder  "BirdsOfTheWorld"
-                                          :required     true}
-                                         {:name         "instance"
-                                          :display-name "Database instance name"
-                                          :placeholder  "N/A"}
-                                         {:name         "domain"
-                                          :display-name "Windows domain"
-                                          :placeholder  "N/A"}
-                                         {:name         "user"
-                                          :display-name "Database username"
-                                          :placeholder  "What username do you use to login to the database?"
-                                          :required     true}
-                                         {:name         "password"
-                                          :display-name "Database password"
-                                          :type         :password
-                                          :placeholder  "*******"}
-                                         {:name         "ssl"
-                                          :display-name "Use a secure connection (SSL)?"
-                                          :type         :boolean
-                                          :default      false}
-                                         {:name         "additional-options"
-                                          :display-name "Additional JDBC connection string options"
-                                          :placeholder  "trustServerCertificate=false"}]))
-          :current-db-time (driver/make-current-db-time-fn sqlserver-db-time-query sqlserver-date-formatters)})
-
+  (merge
+   (sql/IDriverSQLDefaultsMixin)
+   {:date-interval  (u/drop-first-arg date-interval)
+    :details-fields (constantly (ssh/with-tunnel-config
+                                  [{:name         "host"
+                                    :display-name "Host"
+                                    :default      "localhost"}
+                                   {:name         "port"
+                                    :display-name "Port"
+                                    :type         :integer
+                                    :default      1433}
+                                   {:name         "db"
+                                    :display-name "Database name"
+                                    :placeholder  "BirdsOfTheWorld"
+                                    :required     true}
+                                   {:name         "instance"
+                                    :display-name "Database instance name"
+                                    :placeholder  "N/A"}
+                                   {:name         "domain"
+                                    :display-name "Windows domain"
+                                    :placeholder  "N/A"}
+                                   {:name         "user"
+                                    :display-name "Database username"
+                                    :placeholder  "What username do you use to login to the database?"
+                                    :required     true}
+                                   {:name         "password"
+                                    :display-name "Database password"
+                                    :type         :password
+                                    :placeholder  "*******"}
+                                   {:name         "ssl"
+                                    :display-name "Use a secure connection (SSL)?"
+                                    :type         :boolean
+                                    :default      false}
+                                   {:name         "additional-options"
+                                    :display-name "Additional JDBC connection string options"
+                                    :placeholder  "trustServerCertificate=false"}]))
+    :current-db-time (driver/make-current-db-time-fn sqlserver-db-time-query sqlserver-date-formatters)
+    :features        (fn [this]
+                       ;; SQLServer LIKE clauses are case-sensitive or not based on whether the collation of the
+                       ;; server and the columns themselves. Since this isn't something we can really change in the
+                       ;; query itself don't present the option to the users in the UI
+                       (conj (sql/features this) :no-case-sensitivity-string-filter-options))})
 
   sql/ISQLDriver
-  (merge (sql/ISQLDriverDefaultsMixin)
-         {:apply-limit               (u/drop-first-arg apply-limit)
-          :apply-page                (u/drop-first-arg apply-page)
-          :column->base-type         (u/drop-first-arg column->base-type)
-          :connection-details->spec  (u/drop-first-arg connection-details->spec)
-          :current-datetime-fn       (constantly :%getutcdate)
-          :date                      (u/drop-first-arg date)
-          :excluded-schemas          (constantly #{"sys" "INFORMATION_SCHEMA"})
-          :stddev-fn                 (constantly :stdev)
-          :string-length-fn          (u/drop-first-arg string-length-fn)
-          :unix-timestamp->timestamp (u/drop-first-arg unix-timestamp->timestamp)}))
+  (merge
+   (sql/ISQLDriverDefaultsMixin)
+   {:apply-limit               (u/drop-first-arg apply-limit)
+    :apply-page                (u/drop-first-arg apply-page)
+    :column->base-type         (u/drop-first-arg column->base-type)
+    :connection-details->spec  (u/drop-first-arg connection-details->spec)
+    :current-datetime-fn       (constantly :%getutcdate)
+    :date                      (u/drop-first-arg date)
+    :excluded-schemas          (constantly #{"sys" "INFORMATION_SCHEMA"})
+    :stddev-fn                 (constantly :stdev)
+    :string-length-fn          (u/drop-first-arg string-length-fn)
+    :unix-timestamp->timestamp (u/drop-first-arg unix-timestamp->timestamp)}))
 
 (defn -init-driver
   "Register the SQLServer driver"

--- a/test/metabase/query_processor/middleware/expand_macros_test.clj
+++ b/test/metabase/query_processor/middleware/expand_macros_test.clj
@@ -165,7 +165,7 @@
                                                              :order_by    [[1 "ASC"]]}})))
 
 ;; Check that a metric w/ multiple aggregation syntax (nested vector) still works correctly
-(datasets/expect-with-engines (engines-that-support :expression-aggregations)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :expression-aggregations)
   [[2 118]
    [3  39]
    [4  24]]

--- a/test/metabase/query_processor/middleware/parameters/sql_test.clj
+++ b/test/metabase/query_processor/middleware/parameters/sql_test.clj
@@ -5,7 +5,7 @@
             [metabase
              [driver :as driver]
              [query-processor :as qp]
-             [query-processor-test :refer [engines-that-support first-row format-rows-by]]]
+             [query-processor-test :refer [non-timeseries-engines-with-feature first-row format-rows-by]]]
             [metabase.query-processor.middleware.parameters.sql :as sql :refer :all]
             [metabase.test.data :as data]
             [metabase.test.data
@@ -437,7 +437,7 @@
 
 ;; as with the MBQL parameters tests Redshift and Crate fail for unknown reasons; disable their tests for now
 (def ^:private ^:const sql-parameters-engines
-  (disj (engines-that-support :native-parameters) :redshift :crate))
+  (disj (non-timeseries-engines-with-feature :native-parameters) :redshift :crate))
 
 (defn- process-native {:style/indent 0} [& kvs]
   (qp/process-query

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -30,15 +30,17 @@
   "Set of engines for non-timeseries DBs (i.e., every driver except `:druid`)."
   (set/difference datasets/all-valid-engines timeseries-engines))
 
-(defn engines-that-support
+(defn non-timeseries-engines-with-feature
   "Set of engines that support a given FEATURE."
   [feature]
   (set (for [engine non-timeseries-engines
              :when  (contains? (driver/features (driver/engine->driver engine)) feature)]
          engine)))
 
-(defn engines-that-dont-support [feature]
-  (set/difference non-timeseries-engines (engines-that-support feature)))
+(defn non-timeseries-engines-without-feature
+  "Return a set of all non-timeseries engines (e.g., everything except Druid) that DO NOT support `feature`."
+  [feature]
+  (set/difference non-timeseries-engines (non-timeseries-engines-with-feature feature)))
 
 (defmacro expect-with-non-timeseries-dbs
   {:style/indent 0}
@@ -290,9 +292,8 @@
 
 ;; TODO - maybe this needs a new name now that it also removes the results_metadata
 (defn booleanize-native-form
-  "Convert `:native_form` attribute to a boolean to make test results comparisons easier. Remove
-  `data.results_metadata` as well since it just takes a lot of space and the checksum can vary based on whether
-  encryption is enabled."
+  "Convert `:native_form` attribute to a boolean to make test results comparisons easier. Remove `data.results_metadata`
+  as well since it just takes a lot of space and the checksum can vary based on whether encryption is enabled."
   [m]
   (-> m
       (update-in [:data :native_form] boolean)

--- a/test/metabase/query_processor_test/breakout_test.clj
+++ b/test/metabase/query_processor_test/breakout_test.clj
@@ -115,7 +115,7 @@
          booleanize-native-form
          (format-rows-by [int int str]))))
 
-(datasets/expect-with-engines (engines-that-support :foreign-keys)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :foreign-keys)
   [["Wine Bar" "Thai" "Thai" "Thai" "Thai" "Steakhouse" "Steakhouse" "Steakhouse" "Steakhouse" "Southern"]
    ["American" "American" "American" "American" "American" "American" "American" "American" "Artisan" "Artisan"]]
   (data/with-data
@@ -135,21 +135,21 @@
            rows
            (map last))]))
 
-(datasets/expect-with-engines (engines-that-support :binning)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :binning)
   [[10.0 1] [32.0 4] [34.0 57] [36.0 29] [40.0 9]]
   (format-rows-by [(partial u/round-to-decimals 1) int]
     (rows (data/run-query venues
             (ql/aggregation (ql/count))
             (ql/breakout (ql/binning-strategy $latitude :num-bins 20))))))
 
-(datasets/expect-with-engines (engines-that-support :binning)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :binning)
  [[0.0 1] [20.0 90] [40.0 9]]
   (format-rows-by [(partial u/round-to-decimals 1) int]
     (rows (data/run-query venues
             (ql/aggregation (ql/count))
             (ql/breakout (ql/binning-strategy $latitude :num-bins 3))))))
 
-(datasets/expect-with-engines (engines-that-support :binning)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :binning)
    [[10.0 -170.0 1] [32.0 -120.0 4] [34.0 -120.0 57] [36.0 -125.0 29] [40.0 -75.0 9]]
   (format-rows-by [(partial u/round-to-decimals 1) (partial u/round-to-decimals 1) int]
     (rows (data/run-query venues
@@ -159,14 +159,14 @@
 
 ;; Currently defaults to 8 bins when the number of bins isn't
 ;; specified
-(datasets/expect-with-engines (engines-that-support :binning)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :binning)
   [[10.0 1] [30.0 90] [40.0 9]]
   (format-rows-by [(partial u/round-to-decimals 1) int]
     (rows (data/run-query venues
             (ql/aggregation (ql/count))
             (ql/breakout (ql/binning-strategy $latitude :default))))))
 
-(datasets/expect-with-engines (engines-that-support :binning)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :binning)
   [[10.0 1] [30.0 61] [35.0 29] [40.0 9]]
   (tu/with-temporary-setting-values [breakout-bin-width 5.0]
     (format-rows-by [(partial u/round-to-decimals 1) int]
@@ -175,7 +175,7 @@
               (ql/breakout (ql/binning-strategy $latitude :default)))))))
 
 ;; Testing bin-width
-(datasets/expect-with-engines (engines-that-support :binning)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :binning)
   [[10.0 1] [33.0 4] [34.0 57] [37.0 29] [40.0 9]]
   (format-rows-by [(partial u/round-to-decimals 1) int]
     (rows (data/run-query venues
@@ -183,14 +183,14 @@
             (ql/breakout (ql/binning-strategy $latitude :bin-width 1))))))
 
 ;; Testing bin-width using a float
-(datasets/expect-with-engines (engines-that-support :binning)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :binning)
   [[10.0 1] [32.5 61] [37.5 29] [40.0 9]]
   (format-rows-by [(partial u/round-to-decimals 1) int]
     (rows (data/run-query venues
             (ql/aggregation (ql/count))
             (ql/breakout (ql/binning-strategy $latitude :bin-width 2.5))))))
 
-(datasets/expect-with-engines (engines-that-support :binning)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :binning)
   [[33.0 4] [34.0 57]]
   (tu/with-temporary-setting-values [breakout-bin-width 1.0]
     (format-rows-by [(partial u/round-to-decimals 1) int]
@@ -209,7 +209,7 @@
         (update-in [:binning_info :max_value] round-to-decimal))))
 
 ;;Validate binning info is returned with the binning-strategy
-(datasets/expect-with-engines (engines-that-support :binning)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :binning)
   (assoc (breakout-col (venues-col :latitude))
          :binning_info {:binning_strategy :bin-width, :bin_width 10.0,
                         :num_bins         4,          :min_value 10.0
@@ -221,7 +221,7 @@
       (get-in [:data :cols])
       first))
 
-(datasets/expect-with-engines (engines-that-support :binning)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :binning)
   (assoc (breakout-col (venues-col :latitude))
          :binning_info {:binning_strategy :num-bins, :bin_width 7.5,
                         :num_bins         5,         :min_value 7.5,
@@ -234,7 +234,7 @@
       first))
 
 ;;Validate binning info is returned with the binning-strategy
-(datasets/expect-with-engines (engines-that-support :binning)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :binning)
   {:status :failed
    :class Exception
    :error (format "Unable to bin field '%s' with id '%s' without a min/max value"

--- a/test/metabase/query_processor_test/expression_aggregations_test.clj
+++ b/test/metabase/query_processor_test/expression_aggregations_test.clj
@@ -12,7 +12,7 @@
             [toucan.util.test :as tt]))
 
 ;; sum, *
-(datasets/expect-with-engines (engines-that-support :expression-aggregations)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :expression-aggregations)
   [[1 1211]
    [2 5710]
    [3 1845]
@@ -23,7 +23,7 @@
             (ql/breakout $price)))))
 
 ;; min, +
-(datasets/expect-with-engines (engines-that-support :expression-aggregations)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :expression-aggregations)
   [[1 10]
    [2  4]
    [3  4]
@@ -34,7 +34,7 @@
             (ql/breakout $price)))))
 
 ;; max, /
-(datasets/expect-with-engines (engines-that-support :expression-aggregations)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :expression-aggregations)
   [[1 94]
    [2 50]
    [3 26]
@@ -45,7 +45,7 @@
             (ql/breakout $price)))))
 
 ;; avg, -
-(datasets/expect-with-engines (engines-that-support :expression-aggregations)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :expression-aggregations)
   (if (= *engine* :h2)
     [[1  55]
      [2  97]
@@ -61,7 +61,7 @@
             (ql/breakout $price)))))
 
 ;; post-aggregation math w/ 2 args: count + sum
-(datasets/expect-with-engines (engines-that-support :expression-aggregations)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :expression-aggregations)
   [[1  44]
    [2 177]
    [3  52]
@@ -73,7 +73,7 @@
             (ql/breakout $price)))))
 
 ;; post-aggregation math w/ 3 args: count + sum + count
-(datasets/expect-with-engines (engines-that-support :expression-aggregations)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :expression-aggregations)
   [[1  66]
    [2 236]
    [3  65]
@@ -86,7 +86,7 @@
             (ql/breakout $price)))))
 
 ;; post-aggregation math w/ a constant: count * 10
-(datasets/expect-with-engines (engines-that-support :expression-aggregations)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :expression-aggregations)
   [[1 220]
    [2 590]
    [3 130]
@@ -98,7 +98,7 @@
             (ql/breakout $price)))))
 
 ;; nested post-aggregation math: count + (count * sum)
-(datasets/expect-with-engines (engines-that-support :expression-aggregations)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :expression-aggregations)
   [[1  506]
    [2 7021]
    [3  520]
@@ -111,7 +111,7 @@
             (ql/breakout $price)))))
 
 ;; post-aggregation math w/ avg: count + avg
-(datasets/expect-with-engines (engines-that-support :expression-aggregations)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :expression-aggregations)
   (if (= *engine* :h2)
     [[1  77]
      [2 107]
@@ -128,7 +128,7 @@
             (ql/breakout $price)))))
 
 ;; post aggregation math + math inside aggregations: max(venue_price) + min(venue_price - id)
-(datasets/expect-with-engines (engines-that-support :expression-aggregations)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :expression-aggregations)
   [[1 -92]
    [2 -96]
    [3 -74]
@@ -140,7 +140,7 @@
             (ql/breakout $price)))))
 
 ;; aggregation w/o field
-(datasets/expect-with-engines (engines-that-support :expression-aggregations)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :expression-aggregations)
   [[1 23]
    [2 60]
    [3 14]
@@ -151,7 +151,7 @@
             (ql/breakout $price)))))
 
 ;; aggregation with math inside the aggregation :scream_cat:
-(datasets/expect-with-engines (engines-that-support :expression-aggregations)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :expression-aggregations)
   [[1  44]
    [2 177]
    [3  52]
@@ -162,7 +162,7 @@
             (ql/breakout $price)))))
 
 ;; check that we can name an expression aggregation w/ aggregation at top-level
-(datasets/expect-with-engines (engines-that-support :expression-aggregations)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :expression-aggregations)
   {:rows    [[1  44]
              [2 177]
              [3  52]
@@ -175,7 +175,7 @@
                          (ql/breakout $price)))))
 
 ;; check that we can name an expression aggregation w/ expression at top-level
-(datasets/expect-with-engines (engines-that-support :expression-aggregations)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :expression-aggregations)
   {:rows    [[1 -19]
              [2  77]
              [3  -2]
@@ -188,7 +188,7 @@
                          (ql/breakout $price)))))
 
 ;; check that we can handle METRICS (ick) inside expression aggregation clauses
-(datasets/expect-with-engines (engines-that-support :expression-aggregations)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :expression-aggregations)
   [[2 119]
    [3  40]
    [4  25]]
@@ -204,7 +204,7 @@
                           :breakout     [(ql/breakout (ql/field-id (data/id :venues :price)))]}})))))
 
 ;; check that we can handle METRICS (ick) inside a NAMED clause
-(datasets/expect-with-engines (engines-that-support :expression-aggregations)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :expression-aggregations)
   {:rows    [[2 118]
              [3  39]
              [4  24]]
@@ -222,7 +222,7 @@
                                        :breakout     [(ql/breakout (ql/field-id (data/id :venues :price)))]}})))))
 
 ;; check that METRICS (ick) with a nested aggregation still work inside a NAMED clause
-(datasets/expect-with-engines (engines-that-support :expression-aggregations)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :expression-aggregations)
   {:rows    [[2 118]
              [3  39]
              [4  24]]
@@ -240,7 +240,7 @@
                                        :breakout     [(ql/breakout (ql/field-id (data/id :venues :price)))]}})))))
 
 ;; check that named aggregations come back with the correct column metadata (#4002)
-(datasets/expect-with-engines (engines-that-support :expression-aggregations)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :expression-aggregations)
   (let [col-name (driver/format-custom-field-name *driver* "Count of Things")]
     (assoc (aggregate-col :count)
       :name         col-name
@@ -253,7 +253,7 @@
       :data :cols first))
 
 ;; check that we can use cumlative count in expression aggregations
-(datasets/expect-with-engines (engines-that-support :expression-aggregations)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :expression-aggregations)
   [[1000]]
   (format-rows-by [int]
     (rows (qp/process-query

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -22,7 +22,7 @@
 
 
 ;; Do a basic query including an expression
-(datasets/expect-with-engines (engines-that-support :expressions)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :expressions)
   [[1 "Red Medicine"                 4  10.0646 -165.374 3 5.0]
    [2 "Stout Burgers & Beers"        11 34.0996 -118.329 2 4.0]
    [3 "The Apple Pan"                11 34.0406 -118.428 2 4.0]
@@ -35,7 +35,7 @@
             (ql/order-by (ql/asc $id))))))
 
 ;; Make sure FLOATING POINT division is done
-(datasets/expect-with-engines (engines-that-support :expressions)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :expressions)
   [[1 "Red Medicine"           4 10.0646 -165.374 3 1.5]     ; 3 / 2 SHOULD BE 1.5, NOT 1 (!)
    [2 "Stout Burgers & Beers" 11 34.0996 -118.329 2 1.0]
    [3 "The Apple Pan"         11 34.0406 -118.428 2 1.0]]
@@ -46,7 +46,7 @@
             (ql/order-by (ql/asc $id))))))
 
 ;; Can we do NESTED EXPRESSIONS ?
-(datasets/expect-with-engines (engines-that-support :expressions)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :expressions)
   [[1 "Red Medicine"           4 10.0646 -165.374 3 3.0]
    [2 "Stout Burgers & Beers" 11 34.0996 -118.329 2 2.0]
    [3 "The Apple Pan"         11 34.0406 -118.428 2 2.0]]
@@ -57,7 +57,7 @@
             (ql/order-by (ql/asc $id))))))
 
 ;; Can we have MULTIPLE EXPRESSIONS?
-(datasets/expect-with-engines (engines-that-support :expressions)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :expressions)
   [[1 "Red Medicine"           4 10.0646 -165.374 3 2.0 4.0]
    [2 "Stout Burgers & Beers" 11 34.0996 -118.329 2 1.0 3.0]
    [3 "The Apple Pan"         11 34.0406 -118.428 2 1.0 3.0]]
@@ -69,7 +69,7 @@
             (ql/order-by (ql/asc $id))))))
 
 ;; Can we refer to expressions inside a FIELDS clause?
-(datasets/expect-with-engines (engines-that-support :expressions)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :expressions)
   [[4] [4] [5]]
   (format-rows-by [int]
     (rows (data/run-query venues
@@ -79,7 +79,7 @@
             (ql/order-by (ql/asc $id))))))
 
 ;; Can we refer to expressions inside an ORDER BY clause?
-(datasets/expect-with-engines (engines-that-support :expressions)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :expressions)
   [[100 "Mohawk Bend"         46 34.0777 -118.265 2 102.0]
    [99  "Golden Road Brewing" 10 34.1505 -118.274 2 101.0]
    [98  "Lucky Baldwin's Pub"  7 34.1454 -118.149 2 100.0]]
@@ -90,7 +90,7 @@
             (ql/order-by (ql/desc (ql/expression :x)))))))
 
 ;; Can we AGGREGATE + BREAKOUT by an EXPRESSION?
-(datasets/expect-with-engines (engines-that-support :expressions)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :expressions)
   [[2 22] [4 59] [6 13] [8 6]]
   (format-rows-by [int int]
     (rows (data/run-query venues
@@ -99,7 +99,7 @@
             (ql/breakout (ql/expression :x))))))
 
 ;; Custom aggregation expressions should include their type
-(datasets/expect-with-engines (engines-that-support :expressions)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :expressions)
   (conj #{{:name "x" :base_type :type/Float}}
         (if (= datasets/*engine* :oracle)
           {:name (data/format-name "category_id") :base_type :type/Decimal}

--- a/test/metabase/query_processor_test/filter_test.clj
+++ b/test/metabase/query_processor_test/filter_test.clj
@@ -2,7 +2,8 @@
   "Tests for the `:filter` clause."
   (:require [metabase.query-processor-test :refer :all]
             [metabase.query-processor.middleware.expand :as ql]
-            [metabase.test.data :as data]))
+            [metabase.test.data :as data]
+            [metabase.test.data.datasets :as datasets]))
 
 ;;; ------------------------------------------------ "FILTER" CLAUSE -------------------------------------------------
 
@@ -153,14 +154,14 @@
         (ql/order-by (ql/asc $id)))
       rows formatted-venues-rows))
 
-(expect-with-non-timeseries-dbs
+(datasets/expect-with-engines (non-timeseries-engines-without-feature :no-case-sensitivity-string-filter-options)
   []
   (-> (data/run-query venues
         (ql/filter (ql/starts-with $name "CHE"))
         (ql/order-by (ql/asc $id)))
       rows formatted-venues-rows))
 
-(expect-with-non-timeseries-dbs
+(datasets/expect-with-engines (non-timeseries-engines-without-feature :no-case-sensitivity-string-filter-options)
   [[41 "Cheese Steak Shop" 18 37.7855 -122.44  1]
    [74 "Chez Jay"           2 34.0104 -118.493 2]]
   (-> (data/run-query venues
@@ -181,14 +182,14 @@
         (ql/order-by (ql/asc $id)))
       rows formatted-venues-rows))
 
-(expect-with-non-timeseries-dbs
+(datasets/expect-with-engines (non-timeseries-engines-without-feature :no-case-sensitivity-string-filter-options)
   []
   (-> (data/run-query venues
         (ql/filter (ql/ends-with $name "RESTAURANT"))
         (ql/order-by (ql/asc $id)))
       rows formatted-venues-rows))
 
-(expect-with-non-timeseries-dbs
+(datasets/expect-with-engines (non-timeseries-engines-without-feature :no-case-sensitivity-string-filter-options)
   [[ 5 "Brite Spot Family Restaurant" 20 34.0778 -118.261 2]
    [ 7 "Don Day Korean Restaurant"    44 34.0689 -118.305 2]
    [17 "Ruen Pair Thai Restaurant"    71 34.1021 -118.306 2]
@@ -210,7 +211,7 @@
       rows formatted-venues-rows))
 
 ;; case-insensitive
-(expect-with-non-timeseries-dbs
+(datasets/expect-with-engines (non-timeseries-engines-without-feature :no-case-sensitivity-string-filter-options)
   []
   (-> (data/run-query venues
         (ql/filter (ql/contains $name "bbq"))
@@ -218,7 +219,7 @@
       rows formatted-venues-rows))
 
 ;; case-insensitive
-(expect-with-non-timeseries-dbs
+(datasets/expect-with-engines (non-timeseries-engines-without-feature :no-case-sensitivity-string-filter-options)
   [[31 "Bludso's BBQ"             5 33.8894 -118.207 2]
    [34 "Beachwood BBQ & Brewing" 10 33.7701 -118.191 2]
    [39 "Baby Blues BBQ"           5 34.0003 -118.465 2]]

--- a/test/metabase/query_processor_test/joins_test.clj
+++ b/test/metabase/query_processor_test/joins_test.clj
@@ -7,7 +7,7 @@
 
 ;; The top 10 cities by number of Tupac sightings
 ;; Test that we can breakout on an FK field (Note how the FK Field is returned in the results)
-(datasets/expect-with-engines (engines-that-support :foreign-keys)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :foreign-keys)
   [["Arlington"    16]
    ["Albany"       15]
    ["Portland"     14]
@@ -30,7 +30,7 @@
 ;; Number of Tupac sightings in the Expa office
 ;; (he was spotted here 60 times)
 ;; Test that we can filter on an FK field
-(datasets/expect-with-engines (engines-that-support :foreign-keys)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :foreign-keys)
   [[60]]
   (->> (data/dataset tupac-sightings
          (data/run-query sightings
@@ -42,7 +42,7 @@
 ;; THE 10 MOST RECENT TUPAC SIGHTINGS (!)
 ;; (What he was doing when we saw him, sighting ID)
 ;; Check that we can include an FK field in the :fields clause
-(datasets/expect-with-engines (engines-that-support :foreign-keys)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :foreign-keys)
   [[772 "In the Park"]
    [894 "Working at a Pet Store"]
    [684 "At the Airport"]
@@ -65,7 +65,7 @@
 ;;    (this query targets sightings and orders by cities.name and categories.name)
 ;; 2. Check that we can join MULTIPLE tables in a single query
 ;;    (this query joins both cities and categories)
-(datasets/expect-with-engines (engines-that-support :foreign-keys)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :foreign-keys)
   ;; CITY_ID, CATEGORY_ID, ID
   ;; Cities are already alphabetized in the source data which is why CITY_ID is sorted
   [[1 12   6]
@@ -84,11 +84,12 @@
                         (ql/desc $category_id->categories.name)
                         (ql/asc $id))
            (ql/limit 10)))
-       rows (map butlast) (map reverse) (format-rows-by [int int int]))) ; drop timestamps. reverse ordering to make the results columns order match order_by
+       ;; drop timestamps. reverse ordering to make the results columns order match order_by
+       rows (map butlast) (map reverse) (format-rows-by [int int int])))
 
 
 ;; Check that trying to use a Foreign Key fails for Mongo
-(datasets/expect-with-engines (engines-that-dont-support :foreign-keys)
+(datasets/expect-with-engines (non-timeseries-engines-without-feature :foreign-keys)
   {:status :failed
    :error "foreign-keys is not supported by this driver."}
   (select-keys (data/dataset tupac-sightings
@@ -100,9 +101,9 @@
                [:status :error]))
 
 
-;;; +----------------------------------------------------------------------------------------------------------------------+
-;;; |                                                    MULTIPLE JOINS                                                    |
-;;; +----------------------------------------------------------------------------------------------------------------------+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                                 MULTIPLE JOINS                                                 |
+;;; +----------------------------------------------------------------------------------------------------------------+
 
 ;;; CAN WE JOIN AGAINST THE SAME TABLE TWICE (MULTIPLE FKS TO A SINGLE TABLE!?)
 ;; Query should look something like:
@@ -115,7 +116,7 @@
 ;; WHERE USERS__via__RECIEVER_ID.NAME = 'Rasta Toucan'
 ;; GROUP BY USERS__via__SENDER_ID.NAME
 ;; ORDER BY USERS__via__SENDER_ID.NAME ASC
-(datasets/expect-with-engines (engines-that-support :foreign-keys)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :foreign-keys)
   [["Bob the Sea Gull" 2]
    ["Brenda Blackbird" 2]
    ["Lucky Pigeon"     2]

--- a/test/metabase/query_processor_test/nested_field_test.clj
+++ b/test/metabase/query_processor_test/nested_field_test.clj
@@ -7,7 +7,7 @@
 
 ;;; Nested Field in FILTER
 ;; Get the first 10 tips where tip.venue.name == "Kyle's Low-Carb Grill"
-(datasets/expect-with-engines (engines-that-support :nested-fields)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :nested-fields)
   [[8   "Kyle's Low-Carb Grill"]
    [67  "Kyle's Low-Carb Grill"]
    [80  "Kyle's Low-Carb Grill"]
@@ -26,7 +26,7 @@
 
 ;;; Nested Field in ORDER
 ;; Let's get all the tips Kyle posted on Twitter sorted by tip.venue.name
-(datasets/expect-with-engines (engines-that-support :nested-fields)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :nested-fields)
   [[446
     {:mentions ["@cams_mexican_gastro_pub"], :tags ["#mexican" "#gastro" "#pub"], :service "twitter", :username "kyle"}
     "Cam's Mexican Gastro Pub is a historical and underappreciated place to conduct a business meeting with friends."
@@ -63,14 +63,14 @@
 
 ;; Nested Field in AGGREGATION
 ;; Let's see how many *distinct* venue names are mentioned
-(datasets/expect-with-engines (engines-that-support :nested-fields)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :nested-fields)
   [99]
   (first-row (data/dataset geographical-tips
                (data/run-query tips
                  (ql/aggregation (ql/distinct $tips.venue.name))))))
 
 ;; Now let's just get the regular count
-(datasets/expect-with-engines (engines-that-support :nested-fields)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :nested-fields)
   [500]
   (first-row (data/dataset geographical-tips
                (data/run-query tips
@@ -78,7 +78,7 @@
 
 ;;; Nested Field in BREAKOUT
 ;; Let's see how many tips we have by source.service
-(datasets/expect-with-engines (engines-that-support :nested-fields)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :nested-fields)
   {:rows        [["facebook"   107]
                  ["flare"      105]
                  ["foursquare" 100]
@@ -95,7 +95,7 @@
 
 ;;; Nested Field in FIELDS
 ;; Return the first 10 tips with just tip.venue.name
-(datasets/expect-with-engines (engines-that-support :nested-fields)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :nested-fields)
   {:columns ["venue.name"]
    :rows    [["Lucky's Gluten-Free Café"]
              ["Joe's Homestyle Eatery"]
@@ -116,7 +116,7 @@
 
 
 ;;; Nested Field w/ ordering by aggregation
-(datasets/expect-with-engines (engines-that-support :nested-fields)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :nested-fields)
   [["jane"           4]
    ["kyle"           5]
    ["tupac"          5]

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -31,7 +31,7 @@
 
 
 ;; make sure we can do a basic query with MBQL source-query
-(datasets/expect-with-engines (engines-that-support :nested-queries)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :nested-queries)
   {:rows [[1 "Red Medicine"                  4 10.0646 -165.374 3]
           [2 "Stout Burgers & Beers"        11 34.0996 -118.329 2]
           [3 "The Apple Pan"                11 34.0406 -118.428 2]
@@ -74,7 +74,7 @@
   (comp quote-identifier identifier))
 
 ;; make sure we can do a basic query with a SQL source-query
-(datasets/expect-with-engines (engines-that-support :nested-queries)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :nested-queries)
   {:rows [[1 -165.374  4 3 "Red Medicine"                 10.0646]
           [2 -118.329 11 2 "Stout Burgers & Beers"        34.0996]
           [3 -118.428 11 2 "The Apple Pan"                34.0406]
@@ -112,7 +112,7 @@
           {:name "count", :base_type :type/Integer}]})
 
 ;; make sure we can do a query with breakout and aggregation using an MBQL source query
-(datasets/expect-with-engines (engines-that-support :nested-queries)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :nested-queries)
   breakout-results
   (rows+cols
     (format-rows-by [int int]
@@ -124,7 +124,7 @@
                     :breakout     [[:field-literal (keyword (data/format-name :price)) :type/Integer]]}}))))
 
 ;; make sure we can do a query with breakout and aggregation using a SQL source query
-(datasets/expect-with-engines (engines-that-support :nested-queries)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :nested-queries)
   breakout-results
   (rows+cols
     (format-rows-by [int int]
@@ -410,7 +410,7 @@
       results-metadata))
 
 ;; make sure using a time interval filter works
-(datasets/expect-with-engines (engines-that-support :nested-queries)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :nested-queries)
   :completed
   (tt/with-temp Card [card (mbql-card-def
                              :source-table (data/id :checkins))]
@@ -420,7 +420,7 @@
         :status)))
 
 ;; make sure that wrapping a field literal in a datetime-field clause works correctly in filters & breakouts
-(datasets/expect-with-engines (engines-that-support :nested-queries)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :nested-queries)
   :completed
   (tt/with-temp Card [card (mbql-card-def
                              :source-table (data/id :checkins))]

--- a/test/metabase/query_processor_test/order_by_test.clj
+++ b/test/metabase/query_processor_test/order_by_test.clj
@@ -106,7 +106,7 @@
 ;;; ### order_by aggregate ["stddev" field-id]
 ;; SQRT calculations are always NOT EXACT (normal behavior) so round everything to the nearest int.
 ;; Databases might use different versions of SQRT implementations
-(datasets/expect-with-engines (engines-that-support :standard-deviation-aggregations)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :standard-deviation-aggregations)
   {:columns     [(data/format-name "price")
                  "stddev"]
    :rows        [[3 (if (contains? #{:mysql :crate} *engine*) 25 26)]

--- a/test/metabase/query_processor_test/remapping_test.clj
+++ b/test/metabase/query_processor_test/remapping_test.clj
@@ -52,7 +52,7 @@
                    (fn [rows]
                      (map #(mapv % col-indexes) rows))))))
 
-(datasets/expect-with-engines (engines-that-support :foreign-keys)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :foreign-keys)
   {:rows   [["20th Century Cafe" 2 "Café"]
             ["25°" 2 "Burger"]
             ["33 Taps" 2 "Bar"]

--- a/test/metabase/test/mock/toucanery.clj
+++ b/test/metabase/test/mock/toucanery.clj
@@ -1,7 +1,6 @@
 (ns metabase.test.mock.toucanery
-  "A document style database mocked for testing.
-   This is a `:dynamic-schema` db with `:nested-fields`.
-   Most notably meant to serve as a representation of a Mongo database."
+  "A document style database mocked for testing. This is a dynamic schema db with `:nested-fields`. Most notably meant
+  to serve as a representation of a Mongo database."
   (:require [metabase.driver :as driver]
             [metabase.test.mock.util :as mock-util]))
 
@@ -76,7 +75,7 @@
   (merge driver/IDriverDefaultsMixin
          {:describe-database        describe-database
           :describe-table           describe-table
-          :features                 (constantly #{:dynamic-schema :nested-fields})
+          :features                 (constantly #{:nested-fields})
           :details-fields           (constantly [])
           :table-rows-seq           table-rows-seq
           :process-query-in-context mock-util/process-query-in-context}))


### PR DESCRIPTION
Apparently SQLite SQL `LIKE` is always case-insensitive so we really don't have any say in whether an individual LIKE clause is case-sensitive or not. This was causing our test failures in master (new case-sensitive tests were returning results for SQLite that weren't returned for any other SQL driver).

 Fixed this by adding a new "feature" in the drivers features lists called `no-case-sensitivity-string-filter-options` so we can know SQLite doesn't have case-sensitivity options for string filter clauses and treat it accordingly.

Also has a bit of code cleanup -- long lines fixes as well, renaming some test helper functions to better reflect what they do, and removing the unused `dynamic-schema` driver feature.