### PR TITLE
Correctly display Scalar values w/scale in compact cards

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Scalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar.jsx
@@ -127,12 +127,10 @@ export default class Scalar extends Component {
 
     // TODO: some or all of these options should be part of formatValue
     if (typeof scalarValue === "number" && isNumber(column)) {
-      let number = scalarValue;
-
       // scale
       const scale = parseFloat(settings["scalar.scale"]);
       if (!isNaN(scale)) {
-        number *= scale;
+        scalarValue *= scale;
       }
 
       const localeStringOptions = {};
@@ -140,9 +138,11 @@ export default class Scalar extends Component {
       // decimals
       let decimals = parseFloat(settings["scalar.decimals"]);
       if (!isNaN(decimals)) {
-        number = d3.round(number, decimals);
+        scalarValue = d3.round(scalarValue, decimals);
         localeStringOptions.minimumFractionDigits = decimals;
       }
+
+      let number = scalarValue;
 
       // currency
       if (settings["scalar.currency"] != null) {


### PR DESCRIPTION
This PR fixes an issue when displaying scalar values in compact cards on Dashboard with the 'scale' property set.

The current behaviour is *not* applying the `scale` or `decimals` to the scalar when in compact mode, leading to completely different numbers on compact vs. regular mode cards. This PR fixes the issue by applying the scale and rounding.

### An example:
**Scalar value:** 0.44, scale: 100, suffix: '%'.
**Shown on regular cards:** "44%" (expected)
**Shown on compact cards:** "0.44%" (wrong number!)

### Screenshots
#### Before - NORMAL
![screen shot 2018-03-13 at 15 09 37](https://user-images.githubusercontent.com/195925/37347318-d2bf8236-26d1-11e8-948e-6cfafe107bec.png)

#### Before - COMPACT
![screen shot 2018-03-13 at 15 09 53](https://user-images.githubusercontent.com/195925/37347521-5249b576-26d2-11e8-9914-b76e5ec0693f.png)

#### After
![screen shot 2018-03-13 at 15 10 18](https://user-images.githubusercontent.com/195925/37347536-5800b596-26d2-11e8-8083-4e12070d7915.png)

###### TODO 
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)