### PR TITLE
Use clicked column instead of default date column for count-by-time

### DIFF
--- a/frontend/src/metabase/qb/components/drill/SummarizeColumnByTimeDrill.js
+++ b/frontend/src/metabase/qb/components/drill/SummarizeColumnByTimeDrill.js
@@ -32,6 +32,7 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
     return [];
   }
   const { column } = clicked;
+  const pivotField = isDate(column) ? column : dateField;
 
   return ["sum", "count"]
     .map(getAggregator)
@@ -52,7 +53,7 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
               : [aggregator.short],
           )
           .pivot([
-            ["datetime-field", getFieldRefFromColumn(dateField), "as", "day"],
+            ["datetime-field", getFieldRefFromColumn(pivotField), "as", "day"],
           ]),
     }));
 };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/58540/38016616-2d969e74-3235-11e8-9ac6-2329e20fd226.png)

Currently, when clicking 'Count by time', it always pivots by the first date column in the table. That behavior doesn't make much sense when the table has multiple date column and the user clicks 'Count by time' on other date column. In that case, it's obvious that the user wants to pivot by the date column they clicked.

This PR is a simple fix for that behavior.

