### PR TITLE
HTTP/REST driver [PoC]

### DIFF
--- a/frontend/src/metabase/components/DatabaseDetailsForm.jsx
+++ b/frontend/src/metabase/components/DatabaseDetailsForm.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import { findDOMNode } from "react-dom";
 import PropTypes from "prop-types";
 import cx from "classnames";
 import { t, jt } from "c-3po";
@@ -171,6 +172,25 @@ export default class DatabaseDetailsForm extends Component {
             >
               No
             </div>
+          </div>
+        );
+      case "json":
+        return (
+          <div className="Form-input Form-offset full">
+            <textarea
+              className="text-code borderless full"
+              ref={field.name}
+              name={field.name}
+              value={value}
+              placeholder={field.default || field.placeholder}
+              onChange={e => {
+                this.onChange(field.name, e.target.value);
+                findDOMNode(e.target).style.height =
+                  findDOMNode(e.target).scrollHeight + "px";
+              }}
+              required={field.required}
+              autoFocus={fieldIndex === 0}
+            />
           </div>
         );
       default:

--- a/frontend/src/metabase/lib/engine.js
+++ b/frontend/src/metabase/lib/engine.js
@@ -2,6 +2,7 @@ export function getEngineNativeType(engine) {
   switch (engine) {
     case "mongo":
     case "druid":
+    case "http":
     case "googleanalytics":
       return "json";
     default:
@@ -14,6 +15,7 @@ export function getEngineNativeAceMode(engine) {
     case "mongo":
     case "druid":
     case "googleanalytics":
+    case "http":
       return "ace/mode/json";
     case "mysql":
       return "ace/mode/mysql";

--- a/frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx
@@ -161,6 +161,10 @@ export default class GuiQueryEditor extends Component {
       );
     }
 
+    if (!filterList && !addFilterButton) {
+      return;
+    }
+
     return (
       <div className={cx("Query-section", { disabled: !enabled })}>
         <div className="Query-filters">{filterList}</div>
@@ -200,12 +204,19 @@ export default class GuiQueryEditor extends Component {
       return;
     }
 
+    if (
+      query.aggregations().length === 0 &&
+      query.aggregationOptions().length === 0
+    ) {
+      return;
+    }
+
     // aggregation clause.  must have table details available
     if (query.isEditable()) {
       // $FlowFixMe
       let aggregations: (Aggregation | null)[] = query.aggregations();
 
-      if (aggregations.length === 0) {
+      if (aggregations.length === 0 && query.aggregationOptions().length > 0) {
         // add implicit rows aggregation
         aggregations.push(["rows"]);
       }
@@ -290,6 +301,10 @@ export default class GuiQueryEditor extends Component {
       }
     }
 
+    if (breakoutList.length === 0) {
+      return;
+    }
+
     return (
       <div
         className={cx("Query-section Query-section-breakout", {
@@ -342,13 +357,18 @@ export default class GuiQueryEditor extends Component {
       return;
     }
 
+    const filters = this.renderFilters();
+    if (!filters) {
+      return null;
+    }
+
     return (
       <div
         className="GuiBuilder-section GuiBuilder-filtered-by flex align-center"
         ref="filterSection"
       >
         <span className="GuiBuilder-section-label Query-label">{t`Filtered by`}</span>
-        {this.renderFilters()}
+        {filters}
       </div>
     );
   }
@@ -359,13 +379,18 @@ export default class GuiQueryEditor extends Component {
       return;
     }
 
+    const aggregation = this.renderAggregation();
+    if (!aggregation) {
+      return;
+    }
+
     return (
       <div
         className="GuiBuilder-section GuiBuilder-view flex align-center px1 pr2"
         ref="viewSection"
       >
         <span className="GuiBuilder-section-label Query-label">{t`View`}</span>
-        {this.renderAggregation()}
+        {aggregation}
       </div>
     );
   }
@@ -376,13 +401,18 @@ export default class GuiQueryEditor extends Component {
       return;
     }
 
+    const breakouts = this.renderBreakouts();
+    if (!breakouts) {
+      return;
+    }
+
     return (
       <div
         className="GuiBuilder-section GuiBuilder-groupedBy flex align-center px1"
         ref="viewSection"
       >
         <span className="GuiBuilder-section-label Query-label">{t`Grouped By`}</span>
-        {this.renderBreakouts()}
+        {breakouts}
       </div>
     );
   }

--- a/project.clj
+++ b/project.clj
@@ -50,6 +50,7 @@
                   "v3-rev142-1.23.0"]
                  [com.google.apis/google-api-services-bigquery        ; Google BigQuery Java Client Library
                    "v2-rev368-1.23.0"]
+                 [com.jayway.jsonpath/json-path "2.3.0"]
                  [com.jcraft/jsch "0.1.54"]                           ; SSH client for tunnels
                  [com.h2database/h2 "1.4.194"]                        ; embedded SQL database
                  [com.mattbertolini/liquibase-slf4j "2.0.0"]          ; Java Migrations lib

--- a/src/metabase/driver/http.clj
+++ b/src/metabase/driver/http.clj
@@ -12,6 +12,7 @@
   clojure.lang.Named
   (getName [_] "HTTP"))
 
+(declare compile-expression compile-function)
 
 (defn- database->definitions
   [database]
@@ -26,8 +27,45 @@
   (first (filter #(= (:name %) name) (database->table-defs database))))
 
 (defn json-path
-  [body query]
+  [query body]
   (JsonPath/read body query (into-array Predicate [])))
+
+(defn compile-function
+  [[operator & arguments]]
+  (case (keyword operator)
+    :count count
+    :sum   #(reduce + (map (compile-expression (first arguments)) %))
+    :float #(Float/parseFloat ((compile-expression (first arguments)) %))
+           (throw (Exception. (str "Unknown operator: " operator)))))
+
+(defn compile-expression
+  [expr]
+  (cond
+    (string? expr)  (partial json-path expr)
+    (number? expr)  (constantly expr)
+    (vector? expr)  (compile-function expr)
+    :else           (throw (Exception. (str "Unknown expression: " expr)))))
+
+(defn aggregate
+  [rows metrics breakouts]
+  (let [breakouts-fns (map compile-expression breakouts)
+        breakout-fn   (fn [row] (for [breakout breakouts-fns] (breakout row)))
+        metrics-fns   (map compile-expression metrics)]
+    (for [[breakout-key breakout-rows] (group-by breakout-fn rows)]
+      (concat breakout-key (for [metrics-fn metrics-fns]
+                             (metrics-fn breakout-rows))))))
+
+(defn extract-fields
+  [rows fields]
+  (let [fields-fns (map compile-expression fields)]
+    (for [row rows]
+      (for [field-fn fields-fns]
+        (field-fn row)))))
+
+(defn field-names
+  [fields]
+  (for [field fields]
+    (keyword (json/generate-string field))))
 
 (defn execute-query
   [query]
@@ -39,13 +77,18 @@
                                        :headers (:headers query)
                                        :accept  :json
                                        :as      :json})
-        items-path    (or (:path (:result query)) "$")
-        items         (json-path (walk/stringify-keys (:body result)) items-path)
-        fields-paths  (or (:fields (:result query)) (keys (first items)))]
-    {:columns (for [fields-path fields-paths] (keyword fields-path))
-     :rows    (for [item items]
-                (for [fields-path fields-paths]
-                  (json-path item fields-path)))}))
+        rows-path     (or (:path (:result query)) "$")
+        rows          (json-path rows-path (walk/stringify-keys (:body result)))
+        fields        (or (:fields (:result query)) (keys (first rows)))
+        aggregations  (or (:aggregation (:result query)) [])
+        breakouts     (or (:breakout (:result query)) [])
+        raw           (and (= (count breakouts) 0) (= (count aggregations) 0))]
+    {:columns (if raw
+                (field-names fields)
+                (field-names (concat breakouts aggregations)))
+     :rows    (if raw
+                (extract-fields rows fields)
+                (aggregate rows aggregations breakouts))}))
 
 (defn- mbql->native
   [query]

--- a/src/metabase/driver/http.clj
+++ b/src/metabase/driver/http.clj
@@ -10,7 +10,7 @@
 
 (defrecord HTTPAPIDriver []
   clojure.lang.Named
-  (getName [_] "HTTP API"))
+  (getName [_] "HTTP"))
 
 
 (defn- database->definitions
@@ -72,11 +72,13 @@
            :describe-database     (fn [_ database]       (describe-database database))
            :describe-table        (fn [_ database table] (describe-table    database table))
            :details-fields        (constantly [{:name         "definitions"
-                                                :display-name "Table Definitions"}])
+                                                :display-name "Table Definitions"
+                                                :type         :json
+                                                :default      "{\n  \"tables\": [\n  ]\n}"}])
            :mbql->native          (fn [_ query] (mbql->native query))
            :execute-query         (fn [_ query] (execute-query query))}))
 
 (defn -init-driver
-  "Register the BigQuery driver"
+  "Register the HTTP driver"
   []
   (driver/register-driver! :http (HTTPAPIDriver.)))

