### PR TITLE
help ensure key uniqueness for token field items

### DIFF
--- a/frontend/src/metabase/components/TokenField.jsx
+++ b/frontend/src/metabase/components/TokenField.jsx
@@ -547,7 +547,7 @@ export default class TokenField extends Component {
       >
         {value.map((v, index) => (
           <li
-            key={v + index}
+            key={index}
             className={cx(
               `mt1 ml1 py1 pl2 rounded bg-grey-05`,
               multi ? "pr1" : "pr2",

--- a/frontend/src/metabase/components/TokenField.jsx
+++ b/frontend/src/metabase/components/TokenField.jsx
@@ -547,7 +547,7 @@ export default class TokenField extends Component {
       >
         {value.map((v, index) => (
           <li
-            key={v}
+            key={v + index}
             className={cx(
               `mt1 ml1 py1 pl2 rounded bg-grey-05`,
               multi ? "pr1" : "pr2",


### PR DESCRIPTION
A stab at resolving #7043. 

`TokenField` was using the value as a key for the list items in the token field list, which in the case of the pulse recipient list was potentially an entire user object. I think that was causing React to swallow the new items during the DOM update given it was logging this message.

`Encountered two children with the same key, `[object Object]`. Child keys must be unique; when two children share a key, only the first child will be used.` - Pretty much sums up the behavior we saw.

This is a dumb fix to confirm what needs to be changed as index is [somewhat frowned upon](https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318) as a key (which is why I'm guessing this happened in the first place).  There are a couple options as I see it: 

1. Use the v + index solution I did here (probably a bad idea, but hey it works)
2. Allow the user of the  `<TokenField />` component to provide a custom key prop  and if it's not specified fall back to index.
3. Something smarter @tlrobinson or someone else comes up with.