### PR TITLE
Add tri-state "toggle" for chart settings with automagic behavior

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingToggle.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingToggle.jsx
@@ -2,8 +2,22 @@ import React from "react";
 
 import Toggle from "metabase/components/Toggle.jsx";
 
-const ChartSettingToggle = ({ value, onChange }) => (
-  <Toggle value={value} onChange={onChange} />
-);
+import ChartSettingRadio from "./ChartSettingRadio";
+
+const ChartSettingToggle = ({ value, onChange, className, includeAuto }) =>
+  includeAuto ? (
+    <ChartSettingRadio
+      value={value}
+      onChange={onChange}
+      className={"flex-row"}
+      options={[
+        { name: "Auto", value: undefined },
+        { name: "On", value: true },
+        { name: "Off", value: false },
+      ]}
+    />
+  ) : (
+    <Toggle value={value} onChange={onChange} />
+  );
 
 export default ChartSettingToggle;

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -160,6 +160,9 @@ export const LINE_SETTINGS = {
     section: "Display",
     title: t`Show point markers on lines`,
     widget: "toggle",
+    props: {
+      includeAuto: true,
+    },
   },
 };
 

--- a/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
@@ -71,6 +71,9 @@ export default class PieChart extends Component {
       section: "Display",
       title: t`Show legend`,
       widget: "toggle",
+      props: {
+        includeAuto: true,
+      },
     },
     "pie.show_legend_perecent": {
       section: "Display",


### PR DESCRIPTION
Resolves #7127

![screenshot 2018-04-11 17 03 54](https://user-images.githubusercontent.com/18193/38649339-cfda24b4-3daa-11e8-8a42-138a7bbe88d9.png)

@mazameli  Should we just go ahead and make all "toggle" settings use the radio buttons for consistency? (and probably put `Auto` at the end so it's aligned nicely)

I haven't gone through and figured out which other settings have an auto state, except the two
 listed in #7127.