### PR TITLE
Remove the entity type validation from `/api/table/:id`

### DIFF
--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -22,11 +22,6 @@
              [db :as db]
              [hydrate :refer [hydrate]]]))
 
-;; TODO - I don't think this is used for anything any more
-(def ^:private ^:deprecated TableEntityType
-  "Schema for a valid table entity type."
-  (apply s/enum (map name table/entity-types)))
-
 (def ^:private TableVisibilityType
   "Schema for a valid table visibility type."
   (apply s/enum (map name table/visibility-types)))
@@ -54,7 +49,7 @@
   [id :as {{:keys [display_name entity_type visibility_type description caveats points_of_interest
                    show_in_getting_started], :as body} :body}]
   {display_name            (s/maybe su/NonBlankString)
-   entity_type             (s/maybe TableEntityType)
+   entity_type             (s/maybe s/Any)
    visibility_type         (s/maybe TableVisibilityType)
    description             (s/maybe su/NonBlankString)
    caveats                 (s/maybe su/NonBlankString)


### PR DESCRIPTION
Entity type now means something different and the old enum used for
validation no longer makes sense.

Fixes #7256