### PR TITLE
Fix misspelling in the Metabase service script

### DIFF
--- a/docs/operations-guide/running-metabase-on-debian.md
+++ b/docs/operations-guide/running-metabase-on-debian.md
@@ -104,7 +104,7 @@ In `/etc/init.d/metabase`, replace configurable items (they look like `<some-var
       uninstall)
         uninstall
         ;;
-      retart)
+      restart)
         stop
         start
         ;;


### PR DESCRIPTION
I registered the Metabase service with referring [here](https://www.metabase.com/docs/v0.28.1/operations-guide/running-metabase-on-debian.html).

The service almost worked well, but the restart command didn't work.
Checking the service script, I found that there was a misspelling.

This PR fixes the misspelling.

###### TODO
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
