### PR TITLE
Xray candidates grouped by schema [WIP]

### DIFF
--- a/frontend/src/metabase/components/ExplorePane.jsx
+++ b/frontend/src/metabase/components/ExplorePane.jsx
@@ -10,13 +10,13 @@ import Select, { Option } from "metabase/components/Select";
 import { t } from "c-3po";
 import _ from "underscore";
 
-import type { Candidate } from "metabase/meta/types/Auto";
+import type { DatabaseCandidates, Candidate } from "metabase/meta/types/Auto";
 
 const DEFAULT_TITLE = t`Hi, Metabot here.`;
 const DEFAULT_DESCRIPTION = "";
 
 type Props = {
-  candidates?: ?(Candidate[]),
+  candidates?: ?DatabaseCandidates,
   title?: ?string,
   description?: ?string,
 };
@@ -43,20 +43,15 @@ export class ExplorePane extends React.Component {
     let { schemaName, visibleItems } = this.state;
 
     let schemaNames;
+    let tables;
     let hasMore = false;
-    if (candidates) {
-      const candidatesBySchema =
-        candidates &&
-        _.groupBy(
-          candidates,
-          candidate => candidate.table && candidate.table.schema,
-        );
-      schemaNames = Object.keys(candidatesBySchema || {});
+    if (candidates && candidates.length > 0) {
+      schemaNames = candidates.map(schema => schema.schema);
       if (schemaName == null) {
         schemaName = schemaNames[0];
       }
-      candidates = candidatesBySchema[schemaName].slice(0, visibleItems);
-      hasMore = visibleItems < candidatesBySchema[schemaName].length;
+      const schema = _.findWhere(candidates, { schema: schemaName });
+      tables = (schema && schema.tables) || [];
     }
 
     return (
@@ -79,7 +74,9 @@ export class ExplorePane extends React.Component {
         {schemaNames &&
           schemaNames.length > 1 && (
             <div className="px4 inline-block mb4">
-              <div className="pb1 text-paragraph">Here's the schema I looked at:</div>
+              <div className="pb1 text-paragraph">
+                Here's the schema I looked at:
+              </div>
               <Select
                 value={schemaName}
                 onChange={e =>
@@ -97,9 +94,9 @@ export class ExplorePane extends React.Component {
               </Select>
             </div>
           )}
-        {candidates && (
+        {tables && (
           <div className="px4">
-            <ExploreList candidates={candidates} />
+            <ExploreList candidates={tables} />
           </div>
         )}
         {hasMore && (

--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
@@ -75,6 +75,13 @@ const mapStateToProps = (state, props) => ({
 @connect(mapStateToProps, { addUndo, createUndo })
 @DashboardData
 class AutomaticDashboardApp extends React.Component {
+  componentDidUpdate(prevProps) {
+    // scroll to the top when the pathname changes
+    if (prevProps.location.pathname !== this.props.location.pathname) {
+      window.scrollTo(0, 0);
+    }
+  }
+
   save = async () => {
     const { dashboard, addUndo, createUndo } = this.props;
     // remove the transient id before trying to save

--- a/frontend/src/metabase/meta/types/Auto.js
+++ b/frontend/src/metabase/meta/types/Auto.js
@@ -2,8 +2,19 @@
 
 import type { TableId, SchemaName } from "metabase/meta/types/Table";
 
+export type DatabaseCandidates = SchemaCandidates[];
+
+export type SchemaCandidates = {
+  schema: SchemaName,
+  score: number,
+  tables: Candidate[],
+};
+
 export type Candidate = {
   title: string,
+  description: string,
+  score: number,
+  rule: string,
   url: string,
   table?: {
     id: TableId,

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -14,7 +14,7 @@ import getGAMetadata from "promise-loader?global!metabase/lib/ga-metadata"; // e
 import type { Data, Options } from "metabase/lib/api";
 
 import type { DatabaseId } from "metabase/meta/types/Database";
-import type { Candidate } from "metabase/meta/types/Auto";
+import type { DatabaseCandidates } from "metabase/meta/types/Auto";
 import type { DashboardWithCards } from "metabase/meta/types/Dashboard";
 
 export const ActivityApi = {
@@ -95,7 +95,7 @@ export const EmbedApi = {
 
 type $AutoApi = {
   dashboard: ({ subPath: string }) => DashboardWithCards,
-  db_candidates: ({ id: DatabaseId }) => Candidate[],
+  db_candidates: ({ id: DatabaseId }) => DatabaseCandidates,
 };
 
 export const AutoApi: $AutoApi = {

--- a/frontend/src/metabase/setup/containers/PostSetupApp.jsx
+++ b/frontend/src/metabase/setup/containers/PostSetupApp.jsx
@@ -26,7 +26,7 @@ const QUOTES = [
   t`Metabot is feeling pretty good about all this…`,
 ];
 
-import type { Candidate } from "metabase/meta/types/Auto";
+import type { DatabaseCandidates } from "metabase/meta/types/Auto";
 
 type Props = {
   params: {
@@ -36,8 +36,8 @@ type Props = {
 type State = {
   databaseId: ?number,
   isSample: ?boolean,
-  candidates: ?(Candidate[]),
-  sampleCandidates: ?(Candidate[]),
+  candidates: ?DatabaseCandidates,
+  sampleCandidates: ?DatabaseCandidates,
 };
 
 @withBackground("bg-slate-extra-light")

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -642,7 +642,14 @@
 
 (defn candidate-tables
   "Return a list of tables in database with ID `database-id` for which it makes sense
-   to generate an automagic dashboard."
+   to generate an automagic dashboard. Results are grouped by schema and ranked
+   acording to interestingness (both schemas and tables within each schema). Each
+   schema contains up to `max-candidate-tables` tables.
+
+   Tables are ranked based on how specific rule has been used, and the number of
+   fields.
+   Schemes are ranked based on the number of distinct entity types and the
+   interestingness of tables they contain (see above)."
   ([database] (candidate-tables database nil))
   ([database schema]
    (let [rules (rules/load-rules "table")]


### PR DESCRIPTION
Branching off so it does not make the main branch inoperable while we do the changeover.

Changes response from /candidates to a (sorted) list of {:schema "blah", :tables [...]} maps to better mirror how they are used, and enables us to be smarter about what to show by default. The most interesting schema will always be first.