### PR TITLE
Consolidate error colors and names

### DIFF
--- a/frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx
@@ -743,7 +743,7 @@ export class FieldRemapping extends Component {
             />
           </PopoverWithTrigger>,
           dismissedInitialFkTargetPopover && (
-            <div className="text-danger my2">{t`Please select a column to use for display.`}</div>
+            <div className="text-error my2">{t`Please select a column to use for display.`}</div>
           ),
           hasChanged && hasFKMappingValue && <RemappingNamingTip />,
         ]}

--- a/frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx
@@ -55,7 +55,7 @@ const PermissionsConfirm = ({ diff }) => (
               {database.revokedTables && (
                 <TableAccessChange
                   verb={t`denied access to`}
-                  color="text-warning"
+                  color="text-error"
                   tables={database.revokedTables}
                 />
               )}

--- a/frontend/src/metabase/css/core/colors.css
+++ b/frontend/src/metabase/css/core/colors.css
@@ -17,7 +17,6 @@
 
   --success-color: #9cc177;
   --headsup-color: #f5a623;
-  --warning-color: #e35050;
 
   --gold-color: #f9d45c;
   --orange-color: #f9a354;
@@ -25,11 +24,12 @@
   --green-color: #9cc177;
   --green-saturated-color: #84bb4c;
   --dark-color: #4c545b;
-  --error-color: #ef8c8c;
   --slate-color: #9ba5b1;
   --slate-light-color: #dfe8ea;
   --slate-almost-extra-light-color: #edf2f5;
   --slate-extra-light-color: #f9fbfc;
+
+  --error-color: #e35050;
 }
 
 .text-default,
@@ -39,10 +39,6 @@
 
 .text-default-hover:hover {
   color: var(--default-font-color);
-}
-
-.text-danger {
-  color: #eea5a5;
 }
 
 /* brand */
@@ -100,16 +96,6 @@
 }
 .bg-error-input {
   background-color: #fce8e8;
-}
-
-/* warning */
-
-.text-warning {
-  color: var(--warning-color) !important;
-}
-
-.bg-warning {
-  background-color: var(--warning-color);
 }
 
 /* favorite */

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx
@@ -99,7 +99,7 @@ export default class ExpressionWidget extends Component {
           <div>
             {this.props.expression ? (
               <a
-                className="pr2 ml2 text-warning link"
+                className="pr2 ml2 text-error link"
                 onClick={() => this.props.onRemoveExpression(this.props.name)}
               >{t`Remove`}</a>
             ) : null}

--- a/frontend/test/admin/datamodel/FieldApp.integ.spec.js
+++ b/frontend/test/admin/datamodel/FieldApp.integ.spec.js
@@ -401,7 +401,7 @@ describe("FieldApp", () => {
         e: { target: document.documentElement },
       });
       await delay(300); // delay needed because of setState in FieldApp; app.update() does not work for whatever reason
-      expect(section.find(".text-danger").length).toBe(1); // warning that you should choose a column
+      expect(section.find(".text-error").length).toBe(1); // warning that you should choose a column
     });
 
     it("doesn't let you enter custom remappings for a field with string values", async () => {


### PR DESCRIPTION
Some different naming conventions and variations in color for errors led to some unnecessary complexity both visually for our users and in the code. I opted to settle on `error` rather than danger or warning and I'm proposing we just use our strongest red for such things rather than the lighter pink-ish hue we've had in the past.

This should serve as a stepping stone for more consistent input errors as part of the input cleanup work I'm planning on doing next.