### PR TITLE
Add Byte Order Mark to CSV exports

### DIFF
--- a/src/metabase/util/export.clj
+++ b/src/metabase/util/export.clj
@@ -47,7 +47,10 @@
 (defn export-to-csv-writer
   "Write a CSV to `FILE` with the header a and rows found in `RESULTS`"
   [^File file results]
-  (with-open [fw (java.io.FileWriter. file)]
+  (with-open [fw (java.io.PrintWriter. file "UTF-8")]
+    ;; This is a UTF-8 Byte Order Mark and should not be needed, though Excel requires it. Reading in the file via
+    ;; `slurp` appears to ignore the BOM and so does LibreOffice
+    (.print fw \uFEFF)
     (csv/write-csv fw (results->cells results))))
 
 (defn- export-to-json [columns rows]


### PR DESCRIPTION
The Byte Order Mark is not necessary for UTF-8 files, but it appears
that Excel requires it. This doesn't appear to cause problems with
LibreOffice and Java will ignore it when reading the file in using
Java input streams.

Closes #3271

