### PR TITLE
Fix DateTimeValue validation for null/not null queries

### DIFF
--- a/src/metabase/driver/bigquery.clj
+++ b/src/metabase/driver/bigquery.clj
@@ -241,7 +241,6 @@
   (hx/->timestamp (microseconds->str format-str (->microseconds timestamp))))
 
 (defn- date [unit expr]
-  {:pre [expr]}
   (case unit
     :default         expr
     :minute          (trunc-with-format "%Y-%m-%d %H:%M:00" expr)

--- a/src/metabase/driver/mongo/query_processor.clj
+++ b/src/metabase/driver/mongo/query_processor.clj
@@ -18,8 +18,8 @@
              [operators :refer :all]])
   (:import java.sql.Timestamp
            java.util.Date
-           [metabase.query_processor.interface AgFieldRef DateTimeField DateTimeValue Field RelativeDateTimeValue
-            Value]
+           [metabase.query_processor.interface AgFieldRef DateTimeField DateTimeValue Field FieldLiteral
+            RelativeDateTimeValue Value]
            org.bson.types.ObjectId
            org.joda.time.DateTime))
 
@@ -85,6 +85,13 @@
 
 (extend-protocol IField
   Field
+  (->lvalue [this]
+    (field->name this "___"))
+
+  (->initial-rvalue [this]
+    (str \$ (field->name this ".")))
+
+  FieldLiteral
   (->lvalue [this]
     (field->name this "___"))
 
@@ -177,7 +184,7 @@
                        {:___date (u/format-date format-string v)}))
           extract   (u/rpartial u/date-extract value)]
       (case (or unit :default)
-        :default         (u/->Date value)
+        :default         (some-> value u/->Date)
         :minute          (stringify "yyyy-MM-dd'T'HH:mm:00")
         :minute-of-hour  (extract :minute)
         :hour            (stringify "yyyy-MM-dd'T'HH:00:00")

--- a/src/metabase/driver/oracle.clj
+++ b/src/metabase/driver/oracle.clj
@@ -78,7 +78,7 @@
   "Apply truncation / extraction to a date field or value for Oracle."
   [unit v]
   (case unit
-    :default         (hx/->date v)
+    :default         (some-> v hx/->date)
     :minute          (trunc :mi v)
     ;; you can only extract minute + hour from TIMESTAMPs, even though DATEs still have them (WTF), so cast first
     :minute-of-hour  (hsql/call :extract :minute (hx/->timestamp v))

--- a/src/metabase/query_processor/interface.clj
+++ b/src/metabase/query_processor/interface.clj
@@ -304,7 +304,7 @@
                                                           FieldPlaceholder)])
 
 ;; e.g. an absolute point in time (literal)
-(s/defrecord DateTimeValue [value :- Timestamp
+(s/defrecord DateTimeValue [value :- (s/maybe Timestamp)
                             field :- DateTimeField])
 
 (def OrderableValue

--- a/test/metabase/query_processor_test/filter_test.clj
+++ b/test/metabase/query_processor_test/filter_test.clj
@@ -130,6 +130,19 @@
         (ql/aggregation (ql/count))
         (ql/filter (ql/not-null $date))))))
 
+;; Creates a query that uses a field-literal. Normally our test queries will use a field placeholder, but
+;; https://github.com/metabase/metabase/issues/7381 is only triggered by a field literal
+(expect-with-non-timeseries-dbs
+  [1000]
+  (let [vec-filter #(assoc % :filter ["NOT_NULL"
+                                      ["field-id"
+                                       ["field-literal" (data/format-name "date") "type/DateTime"]]])]
+    (first-row
+      (format-rows-by [int]
+        (data/run-query checkins
+          (ql/aggregation (ql/count))
+          vec-filter)))))
+
 (expect-with-non-timeseries-dbs
   true
   (let [result (first-row (data/run-query checkins


### PR DESCRIPTION
This regression was caused by https://github.com/metabase/metabase/commit/f4a5cb1e2e1feba9388efeb0df39ac67d97acf89#diff-90aba221a9b8d7ad86ce77cad0535f91. Nil DateTimeValues were flowing into code that wasn't expecting it.