### PR TITLE
Handle circular references with source cards

### DIFF
--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -69,6 +69,38 @@
 
 ;;; ---------------------------------------------- Permissions Checking ----------------------------------------------
 
+;; Is calculating permissions for Cards complicated? Some would say so. Refer to this handy flow chart to see how things
+;; get calculated.
+;;
+;; Note that `can-read?/can-write?` and `pre-insert/pre-update` are the two entry points into the permissions
+;; labyrinth. `pre-insert`/`pre-update` calculate permissions for the *query* (disregarding collection and publicness)
+;; and thus skip to `query-perms-set`; `can-read?`/`can-write?` want to take those into account (as well as cached
+;; read permissions, if available) and thus starts higher up.
+;;
+;;
+;; can-read?/can-write? --> perms-set-taking-collection-etc-into-account
+;;                                           |
+;;    public? <------------------------------+---------------------------> in collection?
+;;      ↓                                   else                                ↓
+;;     #{}                                   ↓                       collection/perms-objects-set
+;;                                 card-perms-set-for-query
+;;                                           |
+;;         write perms <---------------------+---------------------> read perms
+;;              |                                                        |
+;;              |            does not have cached read_permissions <-----+-----> has cached read_permissions
+;;              |                            ↓                                              ↓
+;;              +-------------------> query-perms-set <------------------+      return cached read_permssions
+;; pre-insert/                           ↑   |                           |
+;; pre-update ---------------------------+   |                           |
+;; (maybe-update                             |                           |
+;; -read-perms)          native card? <------+-----> mbql card?          |
+;;                             ↓                          ↓              |
+;;                     native-perms-path          mbql-perms-path-set    | (recursively for source card)
+;;                                                         |             |
+;;                                     no source card <----+----> has source card
+;;                                            ↓
+;;                              tables->permissions-path-set
+
 (defn- native-permissions-path
   "Return the `:read` (for running) or `:write` (for saving) native permissions path for DATABASE-OR-ID."
   [read-or-write database-or-id]
@@ -103,8 +135,18 @@
 (declare query-perms-set)
 
 (defn- mbql-permissions-path-set
-  "Return the set of required permissions needed to run QUERY."
-  [read-or-write query]
+  "Return the set of required permissions needed to run QUERY.
+
+  Optionally specify `disallowed-source-card-ids`: this is a sequence of Card IDs that should not be allowed to be a
+  source Card ID in this case. For example, you would want to disallow a Card from being its own source; when
+  recursing, this is used to keep track of source Card IDs we've already seen in order to prevent circular
+  references.
+
+  Also optionally specify `throw-exceptions?` -- normally this function avoids throwing Exceptions to avoid breaking
+  things when a single Card is busted (e.g. API endpoints that filter out unreadable Cards) and instead returns 'only
+  admins can see this' permissions -- `#{\"db/0\"}` (DB 0 will never exist, thus normal users will never be able to
+  get permissions for it, but admins have root perms and will still get to see (and hopefully fix) it)."
+  [read-or-write query & [disallowed-source-card-ids throw-exceptions?]]
   {:pre [(map? query) (map? (:query query))]}
   (try
     (or
@@ -116,13 +158,26 @@
      ;;
      ;; See issue #6845 for further discussion.
      (when-let [source-card-id (qputil/query->source-card-id query)]
-       (query-perms-set (db/select-one-field :dataset_query Card :id source-card-id) :read))
+       ;; If this source card ID is disallowed (e.g. due to it being a circular reference) then throw an Exception.
+       ;; Bye Felicia!
+       (when ((set disallowed-source-card-ids) source-card-id)
+         (throw
+          (Exception.
+           (str "Cannot calculate permissions due to circular references. This means a question is either using itself "
+                "as a source or one or more questions are using each other as sources."))))
+       ;; ok, if we've decided that this is not a loooopy situation then go ahead and recurse
+       (query-perms-set (db/select-one-field :dataset_query Card :id source-card-id)
+                        :read
+                        (conj disallowed-source-card-ids source-card-id)
+                        throw-exceptions?))
      ;; otherwise if there's no source card then calculate perms based on the Tables referenced in the query
      (let [{:keys [query database]} (qp/expand query)]
        (tables->permissions-path-set read-or-write database (query->source-and-join-tables query))))
     ;; if for some reason we can't expand the Card (i.e. it's an invalid legacy card) just return a set of permissions
     ;; that means no one will ever get to see it (except for superusers who get to see everything)
     (catch Throwable e
+      (when throw-exceptions?
+        (throw e))
       (log/warn "Error getting permissions for card:" (.getMessage e) "\n"
                 (u/pprint-to-str (u/filtered-stacktrace e)))
       #{"/db/0/"})))                    ; DB 0 will never exist
@@ -138,30 +193,31 @@
   for read permissions you should look at a Card's `:read_permissions`, which is precalculated. If you specifically
   need to calculate permissions for a query directly, and ignore anything precomputed, use this function. Otherwise
   you should rely on one of the optimized ones below."
-  [{query-type :type, database :database, :as query} read-or-write]
+  [{query-type :type, database :database, :as query} read-or-write & [disallowed-source-card-ids throw-exceptions?]]
   (cond
     (empty? query)                   #{}
     (= (keyword query-type) :native) #{(native-permissions-path read-or-write database)}
-    (= (keyword query-type) :query)  (mbql-permissions-path-set read-or-write query)
+    (= (keyword query-type) :query)  (mbql-permissions-path-set read-or-write query disallowed-source-card-ids throw-exceptions?)
     :else                            (throw (Exception. (str "Invalid query type: " query-type)))))
 
 
 (defn- card-perms-set-for-query
   "Return the permissions required to `read-or-write` `card` based on its query, disregarding the collection the Card is
   in, whether it is publicly shared, etc. This will return precalculated `:read_permissions` if they are present."
-  [{read-perms :read_permissions, id :id, query :dataset_query} read-or-write]
+  [{read-perms :read_permissions, card-id :id, query :dataset_query} read-or-write]
   (cond
     ;; for WRITE permissions always recalculate since these will be determined relatively infrequently (hopefully)
     ;; e.g. when updating a Card
-    (= :write read-or-write) (query-perms-set query :write)
-    ;; if the Card has *populated* `:read_permissions` and we're looking up read pems return those rather than calculating
-    ;; on-the-fly. Cast to `set` to be extra-double-sure it's a set like we'd expect when it gets deserialized from JSON
+    (= :write read-or-write) (query-perms-set query :write [card-id])
+    ;; if the Card has *populated* `:read_permissions` and we're looking up read pems return those rather than
+    ;; calculating on-the-fly. Cast to `set` to be extra-double-sure it's a set like we'd expect when it gets
+    ;; deserialized from JSON
     (seq read-perms) (set read-perms)
     ;; otherwise if :read_permissions was NOT populated. This should not normally happen since the data migration
     ;; should have pre-populated values for all the Cards. If it does it might mean something like we fetched the Card
     ;; without its `read_permissions` column. Since that would be "doing something wrong" warn about it.
-    :else (do (log/info "Card" id "does not have cached read_permissions.")
-              (query-perms-set query :read))))
+    :else (do (log/info "Card" card-id "does not have cached read_permissions.")
+              (query-perms-set query :read [card-id]))))
 
 (defn- card-perms-set-taking-collection-etc-into-account
   "Calculate the permissions required to `read-or-write` `card`*for a user. This takes into account whether the Card is
@@ -172,8 +228,10 @@
   This function works the same regardless of whether called with a current user (e.g. `api/*current-user*`, etc.) or
   not! It simply calculates the permssions a User would need to see the Card."
   [{collection-id :collection_id, public-uuid :public_uuid, in-public-dash? :in_public_dashboard,
-    outer-query :dataset_query, :as card}
+    outer-query :dataset_query, card-id :id, :as card}
    read-or-write]
