### PR TITLE
Set a max-width on add-to-dashboard modal

### DIFF
--- a/frontend/src/metabase/questions/containers/AddToDashboard.jsx
+++ b/frontend/src/metabase/questions/containers/AddToDashboard.jsx
@@ -84,7 +84,7 @@ export default class AddToDashboard extends Component {
   render() {
     const { query, collection } = this.state;
     return (
-      <div className="ml-auto mr-auto" style={{ maxWidth: 800 }}>
+      <div className="wrapper wrapper--trim">
         <ModalContent
           title={t`Pick a question to add`}
           className="mb4 scroll-y"

--- a/frontend/src/metabase/questions/containers/AddToDashboard.jsx
+++ b/frontend/src/metabase/questions/containers/AddToDashboard.jsx
@@ -84,44 +84,53 @@ export default class AddToDashboard extends Component {
   render() {
     const { query, collection } = this.state;
     return (
-      <ModalContent
-        title={t`Pick a question to add`}
-        className="px4 mb4 scroll-y"
-        onClose={() => this.props.onClose()}
+      <div
+        className="flex align-center"
+        style={{ maxWidth: 800, marginLeft: "auto", marginRight: "auto" }}
       >
-        <div className="py1">
-          <div className="flex align-center">
-            {!query ? (
-              <ExpandingSearchField
-                defaultValue={query && query.q}
-                onSearch={value =>
-                  this.setState({
-                    collection: null,
-                    query: { q: value },
-                  })
-                }
-              />
-            ) : (
-              <HeaderWithBack
-                name={collection && collection.name}
-                onBack={() => this.setState({ collection: null, query: null })}
-              />
-            )}
-            {query && (
-              <div className="ml-auto flex align-center">
-                <h5>Sort by</h5>
-                <Button borderless>{t`Last modified`}</Button>
-                <Button borderless>{t`Alphabetical order`}</Button>
-              </div>
-            )}
+        <ModalContent
+          title={t`Pick a question to add`}
+          className="mb4 scroll-y"
+          onClose={() => this.props.onClose()}
+        >
+          <div className="py1">
+            <div className="flex align-center ml3 mb3">
+              {!query ? (
+                <ExpandingSearchField
+                  defaultValue={query && query.q}
+                  onSearch={value =>
+                    this.setState({
+                      collection: null,
+                      query: { q: value },
+                    })
+                  }
+                />
+              ) : (
+                <HeaderWithBack
+                  name={collection && collection.name}
+                  onBack={() =>
+                    this.setState({ collection: null, query: null })
+                  }
+                />
+              )}
+              {query && (
+                <div className="ml-auto flex align-center pr2">
+                  <h5>Sort by</h5>
+                  <Button borderless>{t`Last modified`}</Button>
+                  <Button borderless>{t`Alphabetical order`}</Button>
+                </div>
+              )}
+            </div>
           </div>
-        </div>
-        {query
-          ? // a search term has been entered so show the questions list
-            this.renderQuestionList()
-          : // show the collections list
-            this.renderCollections()}
-      </ModalContent>
+          <div className="mx4">
+            {query
+              ? // a search term has been entered so show the questions list
+                this.renderQuestionList()
+              : // show the collections list
+                this.renderCollections()}
+          </div>
+        </ModalContent>
+      </div>
     );
   }
 }


### PR DESCRIPTION
It's been bugging me for a while now how wide the add-to-dashboard modal can get. This is a simple fix for that.

![screen shot 2018-03-16 at 4 46 26 pm](https://user-images.githubusercontent.com/2223916/37549124-6bf77f66-293a-11e8-80f7-67e946668fc7.png)

![screen shot 2018-03-16 at 4 52 46 pm](https://user-images.githubusercontent.com/2223916/37549130-79a624c8-293a-11e8-8b82-9a599c3dd165.png)

For comparison, here's how things are currently:

![current](https://user-images.githubusercontent.com/2223916/37549190-f885f85e-293a-11e8-963c-c45478967118.png)
