### PR TITLE
track events via redux action dispatch

### DIFF
--- a/frontend/src/metabase/store.js
+++ b/frontend/src/metabase/store.js
@@ -28,6 +28,13 @@ const devToolsExtension = window.devToolsExtension
   ? window.devToolsExtension()
   : f => f;
 
+const trackEvent = ({ dispatch, getState }) => next => action => {
+    if(action.type && action.type.indexOf('metabase') > -1) {
+        console.log('action!!!', action.type.split("/"))
+    }
+    return next(action)
+}
+
 export function getStore(reducers, history, intialState, enhancer = a => a) {
   const reducer = combineReducers({
     ...reducers,
@@ -37,6 +44,7 @@ export function getStore(reducers, history, intialState, enhancer = a => a) {
 
   const middleware = [
     thunkWithDispatchAction,
+    trackEvent,
     promise,
     ...(DEBUG ? [logger] : []),
     ...(history ? [routerMiddleware(history)] : []),

--- a/frontend/src/metabase/store.js
+++ b/frontend/src/metabase/store.js
@@ -29,7 +29,7 @@ const devToolsExtension = window.devToolsExtension
   ? window.devToolsExtension()
   : f => f;
 
-// Look for redux action names that take the form `metabase/<app_section>/<action_name>
+// Look for redux action names that take the form `metabase/<app_section>/<ACTION_NAME>
 const METABASE_TRACKABLE_ACTION_REGEX = /^metabase\/(.+)\/([^\/]+)$/;
 
 /**
@@ -43,7 +43,7 @@ const METABASE_TRACKABLE_ACTION_REGEX = /^metabase\/(.+)\/([^\/]+)$/;
  * Any actions with a name takes the form `metabase/.../...` will be automatially captured
  *
  * Ignoring actions:
- * Any actions we want to ignore can me bypassed by including a meta object with ignore: true
+ * Any actions we want to ignore can be bypassed by including a meta object with ignore: true
  * {
  *   type: "...",
  *   meta: {
@@ -67,7 +67,7 @@ const METABASE_TRACKABLE_ACTION_REGEX = /^metabase\/(.+)\/([^\/]+)$/;
  *   }
  *}
  */
-const trackEvent = ({ dispatch, getState }) => next => action => {
+export const trackEvent = ({ dispatch, getState }) => next => action => {
   // look for the meta analytics object if it exists, this gets used to
   // do customization of the event identifiers sent to GA
   const analytics = action.meta && action.meta.analytics;
@@ -85,11 +85,13 @@ const trackEvent = ({ dispatch, getState }) => next => action => {
     // if there is no analytics metadata on the action, look to see if it's
     // an action name we want to track based on the format of the aciton name
 
-    const [_, category, action] = action.type.match(
-      // eslint-disable-line no-unused-vars - the
+    // eslint doesn't like the _ to ignore the first bit
+    // eslint-disable-next-line
+    const [_, categoryName, actionName] = action.type.match(
       METABASE_TRACKABLE_ACTION_REGEX,
     );
-    MetabaseAnalytics.trackEvent(category, action);
+
+    MetabaseAnalytics.trackEvent(categoryName, actionName);
   }
   return next(action);
 };

--- a/frontend/test/redux/store.unit.spec.js
+++ b/frontend/test/redux/store.unit.spec.js
@@ -1,0 +1,64 @@
+import { trackEvent } from "metabase/store";
+import MetabaseAnalytics from "metabase/lib/analytics";
+
+jest.mock("metabase/lib/analytics", () => ({
+  trackEvent: jest.fn(),
+}));
+
+// fake next for redux
+const next = jest.fn();
+
+describe("store", () => {
+  describe("trackEvent", () => {
+    beforeEach(() => {
+      jest.resetAllMocks();
+    });
+    it("should call MetabaseAnalytics with the proper custom values", () => {
+      const testAction = {
+        type: "metabase/test/ACTION_NAME",
+        meta: {
+          analytics: {
+            category: "cool",
+            action: "action",
+            label: "labeled",
+            value: "value",
+          },
+        },
+      };
+
+      trackEvent({})(next)(testAction);
+      expect(MetabaseAnalytics.trackEvent).toHaveBeenCalledTimes(1);
+      expect(MetabaseAnalytics.trackEvent).toHaveBeenCalledWith(
+        "cool",
+        "action",
+        "labeled",
+        "value",
+      );
+    });
+    it("should ignore actions if ignore is true", () => {
+      const testAction = {
+        type: "metabase/test/ACTION_NAME",
+        meta: {
+          analytics: {
+            ignore: true,
+          },
+        },
+      };
+
+      trackEvent({})(next)(testAction);
+      expect(MetabaseAnalytics.trackEvent).toHaveBeenCalledTimes(0);
+    });
+
+    it("should use the action name if no analytics action is present", () => {
+      const testAction = {
+        type: "metabase/test/ACTION_NAME",
+      };
+
+      trackEvent({})(next)(testAction);
+      expect(MetabaseAnalytics.trackEvent).toHaveBeenCalledWith(
+        "test",
+        "ACTION_NAME",
+      );
+    });
+  });
+});


### PR DESCRIPTION
Response to #6968 

We've forgotten to instrument new features as we ship them so that we can get usage data from instances that have enabled anonymous usage collection a few times now. One idea I had to try and help us with this was just take all Metabase related redux action dispatches and "log" them similar to redux logging middleware but just send them over to GA instead of printing them to the console. In this way you get a large portion of your desired event logging for free, since most button clicks, requests etc are dispatched via redux actions.

Plusses:
- Any button click, or request for data that triggers an action gets passed through the middleware and can be logged
- We're just capturing the redux action type which is a string at the high level in middleware, so it makes it hard to accidentally send identifying data over the wire since there's just one spot that this happens
- Keeps us honest about our action names since those provide the source of logging

Potential downsides
- Would need to reconcile existing event names in our own MB instance since there might be slight variations in the event name structure
- Might be hard to get "true, false" values for redux actions that are "TOGGLE"s or other types of patterns where the `action.payload` is important.
- Something someone smarter than me notices
