### PR TITLE
Optimize UI on smaller screens

### DIFF
--- a/frontend/src/metabase/css/core/flex.css
+++ b/frontend/src/metabase/css/core/flex.css
@@ -150,6 +150,12 @@
   flex-direction: row;
 }
 
+@media screen and (--breakpoint-min-sm) {
+  .sm-flex-row {
+    flex-direction: row;
+  }
+}
+
 .flex-wrap {
   flex-wrap: wrap;
 }

--- a/frontend/src/metabase/css/home.css
+++ b/frontend/src/metabase/css/home.css
@@ -6,6 +6,10 @@
   background-color: rgba(0, 0, 0, 0.2);
 }
 
+.NavItem {
+  justify-content: center;
+}
+
 .NavItem > .Icon {
   padding-left: 1em;
   padding-right: 1em;

--- a/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
+++ b/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
@@ -126,7 +126,7 @@ export class NewQueryOptions extends Component {
 
     return (
       <div className="full-height flex">
-        <div className="wrapper wrapper--trim lg-wrapper--trim xl-wrapper--trim flex-full px1 mt4 mb2 align-center">
+        <div className="wrapper wrapper--trim lg-wrapper--trim xl-wrapper--trim flex-full px4 mt4 mb2 align-center">
           <div
             className="flex align-center justify-center"
             style={{ minHeight: "100%" }}

--- a/frontend/src/metabase/pulse/components/PulseList.jsx
+++ b/frontend/src/metabase/pulse/components/PulseList.jsx
@@ -40,8 +40,8 @@ export default class PulseList extends Component {
   render() {
     let { pulses, user } = this.props;
     return (
-      <div className="PulseList pt3">
-        <div className="border-bottom mb2">
+      <div className="PulseList px3">
+        <div className="border-bottom mb2 mt3">
           <div className="wrapper wrapper--trim flex align-center mb2">
             <h1>{t`Pulses`}</h1>
             <a

--- a/frontend/src/metabase/pulse/components/WhatsAPulse.jsx
+++ b/frontend/src/metabase/pulse/components/WhatsAPulse.jsx
@@ -20,6 +20,7 @@ export default class WhatsAPulse extends Component {
             width={574}
             src="app/assets/img/pulse_empty_illustration.png"
             forceOriginalDimensions={false}
+            style={{ maxWidth: "574px", width: '100%' }}
           />
         </div>
         <div

--- a/frontend/src/metabase/questions/containers/CollectionEditorForm.jsx
+++ b/frontend/src/metabase/questions/containers/CollectionEditorForm.jsx
@@ -72,7 +72,7 @@ export class CollectionEditorForm extends Component {
         footer={<CollectionEditorFormActions {...this.props} />}
         onClose={onClose}
       >
-        <div className="NewForm ml-auto mr-auto mt4 pt2" style={{ width: 540 }}>
+        <div className="NewForm ml-auto mr-auto mt4 pt2" style={{ width: '100%', maxWidth: 540 }}>
           <FormField displayName={t`Name`} {...fields.name}>
             <Input
               className="Form-input full"

--- a/frontend/src/metabase/questions/containers/QuestionIndex.jsx
+++ b/frontend/src/metabase/questions/containers/QuestionIndex.jsx
@@ -27,9 +27,9 @@ import EmptyState from "metabase/components/EmptyState";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 
 export const CollectionEmptyState = () => (
-  <div className="flex align-center p2 mt4 bordered border-med border-brand rounded bg-grey-0 text-brand">
-    <Icon name="collection" size={32} className="mr2" />
-    <div className="flex-full">
+  <div className="flex flex-column sm-flex-row align-center p2 mt4 bordered border-med border-brand rounded bg-grey-0 text-brand">
+    <Icon name="collection" size={32} className="mb2 sm-mr2 sm-mb0 hide sm-show" />
+    <div className="flex-full text-centered sm-text-left">
       <h3>{t`Create collections for your saved questions`}</h3>
       <div className="mt1">
         {t`Collections help you organize your questions and allow you to decide who gets to see what.`}{" "}
@@ -41,7 +41,7 @@ export const CollectionEmptyState = () => (
         </a>
       </div>
     </div>
-    <Link to="/collections/create">
+    <Link to="/collections/create" className="mt2 sm-mt0">
       <Button primary>{t`Create a collection`}</Button>
     </Link>
   </div>
@@ -144,7 +144,7 @@ export class QuestionIndex extends Component {
     return (
       <div
         className={cx("relative px4", {
-          "full-height flex flex-column bg-slate-extra-light": showNoSavedQuestionsState,
+          "full-height bg-slate-extra-light": showNoSavedQuestionsState,
         })}
       >
         {/* Use loading wrapper only for displaying the loading indicator as EntityList component should always be in DOM */}

--- a/frontend/src/metabase/reference/components/EditHeader.jsx
+++ b/frontend/src/metabase/reference/components/EditHeader.jsx
@@ -15,7 +15,7 @@ const EditHeader = ({
   onSubmit,
   revisionMessageFormField,
 }) => (
-  <div className={cx("EditHeader wrapper py1", S.editHeader)}>
+  <div className={cx("EditHeader wrapper p1", S.editHeader)}>
     <div>{t`You are editing this page`}</div>
     <div className={S.editHeaderButtons}>
       <button

--- a/frontend/src/metabase/reference/components/GuideHeader.jsx
+++ b/frontend/src/metabase/reference/components/GuideHeader.jsx
@@ -6,7 +6,7 @@ import EditButton from "metabase/reference/components/EditButton.jsx";
 
 const GuideHeader = ({ startEditing, isSuperuser }) => (
   <div>
-    <div className="wrapper wrapper--trim py4 my3">
+    <div className="wrapper wrapper--trim sm-py4 sm-my3">
       <div className="flex align-center">
         <h1
           className="text-dark"

--- a/frontend/src/metabase/reference/guide/GettingStartedGuide.jsx
+++ b/frontend/src/metabase/reference/guide/GettingStartedGuide.jsx
@@ -138,7 +138,7 @@ export default class GettingStartedGuide extends Component {
     } = this.props;
 
     return (
-      <div className="full relative py4" style={style}>
+      <div className="full relative p3" style={style}>
         <LoadingAndErrorWrapper
           className="full"
           style={style}


### PR DESCRIPTION
Made a few changes to better support smaller screens.

Let me know if you'd prefer commits to be squashed. For review/simplicity they are left as-is for now.

Thanks for this amazing project! :smile:

Example:

### Before
<img width="528" alt="screen shot 2018-03-13 at 09 14 24" src="https://user-images.githubusercontent.com/195925/37335773-b909e2a4-26af-11e8-9c3c-39a50e0ff4ad.png">

### After
<img width="552" alt="screen shot 2018-03-13 at 09 20 57" src="https://user-images.githubusercontent.com/195925/37335778-bd052594-26af-11e8-97d1-fe3c8672e5ab.png">

###### TODO 
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