--- a/src/metabase/driver/http.clj
+++ b/src/metabase/driver/http.clj
@@ -34,8 +34,11 @@
   (let [query         (if (string? (:query (:native query)))
                         (json/parse-string (:query (:native query)) keyword)
                         (:query (:native query)))
-        url           (:url query)
-        result        (client/get url {:accept :json, :as :json})
+        result        (client/request {:method  (or (:method query) :get)
+                                       :url     (:url query)
+                                       :headers (:headers query)
+                                       :accept  :json
+                                       :as      :json})
         items-path    (or (:path (:result query)) "$")
         items         (json-path (walk/stringify-keys (:body result)) items-path)
         fields-paths  (or (:fields (:result query)) (keys (first items)))]

--- a/src/metabase/driver/http.clj
+++ b/src/metabase/driver/http.clj
@@ -12,6 +12,19 @@
   clojure.lang.Named
   (getName [_] "HTTP API"))
 
+
+(defn- database->definitions
+  [database]
+  (json/parse-string (:definitions (:details database)) keyword))
+
+(defn- database->table-defs
+  [database]
+  (or (:tables (database->definitions database)) []))
+
+(defn- database->table-def
+  [database name]
+  (first (filter #(= (:name %) name) (database->table-defs database))))
+
 (defn json-path
   [body query]
   (JsonPath/read body query (into-array Predicate [])))
@@ -37,18 +50,6 @@
         table-def (database->table-def (:database query) (:name table))]
     {:query (dissoc table-def :name)
      :mbql? true}))
