### PR TITLE
Add Median aggregation for Postgres, Redshift and SQL Server

### DIFF
--- a/frontend/src/metabase/lib/query.js
+++ b/frontend/src/metabase/lib/query.js
@@ -71,6 +71,7 @@ const METRIC_TYPE_BY_AGGREGATION = {
 
 const SORTABLE_AGGREGATION_TYPES = new Set([
   "avg",
+  "median",
   "count",
   "distinct",
   "stddev",
@@ -612,6 +613,11 @@ var Query = {
           case "avg":
             return [
               t`Average of `,
+              Query.getFieldName(tableMetadata, aggregation[1], options),
+            ];
+          case "Median":
+            return [
+              t`Median of `,
               Query.getFieldName(tableMetadata, aggregation[1], options),
             ];
           case "distinct":

--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -441,6 +441,14 @@ var Aggregators = [
     requiredDriverFeature: "basic-aggregations",
   },
   {
+    name: t`Median of ...`,
+    short: "median",
+    description: t`Median of all the values of a column`,
+    validFieldsFilters: [summableFields],
+    requiresField: true,
+    requiredDriverFeature: "median-aggregations",
+  },
+  {
     name: t`Number of distinct values of ...`,
     short: "distinct",
     description: t`Number of unique values of a column among all the rows in the answer.`,

--- a/frontend/src/metabase/meta/types/Database.js
+++ b/frontend/src/metabase/meta/types/Database.js
@@ -7,6 +7,7 @@ export type DatabaseType = string; // "h2" | "postgres" | etc
 
 export type DatabaseFeature =
   | "basic-aggregations"
+  | "median-aggregations"
   | "standard-deviation-aggregations"
   | "expression-aggregations"
   | "foreign-keys"

--- a/frontend/src/metabase/visualizations/lib/utils.js
+++ b/frontend/src/metabase/visualizations/lib/utils.js
@@ -114,6 +114,7 @@ const FRIENDLY_NAME_MAP = {
   sum: t`Sum`,
   distinct: t`Distinct`,
   stddev: t`Standard Deviation`,
+  median: t`Median`,
 };
 
 export function getXValues(datas, chartType) {

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -142,6 +142,7 @@
   *  `:basic-aggregations` - Does the driver support *basic* aggregations like `:count` and `:sum`? (Currently,
       everything besides standard deviation is considered \"basic\"; only GA doesn't support this).
   *  `:standard-deviation-aggregations` - Does this driver support standard deviation aggregations?
+  *  `:median-aggregations` - Does this driver support median aggregations?
   *  `:expressions` - Does this driver support expressions (e.g. adding the values of 2 columns together)?
   *  `:native-parameters` - Does the driver support parameter substitution on native queries?
   *  `:expression-aggregations` - Does the driver support using expressions inside aggregations? e.g. something like

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -120,6 +120,10 @@
     "*OPTIONAL*. Keyword name of the SQL function that should be used to do a standard deviation aggregation. Defaults
      to `:STDDEV`.")
 
+  (median-fn ^clojure.lang.Keyword [this]
+    "*OPTIONAL*. Keyword name of the SQL function that should be used to do a median aggregation. Defaults
+     to `:MEDIAN`.")
+
   (string-length-fn ^clojure.lang.Keyword [this, ^Keyword field-key]
     "Return a HoneySQL form appropriate for getting the length of a `Field` identified by fully-qualified FIELD-KEY.
      An implementation should return something like:
@@ -405,7 +409,8 @@
    :prepare-sql-param    (u/drop-first-arg identity)
    :quote-style          (constantly :ansi)
    :set-timezone-sql     (constantly nil)
-   :stddev-fn            (constantly :STDDEV)})
+   :stddev-fn            (constantly :STDDEV)
+   :median-fn            (constantly :MEDIAN)})
 
 
 (defn IDriverSQLDefaultsMixin

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -37,7 +37,6 @@
 (defmethod hformat/fn-handler "distinct-count" [_ field]
   (str "count(distinct " (hformat/to-sql field) ")"))
 
-
 ;;; ## Formatting
 
 (defn- qualified-alias
@@ -142,6 +141,7 @@
     ;; aggregation clauses w/ a Field
     (hsql/call (case aggregation-type
                  :avg      :avg
+                 :median   (sql/median-fn driver)
                  :count    :count
                  :distinct :distinct-count
                  :stddev   (sql/stddev-fn driver)

--- a/src/metabase/driver/redshift.clj
+++ b/src/metabase/driver/redshift.clj
@@ -102,6 +102,9 @@
                                                     :type         :password
                                                     :placeholder  "*******"
                                                     :required     true}]))
+          :features                 (fn [this]
+                                      (-> (sql/features this)
+                                          (conj :median-aggregations)))
           :format-custom-field-name (u/drop-first-arg str/lower-case)
           :current-db-time          (driver/make-current-db-time-fn redshift-db-time-query redshift-date-formatters)})
 
@@ -110,7 +113,8 @@
          {:connection-details->spec  (u/drop-first-arg connection-details->spec)
           :current-datetime-fn       (constantly :%getdate)
           :set-timezone-sql          (constantly "SET TIMEZONE TO %s;")
-          :unix-timestamp->timestamp (u/drop-first-arg unix-timestamp->timestamp)}
+          :unix-timestamp->timestamp (u/drop-first-arg unix-timestamp->timestamp)
+          :median-fn                 (constantly :median)}
          ;; HACK ! When we test against Redshift we use a session-unique schema so we can run simultaneous tests
          ;; against a single remote host; when running tests tell the sync process to ignore all the other schemas
          (when config/is-test?

--- a/src/metabase/query_processor/interface.clj
+++ b/src/metabase/query_processor/interface.clj
@@ -387,7 +387,7 @@
                                                                    "Valid aggregation type")
                                       custom-name      :- (s/maybe su/NonBlankString)])
 
