### PR TITLE
Use nicer code examples in the component guide

### DIFF
--- a/frontend/src/metabase/internal/components/ComponentsApp.jsx
+++ b/frontend/src/metabase/internal/components/ComponentsApp.jsx
@@ -6,6 +6,8 @@ import { Link, Route } from "react-router";
 import { slugify } from "metabase/lib/formatting";
 import reactElementToJSXString from "react-element-to-jsx-string";
 import COMPONENTS from "../lib/components-webpack";
+import AceEditor from "metabase/components/TextEditor";
+import CopyButton from "metabase/components/CopyButton";
 
 const Section = ({ title, children }) => (
   <div className="mb2">
@@ -101,9 +103,18 @@ export default class ComponentsApp extends Component {
                             <div className="p2 bordered flex align-center flex-full">
                               <div className="full">{element}</div>
                             </div>
-                            <div className="border-left border-right border-bottom text-code">
-                              <div className="p1">
-                                {reactElementToJSXString(element)}
+                            <div className="relative">
+                              <AceEditor
+                                value={reactElementToJSXString(element)}
+                                mode={"jsx"}
+                                theme="ace/theme/metabase"
+                                readOnly
+                              />
+                              <div className="absolute top right text-brand-hover cursor-pointer z2">
+                                <CopyButton
+                                  className="p1"
+                                  value={reactElementToJSXString(element)}
+                                />
                               </div>
                             </div>
                           </div>

--- a/frontend/src/metabase/internal/components/ComponentsApp.jsx
+++ b/frontend/src/metabase/internal/components/ComponentsApp.jsx
@@ -106,7 +106,7 @@ export default class ComponentsApp extends Component {
                             <div className="relative">
                               <AceEditor
                                 value={reactElementToJSXString(element)}
-                                mode={"jsx"}
+                                mode="ace/mode/jsx"
                                 theme="ace/theme/metabase"
                                 readOnly
                               />


### PR DESCRIPTION
Spruces up our code examples in the component guide to use something more similar to our embed code snippets and sql editor experience (read only as you'd expect). Also lets you copy the code snippet which might prove handy for the less complicated examples like buttons or checkboxes.

<img width="1792" alt="screen shot 2018-03-26 at 11 27 40 pm" src="https://user-images.githubusercontent.com/5248953/37950478-7a5d171c-314d-11e8-8bf6-ea4666387579.png">

ToDos
- [x] Proper syntax highlighting