### PR TITLE
Hash field metadata to bypass field sync if not needed

### DIFF
--- a/frontend/test/services/MetabaseApi.integ.spec.js
+++ b/frontend/test/services/MetabaseApi.integ.spec.js
@@ -21,7 +21,9 @@ function stripKeys(object) {
   if (object && typeof object === "object") {
     for (const key in object) {
       if (
-        /^((updated|created)_at|last_analyzed|timezone|is_on_demand)$/.test(key)
+        /^((updated|created)_at|last_analyzed|timezone|is_on_demand|fields_hash)$/.test(
+          key,
+        )
       ) {
         delete object[key];
       } else {

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -4057,3 +4057,14 @@ databaseChangeLog:
               name: read_permissions
               type: text
               remarks: 'Permissions required to view this Card and run its query.'
+  - changeSet:
+      id: 76
+      author: senior
+      comment: 'Added 0.29.0'
+      changes:
+        - addColumn:
+            tableName: metabase_table
+            columns:
+              name: fields_hash
+              type: text
+              remarks: 'Computed hash of all of the fields associated to this table'

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -45,16 +45,20 @@
 (u/strict-extend (class Table)
   models/IModel
   (merge models/IModelDefaults
-         {:hydration-keys     (constantly [:table])
-          :types              (constantly {:entity_type :keyword, :visibility_type :keyword, :description :clob})
-          :properties         (constantly {:timestamped? true})
-          :pre-insert         pre-insert
-          :pre-delete pre-delete})
+         {:hydration-keys (constantly [:table])
+          :types          (constantly {:entity_type      :keyword,
+                                       :visibility_type  :keyword,
+                                       :description      :clob,
+                                       :has_field_values :clob,
+                                       :fields_hash      :clob})
+          :properties     (constantly {:timestamped? true})
+          :pre-insert     pre-insert
+          :pre-delete     pre-delete})
   i/IObjectPermissions
   (merge i/IObjectPermissionsDefaults
-         {:can-read?          (partial i/current-user-has-full-permissions? :read)
-          :can-write?         i/superuser?
-          :perms-objects-set  perms-objects-set}))
+         {:can-read?         (partial i/current-user-has-full-permissions? :read)
+          :can-write?        i/superuser?
+          :perms-objects-set perms-objects-set}))
 
 
 ;;; --------------------------------------------------- Hydration ----------------------------------------------------

--- a/src/metabase/sync/util.clj
+++ b/src/metabase/sync/util.clj
@@ -1,7 +1,8 @@
 (ns metabase.sync.util
   "Utility functions and macros to abstract away some common patterns and operations across the sync processes, such
   as logging start/end messages."
-  (:require [clojure.math.numeric-tower :as math]
+  (:require [buddy.core.hash :as buddy-hash]
+            [clojure.math.numeric-tower :as math]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [medley.core :as m]
@@ -12,6 +13,8 @@
             [metabase.models.table :refer [Table]]
             [metabase.query-processor.interface :as qpi]
             [metabase.sync.interface :as i]
+            [ring.util.codec :as codec]
+            [taoensso.nippy :as nippy]
             [toucan.db :as db]))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -246,3 +249,13 @@
   i/FieldInstance
   (name-for-logging [{field-name :name, id :id}]
     (format "Field %s '%s'" (or id "") field-name)))
+
+(defn calculate-hash
+  "Calculate a cryptographic hash on `clj-data` and return that hash as a string"
+  [clj-data]
+  (->> clj-data
+       ;; Serialize the sorted list to bytes that can be hashed
+       nippy/fast-freeze
+       buddy-hash/md5
+       ;; Convert the hash bytes to a string for storage/comparison with the hash in the database
+       codec/base64-encode))

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -172,7 +172,8 @@
                 :id              $
                 :db_id           $
                 :raw_table_id    $
-                :created_at      $}))
+                :created_at      $
+                :fields_hash     $}))
       (update :entity_type (comp (partial str "entity/") name))))
 
 
@@ -325,7 +326,8 @@
                                    :id           (data/id :categories)
                                    :raw_table_id $
                                    :db_id        (data/id)
