### PR TITLE
Hide deleted columns

### DIFF
--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -67,7 +67,11 @@
 (defn fields
   "Return the `FIELDS` belonging to a single TABLE."
   [{:keys [id]}]
-  (db/select Field, :table_id id :visibility_type [:not= "retired"], {:order-by [[:position :asc] [:name :asc]]}))
+  (db/select Field
+    :table_id        id
+    :active          true
+    :visibility_type [:not= "retired"]
+    {:order-by [[:position :asc] [:name :asc]]}))
 
 (defn metrics
   "Retrieve the `Metrics` for a single TABLE."
@@ -132,6 +136,7 @@
   (with-objects :fields
     (fn [table-ids]
       (db/select Field
+        :active          true
         :table_id        [:in table-ids]
         :visibility_type [:not= "retired"]
         {:order-by [[:position :asc] [:name :asc]]}))

--- a/test/metabase/sync/sync_metadata/fields_test.clj
+++ b/test/metabase/sync/sync_metadata/fields_test.clj
@@ -18,7 +18,10 @@
              [generic-sql :as sql-test-data]
              h2
              [interface :as tdi]]
-            [toucan.db :as db]
+            [toucan
+             [db :as db]
+             [hydrate :refer [hydrate]]
+             ]
             [toucan.util.test :as tt]))
 
 (defn- with-test-db-before-and-after-dropping-a-column
@@ -79,6 +82,15 @@
             (db/select [Field :name :active]
               :table_id [:in (db/select-ids Table :db_id (u/get-id database))]))))))
 
+;; make sure deleted fields doesn't show up in `:fields` of a table
+(expect
+  {:before-drop #{"species" "example_name"}
+   :after-drop  #{"species"}}
+  (with-test-db-before-and-after-dropping-a-column
+    (fn [database]
+      (let [table (hydrate (db/select-one Table :db_id (u/get-id database)) :fields)]
+        (set
+         (map :name (:fields table)))))))
 
 ;; make sure that inactive columns don't end up getting spliced into queries! This test arguably belongs in the query
 ;; processor tests since it's ultimately checking to make sure columns marked as `:active` = `false` aren't getting


### PR DESCRIPTION
Currently, once a column is deleted in table schema, the corresponding column field will be marked as `inactive`. But inactive fields are still sent to client and shown in Admin, Question and Data Reference pages. This PR fixes this behavior by not sending inactive fields to client.

Related to https://github.com/metabase/metabase/issues/6108
