### PR TITLE
Sync column and table comments

### DIFF
--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -347,7 +347,7 @@
                  :database-type database-type
                  :base-type     (database-type->base-type driver database-type)}
                 (when (not (str/blank? remarks))
-                  {:description remarks})
+                  {:field-comment remarks})
                 (when-let [special-type (calculated-special-type driver column-name database-type)]
                   {:special-type special-type})))))
 

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -323,7 +323,7 @@
          (merge {:name   (:table_name  table)
                  :schema (:table_schem table)}
                 (let [remarks (:remarks table)]
-                  (when (not (str/blank? remarks))
+                  (when-not (str/blank? remarks)
                     {:description remarks}))))))
 
 (defn- database-type->base-type

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -308,9 +308,9 @@
         schemas     (set/difference all-schemas (excluded-schemas driver))]
     (set (for [schema schemas
                table  (get-tables metadata schema)]
-           {:name           (:table_name table)
-            :schema         schema
-            :table-comment  (:remarks table)}))))
+           {:name        (:table_name table)
+            :schema      schema
+            :description (:remarks table)}))))
 
 (defn post-filtered-active-tables
   "Alternative implementation of `ISQLDriver/active-tables` best suited for DBs with little or no support for schemas.
@@ -318,9 +318,9 @@
   [driver, ^DatabaseMetaData metadata]
   (set (for [table (filter #(not (contains? (excluded-schemas driver) (:table_schem %)))
                            (get-tables metadata nil))]
-         {:name           (:table_name table)
-          :schema         (:table_schem table)
-          :table-comment  (:remarks table)})))
+         {:name        (:table_name table)
+          :schema      (:table_schem table)
+          :description (:remarks table)})))
 
 (defn- database-type->base-type
   "Given a `database-type` (e.g. `VARCHAR`) return the mapped Metabase type (e.g. `:type/Text`)."

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -313,9 +313,9 @@
         schemas     (set/difference all-schemas (excluded-schemas driver))]
     (set (for [schema schemas
                table  (get-tables metadata schema)]
-           {:name           (:table_name table)
-            :schema         schema
-            :table-comment  (:remarks table)}))))
+           {:name        (:table_name table)
+            :schema      schema
+            :description (:remarks table)}))))
 
 (defn post-filtered-active-tables
   "Alternative implementation of `ISQLDriver/active-tables` best suited for DBs with little or no support for schemas.
@@ -323,9 +323,9 @@
   [driver, ^DatabaseMetaData metadata]
   (set (for [table (filter #(not (contains? (excluded-schemas driver) (:table_schem %)))
                            (get-tables metadata nil))]
-         {:name           (:table_name table)
-          :schema         (:table_schem table)
-          :table-comment  (:remarks table)})))
+         {:name        (:table_name table)
+          :schema      (:table_schem table)
+          :description (:remarks table)})))
 
 (defn- database-type->base-type
   "Given a `database-type` (e.g. `VARCHAR`) return the mapped Metabase type (e.g. `:type/Text`)."

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -311,10 +311,11 @@
   [driver, ^DatabaseMetaData metadata]
   (let [all-schemas (set (map :table_schem (jdbc/result-set-seq (.getSchemas metadata))))
         schemas     (set/difference all-schemas (excluded-schemas driver))]
-    (set (for [schema     schemas
-               table-name (mapv :table_name (get-tables metadata schema))]
-           {:name   table-name
-            :schema schema}))))
+    (set (for [schema schemas
+               table  (get-tables metadata schema)]
+           {:name           (:table_name table)
+            :schema         schema
+            :table-comment  (:remarks table)}))))
 
 (defn post-filtered-active-tables
   "Alternative implementation of `ISQLDriver/active-tables` best suited for DBs with little or no support for schemas.
@@ -322,8 +323,9 @@
   [driver, ^DatabaseMetaData metadata]
   (set (for [table (filter #(not (contains? (excluded-schemas driver) (:table_schem %)))
                            (get-tables metadata nil))]
-         {:name   (:table_name table)
-          :schema (:table_schem table)})))
+         {:name           (:table_name table)
+          :schema         (:table_schem table)
+          :table-comment  (:remarks table)})))
 
 (defn- database-type->base-type
   "Given a `database-type` (e.g. `VARCHAR`) return the mapped Metabase type (e.g. `:type/Text`)."

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -306,10 +306,11 @@
   [driver, ^DatabaseMetaData metadata]
   (let [all-schemas (set (map :table_schem (jdbc/result-set-seq (.getSchemas metadata))))
         schemas     (set/difference all-schemas (excluded-schemas driver))]
-    (set (for [schema     schemas
-               table-name (mapv :table_name (get-tables metadata schema))]
-           {:name   table-name
-            :schema schema}))))
+    (set (for [schema schemas
+               table  (get-tables metadata schema)]
+           {:name           (:table_name table)
+            :schema         schema
+            :table-comment  (:remarks table)}))))
 
 (defn post-filtered-active-tables
   "Alternative implementation of `ISQLDriver/active-tables` best suited for DBs with little or no support for schemas.
@@ -317,8 +318,9 @@
   [driver, ^DatabaseMetaData metadata]
   (set (for [table (filter #(not (contains? (excluded-schemas driver) (:table_schem %)))
                            (get-tables metadata nil))]
-         {:name   (:table_name table)
-          :schema (:table_schem table)})))
+         {:name           (:table_name table)
+          :schema         (:table_schem table)
+          :table-comment  (:remarks table)})))
 
 (defn- database-type->base-type
   "Given a `database-type` (e.g. `VARCHAR`) return the mapped Metabase type (e.g. `:type/Text`)."

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -337,10 +337,12 @@
     special-type))
 
 (defn- describe-table-fields [^DatabaseMetaData metadata, driver, {schema :schema, table-name :name}]
-  (set (for [{database-type :type_name, column-name :column_name} (jdbc/result-set-seq (.getColumns metadata nil schema table-name nil))]
+  (set (for [{database-type :type_name, column-name :column_name, remarks :remarks} (jdbc/result-set-seq (.getColumns metadata nil schema table-name nil))]
          (merge {:name          column-name
                  :database-type database-type
                  :base-type     (database-type->base-type driver database-type)}
+                (when (not (str/blank? remarks))
+                  {:description remarks})
                 (when-let [special-type (calculated-special-type driver column-name database-type)]
                   {:special-type special-type})))))
 

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -342,10 +342,12 @@
     special-type))
 
 (defn- describe-table-fields [^DatabaseMetaData metadata, driver, {schema :schema, table-name :name}]
-  (set (for [{database-type :type_name, column-name :column_name} (jdbc/result-set-seq (.getColumns metadata nil schema table-name nil))]
+  (set (for [{database-type :type_name, column-name :column_name, remarks :remarks} (jdbc/result-set-seq (.getColumns metadata nil schema table-name nil))]
          (merge {:name          column-name
                  :database-type database-type
                  :base-type     (database-type->base-type driver database-type)}
+                (when (not (str/blank? remarks))
+                  {:description remarks})
                 (when-let [special-type (calculated-special-type driver column-name database-type)]
                   {:special-type special-type})))))
 

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -342,7 +342,7 @@
                  :database-type database-type
                  :base-type     (database-type->base-type driver database-type)}
                 (when (not (str/blank? remarks))
-                  {:description remarks})
+                  {:field-comment remarks})
                 (when-let [special-type (calculated-special-type driver column-name database-type)]
                   {:special-type special-type})))))
 

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -308,11 +308,11 @@
         schemas     (set/difference all-schemas (excluded-schemas driver))]
     (set (for [schema  schemas
                table   (get-tables metadata schema)]
-           (merge {:name   (:table_name table)
-                   :schema schema}
-                  (let [remarks (:remarks table)]
-                    (when (not (str/blank? remarks))
-                      {:description remarks})))))))
+           (let [remarks (:remarks table)]
+             {:name        (:table_name table)
+              :schema      schema
+              :description (when-not (str/blank? remarks)
+                             remarks)})))))
 
 (defn post-filtered-active-tables
   "Alternative implementation of `ISQLDriver/active-tables` best suited for DBs with little or no support for schemas.
@@ -320,11 +320,11 @@
   [driver, ^DatabaseMetaData metadata]
   (set (for [table   (filter #(not (contains? (excluded-schemas driver) (:table_schem %)))
                              (get-tables metadata nil))]
-         (merge {:name   (:table_name  table)
-                 :schema (:table_schem table)}
-                (let [remarks (:remarks table)]
-                  (when-not (str/blank? remarks)
-                    {:description remarks}))))))
+         (let [remarks (:remarks table)]
+           {:name        (:table_name  table)
+            :schema      (:table_schem table)
+            :description (when-not (str/blank? remarks)
+                           remarks)}))))
 
 (defn- database-type->base-type
   "Given a `database-type` (e.g. `VARCHAR`) return the mapped Metabase type (e.g. `:type/Text`)."

--- a/src/metabase/sync/interface.clj
+++ b/src/metabase/sync/interface.clj
@@ -15,7 +15,7 @@
   "Schema for the expected output of `describe-database` for a Table."
   {:name          su/NonBlankString
    :schema        (s/maybe su/NonBlankString)
-   (s/optional-key :table-comment) (s/maybe s/Str)})
+   (s/optional-key :description) (s/maybe s/Str)})
 
 (def DatabaseMetadata
   "Schema for the expected output of `describe-database`."
@@ -38,7 +38,7 @@
   {:name   su/NonBlankString
    :schema (s/maybe su/NonBlankString)
    :fields #{TableMetadataField}
-   (s/optional-key :table-comment)   (s/maybe su/NonBlankString)})
+   (s/optional-key :description)   (s/maybe su/NonBlankString)})
 
 (def FKMetadataEntry
   "Schema for an individual entry in `FKMetadata`."

--- a/src/metabase/sync/interface.clj
+++ b/src/metabase/sync/interface.clj
@@ -15,7 +15,7 @@
   "Schema for the expected output of `describe-database` for a Table."
   {:name          su/NonBlankString
    :schema        (s/maybe su/NonBlankString)
-   (s/optional-key :description) (s/maybe s/Str)})
+   (s/optional-key :description) (s/maybe su/NonBlankString)})
 
 (def DatabaseMetadata
   "Schema for the expected output of `describe-database`."

--- a/src/metabase/sync/interface.clj
+++ b/src/metabase/sync/interface.clj
@@ -13,8 +13,9 @@
 
 (def DatabaseMetadataTable
   "Schema for the expected output of `describe-database` for a Table."
-  {:name   su/NonBlankString
-   :schema (s/maybe su/NonBlankString)})
+  {:name          su/NonBlankString
+   :schema        (s/maybe su/NonBlankString)
+   (s/optional-key :table-comment) (s/maybe s/Str)})
 
 (def DatabaseMetadata
   "Schema for the expected output of `describe-database`."

--- a/src/metabase/sync/interface.clj
+++ b/src/metabase/sync/interface.clj
@@ -27,7 +27,7 @@
    :database-type                  su/NonBlankString
    :base-type                      su/FieldType
    (s/optional-key :special-type)  (s/maybe su/FieldType)
-   (s/optional-key :description)   (s/maybe su/NonBlankString)
+   (s/optional-key :field-comment) (s/maybe su/NonBlankString)
    (s/optional-key :pk?)           s/Bool
    (s/optional-key :nested-fields) #{(s/recursive #'TableMetadataField)}
    (s/optional-key :custom)        {s/Any s/Any}})
