### PR TITLE
Don't fail on Card read_permissions migration if a Card is invalid

### DIFF
--- a/src/metabase/db/migrations.clj
+++ b/src/metabase/db/migrations.clj
@@ -393,7 +393,13 @@
 (defmigration ^{:author "salsakran", :added "0.28.3"} repopulate-card-read-permissions
   (run!
    (fn [card]
-     (db/update! Card (u/get-id card) card))
+     (try
+       (db/update! Card (u/get-id card) card)
+       (catch Throwable e
+         (log/error "Error updating Card to set its read_permissions:"
+                    (class e)
+                    (.getMessage e)
+                    (u/filtered-stacktrace e)))))
    (db/select-reducible Card :archived false)))
 
 ;; Starting in version 0.29.0 we switched the way we decide which Fields should get FieldValues. Prior to 29, Fields


### PR DESCRIPTION
Fixes #7304 and #7303