### PR TITLE
Check to ensure database exists before updating card in migration

### DIFF
--- a/src/metabase/db/migrations.clj
+++ b/src/metabase/db/migrations.clj
@@ -338,10 +338,15 @@
 ;; missing those database ids
 (defmigration ^{:author "senior", :added "0.27.0"} populate-card-database-id
   (doseq [[db-id cards] (group-by #(get-in % [:dataset_query :database])
-                                  (db/select [Card :dataset_query :id] :database_id [:= nil]))
+                                  (db/select [Card :dataset_query :id :name] :database_id [:= nil]))
           :when (not= db-id virtual-id)]
-    (db/update-where! Card {:id [:in (map :id cards)]}
-      :database_id db-id)))
+    (if (and (seq cards)
+             (db/exists? Database :id db-id))
+      (db/update-where! Card {:id [:in (map :id cards)]}
+                        :database_id db-id)
+      (doseq [{id :id card-name :name} cards]
+        (log/warnf "Cleaning up orphaned Question '%s', associated to a now deleted database" card-name)
+        (db/delete! Card :id id)))))
 
 ;; Prior to version 0.28.0 humanization was configured using the boolean setting `enable-advanced-humanization`.
 ;; `true` meant "use advanced humanization", while `false` meant "use simple humanization". In 0.28.0, this Setting


### PR DESCRIPTION
The `populate-card-database-id` migration was introduced to fix a bug
where the database id of native questions weren't be populated
correctly. If the the database associated to the native question is
removed, the question wouldn't be removed since there was no FK
relationship. This fix checks to ensure the database exists before
attempting to update the question with the database id. If it doesn't
exist, it cleans up the orphaned question.

Fixes #6520
