### PR TITLE
Background color and layout fixes [WIP]

### DIFF
--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -41,8 +41,8 @@ export default class App extends Component {
     const { children, location, errorPage } = this.props;
 
     return (
-      <div className="spread flex flex-column">
-        <Navbar location={location} className="flex-no-shrink" />
+      <div>
+        <Navbar location={location} />
         {errorPage ? getErrorComponent(errorPage) : children}
         <UndoListing />
       </div>

--- a/frontend/src/metabase/auth/containers/LoginApp.jsx
+++ b/frontend/src/metabase/auth/containers/LoginApp.jsx
@@ -112,7 +112,7 @@ export default class LoginApp extends Component {
     const ldapEnabled = Settings.ldapEnabled();
 
     return (
-      <div className="full-height full bg-white flex flex-column flex-full md-layout-centered">
+      <div className="viewport-height flex md-layout-centered">
         <div className="Login-wrapper wrapper Grid Grid--full md-Grid--1of2 relative z2">
           <div className="Grid-cell flex layout-centered text-brand">
             <LogoIcon className="Logo my4 sm-my0" width={66} height={85} />

--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -1,10 +1,6 @@
 :root {
   --night-mode-color: rgba(255, 255, 255, 0.86);
 }
-.Dashboard {
-  background-color: #f9fbfc;
-  height: 100vh;
-}
 
 .DashboardHeader {
   background-color: white;

--- a/frontend/src/metabase/dashboard/components/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard.jsx
@@ -10,6 +10,7 @@ import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper.j
 import Parameters from "metabase/parameters/components/Parameters.jsx";
 
 import DashboardControls from "../hoc/DashboardControls";
+import { withBackground } from "metabase/hoc/Background";
 
 import _ from "underscore";
 import cx from "classnames";
@@ -118,6 +119,7 @@ type State = {
 };
 
 @DashboardControls
+@withBackground("bg-slate-extra-light")
 export default class Dashboard extends Component {
   props: Props;
   state: State = {

--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
@@ -71,6 +71,7 @@ const mapStateToProps = (state, props) => ({
 
 @connect(mapStateToProps, { addUndo, createUndo })
 @DashboardData
+@withBackground("bg-slate-extra-light")
 class AutomaticDashboardApp extends React.Component {
   save = async () => {
     const { dashboard, addUndo, createUndo } = this.props;
@@ -146,4 +147,4 @@ class AutomaticDashboardApp extends React.Component {
   }
 }
 
-export default withBackground("bg-slate-extra-light")(AutomaticDashboardApp);
+export default AutomaticDashboardApp;

--- a/frontend/src/metabase/new_query/containers/MetricSearch.jsx
+++ b/frontend/src/metabase/new_query/containers/MetricSearch.jsx
@@ -81,11 +81,11 @@ export default class MetricSearch extends Component {
             );
           } else {
             return (
-              <div className="mt2 flex-full flex align-center justify-center">
+              <div className="spread flex layout-centered">
                 <EmptyState
                   message={
                     <span>
-                      ${t`Defining common metrics for your team makes it even easier to ask questions`}
+                      {t`Defining common metrics for your team makes it even easier to ask questions`}
                     </span>
                   }
                   image="/app/img/metrics_illustration"

--- a/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
+++ b/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
@@ -118,15 +118,15 @@ export class NewQueryOptions extends Component {
 
     if (!hasDatabases) {
       return (
-        <div className="full-height flex align-center justify-center">
+        <div className="viewport-height flex align-center justify-center">
           <NoDatabasesEmptyState />
         </div>
       );
     }
 
     return (
-      <div className="full-height flex">
-        <div className="wrapper wrapper--trim lg-wrapper--trim xl-wrapper--trim flex-full px4 mt4 mb2 align-center">
+      <div className="spread flex">
+        <div className="full-height wrapper wrapper--trim lg-wrapper--trim xl-wrapper--trim flex-full px4 align-center">
           <div
             className="flex align-center justify-center"
             style={{ minHeight: "100%" }}


### PR DESCRIPTION
Trying to clean up a bit of our layout issues stemming from having `className="spread flex flex-column"` at the root of the app which was causing the suggestion sidebar in automatic dashboards to cut off prematurely and causing other persistent layout foibles.

This update will require fixing a couple existing parts of the app that rely on having that positioning and display context to do their own thing, but should hopefully make things saner going forward.

Note I'm basing this off of `autodash-style-polish` and I'm expecting to probably change the base to master after that merges.