@@ -37,7 +37,7 @@
   {:name   su/NonBlankString
    :schema (s/maybe su/NonBlankString)
    :fields #{TableMetadataField}
-   (s/optional-key :description)   (s/maybe su/NonBlankString)})
+   (s/optional-key :table-comment)   (s/maybe su/NonBlankString)})
 
 (def FKMetadataEntry
   "Schema for an individual entry in `FKMetadata`."

--- a/src/metabase/sync/interface.clj
+++ b/src/metabase/sync/interface.clj
@@ -27,6 +27,7 @@
    :database-type                  su/NonBlankString
    :base-type                      su/FieldType
    (s/optional-key :special-type)  (s/maybe su/FieldType)
+   (s/optional-key :description)   (s/maybe su/NonBlankString)
    (s/optional-key :pk?)           s/Bool
    (s/optional-key :nested-fields) #{(s/recursive #'TableMetadataField)}
    (s/optional-key :custom)        {s/Any s/Any}})
@@ -35,7 +36,8 @@
   "Schema for the expected output of `describe-table`."
   {:name   su/NonBlankString
    :schema (s/maybe su/NonBlankString)
-   :fields #{TableMetadataField}})
+   :fields #{TableMetadataField}
+   (s/optional-key :description)   (s/maybe su/NonBlankString)})
 
 (def FKMetadataEntry
   "Schema for an individual entry in `FKMetadata`."

--- a/src/metabase/sync/sync_metadata/fields.clj
+++ b/src/metabase/sync/sync_metadata/fields.clj
@@ -70,14 +70,15 @@
   [table :- i/TableInstance, new-fields :- [i/TableMetadataField], parent-id :- ParentID]
   (when (seq new-fields)
     (db/insert-many! Field
-      (for [{:keys [database-type base-type], field-name :name :as field} new-fields]
+      (for [{:keys [database-type base-type description], field-name :name :as field} new-fields]
         {:table_id      (u/get-id table)
          :name          field-name
          :display_name  (humanization/name->human-readable-name field-name)
          :database_type database-type
          :base_type     base-type
          :special_type  (special-type field)
-         :parent_id     parent-id}))))
+         :parent_id     parent-id
+         :description   description}))))
 
 (s/defn ^:private ->metabase-fields! :- [i/FieldInstance]
   "Return an active Metabase Field instance that matches NEW-FIELD-METADATA. This object will be created or

--- a/src/metabase/sync/sync_metadata/fields.clj
+++ b/src/metabase/sync/sync_metadata/fields.clj
@@ -236,7 +236,7 @@
                         (and (not (:special_type field)) new-special-type)))]
       ;; update special type if one came back from DB metadata but Field doesn't currently have one
       (db/update! Field (u/get-id field)
-                  (merge {:base_type   (:base-type db-field)}
+                  (merge {:base_type (:base-type db-field)}
                          (when-not (:special_type field)
                            {:special_type new-special-type})))
       ;; now recursively do the same for any nested fields

--- a/src/metabase/sync/sync_metadata/fields.clj
+++ b/src/metabase/sync/sync_metadata/fields.clj
@@ -69,7 +69,7 @@
         ;; now return the Field in question
         (Field (u/get-id matching-inactive-field)))
     ;; otherwise insert a new field
-    (let [{field-name :name, :keys [database-type base-type special-type pk? raw-column-id]} new-field-metadata]
+    (let [{field-name :name, :keys [database-type base-type special-type pk? raw-column-id description]} new-field-metadata]
       (db/insert! Field
         :table_id      (u/get-id table)
         :name          field-name
@@ -78,7 +78,8 @@
         :base_type     base-type
         :special_type  (or special-type
                            (when pk? :type/PK))
-        :parent_id     parent-id))))
+        :parent_id     parent-id
+        :description  description))))
 
 
 (s/defn ^:private create-or-reactivate-field!

--- a/src/metabase/sync/sync_metadata/fields.clj
+++ b/src/metabase/sync/sync_metadata/fields.clj
@@ -69,7 +69,7 @@
         ;; now return the Field in question
         (Field (u/get-id matching-inactive-field)))
     ;; otherwise insert a new field
-    (let [{field-name :name, :keys [database-type base-type special-type pk? raw-column-id description]} new-field-metadata]
+    (let [{field-name :name, :keys [database-type base-type special-type pk? raw-column-id field-comment]} new-field-metadata]
       (db/insert! Field
         :table_id      (u/get-id table)
         :name          field-name
@@ -79,7 +79,7 @@
         :special_type  (or special-type
                            (when pk? :type/PK))
         :parent_id     parent-id
-        :description   description))))
+        :description   field-comment))))
 
 
 (s/defn ^:private create-or-reactivate-field!
@@ -99,8 +99,8 @@
 (s/defn ^:private update-field-metadata-if-needed!
   "Update the metadata for a Metabase Field as needed if any of the info coming back from the DB has changed."
   [table :- i/TableInstance, metabase-field :- TableMetadataFieldWithID, field-metadata :- i/TableMetadataField]
-  (let [{old-database-type :database-type, old-base-type :base-type} metabase-field
-        {new-database-type :database-type, new-base-type :base-type} field-metadata]
+  (let [{old-database-type :database-type, old-base-type :base-type, old-field-comment :field-comment} metabase-field
+        {new-database-type :database-type, new-base-type :base-type, new-field-comment :field-comment} field-metadata]
     ;; If the driver is reporting a different `database-type` than what we have recorded in the DB, update it
     (when-not (= old-database-type new-database-type)
       (log/info (format "Database type of %s has changed from '%s' to '%s'."
@@ -112,7 +112,12 @@
       (log/info (format "Base type of %s has changed from '%s' to '%s'."
                         (field-metadata-name-for-logging table metabase-field)
                         old-base-type new-base-type))
-      (db/update! Field (u/get-id metabase-field), :base_type new-base-type))))
+      (db/update! Field (u/get-id metabase-field), :base_type new-base-type))
+    ;; And field comment, but only if the existing description is blank
+    (when (and (str/blank? old-field-comment) (not (str/blank? new-field-comment)))
+      (log/info (format "Comment has been added for %s."
+                        (field-metadata-name-for-logging table metabase-field)))
+      (db/update! Field (u/get-id metabase-field), :description new-field-comment))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -179,7 +184,7 @@
 (s/defn ^:private update-metadata!
   "Make sure things like PK status and base-type are in sync with what has come back from the DB."
   [table :- i/TableInstance, db-metadata :- #{i/TableMetadataField}, parent-id :- ParentID]
-  (let [existing-fields      (db/select [Field :base_type :special_type :name :id]
+  (let [existing-fields      (db/select [Field :base_type :special_type :name :id :description]
                                :table_id  (u/get-id table)
                                :active    true
                                :parent_id parent-id)
@@ -189,7 +194,7 @@
       (when-let [db-field (get field-name->db-metadata (str/lower-case (:name field)))]
         ;; update special type if one came back from DB metadata but Field doesn't currently have one
         (db/update! Field (u/get-id field)
-          (merge {:base_type (:base-type db-field)}
+          (merge {:base_type   (:base-type db-field)}
                  (when-not (:special_type field)
                    {:special_type (or (:special-type db-field)
                                       (when (:pk? db-field) :type/PK))})))
@@ -214,7 +219,7 @@
 (s/defn ^:private parent-id->fields :- {ParentID #{TableMetadataFieldWithID}}
   "Build a map of the Metabase Fields we have for TABLE, keyed by their parent id (usually `nil`)."
   [table :- i/TableInstance]
-  (->> (for [field (db/select [Field :name :database_type :base_type :special_type :parent_id :id]
+  (->> (for [field (db/select [Field :name :database_type :base_type :special_type :parent_id :id :description]
                      :table_id (u/get-id table)
                      :active   true)]
          {:parent-id     (:parent_id field)
@@ -223,7 +228,8 @@
           :database-type (:database_type field)
           :base-type     (:base_type field)
           :special-type  (:special_type field)
-          :pk?           (isa? (:special_type field) :type/PK)})
+          :pk?           (isa? (:special_type field) :type/PK)
+          :field-comment (:description field)})
        ;; make a map of parent-id -> set of
        (group-by :parent-id)
        ;; remove the parent ID because the Metadata from `describe-table` won't have it. Save the results as a set

--- a/src/metabase/sync/sync_metadata/fields.clj
+++ b/src/metabase/sync/sync_metadata/fields.clj
@@ -79,7 +79,7 @@
         :special_type  (or special-type
                            (when pk? :type/PK))
         :parent_id     parent-id
-        :description  description))))
+        :description   description))))
 
 
 (s/defn ^:private create-or-reactivate-field!

--- a/src/metabase/sync/sync_metadata/tables.clj
+++ b/src/metabase/sync/sync_metadata/tables.clj
@@ -128,11 +128,12 @@
             (for [table changed-tables]
               (sync-util/name-for-logging (table/map->TableInstance table))))
   (doseq [{schema :schema, table-name :name, description :description} changed-tables]
-    (db/update-where! Table {:db_id       (u/get-id database)
-                             :schema      schema
-                             :name        table-name
-                             :description nil}
-                      :description description)))
+    (when-not (str/blank? description)
+      (db/update-where! Table {:db_id       (u/get-id database)
+                               :schema      schema
+                               :name        table-name
+                               :description nil}
+                        :description description))))
 
 
 (s/defn ^:private db-metadata :- #{i/DatabaseMetadataTable}

--- a/src/metabase/sync/sync_metadata/tables.clj
+++ b/src/metabase/sync/sync_metadata/tables.clj
@@ -88,7 +88,7 @@
   (log/info "Found new tables:"
             (for [table new-tables]
               (sync-util/name-for-logging (table/map->TableInstance table))))
-  (doseq [{schema :schema, table-name :name, table-comment :table-comment, :as table} new-tables]
+  (doseq [{schema :schema, table-name :name, :as table} new-tables]
     (if-let [existing-id (db/select-one-id Table
                            :db_id  (u/get-id database)
                            :schema schema
@@ -105,8 +105,7 @@
         :display_name    (humanization/name->human-readable-name table-name)
         :active          true
         :visibility_type (when (is-crufty-table? table)
-                           :cruft)
-        :description     table-comment))))
+                           :cruft)))))
 
 
 (s/defn ^:private retire-tables!
@@ -122,6 +121,26 @@
       :active false)))
 
 
+(s/defn ^:private update-table-description!
+  "Update description for any CHANGED-TABLES belonging to DATABASE."
+  [database :- i/DatabaseInstance, changed-tables :- #{i/DatabaseMetadataTable}]
+  (log/info "Updating description for tables:"
+            (for [table changed-tables]
+              (sync-util/name-for-logging (table/map->TableInstance table))))
+  (doseq [{schema :schema, table-name :name, description :description} changed-tables]
+    ;; TODO: seems there should be a way to do OR but I can't figure it out with this lib
+    (db/update-where! Table {:db_id       (u/get-id database)
+                             :schema      schema
+                             :name        table-name
+                             :description nil}
+                      :description description)
+    (db/update-where! Table {:db_id       (u/get-id database)
+                             :schema      schema
+                             :name        table-name
+                             :description ""}
+                      :description description)))
+
+
 (s/defn ^:private db-metadata :- #{i/DatabaseMetadataTable}
   "Return information about DATABASE by calling its driver's implementation of `describe-database`."
   [database :- i/DatabaseInstance]
@@ -133,7 +152,7 @@
   "Return information about what Tables we have for this DB in the Metabase application DB."
   [database :- i/DatabaseInstance]
   (set (map (partial into {})
-            (db/select [Table :name :schema]
+            (db/select [Table :name :schema :description]
               :db_id  (u/get-id database)
               :active true))))
 
@@ -143,7 +162,12 @@
   ;; determine what's changed between what info we have and what's in the DB
   (let [db-metadata             (db-metadata database)
         our-metadata            (our-metadata database)
-        [new-tables old-tables] (data/diff db-metadata our-metadata)]
+        strip-desc              (fn [metadata]
+                                  (set (map #(dissoc % :description) metadata)))
+        [new-tables old-tables] (data/diff
+                                  (strip-desc db-metadata)
+                                  (strip-desc our-metadata))
+        [changed-tables]        (data/diff db-metadata our-metadata)]
     ;; create new tables as needed or mark them as active again
     (when (seq new-tables)
       (sync-util/with-error-handling (format "Error creating/reactivating tables for %s" (sync-util/name-for-logging database))
@@ -151,4 +175,8 @@
     ;; mark old tables as inactive
     (when (seq old-tables)
       (sync-util/with-error-handling (format "Error retiring tables for %s" (sync-util/name-for-logging database))
-        (retire-tables! database old-tables)))))
+        (retire-tables! database old-tables)))
+    ;; update description for changed tables
+    (when (seq changed-tables)
+      (sync-util/with-error-handling (format "Error updating table description for %s" (sync-util/name-for-logging database))
+        (update-table-description! database changed-tables)))))

--- a/src/metabase/sync/sync_metadata/tables.clj
+++ b/src/metabase/sync/sync_metadata/tables.clj
@@ -88,7 +88,7 @@
   (log/info "Found new tables:"
             (for [table new-tables]
               (sync-util/name-for-logging (table/map->TableInstance table))))
-  (doseq [{schema :schema, table-name :name, :as table} new-tables]
+  (doseq [{schema :schema, table-name :name, table-comment :table-comment, :as table} new-tables]
     (if-let [existing-id (db/select-one-id Table
                            :db_id  (u/get-id database)
                            :schema schema
@@ -105,7 +105,8 @@
         :display_name    (humanization/name->human-readable-name table-name)
         :active          true
         :visibility_type (when (is-crufty-table? table)
-                           :cruft)))))
+                           :cruft)
+        :description     table-comment))))
 
 
 (s/defn ^:private retire-tables!

--- a/src/metabase/sync/sync_metadata/tables.clj
+++ b/src/metabase/sync/sync_metadata/tables.clj
@@ -128,16 +128,10 @@
             (for [table changed-tables]
               (sync-util/name-for-logging (table/map->TableInstance table))))
   (doseq [{schema :schema, table-name :name, description :description} changed-tables]
-    ;; TODO: seems there should be a way to do OR but I can't figure it out with this lib
     (db/update-where! Table {:db_id       (u/get-id database)
                              :schema      schema
                              :name        table-name
                              :description nil}
-                      :description description)
-    (db/update-where! Table {:db_id       (u/get-id database)
-                             :schema      schema
-                             :name        table-name
-                             :description ""}
                       :description description)))
 
 

