### PR TITLE
Improve latitude 'inside' filter

### DIFF
--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -19,6 +19,7 @@ import { stripId } from "metabase/lib/formatting";
 import type Field from "metabase-lib/lib/metadata/Field";
 import type { FieldId } from "metabase/meta/types/Field";
 import type { Value } from "metabase/meta/types/Dataset";
+import type { FormattingOptions } from "metabase/lib/formatting";
 import type { LayoutRendererProps } from "metabase/components/TokenField";
 
 const MAX_SEARCH_RESULTS = 100;
@@ -40,6 +41,7 @@ type Props = {
   maxResults: number,
   style?: { [key: string]: string | number },
   placeholder?: string,
+  formatOptions?: FormattingOptions,
   maxWidth?: number,
   minWidth?: number,
   alwaysShowOptions?: boolean,
@@ -72,6 +74,7 @@ export class FieldValuesWidget extends Component {
     maxResults: MAX_SEARCH_RESULTS,
     alwaysShowOptions: true,
     style: {},
+    formatOptions: {},
     maxWidth: 500,
   };
 
@@ -221,6 +224,7 @@ export class FieldValuesWidget extends Component {
       multi,
       autoFocus,
       color,
+      formatOptions,
     } = this.props;
     const { loadingState } = this.state;
 
@@ -281,7 +285,9 @@ export class FieldValuesWidget extends Component {
             <RemappedValue
               value={value}
               column={field}
+              {...formatOptions}
               round={false}
+              compact={false}
               autoLoad={true}
             />
           )}