+  (when-not (seq card)
+    (throw (Exception. "`card` is nil or empty. Cannot calculate permissions.")))
   (let [source-card-id (qputil/query->source-card-id outer-query)]
     (cond
       ;; you don't need any permissions to READ a public card, which is PUBLIC by definition :D
@@ -184,12 +242,6 @@
 
       collection-id
       (collection/perms-objects-set collection-id read-or-write)
-
-      ;; if this is based on a source card then our permissions are based on that; recurse. You can always save a new
-      ;; Card based on a source card you can read, thus read/write permissions for this new Card will be the same as
-      ;; read permissions for its source. This is dicussed in further detail above in `mbql-permissions-path-set`
-      source-card-id
-      (card-perms-set-taking-collection-etc-into-account (Card source-card-id) :read)
 
       :else
       (card-perms-set-for-query card read-or-write))))
@@ -249,13 +301,28 @@
 
 (defn- maybe-update-read-permissions
   "When inserting or updating a `card`, if `:dataset_query` is going to change, calculate the updated `:read_permssions`
-  and `assoc` those to the output so they get changed as well.
+  and `assoc` those to the output so they get changed as well. These cached `read_permissions` are the permissions for
+  the underlying query, disregarding whether the Card is in a collection or present in a public Dashboard or is itself
+  public. Only query permissions are expensive to calculate, so that is the only thing we cache. The other stuff is
+  caclulated every time by `card-perms-set-taking-collection-etc-into-account`.
 
      (maybe-update-read-permssions card-to-be-saved) ;-> updated-card-to-be-saved"
-  [{query :dataset_query, :as card}]
+  [{query :dataset_query, card-id :id, :as card}]
   (if-not (seq query)
     card
-    (assoc card :read_permissions (query-perms-set query :read))))
+    ;; Calculate read_permissions using `query-perms-set`, which calculates perms based on the query along (ignoring
+    ;; collection perms, presence on public dashboards, etc.).
+    (assoc card :read_permissions (query-perms-set query
+                                                   :read
+                                                   ;; If this is an UPDATE operation send along the `card-id` to the
+                                                   ;; list of `disallowed-source-card-ids` because, needless to say, a
+                                                   ;; Card should not be allowed to use itself as a source, whether
+                                                   ;; directly or indirectly. See `query-perms-set` itself for further
+                                                   ;; discussion.
+                                                   (when card-id [card-id])
+                                                   ;; tell `query-perms-set` to throw Exceptions so we don't end up
+                                                   ;; saving a Card that is for some reason invalid
+                                                   :throw-exceptions))))
 
 (defn- pre-insert [{query :dataset_query, :as card}]
   ;; TODO - make sure if `collection_id` is specified that we have write permissions for that collection

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -556,17 +556,11 @@
      (Pulse pulse-id)]))
 
 ;; Adding an additional breakout will cause the alert to be removed
