### PR TITLE
Fix Metabot's exceptions

### DIFF
--- a/src/metabase/metabot.clj
+++ b/src/metabase/metabot.clj
@@ -85,7 +85,7 @@
 (defn- format-exception
   "Format a `Throwable` the way we'd like for posting it on slack."
   [^Throwable e]
-  (tru "Uh oh! :cry:\n>" (.getMessage e)))
+  (tru "Uh oh! :cry:\n> {0}" (.getMessage e)))
 
 (defmacro ^:private do-async {:style/indent 0} [& body]
   `(future (try ~@body


### PR DESCRIPTION
Hi Metabase Team,

I just noticed that Metabot doesn't properly output it's internal exceptions to Slack.
It looks like this is the result of a bug that appeared during the migration to `tru` (aka `puppetlabs/clj-i18n`).

**Before the migration to `clj-i18n`:**
https://github.com/metabase/metabase/blob/82d090ae0368a32a457f7c805407ef85cf1fca61/src/metabase/metabot.clj#L57

**After the migration:**
https://github.com/metabase/metabase/blob/d81ff0009116491d9f904f6269d7d74e53687947/src/metabase/metabot.clj#L88

_As you can see, the new version lacks the format string (e.g. `{0}`) in order to attach a readable version of an exception to a slack message._

This pull request fixes this little problem.

Thanks!