### PR TITLE
Include table visualization in pulses and alerts

### DIFF
--- a/frontend/src/metabase/pulse/components/PulseCardPreview.jsx
+++ b/frontend/src/metabase/pulse/components/PulseCardPreview.jsx
@@ -67,7 +67,12 @@ export default class PulseCardPreview extends Component {
       cardPreview &&
       cardPreview.pulse_card_type == null;
     return (
-      <div className="flex relative flex-full">
+      <div
+        className="flex relative flex-full"
+        style={{
+          maxWidth: 379,
+        }}
+      >
         <div
           className="absolute p2 text-grey-2"
           style={{

--- a/frontend/src/metabase/pulse/components/PulseEditCards.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEditCards.jsx
@@ -11,6 +11,17 @@ import MetabaseAnalytics from "metabase/lib/analytics";
 
 const SOFT_LIMIT = 10;
 const HARD_LIMIT = 25;
+const TABLE_MAX_ROWS = 20;
+const TABLE_MAX_COLS = 10;
+
+function isAutoAttached(cardPreview) {
+  return (
+    cardPreview &&
+    cardPreview.pulse_card_type === "table" &&
+    (cardPreview.row_count > TABLE_MAX_ROWS ||
+      cardPreview.col_cound > TABLE_MAX_COLS)
+  );
+}
 
 export default class PulseEditCards extends Component {
   constructor(props) {
@@ -69,9 +80,10 @@ export default class PulseEditCards extends Component {
     const showSoftLimitWarning = index === SOFT_LIMIT;
     let notices = [];
     const hasAttachment =
-      this.props.attachmentsEnabled &&
-      card &&
-      (card.include_csv || card.include_xls);
+      isAutoAttached(cardPreview) ||
+      (this.props.attachmentsEnabled &&
+        card &&
+        (card.include_csv || card.include_xls));
     if (hasAttachment) {
       notices.push({
         head: t`Attachment`,
@@ -85,6 +97,13 @@ export default class PulseEditCards extends Component {
       });
     }
     if (cardPreview) {
+      if (isAutoAttached(cardPreview)) {
+        notices.push({
+          type: "warning",
+          head: t`Heads up`,
+          body: t`We'll show the first 10 columns and 20 rows of this table in your Pulse. If you email this, we'll add a file attachment with all columns and up to 2,000 rows.`,
+        });
+      }
       if (cardPreview.pulse_card_type == null && !hasAttachment) {
         notices.push({
           type: "warning",
@@ -164,7 +183,10 @@ export default class PulseEditCards extends Component {
                         onChange={this.setCard.bind(this, index)}
                         onRemove={this.removeCard.bind(this, index)}
                         fetchPulseCardPreview={this.props.fetchPulseCardPreview}
-                        attachmentsEnabled={this.props.attachmentsEnabled}
+                        attachmentsEnabled={
+                          this.props.attachmentsEnabled &&
+                          !isAutoAttached(cardPreviews[card.id])
+                        }
                         trackPulseEvent={this.trackPulseEvent}
                       />
                     ) : (

--- a/frontend/test/pulse/pulse.integ.spec.js
+++ b/frontend/test/pulse/pulse.integ.spec.js
@@ -133,8 +133,8 @@ describe("Pulse", () => {
     // NOTE: check text content since enzyme doesn't doesn't seem to work well with dangerouslySetInnerHTML
     expect(previews.at(0).text()).toBe("count12,805");
     expect(previews.at(0).find(".Icon-attachment").length).toBe(1);
-    expect(previews.at(1).text()).toBe(
-      "tableThis question will be added as a file attachment",
+    expect(previews.at(1).text()).toEqual(
+      expect.stringContaining("Showing 20 of 12,805 rows"),
     );
     expect(previews.at(1).find(".Icon-attachment").length).toBe(0);
 
@@ -144,8 +144,8 @@ describe("Pulse", () => {
     previews = app.find(PulseCardPreview);
     expect(previews.at(0).text()).toBe("count12,805");
     expect(previews.at(0).find(".Icon-attachment").length).toBe(0);
-    expect(previews.at(1).text()).toBe(
-      "tableThis question won't be included in your Pulse",
+    expect(previews.at(1).text()).toEqual(
+      expect.stringContaining("Showing 20 of 12,805 rows"),
     );
     expect(previews.at(1).find(".Icon-attachment").length).toBe(0);
 

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -594,7 +594,7 @@
   "Run the query for Card with PARAMETERS and CONSTRAINTS, and return results in the usual format."
   {:style/indent 1}
   [card-id & {:keys [parameters constraints context dashboard-id]
-              :or   {constraints dataset-api/default-query-constraints
+              :or   {constraints qp/default-query-constraints
                      context     :question}}]
   {:pre [(u/maybe? sequential? parameters)]}
   (let [card    (api/read-check (hydrate (Card card-id) :in_public_dashboard))

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -4,6 +4,7 @@
             [compojure.core :refer [DELETE GET POST PUT]]
             [metabase
              [events :as events]
+             [query-processor :as qp]
              [util :as u]]
             [metabase.api
              [common :as api]
@@ -123,7 +124,7 @@
   [{:keys [dataset_query]}]
   (u/ignore-exceptions
     [(qp-util/query-hash dataset_query)
-     (qp-util/query-hash (assoc dataset_query :constraints dataset/default-query-constraints))]))
+     (qp-util/query-hash (assoc dataset_query :constraints qp/default-query-constraints))]))
 
 (defn- dashcard->query-hashes
   "Return a sequence of all the query hashes for this DASHCARD, including the top-level Card and any Series."

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -21,22 +21,6 @@
              [schema :as su]]
             [schema.core :as s]))
 
-;;; --------------------------------------------------- Constants ----------------------------------------------------
-
-(def ^:private ^:const max-results-bare-rows
-  "Maximum number of rows to return specifically on :rows type queries via the API."
-  2000)
-
-(def ^:private ^:const max-results
-  "General maximum number of rows to return from an API query."
-  10000)
-
-(def ^:const default-query-constraints
-  "Default map of constraints that we apply on dataset queries executed by the api."
-  {:max-results           max-results
-   :max-results-bare-rows max-results-bare-rows})
-
-
 ;;; -------------------------------------------- Running a Query Normally --------------------------------------------
 
 (defn- query->source-card-id
@@ -61,8 +45,8 @@
   (let [source-card-id (query->source-card-id query)]
     (api/cancellable-json-response
      (fn []
-       (qp/process-query-and-save-execution! (assoc query :constraints default-query-constraints)
-         {:executed-by api/*current-user-id*, :context :ad-hoc, :card-id source-card-id, :nested? (boolean source-card-id)})))))
+       (qp/process-query-and-save-with-max! query {:executed-by api/*current-user-id*, :context :ad-hoc,
+                                                   :card-id     source-card-id,        :nested? (boolean source-card-id)})))))
 
 
 ;;; ----------------------------------- Downloading Query Results in Other Formats -----------------------------------
@@ -151,7 +135,7 @@
   ;; try calculating the average for the query as it was given to us, otherwise with the default constraints if
   ;; there's no data there. If we still can't find relevant info, just default to 0
   {:average (or (query/average-execution-time-ms (qputil/query-hash query))
-                (query/average-execution-time-ms (qputil/query-hash (assoc query :constraints default-query-constraints)))
+                (query/average-execution-time-ms (qputil/query-hash (assoc query :constraints qp/default-query-constraints)))
                 0)})
 
 (api/define-routes)

--- a/src/metabase/api/pulse.clj
+++ b/src/metabase/api/pulse.clj
@@ -133,7 +133,8 @@
      :pulse_card_html card-html
      :pulse_card_name (:name card)
      :pulse_card_url  (urls/card-url (:id card))
-     :row_count       (:row_count result)}))
+     :row_count       (:row_count result)
+     :col_count       (count (:cols (:data result)))}))
 
 (api/defendpoint GET "/preview_card_png/:id"
   "Get PNG rendering of a `Card` with ID."

--- a/src/metabase/email/_footer_pulse.mustache
+++ b/src/metabase/email/_footer_pulse.mustache
@@ -1,0 +1,11 @@
+  </div>
+  {{#quotation}}
+    <div style="padding-top: 2em; padding-bottom: 1em; text-align: left; color: #CCCCCC; font-size: small;">"{{quotation}}"<br/>- {{quotationAuthor}}</div>
+  {{/quotation}}
+  {{#logoFooter}}
+    <div style="padding-bottom: 2em; padding-top: 1em; text-align: left;">
+      <img width="32" height="40" src="http://static.metabase.com/email_logo.png"/>
+    </div>
+  {{/logoFooter}}
+</body>
+</html>

--- a/src/metabase/email/_header.mustache
+++ b/src/metabase/email/_header.mustache
@@ -14,4 +14,4 @@
       <img width="47" height="60" src="http://static.metabase.com/email_logo.png"/>
     </div>
   {{/logoHeader}}
-  <div class="container" style="margin: 0 auto; padding: 0 0 2em 0; max-width: 500px; font-size: 16px; line-height: 24px; color: #616D75;">
+  <div class="container" style="margin: 0; padding: 0 0 2em 0; max-width: 100%; font-size: 16px; line-height: 24px; color: #616D75;">

--- a/src/metabase/email/pulse.mustache
+++ b/src/metabase/email/pulse.mustache
@@ -1,8 +1,8 @@
 {{> metabase/email/_header}}
   {{#pulseName}}
-    <h1 style="{{sectionStyle}} margin: 16px; color: {{colorGrey4}};">
+    <h1 style="{{sectionStyle}} margin: 16px; color: {{color-brand}};">
       {{pulseName}}
     </h1>
   {{/pulseName}}
   {{{pulse}}}
-{{> metabase/email/_footer}}
+{{> metabase/email/_footer_pulse}}

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -34,9 +34,10 @@
     (let [{:keys [creator_id dataset_query]} card]
       (try
         {:card   card
-         :result (qp/process-query-and-save-execution! dataset_query
-                   (merge {:executed-by creator_id, :context :pulse, :card-id card-id}
-                          options))}
+         :result (qp/process-query-and-save-with-max! dataset_query (merge {:executed-by creator_id,
+                                                                            :context     :pulse,
+                                                                            :card-id     card-id}
+                                                                           options))}
         (catch Throwable t
           (log/warn (format "Error running card query (%n)" card-id) t))))))
 

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -44,14 +44,17 @@
 (def ^:private ^:const sparkline-pad 8)
 
 ;;; ## STYLES
-(def ^:private ^:const color-brand  "rgb(45,134,212)")
-(def ^:private ^:const color-purple "rgb(135,93,175)")
-(def ^:private ^:const color-gold   "#F9D45C")
-(def ^:private ^:const color-error  "#EF8C8C")
-(def ^:private ^:const color-gray-1 "rgb(248,248,248)")
-(def ^:private ^:const color-gray-2 "rgb(189,193,191)")
-(def ^:private ^:const color-gray-3 "rgb(124,131,129)")
+(def ^:private ^:const color-brand      "rgb(45,134,212)")
+(def ^:private ^:const color-purple     "rgb(135,93,175)")
+(def ^:private ^:const color-gold       "#F9D45C")
+(def ^:private ^:const color-error      "#EF8C8C")
+(def ^:private ^:const color-gray-1     "rgb(248,248,248)")
+(def ^:private ^:const color-gray-2     "rgb(189,193,191)")
+(def ^:private ^:const color-gray-3     "rgb(124,131,129)")
 (def ^:const color-gray-4 "A ~25% Gray color." "rgb(57,67,64)")
+(def ^:private ^:const color-dark-gray  "#616D75")
+(def ^:private ^:const color-row-border "#EDF0F1")
+
 
 (def ^:private ^:const font-style    {:font-family "Lato, \"Helvetica Neue\", Helvetica, Arial, sans-serif"})
 (def ^:const section-style
@@ -70,19 +73,47 @@
                      :color       color-brand}))
 
 (def ^:private ^:const bar-th-style
-  (merge font-style {:font-size      :10px
-                     :font-weight    400
-                     :color          color-gray-4
-                     :border-bottom  (str "4px solid " color-gray-1)
-                     :padding-top    :0px
-                     :padding-bottom :10px}))
+  (merge font-style {:font-size       :14.22px
+                     :font-weight     700
+                     :color           color-gray-4
+                     :border-bottom   (str "1px solid " color-row-border)
+                     :padding-top     :20px
+                     :padding-bottom  :5px}))
+
+;; TO-DO for @senior: apply this style to headings of numeric columns
+(def ^:private ^:const bar-th-numeric-style
+  (merge font-style {:text-align      :right
+                     :font-size       :14.22px
+                     :font-weight     700
+                     :color           color-gray-4
+                     :border-bottom   (str "1px solid " color-row-border)
+                     :padding-top     :20px
+                     :padding-bottom  :5px}))
 
 (def ^:private ^:const bar-td-style
-  (merge font-style {:font-size     :16px
-                     :font-weight   400
-                     :text-align    :left
-                     :padding-right :1em
-                     :padding-top   :8px}))
+  (merge font-style {:font-size      :14.22px
+                     :font-weight    400
+                     :color          color-dark-gray
+                     :text-align     :left
+                     :padding-right  :1em
+                     :padding-top    :2px
+                     :padding-bottom :1px
+                     :max-width      :500px
+                     :overflow       :hidden
+                     :text-overflow  :ellipsis
+                     :border-bottom  (str "1px solid " color-row-border)}))
+
+;; TO-DO for @senior: apply this style to numeric cells
+(def ^:private ^:const bar-td-style-numeric
+  (merge font-style {:font-size      :14.22px
+                     :font-weight    400
+                     :color          color-dark-gray
+                     :text-align     :right
+                     :padding-right  :1em
+                     :padding-top    :2px
+                     :padding-bottom :1px
+                     :font-family    "Courier, Monospace"
+                     :border-bottom  (str "1px solid " color-row-border)}))
 
 (def ^:private RenderedPulseCard
   "Schema used for functions that operate on pulse card contents and their attachments"

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -8,7 +8,9 @@
              [string :as str]]
             [clojure.java.io :as io]
             [clojure.tools.logging :as log]
-            [hiccup.core :refer [h html]]
+            [hiccup
+             [core :refer [h html]]
+             [util :as hutil]]
             [metabase.util :as u]
             [metabase.util
              [ui-logic :as ui-logic]
@@ -35,8 +37,8 @@
 ;;; # ------------------------------------------------------------ STYLES ------------------------------------------------------------
 
 (def ^:private ^:const card-width 400)
-(def ^:private ^:const rows-limit 10)
-(def ^:private ^:const cols-limit 3)
+(def ^:private ^:const rows-limit 20)
+(def ^:private ^:const cols-limit 10)
 (def ^:private ^:const sparkline-dot-radius 6)
 (def ^:private ^:const sparkline-thickness 3)
 (def ^:private ^:const sparkline-pad 8)
@@ -98,6 +100,11 @@
                       :let  [v (if (keyword? v) (name v) v)]]
                   (str (name k) ": " v ";"))))
 
+(defn- graphing-columns [card {:keys [cols] :as data}]
+  [(or (ui-logic/x-axis-rowfn card data)
+       first)
+   (or (ui-logic/y-axis-rowfn card data)
+       second)])
 
 (defn- datetime-field?
   [field]
@@ -109,12 +116,53 @@
   (or (isa? (:base_type field)    :type/Number)
       (isa? (:special_type field) :type/Number)))
 
+(defn detect-pulse-card-type
+  "Determine the pulse (visualization) type of a CARD, e.g. `:scalar` or `:bar`."
+  [card data]
+  (let [col-count                 (-> data :cols count)
+        row-count                 (-> data :rows count)
+        [col-1-rowfn col-2-rowfn] (graphing-columns card data)
+        col-1                     (col-1-rowfn (:cols data))
+        col-2                     (col-2-rowfn (:cols data))
+        aggregation               (-> card :dataset_query :query :aggregation first)]
+    (cond
+      (or (zero? row-count)
+          ;; Many aggregations result in [[nil]] if there are no rows to aggregate after filters
+          (= [[nil]] (-> data :rows)))                             :empty
+      (contains? #{:pin_map :state :country} (:display card))      nil
+      (and (= col-count 1)
+           (= row-count 1))                                        :scalar
+      (and (= col-count 2)
+           (> row-count 1)
+           (datetime-field? col-1)
+           (number-field? col-2))                                  :sparkline
+      (and (= col-count 2)
+           (number-field? col-2))                                  :bar
+      :else                                                        :table)))
+
+(defn include-csv-attachment?
+  "Returns true if this card and resultset should include a CSV attachment"
+  [{:keys [include_csv] :as card} {:keys [cols rows] :as result-data}]
+  (or (:include_csv card)
+      (and (= :table (detect-pulse-card-type card result-data))
+           (or (< cols-limit (count cols))
+               (< rows-limit (count rows))))))
+
+(defn include-xls-attachment?
+  "Returns true if this card and resultset should include an XLS attachment"
+  [{:keys [include_csv] :as card} result-data]
+  (:include_xls card))
+
 
 ;;; # ------------------------------------------------------------ FORMATTING ------------------------------------------------------------
 
+(defrecord NumericWrapper [num-str]
+  hutil/ToString
+  (to-str [_] num-str))
+
 (defn- format-number
   [n]
-  (cl-format nil (if (integer? n) "~:d" "~,2f") n))
+  (NumericWrapper. (cl-format nil (if (integer? n) "~:d" "~,2f") n)))
 
 (defn- reformat-timestamp [timezone old-format-timestamp new-format-string]
   (f/unparse (f/with-zone (f/formatter new-format-string)
@@ -251,22 +299,35 @@
     (render-to-png html os width)
     (.toByteArray os)))
 
+
+(defn- heading-style-for-type
+  [cell]
+  (if (instance? NumericWrapper cell)
+    bar-th-numeric-style
+    bar-th-style))
+
+(defn- row-style-for-type
+  [cell]
+  (if (instance? NumericWrapper cell)
+    bar-td-style-numeric
+    bar-td-style))
+
 (defn- render-table
   [header+rows]
-  [:table {:style (style {:padding-bottom :8px, :border-bottom (str "4px solid " color-gray-1)})}
+  [:table {:style (style {:max-width (str "100%"), :white-space :nowrap, :padding-bottom :8px, :border-collapse :collapse})}
    (let [{header-row :row bar-width :bar-width} (first header+rows)]
      [:thead
       [:tr
        (for [header-cell header-row]
-         [:th {:style (style bar-td-style bar-th-style {:min-width :60px})}
+         [:th {:style (style (row-style-for-type header-cell) (heading-style-for-type header-cell) {:min-width :60px})}
           (h header-cell)])
        (when bar-width
          [:th {:style (style bar-td-style bar-th-style {:width (str bar-width "%")})}])]])
    [:tbody
     (map-indexed (fn [row-idx {:keys [row bar-width]}]
-                   [:tr {:style (style {:color (if (odd? row-idx) color-gray-2 color-gray-3)})}
+                   [:tr {:style (style {:color color-gray-3})}
                     (map-indexed (fn [col-idx cell]
-                                   [:td {:style (style bar-td-style (when (and bar-width (= col-idx 1)) {:font-weight 700}))}
+                                   [:td {:style (style (row-style-for-type cell) (when (and bar-width (= col-idx 1)) {:font-weight 700}))}
                                     (h cell)])
                                  row)
                     (when bar-width
@@ -289,18 +350,27 @@
               :when remapped_from]
           [remapped_from col-idx])))
 
+(defn- show-in-table? [{:keys [special_type visibility_type] :as column}]
+  (and (not (isa? special_type :type/Description))
+       (not (contains? #{:details-only :retired :sensitive} visibility_type))))
+
 (defn- query-results->header-row
   "Returns a row structure with header info from `COLS`. These values
   are strings that are ready to be rendered as HTML"
   [remapping-lookup cols include-bar?]
   {:row (for [maybe-remapped-col cols
-              :let [col (if (:remapped_to maybe-remapped-col)
-                          (nth cols (get remapping-lookup (:name maybe-remapped-col)))
-                          maybe-remapped-col)]
+              :when (show-in-table? maybe-remapped-col)
+              :let [{:keys [base_type special_type] :as col} (if (:remapped_to maybe-remapped-col)
+                                                               (nth cols (get remapping-lookup (:name maybe-remapped-col)))
+                                                               maybe-remapped-col)
+                    column-name (name (or (:display_name col) (:name col)))]
               ;; If this column is remapped from another, it's already
               ;; in the output and should be skipped
               :when (not (:remapped_from maybe-remapped-col))]
-          (str/upper-case (name (or (:display_name col) (:name col)))))
+          (if (or (isa? base_type :type/Number)
+                  (isa? special_type :type/Number))
+            (NumericWrapper. column-name)
+            column-name))
    :bar-width (when include-bar? 99)})
 
 (defn- query-results->row-seq
@@ -311,7 +381,8 @@
                   ;; cast to double to avoid "Non-terminating decimal expansion" errors
                   (float (* 100 (/ (double (bar-column row)) max-value))))
      :row (for [[maybe-remapped-col maybe-remapped-row-cell] (map vector cols row)
-                :when (not (:remapped_from maybe-remapped-col))
+                :when (and (not (:remapped_from maybe-remapped-col))
+                           (show-in-table? maybe-remapped-col))
                 :let [[col row-cell] (if (:remapped_to maybe-remapped-col)
                                        [(nth cols (get remapping-lookup (:name maybe-remapped-col)))
                                         (nth row (get remapping-lookup (:name maybe-remapped-col)))]
@@ -328,38 +399,58 @@
      (query-results->header-row remapping-lookup limited-cols bar-column)
      (query-results->row-seq timezone remapping-lookup limited-cols (take rows-limit rows) bar-column max-value))))
 
+(defn- strong-limit-text [number]
+  [:strong {:style (style {:color color-gray-3})} (h (format-number number))])
+
 (defn- render-truncation-warning
   [col-limit col-count row-limit row-count]
-  (if (or (> row-count row-limit)
-          (> col-count col-limit))
-    [:div {:style (style {:padding-top :16px})}
-     (cond
-       (> row-count row-limit)
-       [:div {:style (style {:color color-gray-2
-                             :padding-bottom :10px})}
-        "Showing " [:strong {:style (style {:color color-gray-3})} (format-number row-limit)]
-        " of "     [:strong {:style (style {:color color-gray-3})} (format-number row-count)]
-        " rows."]
+  (let [over-row-limit (> row-count row-limit)
+        over-col-limit (> col-count col-limit)]
+    (when (or over-row-limit over-col-limit)
+      [:div {:style (style {:padding-top :16px})}
+       (cond
 
-       (> col-count col-limit)
-       [:div {:style (style {:color          color-gray-2
-                             :padding-bottom :10px})}
-        "Showing " [:strong {:style (style {:color color-gray-3})} (format-number col-limit)]
-        " of "     [:strong {:style (style {:color color-gray-3})} (format-number col-count)]
-        " columns."])]))
+         (and over-row-limit over-col-limit)
+         [:div {:style (style {:color color-gray-2
+                               :padding-bottom :10px})}
+          "Showing " (strong-limit-text row-limit)
+          " of "     (strong-limit-text row-count)
+          " rows and " (strong-limit-text col-limit)
+          " of "     (strong-limit-text col-count)
+          " columns."]
+
+         over-row-limit
+         [:div {:style (style {:color color-gray-2
+                               :padding-bottom :10px})}
+          "Showing " (strong-limit-text row-limit)
+          " of "     (strong-limit-text row-count)
+          " rows."]
+
+         over-col-limit
+         [:div {:style (style {:color          color-gray-2
+                               :padding-bottom :10px})}
+          "Showing " (strong-limit-text col-limit)
+          " of "     (strong-limit-text col-count)
+          " columns."])])))
+
+(defn- attached-results-text
+  "Returns hiccup structures to indicate truncated results are available as an attachment"
+  [render-type cols cols-limit rows rows-limit]
+  (when (and (not= :inline render-type)
+             (or (< cols-limit (count cols))
+                 (< rows-limit (count rows))))
+    [:div {:style (style {:color color-gray-2})}
+     "More results have been included as a file attachment"]))
 
 (s/defn ^:private render:table :- RenderedPulseCard
-  [timezone card {:keys [cols rows] :as data}]
-  {:attachments nil
-   :content     [:div
-                 (render-table (prep-for-html-rendering timezone cols rows nil nil cols-limit))
-                 (render-truncation-warning cols-limit (count cols) rows-limit (count rows))]})
-
-(defn- graphing-columns [card {:keys [cols] :as data}]
-  [(or (ui-logic/x-axis-rowfn card data)
-       first)
-   (or (ui-logic/y-axis-rowfn card data)
-       second)])
+  [render-type timezone card {:keys [cols rows] :as data}]
+  (let [table-body [:div
+                    (render-table (prep-for-html-rendering timezone cols rows nil nil cols-limit))
+                    (render-truncation-warning cols-limit (count cols) rows-limit (count rows))]]
+    {:attachments nil
+     :content     (if-let [results-attached (attached-results-text render-type cols cols-limit rows rows-limit)]
+                    (list results-attached table-body)
+                    (list table-body))}))
 
 (s/defn ^:private render:bar :- RenderedPulseCard
   [timezone card {:keys [cols rows] :as data}]
@@ -599,31 +690,6 @@
                                       :padding     :16px})}
                  "An error occurred while displaying this card."]})
 
-(defn detect-pulse-card-type
-  "Determine the pulse (visualization) type of a CARD, e.g. `:scalar` or `:bar`."
-  [card data]
-  (let [col-count                 (-> data :cols count)
-        row-count                 (-> data :rows count)
-        [col-1-rowfn col-2-rowfn] (graphing-columns card data)
-        col-1                     (col-1-rowfn (:cols data))
-        col-2                     (col-2-rowfn (:cols data))
-        aggregation               (-> card :dataset_query :query :aggregation first)]
-    (cond
-      (or (zero? row-count)
-          ;; Many aggregations result in [[nil]] if there are no rows to aggregate after filters
-          (= [[nil]] (-> data :rows)))                             :empty
-      (or (> col-count 3)
-          (contains? #{:pin_map :state :country} (:display card))) nil
-      (and (= col-count 1)
-           (= row-count 1))                                        :scalar
-      (and (= col-count 2)
-           (> row-count 1)
-           (datetime-field? col-1)
-           (number-field? col-2))                                  :sparkline
-      (and (= col-count 2)
-           (number-field? col-2))                                  :bar
-      :else                                                        :table)))
-
 (s/defn ^:private make-title-if-needed :- (s/maybe RenderedPulseCard)
   [render-type card]
   (when *include-title*
@@ -659,7 +725,7 @@
       :scalar    (render:scalar    timezone card data)
       :sparkline (render:sparkline render-type timezone card data)
       :bar       (render:bar       timezone card data)
-      :table     (render:table     timezone card data)
+      :table     (render:table     render-type timezone card data)
       (if (is-attached? card)
         (render:attached render-type card data)
         (render:unknown card data)))
@@ -691,16 +757,20 @@
 
 (s/defn render-pulse-section :- RenderedPulseCard
   "Render a specific section of a Pulse, i.e. a single Card, to Hiccup HTML."
-  [timezone {:keys [card result]}]
+  [timezone {card :card {:keys [data] :as result} :result}]
   (let [{:keys [attachments content]} (binding [*include-title* true]
                                         (render-pulse-card :attachment timezone card result))]
     {:attachments attachments
-     :content     [:div {:style (style {:margin-top       :10px
-                                        :margin-bottom    :20px
-                                        :border           "1px solid #dddddd"
-                                        :border-radius    :2px
-                                        :background-color :white
-                                        :box-shadow       "0 1px 2px rgba(0, 0, 0, .08)"})}
+     :content     [:div {:style (style (merge {:margin-top       :10px
+                                               :margin-bottom    :20px}
+                                              ;; Don't include the border on cards rendered with a table as the table
+                                              ;; will be to larger and overrun the border
+                                              (when-not (= :table (detect-pulse-card-type card data))
+                                                {:border           "1px solid #dddddd"
+                                                 :border-radius    :2px
+                                                 :background-color :white
+                                                 :width            "500px !important"
+                                                 :box-shadow       "0 1px 2px rgba(0, 0, 0, .08)"})))}
                    content]}))
 
 (defn render-pulse-card-to-png

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -281,3 +281,22 @@
   (run-and-save-query! (assoc query :info (assoc options
                                             :query-hash (qputil/query-hash query)
                                             :query-type (if (qputil/mbql-query? query) "MBQL" "native")))))
+
+(def ^:private ^:const max-results-bare-rows
+  "Maximum number of rows to return specifically on :rows type queries via the API."
+  2000)
+
+(def ^:private ^:const max-results
+  "General maximum number of rows to return from an API query."
+  10000)
+
+(def default-query-constraints
+  "Default map of constraints that we apply on dataset queries executed by the api."
+  {:max-results           max-results
+   :max-results-bare-rows max-results-bare-rows})
+
+(s/defn process-query-and-save-with-max!
+  "Same as `process-query-and-save-execution!` but will include the default max rows returned as a constraint"
+  {:style/indent 1}
+  [query, options :- DatasetQueryOptions]
+  (process-query-and-save-execution! (assoc query :constraints default-query-constraints) options))

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -8,10 +8,10 @@
             [dk.ative.docjure.spreadsheet :as spreadsheet]
             [expectations :refer :all]
             [medley.core :as m]
-            [metabase.api.dataset :refer [default-query-constraints]]
             [metabase.models
              [database :refer [Database]]
              [query-execution :refer [QueryExecution]]]
+            [metabase.query-processor :as qp]
             [metabase.query-processor.middleware.expand :as ql]
             [metabase.sync :as sync]
             [metabase.test
@@ -75,7 +75,7 @@
                                     (ql/aggregation (ql/count))))
                                 (assoc :type "query")
                                 (assoc-in [:query :aggregation] [{:aggregation-type "count", :custom-name nil}])
-                                (assoc :constraints default-query-constraints))
+                                (assoc :constraints qp/default-query-constraints))
     :started_at             true
     :running_time           true
     :average_execution_time nil}
@@ -113,7 +113,7 @@
     :json_query   {:database    (id)
                    :type        "native"
                    :native      {:query "foobar"}
-                   :constraints default-query-constraints}
+                   :constraints qp/default-query-constraints}
     :started_at   true
     :running_time true}
    ;; QueryExecution entry in the DB

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -2,6 +2,7 @@
   "Tests for /api/user endpoints."
   (:require [expectations :refer :all]
             [metabase
+             [email-test :as et]
              [http-client :as http]
              [middleware :as middleware]
              [util :as u]]
@@ -73,13 +74,14 @@
      :common_name  (str user-name " " user-name)
      :is_superuser false
      :is_qbnewb    true}
-    (do ((user->client :crowberto) :post 200 "user" {:first_name user-name
-                                                     :last_name  user-name
-                                                     :email      email})
-        (u/prog1 (db/select-one [User :email :first_name :last_name :is_superuser :is_qbnewb]
-                   :email email)
-          ;; clean up after ourselves
-          (db/delete! User :email email)))))
+    (et/with-fake-inbox
+      ((user->client :crowberto) :post 200 "user" {:first_name user-name
+                                                   :last_name  user-name
+                                                   :email      email})
+      (u/prog1 (db/select-one [User :email :first_name :last_name :is_superuser :is_qbnewb]
+                              :email email)
+               ;; clean up after ourselves
+               (db/delete! User :email email)))))
 
 
 ;; Test that reactivating a disabled account works

--- a/test/metabase/pulse/render_test.clj
+++ b/test/metabase/pulse/render_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.pulse.render-test
-  (:require [expectations :refer :all]
+  (:require [clojure.walk :as walk]
+            [expectations :refer :all]
             [hiccup.core :refer [html]]
             [metabase.pulse.render :as render :refer :all])
   (:import java.util.TimeZone))
@@ -7,58 +8,120 @@
 (def ^:private pacific-tz (TimeZone/getTimeZone "America/Los_Angeles"))
 
 (def ^:private test-columns
-  [{:name         "ID",
-    :display_name "ID",
-    :base_type    :type/BigInteger
-    :special_type nil}
-   {:name         "latitude"
-    :display_name "Latitude"
-    :base-type    :type/Float
-    :special-type :type/Latitude}
-   {:name         "last_login"
-    :display_name "Last Login"
-    :base_type    :type/DateTime
-    :special_type nil}
-   {:name         "name"
-    :display_name "Name"
-    :base-type    :type/Text
-    :special_type nil}])
+  [{:name            "ID",
+    :display_name    "ID",
+    :base_type       :type/BigInteger
+    :special_type    nil
+    :visibility_type :normal}
+   {:name            "latitude"
+    :display_name    "Latitude"
+    :base_type       :type/Float
+    :special_type    :type/Latitude
+    :visibility_type :normal}
+   {:name            "last_login"
+    :display_name    "Last Login"
+    :base_type       :type/DateTime
+    :special_type    nil
+    :visibility_type :normal}
+   {:name            "name"
+    :display_name    "Name"
+    :base_type       :type/Text
+    :special_type    nil
+    :visibility_type :normal}])
 
 (def ^:private test-data
   [[1 34.0996 "2014-04-01T08:30:00.0000" "Stout Burgers & Beers"]
    [2 34.0406 "2014-12-05T15:15:00.0000" "The Apple Pan"]
    [3 34.0474 "2014-08-01T12:45:00.0000" "The Gorbals"]])
 
+(defn- col-counts [results]
+  (set (map (comp count :row) results)))
+
+(defn- number [x]
+  (#'render/map->NumericWrapper {:num-str x}))
+
+(def ^:private default-header-result
+  [{:row       [(number "ID") (number "Latitude") "Last Login" "Name"]
+    :bar-width nil}
+   #{4}])
+
+(defn- prep-for-html-rendering'
+  [cols rows bar-column max-value]
+  (let [results (#'render/prep-for-html-rendering pacific-tz cols rows bar-column max-value (count cols))]
+    [(first results)
+     (col-counts results)]))
+
+
+
 ;; Testing the format of headers
 (expect
-  {:row ["ID" "LATITUDE" "LAST LOGIN" "NAME"]
-   :bar-width nil}
-  (first (#'render/prep-for-html-rendering pacific-tz test-columns test-data nil nil (count test-columns))))
+  default-header-result
+  (prep-for-html-rendering' test-columns test-data nil nil))
+
+(expect
+  default-header-result
+  (let [cols-with-desc (conj test-columns {:name         "desc_col"
+                                                   :display_name "Description Column"
+                                                   :base_type    :type/Text
+                                                   :special_type :type/Description
+                                                   :visibility_type :normal})
+        data-with-desc (mapv #(conj % "Desc") test-data)]
+    (prep-for-html-rendering' cols-with-desc data-with-desc nil nil)))
+
+(expect
+  default-header-result
+  (let [cols-with-details (conj test-columns {:name            "detail_col"
+                                              :display_name    "Details Column"
+                                              :base_type       :type/Text
+                                              :special_type    nil
+                                              :visibility_type :details-only})
+        data-with-details (mapv #(conj % "Details") test-data)]
+    (prep-for-html-rendering' cols-with-details data-with-details nil nil)))
+
+(expect
+  default-header-result
+  (let [cols-with-sensitive (conj test-columns {:name            "sensitive_col"
+                                                :display_name    "Sensitive Column"
+                                                :base_type       :type/Text
+                                                :special_type    nil
+                                                :visibility_type :sensitive})
+        data-with-sensitive (mapv #(conj % "Sensitive") test-data)]
+    (prep-for-html-rendering' cols-with-sensitive data-with-sensitive nil nil)))
+
+(expect
+  default-header-result
+  (let [columns-with-retired (conj test-columns {:name            "retired_col"
+                                                 :display_name    "Retired Column"
+                                                 :base_type       :type/Text
+                                                 :special_type    nil
+                                                 :visibility_type :retired})
+        data-with-retired    (mapv #(conj % "Retired") test-data)]
+    (prep-for-html-rendering' columns-with-retired data-with-retired nil nil)))
 
 ;; When including a bar column, bar-width is 99%
 (expect
-  {:row ["ID" "LATITUDE" "LAST LOGIN" "NAME"]
-   :bar-width 99}
-  (first (#'render/prep-for-html-rendering pacific-tz test-columns test-data second 40.0 (count test-columns))))
+  (assoc-in default-header-result [0 :bar-width] 99)
+  (prep-for-html-rendering' test-columns test-data second 40.0))
 
 ;; When there are too many columns, #'render/prep-for-html-rendering show narrow it
 (expect
-  {:row ["ID" "LATITUDE"]
-   :bar-width 99}
-  (first (#'render/prep-for-html-rendering pacific-tz test-columns test-data second 40.0 2)))
+  [{:row [(number "ID") (number "Latitude")]
+    :bar-width 99}
+   #{2}]
+  (prep-for-html-rendering' (subvec test-columns 0 2) test-data second 40.0 ))
 
 ;; Basic test that result rows are formatted correctly (dates, floating point numbers etc)
 (expect
-  [{:bar-width nil, :row ["1" "34.10" "Apr 1, 2014" "Stout Burgers & Beers"]}
-   {:bar-width nil, :row ["2" "34.04" "Dec 5, 2014" "The Apple Pan"]}
-   {:bar-width nil, :row ["3" "34.05" "Aug 1, 2014" "The Gorbals"]}]
+  [{:bar-width nil, :row [(number "1") (number "34.10") "Apr 1, 2014" "Stout Burgers & Beers"]}
+   {:bar-width nil, :row [(number "2") (number "34.04") "Dec 5, 2014" "The Apple Pan"]}
+   {:bar-width nil, :row [(number "3") (number "34.05") "Aug 1, 2014" "The Gorbals"]}]
   (rest (#'render/prep-for-html-rendering pacific-tz test-columns test-data nil nil (count test-columns))))
 
 ;; Testing the bar-column, which is the % of this row relative to the max of that column
 (expect
-  [{:bar-width (float 85.249),  :row ["1" "34.10" "Apr 1, 2014" "Stout Burgers & Beers"]}
-   {:bar-width (float 85.1015), :row ["2" "34.04" "Dec 5, 2014" "The Apple Pan"]}
-   {:bar-width (float 85.1185), :row ["3" "34.05" "Aug 1, 2014" "The Gorbals"]}]
+  [{:bar-width (float 85.249),  :row [(number "1") (number "34.10") "Apr 1, 2014" "Stout Burgers & Beers"]}
+   {:bar-width (float 85.1015), :row [(number "2") (number "34.04") "Dec 5, 2014" "The Apple Pan"]}
+   {:bar-width (float 85.1185), :row [(number "3") (number "34.05") "Aug 1, 2014" "The Gorbals"]}]
   (rest (#'render/prep-for-html-rendering pacific-tz test-columns test-data second 40 (count test-columns))))
 
 (defn- add-rating
@@ -91,15 +154,16 @@
 
 ;; With a remapped column, the header should contain the name of the remapped column (not the original)
 (expect
-  {:row ["ID" "LATITUDE" "RATING DESC" "LAST LOGIN" "NAME"]
-   :bar-width nil}
-  (first (#'render/prep-for-html-rendering pacific-tz test-columns-with-remapping test-data-with-remapping nil nil (count test-columns-with-remapping))))
+  [{:row [(number "ID") (number "Latitude") "Rating Desc" "Last Login" "Name"]
+    :bar-width nil}
+   #{5}]
+  (prep-for-html-rendering' test-columns-with-remapping test-data-with-remapping nil nil))
 
 ;; Result rows should include only the remapped column value, not the original
 (expect
-  [["1" "34.10" "Bad" "Apr 1, 2014" "Stout Burgers & Beers"]
-   ["2" "34.04" "Ok" "Dec 5, 2014" "The Apple Pan"]
-   ["3" "34.05" "Good" "Aug 1, 2014" "The Gorbals"]]
+  [[(number "1") (number "34.10") "Bad" "Apr 1, 2014" "Stout Burgers & Beers"]
+   [(number "2") (number "34.04") "Ok" "Dec 5, 2014" "The Apple Pan"]
+   [(number "3") (number "34.05") "Good" "Aug 1, 2014" "The Gorbals"]]
   (map :row (rest (#'render/prep-for-html-rendering pacific-tz test-columns-with-remapping test-data-with-remapping nil nil (count test-columns-with-remapping)))))
 
 ;; There should be no truncation warning if the number of rows/cols is fewer than the row/column limit
@@ -126,9 +190,9 @@
                                 :special_type :type/DateTime}))
 
 (expect
-  [{:bar-width nil, :row ["1" "34.10" "Apr 1, 2014" "Stout Burgers & Beers"]}
-   {:bar-width nil, :row ["2" "34.04" "Dec 5, 2014" "The Apple Pan"]}
-   {:bar-width nil, :row ["3" "34.05" "Aug 1, 2014" "The Gorbals"]}]
+  [{:bar-width nil, :row [(number "1") (number "34.10") "Apr 1, 2014" "Stout Burgers & Beers"]}
+   {:bar-width nil, :row [(number "2") (number "34.04") "Dec 5, 2014" "The Apple Pan"]}
+   {:bar-width nil, :row [(number "3") (number "34.05") "Aug 1, 2014" "The Gorbals"]}]
   (rest (#'render/prep-for-html-rendering pacific-tz test-columns-with-date-special-type test-data nil nil (count test-columns))))
 
 (defn- render-scalar-value [results]
@@ -166,3 +230,47 @@
                                 :base_type    :type/DateTime
                                 :special_type nil}]
                         :rows [["2014-04-01T08:30:00.0000"]]}))
+
+(defn- replace-style-maps [hiccup-map]
+  (walk/postwalk (fn [maybe-map]
+                   (if (and (map? maybe-map)
+                            (contains? maybe-map :style))
+                     :style-map
+                     maybe-map)) hiccup-map))
+
+(def ^:private render-truncation-warning'
+  (comp replace-style-maps #'render/render-truncation-warning))
+
+(expect
+  nil
+  (render-truncation-warning' 10 5 20 10))
+
+(expect
+  [:div :style-map
+   [:div :style-map
+    "Showing " [:strong :style-map "10"] " of "
+    [:strong :style-map "11"] " columns."]]
+  (render-truncation-warning' 10 11 20 10))
+
+(expect
+  [:div
+   :style-map
+   [:div :style-map "Showing "
+    [:strong :style-map "20"] " of " [:strong :style-map "21"] " rows."]]
+  (render-truncation-warning' 10 5 20 21))
+
+(expect
+  [:div
+   :style-map
+   [:div
+    :style-map
+    "Showing "
+    [:strong :style-map "20"]
+    " of "
+    [:strong :style-map "21"]
+    " rows and "
+    [:strong :style-map "10"]
+    " of "
+    [:strong :style-map "11"]
+    " columns."]]
+  (render-truncation-warning' 10 11 20 21))


### PR DESCRIPTION
If the query result is a table visualization show the first 20 rows
and 10 columns. If there are more than 20 rows or 10 columns, include
a CSV that has the full resultset.

Backend TODO
- [x] Limit attached results to 2000
- [x] Ensure message sending exceptions are bubbled up
- [x] Hide "only in detail views" and fields that are of a special_type "description"
- [x] Fix issue with SQL questions failing to preview
- [x] Hide the attachment notification text from slacks
- [x] Add truncated column information along with truncated row info
- [x] Apply numeric specific style to numeric columns (headings and data cells)

Frontend TODO
- [x] Show errors when sending emails fails
- [x] Fixup integ test failures
- [x] In `PulseEditCards.jsx`, add logic to show a notice/warning when a table is larger than either 20 rows or 10 columns to say, "[head]Heads up[\head] [body]We'll display part of this table in your Pulse, and add a file attachment with more results, up to 2,000 rows."
- [x] Because we're automatically including a file attachment when there are more than 10 cols or 20 rows, in `PulseEditCards.jsx` in this state the UI should show the file attachment options automatically for this card, and disable or hide the paperclip icon (to make it clear that the file attachment is going to happen automatically for this question).

Design/CSS to-dos:
- [x] Fix: tables in Gmail on desktop are getting cut off without horizontal scrolling.
- [x] Finish table styling
- [x] Truncate wide columns
- [x] Fix the attachment options colliding with card previews
- [x] Fix the footer centering