-
-(defn- database->definitions
-  [database]
-  (json/parse-string (:definitions (:details database)) keyword))
-
-(defn- database->table-defs
-  [database]
-  (or (:tables (database->definitions database)) []))
-
-(defn- database->table-def
-  [database name]
-  (first (filter #(= (:name %) name) (database->table-defs database))))
 
 (defn- describe-database
   [database]

--- a/src/metabase/driver/http.clj
+++ b/src/metabase/driver/http.clj
@@ -1,0 +1,81 @@
+(ns metabase.driver.http
+  "HTTP API driver."
+  (:require [cheshire.core :as json]
+            [clojure.tools.logging :as log]
+            [clojure.walk :as walk]
+            [metabase.driver :as driver]
+            [metabase.util :as u]
+            [clj-http.client :as client])
+  (:import [com.jayway.jsonpath JsonPath Predicate]))
+
+(defrecord HTTPAPIDriver []
+  clojure.lang.Named
+  (getName [_] "HTTP API"))
+
+(defn json-path
+  [body query]
+  (JsonPath/read body query (into-array Predicate [])))
+
+(defn execute-query
+  [query]
+  (let [query         (if (string? (:query (:native query)))
+                        (json/parse-string (:query (:native query)) keyword)
+                        (:query (:native query)))
+        url           (:url query)
+        result        (client/get url {:accept :json, :as :json})
+        items-path    (or (:path (:result query)) "$")
+        items         (json-path (walk/stringify-keys (:body result)) items-path)
+        fields-paths  (or (:fields (:result query)) (keys (first items)))]
+    {:columns (for [fields-path fields-paths] (keyword fields-path))
+     :rows    (for [item items]
+                (for [fields-path fields-paths]
+                  (json-path item fields-path)))}))
+
+(defn- mbql->native
+  [query]
+  (let [table     (:source-table (:query query))
+        table-def (database->table-def (:database query) (:name table))]
+    {:query (dissoc table-def :name)
+     :mbql? true}))
+
+(defn- database->definitions
+  [database]
+  (json/parse-string (:definitions (:details database)) keyword))
+
+(defn- database->table-defs
+  [database]
+  (or (:tables (database->definitions database)) []))
+
+(defn- database->table-def
+  [database name]
+  (first (filter #(= (:name %) name) (database->table-defs database))))
+
+(defn- describe-database
+  [database]
+  (let [table-defs (database->table-defs database)]
+    {:tables (set (for [table-def table-defs]
+                    {:name   (:name table-def)
+                     :schema (:schema table-def)}))}))
+
+(defn- describe-table
+  [database table]
+  (let [table-def  (database->table-def database (:name table))]
+    {:name   (:name table-def)
+     :schema (:schema table-def)
+     :fields (set [])})) ; {:name "height", :base-type :type/Integer, :database-type "number"}
+
+(u/strict-extend HTTPAPIDriver
+  driver/IDriver
+  (merge driver/IDriverDefaultsMixin
+          {:can-connect?          (constantly true)
+           :describe-database     (fn [_ database]       (describe-database database))
+           :describe-table        (fn [_ database table] (describe-table    database table))
+           :details-fields        (constantly [{:name         "definitions"
+                                                :display-name "Table Definitions"}])
+           :mbql->native          (fn [_ query] (mbql->native query))
+           :execute-query         (fn [_ query] (execute-query query))}))
+
+(defn -init-driver
+  "Register the BigQuery driver"
+  []
+  (driver/register-driver! :http (HTTPAPIDriver.)))


### PR DESCRIPTION
This is a prototype of a generic HTTP/REST driver, i.e. #4831

So far it's pretty basic. The "native" query is a JSON object that must have a `url` property:

```json
{"url":"https://api.coinmarketcap.com/v1/ticker/"}
```

By default it assumes the result is an array and it uses the properties in the first item as the columns:

<img width="1035" alt="screenshot 2018-03-02 00 15 20" src="https://user-images.githubusercontent.com/18193/36858788-d51ad1c4-1dae-11e8-92ee-4563ddd4b120.png">

You can also specify the fields you want (this filters in the backend, so you still have to fetch the full results):

```json
{
  "url":"https://api.coinmarketcap.com/v1/ticker/",
  "result": {
    "fields": ["id", "price_usd"]
  }
}
```

And if the result isn't an array you can specify the path to the array:

```json
{
  "url":"https://blockchain.info/blocks?format=json",
  "result":{
    "path":"blocks",
    "fields":["height","time"]
  }
}
```

Both the `path` and `fields` are actually [JSONPath](https://github.com/json-path/JsonPath).

In addition to "native" query you can pre-define "tables" that will appear in the query builder using a JSON definition in the database configuration that looks like this:

```json
{
  "tables": [
    {
      "name": "Blocks",
      "url": "https://blockchain.info/blocks?format=json",
      "result": { "path": "blocks" }
    },
    {
      "name": "Prices",
      "url": "https://api.coinmarketcap.com/v1/ticker/"
    }
  ]
}
```

<img width="997" alt="screenshot 2018-03-02 00 31 14" src="https://user-images.githubusercontent.com/18193/36859482-10201c0a-1db1-11e8-9add-cbcc84806183.png">

Eventually you'd be able to define fields that you can filter on (map fields to variables in a URL template string and/or query string arguments), and specify more rich metadata about the columns, etc.

Other open questions include:

* authentication
* pagination
* aggregation/grouping?