### PR TITLE
MS SQL Server 2008 support for month/hour/quarter grouping

### DIFF
--- a/src/metabase/driver/sqlserver.clj
+++ b/src/metabase/driver/sqlserver.clj
@@ -135,7 +135,8 @@
     :month-of-year   (date-part :month expr)
     :quarter         (date-add :quarter
                                (hx/dec (date-part :quarter expr))
-                               (hx/cast :varchar (hx/year expr)))
+                               (hx/+ (hx/cast :varchar (hx/year expr)) 
+                                     (hx/literal "-01-01")))
     :quarter-of-year (date-part :quarter expr)
     :year            (date-part :year expr)))
 

--- a/src/metabase/driver/sqlserver.clj
+++ b/src/metabase/driver/sqlserver.clj
@@ -102,7 +102,15 @@
     :default         expr
     :minute          (hx/cast :smalldatetime expr)
     :minute-of-hour  (date-part :minute expr)
-    :hour            (hx/->datetime (hx/format "yyyy-MM-dd HH:00:00" expr))
+    :hour            (hx/->datetime (hx/+ (hx/cast :varchar (hx/year expr))
+                                          (hx/literal "-")
+                                          (hx/cast :varchar (hx/month expr))
+                                          (hx/literal "-")
+                                          (hx/cast :varchar (hx/day expr))
+                                          (hx/literal " ")
+                                          (hx/cast :varchar (date-part :hour expr))
+                                          (hx/literal ":00:00")
+                      ))
     :hour-of-day     (date-part :hour expr)
     ;; jTDS is retarded; I sense an ongoing theme here. It returns DATEs as strings instead of as java.sql.Dates like
     ;; every other SQL DB we support. Work around that by casting to DATE for truncation then back to DATETIME so we
@@ -121,14 +129,11 @@
                                 (hx/- 1 (date-part :weekday expr))
                                 (hx/->date expr)))
     :week-of-year    (date-part :iso_week expr)
-    :month           (hx/->datetime (hx/format "yyyy-MM-01" expr))
+    :month           (hx/->datetime (hx/+ (hx/cast :varchar (hx/year expr)) (hx/literal "-") (hx/cast :varchar (hx/month expr)) (hx/literal "-01")))
     :month-of-year   (date-part :month expr)
-    ;; Format date as yyyy-01-01 then add the appropriate number of quarter
-    ;; Equivalent SQL:
-    ;;     DATEADD(quarter, DATEPART(quarter, %s) - 1, FORMAT(%s, 'yyyy-01-01'))
     :quarter         (date-add :quarter
                                (hx/dec (date-part :quarter expr))
-                               (hx/format "yyyy-01-01" expr))
+                               (hx/cast :varchar (hx/year expr)))
     :quarter-of-year (date-part :quarter expr)
     :year            (date-part :year expr)))
 

--- a/src/metabase/driver/sqlserver.clj
+++ b/src/metabase/driver/sqlserver.clj
@@ -109,8 +109,7 @@
                                           (hx/cast :varchar (hx/day expr))
                                           (hx/literal " ")
                                           (hx/cast :varchar (date-part :hour expr))
-                                          (hx/literal ":00:00")
-                      ))
+                                          (hx/literal ":00:00")))
     :hour-of-day     (date-part :hour expr)
     ;; jTDS is retarded; I sense an ongoing theme here. It returns DATEs as strings instead of as java.sql.Dates like
     ;; every other SQL DB we support. Work around that by casting to DATE for truncation then back to DATETIME so we
@@ -129,7 +128,10 @@
                                 (hx/- 1 (date-part :weekday expr))
                                 (hx/->date expr)))
     :week-of-year    (date-part :iso_week expr)
-    :month           (hx/->datetime (hx/+ (hx/cast :varchar (hx/year expr)) (hx/literal "-") (hx/cast :varchar (hx/month expr)) (hx/literal "-01")))
+    :month           (hx/->datetime (hx/+ (hx/cast :varchar (hx/year expr)) 
+                                          (hx/literal "-")
+                                          (hx/cast :varchar (hx/month expr))
+                                          (hx/literal "-01")))
     :month-of-year   (date-part :month expr)
     :quarter         (date-add :quarter
                                (hx/dec (date-part :quarter expr))

--- a/src/metabase/util/honeysql_extensions.clj
+++ b/src/metabase/util/honeysql_extensions.clj
@@ -140,6 +140,7 @@
 (def ^{:arglists '([& exprs])} floor   "SQL `floor` function."  (partial hsql/call :floor))
 (def ^{:arglists '([& exprs])} hour    "SQL `hour` function."   (partial hsql/call :hour))
 (def ^{:arglists '([& exprs])} minute  "SQL `minute` function." (partial hsql/call :minute))
+(def ^{:arglists '([& exprs])} day     "SQL `day` function."    (partial hsql/call :day))
 (def ^{:arglists '([& exprs])} week    "SQL `week` function."   (partial hsql/call :week))
 (def ^{:arglists '([& exprs])} month   "SQL `month` function."  (partial hsql/call :month))
 (def ^{:arglists '([& exprs])} quarter "SQL `quarter` function."(partial hsql/call :quarter))


### PR DESCRIPTION
This addresses the issue with 'format' when using SQL Server 2008 (see [#6892](https://github.com/metabase/metabase/issues/6892), [#5893](https://github.com/metabase/metabase/issues/5983) and [#2330](https://github.com/metabase/metabase/issues/2330)), replacing its occurrences with an equivalent SQL expression. Additionally, the function `day` was added to `honeysql-extensions`.
