### PR TITLE
Switch sql templates to an instaparse grammar [ci drivers]

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -64,6 +64,7 @@
                  [hiccup "1.0.5"]                                     ; HTML templating
                  [honeysql "0.8.2"]                                   ; Transform Clojure data structures to SQL
                  [io.crate/crate-jdbc "2.1.6"]                        ; Crate JDBC driver
+                 [instaparse "1.4.0"]                                 ; Insaparse parser generator
                  [kixi/stats "0.3.10"                                 ; Various statistic measures implemented as transducers
                   :exclusions [org.clojure/test.check                 ; test.check and AVL trees are used in kixi.stats.random. Remove exlusion if using.
                                org.clojure/data.avl]]

--- a/src/metabase/driver/bigquery.clj
+++ b/src/metabase/driver/bigquery.clj
@@ -510,7 +510,8 @@
                                                              :standard-deviation-aggregations
                                                              :native-parameters
                                                              :expression-aggregations
-                                                             :binning}
+                                                             :binning
+                                                             :native-query-params}
                                                            (when-not config/is-test?
                                                              ;; during unit tests don't treat bigquery as having FK
                                                              ;; support

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -277,7 +277,8 @@
             :expression-aggregations
             :native-parameters
             :nested-queries
-            :binning}
+            :binning
+            :native-query-params}
     (set-timezone-sql driver) (conj :set-timezone)))
 
 

--- a/src/metabase/driver/presto.clj
+++ b/src/metabase/driver/presto.clj
@@ -335,7 +335,8 @@
                                                                       :expressions
                                                                       :native-parameters
                                                                       :expression-aggregations
