### PR TITLE
new components for easier question and result loading

### DIFF
--- a/frontend/src/metabase/containers/AdHocQuestionLoader.jsx
+++ b/frontend/src/metabase/containers/AdHocQuestionLoader.jsx
@@ -1,0 +1,124 @@
+/* @flow */
+import React from "react";
+import { connect } from "react-redux";
+
+// things that will eventually load the quetsion
+import { deserializeCardFromUrl } from "metabase/lib/card";
+import { loadMetadataForCard } from "metabase/query_builder/actions";
+import { getMetadata } from "metabase/selectors/metadata";
+
+import Question from "metabase-lib/lib/Question";
+
+// type annotations
+import type Metadata from "metabase-lib/lib/metadata/Metadata";
+
+/*
+ * AdHocQuestionLoader
+ *
+ * Load a transient quetsion via its encoded URL and return it to the calling
+ * component
+ *
+ * @example
+ *
+ * Render prop style
+ * import AdHocQuestionLoader from 'metabase/containers/AdHocQuestionLoader'
+ *
+ * // assuming
+ * class ExampleAdHocQuestionFeature extends React.Component {
+ *    render () {
+ *      return (
+ *        <AdHocQuestionLoader questionId={this.props.params.questionId}>
+ *        { (question) => {
+ *
+ *        }}
+ *        </SavedQuestion>
+ *      )
+ *    }
+ * }
+ *
+ * @example
+ *
+ * The raw un-connected component is also exported so we can unit test it
+ * without the redux store.
+ */
+
+type Props = {
+  children: Function,
+  loadMetadataForCard: Function,
+  metadata: Metadata,
+  questionHash: string,
+};
+
+type State = {
+  // the question should be of type Question if it is set
+  question: ?Question,
+};
+
+export class AdHocQuestionLoader extends React.Component {
+  props: Props;
+
+  state: State = {
+    // this will store the loaded question
+    question: null,
+  };
+
+  componentWillMount() {
+    // load the specified question when the component mounts
+    this._loadQuestion(this.props.questionHash);
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    // if the questionHash changes (this will most likely be the result of a
+    // url change) then we need to load this new question
+    if (nextProps.questionHash !== this.props.questionHash) {
+      this._loadQuestion(nextProps.questionHash);
+    }
+  }
+
+  /*
+   * Load an AdHoc question and any required metadata
+   *
+   * 1. Decode the question via the URL
+   * 2. Load any required metadata into the redux store
+   * 3. Create a new Question object to return to metabase-lib methods can
+   *    be used
+   * 4. Set the component state to the new Question
+   */
+  async _loadQuestion(questionHash: string) {
+    const card = deserializeCardFromUrl(questionHash);
+    // pass the decoded card to load any necessary metadata
+    // (tables, source db, segments, etc) into
+    // the redux store, the resulting metadata will be avaliable as metadata on the
+    // component props once it's avaliable
+    await this.props.loadMetadataForCard(card);
+
+    // instantiate a new question object using the metadata and saved question
+    // so we can use metabase-lib methods to retrieve information and modify
+    // the question
+    const question = new Question(this.props.metadata, card);
+
+    // finally, set state to store the Question object so it can be passed
+    // to the component using the loader
+    this.setState({ question });
+  }
+
+  render() {
+    // call the child function with our loaded question
+    return this.props.children(this.state.question);
+  }
+}
+
+// redux stuff
+function mapStateToProps(state) {
+  return {
+    metadata: getMetadata(state),
+  };
+}
+
+const mapDispatchToProps = {
+  loadMetadataForCard,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(
+  AdHocQuestionLoader,
+);

--- a/frontend/src/metabase/containers/AdHocQuestionLoader.jsx
+++ b/frontend/src/metabase/containers/AdHocQuestionLoader.jsx
@@ -21,8 +21,8 @@ type ChildProps = {
 };
 
 type Props = {
-  questionHash: string,
-  children: (props: ChildProps) => React$Element<any>,
+  questionHash?: string,
+  children?: (props: ChildProps) => React$Element<any>,
   // provided by redux
   loadMetadataForCard: (card: Card) => Promise<void>,
   metadata: Metadata,
@@ -108,7 +108,16 @@ export class AdHocQuestionLoader extends React.Component {
    *    be used
    * 4. Set the component state to the new Question
    */
-  async _loadQuestion(questionHash: string) {
+  async _loadQuestion(questionHash: ?string) {
+    if (!questionHash) {
+      this.setState({
+        loading: false,
+        error: null,
+        question: null,
+        card: null,
+      });
+      return;
+    }
     try {
       this.setState({ loading: true, error: null });
       // get the card definition from the URL, the "card"
@@ -134,9 +143,10 @@ export class AdHocQuestionLoader extends React.Component {
   }
 
   render() {
+    const { children } = this.props;
     const { question, loading, error } = this.state;
     // call the child function with our loaded question
-    return this.props.children({ question, loading, error });
+    return children && children({ question, loading, error });
   }
 }
 

--- a/frontend/src/metabase/containers/AdHocQuestionLoader.jsx
+++ b/frontend/src/metabase/containers/AdHocQuestionLoader.jsx
@@ -11,7 +11,7 @@ import Question from "metabase-lib/lib/Question";
 
 // type annotations
 import type Metadata from "metabase-lib/lib/metadata/Metadata";
-import type { Card } from 'metabase/meta/types/Card'
+import type { Card } from "metabase/meta/types/Card";
 
 /*
  * AdHocQuestionLoader
@@ -53,7 +53,7 @@ type Props = {
 type State = {
   // the question should be of type Question if it is set
   question: ?Question,
-  card: ?Card
+  card: ?Card,
 };
 
 export class AdHocQuestionLoader extends React.Component {
@@ -64,7 +64,7 @@ export class AdHocQuestionLoader extends React.Component {
     question: null,
     // keep a reference to the card as well to help with re-creating question
     // objects if the underlying metadata changes
-    card: null
+    card: null,
   };
 
   componentWillMount() {
@@ -81,10 +81,10 @@ export class AdHocQuestionLoader extends React.Component {
 
     // if the metadata changes for some reason we need to make sure we
     // update the question with that metadata
-    if(nextProps.metadata !== this.props.metadata && this.state.card) {
+    if (nextProps.metadata !== this.props.metadata && this.state.card) {
       this.setState({
-        question: new Question(nextProps.metadata, this.state.card)
-      })
+        question: new Question(nextProps.metadata, this.state.card),
+      });
     }
   }
 

--- a/frontend/src/metabase/containers/AdHocQuestionLoader.jsx
+++ b/frontend/src/metabase/containers/AdHocQuestionLoader.jsx
@@ -1,4 +1,5 @@
 /* @flow */
+
 import React from "react";
 import { connect } from "react-redux";
 
@@ -12,6 +13,28 @@ import Question from "metabase-lib/lib/Question";
 // type annotations
 import type Metadata from "metabase-lib/lib/metadata/Metadata";
 import type { Card } from "metabase/meta/types/Card";
+
+type ChildProps = {
+  loading: boolean,
+  error: ?any,
+  question: ?Question,
+};
+
+type Props = {
+  questionHash: string,
+  children: (props: ChildProps) => React$Element<any>,
+  // provided by redux
+  loadMetadataForCard: (card: Card) => Promise<void>,
+  metadata: Metadata,
+};
+
+type State = {
+  // the question should be of type Question if it is set
+  question: ?Question,
+  card: ?Card,
+  loading: boolean,
+  error: ?any,
+};
 
 /*
  * AdHocQuestionLoader
@@ -29,7 +52,7 @@ import type { Card } from "metabase/meta/types/Card";
  *    render () {
  *      return (
  *        <AdHocQuestionLoader questionId={this.props.params.questionId}>
- *        { (question) => {
+ *        { ({ question, loading, error }) => {
  *
  *        }}
  *        </SavedQuestion>
@@ -42,20 +65,6 @@ import type { Card } from "metabase/meta/types/Card";
  * The raw un-connected component is also exported so we can unit test it
  * without the redux store.
  */
-
-type Props = {
-  children: Function,
-  loadMetadataForCard: (card: Card) => Promise<void>,
-  metadata: Metadata,
-  questionHash: string,
-};
-
-type State = {
-  // the question should be of type Question if it is set
-  question: ?Question,
-  card: ?Card,
-};
-
 export class AdHocQuestionLoader extends React.Component {
   props: Props;
 
@@ -65,6 +74,8 @@ export class AdHocQuestionLoader extends React.Component {
     // keep a reference to the card as well to help with re-creating question
     // objects if the underlying metadata changes
     card: null,
+    loading: false,
+    error: null,
   };
 
   componentWillMount() {
@@ -98,28 +109,34 @@ export class AdHocQuestionLoader extends React.Component {
    * 4. Set the component state to the new Question
    */
   async _loadQuestion(questionHash: string) {
-    // get the card definition from the URL, the "card"
-    const card = deserializeCardFromUrl(questionHash);
-    // pass the decoded card to load any necessary metadata
-    // (tables, source db, segments, etc) into
-    // the redux store, the resulting metadata will be avaliable as metadata on the
-    // component props once it's avaliable
-    await this.props.loadMetadataForCard(card);
+    try {
+      this.setState({ loading: true, error: null });
+      // get the card definition from the URL, the "card"
+      const card = deserializeCardFromUrl(questionHash);
+      // pass the decoded card to load any necessary metadata
+      // (tables, source db, segments, etc) into
+      // the redux store, the resulting metadata will be avaliable as metadata on the
+      // component props once it's avaliable
+      await this.props.loadMetadataForCard(card);
 
-    // instantiate a new question object using the metadata and saved question
-    // so we can use metabase-lib methods to retrieve information and modify
-    // the question
-    const question = new Question(this.props.metadata, card);
+      // instantiate a new question object using the metadata and saved question
+      // so we can use metabase-lib methods to retrieve information and modify
+      // the question
+      const question = new Question(this.props.metadata, card);
 
-    // finally, set state to store the Question object so it can be passed
-    // to the component using the loader, keep a reference to the card
-    // as well
-    this.setState({ question, card });
+      // finally, set state to store the Question object so it can be passed
+      // to the component using the loader, keep a reference to the card
+      // as well
+      this.setState({ loading: false, question, card });
+    } catch (error) {
+      this.setState({ loading: false, error });
+    }
   }
 
   render() {
+    const { question, loading, error } = this.state;
     // call the child function with our loaded question
-    return this.props.children(this.state.question);
+    return this.props.children({ question, loading, error });
   }
 }
 

--- a/frontend/src/metabase/containers/QuestionAndResultLoader.jsx
+++ b/frontend/src/metabase/containers/QuestionAndResultLoader.jsx
@@ -5,8 +5,6 @@ import React from "react";
 import QuestionLoader from "metabase/containers/QuestionLoader";
 import QuestionResultLoader from "metabase/containers/QuestionResultLoader";
 
-import Question from "metabase-lib/lib/Question";
-
 import type { ChildProps as QuestionLoaderChildProps } from "./QuestionLoader";
 import type { ChildProps as QuestionResultLoaderChildProps } from "./QuestionResultLoader";
 

--- a/frontend/src/metabase/containers/QuestionAndResultLoader.jsx
+++ b/frontend/src/metabase/containers/QuestionAndResultLoader.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+import QuestionLoader from "metabase/containers/QuestionLoader";
+import QuestionResultLoader from "metabase/containers/QuestionResultLoader";
+
+/*
+ * QuestionAndResultLoader
+ *
+ * Load a question and also run the query to get the result. Useful when you want
+ * to load both a question and its visualization at the same time.
+ *
+ * @example
+ *
+ * import QuestionAndResultLoader from 'metabase/containers/QuestionAndResultLoader'
+ *
+ * const MyNewFeature = ({ params, location }) =>
+ * <QuestionAndResultLoader question={question}>
+ * { ({ question, result, cancel, reload }) =>
+ *   <div>
+ *   </div>
+ * </QuestionAndResultLoader>
+ *
+ */
+const QuestionAndResultLoader = ({ questionId, questionHash, children }) => (
+  <QuestionLoader questionId={questionId} questionHash={questionHash}>
+    {question => (
+      <QuestionResultLoader question={question}>
+        {props => children({ question, ...props })}
+      </QuestionResultLoader>
+    )}
+  </QuestionLoader>
+);
+
+export default QuestionAndResultLoader;

--- a/frontend/src/metabase/containers/QuestionAndResultLoader.jsx
+++ b/frontend/src/metabase/containers/QuestionAndResultLoader.jsx
@@ -1,7 +1,22 @@
+/* @flow */
+
 import React from "react";
 
 import QuestionLoader from "metabase/containers/QuestionLoader";
 import QuestionResultLoader from "metabase/containers/QuestionResultLoader";
+
+import Question from "metabase-lib/lib/Question";
+
+import type { ChildProps as QuestionLoaderChildProps } from "./QuestionLoader";
+import type { ChildProps as QuestionResultLoaderChildProps } from "./QuestionResultLoader";
+
+type ChildProps = QuestionLoaderChildProps & QuestionResultLoaderChildProps;
+
+type Props = {
+  questionId: ?number,
+  questionHash: ?string,
+  children: (props: ChildProps) => React$Element<any>,
+};
 
 /*
  * QuestionAndResultLoader
@@ -21,11 +36,24 @@ import QuestionResultLoader from "metabase/containers/QuestionResultLoader";
  * </QuestionAndResultLoader>
  *
  */
-const QuestionAndResultLoader = ({ questionId, questionHash, children }) => (
+const QuestionAndResultLoader = ({
+  questionId,
+  questionHash,
+  children,
+}: Props) => (
+  // $FlowFixMe: doesn't recognize JSX children
   <QuestionLoader questionId={questionId} questionHash={questionHash}>
-    {question => (
-      <QuestionResultLoader question={question}>
-        {props => children({ question, ...props })}
+    {({ loading: questionLoading, error: questionError, ...questionProps }) => (
+      // $FlowFixMe: doesn't recognize JSX children
+      <QuestionResultLoader question={questionProps.question}>
+        {({ loading: resultLoading, error: resultError, ...resultProps }) =>
+          children({
+            ...questionProps,
+            ...resultProps,
+            loading: resultLoading || questionLoading,
+            error: resultError || questionError,
+          })
+        }
       </QuestionResultLoader>
     )}
   </QuestionLoader>

--- a/frontend/src/metabase/containers/QuestionAndResultLoader.jsx
+++ b/frontend/src/metabase/containers/QuestionAndResultLoader.jsx
@@ -13,9 +13,9 @@ import type { ChildProps as QuestionResultLoaderChildProps } from "./QuestionRes
 type ChildProps = QuestionLoaderChildProps & QuestionResultLoaderChildProps;
 
 type Props = {
-  questionId: ?number,
-  questionHash: ?string,
-  children: (props: ChildProps) => React$Element<any>,
+  questionId?: ?number,
+  questionHash?: ?string,
+  children?: (props: ChildProps) => React$Element<any>,
 };
 
 /*
@@ -41,12 +41,11 @@ const QuestionAndResultLoader = ({
   questionHash,
   children,
 }: Props) => (
-  // $FlowFixMe: doesn't recognize JSX children
   <QuestionLoader questionId={questionId} questionHash={questionHash}>
     {({ loading: questionLoading, error: questionError, ...questionProps }) => (
-      // $FlowFixMe: doesn't recognize JSX children
       <QuestionResultLoader question={questionProps.question}>
         {({ loading: resultLoading, error: resultError, ...resultProps }) =>
+          children &&
           children({
             ...questionProps,
             ...resultProps,

--- a/frontend/src/metabase/containers/QuestionLoader.jsx
+++ b/frontend/src/metabase/containers/QuestionLoader.jsx
@@ -1,0 +1,56 @@
+import React from "react";
+
+import AdHocQuestionLoader from "metabase/containers/AdHocQuestionLoader";
+import SavedQuestionLoader from "metabase/containers/SavedQuestionLoader";
+
+/*
+ * QuestionLoader
+ *
+ * Load either a saved or ad-hoc question depending on which is needed. Use
+ * this component if you need to moved between saved and ad-hoc questions
+ * as part of the same experience in the same part of the app.
+ *
+ * @example
+ * import QuestionLoader from 'metabase/containers/QuestionLoader
+ *
+ * const MyQuestionExplorer = ({ params, location }) =>
+ *  <QuestionLoader questionId={params.questionId} questionHash={
+ *  { question =>
+ *      <div>
+ *        { // display info about the loaded question }
+ *        <h1>{ question.displayName() }</h1>
+ *
+ *        { // link to a new question created by adding a filter }
+ *        <Link
+ *          to={
+ *            question.query()
+ *                    .addFilter([
+ *                      "SEGMENT",
+ *                      question.query().filterSegmentOptions()[0]
+ *                    ])
+ *                    .question()
+ *                    .getUrl()
+ *          }
+ *        >
+ *          View this ad-hoc exploration
+ *        </Link>
+ *      </div>
+ *  }
+ *  </QuestionLoader>
+ *
+ */
+
+const QuestionLoader = (
+  { questionId, questionHash, children },
+  { questionId: number, quetsionHash: string },
+) =>
+  // if there's a questionHash it means we're in ad-hoc land
+  questionHash ? (
+    <AdHocQuestionLoader questionHash={questionHash} children={children} />
+  ) : // otherwise if there's a non-null questionId it means we're in saved land
+  questionId !== null ? (
+    <SavedQuestionLoader questionId={questionId} children={children} />
+  ) : // finally, if neither is present, just don't do anything
+  null;
+
+export default QuestionLoader;

--- a/frontend/src/metabase/containers/QuestionLoader.jsx
+++ b/frontend/src/metabase/containers/QuestionLoader.jsx
@@ -1,7 +1,23 @@
+/* @flow */
+
 import React from "react";
 
 import AdHocQuestionLoader from "metabase/containers/AdHocQuestionLoader";
 import SavedQuestionLoader from "metabase/containers/SavedQuestionLoader";
+
+import Question from "metabase-lib/lib/Question";
+
+export type ChildProps = {
+  loading: boolean,
+  error: ?any,
+  question: ?Question,
+};
+
+type Props = {
+  questionId?: ?number,
+  questionHash?: ?string,
+  children: (props: ChildProps) => React$Element<any>,
+};
 
 /*
  * QuestionLoader
@@ -15,7 +31,7 @@ import SavedQuestionLoader from "metabase/containers/SavedQuestionLoader";
  *
  * const MyQuestionExplorer = ({ params, location }) =>
  *  <QuestionLoader questionId={params.questionId} questionHash={
- *  { question =>
+ *  { ({ question, loading, error }) =>
  *      <div>
  *        { // display info about the loaded question }
  *        <h1>{ question.displayName() }</h1>
@@ -40,15 +56,12 @@ import SavedQuestionLoader from "metabase/containers/SavedQuestionLoader";
  *
  */
 
-const QuestionLoader = (
-  { questionId, questionHash, children },
-  { questionId: number, quetsionHash: string },
-) =>
+const QuestionLoader = ({ questionId, questionHash, children }: Props) =>
   // if there's a questionHash it means we're in ad-hoc land
   questionHash ? (
     <AdHocQuestionLoader questionHash={questionHash} children={children} />
   ) : // otherwise if there's a non-null questionId it means we're in saved land
-  questionId !== null ? (
+  questionId != null ? (
     <SavedQuestionLoader questionId={questionId} children={children} />
   ) : // finally, if neither is present, just don't do anything
   null;

--- a/frontend/src/metabase/containers/QuestionLoader.jsx
+++ b/frontend/src/metabase/containers/QuestionLoader.jsx
@@ -16,7 +16,7 @@ export type ChildProps = {
 type Props = {
   questionId?: ?number,
   questionHash?: ?string,
-  children: (props: ChildProps) => React$Element<any>,
+  children?: (props: ChildProps) => React$Element<any>,
 };
 
 /*

--- a/frontend/src/metabase/containers/QuestionResultLoader.jsx
+++ b/frontend/src/metabase/containers/QuestionResultLoader.jsx
@@ -32,7 +32,11 @@ export class QuestionResultLoader extends React.Component {
   componentWillReceiveProps(nextProps) {
     // if the question is different, we need to do a fresh load, check the
     // difference by comparing the URL we'd generate for the question
-    if (nextProps.question && nextProps.question.getUrl() !== this.props.question && this.props.question.getUrl()) {
+    if (
+      nextProps.question &&
+      nextProps.question.getUrl() !== this.props.question &&
+      this.props.question.getUrl()
+    ) {
       this._loadResult(nextProps.question);
     }
   }

--- a/frontend/src/metabase/containers/QuestionResultLoader.jsx
+++ b/frontend/src/metabase/containers/QuestionResultLoader.jsx
@@ -30,10 +30,9 @@ export class QuestionResultLoader extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    // if the question is different, we need to do a fresh load
-    // TODO - is this the best way to check for new questions? any performance
-    // implications?
-    if (nextProps.question !== this.props.question) {
+    // if the question is different, we need to do a fresh load, check the
+    // difference by comparing the URL we'd generate for the question
+    if (nextProps.question && nextProps.question.getUrl() !== this.props.question && this.props.question.getUrl()) {
       this._loadResult(nextProps.question);
     }
   }

--- a/frontend/src/metabase/containers/QuestionResultLoader.jsx
+++ b/frontend/src/metabase/containers/QuestionResultLoader.jsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { defer } from "metabase/lib/promise";
+
+/*
+ * Question result loader
+ *
+ * Handle runninng, canceling, and reloading Question results
+ *
+ * @example
+ * <QuestionResultLoader question={question}>
+ * { ({ result, cancel, reload }) =>
+ *     <div>
+ *       { result && (<Visualization ... />) }
+ *
+ *       <a onClick={() => reload()}>Reload this please</a>
+ *       <a onClick={() => cancel()}>Changed my mind</a>
+ *     </div>
+ * }
+ * </QuestionResultLoader>
+ *
+ */
+export class QuestionResultLoader extends React.Component {
+  state = {
+    result: null,
+    cancel: null,
+  };
+
+  componentWillMount() {
+    this._loadResult(this.props.question);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    // if the question is different, we need to do a fresh load
+    // TODO - is this the best way to check for new questions? any performance
+    // implications?
+    if (nextProps.question !== this.props.question) {
+      this._loadResult(nextProps.question);
+    }
+  }
+
+  /*
+   * load the result by calling question.apiGetResults
+   */
+  async _loadResult(question) {
+    // we need to have a question for anything to happen
+    if (question) {
+      // set up a defer for cancelation
+      let cancelDeferred = defer();
+
+      // begin the request, set cancel in state so the query can be canceled
+      this.setState({ cancel: cancelDeferred, result: null });
+
+      // call apiGetResults and pass our cancel to allow for cancelation
+      const result = await question.apiGetResults({ cancelDeferred });
+
+      // setState with our result, remove our cancel since we've finished
+      this.setState({ cancel: null, result });
+    } else {
+      // if there's not a question we can't do anything so go back to our initial
+      // state
+      this.setState({ cancel: null, result: null });
+    }
+  }
+
+  /*
+   * a function to pass to the child to allow the component to call
+   * load again
+   */
+  _reload = () => {
+    this._loadResult(this.props.question);
+  };
+
+  /*
+   * a function to pass to the child to allow the component to interrupt
+   * the query
+   */
+  _cancel = () => {
+    // we only want to do things if cancel has been set
+    if (this.state.cancel) {
+      // call our cancel to cancel the query
+      this.state.cancel();
+      // cancel our cancel...
+      this.setState({ cancel: null });
+    }
+  };
+
+  render() {
+    const { result } = this.state;
+    return this.props.children({
+      cancel: this._cancel,
+      reload: this._reload,
+      result,
+    });
+  }
+}
+
+export default QuestionResultLoader;

--- a/frontend/src/metabase/containers/QuestionResultLoader.jsx
+++ b/frontend/src/metabase/containers/QuestionResultLoader.jsx
@@ -4,6 +4,7 @@ import React from "react";
 import { defer } from "metabase/lib/promise";
 
 import type { Dataset } from "metabase/meta/types/Dataset";
+import type { RawSeries } from "metabase/meta/types/Visualization";
 
 import Question from "metabase-lib/lib/Question";
 
@@ -12,13 +13,14 @@ export type ChildProps = {
   error: ?any,
   results: ?(Dataset[]),
   result: ?Dataset,
+  rawSeries: ?RawSeries,
   cancel: () => void,
   reload: () => void,
 };
 
 type Props = {
   question: ?Question,
-  children: (props: ChildProps) => React$Element<any>,
+  children?: (props: ChildProps) => React$Element<any>,
 };
 
 type State = {
@@ -125,15 +127,24 @@ export class QuestionResultLoader extends React.Component {
   };
 
   render() {
+    const { question, children } = this.props;
     const { results, loading, error } = this.state;
-    return this.props.children({
-      result: results && results[0],
-      results,
-      loading,
-      error,
-      cancel: this._cancel,
-      reload: this._reload,
-    });
+    return (
+      children &&
+      children({
+        results,
+        result: results && results[0],
+        // convienence for <Visualization /> component. Only support single series for now
+        rawSeries:
+          question && results
+            ? [{ card: question.card(), data: results[0].data }]
+            : null,
+        loading,
+        error,
+        cancel: this._cancel,
+        reload: this._reload,
+      })
+    );
   }
 }
 

--- a/frontend/src/metabase/containers/SavedQuestionLoader.jsx
+++ b/frontend/src/metabase/containers/SavedQuestionLoader.jsx
@@ -1,0 +1,126 @@
+/* @flow */
+import React from "react";
+import { connect } from "react-redux";
+
+// things that will eventually load the quetsion
+import { CardApi } from "metabase/services";
+import { loadMetadataForCard } from "metabase/query_builder/actions";
+import { getMetadata } from "metabase/selectors/metadata";
+
+import Question from "metabase-lib/lib/Question";
+
+// type annotations
+import type Metadata from "metabase-lib/lib/metadata/Metadata";
+
+/*
+ * SavedQuestionLaoder
+ *
+ * Load a saved quetsion and return it to the calling component
+ *
+ * @example
+ *
+ * Render prop style
+ * import SavedQuestionLoader from 'metabase/containers/SavedQuestionLoader'
+ *
+ * // assuming
+ * class ExampleSavedQuestionFeature extends React.Component {
+ *    render () {
+ *      return (
+ *        <SavedQuestionLoader questionId={this.props.params.questionId}>
+ *        { (question) => {
+ *
+ *        }}
+ *        </SavedQuestion>
+ *      )
+ *    }
+ * }
+ *
+ * @example
+ *
+ * The raw un-connected component is also exported so we can unit test it
+ * without the redux store.
+ */
+
+type Props = {
+  children: Function,
+  metadata: Metadata,
+  loadMetadataForCard: Function,
+  questionId: number,
+};
+
+type State = {
+  // the question should be of type Question if it is set
+  question: ?Question,
+};
+
+export class SavedQuestionLoader extends React.Component {
+  props: Props;
+
+  state: State = {
+    // this will store the loaded question
+    question: null,
+  };
+
+  componentWillMount() {
+    // load the specified question when the component mounts
+    this._loadQuestion(this.props.questionId);
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    // if the questionId changes (this will most likely be the result of a
+    // url change) then we need to load this new question
+    if (nextProps.questionId !== this.props.questionId) {
+      this._loadQuestion(nextProps.questionId);
+    }
+  }
+
+  /*
+   * Load a saved question and any required metadata
+   *
+   * 1. Get the card from the api
+   * 2. Load any required metadata into the redux store
+   * 3. Create a new Question object to return to metabase-lib methods can
+   *    be used
+   * 4. Set the component state to the new Question
+   */
+  async _loadQuestion(questionId: number) {
+    // get the saved question via the card API
+    const card = await CardApi.get({ cardId: questionId });
+
+    // pass the retrieved card to load any necessary metadata
+    // (tables, source db, segments, etc) into
+    // the redux store, the resulting metadata will be avaliable as metadata on the
+    // component props once it's avaliable
+    await this.props.loadMetadataForCard(card);
+
+    // instantiate a new question object using the metadata and saved question
+    // so we can use metabase-lib methods to retrieve information and modify
+    // the question
+    //
+    const question = new Question(this.props.metadata, card);
+
+    // finally, set state to store the Question object so it can be passed
+    // to the component using the loader
+    this.setState({ question });
+  }
+
+  render() {
+    // call the child function with our loaded question
+    return this.props.children(this.state.question);
+  }
+}
+
+// redux stuff
+function mapStateToProps(state) {
+  return {
+    metadata: getMetadata(state),
+  };
+}
+
+const mapDispatchToProps = {
+  loadMetadataForCard,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(
+  SavedQuestionLoader,
+);

--- a/frontend/src/metabase/containers/SavedQuestionLoader.jsx
+++ b/frontend/src/metabase/containers/SavedQuestionLoader.jsx
@@ -11,7 +11,7 @@ import Question from "metabase-lib/lib/Question";
 
 // type annotations
 import type Metadata from "metabase-lib/lib/metadata/Metadata";
-import type { Card } from 'metabase/meta/types/Card'
+import type { Card } from "metabase/meta/types/Card";
 
 /*
  * SavedQuestionLaoder
@@ -54,7 +54,7 @@ type State = {
   question: ?Question,
   // keep a reference to the card as well to help with re-creating question
   // objects if the underlying metadata changes
-  card: ?Card
+  card: ?Card,
 };
 
 export class SavedQuestionLoader extends React.Component {
@@ -79,10 +79,10 @@ export class SavedQuestionLoader extends React.Component {
 
     // if the metadata changes for some reason we need to make sure we
     // update the question with that metadata
-    if(nextProps.metadata !== this.props.metadata && this.state.card) {
+    if (nextProps.metadata !== this.props.metadata && this.state.card) {
       this.setState({
-        question: new Question(nextProps.metadata, this.state.card)
-      })
+        question: new Question(nextProps.metadata, this.state.card),
+      });
     }
   }
 

--- a/frontend/src/metabase/containers/SavedQuestionLoader.jsx
+++ b/frontend/src/metabase/containers/SavedQuestionLoader.jsx
@@ -21,8 +21,8 @@ type ChildProps = {
 };
 
 type Props = {
-  questionId: number,
-  children: (props: ChildProps) => React$Element<any>,
+  questionId: ?number,
+  children?: (props: ChildProps) => React$Element<any>,
   // provided by redux
   loadMetadataForCard: (card: Card) => Promise<void>,
   metadata: Metadata,
@@ -107,7 +107,16 @@ export class SavedQuestionLoader extends React.Component {
    *    be used
    * 4. Set the component state to the new Question
    */
-  async _loadQuestion(questionId: number) {
+  async _loadQuestion(questionId: ?number) {
+    if (questionId == null) {
+      this.setState({
+        loading: false,
+        error: null,
+        question: null,
+        card: null,
+      });
+      return;
+    }
     try {
       this.setState({ loading: true, error: null });
       // get the saved question via the card API
@@ -135,9 +144,10 @@ export class SavedQuestionLoader extends React.Component {
   }
 
   render() {
+    const { children } = this.props;
     const { question, loading, error } = this.state;
     // call the child function with our loaded question
-    return this.props.children({ question, loading, error });
+    return children && children({ question, loading, error });
   }
 }
 

--- a/frontend/src/metabase/internal/components/ColorsApp.jsx
+++ b/frontend/src/metabase/internal/components/ColorsApp.jsx
@@ -1,3 +1,5 @@
+/* @flow */
+
 import React from "react";
 
 import cx from "classnames";

--- a/frontend/src/metabase/internal/components/ComponentsApp.jsx
+++ b/frontend/src/metabase/internal/components/ComponentsApp.jsx
@@ -1,5 +1,7 @@
+/* @flow */
+
 import React, { Component } from "react";
-import { Link } from "react-router";
+import { Link, Route } from "react-router";
 
 import { slugify } from "metabase/lib/formatting";
 import reactElementToJSXString from "react-element-to-jsx-string";
@@ -13,6 +15,7 @@ const Section = ({ title, children }) => (
 );
 
 export default class ComponentsApp extends Component {
+  static routes: ?[React$Element<Route>];
   render() {
     const componentName = slugify(this.props.params.componentName);
     const exampleName = slugify(this.props.params.exampleName);
@@ -116,3 +119,12 @@ export default class ComponentsApp extends Component {
     );
   }
 }
+
+ComponentsApp.routes = [
+  <Route path="components" component={ComponentsApp} />,
+  <Route path="components/:componentName" component={ComponentsApp} />,
+  <Route
+    path="components/:componentName/:exampleName"
+    component={ComponentsApp}
+  />,
+];

--- a/frontend/src/metabase/internal/components/IconsApp.jsx
+++ b/frontend/src/metabase/internal/components/IconsApp.jsx
@@ -1,16 +1,21 @@
+/* @flow */
+
 import React, { Component } from "react";
 
 import Icon from "metabase/components/Icon.jsx";
 
 const SIZES = [12, 16];
 
+type Props = {};
+type State = {
+  size: number,
+};
+
 export default class IconsApp extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      size: 32,
-    };
-  }
+  props: Props;
+  state: State = {
+    size: 32,
+  };
   render() {
     let sizes = SIZES.concat(this.state.size);
     return (

--- a/frontend/src/metabase/internal/components/QuestionApp.jsx
+++ b/frontend/src/metabase/internal/components/QuestionApp.jsx
@@ -1,0 +1,51 @@
+/* @flow */
+
+import React from "react";
+import { Route } from "react-router";
+
+import QuestionAndResultLoader from "metabase/containers/QuestionAndResultLoader";
+import Visualization from "metabase/visualizations/components/Visualization";
+
+type Props = {
+  location: {
+    hash: ?string,
+  },
+  params: {
+    questionId?: string,
+  },
+};
+
+export default class QuestionApp extends React.Component {
+  props: Props;
+
+  static routes: ?[React$Element<Route>];
+
+  render() {
+    const { location, params } = this.props;
+    if (!location.hash && !params.questionId) {
+      return (
+        <div className="p4 text-centered flex-full">
+          Visit <strong>/_internal/question/:id</strong> or{" "}
+          <strong>/_internal/question#:hash</strong>.
+        </div>
+      );
+    }
+    return (
+      <QuestionAndResultLoader
+        questionHash={location.hash}
+        questionId={params.questionId ? parseInt(params.questionId) : null}
+      >
+        {({ rawSeries }) =>
+          rawSeries && (
+            <Visualization className="flex-full" rawSeries={rawSeries} />
+          )
+        }
+      </QuestionAndResultLoader>
+    );
+  }
+}
+
+QuestionApp.routes = [
+  <Route path="question" component={QuestionApp} />,
+  <Route path="question/:questionId" component={QuestionApp} />,
+];

--- a/frontend/src/metabase/internal/routes.js
+++ b/frontend/src/metabase/internal/routes.js
@@ -1,15 +1,20 @@
+/* @flow */
+
 import React from "react";
 import { Route, IndexRoute } from "react-router";
 
-import IconsApp from "metabase/internal/components/IconsApp";
-import ColorsApp from "metabase/internal/components/ColorsApp";
-import ComponentsApp from "metabase/internal/components/ComponentsApp";
+// $FlowFixMe: doesn't know about require.context
+const req = require.context(
+  "metabase/internal/components",
+  true,
+  /(\w+)App.jsx$/,
+);
 
-const PAGES = {
-  Icons: IconsApp,
-  Colors: ColorsApp,
-  Components: ComponentsApp,
-};
+const PAGES = {};
+for (const key of req.keys()) {
+  const name = key.match(/(\w+)App.jsx$/)[1];
+  PAGES[name] = req(key).default;
+}
 
 const WelcomeApp = () => {
   return (
@@ -49,13 +54,12 @@ const InternalLayout = ({ children }) => {
 export default (
   <Route component={InternalLayout}>
     <IndexRoute component={WelcomeApp} />
-    {Object.entries(PAGES).map(([name, Component]) => (
-      <Route path={name.toLowerCase()} component={Component} />
-    ))}
-    <Route path="components/:componentName" component={ComponentsApp} />
-    <Route
-      path="components/:componentName/:exampleName"
-      component={ComponentsApp}
-    />
+    {Object.entries(PAGES).map(
+      ([name, Component]) =>
+        Component &&
+        (Component.routes || (
+          <Route path={name.toLowerCase()} component={Component} />
+        )),
+    )}
   </Route>
 );

--- a/frontend/src/metabase/meta/types/Visualization.js
+++ b/frontend/src/metabase/meta/types/Visualization.js
@@ -68,8 +68,11 @@ export type ClickActionPopoverProps = {
 };
 
 export type SingleSeries = { card: Card, data: DatasetData };
-export type Series = SingleSeries[] & { _raw: Series };
+export type RawSeries = SingleSeries[];
+export type TransformedSeries = RawSeries & { _raw: Series };
+export type Series = RawSeries | TransformedSeries;
 
+// These are the props provided to the visualization implementations BY the Visualization component
 export type VisualizationProps = {
   series: Series,
   card: Card,

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -46,12 +46,13 @@ import type {
   HoverObject,
   ClickObject,
   Series,
+  RawSeries,
   OnChangeCardAndRun,
 } from "metabase/meta/types/Visualization";
 import Metadata from "metabase-lib/lib/metadata/Metadata";
 
 type Props = {
-  rawSeries: Series,
+  rawSeries: RawSeries,
 
   className: string,
 

--- a/frontend/src/metabase/visualizations/index.js
+++ b/frontend/src/metabase/visualizations/index.js
@@ -70,7 +70,6 @@ export function getVisualizationTransformed(series: Series) {
       series = CardVisualization.transformSeries(series);
     }
     if (series !== lastSeries) {
-      // $FlowFixMe
       series = [...series];
       // $FlowFixMe
       series._raw = lastSeries;

--- a/frontend/src/metabase/visualizations/visualizations/Progress.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Progress.jsx
@@ -110,7 +110,8 @@ export default class Progress extends Component {
       onVisualizationClick,
       visualizationIsClickable,
     } = this.props;
-    const value: number = rows[0][0];
+    const value: number =
+      rows[0] && typeof rows[0][0] === "number" ? rows[0][0] : 0;
     const goal = settings["progress.goal"] || 0;
 
     const mainColor = settings["progress.color"];

--- a/frontend/test/containers/AdHocQuestionLoader.unit.spec.js
+++ b/frontend/test/containers/AdHocQuestionLoader.unit.spec.js
@@ -1,0 +1,51 @@
+import React from "react";
+import { shallow } from "enzyme";
+
+// import the un-connected component so we can test its internal logic sans
+// redux
+import { AdHocQuestionLoader } from "metabase/containers/AdHocQuestionLoader";
+
+describe("AdHocQuestionLoader", () => {
+  beforeEach(() => {
+    // reset mocks between tests so we have fresh spies, etc
+    jest.resetAllMocks();
+  });
+
+  it("should load a question given a questionHash", () => {
+    const questionHash = "#abc123";
+
+    const loadSpy = jest.spyOn(AdHocQuestionLoader.prototype, "_loadQuestion");
+
+    shallow(
+      <AdHocQuestionLoader questionHash={questionHash}>
+        {() => <div />}
+      </AdHocQuestionLoader>,
+    );
+
+    expect(loadSpy).toHaveBeenCalledWith(questionHash);
+  });
+
+  it("should load a new question if the question ID changes", () => {
+    // create some junk strigs, real question hashes are more ludicrous but this
+    // is easier to verify
+    const originalQuestionHash = "#abc123";
+    const newQuestionHash = "#def456";
+
+    const loadSpy = jest.spyOn(AdHocQuestionLoader.prototype, "_loadQuestion");
+
+    const wrapper = shallow(
+      <AdHocQuestionLoader questionHash={originalQuestionHash}>
+        {() => <div />}
+      </AdHocQuestionLoader>,
+    );
+
+    expect(loadSpy).toHaveBeenCalledWith(originalQuestionHash);
+
+    // update the question hash, a new location.hash in the url would most
+    // likely do this
+    wrapper.setProps({ questionHash: newQuestionHash });
+
+    // question loading should begin with the new ID
+    expect(loadSpy).toHaveBeenCalledWith(newQuestionHash);
+  });
+});

--- a/frontend/test/containers/AdHocQuestionLoader.unit.spec.js
+++ b/frontend/test/containers/AdHocQuestionLoader.unit.spec.js
@@ -33,10 +33,13 @@ describe("AdHocQuestionLoader", () => {
 
     const loadSpy = jest.spyOn(AdHocQuestionLoader.prototype, "_loadQuestion");
 
-    const mockChild = jest.fn().mockReturnValue(<div />)
+    const mockChild = jest.fn().mockReturnValue(<div />);
 
     const wrapper = shallow(
-      <AdHocQuestionLoader questionHash={originalQuestionHash} children={mockChild} />
+      <AdHocQuestionLoader
+        questionHash={originalQuestionHash}
+        children={mockChild}
+      />,
     );
 
     expect(loadSpy).toHaveBeenCalledWith(originalQuestionHash);
@@ -48,6 +51,6 @@ describe("AdHocQuestionLoader", () => {
     // question loading should begin with the new ID
     expect(loadSpy).toHaveBeenCalledWith(newQuestionHash);
 
-    expect(mockChild).toHaveBeenCalled()
+    expect(mockChild).toHaveBeenCalled();
   });
 });

--- a/frontend/test/containers/AdHocQuestionLoader.unit.spec.js
+++ b/frontend/test/containers/AdHocQuestionLoader.unit.spec.js
@@ -25,7 +25,7 @@ describe("AdHocQuestionLoader", () => {
     expect(loadSpy).toHaveBeenCalledWith(questionHash);
   });
 
-  it("should load a new question if the question ID changes", () => {
+  it("should load a new question if the question hash changes", () => {
     // create some junk strigs, real question hashes are more ludicrous but this
     // is easier to verify
     const originalQuestionHash = "#abc123";
@@ -33,10 +33,10 @@ describe("AdHocQuestionLoader", () => {
 
     const loadSpy = jest.spyOn(AdHocQuestionLoader.prototype, "_loadQuestion");
 
+    const mockChild = jest.fn().mockReturnValue(<div />)
+
     const wrapper = shallow(
-      <AdHocQuestionLoader questionHash={originalQuestionHash}>
-        {() => <div />}
-      </AdHocQuestionLoader>,
+      <AdHocQuestionLoader questionHash={originalQuestionHash} children={mockChild} />
     );
 
     expect(loadSpy).toHaveBeenCalledWith(originalQuestionHash);
@@ -47,5 +47,7 @@ describe("AdHocQuestionLoader", () => {
 
     // question loading should begin with the new ID
     expect(loadSpy).toHaveBeenCalledWith(newQuestionHash);
+
+    expect(mockChild).toHaveBeenCalled()
   });
 });

--- a/frontend/test/containers/AdHocQuestionLoader.unit.spec.js
+++ b/frontend/test/containers/AdHocQuestionLoader.unit.spec.js
@@ -1,28 +1,51 @@
 import React from "react";
-import { shallow } from "enzyme";
+import { shallow, mount } from "enzyme";
+
+import Question from "metabase-lib/lib/Question";
+import { delay } from "metabase/lib/promise";
 
 // import the un-connected component so we can test its internal logic sans
 // redux
 import { AdHocQuestionLoader } from "metabase/containers/AdHocQuestionLoader";
 
 describe("AdHocQuestionLoader", () => {
+  let loadQuestionSpy, loadMetadataSpy, mockChild;
   beforeEach(() => {
     // reset mocks between tests so we have fresh spies, etc
     jest.resetAllMocks();
+    mockChild = jest.fn().mockReturnValue(<div />);
+    loadMetadataSpy = jest.fn();
+    loadQuestionSpy = jest.spyOn(
+      AdHocQuestionLoader.prototype,
+      "_loadQuestion",
+    );
   });
 
-  it("should load a question given a questionHash", () => {
-    const questionHash = "#abc123";
+  it("should load a question given a questionHash", async () => {
+    const q = new Question.create({ databaseId: 1, tableId: 2 });
+    const questionHash = q.getUrl().match(/(#.*)/)[1];
 
-    const loadSpy = jest.spyOn(AdHocQuestionLoader.prototype, "_loadQuestion");
-
-    shallow(
-      <AdHocQuestionLoader questionHash={questionHash}>
-        {() => <div />}
-      </AdHocQuestionLoader>,
+    const wrapper = mount(
+      <AdHocQuestionLoader
+        questionHash={questionHash}
+        loadMetadataForCard={loadMetadataSpy}
+        children={mockChild}
+      />,
     );
+    expect(mockChild.mock.calls[0][0].loading).toEqual(true);
+    expect(mockChild.mock.calls[0][0].error).toEqual(null);
 
-    expect(loadSpy).toHaveBeenCalledWith(questionHash);
+    // stuff happens asynchronously
+    wrapper.update();
+    await delay(0);
+
+    expect(loadMetadataSpy.mock.calls[0][0]).toEqual(q.card());
+
+    const calls = mockChild.mock.calls;
+    const { question, loading, error } = calls[calls.length - 1][0];
+    expect(question.card()).toEqual(q.card());
+    expect(loading).toEqual(false);
+    expect(error).toEqual(null);
   });
 
   it("should load a new question if the question hash changes", () => {
@@ -31,25 +54,22 @@ describe("AdHocQuestionLoader", () => {
     const originalQuestionHash = "#abc123";
     const newQuestionHash = "#def456";
 
-    const loadSpy = jest.spyOn(AdHocQuestionLoader.prototype, "_loadQuestion");
-
-    const mockChild = jest.fn().mockReturnValue(<div />);
-
     const wrapper = shallow(
       <AdHocQuestionLoader
         questionHash={originalQuestionHash}
+        loadMetadataForCard={loadMetadataSpy}
         children={mockChild}
       />,
     );
 
-    expect(loadSpy).toHaveBeenCalledWith(originalQuestionHash);
+    expect(loadQuestionSpy).toHaveBeenCalledWith(originalQuestionHash);
 
     // update the question hash, a new location.hash in the url would most
     // likely do this
     wrapper.setProps({ questionHash: newQuestionHash });
 
     // question loading should begin with the new ID
-    expect(loadSpy).toHaveBeenCalledWith(newQuestionHash);
+    expect(loadQuestionSpy).toHaveBeenCalledWith(newQuestionHash);
 
     expect(mockChild).toHaveBeenCalled();
   });

--- a/frontend/test/containers/QuestionAndResultLoader.unit.spec.js
+++ b/frontend/test/containers/QuestionAndResultLoader.unit.spec.js
@@ -1,0 +1,10 @@
+import React from "react";
+import { shallow } from "enzyme";
+
+import QuestionAndResultLoader from "metabase/containers/QuestionAndResultLoader";
+
+describe("QuestionAndResultLoader", () => {
+  it("should load a question and a result", () => {
+    shallow(<QuestionAndResultLoader>{() => <div />}</QuestionAndResultLoader>);
+  });
+});

--- a/frontend/test/containers/QuestionLoader.unit.spec.js
+++ b/frontend/test/containers/QuestionLoader.unit.spec.js
@@ -1,0 +1,46 @@
+import React from "react";
+import { shallow } from "enzyme";
+
+import QuestionLoader from "metabase/containers/QuestionLoader";
+
+import AdHocQuestionLoader from "metabase/containers/AdHocQuestionLoader";
+import SavedQuestionLoader from "metabase/containers/SavedQuestionLoader";
+
+describe("QuestionLoader", () => {
+  describe("initial load", () => {
+    it("should use SavedQuestionLoader if there is a saved question", () => {
+      const wrapper = shallow(
+        <QuestionLoader questionId={1}>{() => <div />}</QuestionLoader>,
+      );
+
+      expect(wrapper.find(SavedQuestionLoader).length).toBe(1);
+    });
+
+    it("should use AdHocQuestionLoader if there is an ad-hoc question", () => {
+      const wrapper = shallow(
+        <QuestionLoader questionHash={"#abc123"}>
+          {() => <div />}
+        </QuestionLoader>,
+      );
+
+      expect(wrapper.find(AdHocQuestionLoader).length).toBe(1);
+    });
+  });
+  describe("subsequent movement", () => {
+    it("should transition between loaders when props change", () => {
+      // start with a quesitonId
+      const wrapper = shallow(
+        <QuestionLoader questionId={4}>{() => <div />}</QuestionLoader>,
+      );
+
+      expect(wrapper.find(SavedQuestionLoader).length).toBe(1);
+
+      wrapper.setProps({
+        questionId: undefined,
+        questionHash: "#abc123",
+      });
+
+      expect(wrapper.find(AdHocQuestionLoader).length).toBe(1);
+    });
+  });
+});

--- a/frontend/test/containers/QuestionResultLoader.unit.spec.js
+++ b/frontend/test/containers/QuestionResultLoader.unit.spec.js
@@ -1,0 +1,22 @@
+import React from "react";
+import { shallow } from "enzyme";
+
+import { QuestionResultLoader } from "metabase/containers/QuestionResultLoader";
+
+describe("QuestionResultLoader", () => {
+  it("should load a result given a question", () => {
+    const question = {
+      id: 1,
+    };
+
+    const loadSpy = jest.spyOn(QuestionResultLoader.prototype, "_loadResult");
+
+    shallow(
+      <QuestionResultLoader question={question}>
+        {() => <div />}
+      </QuestionResultLoader>,
+    );
+
+    expect(loadSpy).toHaveBeenCalledWith(question);
+  });
+});

--- a/frontend/test/containers/SavedQuestionLoader.unit.spec.js
+++ b/frontend/test/containers/SavedQuestionLoader.unit.spec.js
@@ -1,5 +1,9 @@
 import React from "react";
-import { shallow } from "enzyme";
+import { shallow, mount } from "enzyme";
+
+import Question from "metabase-lib/lib/Question";
+import { delay } from "metabase/lib/promise";
+import { CardApi } from "metabase/services";
 
 // import the un-connected component so we can test its internal logic sans
 // redux
@@ -9,43 +13,64 @@ import { SavedQuestionLoader } from "metabase/containers/SavedQuestionLoader";
 jest.mock("metabase/services");
 
 describe("SavedQuestionLoader", () => {
+  let loadQuestionSpy, loadMetadataSpy, mockChild;
   beforeEach(() => {
     // reset mocks between tests so we have fresh spies, etc
     jest.resetAllMocks();
+    mockChild = jest.fn().mockReturnValue(<div />);
+    loadMetadataSpy = jest.fn();
+    loadQuestionSpy = jest.spyOn(
+      SavedQuestionLoader.prototype,
+      "_loadQuestion",
+    );
   });
 
-  it("should load a question given a questionId", () => {
+  it("should load a question given a questionId", async () => {
     const questionId = 1;
+    const q = new Question.create({ databaseId: 1, tableId: 2 });
+    jest.spyOn(CardApi, "get").mockReturnValue(q.card());
 
-    const loadSpy = jest.spyOn(SavedQuestionLoader.prototype, "_loadQuestion");
-
-    shallow(
-      <SavedQuestionLoader questionId={questionId}>
-        {() => <div />}
-      </SavedQuestionLoader>,
+    const wrapper = mount(
+      <SavedQuestionLoader
+        questionId={questionId}
+        loadMetadataForCard={loadMetadataSpy}
+        children={mockChild}
+      />,
     );
+    expect(mockChild.mock.calls[0][0].loading).toEqual(true);
+    expect(mockChild.mock.calls[0][0].error).toEqual(null);
 
-    expect(loadSpy).toHaveBeenCalledWith(questionId);
+    // stuff happens asynchronously
+    wrapper.update();
+    await delay(0);
+
+    expect(loadQuestionSpy).toHaveBeenCalledWith(questionId);
+
+    const calls = mockChild.mock.calls;
+    const { question, loading, error } = calls[calls.length - 1][0];
+    expect(question.card()).toEqual(q.card());
+    expect(loading).toEqual(false);
+    expect(error).toEqual(null);
   });
 
   it("should load a new question if the question ID changes", () => {
     const originalQuestionId = 1;
     const newQuestionId = 2;
 
-    const loadSpy = jest.spyOn(SavedQuestionLoader.prototype, "_loadQuestion");
-
     const wrapper = shallow(
-      <SavedQuestionLoader questionId={originalQuestionId}>
-        {() => <div />}
-      </SavedQuestionLoader>,
+      <SavedQuestionLoader
+        questionId={originalQuestionId}
+        loadMetadataForCard={loadMetadataSpy}
+        children={mockChild}
+      />,
     );
 
-    expect(loadSpy).toHaveBeenCalledWith(originalQuestionId);
+    expect(loadQuestionSpy).toHaveBeenCalledWith(originalQuestionId);
 
     // update the question ID, a new question id param in the url would do this
     wrapper.setProps({ questionId: newQuestionId });
 
     // question loading should begin with the new ID
-    expect(loadSpy).toHaveBeenCalledWith(newQuestionId);
+    expect(loadQuestionSpy).toHaveBeenCalledWith(newQuestionId);
   });
 });

--- a/frontend/test/containers/SavedQuestionLoader.unit.spec.js
+++ b/frontend/test/containers/SavedQuestionLoader.unit.spec.js
@@ -1,0 +1,51 @@
+import React from "react";
+import { shallow } from "enzyme";
+
+// import the un-connected component so we can test its internal logic sans
+// redux
+import { SavedQuestionLoader } from "metabase/containers/SavedQuestionLoader";
+
+// we need to mock the things that try and actually load the question
+jest.mock("metabase/services");
+
+describe("SavedQuestionLoader", () => {
+  beforeEach(() => {
+    // reset mocks between tests so we have fresh spies, etc
+    jest.resetAllMocks();
+  });
+
+  it("should load a question given a questionId", () => {
+    const questionId = 1;
+
+    const loadSpy = jest.spyOn(SavedQuestionLoader.prototype, "_loadQuestion");
+
+    shallow(
+      <SavedQuestionLoader questionId={questionId}>
+        {() => <div />}
+      </SavedQuestionLoader>,
+    );
+
+    expect(loadSpy).toHaveBeenCalledWith(questionId);
+  });
+
+  it("should load a new question if the question ID changes", () => {
+    const originalQuestionId = 1;
+    const newQuestionId = 2;
+
+    const loadSpy = jest.spyOn(SavedQuestionLoader.prototype, "_loadQuestion");
+
+    const wrapper = shallow(
+      <SavedQuestionLoader questionId={originalQuestionId}>
+        {() => <div />}
+      </SavedQuestionLoader>,
+    );
+
+    expect(loadSpy).toHaveBeenCalledWith(originalQuestionId);
+
+    // update the question ID, a new question id param in the url would do this
+    wrapper.setProps({ questionId: newQuestionId });
+
+    // question loading should begin with the new ID
+    expect(loadSpy).toHaveBeenCalledWith(newQuestionId);
+  });
+});


### PR DESCRIPTION
### The tl;dr; 
```jsx
const MyGoodNewFeature = ({
  // these probably come from the router, but they could be set by you too
  questionId,
  questionHash, 
}) =>
<QuestionAndResultLoader questionId={questionId} questionHash={questionHash}>
{ ({ question, result, cancel, reload }) =>
  <div>{ question.displayName() }</div>
  { result && ( <Visualization rawData={[{ card. question.card(), data: result.data }]} />)
  <a onClick={() => cancel()}>Cancel this query please</a>
  <a onClick={() => reload()}>Freshen this up for me</a>
}
</QuestionAndResultLoader>
```

[A more real example of this in use can be seen here.
](https://github.com/metabase/metabase/blob/entity-pages/frontend/src/metabase/components/EntityPage.jsx)

### Motivation
A few important things need to happen when you want to pull down a question. First you need to get the question either from the API or the URL (if it's ad-hoc), then you need to make sure you have metadata about the source table, or db for said loaded, and then to manipulate it nicely with metabase-lib you need to instantiate a new Question object. If you want to work with the result, you also need to call a method on that question object and then if you want to reload or cancel that... 

These steps weren't really fully documented or easily discoverable without spending a fair bit of time or having familiarity with the metabase codebase.

@tlrobinson and I decided to clean this up a bit by creating some convenience components to help with Saved Question loading, Ad-Hoc question loading, result loading, and then for convenience, handling all those situations in one simple component. Props to Tom for the clever way this is split out.

Each component can be used on its own for cases where you might only care about information about a Saved Question or together in cases where you're doing something more custom, but the power for prototyping or new features comes from `<QuestionAndResultLoader>` which combines everything together to give you your question, the result, and basic controls for canceling or reloading the query.

### Future thoughts
Eventually I'd love it if this also handed loading state as well, right now you need to add something akin to: 
```jsx
if(!question) {
  return <div>Loading...</div>
}
```
to make sure that you aren't trying to access information that isn't there yet.