-(tt/expect-with-temp [Database
-                      [{database-id :id}]
-
-                      Table
-                      [{table-id :id} {:db_id database-id}]
-
-                      Card
+(tt/expect-with-temp [Card
                       [card {:display                :line
                              :visualization_settings {:graph.goal_value 10}
                              :dataset_query          (assoc-in
-                                                      (mbql-count-query database-id table-id)
+                                                      (mbql-count-query (data/id) (data/id :checkins))
                                                       [:query :breakout]
                                                       [["datetime-field" (data/id :checkins :date) "hour"]])}]
 
@@ -592,9 +586,9 @@
   (et/with-fake-inbox
     (et/with-expected-messages 1
       ((user->client :crowberto) :put 200 (str "card/" (u/get-id card))
-       {:dataset_query (assoc-in (mbql-count-query database-id table-id)
+       {:dataset_query (assoc-in (mbql-count-query (data/id) (data/id :checkins))
                                  [:query :breakout] [["datetime-field" (data/id :checkins :date) "hour"]
-                                                     ["datetime-field" (data/id :checkins :date) "second"]])}))
+                                                     ["datetime-field" (data/id :checkins :date) "minute"]])}))
     [(et/regex-email-bodies #"the question was edited by Crowberto Corv")
      (Pulse pulse-id)]))
 

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -459,18 +459,18 @@
                       Card [_ (assoc (card-with-mbql-query "Cum Count Card"
                                        :source-table (data/id :checkins)
                                        :aggregation  [[:cum-count]]
-                                       :breakout     [[:datetime-field [:field-id (data/id :checkins :date) :month]]])
+                                       :breakout     [[:datetime-field [:field-id (data/id :checkins :date)] :month]])
                                 :result_metadata [{:name "num_toucans"}])]]
   (saved-questions-virtual-db
     (virtual-table-for-card ok-card))
   (fetch-virtual-database))
 