--- a/test/metabase/sync/sync_metadata/comments_test.clj
+++ b/test/metabase/sync/sync_metadata/comments_test.clj
@@ -13,6 +13,9 @@
              [interface :as i]]
             [toucan.db :as db]))
 
+
+;; Tests for field comments: ------------------
+
 (defn- db->fields [db]
   (let [table-ids (db/select-ids 'Table :db_id (u/get-id db))]
     (set (map (partial into {}) (db/select ['Field :name :description] :table_id [:in table-ids])))))
@@ -62,12 +65,40 @@
     (sync/sync-table! (Table (data/id "comment_after_sync")))
     (db->fields db)))
 
+
+;; Tests for table comments: ------------------
+
+(defn- basic-table [table-name comment]
+  (i/map->DatabaseDefinition {:database-name     (str table-name "_db")
+                              :table-definitions [{:table-name        table-name
+                                                   :field-definitions [{:field-name "foo", :base-type :type/Text}]
+                                                   :rows              [["bar"]]
+                                                   :table-comment     comment}]}))
+
+(defn- db->tables [db]
+  (set (map (partial into {}) (db/select ['Table :name :description] :db_id (u/get-id db)))))
+
 ;; test basic comments on table
 (ds/expect-with-engines #{:h2 :postgres}
   #{{:name (data/format-name "table_with_comment"), :description "table comment"}}
-  (data/with-temp-db [db (i/map->DatabaseDefinition {:database-name     "table_with_comment_db"
-                                                     :table-definitions [{:table-name        "table_with_comment"
-                                                                          :field-definitions [{:field-name "foo", :base-type :type/Text}]
-                                                                          :rows              [["bar"]]
-                                                                          :table-comment     "table comment"}]})]
-    (set (map (partial into {}) (db/select ['Table :name :description] :db_id (u/get-id db))))))
+  (data/with-temp-db [db (basic-table "table_with_comment" "table comment")]
+    (db->tables db)))
+
+;; test changing the description in metabase on table to check it is not overwritten by comment in source db when resyncing
+(ds/expect-with-engines #{:h2 :postgres}
+  #{{:name (data/format-name "table_with_updated_desc"), :description "updated table description"}}
+  (data/with-temp-db [db (basic-table "table_with_updated_desc" "table comment")]
+     ;; change the description in metabase while the source table comment remains the same
+     (db/update-where! Table {:id (data/id "table_with_updated_desc")}, :description "updated table description")
+     ;; now sync the DB again, this should NOT overwrite the manually updated description
+     (metabase.sync.sync-metadata.tables/sync-tables! db)
+     (db->tables db)))
+
+;; test adding a comment to the source table that was initially empty, so we can check that the resync picks it up
+(ds/expect-with-engines #{:h2 :postgres}
+  #{{:name (data/format-name "table_with_comment_after_sync"), :description "added comment"}}
+  (data/with-temp-db [db (basic-table "table_with_comment_after_sync" nil)]
+     ;; modify the source DB to add the comment and resync
+     (i/create-db! ds/*driver* (basic-table "table_with_comment_after_sync" "added comment") true)
+     (metabase.sync.sync-metadata.tables/sync-tables! db)
+     (db->tables db)))

--- a/test/metabase/sync/sync_metadata/comments_test.clj
+++ b/test/metabase/sync/sync_metadata/comments_test.clj
@@ -1,0 +1,37 @@
+(ns metabase.sync.sync-metadata.comments-test
+  "Test for the logic that syncs Table column descriptions with the comments fetched from a DB."
+  (:require [expectations :refer :all]
+            [metabase.models.table :refer [Table]]
+            [metabase.models.field :refer [Field]]
+            [metabase.test.data :as data]
+            [metabase.test.data.datasets :as datasets]
+            [metabase.test.data.interface :as i]
+            [metabase.sync :as sync]
+            [toucan.db :as db]))
+
+(i/def-database-definition ^:const ^:private db-with-desc
+ ["table_with_comment"
+  [{:field-name "string_with_comment", :base-type :type/Text, :description "string comment"}
+   {:field-name "int_with_comment", :base-type :type/Integer, :description "int comment"}
+   {:field-name "no_comment", :base-type :type/Integer}
+   ;;{:field-name "added_comment_after_create", :base-type :type/Integer}
+   {:field-name "updated_description_in_metabase", :base-type :type/Integer, :description "original comment"}]
+  [["val" 1 1 1 1]]])
+
+;; check field descriptions sync correctly
+(datasets/expect-with-engines #{:h2 :postgres}
+  #{{:name (data/format-name "id"), :description nil}
+    {:name (data/format-name "string_with_comment"), :description "string comment"}
+    {:name (data/format-name "int_with_comment"), :description "int comment"}
+    {:name (data/format-name "no_comment"), :description nil}
+    ;;{:name (data/format-name "added_comment_after_create"), :description "added comment"}
+    {:name (data/format-name "updated_description_in_metabase"), :description "updated description"}}
+  (data/dataset metabase.sync.sync-metadata.comments-test/db-with-desc
+    ;; TODO: add a comment to the source data that was initially empty, so we can check that the resync picks it up
+    ;;(data/execute-sql! driver :db dbdef (standalone-column-comment-sql driver dbdef tabledef fielddef))
+    ;; change the description in metabase db so we can check it is not overwritten by comment in source db when resyncing
+    (db/update-where! Field {:id (data/id "table_with_comment" "updated_description_in_metabase")}, :description "updated description")
+    ;; now sync the DB again
+    (sync/sync-table! (Table (data/id "table_with_comment")))
+    (set (for [field (db/select [Field :name :description], :table_id (data/id "table_with_comment"))]
+           (into {} field)))))

--- a/test/metabase/sync/sync_metadata/comments_test.clj
+++ b/test/metabase/sync/sync_metadata/comments_test.clj
@@ -4,17 +4,13 @@
             [metabase
              [sync :as sync]
              [util :as u]]
-            [metabase.driver.generic-sql :as sql]
-            [metabase.models.database :refer [Database]]
-            [metabase.test
-             [data :as data]
-             [util :as tu]]
             [metabase.models
              [table :refer [Table]]
              [field :refer [Field]]]
+            [metabase.test.data :as data]
             [metabase.test.data
-             [datasets :refer [expect-with-engines]]
-             [interface :refer [def-database-definition]]]
+             [datasets :as ds]
+             [interface :as i]]
             [toucan.db :as db]))
 
 (defn- db->fields [db]
@@ -22,13 +18,13 @@
     (set (map (partial into {}) (db/select ['Field :name :description] :table_id [:in table-ids])))))
 
 ;; test basic field comments sync
-(def-database-definition ^:const ^:private basic-field-comments
+(i/def-database-definition ^:const ^:private basic-field-comments
  ["basic_field_comments"
-  [{:field-name "with_comment", :base-type :type/Text, :description "comment"}
+  [{:field-name "with_comment", :base-type :type/Text, :field-comment "comment"}
    {:field-name "no_comment", :base-type :type/Text}]
   [["foo" "bar"]]])
 
-(expect-with-engines #{:h2 :postgres}
+(ds/expect-with-engines #{:h2 :postgres}
   #{{:name (data/format-name "id"), :description nil}
     {:name (data/format-name "with_comment"), :description "comment"}
     {:name (data/format-name "no_comment"), :description nil}}
@@ -36,12 +32,12 @@
      (db->fields db)))
 
 ;; test changing the description in metabase db so we can check it is not overwritten by comment in source db when resyncing
-(def-database-definition ^:const ^:private update-desc
+(i/def-database-definition ^:const ^:private update-desc
  ["update_desc"
-  [{:field-name "updated_desc", :base-type :type/Text, :description "original comment"}]
+  [{:field-name "updated_desc", :base-type :type/Text, :field-comment "original comment"}]
   [["foo"]]])
 
-(expect-with-engines #{:h2 :postgres}
+(ds/expect-with-engines #{:h2 :postgres}
   #{{:name (data/format-name "id"), :description nil}
     {:name (data/format-name "updated_desc"), :description "updated description"}}
   (data/with-temp-db [db update-desc]
@@ -52,15 +48,25 @@
     (db->fields db)))
 
 ;; test adding a comment to the source data that was initially empty, so we can check that the resync picks it up
-(def-database-definition ^:const ^:private comment-after-sync
+(i/def-database-definition ^:const ^:private comment-after-sync
  ["comment_after_sync"
   [{:field-name "comment_after_sync", :base-type :type/Text}]
   [["foo"]]])
 
-; Commented out until I figure out how to make this work
+(ds/expect-with-engines #{:h2 :postgres}
+  #{{:name (data/format-name "id"), :description nil}
+    {:name (data/format-name "comment_after_sync"), :description "added comment"}}
+  (data/with-temp-db [db comment-after-sync]
+    ;; modify the source DB to add the comment and resync
+    (i/create-db! ds/*driver* (assoc-in comment-after-sync [:table-definitions 0 :field-definitions 0 :field-comment] "added comment") true)
+    (sync/sync-table! (Table (data/id "comment_after_sync")))
+    (db->fields db)))
+
+;; TODO: test basic comments on table
 ;(expect-with-engines #{:h2 :postgres}
-;  #{{:name (data/format-name "id"), :description nil}
-;    {:name (data/format-name "comment_after_sync"), :description "added comment"}}
-;  (data/with-temp-db [db comment-after-sync]
-;    ;; TODO: need to modify the source DB to add the comment but I'm at a loss about how to do this, test will fail
-;    (db->fields db)))
+;  #{{:name (data/format-name "table_with_comment"), :description "table comment"}}
+;  (data/with-temp-db [db (map->DatabaseDefinition {:database-name     "table_with_comment_db"
+;                                                   :table-definitions [{:table-name        "table_with_comment"
+;                                                                        :field-definitions [{:field-name "foo", :base-type :type/Text}]}]
+;                                                   :table-comment     "table comment"})]
+;    (set (map (partial into {}) (db/select ['Table :name :description])))))

--- a/test/metabase/sync/sync_metadata/comments_test.clj
+++ b/test/metabase/sync/sync_metadata/comments_test.clj
@@ -22,10 +22,10 @@
 
 ;; test basic field comments sync
 (i/def-database-definition ^:const ^:private basic-field-comments
- ["basic_field_comments"
-  [{:field-name "with_comment", :base-type :type/Text, :field-comment "comment"}
-   {:field-name "no_comment", :base-type :type/Text}]
-  [["foo" "bar"]]])
+ [["basic_field_comments"
+   [{:field-name "with_comment", :base-type :type/Text, :field-comment "comment"}
+    {:field-name "no_comment", :base-type :type/Text}]
+   [["foo" "bar"]]]])
 
 (ds/expect-with-engines #{:h2 :postgres}
   #{{:name (data/format-name "id"), :description nil}
@@ -36,9 +36,9 @@
 
 ;; test changing the description in metabase db so we can check it is not overwritten by comment in source db when resyncing
 (i/def-database-definition ^:const ^:private update-desc
- ["update_desc"
-  [{:field-name "updated_desc", :base-type :type/Text, :field-comment "original comment"}]
-  [["foo"]]])
+ [["update_desc"
+   [{:field-name "updated_desc", :base-type :type/Text, :field-comment "original comment"}]
+   [["foo"]]]])
 
 (ds/expect-with-engines #{:h2 :postgres}
   #{{:name (data/format-name "id"), :description nil}
@@ -52,9 +52,9 @@
 
 ;; test adding a comment to the source data that was initially empty, so we can check that the resync picks it up
 (i/def-database-definition ^:const ^:private comment-after-sync
- ["comment_after_sync"
-  [{:field-name "comment_after_sync", :base-type :type/Text}]
-  [["foo"]]])
+ [["comment_after_sync"
+   [{:field-name "comment_after_sync", :base-type :type/Text}]
+   [["foo"]]]])
 
 (ds/expect-with-engines #{:h2 :postgres}
   #{{:name (data/format-name "id"), :description nil}

--- a/test/metabase/sync/sync_metadata/comments_test.clj
+++ b/test/metabase/sync/sync_metadata/comments_test.clj
@@ -1,37 +1,66 @@
 (ns metabase.sync.sync-metadata.comments-test
   "Test for the logic that syncs Table column descriptions with the comments fetched from a DB."
   (:require [expectations :refer :all]
-            [metabase.models.table :refer [Table]]
-            [metabase.models.field :refer [Field]]
-            [metabase.test.data :as data]
-            [metabase.test.data.datasets :as datasets]
-            [metabase.test.data.interface :as i]
-            [metabase.sync :as sync]
+            [metabase
+             [sync :as sync]
+             [util :as u]]
+            [metabase.driver.generic-sql :as sql]
+            [metabase.models.database :refer [Database]]
+            [metabase.test
+             [data :as data]
+             [util :as tu]]
+            [metabase.models
+             [table :refer [Table]]
+             [field :refer [Field]]]
+            [metabase.test.data
+             [datasets :refer [expect-with-engines]]
+             [interface :refer [def-database-definition]]]
             [toucan.db :as db]))
 
-(i/def-database-definition ^:const ^:private db-with-desc
- ["table_with_comment"
-  [{:field-name "string_with_comment", :base-type :type/Text, :description "string comment"}
-   {:field-name "int_with_comment", :base-type :type/Integer, :description "int comment"}
-   {:field-name "no_comment", :base-type :type/Integer}
-   ;;{:field-name "added_comment_after_create", :base-type :type/Integer}
-   {:field-name "updated_description_in_metabase", :base-type :type/Integer, :description "original comment"}]
-  [["val" 1 1 1 1]]])
+(defn- db->fields [db]
+  (let [table-ids (db/select-ids 'Table :db_id (u/get-id db))]
+    (set (map (partial into {}) (db/select ['Field :name :description] :table_id [:in table-ids])))))
 
-;; check field descriptions sync correctly
-(datasets/expect-with-engines #{:h2 :postgres}
+;; test basic field comments sync
+(def-database-definition ^:const ^:private basic-field-comments
+ ["basic_field_comments"
+  [{:field-name "with_comment", :base-type :type/Text, :description "comment"}
+   {:field-name "no_comment", :base-type :type/Text}]
+  [["foo" "bar"]]])
+
+(expect-with-engines #{:h2 :postgres}
   #{{:name (data/format-name "id"), :description nil}
-    {:name (data/format-name "string_with_comment"), :description "string comment"}
-    {:name (data/format-name "int_with_comment"), :description "int comment"}
-    {:name (data/format-name "no_comment"), :description nil}
-    ;;{:name (data/format-name "added_comment_after_create"), :description "added comment"}
-    {:name (data/format-name "updated_description_in_metabase"), :description "updated description"}}
-  (data/dataset metabase.sync.sync-metadata.comments-test/db-with-desc
-    ;; TODO: add a comment to the source data that was initially empty, so we can check that the resync picks it up
-    ;;(data/execute-sql! driver :db dbdef (standalone-column-comment-sql driver dbdef tabledef fielddef))
-    ;; change the description in metabase db so we can check it is not overwritten by comment in source db when resyncing
-    (db/update-where! Field {:id (data/id "table_with_comment" "updated_description_in_metabase")}, :description "updated description")
-    ;; now sync the DB again
-    (sync/sync-table! (Table (data/id "table_with_comment")))
-    (set (for [field (db/select [Field :name :description], :table_id (data/id "table_with_comment"))]
-           (into {} field)))))
+    {:name (data/format-name "with_comment"), :description "comment"}
+    {:name (data/format-name "no_comment"), :description nil}}
+  (data/with-temp-db [db basic-field-comments]
+     (db->fields db)))
+
+;; test changing the description in metabase db so we can check it is not overwritten by comment in source db when resyncing
+(def-database-definition ^:const ^:private update-desc
+ ["update_desc"
+  [{:field-name "updated_desc", :base-type :type/Text, :description "original comment"}]
+  [["foo"]]])
+
+(expect-with-engines #{:h2 :postgres}
+  #{{:name (data/format-name "id"), :description nil}
+    {:name (data/format-name "updated_desc"), :description "updated description"}}
+  (data/with-temp-db [db update-desc]
+    ;; change the description in metabase while the source table comment remains the same
+    (db/update-where! Field {:id (data/id "update_desc" "updated_desc")}, :description "updated description")
+    ;; now sync the DB again, this should NOT overwrite the manually updated description
+    (sync/sync-table! (Table (data/id "update_desc")))
+    (db->fields db)))
+
+;; test adding a comment to the source data that was initially empty, so we can check that the resync picks it up
+(def-database-definition ^:const ^:private comment-after-sync
+ ["comment_after_sync"
+  [{:field-name "comment_after_sync", :base-type :type/Text}]
+  [["foo"]]])
+
+; Commented out until I figure out how to make this work
+;(expect-with-engines #{:h2 :postgres}
+;  #{{:name (data/format-name "id"), :description nil}
+;    {:name (data/format-name "comment_after_sync"), :description "added comment"}}
+;  (data/with-temp-db [db comment-after-sync]
+;    ;; TODO: need to modify the source DB to add the comment but I'm at a loss about how to do this, test will fail
+;    (db->fields db)))

--- a/test/metabase/sync/sync_metadata/comments_test.clj
+++ b/test/metabase/sync/sync_metadata/comments_test.clj
@@ -62,11 +62,12 @@
     (sync/sync-table! (Table (data/id "comment_after_sync")))
     (db->fields db)))
 
-;; TODO: test basic comments on table
-;(expect-with-engines #{:h2 :postgres}
-;  #{{:name (data/format-name "table_with_comment"), :description "table comment"}}
-;  (data/with-temp-db [db (map->DatabaseDefinition {:database-name     "table_with_comment_db"
-;                                                   :table-definitions [{:table-name        "table_with_comment"
-;                                                                        :field-definitions [{:field-name "foo", :base-type :type/Text}]}]
-;                                                   :table-comment     "table comment"})]
-;    (set (map (partial into {}) (db/select ['Table :name :description])))))
+;; test basic comments on table
+(ds/expect-with-engines #{:h2 :postgres}
+  #{{:name (data/format-name "table_with_comment"), :description "table comment"}}
+  (data/with-temp-db [db (i/map->DatabaseDefinition {:database-name     "table_with_comment_db"
+                                                     :table-definitions [{:table-name        "table_with_comment"
+                                                                          :field-definitions [{:field-name "foo", :base-type :type/Text}]
+                                                                          :rows              [["bar"]]
+                                                                          :table-comment     "table comment"}]})]
+    (set (map (partial into {}) (db/select ['Table :name :description] :db_id (u/get-id db))))))

--- a/test/metabase/sync/sync_metadata/tables_test.clj
+++ b/test/metabase/sync/sync_metadata/tables_test.clj
@@ -6,6 +6,7 @@
             [metabase.test.data :as data]
             [metabase.test.data.datasets :as datasets]
             [metabase.test.data.interface :as i]
+            [metabase.sync :as sync]
             [toucan.db :as db]
             [metabase.models.table :as table]
             [metabase.models.field :as field]))
@@ -33,16 +34,28 @@
            (into {} table)))))
 
 (i/def-database-definition ^:const ^:private db-with-desc
- ["table_with_description"
-  [{:field-name "string_with_description", :base-type :type/Text, :description "string description"}
-   {:field-name "int_with_description", :base-type :type/Integer, :description "int description"}]
-  [["val" 1]]])
+ ["table_with_comment"
+  [{:field-name "string_with_comment", :base-type :type/Text, :description "string comment"}
+   {:field-name "int_with_comment", :base-type :type/Integer, :description "int comment"}
+   {:field-name "no_comment", :base-type :type/Integer}
+   ;;{:field-name "added_comment_after_create", :base-type :type/Integer}
+   {:field-name "updated_description_in_metabase", :base-type :type/Integer, :description "original comment"}
+   ]
+  [["val" 1 1 1 1]]])
 
-;; check field descriptions were synced
+;; check field descriptions sync correctly
 (datasets/expect-with-engines #{:h2 :postgres}
   #{{:name (data/format-name "id"), :description nil}
-    {:name (data/format-name "string_with_description"), :description "string description"}
-    {:name (data/format-name "int_with_description"), :description "int description"}}
+    {:name (data/format-name "string_with_comment"), :description "string comment"}
+    {:name (data/format-name "int_with_comment"), :description "int comment"}
+    {:name (data/format-name "no_comment"), :description nil}
+    ;;{:name (data/format-name "added_comment_after_create"), :description "added comment"}
+    {:name (data/format-name "updated_description_in_metabase"), :description "updated description"}
+    }
   (data/dataset metabase.sync.sync-metadata.tables-test/db-with-desc
-    (set (for [field (db/select [Field :name :description], :table_id (data/id "table_with_description"))]
+    ;; change the description in metabase so we can check it is not overwritten by comment in source db when resyncing
+    (db/update-where! Field {:id (data/id "table_with_comment" "updated_description_in_metabase")}, :description "updated description")
+    ;; now sync the DB again
+    (sync/sync-table! (Table (data/id "table_with_comment")))
+    (set (for [field (db/select [Field :name :description], :table_id (data/id "table_with_comment"))]
            (into {} field)))))

--- a/test/metabase/sync/sync_metadata/tables_test.clj
+++ b/test/metabase/sync/sync_metadata/tables_test.clj
@@ -2,14 +2,9 @@
   "Test for the logic that syncs Table models with the metadata fetched from a DB."
   (:require [expectations :refer :all]
             [metabase.models.table :refer [Table]]
-            [metabase.models.field :refer [Field]]
             [metabase.test.data :as data]
-            [metabase.test.data.datasets :as datasets]
             [metabase.test.data.interface :as i]
-            [metabase.sync :as sync]
-            [toucan.db :as db]
-            [metabase.models.table :as table]
-            [metabase.models.field :as field]))
+            [toucan.db :as db]))
 
 (i/def-database-definition ^:const ^:private db-with-some-cruft
   ["acquired_toucans"
@@ -32,30 +27,3 @@
   (data/dataset metabase.sync.sync-metadata.tables-test/db-with-some-cruft
     (set (for [table (db/select [Table :name :visibility_type], :db_id (data/id))]
            (into {} table)))))
-
-(i/def-database-definition ^:const ^:private db-with-desc
- ["table_with_comment"
-  [{:field-name "string_with_comment", :base-type :type/Text, :description "string comment"}
-   {:field-name "int_with_comment", :base-type :type/Integer, :description "int comment"}
-   {:field-name "no_comment", :base-type :type/Integer}
-   ;;{:field-name "added_comment_after_create", :base-type :type/Integer}
-   {:field-name "updated_description_in_metabase", :base-type :type/Integer, :description "original comment"}
-   ]
-  [["val" 1 1 1 1]]])
-
-;; check field descriptions sync correctly
-(datasets/expect-with-engines #{:h2 :postgres}
-  #{{:name (data/format-name "id"), :description nil}
-    {:name (data/format-name "string_with_comment"), :description "string comment"}
-    {:name (data/format-name "int_with_comment"), :description "int comment"}
-    {:name (data/format-name "no_comment"), :description nil}
-    ;;{:name (data/format-name "added_comment_after_create"), :description "added comment"}
-    {:name (data/format-name "updated_description_in_metabase"), :description "updated description"}
-    }
-  (data/dataset metabase.sync.sync-metadata.tables-test/db-with-desc
-    ;; change the description in metabase so we can check it is not overwritten by comment in source db when resyncing
-    (db/update-where! Field {:id (data/id "table_with_comment" "updated_description_in_metabase")}, :description "updated description")
-    ;; now sync the DB again
-    (sync/sync-table! (Table (data/id "table_with_comment")))
-    (set (for [field (db/select [Field :name :description], :table_id (data/id "table_with_comment"))]
-           (into {} field)))))

--- a/test/metabase/sync/sync_metadata/tables_test.clj
+++ b/test/metabase/sync/sync_metadata/tables_test.clj
@@ -2,9 +2,12 @@
   "Test for the logic that syncs Table models with the metadata fetched from a DB."
   (:require [expectations :refer :all]
             [metabase.models.table :refer [Table]]
+            [metabase.models.field :refer [Field]]
             [metabase.test.data :as data]
             [metabase.test.data.interface :as i]
-            [toucan.db :as db]))
+            [toucan.db :as db]
+            [metabase.models.table :as table]
+            [metabase.models.field :as field]))
 
 (i/def-database-definition ^:const ^:private db-with-some-cruft
   [["acquired_toucans"
@@ -27,3 +30,15 @@
   (data/dataset metabase.sync.sync-metadata.tables-test/db-with-some-cruft
     (set (for [table (db/select [Table :name :visibility_type], :db_id (data/id))]
            (into {} table)))))
+
+(i/def-database-definition ^:const ^:private db-with-desc
+ ["table_with_description"
+  [{:field-name "field_with_description", :base-type :type/Text, :description "field description"}]
+  [["val"]]])
+
+;; check field descriptions were synced
+(expect
+  #{{:name "FIELD_WITH_DESCRIPTION", :description "field description"}}
+  (data/dataset metabase.sync.sync-metadata.tables-test/db-with-desc
+    (set (for [field (db/select [Field :name :description], :id (data/id "TABLE_WITH_DESCRIPTION" "FIELD_WITH_DESCRIPTION"))]
+           (into {} field)))))

--- a/test/metabase/sync/sync_metadata/tables_test.clj
+++ b/test/metabase/sync/sync_metadata/tables_test.clj
@@ -2,14 +2,9 @@
   "Test for the logic that syncs Table models with the metadata fetched from a DB."
   (:require [expectations :refer :all]
             [metabase.models.table :refer [Table]]
-            [metabase.models.field :refer [Field]]
             [metabase.test.data :as data]
-            [metabase.test.data.datasets :as datasets]
             [metabase.test.data.interface :as i]
-            [metabase.sync :as sync]
-            [toucan.db :as db]
-            [metabase.models.table :as table]
-            [metabase.models.field :as field]))
+            [toucan.db :as db]))
 
 (i/def-database-definition ^:const ^:private db-with-some-cruft
   [["acquired_toucans"
@@ -32,30 +27,3 @@
   (data/dataset metabase.sync.sync-metadata.tables-test/db-with-some-cruft
     (set (for [table (db/select [Table :name :visibility_type], :db_id (data/id))]
            (into {} table)))))
-
-(i/def-database-definition ^:const ^:private db-with-desc
- ["table_with_comment"
-  [{:field-name "string_with_comment", :base-type :type/Text, :description "string comment"}
-   {:field-name "int_with_comment", :base-type :type/Integer, :description "int comment"}
-   {:field-name "no_comment", :base-type :type/Integer}
-   ;;{:field-name "added_comment_after_create", :base-type :type/Integer}
-   {:field-name "updated_description_in_metabase", :base-type :type/Integer, :description "original comment"}
-   ]
-  [["val" 1 1 1 1]]])
-
-;; check field descriptions sync correctly
-(datasets/expect-with-engines #{:h2 :postgres}
-  #{{:name (data/format-name "id"), :description nil}
-    {:name (data/format-name "string_with_comment"), :description "string comment"}
-    {:name (data/format-name "int_with_comment"), :description "int comment"}
-    {:name (data/format-name "no_comment"), :description nil}
-    ;;{:name (data/format-name "added_comment_after_create"), :description "added comment"}
-    {:name (data/format-name "updated_description_in_metabase"), :description "updated description"}
-    }
-  (data/dataset metabase.sync.sync-metadata.tables-test/db-with-desc
-    ;; change the description in metabase so we can check it is not overwritten by comment in source db when resyncing
-    (db/update-where! Field {:id (data/id "table_with_comment" "updated_description_in_metabase")}, :description "updated description")
-    ;; now sync the DB again
-    (sync/sync-table! (Table (data/id "table_with_comment")))
-    (set (for [field (db/select [Field :name :description], :table_id (data/id "table_with_comment"))]
-           (into {} field)))))

--- a/test/metabase/sync/sync_metadata/tables_test.clj
+++ b/test/metabase/sync/sync_metadata/tables_test.clj
@@ -2,9 +2,12 @@
   "Test for the logic that syncs Table models with the metadata fetched from a DB."
   (:require [expectations :refer :all]
             [metabase.models.table :refer [Table]]
+            [metabase.models.field :refer [Field]]
             [metabase.test.data :as data]
             [metabase.test.data.interface :as i]
-            [toucan.db :as db]))
+            [toucan.db :as db]
+            [metabase.models.table :as table]
+            [metabase.models.field :as field]))
 
 (i/def-database-definition ^:const ^:private db-with-some-cruft
   ["acquired_toucans"
@@ -27,3 +30,15 @@
   (data/dataset metabase.sync.sync-metadata.tables-test/db-with-some-cruft
     (set (for [table (db/select [Table :name :visibility_type], :db_id (data/id))]
            (into {} table)))))
+
+(i/def-database-definition ^:const ^:private db-with-desc
+ ["table_with_description"
+  [{:field-name "field_with_description", :base-type :type/Text, :description "field description"}]
+  [["val"]]])
+
+;; check field descriptions were synced
+(expect
+  #{{:name "FIELD_WITH_DESCRIPTION", :description "field description"}}
+  (data/dataset metabase.sync.sync-metadata.tables-test/db-with-desc
+    (set (for [field (db/select [Field :name :description], :id (data/id "TABLE_WITH_DESCRIPTION" "FIELD_WITH_DESCRIPTION"))]
+           (into {} field)))))

--- a/test/metabase/test/data/generic_sql.clj
+++ b/test/metabase/test/data/generic_sql.clj
@@ -46,8 +46,11 @@
   (add-fk-sql ^String [this, ^DatabaseDefinition dbdef, ^TableDefinition tabledef, ^FieldDefinition fielddef]
     "*Optional* Return a `ALTER TABLE ADD CONSTRAINT FOREIGN KEY` statement.")
 
-  (column-comment-sql ^String [this, ^String comment]
-    "*Optional* Return a `COMMENT` statement for a column.")
+  (inline-column-comment-sql ^String [this, ^String comment]
+    "*Optional* Return an inline `COMMENT` statement for a column.")
+
+  (standalone-column-comment-sql ^String [this, ^DatabaseDefinition dbdef, ^TableDefinition tabledef, ^FieldDefinition fielddef]
+    "*Optional* Return standalone `COMMENT` statement for a column.")
 
   (prepare-identifier [this, ^String identifier]
     "*OPTIONAL*. Prepare an identifier, such as a Table or Field name, when it is used in a SQL query.
@@ -110,7 +113,7 @@
                                 (if (map? base-type)
                                   (:native base-type)
                                   (field-base-type->sql-type driver base-type))
-                                (column-comment-sql driver description))))
+                                (inline-column-comment-sql driver description))))
                  (interpose ", ")
                  (apply str))
             pk-field-name (pk-sql-type driver)
@@ -136,9 +139,17 @@
             (qualify+quote-name driver database-name dest-table-name)
             (quot (pk-field-name driver)))))
 
-(defn- default-column-comment-sql [_ comment]
-  "Assume that COMMENT is not supported unless driver specifically overrides."
-  (""))
+(defn standard-inline-column-comment-sql
+  "Generic inline COMMENT that driver can mixin if supported."
+  [_ comment]
+  (format "COMMENT '%s'" comment))
+
+(defn standard-standalone-column-comment-sql
+  "Generic standalone COMMENT that driver can mixin if supported."
+  [driver {:keys [database-name]} {:keys [table-name]} {:keys [field-name description]}]
+  (format "COMMENT ON COLUMN %s IS '%s';"
+          (qualify+quote-name driver database-name table-name field-name)
+          description))
 
 (defn- default-qualified-name-components
   ([_ db-name]                       [db-name])
@@ -281,20 +292,21 @@
 
 (def DefaultsMixin
   "Default implementations for methods marked *Optional* in `IGenericSQLTestExtensions`."
-  {:add-fk-sql                default-add-fk-sql
-   :column-comment-sql        default-column-comment-sql
-   :create-db-sql             default-create-db-sql
-   :create-table-sql          default-create-table-sql
-   :database->spec            default-database->spec
-   :drop-db-if-exists-sql     default-drop-db-if-exists-sql
-   :drop-table-if-exists-sql  default-drop-table-if-exists-sql
-   :execute-sql!              default-execute-sql!
-   :load-data!                load-data-chunked!
-   :pk-field-name             (constantly "id")
-   :prepare-identifier        (u/drop-first-arg identity)
-   :qualified-name-components default-qualified-name-components
-   :qualify+quote-name        default-qualify+quote-name
-   :quote-name                default-quote-name})
+  {:add-fk-sql                    default-add-fk-sql
+   :inline-column-comment-sql     (constantly nil)
+   :standalone-column-comment-sql (constantly nil)
+   :create-db-sql                 default-create-db-sql
+   :create-table-sql              default-create-table-sql
+   :database->spec                default-database->spec
+   :drop-db-if-exists-sql         default-drop-db-if-exists-sql
+   :drop-table-if-exists-sql      default-drop-table-if-exists-sql
+   :execute-sql!                  default-execute-sql!
+   :load-data!                    load-data-chunked!
+   :pk-field-name                 (constantly "id")
+   :prepare-identifier            (u/drop-first-arg identity)
+   :qualified-name-components     default-qualified-name-components
+   :qualify+quote-name            default-qualify+quote-name
+   :quote-name                    default-quote-name})
 
 
 ;;; ------------------------------------------- IDriverTestExtensions impl -------------------------------------------
@@ -315,7 +327,7 @@
   ;; Exec SQL for creating the DB
   (execute-sql! driver :server dbdef (str (drop-db-if-exists-sql driver dbdef) ";\n"
                                           (create-db-sql driver dbdef)))
-  ;; Build combined statement for creating tables + FKs
+  ;; Build combined statement for creating tables + FKs + comments
   (let [statements (atom [])]
     ;; Add the SQL for creating each Table
     (doseq [tabledef table-definitions]
@@ -326,6 +338,11 @@
       (doseq [{:keys [fk], :as fielddef} field-definitions]
         (when fk
           (swap! statements conj (add-fk-sql driver dbdef tabledef fielddef)))))
+    ;; Add the SQL for adding column comments
+    (doseq [{:keys [field-definitions], :as tabledef} table-definitions]
+      (doseq [{:keys [description], :as fielddef} field-definitions]
+        (when description
+          (swap! statements conj (standalone-column-comment-sql driver dbdef tabledef fielddef)))))
     ;; exec the combined statement
     (execute-sql! driver :db dbdef (s/join ";\n" (map hx/unescape-dots @statements))))
   ;; Now load the data for each Table

--- a/test/metabase/test/data/generic_sql.clj
+++ b/test/metabase/test/data/generic_sql.clj
@@ -142,14 +142,16 @@
 (defn standard-inline-column-comment-sql
   "Generic inline COMMENT that driver can mixin if supported."
   [_ comment]
-  (format "COMMENT '%s'" comment))
+  (when comment
+    (format "COMMENT '%s'" comment)))
 
 (defn standard-standalone-column-comment-sql
   "Generic standalone COMMENT that driver can mixin if supported."
   [driver {:keys [database-name]} {:keys [table-name]} {:keys [field-name description]}]
-  (format "COMMENT ON COLUMN %s IS '%s';"
-          (qualify+quote-name driver database-name table-name field-name)
-          description))
+  (when description
+    (format "COMMENT ON COLUMN %s IS '%s';"
+            (qualify+quote-name driver database-name table-name field-name)
+            description)))
 
 (defn- default-qualified-name-components
   ([_ db-name]                       [db-name])

--- a/test/metabase/test/data/generic_sql.clj
+++ b/test/metabase/test/data/generic_sql.clj
@@ -45,6 +45,9 @@
   (add-fk-sql ^String [this, ^DatabaseDefinition dbdef, ^TableDefinition tabledef, ^FieldDefinition fielddef]
     "*Optional* Return a `ALTER TABLE ADD CONSTRAINT FOREIGN KEY` statement.")
 
+  (column-comment-sql ^String [this, ^String comment]
+    "*Optional* Return a `COMMENT` statement for a column.")
+
   (prepare-identifier [this, ^String identifier]
     "*OPTIONAL*. Prepare an identifier, such as a Table or Field name, when it is used in a SQL query.
      This is used by drivers like H2 to transform names to upper-case.
@@ -97,10 +100,13 @@
     (format "CREATE TABLE %s (%s, %s %s, PRIMARY KEY (%s));"
             (qualify+quote-name driver database-name table-name)
             (->> field-definitions
-                 (map (fn [{:keys [field-name base-type]}]
-                        (format "%s %s" (quot field-name) (if (map? base-type)
-                                                            (:native base-type)
-                                                            (field-base-type->sql-type driver base-type)))))
+                 (map (fn [{:keys [field-name base-type description]}]
+                        (format "%s %s %s"
+                                (quot field-name)
+                                (if (map? base-type)
+                                  (:native base-type)
+                                  (field-base-type->sql-type driver base-type))
+                                (column-comment-sql driver description))))
                  (interpose ", ")
                  (apply str))
             pk-field-name (pk-sql-type driver)
@@ -124,6 +130,10 @@
             (quot field-name)
             (qualify+quote-name driver database-name dest-table-name)
             (quot (pk-field-name driver)))))
+
+(defn- default-column-comment-sql [_ comment]
+  "Assume that COMMENT is not supported unless driver specifically overrides."
+  (""))
 
 (defn- default-qualified-name-components
   ([_ db-name]                       [db-name])
@@ -262,6 +272,7 @@
 (def DefaultsMixin
   "Default implementations for methods marked *Optional* in `IGenericSQLTestExtensions`."
   {:add-fk-sql                default-add-fk-sql
+   :column-comment-sql        default-column-comment-sql
    :create-db-sql             default-create-db-sql
    :create-table-sql          default-create-table-sql
    :database->spec            default-database->spec

--- a/test/metabase/test/data/generic_sql.clj
+++ b/test/metabase/test/data/generic_sql.clj
@@ -137,14 +137,16 @@
 (defn standard-inline-column-comment-sql
   "Generic inline COMMENT that driver can mixin if supported."
   [_ comment]
-  (format "COMMENT '%s'" comment))
+  (when comment
+    (format "COMMENT '%s'" comment)))
 
 (defn standard-standalone-column-comment-sql
   "Generic standalone COMMENT that driver can mixin if supported."
   [driver {:keys [database-name]} {:keys [table-name]} {:keys [field-name description]}]
-  (format "COMMENT ON COLUMN %s IS '%s';"
-          (qualify+quote-name driver database-name table-name field-name)
-          description))
+  (when description
+    (format "COMMENT ON COLUMN %s IS '%s';"
+            (qualify+quote-name driver database-name table-name field-name)
+            description)))
 
 (defn- default-qualified-name-components
   ([_ db-name]                       [db-name])

--- a/test/metabase/test/data/generic_sql.clj
+++ b/test/metabase/test/data/generic_sql.clj
@@ -52,6 +52,12 @@
   (standalone-column-comment-sql ^String [this, ^DatabaseDefinition dbdef, ^TableDefinition tabledef, ^FieldDefinition fielddef]
     "*Optional* Return standalone `COMMENT` statement for a column.")
 
+  (inline-table-comment-sql ^String [this, ^String comment]
+    "*Optional* Return an inline `COMMENT` statement for a table.")
+
+  (standalone-table-comment-sql ^String [this, ^DatabaseDefinition dbdef, ^TableDefinition tabledef]
+    "*Optional* Return standalone `COMMENT` statement for a table.")
+
   (prepare-identifier [this, ^String identifier]
     "*OPTIONAL*. Prepare an identifier, such as a Table or Field name, when it is used in a SQL query.
      This is used by drivers like H2 to transform names to upper-case.
@@ -101,23 +107,24 @@
 (defn default-drop-db-if-exists-sql [driver {:keys [database-name]}]
   (format "DROP DATABASE IF EXISTS %s;" (qualify+quote-name driver database-name)))
 
-(defn default-create-table-sql [driver {:keys [database-name], :as dbdef} {:keys [table-name field-definitions]}]
+(defn default-create-table-sql [driver {:keys [database-name], :as dbdef} {:keys [table-name field-definitions table-comment]}]
   (let [quot          (partial quote-name driver)
         pk-field-name (quot (pk-field-name driver))]
-    (format "CREATE TABLE %s (%s, %s %s, PRIMARY KEY (%s));"
+    (format "CREATE TABLE %s (%s, %s %s, PRIMARY KEY (%s)) %s;"
             (qualify+quote-name driver database-name table-name)
             (->> field-definitions
-                 (map (fn [{:keys [field-name base-type description]}]
+                 (map (fn [{:keys [field-name base-type field-comment]}]
                         (format "%s %s %s"
                                 (quot field-name)
                                 (if (map? base-type)
                                   (:native base-type)
                                   (field-base-type->sql-type driver base-type))
-                                (inline-column-comment-sql driver description))))
+                                (inline-column-comment-sql driver field-comment))))
                  (interpose ", ")
                  (apply str))
             pk-field-name (pk-sql-type driver)
-            pk-field-name)))
+            pk-field-name
+            (inline-table-comment-sql driver table-comment))))
 
 (defn- default-drop-table-if-exists-sql [driver {:keys [database-name]} {:keys [table-name]}]
   (format "DROP TABLE IF EXISTS %s;" (qualify+quote-name driver database-name table-name)))
@@ -141,17 +148,35 @@
 
 (defn standard-inline-column-comment-sql
   "Generic inline COMMENT that driver can mixin if supported."
-  [_ comment]
-  (when comment
-    (format "COMMENT '%s'" comment)))
+  [_ field-comment]
+  (if field-comment
+    (format "COMMENT '%s'" field-comment)
+    (str "")))
 
 (defn standard-standalone-column-comment-sql
   "Generic standalone COMMENT that driver can mixin if supported."
-  [driver {:keys [database-name]} {:keys [table-name]} {:keys [field-name description]}]
-  (when description
+  [driver {:keys [database-name]} {:keys [table-name]} {:keys [field-name field-comment]}]
+  (if field-comment
     (format "COMMENT ON COLUMN %s IS '%s';"
-            (qualify+quote-name driver database-name table-name field-name)
-            description)))
+      (qualify+quote-name driver database-name table-name field-name)
+      field-comment)
+    (str "")))
+
+(defn standard-inline-table-comment-sql
+  "Generic inline COMMENT that driver can mixin if supported."
+  [_ table-comment]
+  (if table-comment
+    (format "COMMENT '%s'" table-comment)
+    (str "")))
+
+(defn standard-standalone-table-comment-sql
+  "Generic standalone COMMENT that driver can mixin if supported."
+  [driver {:keys [database-name]} {:keys [table-name table-comment]}]
+  (if table-comment
+    (format "COMMENT ON TABLE %s IS '%s';"
+      (qualify+quote-name driver database-name table-name)
+      table-comment)
+    (str "")))
 
 (defn- default-qualified-name-components
   ([_ db-name]                       [db-name])
@@ -295,8 +320,10 @@
 (def DefaultsMixin
   "Default implementations for methods marked *Optional* in `IGenericSQLTestExtensions`."
   {:add-fk-sql                    default-add-fk-sql
-   :inline-column-comment-sql     (constantly nil)
-   :standalone-column-comment-sql (constantly nil)
+   :inline-column-comment-sql     (constantly "")
+   :standalone-column-comment-sql (constantly "")
+   :inline-table-comment-sql      (constantly "")
+   :standalone-table-comment-sql  (constantly "")
    :create-db-sql                 default-create-db-sql
    :create-table-sql              default-create-table-sql
    :database->spec                default-database->spec
@@ -325,32 +352,40 @@
       (when (seq statement)
         (default-execute-sql! driver context dbdef (s/replace statement #"⅋" ";"))))))
 
-(defn- create-db! [driver {:keys [table-definitions], :as dbdef}]
-  ;; Exec SQL for creating the DB
-  (execute-sql! driver :server dbdef (str (drop-db-if-exists-sql driver dbdef) ";\n"
-                                          (create-db-sql driver dbdef)))
-  ;; Build combined statement for creating tables + FKs + comments
-  (let [statements (atom [])]
-    ;; Add the SQL for creating each Table
+(defn- create-db!
+  ([driver database-definition]
+    (create-db! driver database-definition false))
+  ([driver {:keys [table-definitions], :as dbdef} skip-drop-db]
+    (if-not skip-drop-db
+      ;; Exec SQL for creating the DB
+      (execute-sql! driver :server dbdef (str (drop-db-if-exists-sql driver dbdef) ";\n"
+                                              (create-db-sql driver dbdef))))
+    ;; Build combined statement for creating tables + FKs + comments
+    (let [statements (atom [])]
+      ;; Add the SQL for creating each Table
+      (doseq [tabledef table-definitions]
+        (swap! statements conj (drop-table-if-exists-sql driver dbdef tabledef)
+               (create-table-sql driver dbdef tabledef)))
+      ;; Add the SQL for adding FK constraints
+      (doseq [{:keys [field-definitions], :as tabledef} table-definitions]
+        (doseq [{:keys [fk], :as fielddef} field-definitions]
+          (when fk
+            (swap! statements conj (add-fk-sql driver dbdef tabledef fielddef)))))
+      ;; Add the SQL for adding table comments
+      (doseq [{:keys [table-comment], :as tabledef} table-definitions]
+        (when table-comment
+          (swap! statements conj (standalone-table-comment-sql driver dbdef tabledef))))
+      ;; Add the SQL for adding column comments
+      (doseq [{:keys [field-definitions], :as tabledef} table-definitions]
+        (doseq [{:keys [field-comment], :as fielddef} field-definitions]
+          (when field-comment
+            (swap! statements conj (standalone-column-comment-sql driver dbdef tabledef fielddef)))))
+      ;; exec the combined statement
+      (execute-sql! driver :db dbdef (s/join ";\n" (map hx/unescape-dots @statements))))
+    ;; Now load the data for each Table
     (doseq [tabledef table-definitions]
-      (swap! statements conj (drop-table-if-exists-sql driver dbdef tabledef)
-             (create-table-sql driver dbdef tabledef)))
-    ;; Add the SQL for adding FK constraints
-    (doseq [{:keys [field-definitions], :as tabledef} table-definitions]
-      (doseq [{:keys [fk], :as fielddef} field-definitions]
-        (when fk
-          (swap! statements conj (add-fk-sql driver dbdef tabledef fielddef)))))
-    ;; Add the SQL for adding column comments
-    (doseq [{:keys [field-definitions], :as tabledef} table-definitions]
-      (doseq [{:keys [description], :as fielddef} field-definitions]
-        (when description
-          (swap! statements conj (standalone-column-comment-sql driver dbdef tabledef fielddef)))))
-    ;; exec the combined statement
-    (execute-sql! driver :db dbdef (s/join ";\n" (map hx/unescape-dots @statements))))
-  ;; Now load the data for each Table
-  (doseq [tabledef table-definitions]
-    (u/profile (format "load-data for %s %s %s" (name driver) (:database-name dbdef) (:table-name tabledef))
-      (load-data! driver dbdef tabledef))))
+      (u/profile (format "load-data for %s %s %s" (name driver) (:database-name dbdef) (:table-name tabledef))
+        (load-data! driver dbdef tabledef)))))
 
 (def IDriverTestExtensionsMixin
   "Mixin for `IGenericSQLTestExtensions` types to implement `create-db!` from `IDriverTestExtensions`."

--- a/test/metabase/test/data/h2.clj
+++ b/test/metabase/test/data/h2.clj
@@ -55,13 +55,11 @@
     (merge mixin
            {:create-db-sql             (constantly create-db-sql)
             :create-table-sql          create-table-sql
-            ;; Don't use the h2 driver implementation, which makes the connection string read-only & if-exists only
-            :database->spec            (comp dbspec/h2 i/database->connection-details)
+            ; ; Don't use the h2 driver implementation, which makes the connection string read-only & if-exists only:database->spec            (comp dbspec/h2 i/database->connection-details)
             :drop-db-if-exists-sql     (constantly nil)
             :execute-sql!              (fn [this _ dbdef sql]
-                                         ;; we always want to use 'server' context when execute-sql! is called (never
-                                         ;; try connect as GUEST, since we're not giving them priviledges to create
-                                         ;; tables / etc)
+                                         ;; we always want to use 'server' context when execute-sql! is called(never
+                                         ;;  try connect as GUEST, since we're not giving them priviledges to create;; tables / etc)
                                          (execute-sql! this :server dbdef sql))
             :field-base-type->sql-type (u/drop-first-arg field-base-type->sql-type)
             :load-data!                generic/load-data-all-at-once!
@@ -69,7 +67,8 @@
             :pk-sql-type               (constantly "BIGINT AUTO_INCREMENT")
             :prepare-identifier        (u/drop-first-arg s/upper-case)
             :quote-name                (u/drop-first-arg quote-name)
-            :inline-column-comment-sql generic/standard-inline-column-comment-sql}))
+            :inline-column-comment-sql generic/standard-inline-column-comment-sql
+            :standalone-table-comment-sql generic/standard-standalone-table-comment-sql}))
 
   i/IDriverTestExtensions
   (merge generic/IDriverTestExtensionsMixin

--- a/test/metabase/test/data/h2.clj
+++ b/test/metabase/test/data/h2.clj
@@ -49,15 +49,11 @@
    ;; Grant the GUEST account r/w permissions for this table
    (format "GRANT ALL ON %s TO GUEST;" (quote-name table-name))))
 
-(defn- column-comment-sql [_ comment]
-  (format "COMMENT '%s'" comment))
-
 (u/strict-extend H2Driver
   generic/IGenericSQLTestExtensions
   (let [{:keys [execute-sql!], :as mixin} generic/DefaultsMixin]
     (merge mixin
-           {:column-comment-sql        column-comment-sql
-            :create-db-sql             (constantly create-db-sql)
+           {:create-db-sql             (constantly create-db-sql)
             :create-table-sql          create-table-sql
             :database->spec            (comp dbspec/h2 i/database->connection-details) ; Don't use the h2 driver implementation, which makes the connection string read-only & if-exists only
             :drop-db-if-exists-sql     (constantly nil)
@@ -70,7 +66,8 @@
             :pk-field-name             (constantly "ID")
             :pk-sql-type               (constantly "BIGINT AUTO_INCREMENT")
             :prepare-identifier        (u/drop-first-arg s/upper-case)
-            :quote-name                (u/drop-first-arg quote-name)}))
+            :quote-name                (u/drop-first-arg quote-name)
+            :inline-column-comment-sql generic/standard-inline-column-comment-sql}))
 
   i/IDriverTestExtensions
   (merge generic/IDriverTestExtensionsMixin

--- a/test/metabase/test/data/h2.clj
+++ b/test/metabase/test/data/h2.clj
@@ -49,15 +49,11 @@
    ;; Grant the GUEST account r/w permissions for this table
    (format "GRANT ALL ON %s TO GUEST;" (quote-name table-name))))
 
-(defn- column-comment-sql [_ comment]
-  (format "COMMENT '%s'" comment))
-
 (u/strict-extend H2Driver
   generic/IGenericSQLTestExtensions
   (let [{:keys [execute-sql!], :as mixin} generic/DefaultsMixin]
     (merge mixin
-           {:column-comment-sql        column-comment-sql
-            :create-db-sql             (constantly create-db-sql)
+           {:create-db-sql             (constantly create-db-sql)
             :create-table-sql          create-table-sql
             ;; Don't use the h2 driver implementation, which makes the connection string read-only & if-exists only
             :database->spec            (comp dbspec/h2 i/database->connection-details)
@@ -72,7 +68,8 @@
             :pk-field-name             (constantly "ID")
             :pk-sql-type               (constantly "BIGINT AUTO_INCREMENT")
             :prepare-identifier        (u/drop-first-arg s/upper-case)
-            :quote-name                (u/drop-first-arg quote-name)}))
+            :quote-name                (u/drop-first-arg quote-name)
+            :inline-column-comment-sql generic/standard-inline-column-comment-sql}))
 
   i/IDriverTestExtensions
   (merge generic/IDriverTestExtensionsMixin

--- a/test/metabase/test/data/h2.clj
+++ b/test/metabase/test/data/h2.clj
@@ -49,17 +49,20 @@
    ;; Grant the GUEST account r/w permissions for this table
    (format "GRANT ALL ON %s TO GUEST;" (quote-name table-name))))
 
+
 (u/strict-extend H2Driver
   generic/IGenericSQLTestExtensions
   (let [{:keys [execute-sql!], :as mixin} generic/DefaultsMixin]
     (merge mixin
            {:create-db-sql             (constantly create-db-sql)
             :create-table-sql          create-table-sql
-            ; ; Don't use the h2 driver implementation, which makes the connection string read-only & if-exists only:database->spec            (comp dbspec/h2 i/database->connection-details)
+            ;; Don't use the h2 driver implementation, which makes the connection string read-only & if-exists only
+            :database->spec            (comp dbspec/h2 i/database->connection-details)
             :drop-db-if-exists-sql     (constantly nil)
             :execute-sql!              (fn [this _ dbdef sql]
                                          ;; we always want to use 'server' context when execute-sql! is called(never
-                                         ;;  try connect as GUEST, since we're not giving them priviledges to create;; tables / etc)
+                                         ;; try connect as GUEST, since we're not giving them priviledges to create
+                                         ;; tables / etc)
                                          (execute-sql! this :server dbdef sql))
             :field-base-type->sql-type (u/drop-first-arg field-base-type->sql-type)
             :load-data!                generic/load-data-all-at-once!

--- a/test/metabase/test/data/h2.clj
+++ b/test/metabase/test/data/h2.clj
@@ -53,21 +53,22 @@
   generic/IGenericSQLTestExtensions
   (let [{:keys [execute-sql!], :as mixin} generic/DefaultsMixin]
     (merge mixin
-           {:create-db-sql             (constantly create-db-sql)
-            :create-table-sql          create-table-sql
-            :database->spec            (comp dbspec/h2 i/database->connection-details) ; Don't use the h2 driver implementation, which makes the connection string read-only & if-exists only
-            :drop-db-if-exists-sql     (constantly nil)
-            :execute-sql!              (fn [this _ dbdef sql]
-                                         ;; we always want to use 'server' context when execute-sql! is called
-                                         ;; (never try connect as GUEST, since we're not giving them priviledges to create tables / etc)
-                                         (execute-sql! this :server dbdef sql))
-            :field-base-type->sql-type (u/drop-first-arg field-base-type->sql-type)
-            :load-data!                generic/load-data-all-at-once!
-            :pk-field-name             (constantly "ID")
-            :pk-sql-type               (constantly "BIGINT AUTO_INCREMENT")
-            :prepare-identifier        (u/drop-first-arg s/upper-case)
-            :quote-name                (u/drop-first-arg quote-name)
-            :inline-column-comment-sql generic/standard-inline-column-comment-sql}))
+           {:create-db-sql                (constantly create-db-sql)
+            :create-table-sql             create-table-sql
+            :database->spec               (comp dbspec/h2 i/database->connection-details) ; Don't use the h2 driver implementation, which makes the connection string read-only & if-exists only
+            :drop-db-if-exists-sql        (constantly nil)
+            :execute-sql!                 (fn [this _ dbdef sql]
+                                            ;; we always want to use 'server' context when execute-sql! is called
+                                            ;; (never try connect as GUEST, since we're not giving them priviledges to create tables / etc)
+                                            (execute-sql! this :server dbdef sql))
+            :field-base-type->sql-type    (u/drop-first-arg field-base-type->sql-type)
+            :load-data!                   generic/load-data-all-at-once!
+            :pk-field-name                (constantly "ID")
+            :pk-sql-type                  (constantly "BIGINT AUTO_INCREMENT")
+            :prepare-identifier           (u/drop-first-arg s/upper-case)
+            :quote-name                   (u/drop-first-arg quote-name)
+            :inline-column-comment-sql    generic/standard-inline-column-comment-sql
+            :standalone-table-comment-sql generic/standard-standalone-table-comment-sql}))
 
   i/IDriverTestExtensions
   (merge generic/IDriverTestExtensionsMixin

--- a/test/metabase/test/data/h2.clj
+++ b/test/metabase/test/data/h2.clj
@@ -54,23 +54,23 @@
   generic/IGenericSQLTestExtensions
   (let [{:keys [execute-sql!], :as mixin} generic/DefaultsMixin]
     (merge mixin
-           {:create-db-sql             (constantly create-db-sql)
-            :create-table-sql          create-table-sql
+           {:create-db-sql                (constantly create-db-sql)
+            :create-table-sql             create-table-sql
             ;; Don't use the h2 driver implementation, which makes the connection string read-only & if-exists only
-            :database->spec            (comp dbspec/h2 i/database->connection-details)
-            :drop-db-if-exists-sql     (constantly nil)
-            :execute-sql!              (fn [this _ dbdef sql]
-                                         ;; we always want to use 'server' context when execute-sql! is called(never
-                                         ;; try connect as GUEST, since we're not giving them priviledges to create
-                                         ;; tables / etc)
-                                         (execute-sql! this :server dbdef sql))
-            :field-base-type->sql-type (u/drop-first-arg field-base-type->sql-type)
-            :load-data!                generic/load-data-all-at-once!
-            :pk-field-name             (constantly "ID")
-            :pk-sql-type               (constantly "BIGINT AUTO_INCREMENT")
-            :prepare-identifier        (u/drop-first-arg s/upper-case)
-            :quote-name                (u/drop-first-arg quote-name)
-            :inline-column-comment-sql generic/standard-inline-column-comment-sql
+            :database->spec               (comp dbspec/h2 i/database->connection-details)
+            :drop-db-if-exists-sql        (constantly nil)
+            :execute-sql!                 (fn [this _ dbdef sql]
+                                            ;; we always want to use 'server' context when execute-sql! is called (never
+                                            ;; try connect as GUEST, since we're not giving them priviledges to create
+                                            ;; tables / etc)
+                                            (execute-sql! this :server dbdef sql))
+            :field-base-type->sql-type    (u/drop-first-arg field-base-type->sql-type)
+            :load-data!                   generic/load-data-all-at-once!
+            :pk-field-name                (constantly "ID")
+            :pk-sql-type                  (constantly "BIGINT AUTO_INCREMENT")
+            :prepare-identifier           (u/drop-first-arg s/upper-case)
+            :quote-name                   (u/drop-first-arg quote-name)
+            :inline-column-comment-sql    generic/standard-inline-column-comment-sql
             :standalone-table-comment-sql generic/standard-standalone-table-comment-sql}))
 
   i/IDriverTestExtensions

--- a/test/metabase/test/data/h2.clj
+++ b/test/metabase/test/data/h2.clj
@@ -49,12 +49,15 @@
    ;; Grant the GUEST account r/w permissions for this table
    (format "GRANT ALL ON %s TO GUEST;" (quote-name table-name))))
 
+(defn- column-comment-sql [_ comment]
+  (format "COMMENT '%s'" comment))
 
 (u/strict-extend H2Driver
   generic/IGenericSQLTestExtensions
   (let [{:keys [execute-sql!], :as mixin} generic/DefaultsMixin]
     (merge mixin
-           {:create-db-sql             (constantly create-db-sql)
+           {:column-comment-sql        column-comment-sql
+            :create-db-sql             (constantly create-db-sql)
             :create-table-sql          create-table-sql
             :database->spec            (comp dbspec/h2 i/database->connection-details) ; Don't use the h2 driver implementation, which makes the connection string read-only & if-exists only
             :drop-db-if-exists-sql     (constantly nil)

--- a/test/metabase/test/data/h2.clj
+++ b/test/metabase/test/data/h2.clj
@@ -49,12 +49,15 @@
    ;; Grant the GUEST account r/w permissions for this table
    (format "GRANT ALL ON %s TO GUEST;" (quote-name table-name))))
 
+(defn- column-comment-sql [_ comment]
+  (format "COMMENT '%s'" comment))
 
 (u/strict-extend H2Driver
   generic/IGenericSQLTestExtensions
   (let [{:keys [execute-sql!], :as mixin} generic/DefaultsMixin]
     (merge mixin
-           {:create-db-sql             (constantly create-db-sql)
+           {:column-comment-sql        column-comment-sql
+            :create-db-sql             (constantly create-db-sql)
             :create-table-sql          create-table-sql
             ;; Don't use the h2 driver implementation, which makes the connection string read-only & if-exists only
             :database->spec            (comp dbspec/h2 i/database->connection-details)

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -24,11 +24,12 @@
                               special-type    :- (s/maybe su/FieldType)
                               visibility-type :- (s/maybe (apply s/enum field/visibility-types))
                               fk              :- (s/maybe s/Keyword)
-                              description     :- (s/maybe su/NonBlankString)])
+                              field-comment   :- (s/maybe su/NonBlankString)])
 
 (s/defrecord TableDefinition [table-name        :- su/NonBlankString
                               field-definitions :- [FieldDefinition]
-                              rows              :- [[s/Any]]])
+                              rows              :- [[s/Any]]
+                              table-comment     :- (s/maybe su/NonBlankString)])
 
 (s/defrecord DatabaseDefinition [database-name     :- su/NonBlankString
                                  table-definitions :- [TableDefinition]])
@@ -108,6 +109,7 @@
      *  `:db`     - Return details for connecting specifically to the DB.")
 
   (create-db! [this, ^DatabaseDefinition database-definition]
+              [this, ^DatabaseDefinition database-definition, ^Boolean skip-drop-db]
     "Create a new database from DATABASE-DEFINITION, including adding tables, fields, and foreign key constraints,
      and add the appropriate data. This method should drop existing databases with the same name if applicable.
      (This refers to creating the actual *DBMS* database itself, *not* a Metabase `Database` object.)")

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -23,11 +23,12 @@
                               special-type    :- (s/maybe su/FieldType)
                               visibility-type :- (s/maybe (apply s/enum field/visibility-types))
                               fk              :- (s/maybe s/Keyword)
-                              description     :- (s/maybe su/NonBlankString)])
+                              field-comment   :- (s/maybe su/NonBlankString)])
 
 (s/defrecord TableDefinition [table-name        :- su/NonBlankString
                               field-definitions :- [FieldDefinition]
-                              rows              :- [[s/Any]]])
+                              rows              :- [[s/Any]]
+                              table-comment     :- (s/maybe su/NonBlankString)])
 
 (s/defrecord DatabaseDefinition [database-name     :- su/NonBlankString
                                  table-definitions :- [TableDefinition]])
@@ -107,6 +108,7 @@
      *  `:db`     - Return details for connecting specifically to the DB.")
 
   (create-db! [this, ^DatabaseDefinition database-definition]
+              [this, ^DatabaseDefinition database-definition, ^Boolean skip-drop-db]
     "Create a new database from DATABASE-DEFINITION, including adding tables, fields, and foreign key constraints,
      and add the appropriate data. This method should drop existing databases with the same name if applicable.
      (This refers to creating the actual *DBMS* database itself, *not* a Metabase `Database` object.)")

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -23,7 +23,8 @@
                                                              su/FieldType)
                               special-type    :- (s/maybe su/FieldType)
                               visibility-type :- (s/maybe (apply s/enum field/visibility-types))
-                              fk              :- (s/maybe s/Keyword)])
+                              fk              :- (s/maybe s/Keyword)
+                              description     :- (s/maybe su/NonBlankString)])
 
 (s/defrecord TableDefinition [table-name        :- su/NonBlankString
                               field-definitions :- [FieldDefinition]

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -109,10 +109,10 @@
      *  `:db`     - Return details for connecting specifically to the DB.")
 
   (create-db! [this, ^DatabaseDefinition database-definition]
-              [this, ^DatabaseDefinition database-definition, ^Boolean skip-drop-db]
+              [this, ^DatabaseDefinition database-definition, ^Boolean skip-drop-db?]
     "Create a new database from DATABASE-DEFINITION, including adding tables, fields, and foreign key constraints,
      and add the appropriate data. This method should drop existing databases with the same name if applicable,
-     unless the skip-drop-db arg is true. This is to workaround a scenario where the postgres driver terminates
+     unless the skip-drop-db? arg is true. This is to workaround a scenario where the postgres driver terminates
      the connection before dropping the DB and causes some tests to fail.
      (This refers to creating the actual *DBMS* database itself, *not* a Metabase `Database` object.)")
 

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -22,7 +22,8 @@
                                                              su/FieldType)
                               special-type    :- (s/maybe su/FieldType)
                               visibility-type :- (s/maybe (apply s/enum field/visibility-types))
-                              fk              :- (s/maybe s/Keyword)])
+                              fk              :- (s/maybe s/Keyword)
+                              description     :- (s/maybe su/NonBlankString)])
 
 (s/defrecord TableDefinition [table-name        :- su/NonBlankString
                               field-definitions :- [FieldDefinition]

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -111,7 +111,9 @@
   (create-db! [this, ^DatabaseDefinition database-definition]
               [this, ^DatabaseDefinition database-definition, ^Boolean skip-drop-db]
     "Create a new database from DATABASE-DEFINITION, including adding tables, fields, and foreign key constraints,
-     and add the appropriate data. This method should drop existing databases with the same name if applicable.
+     and add the appropriate data. This method should drop existing databases with the same name if applicable,
+     unless the skip-drop-db arg is true. This is to workaround a scenario where the postgres driver terminates
+     the connection before dropping the DB and causes some tests to fail.
      (This refers to creating the actual *DBMS* database itself, *not* a Metabase `Database` object.)")
 
   ;; TODO - this would be more useful if DATABASE-DEFINITION was a parameter

--- a/test/metabase/test/data/postgres.clj
+++ b/test/metabase/test/data/postgres.clj
@@ -54,7 +54,8 @@
           :field-base-type->sql-type     (u/drop-first-arg field-base-type->sql-type)
           :load-data!                    generic/load-data-all-at-once!
           :pk-sql-type                   (constantly "SERIAL")
-          :standalone-column-comment-sql generic/standard-standalone-column-comment-sql})
+          :standalone-column-comment-sql generic/standard-standalone-column-comment-sql
+          :standalone-table-comment-sql  generic/standard-standalone-table-comment-sql})
   i/IDriverTestExtensions
   (merge generic/IDriverTestExtensionsMixin
          {:database->connection-details       (u/drop-first-arg database->connection-details)

--- a/test/metabase/test/data/postgres.clj
+++ b/test/metabase/test/data/postgres.clj
@@ -49,11 +49,12 @@
 (u/strict-extend PostgresDriver
   generic/IGenericSQLTestExtensions
   (merge generic/DefaultsMixin
-         {:drop-db-if-exists-sql     drop-db-if-exists-sql
-          :drop-table-if-exists-sql  generic/drop-table-if-exists-cascade-sql
-          :field-base-type->sql-type (u/drop-first-arg field-base-type->sql-type)
-          :load-data!                generic/load-data-all-at-once!
-          :pk-sql-type               (constantly "SERIAL")})
+         {:drop-db-if-exists-sql         drop-db-if-exists-sql
+          :drop-table-if-exists-sql      generic/drop-table-if-exists-cascade-sql
+          :field-base-type->sql-type     (u/drop-first-arg field-base-type->sql-type)
+          :load-data!                    generic/load-data-all-at-once!
+          :pk-sql-type                   (constantly "SERIAL")
+          :standalone-column-comment-sql generic/standard-standalone-column-comment-sql})
   i/IDriverTestExtensions
   (merge generic/IDriverTestExtensionsMixin
          {:database->connection-details       (u/drop-first-arg database->connection-details)


### PR DESCRIPTION
Hi,

Here is an implementation of the feature to use the COMMENTs on tables and fields to populate the metabase descriptions when syncing.
Related issue: https://github.com/metabase/metabase/issues/3089

This is my first time using Clojure so I'm sure I've committed many faux pas. Feedback is welcomed! 

Note I've only got unit tests against H2 and Postgres. Happy to test against other DBs if you can point me to docs about how to do so. I definitely will test against Presto and SQL Server, which are the DBs I need! But I also didn't want to do too much of that without first getting a code review and a general thumbs up for the approach.

Cheers
Tom

###### TODO 
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