-(s/defrecord AggregationWithField [aggregation-type :- (s/named (s/enum :avg :count :cumulative-sum :distinct :max
+(s/defrecord AggregationWithField [aggregation-type :- (s/named (s/enum :avg :median :count :cumulative-sum :distinct :max
                                                                         :min :stddev :sum)
                                                                 "Valid aggregation type")
                                    field            :- (s/cond-pre AnyField
@@ -397,6 +397,8 @@
 (defn- valid-aggregation-for-driver? [{:keys [aggregation-type]}]
   (when (= aggregation-type :stddev)
     (assert-driver-supports :standard-deviation-aggregations))
+  (when (= aggregation-type :median)
+    (assert-driver-supports :median-aggregations))
   true)
 
 (def Aggregation
@@ -404,7 +406,7 @@
   (s/constrained
    (s/cond-pre AggregationWithField AggregationWithoutField Expression)
    valid-aggregation-for-driver?
-   "standard-deviation-aggregations is not supported by this driver."))
+   "Aggregation type is not supported by this driver."))
 
 
 ;;; filter

--- a/src/metabase/query_processor/middleware/expand.clj
+++ b/src/metabase/query_processor/middleware/expand.clj
@@ -175,6 +175,13 @@
   (i/assert-driver-supports :standard-deviation-aggregations)
   (ag-with-field :stddev f))
 
+(defn ^:ql median
+  "Aggregation clause. Return the median of values of F.
+   Requires the feature `:median-aggregations`."
+  [f]
+  (i/assert-driver-supports :median-aggregations)
+  (ag-with-field :median f))
+
 (s/defn ^:ql count :- i/Aggregation
   "Aggregation clause. Return total row count (e.g., `COUNT(*)`). If F is specified, only count rows where F is non-null (e.g. `COUNT(f)`)."
   ([]  (i/map->AggregationWithoutField {:aggregation-type :count}))

--- a/test/metabase/query_processor_test/aggregation_test.clj
+++ b/test/metabase/query_processor_test/aggregation_test.clj
@@ -44,7 +44,23 @@
          booleanize-native-form
          (format-rows-by [(partial u/round-to-decimals 4)])))
 
+;;; ----------------------------------------------- "MEDIAN" AGGREGATION ------------------------------------------------
+(qp-expect-with-engines (non-timeseries-engines-with-feature :median-aggregations)
+ {:rows        [[34.1135]]
+  :columns     ["median"]
+  :cols        [(aggregate-col :median (venues-col :latitude))]
+  :native_form true}
+ (->> (data/run-query venues
+                      (ql/aggregation (ql/median $latitude)))
+      booleanize-native-form
+      (format-rows-by [(partial u/round-to-decimals 4)])))
 
+(datasets/expect-with-engines (non-timeseries-engines-without-feature :median-aggregations)
+                              {:status :failed
+                               :error  "Aggregation type is not supported by this driver."}
+                              (select-keys (data/run-query venues
+                                                           (ql/aggregation (ql/median $latitude)))
+                                           [:status :error]))
 ;;; ------------------------------------------ "DISTINCT COUNT" AGGREGATION ------------------------------------------
 (qp-expect-with-all-engines
     {:rows        [[15]]
@@ -97,7 +113,7 @@
 ;; Make sure standard deviation fails for the Mongo driver since its not supported
 (datasets/expect-with-engines (non-timeseries-engines-without-feature :standard-deviation-aggregations)
   {:status :failed
-   :error  "standard-deviation-aggregations is not supported by this driver."}
+   :error  "Aggregation type is not supported by this driver."}
   (select-keys (data/run-query venues
                  (ql/aggregation (ql/stddev $latitude)))
                [:status :error]))

--- a/test/metabase/query_processor_test/order_by_test.clj
+++ b/test/metabase/query_processor_test/order_by_test.clj
@@ -103,6 +103,24 @@
        booleanize-native-form
        :data (format-rows-by [int int])))
 
+;;; order_by aggregate ["median" field-id]
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :median-aggregations)
+ {:columns     [(data/format-name "price")
+                "median"]
+  :rows        [[3 7]
+                [2 20]
+                [1 30]
+                [4 53]]
+  :cols        [(breakout-col (venues-col :price))
+                (aggregate-col :median (venues-col :category_id))]
+  :native_form true}
+ (->> (data/run-query venues
+                      (ql/aggregation (ql/median $category_id))
+                      (ql/breakout $price)
+                      (ql/order-by (ql/asc (ql/aggregate-field 0))))
+      booleanize-native-form
+      :data (format-rows-by [int int])))
+
 ;;; ### order_by aggregate ["stddev" field-id]
 ;; SQRT calculations are always NOT EXACT (normal behavior) so round everything to the nearest int.
 ;; Databases might use different versions of SQRT implementations


