### PR TITLE
Automatic dashboards frontend [WIP]

### DIFF
--- a/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
@@ -32,7 +32,7 @@ import { parseHashOptions } from "metabase/lib/browser";
 
 const mapStateToProps = (state, props) => {
   return {
-    dashboardId: props.params.dashboardId,
+    dashboardId: props.dashboardId || props.params.dashboardId,
 
     isAdmin: getUserIsAdmin(state, props),
     isEditing: getIsEditing(state, props),

--- a/frontend/src/metabase/dashboard/dashboard.js
+++ b/frontend/src/metabase/dashboard/dashboard.js
@@ -42,6 +42,7 @@ import {
   RevisionApi,
   PublicApi,
   EmbedApi,
+  AutoApi,
 } from "metabase/services";
 
 import { getDashboard, getDashboardComplete } from "./selectors";
@@ -108,6 +109,8 @@ function getDashboardType(id) {
     return "public";
   } else if (Utils.isJWT(id)) {
     return "embed";
+  } else if (/\/auto\/dashboard/.test(id)) {
+    return "auto";
   } else {
     return "normal";
   }
@@ -505,6 +508,17 @@ export const fetchDashboard = createThunkAction(FETCH_DASHBOARD, function(
       };
     } else if (dashboardType === "embed") {
       result = await EmbedApi.dashboard({ token: dashId });
+      result = {
+        ...result,
+        id: dashId,
+        ordered_cards: result.ordered_cards.map(dc => ({
+          ...dc,
+          dashboard_id: dashId,
+        })),
+      };
+    } else if (dashboardType === "auto") {
+      const [type, id] = dashId.split("/").slice(3);
+      result = await AutoApi.dashboard({ type, id });
       result = {
         ...result,
         id: dashId,

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -224,6 +224,13 @@ export const getRoutes = store => (
           <ModalRoute path="history" modal={DashboardHistoryModal} />
         </Route>
 
+        <Route
+          path="/auto/:type/:subtype/:id"
+          component={props => (
+            <DashboardApp {...props} dashboardId={props.location.pathname} />
+          )}
+        />
+
         {/* QUERY BUILDER */}
         <Route path="/question">
           <IndexRoute component={QueryBuilder} />

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -84,6 +84,10 @@ export const EmbedApi = {
   ),
 };
 
+export const AutoApi = {
+  dashboard: GET("/api/auto/dashboard/:type/:id"),
+};
+
 export const EmailApi = {
   updateSettings: PUT("/api/email"),
   sendTest: POST("/api/email/test"),

--- a/src/metabase/api/auto.clj
+++ b/src/metabase/api/auto.clj
@@ -1,0 +1,23 @@
+(ns metabase.api.auto
+  "`/api/auto` endpoints."
+  (:require [clojure.tools.logging :as log]
+            [compojure.core :refer [GET]]
+            [metabase.api.common :as api :refer [defendpoint define-routes]]
+            [metabase.models
+             [dashboard :as dashboard :refer [Dashboard]]]
+            [metabase.util :as u]
+            [toucan
+             [db :as db]
+             [hydrate :refer [hydrate]]]))
+
+(defendpoint GET "/dashboard/:type/:id"
+  "FIXME PLACHOLDER ENDPOINT FOR AUTOMATIC DASHBOARDS"
+  [type id]
+  (u/prog1 (-> (Dashboard 10)
+               api/check-404
+               (hydrate [:ordered_cards [:card :in_public_dashboard] :series])
+               api/read-check
+               (dissoc :id)
+               (assoc-in [:ordered_cards 0 :card :dataset_query]))))
+
+(define-routes)

--- a/src/metabase/api/routes.clj
+++ b/src/metabase/api/routes.clj
@@ -6,6 +6,7 @@
              [activity :as activity]
              [alert    :as alert]
              [async :as async]
+             [auto :as auto]
              [card :as card]
              [collection :as collection]
              [dashboard :as dashboard]
@@ -59,6 +60,7 @@
   (context "/activity"        [] (+auth activity/routes))
   (context "/alert"           [] (+auth alert/routes))
   (context "/async"           [] (+auth async/routes))
+  (context "/auto"            [] (+auth auto/routes))
   (context "/card"            [] (+auth card/routes))
   (context "/collection"      [] (+auth collection/routes))
   (context "/dashboard"       [] (+auth dashboard/routes))


### PR DESCRIPTION
Adds `/auto/dashboard/:type/:id` frontend route and corresponding (currently fake) `/api/auto/dashboard/:type/:id` backend route which should return a dashboard object (with dashcards/cards) similar to that returned by `/api/dashboard/:id` (except presumably without `id` properties on the `dashboard`, `dashcard`, or `card` objects, since they are unsaved)

Doesn't yet handle saving.