### PR TITLE
Switch analyze steps to database focused rather than table

### DIFF
--- a/src/metabase/sync/analyze/classify.clj
+++ b/src/metabase/sync/analyze/classify.clj
@@ -124,3 +124,21 @@
    setting) entitiy type of TABLE."
   [table :- i/TableInstance]
   (save-model-updates! table (name/infer-entity-type table)))
+
+(s/defn classify-tables-for-db!
+  "Classify all tables found in a given database"
+  [database :- i/DatabaseInstance
+   tables :- [i/TableInstance]
+   log-progress-fn]
+  (doseq [table tables]
+    (classify-table! table)
+    (log-progress-fn "clasify-tables" table)))
+
+(s/defn classify-fields-for-db!
+  "Classify all fields found in a given database"
+  [database :- i/DatabaseInstance
+   tables :- [i/TableInstance]
+   log-progress-fn]
+  (doseq [table tables]
+    (classify-fields! table)
+    (log-progress-fn "classify-fields" table)))

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -156,3 +156,12 @@
   [table :- i/TableInstance]
   (when-let [fields (fields-to-fingerprint table)]
     (fingerprint-table! table fields)))
+
+(s/defn fingerprint-fields-for-db!
+  "Invokes `fingerprint-fields!` on every table in `database`"
+  [database :- i/DatabaseInstance
+   tables :- [i/TableInstance]
+   log-progress-fn]
+  (doseq [table tables]
+    (fingerprint-fields! table)
+    (log-progress-fn "fingerprint-fields" table)))

--- a/src/metabase/sync/util.clj
+++ b/src/metabase/sync/util.clj
@@ -188,14 +188,16 @@
 
      (emoji-progress-bar 10 40)
        -> \"[************······································] 😒   25%"
-  [completed total]
+  [completed total log-every-n]
   (let [percent-done (float (/ completed total))
         filleds      (int (* percent-done emoji-meter-width))
         blanks       (- emoji-meter-width filleds)]
-    (str "["
-         (str/join (repeat filleds "*"))
-         (str/join (repeat blanks "·"))
-         (format "] %s  %3.0f%%" (u/emoji (percent-done->emoji percent-done)) (* percent-done 100.0)))))
+    (when (or (zero? (mod completed log-every-n))
+              (= completed total))
+      (str "["
+           (str/join (repeat filleds "*"))
+           (str/join (repeat blanks "·"))
+           (format "] %s  %3.0f%%" (u/emoji (percent-done->emoji percent-done)) (* percent-done 100.0))))))
 
 (defmacro with-emoji-progress-bar
   "Run BODY with access to a function that makes using our amazing emoji-progress-bar easy like Sunday morning.
@@ -209,7 +211,8 @@
   [[emoji-progress-fn-binding total-count] & body]
   `(let [finished-count#            (atom 0)
          total-count#               ~total-count
-         ~emoji-progress-fn-binding (fn [] (emoji-progress-bar (swap! finished-count# inc) total-count#))]
+         log-every-n#               (Math/ceil (/ total-count# 10))
+         ~emoji-progress-fn-binding (fn [] (emoji-progress-bar (swap! finished-count# inc) total-count# log-every-n#))]
      ~@body))
 
 


### PR DESCRIPTION
Analyze will now work at the database level of granularity, rather
than the table level of granularity. This will allow logging of
summary information, such as when the step started and finished along
with it's duration. This matches how sync is currently structured.