-                                   :created_at   $}))]}))
+                                   :created_at   $
+                                   :fields_hash  $}))]}))
   (let [resp ((user->client :rasta) :get 200 (format "database/%d/metadata" (data/id)))]
     (assoc resp :tables (filter #(= "CATEGORIES" (:name %)) (:tables resp)))))
 

--- a/test/metabase/api/field_test.clj
+++ b/test/metabase/api/field_test.clj
@@ -67,7 +67,8 @@
                              :points_of_interest      nil
                              :show_in_getting_started false
                              :raw_table_id            $
-                             :created_at              $})
+                             :created_at              $
+                             :fields_hash             $})
      :special_type        "type/Name"
      :name                "NAME"
      :display_name        "Name"

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -133,9 +133,7 @@
      :entity_type  "entity/GenericTable"}}
   (->> ((user->client :rasta) :get 200 "table")
        (filter #(= (:db_id %) (data/id))) ; prevent stray tables from affecting unit test results
-       (map #(dissoc %
-                     :raw_table_id :db :created_at :updated_at :schema :entity_name :description :visibility_type
-                     :caveats :points_of_interest :show_in_getting_started :db_id :active))
+       (map #(select-keys % [:name :display_name :rows :id :entity_type]))
        set))
 
 
@@ -152,7 +150,8 @@
             :id           (data/id :venues)
             :db_id        (data/id)
             :raw_table_id $
-            :created_at   $}))
+            :created_at   $
+            :fields_hash  $}))
   ((user->client :rasta) :get 200 (format "table/%d" (data/id :venues))))
 
 ;; GET /api/table/:id should return a 403 for a user that doesn't have read permissions for the table
@@ -201,7 +200,8 @@
             :updated_at   $
             :id           (data/id :categories)
             :raw_table_id $
-            :created_at   $}))
+            :created_at   $
+            :fields_hash  $}))
   ((user->client :rasta) :get 200 (format "table/%d/query_metadata" (data/id :categories))))
 
 
@@ -275,7 +275,8 @@
             :updated_at   $
             :id           (data/id :users)
             :raw_table_id $
-            :created_at   $}))
+            :created_at   $
+            :fields_hash  $}))
   ((user->client :rasta) :get 200 (format "table/%d/query_metadata?include_sensitive_fields=true" (data/id :users))))
 
 ;;; GET api/table/:id/query_metadata
@@ -316,7 +317,8 @@
             :updated_at   $
             :id           (data/id :users)
             :raw_table_id $
-            :created_at   $}))
+            :created_at   $
+            :fields_hash  $}))
   ((user->client :rasta) :get 200 (format "table/%d/query_metadata" (data/id :users))))
 
 ;; Check that FK fields belonging to Tables we don't have permissions for don't come back as hydrated `:target`(#3867)
@@ -355,7 +357,8 @@
             :pk_field        (#'table/pk-field-id $$)
             :id              $
             :raw_table_id    $
-            :created_at      $}))
+            :created_at      $
+            :fields_hash     $}))
   (do ((user->client :crowberto) :put 200 (format "table/%d" (:id table)) {:display_name    "Userz"
                                                                            :visibility_type "hidden"
                                                                            :description     "What a nice table!"})
@@ -410,7 +413,8 @@
                                                           :updated_at   $
                                                           :id           $
                                                           :raw_table_id $
-                                                          :created_at   $}))))
+                                                          :created_at   $
+                                                          :fields_hash  $}))))
       :destination    (-> (fk-field-details users-id-field)
                           (dissoc :target :dimensions :values)
                           (assoc :table_id      (data/id :users)
@@ -429,7 +433,8 @@
                                                           :updated_at   $
                                                           :id           $
                                                           :raw_table_id $
-                                                          :created_at   $}))))}])
+                                                          :created_at   $
+                                                          :fields_hash  $}))))}])
   ((user->client :rasta) :get 200 (format "table/%d/fks" (data/id :users))))
 
 ;; Make sure metadata for 'virtual' tables comes back as expected from GET /api/table/:id/query_metadata

--- a/test/metabase/sync/sync_metadata/sync_database_type_test.clj
+++ b/test/metabase/sync/sync_metadata/sync_database_type_test.clj
@@ -28,6 +28,7 @@
       ;; ok, now give all the Fields `?` as their `database_type`. (This is what the DB migration does for existing
       ;; Fields)
       (db/update-where! Field {:table_id (u/get-id venues-table)}, :database_type "?")
+      (db/update! Table (u/get-id venues-table) :fields_hash "something new")
       ;; now sync the DB again
       (sync/sync-database! db)
       ;; The database_type of these Fields should get set to the correct types. Let's see...
