### PR TITLE
define setting section slugs manually

### DIFF
--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -2,7 +2,6 @@ import _ from "underscore";
 import { createSelector } from "reselect";
 import MetabaseSettings from "metabase/lib/settings";
 import { t } from "c-3po";
-import { slugify } from "metabase/lib/formatting";
 import CustomGeoJSONWidget from "./components/widgets/CustomGeoJSONWidget.jsx";
 import {
   PublicLinksDashboardListing,

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -17,13 +17,16 @@ import LdapGroupMappingsWidget from "./components/widgets/LdapGroupMappingsWidge
 
 import { UtilApi } from "metabase/services";
 
+/* Note - do not translate slugs */
 const SECTIONS = [
   {
     name: t`Setup`,
+    slug: "setup",
     settings: [],
   },
   {
     name: t`General`,
+    slug: "general",
     settings: [
       {
         key: "site-name",
@@ -92,6 +95,7 @@ const SECTIONS = [
   },
   {
     name: t`Updates`,
+    slug: "updates",
     settings: [
       {
         key: "check-for-updates",
@@ -102,6 +106,7 @@ const SECTIONS = [
   },
   {
     name: t`Email`,
+    slug: "email",
     settings: [
       {
         key: "email-smtp-host",
@@ -153,6 +158,7 @@ const SECTIONS = [
   },
   {
     name: "Slack",
+    slug: "slack",
     settings: [
       {
         key: "slack-token",
@@ -176,6 +182,7 @@ const SECTIONS = [
   },
   {
     name: t`Single Sign-On`,
+    slug: "single_sign_on",
     sidebar: false,
     settings: [
       {
@@ -188,10 +195,12 @@ const SECTIONS = [
   },
   {
     name: t`Authentication`,
+    slug: "authentication",
     settings: [],
   },
   {
     name: t`LDAP`,
+    slug: "ldap",
     sidebar: false,
     settings: [
       {
@@ -278,6 +287,7 @@ const SECTIONS = [
   },
   {
     name: t`Maps`,
+    slug: "maps",
     settings: [
       {
         key: "map-tile-server-url",
@@ -296,6 +306,7 @@ const SECTIONS = [
   },
   {
     name: t`Public Sharing`,
+    slug: "public_sharing",
     settings: [
       {
         key: "enable-public-sharing",
@@ -318,6 +329,7 @@ const SECTIONS = [
   },
   {
     name: t`Embedding in other Applications`,
+    slug: "embedding_in_other_applications",
     settings: [
       {
         key: "enable-embedding",
@@ -373,6 +385,7 @@ const SECTIONS = [
   },
   {
     name: t`Caching`,
+    slug: "caching",
     settings: [
       {
         key: "enable-query-caching",
@@ -404,6 +417,7 @@ const SECTIONS = [
   },
   {
     name: t`X-Rays`,
+    slug: "x_rays",
     settings: [
       {
         key: "enable-xrays",
@@ -431,9 +445,6 @@ const SECTIONS = [
     }
     */
 ];
-for (const section of SECTIONS) {
-  section.slug = slugify(section.name);
-}
 
 export const getSettings = createSelector(
   state => state.settings.settings,


### PR DESCRIPTION
Resolves #7155. `name` properties in the section objects were being auto converted into slugs, which when translated, resulted in the behavior @joebordes reported. This changes to self defined section slugs to prevent this and provide more control over the urls.