### PR TITLE
xray: pick a random color for autogenerated collections

### DIFF
--- a/src/metabase/automagic_dashboards/populate.clj
+++ b/src/metabase/automagic_dashboards/populate.clj
@@ -29,7 +29,8 @@
       :color       color
       :description description)))
 
-(def ^:private colors
+(def colors
+  "Colors used for coloring charts and collections."
   ["#509EE3" "#9CC177" "#A989C5" "#EF8C8C" "#f9d45c" "#F1B556" "#A6E7F3" "#7172AD"])
 
 (defn- ensure-distinct-colors

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -281,7 +281,7 @@
         collection (magic.populate/create-collection!
                     (ensure-unique-collection-name
                      (format "Questions for your \"%s\" dashboard" (:name dashboard)))
-                    "#509EE3"
+                    (rand-nth magic.populate/colors)
                     "Automatically generated cards.")]
     (doseq [dashcard dashcards]
       (let [card     (some-> dashcard :card (assoc :collection_id (:id collection)) save-card!)


### PR DESCRIPTION
Now that we are generating a new collection for each saved xray it makes more sense to color them differently. This patch does that.