### PR TITLE
Docs: Fix links to upgrading deployments on cloud infra

### DIFF
--- a/docs/operations-guide/start.md
+++ b/docs/operations-guide/start.md
@@ -66,10 +66,10 @@ If you are using the Metabase macOS app, you will be notified when there is a ne
 
 ![Autoupdate Confirmation Dialog](images/AutoupdateScreenshot.png)
 
-#### [Upgrading AWS Elastic Beanstalk deployments](running-metabase-on-elastic-beanstalk.html#deploying-new-versions-of-metabase)
+#### [Upgrading AWS Elastic Beanstalk deployments](running-metabase-on-elastic-beanstalk.md#deploying-new-versions-of-metabase)
 Step-by-step instructions on how to upgrade Metabase running on Elastic Beanstalk using RDS.
 
-#### [Upgrading Heroku deployments](running-metabase-on-heroku.html#deploying-new-versions-of-metabase)
+#### [Upgrading Heroku deployments](running-metabase-on-heroku.md#deploying-new-versions-of-metabase)
 Step-by-step instructions on how to upgrade Metabase running on Heroku.
 
 # Configuring the Metabase Application Database


### PR DESCRIPTION
Small docs change here: Noticed this link was broken on the site (see https://www.metabase.com/docs/v0.19.2/operations-guide/start.html#upgrading-metabase), guessing this is why. Didn't sign the CLA since it's a "tiny documentation change"
###### TODO 
-  [ ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