@@ -46,6 +47,7 @@
   (tt/with-temp Database [db (select-keys (data/db) [:details :engine])]
     (sync/sync-database! db)
     (let [venues-table (Table :db_id (u/get-id db), :display_name "Venues")]
+      (db/update! Table (u/get-id venues-table) :fields_hash "something new")
       ;; ok, now give all the Fields `:type/*` as their `base_type`
       (db/update-where! Field {:table_id (u/get-id venues-table)}, :base_type "type/*")
       ;; now sync the DB again

--- a/test/metabase/sync_database/sync_dynamic_test.clj
+++ b/test/metabase/sync_database/sync_dynamic_test.clj
@@ -61,6 +61,7 @@
           details-field-id      (u/get-id (db/select-one-id Field :table_id transactions-table-id, :name "details", :parent_id toucan-field-id))
           age-field-id          (u/get-id (db/select-one-id Field :table_id transactions-table-id, :name "age", :parent_id details-field-id))]
       (db/delete! Field :id age-field-id)
+      (db/update! Table transactions-table-id :fields_hash "something new")
       ;; now sync again.
       (sync-metadata/sync-db-metadata! db)
       ;; field should be added back
@@ -118,6 +119,7 @@
                                             :active        true))]
 
       ;; now sync again.
+      (db/update! Table transactions-table-id :fields_hash "something new")
       (sync-metadata/sync-db-metadata! db)
       ;; field should become inactive
       (db/select-one-field :active Field :id gender-field-id))))
@@ -148,6 +150,7 @@
                                             :active        true))]
 
       ;; now sync again.
+      (db/update! Table transactions-table-id :fields_hash "something new")
       (sync-metadata/sync-db-metadata! db)
       ;; field should become inactive
       (db/select-one-field :active Field :id blueberries-field-id))))

--- a/test/metabase/sync_database_test.clj
+++ b/test/metabase/sync_database_test.clj
@@ -106,7 +106,8 @@
    :schema                  nil
    :show_in_getting_started false
    :updated_at              true
-   :visibility_type         nil})
+   :visibility_type         nil
+   :fields_hash             true})
 
 (def ^:private field-defaults
   {:active              true
@@ -269,6 +270,12 @@
 
 ;; ## Individual Helper Fns
 
+(defn- force-sync-table!
+  "Updates the `:fields_hash` to ensure that the sync process will include fields in the sync"
+  [table]
+  (db/update! Table (u/get-id table), :fields_hash "something new")
+  (sync-table! (Table (data/id :venues))))
+
 ;; ## TEST PK SYNCING
 (expect [:type/PK
          nil
@@ -282,14 +289,14 @@
      (do (db/update! Field (data/id :venues :id), :special_type nil)
          (get-special-type))
      ;; Calling sync-table! should set the special type again
-     (do (sync-table! (Table (data/id :venues)))
+     (do (force-sync-table! (data/id :venues))
          (get-special-type))
      ;; sync-table! should *not* change the special type of fields that are marked with a different type
      (do (db/update! Field (data/id :venues :id), :special_type :type/Latitude)
          (get-special-type))
      ;; Make sure that sync-table runs set-table-pks-if-needed!
      (do (db/update! Field (data/id :venues :id), :special_type nil)
-         (sync-table! (Table (data/id :venues)))
+         (force-sync-table! (Table (data/id :venues)))
          (get-special-type))]))
 
 ;; ## FK SYNCING
@@ -366,28 +373,39 @@
        (str/join ", " (for [n rang]
                         (str "(" n ")")))))
 
