### PR TITLE
FieldLiterals on date fields should parse as dates [ci drivers]

### DIFF
--- a/src/metabase/query_processor/middleware/expand.clj
+++ b/src/metabase/query_processor/middleware/expand.clj
@@ -109,7 +109,10 @@
     (instance? DateTimeValue v)         v
     (instance? RelativeDatetime v)      (i/map->RelativeDateTimeValue (assoc v :unit (datetime-unit f v), :field (datetime-field f (datetime-unit f v))))
     (instance? DateTimeField f)         (i/map->DateTimeValue {:value (u/->Timestamp v), :field f})
-    (instance? FieldLiteral f)          (i/map->Value {:value v, :field f})
+    (instance? FieldLiteral f)          (if (isa? (:base-type f) :type/DateTime)
+                                          (i/map->DateTimeValue {:value (u/->Timestamp v)
+                                                                 :field (i/map->DateTimeField {:field f :unit :default})})
+                                          (i/map->Value {:value v, :field f}))
     :else                               (i/map->ValuePlaceholder {:field-placeholder (field f), :value v})))
 
 (s/defn ^:private field-or-value

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -922,7 +922,7 @@
   "Parse `TIME-STR` and return a `java.sql.Time` instance. Returns nil
   if `TIME-STR` can't be parsed."
   ([^String date-str]
-   (str->date-time date-str nil))
+   (str->time date-str nil))
   ([^String date-str ^TimeZone tz]
    (some-> (str->date-time-with-formatters ordered-time-parsers date-str tz)
            coerce/to-long

--- a/test/metabase/query_processor/middleware/fetch_source_query_test.clj
+++ b/test/metabase/query_processor/middleware/fetch_source_query_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.query-processor.middleware.fetch-source-query-test
-  (:require [expectations :refer [expect]]
+  (:require [clj-time.coerce :as tcoerce]
+            [expectations :refer [expect]]
             [medley.core :as m]
             [metabase
              [query-processor :as qp]
@@ -46,23 +47,47 @@
                                     :aggregation  [:count]
                                     :breakout     [[:field-literal :price :type/Integer]]}})))
 
+(defn- expand-and-scrub [query-map]
+  (-> query-map
+      qp/expand
+      (m/dissoc-in [:database :features])
+      (m/dissoc-in [:database :details])
+      (m/dissoc-in [:database :timezone])))
+
+(defn default-expanded-results [query]
+  {:database     {:name "test-data", :id (data/id), :engine :h2}
+   :type         :query
+   :fk-field-ids #{}
+   :query        query})
 
 ;; test that the `metabase.query-processor/expand` function properly handles nested queries (this function should call `fetch-source-query`)
 (expect
-  {:database     {:name "test-data", :id (data/id), :engine :h2}
-   :type         :query
-   :query        {:source-query {:source-table {:schema "PUBLIC", :name "VENUES", :id (data/id :venues)}
-                                 :join-tables  nil}}
-   :fk-field-ids #{}}
+  (default-expanded-results
+   {:source-query {:source-table {:schema "PUBLIC", :name "VENUES", :id (data/id :venues)}
+                   :join-tables  nil}})
   (tt/with-temp Card [card {:dataset_query {:database (data/id)
                                             :type     :query
                                             :query    {:source-table (data/id :venues)}}}]
-    (-> (qp/expand {:database database/virtual-id
-                    :type     :query
-                    :query    {:source-table (str "card__" (u/get-id card))}})
-        (m/dissoc-in [:database :features])
-        (m/dissoc-in [:database :details])
-        (m/dissoc-in [:database :timezone]))))
+    (expand-and-scrub {:database database/virtual-id
+                       :type     :query
+                       :query    {:source-table (str "card__" (u/get-id card))}})))
+
+(expect
+  (default-expanded-results
+   {:source-query {:source-table {:schema "PUBLIC" :name "CHECKINS" :id (data/id :checkins)}, :join-tables nil}
+    :filter {:filter-type :between,
+             :field {:field-name "date", :base-type :type/Date},
+             :min-val {:value (tcoerce/to-timestamp (u/str->date-time "2015-01-01"))
+                       :field {:field {:field-name "date", :base-type :type/Date}, :unit :default}},
+             :max-val {:value (tcoerce/to-timestamp (u/str->date-time "2015-02-01"))
+                       :field {:field {:field-name "date", :base-type :type/Date}, :unit :default}}}})
+  (tt/with-temp Card [card {:dataset_query {:database (data/id)
+                                            :type     :query
+                                            :query    {:source-table (data/id :checkins)}}}]
+    (expand-and-scrub {:database database/virtual-id
+                       :type     :query
+                       :query    {:source-table (str "card__" (u/get-id card))
+                                  :filter ["BETWEEN" ["field-id" ["field-literal" "date" "type/Date"]] "2015-01-01" "2015-02-01"]}})))
 
 ;; make sure that nested nested queries work as expected
 (expect
@@ -83,23 +108,18 @@
                                                        :query    {:source-table (str "card__" (u/get-id card-2)), :limit 25}})))
 
 (expect
-  {:database     {:name "test-data", :id (data/id), :engine :h2}
-   :type         :query
-   :query        {:limit        25
-                  :source-query {:limit 50
-                                 :source-query {:source-table {:schema "PUBLIC", :name "VENUES", :id (data/id :venues)}
-                                                :limit        100
-                                                :join-tables  nil}}}
-   :fk-field-ids #{}}
+  (default-expanded-results
+   {:limit        25
+    :source-query {:limit 50
+                   :source-query {:source-table {:schema "PUBLIC", :name "VENUES", :id (data/id :venues)}
+                                  :limit        100
+                                  :join-tables  nil}}})
   (tt/with-temp* [Card [card-1 {:dataset_query {:database (data/id)
                                                 :type     :query
                                                 :query    {:source-table (data/id :venues), :limit 100}}}]
                   Card [card-2 {:dataset_query {:database database/virtual-id
                                                 :type     :query
                                                 :query    {:source-table (str "card__" (u/get-id card-1)), :limit 50}}}]]
-    (-> (qp/expand {:database database/virtual-id
-                    :type     :query
-                    :query    {:source-table (str "card__" (u/get-id card-2)), :limit 25}})
-        (m/dissoc-in [:database :features])
-        (m/dissoc-in [:database :details])
-        (m/dissoc-in [:database :timezone]))))
+    (expand-and-scrub {:database database/virtual-id
+                       :type     :query
+                       :query    {:source-table (str "card__" (u/get-id card-2)), :limit 25}})))


### PR DESCRIPTION
Specifically this occurred when filtering on a field from a nested
query. The date string wasn't getting parsed as a date and just
getting passed as a string to the database causing a type mismatch.

Fixes #6988

