### PR TITLE
Add segments convenience method to help get at currently applied segments

### DIFF
--- a/frontend/src/metabase-lib/lib/metadata/Metadata.js
+++ b/frontend/src/metabase-lib/lib/metadata/Metadata.js
@@ -44,6 +44,14 @@ export default class Metadata extends Base {
     return (Object.values(this.segments): Segment[]);
   }
 
+  segment(segmentId): ?Segment {
+    return (segmentId != null && this.segments[segmentId]) || null;
+  }
+
+  metric(metricId): ?Metric {
+    return (metricId != null && this.metrics[metricId]) || null;
+  }
+
   database(databaseId): ?Database {
     return (databaseId != null && this.databases[databaseId]) || null;
   }

--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
@@ -49,6 +49,8 @@ import AggregationWrapper from "./Aggregation";
 import AggregationOption from "metabase-lib/lib/metadata/AggregationOption";
 import Utils from "metabase/lib/utils";
 
+import { isSegmentFilter } from 'metabase/lib/query/filter'
+
 export const STRUCTURED_QUERY_TEMPLATE = {
   database: null,
   type: "query",
@@ -476,6 +478,21 @@ export default class StructuredQuery extends AtomicQuery {
    */
   filterSegmentOptions(): Segment[] {
     return this.table().segments.filter(sgmt => sgmt.is_active === true);
+  }
+
+
+  /**
+   *  @returns @type {Segment}s that are currently applied to the question
+   */
+  segments() {
+    return this.filters()
+      .filter(f => isSegmentFilter(f))
+      .map(segmentFilter => {
+        // segment id is stored as the second part of the filter clause
+        // e.x. ["SEGMENT", 1]
+        const segmentId = segmentFilter[1]
+        return this.metadata().segments[segmentId]
+      })
   }
 
   /**

--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
@@ -490,7 +490,7 @@ export default class StructuredQuery extends AtomicQuery {
         // segment id is stored as the second part of the filter clause
         // e.x. ["SEGMENT", 1]
         const segmentId = segmentFilter[1];
-        return this.metadata().segments[segmentId];
+        return this.metadata().segment(segmentId)
       });
   }
 

--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
@@ -490,7 +490,7 @@ export default class StructuredQuery extends AtomicQuery {
         // segment id is stored as the second part of the filter clause
         // e.x. ["SEGMENT", 1]
         const segmentId = segmentFilter[1];
-        return this.metadata().segment(segmentId)
+        return this.metadata().segment(segmentId);
       });
   }
 

--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
@@ -49,7 +49,7 @@ import AggregationWrapper from "./Aggregation";
 import AggregationOption from "metabase-lib/lib/metadata/AggregationOption";
 import Utils from "metabase/lib/utils";
 
-import { isSegmentFilter } from 'metabase/lib/query/filter'
+import { isSegmentFilter } from "metabase/lib/query/filter";
 
 export const STRUCTURED_QUERY_TEMPLATE = {
   database: null,
@@ -480,7 +480,6 @@ export default class StructuredQuery extends AtomicQuery {
     return this.table().segments.filter(sgmt => sgmt.is_active === true);
   }
 
-
   /**
    *  @returns @type {Segment}s that are currently applied to the question
    */
@@ -490,9 +489,9 @@ export default class StructuredQuery extends AtomicQuery {
       .map(segmentFilter => {
         // segment id is stored as the second part of the filter clause
         // e.x. ["SEGMENT", 1]
-        const segmentId = segmentFilter[1]
-        return this.metadata().segments[segmentId]
-      })
+        const segmentId = segmentFilter[1];
+        return this.metadata().segments[segmentId];
+      });
   }
 
   /**

--- a/frontend/test/metabase-lib/queries/StructuredQuery.unit.spec.js
+++ b/frontend/test/metabase-lib/queries/StructuredQuery.unit.spec.js
@@ -14,6 +14,7 @@ import {
   PRODUCT_TILE_FIELD_ID,
 } from "__support__/sample_dataset_fixture";
 
+import Segment from "metabase-lib/lib/metadata/Segment";
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 
 function makeDatasetQuery(query) {
@@ -381,13 +382,14 @@ describe("StructuredQuery unit tests", () => {
     });
 
     describe("segments", () => {
-      it('should list any applied segments that are currently active filters', () => {
-
-        const queryWithSegmentFilter = query.addFilter(["SEGMENT", 1])
-        expect(queryWithSegmentFilter.segments()).toBeDefined()
-
-      })
-    })
+      it("should list any applied segments that are currently active filters", () => {
+        const queryWithSegmentFilter = query.addFilter(["SEGMENT", 1]);
+        // expect there to be segments
+        expect(queryWithSegmentFilter.segments().length).toBe(1);
+        // and they should actually be segments
+        expect(queryWithSegmentFilter.segments()[0]).toBeInstanceOf(Segment);
+      });
+    });
 
     describe("canAddFilter", () => {
       pending();

--- a/frontend/test/metabase-lib/queries/StructuredQuery.unit.spec.js
+++ b/frontend/test/metabase-lib/queries/StructuredQuery.unit.spec.js
@@ -380,6 +380,15 @@ describe("StructuredQuery unit tests", () => {
       pending();
     });
 
+    describe("segments", () => {
+      it('should list any applied segments that are currently active filters', () => {
+
+        const queryWithSegmentFilter = query.addFilter(["SEGMENT", 1])
+        expect(queryWithSegmentFilter.segments()).toBeDefined()
+
+      })
+    })
+
     describe("canAddFilter", () => {
       pending();
     });


### PR DESCRIPTION
For some of the work on #6989 we need an easy way to get at currently applied segments in the query. This adds `question.query().segments()` which will return any Segment objects that are currently applied to the query.

ToDos
- [x] Need to make the test a little more real.