### PR TITLE
fix(frontend) auto-refresh after dashboard redirect

### DIFF
--- a/frontend/src/metabase/dashboard/components/RefreshWidget.jsx
+++ b/frontend/src/metabase/dashboard/components/RefreshWidget.jsx
@@ -1,3 +1,4 @@
+import _ from "underscore";
 import React, { Component } from "react";
 import styles from "./RefreshWidget.css";
 
@@ -22,12 +23,12 @@ const OPTIONS = [
 export default class RefreshWidget extends Component {
   render() {
     const { period, elapsed, onChangePeriod, className } = this.props;
-    const remaining = period - elapsed;
+    const remaining = calculateRemaining(period, elapsed);
     return (
       <PopoverWithTrigger
         ref="popover"
         triggerElement={
-          elapsed == null ? (
+          remaining == null ? (
             <Tooltip tooltip={t`Auto-refresh`}>
               <ClockIcon width={18} height={18} className={className} />
             </Tooltip>
@@ -46,7 +47,7 @@ export default class RefreshWidget extends Component {
                 width={18}
                 height={18}
                 className="text-green"
-                percent={Math.min(0.95, (period - elapsed) / period)}
+                percent={Math.min(0.95, remaining / period)}
               />
             </Tooltip>
           )
@@ -89,3 +90,8 @@ const RefreshOption = ({ name, period, selected, onClick }) => (
     <span className={styles.nameSuffix}> {name.split(" ")[1]}</span>
   </li>
 );
+
+const calculateRemaining = (period, elapsed) => {
+  const option = _.find(OPTIONS, option => period === option.period);
+  return option && option.period ? period - elapsed : null;
+};

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -122,16 +122,7 @@ const UserIsAuthenticated = UserAuthWrapper({
   failureRedirectPath: "/auth/login",
   authSelector: state => state.currentUser,
   wrapperDisplayName: "UserIsAuthenticated",
-  redirectAction: location =>
-    // HACK: workaround for redux-auth-wrapper not including hash
-    // https://github.com/mjrussell/redux-auth-wrapper/issues/121
-    routerActions.replace({
-      ...location,
-      query: {
-        ...location.query,
-        redirect: location.query.redirect + (window.location.hash || ""),
-      },
-    }),
+  redirectAction: routerActions.replace,
 });
 
 const UserIsAdmin = UserAuthWrapper({


### PR DESCRIPTION
This resolves #7244

On dashboard redirect, the hash/fragment portion of URL is being duplicated, which is related to existing hack/workaround for "redux-auth-wrapper", https://github.com/mjrussell/redux-auth-wrapper/issues/121 The library was fixed and merged/released (also 1.x which used by metabase), https://github.com/mjrussell/redux-auth-wrapper/commit/c10060ae49ddc3fa44c05e69b3e7557d4abc03dc So because of that, a portion of the URL was duplicated.

The fix was removed, the hash portion of the URL is now handled by the library and adding a better handling for calculating the remaining time - on dashboard refresh. It should only allow predefined periods. I'm a bit confused (regarding tests setup), where to add any test, maybe a unit test for the new function?