-;; cum sum using old-style single aggregation syntax
+;; cum count using old-style single aggregation syntax
 (tt/expect-with-temp [Card [ok-card (ok-mbql-card)]
                       Card [_ (assoc (card-with-mbql-query "Cum Sum Card"
                                        :source-table (data/id :checkins)
-                                       :aggregation  [:cum-sum]
-                                       :breakout     [[:datetime-field [:field-id (data/id :checkins :date) :month]]])
+                                       :aggregation  [:cum-count]
+                                       :breakout     [[:datetime-field [:field-id (data/id :checkins :date)] :month]])
                                 :result_metadata [{:name "num_toucans"}])]]
   (saved-questions-virtual-db
     (virtual-table-for-card ok-card))

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -1,8 +1,9 @@
 (ns metabase.models.card-test
-  (:require [expectations :refer :all]
+  (:require [cheshire.core :as json]
+            [expectations :refer :all]
             [metabase.api.common :refer [*current-user-permissions-set*]]
             [metabase.models
-             [card :refer :all]
+             [card :refer :all :as card]
              [dashboard :refer [Dashboard]]
              [dashboard-card :refer [DashboardCard]]
              [database :as database]
@@ -217,6 +218,96 @@
        (db/update! Card id {:name          "another name"
                             :dataset_query (dummy-dataset-query (data/id))})
        (into {} (db/select-one [Card :name :database_id] :id id)))]))
