### PR TITLE
Pulses-  fix numeric wrapper rendering and change column limit calculation

### DIFF
--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -201,7 +201,9 @@
 
 (defrecord NumericWrapper [num-str]
   hutil/ToString
-  (to-str [_] num-str))
+  (to-str [_] num-str)
+  java.lang.Object
+  (toString [_] num-str))
 
 (defn- format-number
   [n]

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -171,19 +171,31 @@
            (number-field? col-2))                                  :bar
       :else                                                        :table)))
 
+(defn- show-in-table? [{:keys [special_type visibility_type] :as column}]
+  (and (not (isa? special_type :type/Description))
+       (not (contains? #{:details-only :retired :sensitive} visibility_type))))
+
 (defn include-csv-attachment?
   "Returns true if this card and resultset should include a CSV attachment"
   [{:keys [include_csv] :as card} {:keys [cols rows] :as result-data}]
   (or (:include_csv card)
       (and (= :table (detect-pulse-card-type card result-data))
-           (or (< cols-limit (count cols))
-               (< rows-limit (count rows))))))
+           (or
+            ;; If some columns are not shown, include an attachment
+            (some (complement show-in-table?) cols)
+            ;; If there are too many rows or columns, include an attachment
+            (< cols-limit (count cols))
+            (< rows-limit (count rows))))))
 
 (defn include-xls-attachment?
   "Returns true if this card and resultset should include an XLS attachment"
   [{:keys [include_csv] :as card} result-data]
   (:include_xls card))
 
+(defn count-displayed-columns
+  "Return a count of the number of columns to be included in a table display"
+  [cols]
+  (count (filter show-in-table? cols)))
 
 ;;; # ------------------------------------------------------------ FORMATTING ------------------------------------------------------------
 
@@ -389,10 +401,6 @@
               :when remapped_from]
           [remapped_from col-idx])))
 
-(defn- show-in-table? [{:keys [special_type visibility_type] :as column}]
-  (and (not (isa? special_type :type/Description))
-       (not (contains? #{:details-only :retired :sensitive} visibility_type))))
-
 (defn- query-results->header-row
   "Returns a row structure with header info from `COLS`. These values
   are strings that are ready to be rendered as HTML"
@@ -476,7 +484,7 @@
   "Returns hiccup structures to indicate truncated results are available as an attachment"
   [render-type cols cols-limit rows rows-limit]
   (when (and (not= :inline render-type)
-             (or (< cols-limit (count cols))
+             (or (< cols-limit (count-displayed-columns cols))
                  (< rows-limit (count rows))))
     [:div {:style (style {:color color-gray-2})}
      "More results have been included as a file attachment"]))
@@ -485,7 +493,7 @@
   [render-type timezone card {:keys [cols rows] :as data}]
   (let [table-body [:div
                     (render-table (prep-for-html-rendering timezone cols rows nil nil cols-limit))
-                    (render-truncation-warning cols-limit (count cols) rows-limit (count rows))]]
+                    (render-truncation-warning cols-limit (count-displayed-columns cols) rows-limit (count rows))]]
     {:attachments nil
      :content     (if-let [results-attached (attached-results-text render-type cols cols-limit rows rows-limit)]
                     (list results-attached table-body)
@@ -498,7 +506,7 @@
     {:attachments nil
      :content     [:div
                    (render-table (prep-for-html-rendering timezone cols rows y-axis-rowfn max-value 2))
-                   (render-truncation-warning 2 (count cols) rows-limit (count rows))]}))
+                   (render-truncation-warning 2 (count-displayed-columns cols) rows-limit (count rows))]}))
 
 (s/defn ^:private render:scalar :- RenderedPulseCard
   [timezone card {:keys [cols rows]}]

--- a/test/metabase/pulse/render_test.clj
+++ b/test/metabase/pulse/render_test.clj
@@ -51,7 +51,28 @@
     [(first results)
      (col-counts results)]))
 
+(def ^:private description-col {:name         "desc_col"
+                                :display_name "Description Column"
+                                :base_type    :type/Text
+                                :special_type :type/Description
+                                :visibility_type :normal})
+(def ^:private detail-col      {:name            "detail_col"
+                                :display_name    "Details Column"
+                                :base_type       :type/Text
+                                :special_type    nil
+                                :visibility_type :details-only})
 
+(def ^:private sensitive-col   {:name            "sensitive_col"
+                                :display_name    "Sensitive Column"
+                                :base_type       :type/Text
+                                :special_type    nil
+                                :visibility_type :sensitive})
+
+(def ^:private retired-col     {:name            "retired_col"
+                                :display_name    "Retired Column"
+                                :base_type       :type/Text
+                                :special_type    nil
+                                :visibility_type :retired})
 
 ;; Testing the format of headers
 (expect
@@ -60,41 +81,25 @@
 
 (expect
   default-header-result
-  (let [cols-with-desc (conj test-columns {:name         "desc_col"
-                                                   :display_name "Description Column"
-                                                   :base_type    :type/Text
-                                                   :special_type :type/Description
-                                                   :visibility_type :normal})
+  (let [cols-with-desc (conj test-columns description-col)
         data-with-desc (mapv #(conj % "Desc") test-data)]
     (prep-for-html-rendering' cols-with-desc data-with-desc nil nil)))
 
 (expect
   default-header-result
-  (let [cols-with-details (conj test-columns {:name            "detail_col"
-                                              :display_name    "Details Column"
-                                              :base_type       :type/Text
-                                              :special_type    nil
-                                              :visibility_type :details-only})
+  (let [cols-with-details (conj test-columns detail-col)
         data-with-details (mapv #(conj % "Details") test-data)]
     (prep-for-html-rendering' cols-with-details data-with-details nil nil)))
 
 (expect
   default-header-result
-  (let [cols-with-sensitive (conj test-columns {:name            "sensitive_col"
-                                                :display_name    "Sensitive Column"
-                                                :base_type       :type/Text
-                                                :special_type    nil
-                                                :visibility_type :sensitive})
+  (let [cols-with-sensitive (conj test-columns sensitive-col)
         data-with-sensitive (mapv #(conj % "Sensitive") test-data)]
     (prep-for-html-rendering' cols-with-sensitive data-with-sensitive nil nil)))
 
 (expect
   default-header-result
-  (let [columns-with-retired (conj test-columns {:name            "retired_col"
-                                                 :display_name    "Retired Column"
-                                                 :base_type       :type/Text
-                                                 :special_type    nil
-                                                 :visibility_type :retired})
+  (let [columns-with-retired (conj test-columns retired-col)
         data-with-retired    (mapv #(conj % "Retired") test-data)]
     (prep-for-html-rendering' columns-with-retired data-with-retired nil nil)))
 
@@ -274,3 +279,12 @@
     [:strong :style-map "11"]
     " columns."]]
   (render-truncation-warning' 10 11 20 21))
+
+(expect
+  4
+  (count-displayed-columns test-columns))
+
+(expect
+  4
+  (count-displayed-columns
+   (concat test-columns [description-col detail-col sensitive-col retired-col])))


### PR DESCRIPTION
Change how the column limit is calculated. Previously all columns in the result were included, even those that wouldn't be displayed. This changes that to only include columns included in the rendered table. It will also include a CSV when a description/details column in present in addition to when the column limit has been exceeded.

This PR also fixes up a rendering issue with the new `NumericWrapper` defrecord.