### PR TITLE
server_https before server_name to avoid overwrite

### DIFF
--- a/bin/aws-eb-docker/.ebextensions/01_metabase.config
+++ b/bin/aws-eb-docker/.ebextensions/01_metabase.config
@@ -15,13 +15,14 @@ container_commands:
         #command: true
         #ignoreErrors: false
 
-    01_server-name:
-        command: ".ebextensions/metabase_config/metabase-setup.sh server_name"
-        test: test $NGINX_SERVER_NAME
+    # do server_https first to avoid overwriting other config changes
+    01_server_https:
+        command: ".ebextensions/metabase_config/metabase-setup.sh server_https"
         ignoreErrors: true
 
-    02_server_https:
-        command: ".ebextensions/metabase_config/metabase-setup.sh server_https"
+    02_server_name:
+        command: ".ebextensions/metabase_config/metabase-setup.sh server_name"
+        test: test $NGINX_SERVER_NAME
         ignoreErrors: true
 
     03_log_x_real_ip:


### PR DESCRIPTION
Commit 6b51f30 changed server_https to replace entire config file contents, overwriting any earlier edits made by server_name. Although there's probably a better solution to enforce or remove dependence on order of setup functions in metabase.sh (combine server_https and server_name into one?) simply moving server_https to the first operation is an expedient fix.



###### Before submitting the PR, please make sure you do the following 
-  [ ] If there are changes to the backend codebase, run the backend tests with `lein test && lein eastwood && lein bikeshed && lein docstring-checker && ./bin/reflection-linter`
-  [ ] Run the frontend and integration tests with  `yarn && yarn run prettier && yarn run lint && yarn run flow && ./bin/build version uberjar && yarn run test`)
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