@@ -291,6 +297,7 @@ export class FieldValuesWidget extends Component {
               column={field}
               round={false}
               autoLoad={false}
+              {...formatOptions}
             />
           )}
           layoutRenderer={props => (

--- a/frontend/src/metabase/components/Value.jsx
+++ b/frontend/src/metabase/components/Value.jsx
@@ -14,6 +14,9 @@ type Props = {
 } & FormattingOptions;
 
 const Value = ({ value, ...options }: Props) => {
+  if (options.hide) {
+    return null;
+  }
   if (options.remap) {
     return <RemappedValue value={value} {...options} />;
   }

--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -47,6 +47,7 @@ const PRECISION_NUMBER_FORMATTER = d3.format(".2r");
 const FIXED_NUMBER_FORMATTER = d3.format(",.f");
 const FIXED_NUMBER_FORMATTER_NO_COMMA = d3.format(".f");
 const DECIMAL_DEGREES_FORMATTER = d3.format(".08f");
+const DECIMAL_DEGREES_FORMATTER_COMPACT = d3.format(".02f");
 const BINNING_DEGREES_FORMATTER = (value, binWidth) => {
   return d3.format(`.0${decimalCount(binWidth)}f`)(value);
 };
@@ -109,7 +110,9 @@ export function formatCoordinate(
 
   const formattedValue = binWidth
     ? BINNING_DEGREES_FORMATTER(value, binWidth)
-    : DECIMAL_DEGREES_FORMATTER(value);
+    : options.compact
+      ? DECIMAL_DEGREES_FORMATTER_COMPACT(value)
+      : DECIMAL_DEGREES_FORMATTER(value);
   return formattedValue + "°" + direction;
 }
 

--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -196,6 +196,7 @@ function equivalentArgument(field, table) {
     return {
       type: "select",
       values: [{ key: true, name: t`True` }, { key: false, name: t`False` }],
+      default: true,
     };
   }
 
@@ -217,15 +218,23 @@ function equivalentArgument(field, table) {
 }
 
 function longitudeFieldSelectArgument(field, table) {
-  return {
-    type: "select",
-    values: table.fields
-      .filter(field => isa(field.special_type, TYPE.Longitude))
-      .map(field => ({
-        key: field.id,
-        name: field.display_name,
-      })),
-  };
+  const values = table.fields
+    .filter(field => isa(field.special_type, TYPE.Longitude))
+    .map(field => ({
+      key: field.id,
+      name: field.display_name,
+    }));
+  if (values.length === 1) {
+    return {
+      type: "hidden",
+      default: values[0].key,
+    };
+  } else {
+    return {
+      type: "select",
+      values: values,
+    };
+  }
 }
 
 const CASE_SENSITIVE_OPTION = {
@@ -275,6 +284,13 @@ const OPERATORS = {
       t`Enter left longitude`,
       t`Enter lower latitude`,
       t`Enter right longitude`,
+    ],
+    formatOptions: [
+      { hide: true },
+      { column: { special_type: TYPE.Latitude }, compact: true },
+      { column: { special_type: TYPE.Longitude }, compact: true },
+      { column: { special_type: TYPE.Latitude }, compact: true },
+      { column: { special_type: TYPE.Longitude }, compact: true },
     ],
   },
   BETWEEN: {
@@ -358,7 +374,7 @@ const OPERATORS_BY_TYPE_ORDERED = {
     { name: "INSIDE", verboseName: t`Inside` },
   ],
   [BOOLEAN]: [
-    { name: "=", verboseName: t`Is`, multi: false, defaults: [true] },
+    { name: "=", verboseName: t`Is`, multi: false },
     { name: "IS_NULL", verboseName: t`Is empty` },
     { name: "NOT_NULL", verboseName: t`Not empty` },
   ],
@@ -628,4 +644,10 @@ export function computeMetadataStrength(table) {
   }
 
   return completed / total;
+}
+
+export function getFilterArgumentFormatOptions(operator, index) {
+  return (
+    (operator && operator.formatOptions && operator.formatOptions[index]) || {}
+  );
 }

--- a/frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx
@@ -16,7 +16,11 @@ import FieldValuesWidget from "metabase/components/FieldValuesWidget.jsx";
 import Icon from "metabase/components/Icon.jsx";
 
 import Query from "metabase/lib/query";
-import { isDate, isTime } from "metabase/lib/schema_metadata";
+import {
+  isDate,
+  isTime,
+  getFilterArgumentFormatOptions,
+} from "metabase/lib/schema_metadata";
 import { formatField, singularize } from "metabase/lib/formatting";
 
 import cx from "classnames";
@@ -136,8 +140,8 @@ export default class FilterPopover extends Component {
 
     if (operator) {
       for (let i = 0; i < operator.fields.length; i++) {
-        if (operator.defaults && operator.defaults[i] !== undefined) {
-          filter.push(operator.defaults[i]);
+        if (operator.fields[i].default !== undefined) {
+          filter.push(operator.fields[i].default);
         } else {
           filter.push(undefined);
         }
@@ -220,7 +224,9 @@ export default class FilterPopover extends Component {
           values = [this.state.filter[2 + index]];
           onValuesChange = values => this.setValue(index, values[0]);
         }
-        if (operatorField.type === "select") {
+        if (operatorField.type === "hidden") {
+          return null;
+        } else if (operatorField.type === "select") {
           return (
             <SelectPicker
               key={index}
@@ -244,6 +250,7 @@ export default class FilterPopover extends Component {
               searchField={field.filterSearchField()}
               autoFocus={index === 0}
               alwaysShowOptions={operator.fields.length === 1}
+              formatOptions={getFilterArgumentFormatOptions(operator, index)}
               minWidth={440}
               maxWidth={440}
             />

--- a/frontend/src/metabase/query_builder/components/filters/FilterWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterWidget.jsx
@@ -10,6 +10,7 @@ import Value from "metabase/components/Value";
 
 import { generateTimeFilterValuesDescriptions } from "metabase/lib/query_time";
 import { hasFilterOptions } from "metabase/lib/query/filter";
+import { getFilterArgumentFormatOptions } from "metabase/lib/schema_metadata";
 
 import cx from "classnames";
 import _ from "underscore";
@@ -76,10 +77,20 @@ export default class FilterWidget extends Component {
     } else if (dimension.field().isDate() && !dimension.field().isTime()) {
       formattedValues = generateTimeFilterValuesDescriptions(filter);
     } else {
-      formattedValues = values
-        .filter(value => value !== undefined)
-        .map((value, index) => (
-          <Value key={index} value={value} column={dimension.field()} remap />
+      const valuesWithOptions = values.map((value, index) => [
+        value,
+        getFilterArgumentFormatOptions(operator, index),
+      ]);
+      formattedValues = valuesWithOptions
+        .filter(([value, options]) => value !== undefined && !options.hide)
+        .map(([value, options], index) => (
+          <Value
+            key={index}
+            value={value}
+            column={dimension.field()}
+            remap
+            {...options}
+          />
         ));
     }
 


### PR DESCRIPTION
* adds a way to set formatting options for filter arguments, so we can format latitude/longitude correctly
* add compact formatting for lat/lon for "inside" filter
* if there's only one option for the longitude field just default to it and don't show the widget. this is probably the common case, no point in confusing users by asking them to select the longitude field

<img width="445" alt="screenshot 2018-02-23 14 20 08" src="https://user-images.githubusercontent.com/18193/36582585-ada03a62-18a4-11e8-9b3b-2f19c54c7f38.png">
