### PR TITLE
Replace c3p0 connection pool with HikariCP

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -53,7 +53,7 @@
                  [com.jcraft/jsch "0.1.54"]                           ; SSH client for tunnels
                  [com.h2database/h2 "1.4.194"]                        ; embedded SQL database
                  [com.mattbertolini/liquibase-slf4j "2.0.0"]          ; Java Migrations lib
-                 [com.mchange/c3p0 "0.9.5.2"]                         ; connection pooling library
+                 [com.zaxxer/HikariCP "2.7.8"]                        ; connection pooling library
                  [com.microsoft.sqlserver/mssql-jdbc "6.2.1.jre7"]    ; SQLServer JDBC driver. TODO - Switch this to `.jre8` once we officially switch to Java 8
                  [com.novemberain/monger "3.1.0"]                     ; MongoDB Driver
                  [com.taoensso/nippy "2.13.0"]                        ; Fast serialization (i.e., GZIP) library for Clojure

--- a/resources/log4j.properties
+++ b/resources/log4j.properties
@@ -25,5 +25,3 @@ log4j.logger.metabase.query-processor=INFO
 log4j.logger.metabase.sync=DEBUG
 log4j.logger.metabase.models.field-values=INFO
 log4j.logger.metabase=INFO
-# c3p0 connection pools tend to log useless warnings way too often; only log actual errors
-log4j.logger.com.mchange=ERROR

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -287,7 +287,6 @@
                 (doto (HikariConfig.)
                   (.setDriverClassName              classname)
                   (.setJdbcUrl                      (str "jdbc:" subprotocol ":" subname))
-                  (.setMaxLifetime                  (* 3 60 60))
                   (.setMaximumPoolSize              15)
                   (.setDataSourceProperties         (u/prog1 (Properties.)
                                                              (doseq [[k v] (dissoc spec :classname :subprotocol :subname

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -21,6 +21,7 @@
              [honeysql-extensions :as hx]
              [ssh :as ssh]])
   (:import [clojure.lang Keyword PersistentVector]
+           com.zaxxer.hikari.HikariDataSource
            [java.sql DatabaseMetaData ResultSet]
            java.util.Map
            metabase.models.field.FieldInstance
@@ -164,7 +165,7 @@
     ;; remove the cached reference to the pool so we don't try to use it anymore
     (swap! database-id->connection-pool dissoc id)
     ;; now actively shut down the pool so that any open connections are closed
-    (.close ^ComboPooledDataSource (:datasource pool))
+    (.close ^HikariDataSource (:datasource pool))
     (when-let [ssh-tunnel (:ssh-tunnel pool)]
       (.disconnect ^com.jcraft.jsch.Session ssh-tunnel))))
 

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -21,7 +21,6 @@
              [honeysql-extensions :as hx]
              [ssh :as ssh]])
   (:import [clojure.lang Keyword PersistentVector]
-           com.mchange.v2.c3p0.ComboPooledDataSource
            [java.sql DatabaseMetaData ResultSet]
            java.util.Map
            metabase.models.field.FieldInstance
@@ -143,7 +142,7 @@
   (atom {}))
 
 (defn- create-connection-pool
-  "Create a new C3P0 `ComboPooledDataSource` for connecting to the given DATABASE."
+  "Create a new Hikari `HikariCP` for connecting to the given DATABASE."
   [{:keys [id engine details]}]
   (log/debug (u/format-color 'cyan "Creating new connection pool for database %d ..." id))
   (let [details-with-tunnel (ssh/include-ssh-tunnel details) ;; If the tunnel is disabled this returned unchanged
@@ -181,7 +180,7 @@
       (swap! database-id->connection-pool assoc id <>))))
 
 (defn db->jdbc-connection-spec
-  "Return a JDBC connection spec for DATABASE. This will have a C3P0 pool as its datasource."
+  "Return a JDBC connection spec for DATABASE. This will have a HikariCP pool as its datasource."
   [{:keys [engine details], :as database}]
   (db->pooled-connection-spec database))
 


### PR DESCRIPTION
#3052 denotes other projects gained a lot
of replacing c3p0 with [HikariCP](https://github.com/brettwooldridge/HikariCP).

I've had success with replacing HikariCP in a lot of personnal projects
and gained quite a lot in term of performances. HikariCP also has less configuration options and
saner defaults.

Here is my attempt at replacing c3p0 with HikariCP.



###### TODO 
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**