### PR TITLE
Improve memory usage for computation job result cleanup

### DIFF
--- a/src/metabase/task/cleanup_temporary_computation_job_results.clj
+++ b/src/metabase/task/cleanup_temporary_computation_job_results.clj
@@ -14,7 +14,7 @@
 
 (defn- cleanup-temporary-results!
   []
-  (db/delete! 'ComputationJobResult
+  (db/simple-delete! 'ComputationJobResult
     :created_at [:< (-> (t/now)
                         (t/minus temporary-result-lifetime)
                         t.coerce/to-sql-time)]


### PR DESCRIPTION
Previously the code was using `delete!` which will read in each of the
rows to trigger related deletes before issuing a delete of that
row. The model doesn't have any `pre-delete` actions that are needed
so this switches to a `simple-delete!` which will not cause any of the
rows to be read but rather just a delete statement to the database.

Fixes #7184