-                                                                      :binning}
+                                                                      :binning
+                                                                      :native-query-params}
                                                                     (when-not config/is-test?
                                                                       ;; during unit tests don't treat presto as having FK support
                                                                       #{:foreign-keys})))

--- a/src/metabase/query_processor/middleware/parameters/sql.clj
+++ b/src/metabase/query_processor/middleware/parameters/sql.clj
@@ -6,6 +6,8 @@
   (:require [clojure.string :as str]
             [clojure.tools.logging :as log]
             [honeysql.core :as hsql]
+            [instaparse.core :as insta]
+            [metabase.driver :as driver]
             [metabase.models.field :as field :refer [Field]]
             [metabase.query-processor.middleware.parameters.dates :as date-params]
             [metabase.query-processor.middleware.expand :as ql]
@@ -62,6 +64,8 @@
 ;; values.
 (defrecord ^:private NoValue [])
 
+(defn- no-value? [x]
+  (instance? NoValue x))
 
 ;; various schemas are used to check that various functions return things in expected formats
 
@@ -108,11 +112,7 @@
   {s/Keyword ParamValue})
 
 (def ^:private ParamSnippetInfo
-  {(s/optional-key :param-key)               s/Keyword
-   (s/optional-key :original-snippet)        su/NonBlankString
-   (s/optional-key :variable-snippet)        su/NonBlankString
-   (s/optional-key :optional-snippet)        (s/maybe su/NonBlankString)
-   (s/optional-key :replacement-snippet)     s/Str                       ; allowed to be blank if this is an optional param
+  {(s/optional-key :replacement-snippet)     s/Str                       ; allowed to be blank if this is an optional param
    (s/optional-key :prepared-statement-args) [s/Any]})
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -223,7 +223,7 @@
 (s/defn ^:private parse-value-for-type :- ParamValue
   [param-type value]
   (cond
-    (instance? NoValue value)                        value
+    (no-value? value)                                value
     (= param-type "number")                          (value->number value)
     (= param-type "date")                            (map->Date {:s value})
     (and (= param-type "dimension")
@@ -389,136 +389,124 @@
       :else
       (update (dimension->replacement-snippet-info param) :replacement-snippet (partial str (field->identifier field (:type param)) " ")))))
 
-
 ;;; +----------------------------------------------------------------------------------------------------------------+
-;;; |                                         QUERY PARSING / PARAM SNIPPETS                                         |
-;;; +----------------------------------------------------------------------------------------------------------------+
-
-;; These functions parse a query and look for param snippets, which look like:
-;;
-;; * {{...}} (required)
-;; * [[...{{...}}...]] (optional)
-;;
-;; and creates a list of these snippets, keeping the original order.
-;;
-;; The details maps returned have the format:
-;;
-;;    {:param-key        :timestamp                           ; name of the param being replaced
-;;     :original-snippet "[[AND timestamp < {{timestamp}}]]"  ; full text of the snippet to be replaced
-;;     :optional-snippet "AND timestamp < {{timestamp}}"      ; portion of the snippet inside [[optional]] brackets, or `nil` if the snippet isn't optional
-;;     :variable-snippet "{{timestamp}}"}                     ; portion of the snippet referencing the variable itself, e.g. {{x}}
-
-(s/defn ^:private param-snippet->param-name :- s/Keyword
-  "Return the keyword name of the param being referenced inside PARAM-SNIPPET.
-
-     (param-snippet->param-name \"{{x}}\") -> :x"
-  [param-snippet :- su/NonBlankString]
-  (keyword (second (re-find #"\{\{\s*(\w+)\s*\}\}" param-snippet))))
-
-(s/defn ^:private sql->params-snippets-info :- [ParamSnippetInfo]
-  "Return a sequence of maps containing information about the param snippets found by paring SQL."
-  [sql :- su/NonBlankString]
-  (for [[param-snippet optional-replacement-snippet] (re-seq #"(?:\[\[(.+?)\]\])|(?:\{\{\s*\w+\s*\}\})" sql)]
-    {:param-key        (param-snippet->param-name param-snippet)
-     :original-snippet  param-snippet
-     :variable-snippet (re-find #"\{\{\s*\w+\s*\}\}" param-snippet)
-     :optional-snippet optional-replacement-snippet}))
-
-
-;;; +----------------------------------------------------------------------------------------------------------------+
-;;; |                                              PARAMS DETAILS LIST                                               |
+;;; |                                            PARSING THE SQL TEMPLATE                                            |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-;; These functions combine the info from the other 3 stages (Param Info Resolution, Param->SQL Substitution, and Query
-;; Parsing) and create a sequence of maps containing param details that has all the information needed to do SQL
-;; substituion. This sequence is returned in the same order as params encountered in the
-;;
-;; original query, making passing prepared statement args simple
-;;
-;; The details maps returned have the format:
-;;
-;;    {:original-snippet        "[[AND timestamp < {{timestamp}}]]"  ; full text of the snippet to be replaced
-;;     :replacement-snippet     "AND timestamp < ?"                  ; full text that the snippet should be replaced with
-;;     :prepared-statement-args [#inst "2016-01-01"]}                ; prepared statement args needed by the replacement snippet
-;;
-;; (Basically these functions take `:param-key`, `:optional-snippet`, and `:variable-snippet` from the Query Parsing stage and the info from the other stages
-;; to add the appropriate info for `:replacement-snippet` and `:prepared-statement-args`.)
+(def ^:private sql-template-parser
+  (insta/parser
+   "SQL := (ANYTHING_NOT_RESERVED | SINGLE_BRACKET_PLUS_ANYTHING | SINGLE_BRACE_PLUS_ANYTHING | OPTIONAL | PARAM)*
 
-(s/defn ^:private snippet-value :- ParamValue
-  "Fetch the value from PARAM-KEY->VALUE for SNIPPET-INFO.
-   If no value is specified, return `NoValue` if the snippet is optional; otherwise throw an Exception."
-  [{:keys [param-key optional-snippet]} :- ParamSnippetInfo, param-key->value :- ParamValues]
-  (u/prog1 (get param-key->value param-key (NoValue.))
-    ;; if ::no-value was specified an the param is not [[optional]], throw an exception
-    (when (and (instance? NoValue <>)
-               (not optional-snippet))
-      (throw (ex-info (format "Unable to substitute '%s': param not specified.\nFound: %s" param-key (keys param-key->value))
-               {:status-code 400})))))
+    (* Treat double brackets and braces as special, pretty much everything else is good to go *)
+    <SINGLE_BRACKET_PLUS_ANYTHING> := !'[[' '[' (ANYTHING_NOT_RESERVED | ']' | SINGLE_BRACKET_PLUS_ANYTHING | SINGLE_BRACE_PLUS_ANYTHING)*
+    <SINGLE_BRACE_PLUS_ANYTHING> := !'{{' '{' (ANYTHING_NOT_RESERVED | '}' | SINGLE_BRACE_PLUS_ANYTHING  | SINGLE_BRACKET_PLUS_ANYTHING)*
+    <ANYTHING_NOT_RESERVED> := #'[^\\[\\]\\{\\}]+'
 
-(s/defn ^:private handle-optional-snippet :- ParamSnippetInfo
-  "Create the approprate `:replacement-snippet` for PARAM, combining the value of REPLACEMENT-SNIPPET from the Param->SQL Substitution phase
-   with the OPTIONAL-SNIPPET, if any."
-  [{:keys [variable-snippet optional-snippet replacement-snippet prepared-statement-args], :as snippet-info} :- ParamSnippetInfo]
-  (assoc snippet-info
-    :replacement-snippet     (cond
-                               (not optional-snippet)    replacement-snippet                                                 ; if there is no optional-snippet return replacement as-is
-                               (seq replacement-snippet) (str/replace optional-snippet variable-snippet replacement-snippet) ; if replacement-snippet is non blank splice into optional-snippet
-                               :else                     "")                                                                 ; otherwise return blank replacement (i.e. for NoValue)
-    ;; for every thime the `variable-snippet` occurs in the `optional-snippet` we need to supply an additional set of `prepared-statment-args`
-    ;; e.g. [[ AND ID = {{id}} OR USER_ID = {{id}} ]] should have *2* sets of the prepared statement args for {{id}} since it occurs twice
-    :prepared-statement-args (if-let [occurances (u/occurances-of-substring optional-snippet variable-snippet)]
-                               (apply concat (repeat occurances prepared-statement-args))
-                               prepared-statement-args)))
+    (* Parameters can have whitespace, but must be word characters for the name of the parameter *)
+    PARAM = <'{{'> <WHITESPACE*> TOKEN <WHITESPACE*> <'}}'>
 
-(s/defn ^:private add-replacement-snippet-info :- [ParamSnippetInfo]
-  "Add `:replacement-snippet` and `:prepared-statement-args` info to the maps in PARAMS-SNIPPETS-INFO by looking at
-   PARAM-KEY->VALUE and using the Param->SQL substituion functions."
-  [params-snippets-info :- [ParamSnippetInfo], param-key->value :- ParamValues]
-  (for [snippet-info params-snippets-info]
-    (handle-optional-snippet
-     (merge snippet-info
-            (s/validate ParamSnippetInfo (->replacement-snippet-info (snippet-value snippet-info param-key->value)))))))
+    (* Parameters, braces and brackets are all good here, just no nesting of optional clauses *)
+    OPTIONAL := <'[['> (ANYTHING_NOT_RESERVED | SINGLE_BRACKET_PLUS_ANYTHING | SINGLE_BRACE_PLUS_ANYTHING | PARAM)* <']]'>
+    <TOKEN>    := #'(\\w)+'
+    WHITESPACE := #'\\s+'"))
 
+(defrecord ^:private Param [param-key sql-value prepared-statement-args])
 
-;;; +----------------------------------------------------------------------------------------------------------------+
-;;; |                                                 SUBSTITUITION                                                  |
-;;; +----------------------------------------------------------------------------------------------------------------+
+(defn- param? [maybe-param]
+  (instance? Param maybe-param))
 
-;; These functions take the information about parameters from the Params Details List functions and then convert the
-;; original SQL Query into a SQL query with appropriate subtitutions and a sequence of prepared statement args
+(defn- merge-query-map [query-map node]
+  (cond
+    (string? node)
+    (update query-map :query str node)
 
-(s/defn ^:private substitute-one
-  [sql :- su/NonBlankString, {:keys [original-snippet replacement-snippet]} :- ParamSnippetInfo]
-  (str/replace-first sql original-snippet replacement-snippet))
+    (param? node)
+    (-> query-map
+        (update :query str (:sql-value node))
+        (update :params concat (:prepared-statement-args node)))
 
+    :else
+    (-> query-map
+        (update :query str (:query node))
+        (update :params concat (:params node)))))
 
-(s/defn ^:private substitute :- {:query su/NonBlankString, :params [s/Any]}
-  "Using the PARAM-SNIPPET-INFO built from the stages above, replace the snippets in SQL and return a vector of
-   `[sql & prepared-statement-params]`."
-  {:style/indent 1}
-  [sql :- su/NonBlankString, param-snippets-info :- [ParamSnippetInfo]]
-  (log/debug (format "PARAM INFO: %s\n%s" (u/emoji "🔥") (u/pprint-to-str 'yellow param-snippets-info)))
-  (loop [sql sql, prepared-statement-args [], [snippet-info & more] param-snippets-info]
-    (if-not snippet-info
-      {:query (str/trim sql), :params (for [arg prepared-statement-args]
-                                        ((resolve 'metabase.driver.generic-sql/prepare-sql-param) *driver* arg))}
-      (recur (substitute-one sql snippet-info)
-             (concat prepared-statement-args (:prepared-statement-args snippet-info))
-             more))))
+(def ^:private empty-query-map {:query "" :params []})
 
+(defn- no-value-param? [maybe-param]
+  (and (param? maybe-param)
+       (no-value? (:sql-value maybe-param))))
+
+(defn- transform-sql
+  "Returns the combined query-map from all of the parameters, optional clauses etc. At this point there should not be
+  a NoValue leaf. If so, it's an error (i.e. missing a required parameter."
+  [param-key->value]
+  (fn [& nodes]
+    (doseq [maybe-param nodes
+            :when (no-value-param? maybe-param)]
+      (throw (ex-info (format "Unable to substitute '%s': param not specified.\nFound: %s"
+                              (:param-name maybe-param) (keys param-key->value))
+               {:status-code 400})))
+    (-> (reduce merge-query-map empty-query-map nodes)
+        (update :query str/trim))))
+
+(defn- transform-optional
+  "Converts the `OPTIONAL` clause to a query map. If one or more parameters are not populated for this optional
+  clause, it will return an empty-query-map, which will be omitted from the query."
+  [& nodes]
+  (if (some no-value-param? nodes)
+    empty-query-map
+    (reduce merge-query-map empty-query-map nodes)))
+
+(defn- transform-param
+  "Converts a `PARAM` parse leaf to a query map that includes the SQL snippet to replace the `{{param}}` value and the
+  param itself for the prepared statement"
+  [param-key->value]
+  (fn [token]
+    (let [val (get param-key->value (keyword token) (NoValue.))]
+      (if (no-value? val)
+        (map->Param {:param-key token, :sql-value val, :prepared-statement-args []})
+        (let [{:keys [replacement-snippet prepared-statement-args]} (->replacement-snippet-info val)]
+          (map->Param {:param-key               token
+                       :sql-value               replacement-snippet
+                       :prepared-statement-args prepared-statement-args}))))))
+
+(defn- parse-transform-map
+  "Instaparse returns things like [:SQL token token token...]. This map will be used when crawling the parse tree from
+  the bottom up. When encountering the a `:PARAM` node, it will invoke the included function, invoking the function
+  with each item in the list as arguments "
+  [param-key->value]
+  {:SQL      (transform-sql param-key->value)
+   :OPTIONAL transform-optional
+   :PARAM    (transform-param param-key->value)})
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                            PUTTING IT ALL TOGETHER                                             |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
+(defn- prepare-sql-param-for-driver [param]
+  ((resolve 'metabase.driver.generic-sql/prepare-sql-param) *driver* param))
+
 (s/defn ^:private expand-query-params
   [{sql :query, :as native}, param-key->value :- ParamValues]
-  (merge native (when-let [param-snippets-info (seq (add-replacement-snippet-info (sql->params-snippets-info sql) param-key->value))]
-                  (substitute sql param-snippets-info))))
+  (merge native
+         (-> (parse-transform-map param-key->value)
+             (insta/transform (insta/parse sql-template-parser sql))
+             ;; `prepare-sql-param-for-driver` can't be lazy as it needs `*driver*` to be bound
+             (update :params #(mapv prepare-sql-param-for-driver %)))))
+
+(defn- ensure-driver
+  "Depending on where the query came from (the user, permissions check etc) there might not be an driver associated to
+  the query. If there is no driver, use the database to find the right driver or throw."
+  [{:keys [driver database] :as query}]
+  (or driver
+      (driver/database-id->driver database)
+      (throw (IllegalArgumentException. "Could not resolve driver"))))
 
 (defn expand
   "Expand parameters inside a *SQL* QUERY."
   [query]
-  (binding [*driver*   (:driver query)
+  (binding [*driver*   (ensure-driver query)
             *timezone* (get-in query [:settings :report-timezone])]
-    (update query :native expand-query-params (query->params-map query))))
+    (if (driver/driver-supports? *driver* :native-query-params)
+      (update query :native expand-query-params (query->params-map query))
+      query)))

--- a/test/metabase/driver/generic_sql/native_test.clj
+++ b/test/metabase/driver/generic_sql/native_test.clj
@@ -17,7 +17,7 @@
                              [99]]
                :columns     ["ID"]
                :cols        [(merge col-defaults {:name "ID", :display_name "ID", :base_type :type/Integer})]
-               :native_form {:query "SELECT ID FROM VENUES ORDER BY ID DESC LIMIT 2;"}}}
+               :native_form {:query "SELECT ID FROM VENUES ORDER BY ID DESC LIMIT 2;", :params []}}}
   (-> (qp/process-query {:native   {:query "SELECT ID FROM VENUES ORDER BY ID DESC LIMIT 2;"}
                          :type     :native
                          :database (id)})
@@ -34,7 +34,7 @@
                                   [{:name "ID",          :display_name "ID",          :base_type :type/Integer}
                                    {:name "NAME",        :display_name "Name",        :base_type :type/Text}
                                    {:name "CATEGORY_ID", :display_name "Category ID", :base_type :type/Integer}])
-               :native_form {:query "SELECT ID, NAME, CATEGORY_ID FROM VENUES ORDER BY ID DESC LIMIT 2;"}}}
+               :native_form {:query "SELECT ID, NAME, CATEGORY_ID FROM VENUES ORDER BY ID DESC LIMIT 2;", :params []}}}
   (-> (qp/process-query {:native   {:query "SELECT ID, NAME, CATEGORY_ID FROM VENUES ORDER BY ID DESC LIMIT 2;"}
                          :type     :native
                          :database (id)})


### PR DESCRIPTION
This commit switches the SQL template parsing to a formally specified
EBNF grammar using instaparse. By specifying it in this way, changes
to the language become more flexible and explicit. This commit also
adds support for multiple parameters specified in an optional clause
as it's baked into the grammar.

Fixes #5492
