### PR TITLE
Fix field value widgets on auto dashboards

### DIFF
--- a/frontend/src/metabase/dashboard/dashboard.js
+++ b/frontend/src/metabase/dashboard/dashboard.js
@@ -552,7 +552,7 @@ export const fetchDashboard = createThunkAction(FETCH_DASHBOARD, function(
       }
     }
 
-    if (dashboardType === "normal") {
+    if (dashboardType === "normal" || dashboardType === "transient") {
       // fetch database metadata for every card
       _.chain(result.ordered_cards)
         .map(dc => [dc.card].concat(dc.series))


### PR DESCRIPTION
We weren't loading metadata for auto dashboards so the field value widgets weren't appearing.