+
+
+
+;;; ------------------------------------------ Circular Reference Detection ------------------------------------------
+
+(defn- card-with-source-table
+  "Generate values for a Card with `source-table` for use with `with-temp`."
+  {:style/indent 1}
+  [source-table & {:as kvs}]
+  (merge {:dataset_query {:database (data/id)
+                          :type     :query
+                          :query    {:source-table source-table}}}
+         kvs))
+
+(defn- force-update-card-to-reference-source-table!
+  "Skip normal pre-update stuff so we can force a Card to get into an invalid state."
+  [card source-table]
+  (db/update! Card {:where [:= :id (u/get-id card)]
+                    :set   (-> (card-with-source-table source-table
+                                 ;; clear out cached read permissions to make sure those aren't used for calcs
+                                 :read_permissions nil)
+                               ;; we have to manually JSON-encode since we're skipping normal pre-update stuff
+                               (update :dataset_query json/generate-string))}))
+
+;; No circular references = it should work!
+(expect
+  {:card-a #{(perms/object-path (data/id) "PUBLIC" (data/id :venues))}
+   :card-b #{(perms/object-path (data/id) "PUBLIC" (data/id :venues))}}
+  ;; Make two cards. Card B references Card A.
+  (tt/with-temp* [Card [card-a (card-with-source-table (data/id :venues))]
+                  Card [card-b (card-with-source-table (str "card__" (u/get-id card-a)))]]
+    {:card-a (#'card/card-perms-set-taking-collection-etc-into-account (Card (u/get-id card-a)) :read)
+     :card-b (#'card/card-perms-set-taking-collection-etc-into-account (Card (u/get-id card-b)) :read)}))
+
+;; If a Card uses itself as a source, perms calculations should fallback to the 'only admins can see it' perms of
+;; #{"/db/0"} (DB 0 will never exist, so regular users will never get to see it, but because admins have root perms,
+;; they will still get to see it and perhaps fix it.)
+(expect
+  Exception
+  (tt/with-temp Card [card (card-with-source-table (data/id :venues))]
+    ;; now try to make the Card reference itself. Should throw Exception
+    (db/update! Card (u/get-id card)
+      (card-with-source-table (str "card__" (u/get-id card))))))
+
+;; if for some reason somebody such an invalid Card was already saved in the DB make sure that calculating permissions
+;; for it just returns the admin-only #{"/db/0"} perms set
+(expect
+  #{"/db/0/"}
+  (tt/with-temp Card [card (card-with-source-table (data/id :venues))]
+    ;; now *make* the Card reference itself
+    (force-update-card-to-reference-source-table! card (str "card__" (u/get-id card)))
+    ;; ok. Calculate perms. Should fail and fall back to admin-only perms
+    (#'card/card-perms-set-taking-collection-etc-into-account (Card (u/get-id card)) :read)))
+
+;; Do the same stuff with circular reference between two Cards... (A -> B -> A)
+(expect
+  Exception
+  (tt/with-temp* [Card [card-a (card-with-source-table (data/id :venues))]
+                  Card [card-b (card-with-source-table (str "card__" (u/get-id card-a)))]]
+    (db/update! Card (u/get-id card-a)
+      (card-with-source-table (str "card__" (u/get-id card-b))))))
+
+(expect
+  #{"/db/0/"}
+  ;; Make two cards. Card B references Card A
+  (tt/with-temp* [Card [card-a (card-with-source-table (data/id :venues))]
+                  Card [card-b (card-with-source-table (str "card__" (u/get-id card-a)))]]
+    ;; force Card A to reference Card B
+    (force-update-card-to-reference-source-table! card-a (str "card__" (u/get-id card-b)))
+    ;; perms calc should fail and we should get admin-only perms
+    (#'card/card-perms-set-taking-collection-etc-into-account (Card (u/get-id card-a)) :read)))
+
+;; ok now try it with A -> C -> B -> A
+(expect
+  Exception
+  (tt/with-temp* [Card [card-a (card-with-source-table (data/id :venues))]
+                  Card [card-b (card-with-source-table (str "card__" (u/get-id card-a)))]
+                  Card [card-c (card-with-source-table (str "card__" (u/get-id card-b)))]]
+    (db/update! Card (u/get-id card-a)
+      (card-with-source-table (str "card__" (u/get-id card-c))))))
+
+(expect
+  #{"/db/0/"}
+  (tt/with-temp* [Card [card-a (card-with-source-table (data/id :venues))]
+                  Card [card-b (card-with-source-table (str "card__" (u/get-id card-a)))]
+                  Card [card-c (card-with-source-table (str "card__" (u/get-id card-b)))]]
+    ;; force Card A to reference Card C
+    (force-update-card-to-reference-source-table! card-a (str "card__" (u/get-id card-c)))
+    ;; perms calc should fail and we should get admin-only perms
+    (#'card/card-perms-set-taking-collection-etc-into-account (Card (u/get-id card-a)) :read)))
 
 
 ;;; ---------------------------------------------- Updating Read Perms -----------------------------------------------


### PR DESCRIPTION
A few things here:

*  Disallow saving circular references in the future
*  For existing circular references just fall back to "admin only" perms (`#{"/db/0"}`) so maybe an admin can go in and unbreak their broken Question(s)
*  Beautiful flow chart in comments explaining how everything works
*  Lots of new tests

Fixes #7223