### PR TITLE
Fix parameters for Bigquery queries that take a long time.

### DIFF
--- a/src/metabase/driver/bigquery.clj
+++ b/src/metabase/driver/bigquery.clj
@@ -29,6 +29,7 @@
             [metabase.util.honeysql-extensions :as hx]
             [toucan.db :as db])
   (:import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
+           [com.google.api.client.http HttpRequestInitializer HttpRequest]
            [com.google.api.services.bigquery Bigquery Bigquery$Builder BigqueryScopes]
            [com.google.api.services.bigquery.model QueryRequest QueryResponse Table TableCell TableFieldSchema
             TableList TableList$Tables TableReference TableRow TableSchema]
@@ -44,7 +45,14 @@
 ;;; ----------------------------------------------------- Client -----------------------------------------------------
 
 (defn- ^Bigquery credential->client [^GoogleCredential credential]
-  (.build (doto (Bigquery$Builder. google/http-transport google/json-factory credential)
+  (.build (doto (Bigquery$Builder.
+                 google/http-transport
+                 google/json-factory
+                 (reify HttpRequestInitializer
+                   (initialize [this httpRequest]
+                     (.initialize credential httpRequest)
+                     (.setConnectTimeout httpRequest 0)
+                     (.setReadTimeout httpRequest 0))))
             (.setApplicationName google/application-name))))
 
 (def ^:private ^{:arglists '([database])} ^GoogleCredential database->credential


### PR DESCRIPTION
Issuing a long query for BigQuery causes a socket timeout.
```:have_error_message
{:status :failed,
 :class java.net.SocketTimeoutException,
 :error "Read timed out",
 :stacktrace
 [...stacktrace
}
```
Looking at the driver of BigQuery, it seems that the timeout parameter is not set.

for your information.
https://developers.google.com/api-client-library/java/google-http-java-client/reference/1.19.0/com/google/api/client/http/HttpRequestInitializer

I think that the timeout of the query should be discussed separately,
but I think that this correction is effective against the timeout of socket.

It seems to be related to this issue.
#6060 #3268