+(defn- exec! [conn statements]
+  (doseq [statement statements]
+    (jdbc/execute! conn [statement])))
+
+(defmacro ^:private with-new-mem-db
+  "Setup a in-memory H2 database with a `Database` instance bound to `db-sym` and a connection to that H3 database
+  bound to `conn-sym`."
+  [db-sym conn-sym & body]
+  `(let [details# {:db (str "mem:" (tu/random-name) ";DB_CLOSE_DELAY=10")}]
+     (binding [mdb/*allow-potentailly-unsafe-connections* true]
+       (tt/with-temp Database [db# {:engine :h2, :details details#}]
+         (jdbc/with-db-connection [conn# (sql/connection-details->spec (driver/engine->driver :h2) details#)]
+           (let [~db-sym db#
+                 ~conn-sym conn#]
+             ~@body))))))
+
 (expect
   false
-  (let [details {:db (str "mem:" (tu/random-name) ";DB_CLOSE_DELAY=10")}]
-    (binding [mdb/*allow-potentailly-unsafe-connections* true]
-      (tt/with-temp Database [db {:engine :h2, :details details}]
-        (jdbc/with-db-connection [conn (sql/connection-details->spec (driver/engine->driver :h2) details)]
-          (let [exec! #(doseq [statement %]
-                         (jdbc/execute! conn [statement]))]
-            ;; create the `blueberries_consumed` table and insert 50 values
-            (exec! ["CREATE TABLE blueberries_consumed (num INTEGER NOT NULL);"
-                    (insert-range-sql (range 50))])
-            (sync-database! db)
-            (let [table-id (db/select-one-id Table :db_id (u/get-id db))
-                  field-id (db/select-one-id Field :table_id table-id)]
-              ;; field values should exist...
-              (assert (= (count (db/select-one-field :values FieldValues :field_id field-id))
-                         50))
-              ;; ok, now insert enough rows to push the field past the `list-cardinality-threshold` and sync again,
-              ;; there should be no more field values
-              (exec! [(insert-range-sql (range 50 (+ 100 field-values/list-cardinality-threshold)))])
-              (sync-database! db)
-              (db/exists? FieldValues :field_id field-id))))))))
+  (with-new-mem-db db conn
+    ;; create the `blueberries_consumed` table and insert 50 values
+    (exec! conn ["CREATE TABLE blueberries_consumed (num INTEGER NOT NULL);"
+                 (insert-range-sql (range 50))])
+    (sync-database! db)
+    (let [table-id (db/select-one-id Table :db_id (u/get-id db))
+          field-id (db/select-one-id Field :table_id table-id)]
+      ;; field values should exist...
+      (assert (= (count (db/select-one-field :values FieldValues :field_id field-id))
+                 50))
+      ;; ok, now insert enough rows to push the field past the `list-cardinality-threshold` and sync again,
+      ;; there should be no more field values
+      (exec! conn [(insert-range-sql (range 50 (+ 100 field-values/list-cardinality-threshold)))])
+      (sync-database! db)
+      (db/exists? FieldValues :field_id field-id))))
 
 (defn- narrow-to-min-max [row]
   (-> row
@@ -405,3 +423,136 @@
     (map narrow-to-min-max
          [(db/select-one-field :fingerprint Field, :id (data/id :venues :longitude))
           (db/select-one-field :fingerprint Field, :id (data/id :venues :latitude))])))
+
+(defmacro ^{:style/indent 2} throw-if-called [fn-var & body]
+  `(with-redefs [~fn-var (fn [& args#]
+                           (throw (RuntimeException. "Should not be called!")))]
+     ~@body))
+
+;; Validate the changing of a column's type triggers a hash miss and sync
+(expect
+  [ ;; Original column type
+   "SMALLINT"
+   ;; Altered the column, now it's an integer
+   "INTEGER"
+   ;; Original hash and the new one are not equal
+   false
+   ;; Reruning sync shouldn't change the hash
+   true]
+  (with-new-mem-db db conn
+    (let [get-table #(db/select-one Table :db_id (u/get-id db))]
+      ;; create the `blueberries_consumed` table and insert 50 values
+      (exec! conn ["CREATE TABLE blueberries_consumed (num SMALLINT NOT NULL);"
+                   (insert-range-sql (range 50))])
+      (sync-database! db)
+      ;; After this sync, we know about the new table and it's SMALLINT column
+      (let [table-id                     (u/get-id (get-table))
+            get-field                    #(db/select-one Field :table_id table-id)
+            {old-hash :fields_hash}      (get-table)
+            {old-db-type :database_type} (get-field)]
+        ;; Change the column from SMALLINT to INTEGER. In clojure-land these are both integers, but this change
+        ;; should trigger a hash miss and thus resync the table, since something has changed
+        (exec! conn ["ALTER TABLE blueberries_consumed ALTER COLUMN num INTEGER"])
+        (sync-database! db)
+        (let [{new-hash :fields_hash}      (get-table)
+              {new-db-type :database_type} (get-field)]
+
+          ;; Syncing again with no change should not call sync-field-instances! or update the hash
+          (throw-if-called metabase.sync.sync-metadata.fields/sync-field-instances!
+              (sync-database! db)
+            [old-db-type
+             new-db-type
+             (= old-hash new-hash)
+             (= new-hash (:fields_hash (get-table)))]))))))
+
+(defn- table-md-with-hash [table-id]
+  {:active-fields   (count (db/select Field :table_id table-id :active true))
+   :inactive-fields (count (db/select Field :table_id table-id :active false))
+   :fields-hash     (:fields_hash (db/select-one Table :id table-id))})
+
+(defn- no-fields-hash [m]
+  (dissoc m :fields-hash))
+
+;; This tests a table that adds a column, ensures sync picked up the new column and the hash changed
+(expect
+  [
+   ;; Only the num column should be found
+   {:active-fields 1, :inactive-fields 0}
+   ;; Add a column, should still be no inactive
+   {:active-fields 2, :inactive-fields 0}
+   ;; Adding a column should make the hashes not equal
+   false
+   ]
+  (with-new-mem-db db conn
+    (let [get-table #(db/select-one Table :db_id (u/get-id db))]
+      ;; create the `blueberries_consumed` table and insert 50 values
+      (exec! conn ["CREATE TABLE blueberries_consumed (num SMALLINT NOT NULL)"
+                   (insert-range-sql (range 50))])
+      (sync-database! db)
+      ;; We should now have a hash value for num as a SMALLINT
+      (let [table-id        (u/get-id (get-table))
+            before-table-md (table-md-with-hash table-id)
+            _               (exec! conn ["ALTER TABLE blueberries_consumed ADD COLUMN weight FLOAT"])
+            _               (sync-database! db)
+            ;; Now that hash will include num and weight
+            after-table-md  (table-md-with-hash table-id)]
+        [(no-fields-hash before-table-md)
+         (no-fields-hash after-table-md)
+         (= (:fields-hash before-table-md)
+            (:fields-hash after-table-md))]))))
+
+;; Drops a column, ensures sync finds the drop, updates the hash
+(expect
+  [
+   ;; Test starts with two columns
+   {:active-fields 2, :inactive-fields 0}
+   ;; Dropped the weight column
+   {:active-fields 1, :inactive-fields 1}
+   ;; Hashes should be different without the weight column
+   false]
+  (with-new-mem-db db conn
+    (let [get-table #(db/select-one Table :db_id (u/get-id db))]
+      ;; create the `blueberries_consumed` table and insert 50 values
+      (exec! conn ["CREATE TABLE blueberries_consumed (num SMALLINT NOT NULL, weight FLOAT)"
+                   (insert-range-sql (range 50))])
+      (sync-database! db)
+      ;; We should now have a hash value for num as a SMALLINT
+      (let [table-id        (u/get-id (get-table))
+            before-table-md (table-md-with-hash table-id)
+            _               (exec! conn ["ALTER TABLE blueberries_consumed DROP COLUMN weight"])
+            _               (sync-database! db)
+            ;; Now that hash will include num and weight
+            after-table-md  (table-md-with-hash table-id)]
+        [(no-fields-hash before-table-md)
+         (no-fields-hash after-table-md)
+         (= (:fields-hash before-table-md)
+            (:fields-hash after-table-md))]))))
+
+;; Drops and readds a column, ensures that the hash is back to it's original value
+(expect
+  [
+   ;; Both num and weight columns should be found
+   {:active-fields 2, :inactive-fields 0}
+   ;; Both columns should still be present
+   {:active-fields 2, :inactive-fields 0}
+   ;; The hashes should be the same
+   true]
+  (with-new-mem-db db conn
+    (let [get-table #(db/select-one Table :db_id (u/get-id db))]
+      ;; create the `blueberries_consumed` table and insert 50 values
+      (exec! conn ["CREATE TABLE blueberries_consumed (num SMALLINT NOT NULL, weight FLOAT)"
+                   (insert-range-sql (range 50))])
+      (sync-database! db)
+      ;; We should now have a hash value for num as a SMALLINT
+      (let [table-id        (u/get-id (get-table))
+            before-table-md (table-md-with-hash table-id)
+            _               (exec! conn ["ALTER TABLE blueberries_consumed DROP COLUMN weight"])
+            _               (sync-database! db)
+            _               (exec! conn ["ALTER TABLE blueberries_consumed ADD COLUMN weight FLOAT"])
+            _               (sync-database! db)
+            ;; Now that hash will include num and weight
+            after-table-md  (table-md-with-hash table-id)]
+        [(no-fields-hash before-table-md)
+         (no-fields-hash after-table-md)
+         (= (:fields-hash before-table-md)
+            (:fields-hash after-table-md))])))  )

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -105,7 +105,7 @@
   ([data]
    (boolean-ids-and-timestamps
     (every-pred (some-fn keyword? string?)
-                (some-fn #{:id :created_at :updated_at :last_analyzed :created-at :updated-at :field-value-id :field-id}
+                (some-fn #{:id :created_at :updated_at :last_analyzed :created-at :updated-at :field-value-id :field-id :fields_hash}
                          #(.endsWith (name %) "_id")))
     data))
   ([pred data]


### PR DESCRIPTION
This commit stores an MD5 hash of all field metadata received from the
database for a given table. Most of the time when sync runs, there
will have been no changes to the related fields of that table. By
hashing this and comparing that hash in subsequent sync runs, we can
avoid comparing stored field metadata with the field metadata that
comes back from the database driver. By avoiding this work, we
significantly increase sync performance and lower the impact of sync
on the rest of the system.

This hashing code only impacts the sync of fields as that was shown to
be the slowest part of the sync process. The other steps/stages of
sync/analyze are not affected by this change.