### PR TITLE
Remove unnecessary double quote

### DIFF
--- a/frontend/src/metabase/components/SchedulePicker.jsx
+++ b/frontend/src/metabase/components/SchedulePicker.jsx
@@ -20,7 +20,7 @@ export const AM_PM_OPTIONS = [
 ];
 
 export const DAY_OF_WEEK_OPTIONS = [
-  { name: t`"Sunday`, value: "sun" },
+  { name: t`Sunday`, value: "sun" },
   { name: t`Monday`, value: "mon" },
   { name: t`Tuesday`, value: "tue" },
   { name: t`Wednesday`, value: "wed" },


### PR DESCRIPTION
Remove unnecessary double quote on pulse week day dropdown

###### TODO 
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
