### PR TITLE
Fix SSH tunnel details

### DIFF
--- a/src/metabase/util/ssh.clj
+++ b/src/metabase/util/ssh.clj
@@ -82,7 +82,7 @@
           [connection tunnel-entrance-port] (start-ssh-tunnel (assoc details :host host)) ;; don't include L7 protocol in ssh tunnel
           details-with-tunnel (assoc details
                                 :port tunnel-entrance-port ;; This parameter is set dynamically when the connection is established
-                                :host (str proto (:tunnel-host details))
+                                :host (str proto "localhost")
                                 :tunnel-entrance-port tunnel-entrance-port ;; the input port is not known until the connection is opened
                                 :tunnel-connection connection)]
       details-with-tunnel)


### PR DESCRIPTION
After setting up an SSH tunnel, Metabase should always connect to the database through localhost.

Fixes #6851



###### TODO 
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