### PR DESCRIPTION
Resolves #1660

Add the interface for Median aggregation, and implemented it in Postgres, Redshift and SQL Server.

Note, H2 also supports median with `MEDIAN` aggregation function in latest version v1.4.197. And it works properly in Metabase web app. But after upgrading to H2 v1.4.197, the unit-tests failed with the following error, 

```
Caused by: clojure.lang.ExceptionInfo: Input to sync-database! does not match schema:

	   [(named (not (instance? metabase.models.database.DatabaseInstance nil)) database)]

 {:type :schema.core/error, :schema [#schema.core.One{:schema metabase.models.database.DatabaseInstance, :optional? false, :name database}], :value [nil], :error [(named (not (instance? metabase.models.database.DatabaseInstance nil)) database)]}
	at metabase.sync$eval52441$sync_database_BANG___52446.invoke(sync.clj:19)
	at metabase.test.data$create_database_BANG_.invokeStatic(data.clj:227)
	at metabase.test.data$create_database_BANG_.invoke(data.clj:218)
	at metabase.test.data$get_or_create_database_BANG_$get_or_create_BANG___94197.invoke(data.clj:250)
	at metabase.test.data$get_or_create_database_BANG_.invokeStatic(data.clj:252)
	at metabase.test.data$get_or_create_database_BANG_.invoke(data.clj:239)
	at metabase.test.data$get_or_create_test_data_db_BANG_.invokeStatic(data.clj:41)
	at metabase.test.data$get_or_create_test_data_db_BANG_.invoke(data.clj:38)
	at metabase.test.data$get_or_create_test_data_db_BANG_.invokeStatic(data.clj:40)
	at metabase.test.data$get_or_create_test_data_db_BANG_.invoke(data.clj:38)
	at metabase.test.data$db.invokeStatic(data.clj:53)
	at metabase.test.data$db.invoke(data.clj:49)
	at metabase.test.data$id.invokeStatic(data.clj:158)
	at metabase.test.data$id.invoke(data.clj:153)
	at clojure.lang.AFn.applyToHelper(AFn.java:152)
	at clojure.lang.RestFn.applyTo(RestFn.java:132)
	at clojure.lang.Compiler$InvokeExpr.eval(Compiler.java:3652)
	... 46 more
```

The issues is that `toucan.db/insert!` (metabase/test/data.clj:222) returns nil when initializing test db. I was unable to track down the root cause, thus removed median support for H2.

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**