### PR TITLE
set default className of full-height for `Visualization` component

### DIFF
--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -130,6 +130,7 @@ export default class Visualization extends Component {
   }
 
   static defaultProps = {
+    className: "full-height",
     showTitle: false,
     isDashboard: false,
     isEditing: false,

--- a/frontend/src/metabase/xray/Histogram.jsx
+++ b/frontend/src/metabase/xray/Histogram.jsx
@@ -5,7 +5,6 @@ import { normal } from "metabase/lib/colors";
 
 const Histogram = ({ histogram, color, showAxis }) => (
   <Visualization
-    className="full-height"
     rawSeries={[
       {
         card: {

--- a/frontend/src/metabase/xray/components/XRayComparison.jsx
+++ b/frontend/src/metabase/xray/components/XRayComparison.jsx
@@ -111,7 +111,6 @@ const CompareHistograms = ({
   <div className="flex" style={{ height }}>
     <div className="flex-full">
       <Visualization
-        className="full-height"
         rawSeries={[
           {
             card: {

--- a/frontend/src/metabase/xray/containers/CardXRay.jsx
+++ b/frontend/src/metabase/xray/containers/CardXRay.jsx
@@ -137,7 +137,6 @@ class CardXRay extends Component {
                         data: xray.features["linear-regression"].value,
                       },
                     ]}
-                    className="full-height"
                   />
                 </div>
               </div>
@@ -166,7 +165,6 @@ class CardXRay extends Component {
                       },
                     },
                   ]}
-                  className="full-height"
                 />
               </div>
             </div>
@@ -210,7 +208,6 @@ class CardXRay extends Component {
                         xray.features["seasonal-decomposition"].value.residual,
                     },
                   ]}
-                  className="full-height"
                 />
               </div>
             </div>


### PR DESCRIPTION
In a fair number of cases it seems like you need to supply a CSS class specifying some sort of height or display property to get your `Visualization` component to render (note the diff) which has led me to a bit of debugging confusion each time I forget this fact. This just sets a default className prop of `full-height` to specify that the Visualization should take up 100% of the height of its parent.