### PR TITLE
Quick grammar/spelling fix for alert setup

### DIFF
--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -319,7 +319,7 @@
 (defn send-new-alert-email!
   "Send out the initial 'new alert' email to the `CREATOR` of the alert"
   [{:keys [creator] :as alert}]
-  (send-email! creator "You setup an alert" new-alert-template
+  (send-email! creator "You set up an alert" new-alert-template
                (default-alert-context alert alert-condition-text)))
 
 (defn send-you-unsubscribed-alert-email!

--- a/test/metabase/api/alert_test.clj
+++ b/test/metabase/api/alert_test.clj
@@ -185,7 +185,7 @@
        (assoc :creator (user-details :crowberto))
        (assoc-in [:card :include_csv] true)
        (update-in [:channels 0] merge {:schedule_hour 12, :schedule_type "daily", :recipients (set (map recipient-details [:rasta :crowberto]))}))
-   (merge (et/email-to :crowberto {:subject "You setup an alert",
+   (merge (et/email-to :crowberto {:subject "You set up an alert",
                                    :body {"https://metabase.com/testmb" true,
                                           "My question" true
                                           "now getting alerts" false

--- a/test/metabase/api/alert_test.clj
+++ b/test/metabase/api/alert_test.clj
@@ -110,7 +110,7 @@
        ~@body)))
 
 (defn- rasta-new-alert-email [body-map]
-  (et/email-to :rasta {:subject "You setup an alert",
+  (et/email-to :rasta {:subject "You set up an alert",
                        :body (merge {"https://metabase.com/testmb" true,
                                      "My question" true}
                                     body-map)}))


### PR DESCRIPTION
This PR changes the email subject for alerts to use "set up" (verb) instead of "setup" (noun): "You set up a new alert" 

Thanks for an amazing product!

###### Before submitting the PR, please make sure you do the following 
-  [x] If there are changes to the backend codebase, run the backend tests with `lein test && lein eastwood && lein bikeshed && lein docstring-checker && ./bin/reflection-linter`
-  [x] Run the frontend and integration tests with  `yarn && yarn run prettier && yarn run lint && yarn run flow && ./bin/build version uberjar && yarn run test`)
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
