### PR TITLE
Allow LDAP group mapping for rfc2307 scheme

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx
@@ -41,7 +41,7 @@ export default class SettingsLdapForm extends Component {
           },
           {
             title: t`Group Schema`,
-            settings: ["ldap-group-sync", "ldap-group-base"],
+            settings: ["ldap-group-sync", "ldap-group-base", "ldap-group-schema"],
           },
         ]}
         updateSettings={this.props.updateLdapSettings}

--- a/frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx
@@ -36,6 +36,7 @@ export default class SettingsLdapForm extends Component {
               "ldap-attribute-email",
               "ldap-attribute-firstname",
               "ldap-attribute-lastname",
+              "ldap-attribute-uid",
             ],
           },
           {

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -268,6 +268,11 @@ const SECTIONS = [
         type: "string",
       },
       {
+        key: "ldap-attribute-uid",
+        display_name: t`User ID attribute`,
+        type: "string",
+      },
+      {
         key: "ldap-attribute-firstname",
         display_name: t`First name attribute`,
         type: "string",
@@ -290,6 +295,16 @@ const SECTIONS = [
       },
       {
         key: "ldap-group-mappings",
+      },
+      {
+        key: "ldap-group-schema",
+        display_name: t`Group Schema`,
+        type: "select",
+        options: [
+          { value: "rfc2307", name: t`memberUid attribute` },
+          { value: "rfc2307bis", name: t`member attribute` },
+        ],
+        defaultValue: "rfc2307bis",
       },
     ],
   },

--- a/src/metabase/api/ldap.clj
+++ b/src/metabase/api/ldap.clj
@@ -22,7 +22,8 @@
    :ldap-attribute-lastname  :attribute-lastname
    :ldap-attribute-uid       :attribute-uid
    :ldap-group-sync          :group-sync
-   :ldap-group-base          :group-base})
+   :ldap-group-base          :group-base
+   :ldap-group-schema        :group-schema})
 
 (defn- humanize-error-messages
   "Convert raw error message responses from our LDAP tests into our normal api error response structure."

--- a/src/metabase/api/ldap.clj
+++ b/src/metabase/api/ldap.clj
@@ -20,6 +20,7 @@
    :ldap-attribute-email     :attribute-email
    :ldap-attribute-firstname :attribute-firstname
    :ldap-attribute-lastname  :attribute-lastname
+   :ldap-attribute-uid       :attribute-uid
    :ldap-group-sync          :group-sync
    :ldap-group-base          :group-base})
 

--- a/src/metabase/integrations/ldap.clj
+++ b/src/metabase/integrations/ldap.clj
@@ -52,6 +52,10 @@
   (deferred-tru "Attribute to use for the user's email. (usually ''mail'', ''email'' or ''userPrincipalName'')")
   :default "mail")
 
+(defsetting ldap-attribute-uid
+  (deferred-tru "Attribute to use for the user's id. (usually ''uid'')")
+  :default "uid")
+
 (defsetting ldap-attribute-firstname
   (deferred-tru "Attribute to use for the user''s first name. (usually ''givenName'')")
   :default "givenName")

--- a/test/metabase/integrations/ldap_test.clj
+++ b/test/metabase/integrations/ldap_test.clj
@@ -112,3 +112,31 @@
                                                           "cn=shipping,ou=groups,dc=metabase,dc=com" [2 3]}]
     (#'ldap/ldap-groups->mb-group-ids ["CN=Accounting,OU=Groups,DC=metabase,DC=com"
                                        "CN=Shipping,OU=Groups,DC=metabase,DC=com"])))
+
+;; Find by username and get group should work
+(expect
+  {:dn         "cn=Sally Brown,ou=People,dc=metabase,dc=com"
+   :first-name "Sally"
+   :last-name  "Brown"
+   :email      "sally.brown@metabase.com"
+   :groups     ["cn=Support,ou=Groups,dc=metabase,dc=com"]}
+  (tu/with-temporary-setting-values [ldap-group-schema "rfc2307"]
+    (ldap.test/with-ldap-server
+      (ldap/find-user "sbrown20"))))
+
+;; Find by email and get group by rfc2307 should also work
+(expect
+  {:dn         "cn=Sally Brown,ou=People,dc=metabase,dc=com"
+   :first-name "Sally"
+   :last-name  "Brown"
+   :email      "sally.brown@metabase.com"
+   :groups     ["cn=Support,ou=Groups,dc=metabase,dc=com"]}
+  (tu/with-temporary-setting-values [ldap-group-schema "rfc2307"]
+    (ldap.test/with-ldap-server
+      (ldap/find-user "sally.brown@metabase.com"))))
+
+;; Find by username and get group by rfc2307 should work
+(expect
+  ["cn=Support,ou=Groups,dc=metabase,dc=com"]
+  (ldap.test/with-ldap-server
+    (ldap/get-user-groups-rfc2307 "sbrown20")))

--- a/test/metabase/test/integrations/ldap.clj
+++ b/test/metabase/test/integrations/ldap.clj
@@ -13,7 +13,7 @@
 (defn- get-server-config []
   (doto (InMemoryDirectoryServerConfig. (into-array String ["dc=metabase,dc=com"]))
     (.addAdditionalBindCredentials "cn=Directory Manager" "password")
-    (.setSchema (Schema/getDefaultStandardSchema))
+    (.setSchema (Schema/mergeSchemas (into-array Schema [(Schema/getDefaultStandardSchema) (Schema/getSchema [(io/file (io/resource "posixGroup.schema.ldif"))])])))
     (.setListenerConfigs (into-array InMemoryListenerConfig [(InMemoryListenerConfig/createLDAPConfig "LDAP" 0)]))))
 
 (defn- start-ldap-server! []

--- a/test_resources/ldap.ldif
+++ b/test_resources/ldap.ldif
@@ -74,3 +74,9 @@ objectClass: groupOfNames
 cn: Accounting
 member: cn=John Smith,ou=People,dc=metabase,dc=com
 member: cn=Rasta Toucan,ou=Birds,dc=metabase,dc=com
+
+dn: cn=Support,ou=Groups,dc=metabase,dc=com
+objectClass: posixGroup
+gidNumber: 1000
+cn: Support
+memberUid: sbrown20

--- a/test_resources/posixGroup.schema.ldif
+++ b/test_resources/posixGroup.schema.ldif
@@ -1,0 +1,6 @@
+dn: cn=schema
+objectClass: subschema
+cn: schema
+AttributeTypes: ( 1.3.6.1.1.1.1.1 NAME 'gidNumber' DESC 'An integer uniquely identifying a group in an administrative domain' EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+AttributeTypes: ( 1.3.6.1.1.1.1.12 NAME 'memberUid' EQUALITY caseExactIA5Match SUBSTR caseExactIA5SubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+ObjectClasses: ( 1.3.6.1.1.1.2.2 NAME 'posixGroup' DESC 'Abstraction of a group of accounts' SUP top STRUCTURAL MUST ( cn $ gidNumber ) MAY ( userPassword $ memberUid $ description ) )


### PR DESCRIPTION
The current approach of mapping LDAP groups is or either by using the 'memberOf' attribute or by using the 'member' attribute as defined on rfc2307bis. This patch gives support for LDAP servers where the group membership is handled by 'memberUid' attribute .