### PR TITLE
Fix the 'Missing Values' setting on charts

### DIFF
--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -595,10 +595,10 @@ export default function lineAreaBar(element: Element, props: LineAreaBarProps) {
     settings["graph.x_axis.scale"] = "ordinal";
   }
 
-  const datas = getDatas(props, warn);
+  let datas = getDatas(props, warn);
   const xAxisProps = getXAxisProps(props, datas);
 
-  fillMissingValuesInDatas(props, xAxisProps, datas);
+  datas = fillMissingValuesInDatas(props, xAxisProps, datas);
 
   if (isScalarSeries) xAxisProps.xValues = datas.map(data => data[0][0]); // TODO - what is this for?
 

--- a/frontend/src/metabase/visualizations/lib/fill_data.js
+++ b/frontend/src/metabase/visualizations/lib/fill_data.js
@@ -99,4 +99,5 @@ export default function fillMissingValuesInDatas(
       datas = fillMissingValues(datas, xValues, fillValue);
     }
   }
+  return datas;
 }


### PR DESCRIPTION
Looks like this was broken due to some refactoring.

Resolves #6998

Related to #4122 #4802 #5458 #6779