### PR TITLE
Raise GeoJSON file timeout & stream GeoJSON parsing and API responses

### DIFF
--- a/src/metabase/api/geojson.clj
+++ b/src/metabase/api/geojson.clj
@@ -7,15 +7,22 @@
             [metabase.util :as u]
             [metabase.util.schema :as su]
             [puppetlabs.i18n.core :refer [tru]]
-            [schema.core :as s]))
+            [ring.util.response :as rr]
+            [schema.core :as s])
+  (:import org.apache.commons.io.input.ReaderInputStream))
+
+(def ^:private ^:const ^Integer geojson-fetch-timeout-ms
+  "Number of milliseconds we have to fetch (and parse, if applicable) a GeoJSON file before we consider the request to
+  have timed out."
+  (int (* 60 1000)))
 
 (defn- valid-json?
   "Does this URL-OR-RESOURCE point to valid JSON?
   URL-OR-RESOURCE should be something that can be passed to `slurp`, like an HTTP URL or a `java.net.URL` (which is
   what `io/resource` returns below)."
   [url-or-resource]
-  (u/with-timeout 5000
-    (json/parse-string (slurp url-or-resource)))
+  (u/with-timeout geojson-fetch-timeout-ms
+    (dorun (json/parse-stream (io/reader url-or-resource))))
   true)
 
 (defn- valid-json-resource?
@@ -82,10 +89,9 @@
   (let [url (or (get-in (custom-geojson) [(keyword key) :url])
                 (throw (ex-info (str "Invalid custom GeoJSON key: " key)
                          {:status-code 400})))]
-    {:status  200
-     :headers {"Content-Type" "application/json"}
-     :body    (u/with-timeout 5000
-                (slurp url))}))
+    ;; TODO - it would be nice if we could also avoid returning our usual cache-busting headers with the response here
+    (-> (rr/response (ReaderInputStream. (io/reader url)))
+        (rr/content-type "application/json"))))
 
 
 (define-routes)


### PR DESCRIPTION
Fixes #6714 by raising the timeout for fetching GeoJSON files from 5 seconds to 60.

Also made a couple of changes that should reduce memory consumption and boost performance (slightly) when using custom GeoJSON files:

*  when validating GeoJSON files when adding them, do a streaming parse. This avoids keeping the entire object in memory to the extent this is possible
*  when returning GeoJSON files as responses, do a streaming response. This dramatically lowers memory usage and improves performance somewhat