### PR TITLE
Ensure users have been created [ci drivers]

### DIFF
--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -21,7 +21,7 @@
              [util :as tu]]
             [metabase.test.data
              [datasets :as datasets]
-             [users :refer [user->client]]]
+             [users :refer [create-users-if-needed! user->client]]]
             [toucan.db :as db]
             [toucan.util.test :as tt]))
 
@@ -487,6 +487,7 @@
   db)`."
   [f]
   (tt/with-temp Database [db {:details (:details (data/db)), :engine "h2"}]
+    (create-users-if-needed!)
     (f db)))
 
 (defn- save-card-via-API-with-native-source-query!

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -21,6 +21,7 @@
              [util :as tu]]
             [metabase.test.data
              [datasets :as datasets]
+             [dataset-definitions :as defs]
              [users :refer [create-users-if-needed! user->client]]]
             [toucan.db :as db]
             [toucan.util.test :as tt]))
@@ -486,9 +487,10 @@
   "Run `f` with a temporary Database that copies the details from the standard test database. `f` is invoked as `(f
   db)`."
   [f]
-  (tt/with-temp Database [db {:details (:details (data/db)), :engine "h2"}]
+  (data/with-db (data/get-or-create-database! defs/test-data)
     (create-users-if-needed!)
-    (f db)))
+    (tt/with-temp Database [db {:details (:details (data/db)), :engine "h2"}]
+      (f db))))
 
 (defn- save-card-via-API-with-native-source-query!
   "Attempt to save a Card that uses a native source query for Database with `db-id` via the API using Rasta. Use this to


### PR DESCRIPTION
There are occasional test failures in nested-queries-test that is due
to the order of tests being ran and the presence (or absence of test
users. This commit just always ensures the users are there before the
test runs.