### PR TITLE
Add "America/Sao_Paulo" timezone

### DIFF
--- a/src/metabase/models/common.clj
+++ b/src/metabase/models/common.clj
@@ -20,6 +20,7 @@
    "America/Mexico_City"
    "America/Montevideo"
    "America/Santiago"
+   "America/Sao_Paulo"
    "America/Tijuana"
    "Asia/Amman"
    "Asia/Baghdad"


### PR DESCRIPTION
Add missing timezone for Brazil "America/Sao_Paulo".


###### TODO 
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
