### PR TITLE
Enable eslint no-var rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -39,7 +39,8 @@
         "react/no-did-update-set-state": 0,
         "react/no-find-dom-node": 0,
         "flowtype/define-flow-type": 1,
-        "flowtype/use-flow-type": 1
+        "flowtype/use-flow-type": 1,
+        "no-var": 1
     },
     "globals": {
         "pending": false

--- a/frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx
+++ b/frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx
@@ -33,9 +33,9 @@ export default class DeleteDatabaseModal extends Component {
   render() {
     const { database } = this.props;
 
-    var formError;
+    let formError;
     if (this.state.error) {
-      var errorMessage = t`Server error encountered`;
+      let errorMessage = t`Server error encountered`;
       if (this.state.error.data && this.state.error.data.message) {
         errorMessage = this.state.error.data.message;
       } else {

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx
@@ -31,11 +31,11 @@ export default class MetadataHeader extends Component {
   }
 
   renderDbSelector() {
-    var database = this.props.databases.filter(
+    let database = this.props.databases.filter(
       db => db.id === this.props.databaseId,
     )[0];
     if (database) {
-      var columns = [
+      let columns = [
         {
           selectedItem: database,
           items: this.props.databases,
@@ -46,7 +46,7 @@ export default class MetadataHeader extends Component {
           },
         },
       ];
-      var triggerElement = (
+      let triggerElement = (
         <span className="text-bold cursor-pointer text-default">
           {database.name}
           <Icon className="ml1" name="chevrondown" size={8} />

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx
@@ -13,7 +13,7 @@ export default class MetadataSchema extends Component {
       return false;
     }
 
-    var fields = tableMetadata.fields.map(field => {
+    let fields = tableMetadata.fields.map(field => {
       return (
         <li key={field.id} className="px1 py2 flex border-bottom">
           <div className="flex-full flex flex-column mr1">

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx
@@ -50,7 +50,7 @@ export default class MetadataTable extends Component {
   }
 
   renderVisibilityType(text, type, any) {
-    var classes = cx(
+    let classes = cx(
       "mx1",
       "text-bold",
       "text-brand-hover",
@@ -73,7 +73,7 @@ export default class MetadataTable extends Component {
   }
 
   renderVisibilityWidget() {
-    var subTypes;
+    let subTypes;
     if (this.props.tableMetadata.visibility_type) {
       subTypes = (
         <span id="VisibilitySubTypes" className="border-left mx2">

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx
@@ -37,14 +37,14 @@ export default class MetadataTableList extends Component {
   }
 
   render() {
-    var queryableTablesHeader, hiddenTablesHeader;
-    var queryableTables = [];
-    var hiddenTables = [];
+    let queryableTablesHeader, hiddenTablesHeader;
+    let queryableTables = [];
+    let hiddenTables = [];
 
     if (this.props.tables) {
-      var tables = _.sortBy(this.props.tables, "display_name");
+      let tables = _.sortBy(this.props.tables, "display_name");
       _.each(tables, table => {
-        var row = (
+        let row = (
           <li key={table.id}>
             <a
               className={cx("AdminList-item flex align-center no-decoration", {
@@ -60,7 +60,7 @@ export default class MetadataTableList extends Component {
             </a>
           </li>
         );
-        var regex = this.state.searchRegex;
+        let regex = this.state.searchRegex;
         if (
           !regex ||
           regex.test(table.display_name) ||

--- a/frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx
@@ -77,12 +77,12 @@ export default class MetadataEditor extends Component {
   }
 
   render() {
-    var tableMetadata = this.props.databaseMetadata
+    let tableMetadata = this.props.databaseMetadata
       ? _.findWhere(this.props.databaseMetadata.tables, {
           id: this.props.editingTable,
         })
       : null;
-    var content;
+    let content;
     if (tableMetadata) {
       if (this.state.isShowingSchema) {
         content = <MetadataSchema tableMetadata={tableMetadata} />;

--- a/frontend/src/metabase/admin/people/people.js
+++ b/frontend/src/metabase/admin/people/people.js
@@ -125,7 +125,7 @@ export const fetchUsers = createThunkAction(FETCH_USERS, function() {
   return async function(dispatch, getState) {
     let users = await UserApi.list();
 
-    for (var u of users) {
+    for (let u of users) {
       u.date_joined = u.date_joined ? moment(u.date_joined) : null;
       u.last_login = u.last_login ? moment(u.last_login) : null;
     }

--- a/frontend/src/metabase/components/Calendar.jsx
+++ b/frontend/src/metabase/components/Calendar.jsx
@@ -129,7 +129,7 @@ export default class Calendar extends Component {
   }
 
   renderWeeks(current) {
-    var weeks = [],
+    let weeks = [],
       done = false,
       date = moment(current)
         .startOf("month")

--- a/frontend/src/metabase/components/ColumnarSelector.jsx
+++ b/frontend/src/metabase/components/ColumnarSelector.jsx
@@ -22,15 +22,15 @@ export default class ColumnarSelector extends Component {
         ? column.disabledOptionIds.includes(item.id)
         : false;
 
-    var columns = this.props.columns.map((column, columnIndex) => {
-      var sectionElements;
+    let columns = this.props.columns.map((column, columnIndex) => {
+      let sectionElements;
       if (column) {
-        var lastColumn = columnIndex === this.props.columns.length - 1;
-        var sections = column.sections || [column];
+        let lastColumn = columnIndex === this.props.columns.length - 1;
+        let sections = column.sections || [column];
         sectionElements = sections.map((section, sectionIndex) => {
-          var title = section.title;
-          var items = section.items.map((item, rowIndex) => {
-            var itemClasses = cx({
+          let title = section.title;
+          let items = section.items.map((item, rowIndex) => {
+            let itemClasses = cx({
               "ColumnarSelector-row": true,
               "ColumnarSelector-row--selected": isItemSelected(item, column),
               "ColumnarSelector-row--disabled": isItemDisabled(item, column),
@@ -38,9 +38,9 @@ export default class ColumnarSelector extends Component {
               "no-decoration": true,
               "cursor-default": isItemDisabled(item, column),
             });
-            var checkIcon = lastColumn ? <Icon name="check" size={14} /> : null;
-            var descriptionElement;
-            var description =
+            let checkIcon = lastColumn ? <Icon name="check" size={14} /> : null;
+            let descriptionElement;
+            let description =
               column.itemDescriptionFn && column.itemDescriptionFn(item);
             if (description) {
               descriptionElement = (
@@ -67,7 +67,7 @@ export default class ColumnarSelector extends Component {
               </li>
             );
           });
-          var titleElement;
+          let titleElement;
           if (title) {
             titleElement = (
               <div className="ColumnarSelector-title">{title}</div>

--- a/frontend/src/metabase/components/CreateDashboardModal.jsx
+++ b/frontend/src/metabase/components/CreateDashboardModal.jsx
@@ -35,17 +35,17 @@ export default class CreateDashboardModal extends Component {
   createNewDash(event) {
     event.preventDefault();
 
-    var name = this.state.name && this.state.name.trim();
-    var description = this.state.description && this.state.description.trim();
+    let name = this.state.name && this.state.name.trim();
+    let description = this.state.description && this.state.description.trim();
 
     // populate a new Dash object
-    var newDash = {
+    let newDash = {
       name: name && name.length > 0 ? name : null,
       description: description && description.length > 0 ? description : null,
     };
 
     // create a new dashboard
-    var component = this;
+    let component = this;
     this.props.createDashboardFn(newDash).then(null, function(error) {
       component.setState({
         errors: error,
@@ -54,9 +54,9 @@ export default class CreateDashboardModal extends Component {
   }
 
   render() {
-    var formError;
+    let formError;
     if (this.state.errors) {
-      var errorMessage = t`Server error encountered`;
+      let errorMessage = t`Server error encountered`;
       if (this.state.errors.data && this.state.errors.data.message) {
         errorMessage = this.state.errors.data.message;
       }
@@ -65,9 +65,9 @@ export default class CreateDashboardModal extends Component {
       formError = <span className="text-error px2">{errorMessage}</span>;
     }
 
-    var name = this.state.name && this.state.name.trim();
+    let name = this.state.name && this.state.name.trim();
 
-    var formReady = name !== null && name !== "";
+    let formReady = name !== null && name !== "";
 
     return (
       <ModalContent

--- a/frontend/src/metabase/components/DatabaseDetailsForm.jsx
+++ b/frontend/src/metabase/components/DatabaseDetailsForm.jsx
@@ -252,7 +252,7 @@ export default class DatabaseDetailsForm extends Component {
     } else if (field.name === "client-id" && CREDENTIALS_URL_PREFIXES[engine]) {
       let { details } = this.state;
       let projectID = details && details["project-id"];
-      var credentialsURLLink;
+      let credentialsURLLink;
       // if (projectID) {
       let credentialsURL = CREDENTIALS_URL_PREFIXES[engine] + (projectID || "");
       credentialsURLLink = (
@@ -279,7 +279,7 @@ export default class DatabaseDetailsForm extends Component {
     } else if (field.name === "auth-code" && AUTH_URL_PREFIXES[engine]) {
       let { details } = this.state;
       const clientID = details && details["client-id"];
-      var authURLLink;
+      let authURLLink;
       if (clientID) {
         let authURL = AUTH_URL_PREFIXES[engine] + clientID;
         authURLLink = (

--- a/frontend/src/metabase/components/Header.jsx
+++ b/frontend/src/metabase/components/Header.jsx
@@ -75,7 +75,7 @@ export default class Header extends Component {
   }
 
   render() {
-    var titleAndDescription;
+    let titleAndDescription;
     if (this.props.isEditingInfo) {
       titleAndDescription = (
         <div className="Header-title flex flex-column flex-full bordered rounded my1">
@@ -112,7 +112,7 @@ export default class Header extends Component {
       }
     }
 
-    var attribution;
+    let attribution;
     if (this.props.item && this.props.item.creator) {
       attribution = (
         <div className="Header-attribution">
@@ -121,7 +121,7 @@ export default class Header extends Component {
       );
     }
 
-    var headerButtons = this.props.headerButtons.map(
+    let headerButtons = this.props.headerButtons.map(
       (section, sectionIndex) => {
         return (
           section &&

--- a/frontend/src/metabase/components/HistoryModal.jsx
+++ b/frontend/src/metabase/components/HistoryModal.jsx
@@ -8,7 +8,7 @@ import ModalContent from "metabase/components/ModalContent.jsx";
 import moment from "moment";
 
 function formatDate(date) {
-  var m = moment(date);
+  let m = moment(date);
   if (m.isSame(moment(), "day")) {
     return t`Today, ` + m.format("h:mm a");
   } else if (m.isSame(moment().subtract(1, "day"), "day")) {
@@ -74,7 +74,7 @@ export default class HistoryModal extends Component {
   }
 
   render() {
-    var { revisions } = this.props;
+    let { revisions } = this.props;
     return (
       <ModalContent
         title={t`Revision history`}

--- a/frontend/src/metabase/components/LoadingSpinner.jsx
+++ b/frontend/src/metabase/components/LoadingSpinner.jsx
@@ -11,7 +11,7 @@ export default class LoadingSpinner extends Component {
   };
 
   render() {
-    var { size, borderWidth, className, spinnerClassName } = this.props;
+    let { size, borderWidth, className, spinnerClassName } = this.props;
     return (
       <div className={className}>
         <div

--- a/frontend/src/metabase/components/NewsletterForm.jsx
+++ b/frontend/src/metabase/components/NewsletterForm.jsx
@@ -35,7 +35,7 @@ export default class NewsletterForm extends Component {
   subscribeUser(e) {
     e.preventDefault();
 
-    var formData = new FormData();
+    let formData = new FormData();
     formData.append("EMAIL", ReactDOM.findDOMNode(this.refs.email).value);
     formData.append("b_869fec0e4689e8fd1db91e795_b9664113a8", "");
 

--- a/frontend/src/metabase/components/OnClickOutsideWrapper.jsx
+++ b/frontend/src/metabase/components/OnClickOutsideWrapper.jsx
@@ -44,7 +44,7 @@ export default class OnClickOutsideWrapper extends Component {
     // remove from the stack after a delay, if it is removed through some other
     // means this will happen too early causing parent modal to close
     setTimeout(() => {
-      var index = popoverStack.indexOf(this);
+      let index = popoverStack.indexOf(this);
       if (index >= 0) {
         popoverStack.splice(index, 1);
       }

--- a/frontend/src/metabase/components/Popover.jsx
+++ b/frontend/src/metabase/components/Popover.jsx
@@ -286,7 +286,7 @@ export default class Popover extends Component {
     );
 
     if (isOpen) {
-      var tetherOptions = {
+      let tetherOptions = {
         element: popoverElement,
         target: this._getTarget(),
       };

--- a/frontend/src/metabase/components/SaveStatus.jsx
+++ b/frontend/src/metabase/components/SaveStatus.jsx
@@ -25,7 +25,7 @@ export default class SaveStatus extends Component {
 
   setSaved() {
     clearTimeout(this.state.recentlySavedTimeout);
-    var recentlySavedTimeout = setTimeout(
+    let recentlySavedTimeout = setTimeout(
       () => this.setState({ recentlySavedTimeout: null }),
       5000,
     );

--- a/frontend/src/metabase/components/Select.jsx
+++ b/frontend/src/metabase/components/Select.jsx
@@ -304,11 +304,11 @@ class LegacySelect extends Component {
       disabled,
     } = this.props;
 
-    var selectedName = value
+    let selectedName = value
       ? optionNameFn(value)
       : options && options.length > 0 ? placeholder : emptyPlaceholder;
 
-    var triggerElement = (
+    let triggerElement = (
       <div
         className={cx(
           "flex align-center",
@@ -331,9 +331,9 @@ class LegacySelect extends Component {
       </div>
     );
 
-    var sections = {};
+    let sections = {};
     options.forEach(function(option) {
-      var sectionName = option.section || "";
+      let sectionName = option.section || "";
       sections[sectionName] = sections[sectionName] || {
         title: sectionName || undefined,
         items: [],
@@ -342,7 +342,7 @@ class LegacySelect extends Component {
     });
     sections = Object.keys(sections).map(sectionName => sections[sectionName]);
 
-    var columns = [
+    let columns = [
       {
         selectedItem: value,
         selectedItems: values,

--- a/frontend/src/metabase/components/SortableItemList.jsx
+++ b/frontend/src/metabase/components/SortableItemList.jsx
@@ -27,7 +27,7 @@ export default class SortableItemList extends Component {
   }
 
   render() {
-    var items;
+    let items;
     if (this.state.sort === "Last Modified") {
       items = this.props.items
         .slice()

--- a/frontend/src/metabase/containers/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.jsx
@@ -135,9 +135,9 @@ export default class SaveQuestionModal extends Component {
 
   render() {
     let { error, details } = this.state;
-    var formError;
+    let formError;
     if (error) {
-      var errorMessage;
+      let errorMessage;
       if (error.status === 500) {
         errorMessage = t`Server error encountered`;
       }
@@ -155,7 +155,7 @@ export default class SaveQuestionModal extends Component {
       }
     }
 
-    var saveOrUpdate = null;
+    let saveOrUpdate = null;
     if (!this.props.card.id && this.props.originalCard) {
       saveOrUpdate = (
         <FormField

--- a/frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx
+++ b/frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx
@@ -28,9 +28,9 @@ export default class ArchiveDashboardModal extends Component {
   }
 
   render() {
-    var formError;
+    let formError;
     if (this.state.error) {
-      var errorMessage = "Server error encountered";
+      let errorMessage = "Server error encountered";
       if (this.state.error.data && this.state.error.data.message) {
         errorMessage = this.state.error.data.message;
       } else {

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -73,11 +73,11 @@ export default class DashboardGrid extends Component {
   }
 
   onLayoutChange(layout) {
-    var changes = layout.filter(
+    let changes = layout.filter(
       newLayout =>
         !_.isEqual(newLayout, this.getLayoutForDashCard(newLayout.dashcard)),
     );
-    for (var change of changes) {
+    for (let change of changes) {
       this.props.setDashCardAttributes({
         id: change.dashcard.id,
         attributes: {

--- a/frontend/src/metabase/dashboard/components/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader.jsx
@@ -325,7 +325,7 @@ export default class DashboardHeader extends Component {
   }
 
   render() {
-    var { dashboard } = this.props;
+    let { dashboard } = this.props;
 
     return (
       <Header

--- a/frontend/src/metabase/dashboard/dashboard.js
+++ b/frontend/src/metabase/dashboard/dashboard.js
@@ -138,7 +138,7 @@ export const fetchCards = createThunkAction(FETCH_CARDS, function(
 ) {
   return async function(dispatch, getState) {
     let cards = await CardApi.list({ f: filterMode });
-    for (var c of cards) {
+    for (let c of cards) {
       c.updated_at = moment(c.updated_at);
     }
     return normalize(cards, [card]);

--- a/frontend/src/metabase/home/actions.js
+++ b/frontend/src/metabase/home/actions.js
@@ -14,7 +14,7 @@ export const FETCH_RECENT_VIEWS = "FETCH_RECENT_VIEWS";
 export const fetchActivity = createThunkAction(FETCH_ACTIVITY, function() {
   return async function(dispatch, getState) {
     let activity = await ActivityApi.list();
-    for (var ai of activity) {
+    for (let ai of activity) {
       ai.timestamp = moment(ai.timestamp);
       ai.hasLinkableModel = function() {
         return _.contains(["card", "dashboard"], this.model);
@@ -29,7 +29,7 @@ export const fetchRecentViews = createThunkAction(
   function() {
     return async function(dispatch, getState) {
       let recentViews = await ActivityApi.recent_views();
-      for (var v of recentViews) {
+      for (let v of recentViews) {
         v.timestamp = moment(v.timestamp);
       }
       return recentViews;

--- a/frontend/src/metabase/home/components/Activity.jsx
+++ b/frontend/src/metabase/home/components/Activity.jsx
@@ -48,11 +48,11 @@ export default class Activity extends Component {
     const maxColorUsed = _.isEmpty(userColors)
       ? 0
       : _.max(_.values(userColors));
-    var currColor =
+    let currColor =
       maxColorUsed && maxColorUsed < colors.length ? maxColorUsed : 0;
 
     if (user && activity) {
-      for (var item of activity) {
+      for (let item of activity) {
         if (!(item.user_id in userColors)) {
           // assign the user a color
           if (item.user_id === user.id) {

--- a/frontend/src/metabase/icon_paths.js
+++ b/frontend/src/metabase/icon_paths.js
@@ -7,7 +7,7 @@
     These paths represent the current canonical icon set for Metabase.
 */
 
-export var ICON_PATHS = {
+export const ICON_PATHS = {
   add:
     "M19,13 L19,2 L14,2 L14,13 L2,13 L2,18 L14,18 L14,30 L19,30 L19,18 L30,18 L30,13 L19,13 Z",
   addtodash: {
@@ -373,7 +373,7 @@ export function parseViewBox(viewBox: string): Array<number> {
 }
 
 export function loadIcon(name: string) {
-  var def = ICON_PATHS[name];
+  let def = ICON_PATHS[name];
   if (!def) {
     console.warn('Icon "' + name + '" does not exist.');
     return;
@@ -383,7 +383,7 @@ export function loadIcon(name: string) {
     return { ...def, attrs: { ...def.attrs, className: "Icon Icon-" + name } };
   }
 
-  var icon = {
+  let icon = {
     attrs: {
       className: "Icon Icon-" + name,
       viewBox: "0 0 32 32",
@@ -398,8 +398,8 @@ export function loadIcon(name: string) {
   if (typeof def === "string") {
     icon.path = def;
   } else if (def != null) {
-    var { svg, path, attrs } = def;
-    for (var attr in attrs) {
+    let { svg, path, attrs } = def;
+    for (let attr in attrs) {
       icon.attrs[attr] = attrs[attr];
     }
 

--- a/frontend/src/metabase/internal/lib/components-node.js
+++ b/frontend/src/metabase/internal/lib/components-node.js
@@ -3,7 +3,7 @@
 import path from "path";
 import fs from "fs";
 
-var normalizedPath = path.join(__dirname, "..", "..", "components");
+let normalizedPath = path.join(__dirname, "..", "..", "components");
 
 export default fs
   .readdirSync(normalizedPath)

--- a/frontend/src/metabase/lib/ace/sql_behaviour.js
+++ b/frontend/src/metabase/lib/ace/sql_behaviour.js
@@ -37,22 +37,22 @@
 ace.require(
   ["ace/lib/oop", "ace/mode/behaviour", "ace/token_iterator", "ace/lib/lang"],
   function(oop, { Behaviour }, { TokenIterator }, lang) {
-    var SAFE_INSERT_IN_TOKENS = [
+    let SAFE_INSERT_IN_TOKENS = [
       "text",
       "paren.rparen",
       "punctuation.operator",
     ];
-    var SAFE_INSERT_BEFORE_TOKENS = [
+    let SAFE_INSERT_BEFORE_TOKENS = [
       "text",
       "paren.rparen",
       "punctuation.operator",
       "comment",
     ];
 
-    var context;
-    var contextCache = {};
-    var initContext = function(editor) {
-      var id = -1;
+    let context;
+    let contextCache = {};
+    let initContext = function(editor) {
+      let id = -1;
       if (editor.multiSelect) {
         id = editor.selection.index;
         if (contextCache.rangeCount != editor.multiSelect.rangeCount)
@@ -70,8 +70,8 @@ ace.require(
       };
     };
 
-    var getWrapped = function(selection, selected, opening, closing) {
-      var rowDiff = selection.end.row - selection.start.row;
+    let getWrapped = function(selection, selected, opening, closing) {
+      let rowDiff = selection.end.row - selection.start.row;
       return {
         text: opening + selected + closing,
         selection: [
@@ -83,7 +83,7 @@ ace.require(
       };
     };
 
-    var SQLBehaviour = function() {
+    const SQLBehaviour = function() {
       function createInsertDeletePair(name, opening, closing) {
         this.add(name, "insertion", function(
           state,
@@ -94,8 +94,8 @@ ace.require(
         ) {
           if (text == opening) {
             initContext(editor);
-            var selection = editor.getSelectionRange();
-            var selected = session.doc.getTextRange(selection);
+            let selection = editor.getSelectionRange();
+            let selected = session.doc.getTextRange(selection);
             if (selected !== "" && editor.getWrapBehavioursEnabled()) {
               return getWrapped(selection, selected, opening, closing);
             } else if (SQLBehaviour.isSaneInsertion(editor, session)) {
@@ -107,11 +107,11 @@ ace.require(
             }
           } else if (text == closing) {
             initContext(editor);
-            var cursor = editor.getCursorPosition();
-            var line = session.doc.getLine(cursor.row);
-            var rightChar = line.substring(cursor.column, cursor.column + 1);
+            let cursor = editor.getCursorPosition();
+            let line = session.doc.getLine(cursor.row);
+            let rightChar = line.substring(cursor.column, cursor.column + 1);
             if (rightChar == closing) {
-              var matching = session.$findOpeningBracket(closing, {
+              let matching = session.$findOpeningBracket(closing, {
                 column: cursor.column + 1,
                 row: cursor.row,
               });
@@ -136,11 +136,11 @@ ace.require(
           session,
           range,
         ) {
-          var selected = session.doc.getTextRange(range);
+          let selected = session.doc.getTextRange(range);
           if (!range.isMultiLine() && selected == opening) {
             initContext(editor);
-            var line = session.doc.getLine(range.start.row);
-            var rightChar = line.substring(
+            let line = session.doc.getLine(range.start.row);
+            let rightChar = line.substring(
               range.start.column + 1,
               range.start.column + 2,
             );
@@ -170,9 +170,9 @@ ace.require(
           )
             return;
           initContext(editor);
-          var quote = text;
-          var selection = editor.getSelectionRange();
-          var selected = session.doc.getTextRange(selection);
+          let quote = text;
+          let selection = editor.getSelectionRange();
+          let selected = session.doc.getTextRange(selection);
           if (
             selected !== "" &&
             selected !== "'" &&
@@ -181,33 +181,33 @@ ace.require(
           ) {
             return getWrapped(selection, selected, quote, quote);
           } else if (!selected) {
-            var cursor = editor.getCursorPosition();
-            var line = session.doc.getLine(cursor.row);
-            var leftChar = line.substring(cursor.column - 1, cursor.column);
-            var rightChar = line.substring(cursor.column, cursor.column + 1);
+            let cursor = editor.getCursorPosition();
+            let line = session.doc.getLine(cursor.row);
+            let leftChar = line.substring(cursor.column - 1, cursor.column);
+            let rightChar = line.substring(cursor.column, cursor.column + 1);
 
-            var token = session.getTokenAt(cursor.row, cursor.column);
-            var rightToken = session.getTokenAt(cursor.row, cursor.column + 1);
+            let token = session.getTokenAt(cursor.row, cursor.column);
+            let rightToken = session.getTokenAt(cursor.row, cursor.column + 1);
             // We're escaped.
             if (leftChar == "\\" && token && /escape/.test(token.type))
               return null;
 
-            var stringBefore = token && /string|escape/.test(token.type);
-            var stringAfter =
+            let stringBefore = token && /string|escape/.test(token.type);
+            let stringAfter =
               !rightToken || /string|escape/.test(rightToken.type);
 
-            var pair;
+            let pair;
             if (rightChar == quote) {
               pair = stringBefore !== stringAfter;
               if (pair && /string\.end/.test(rightToken.type)) pair = false;
             } else {
               if (stringBefore && !stringAfter) return null; // wrap string with different quote
               if (stringBefore && stringAfter) return null; // do not pair quotes inside strings
-              var wordRe = session.$mode.tokenRe;
+              let wordRe = session.$mode.tokenRe;
               wordRe.lastIndex = 0;
-              var isWordBefore = wordRe.test(leftChar);
+              let isWordBefore = wordRe.test(leftChar);
               wordRe.lastIndex = 0;
-              var isWordAfter = wordRe.test(leftChar);
+              let isWordAfter = wordRe.test(leftChar);
               if (isWordBefore || isWordAfter) return null; // before or after alphanumeric
               if (rightChar && !/[\s;,.})\]\\]/.test(rightChar)) return null; // there is rightChar and it isn't closing
               pair = true;
@@ -227,11 +227,11 @@ ace.require(
         session,
         range,
       ) {
-        var selected = session.doc.getTextRange(range);
+        let selected = session.doc.getTextRange(range);
         if (!range.isMultiLine() && (selected == '"' || selected == "'")) {
           initContext(editor);
-          var line = session.doc.getLine(range.start.row);
-          var rightChar = line.substring(
+          let line = session.doc.getLine(range.start.row);
+          let rightChar = line.substring(
             range.start.column + 1,
             range.start.column + 2,
           );
@@ -244,8 +244,8 @@ ace.require(
     };
 
     SQLBehaviour.isSaneInsertion = function(editor, session) {
-      var cursor = editor.getCursorPosition();
-      var iterator = new TokenIterator(session, cursor.row, cursor.column);
+      let cursor = editor.getCursorPosition();
+      let iterator = new TokenIterator(session, cursor.row, cursor.column);
 
       // Don't insert in the middle of a keyword/identifier/lexical
       if (
@@ -255,7 +255,7 @@ ace.require(
         )
       ) {
         // Look ahead in case we're at the end of a token
-        var iterator2 = new TokenIterator(
+        let iterator2 = new TokenIterator(
           session,
           cursor.row,
           cursor.column + 1,
@@ -285,8 +285,8 @@ ace.require(
     };
 
     SQLBehaviour.recordAutoInsert = function(editor, session, bracket) {
-      var cursor = editor.getCursorPosition();
-      var line = session.doc.getLine(cursor.row);
+      let cursor = editor.getCursorPosition();
+      let line = session.doc.getLine(cursor.row);
       // Reset previous state if text or context changed too much
       if (
         !this.isAutoInsertedClosing(
@@ -302,8 +302,8 @@ ace.require(
     };
 
     SQLBehaviour.recordMaybeInsert = function(editor, session, bracket) {
-      var cursor = editor.getCursorPosition();
-      var line = session.doc.getLine(cursor.row);
+      let cursor = editor.getCursorPosition();
+      let line = session.doc.getLine(cursor.row);
       if (!this.isMaybeInsertedClosing(cursor, line))
         context.maybeInsertedBrackets = 0;
       context.maybeInsertedRow = cursor.row;

--- a/frontend/src/metabase/lib/ace/theme-metabase.js
+++ b/frontend/src/metabase/lib/ace/theme-metabase.js
@@ -105,7 +105,7 @@ background: #e8e8e8;\
 background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAACCAYAAACZgbYnAAAAE0lEQVQImWP4////f4bLly//BwAmVgd1/w11/gAAAABJRU5ErkJggg==") right repeat-y;\
 }';
 
-    var dom = require("../lib/dom");
+    let dom = require("../lib/dom");
     dom.importCssString(exports.cssText, exports.cssClass);
   },
 );

--- a/frontend/src/metabase/lib/analytics.js
+++ b/frontend/src/metabase/lib/analytics.js
@@ -50,7 +50,7 @@ export function registerAnalyticsClickListener() {
   document.body.addEventListener(
     "click",
     function(e) {
-      var node = e.target;
+      let node = e.target;
 
       // check the target and all parent elements
       while (node) {

--- a/frontend/src/metabase/lib/browser.js
+++ b/frontend/src/metabase/lib/browser.js
@@ -2,7 +2,7 @@ import querystring from "querystring";
 
 export function parseHashOptions(hash) {
   let options = querystring.parse(hash.replace(/^#/, ""));
-  for (var name in options) {
+  for (let name in options) {
     if (options[name] === "") {
       options[name] = true;
     } else if (/^(true|false|-?\d+(\.\d+)?)$/.test(options[name])) {

--- a/frontend/src/metabase/lib/card.js
+++ b/frontend/src/metabase/lib/card.js
@@ -84,12 +84,12 @@ export function isCardRunnable(card, tableMetadata) {
 
 // TODO Atte Keinänen 5/31/17 Deprecated, we should move tests to Questions.spec.js
 export function serializeCardForUrl(card) {
-  var dataset_query = Utils.copy(card.dataset_query);
+  let dataset_query = Utils.copy(card.dataset_query);
   if (dataset_query.query) {
     dataset_query.query = Query.cleanQuery(dataset_query.query);
   }
 
-  var cardCopy = {
+  let cardCopy = {
     name: card.name,
     description: card.description,
     dataset_query: dataset_query,
@@ -134,8 +134,8 @@ export function urlForCardState(state, dirty) {
 }
 
 export function cleanCopyCard(card) {
-  var cardCopy = {};
-  for (var name in card) {
+  let cardCopy = {};
+  for (let name in card) {
     if (name.charAt(0) !== "$") {
       cardCopy[name] = card[name];
     }

--- a/frontend/src/metabase/lib/cookies.js
+++ b/frontend/src/metabase/lib/cookies.js
@@ -6,7 +6,7 @@ export const METABASE_SESSION_COOKIE = "metabase.SESSION_ID";
 export const METABASE_SEEN_ALERT_SPLASH_COOKIE = "metabase.SEEN_ALERT_SPLASH";
 
 // Handles management of Metabase cookie work
-var MetabaseCookies = {
+let MetabaseCookies = {
   // set the session cookie.  if sessionId is null, clears the cookie
   setSessionCookie: function(sessionId) {
     const options = {

--- a/frontend/src/metabase/lib/data_grid.js
+++ b/frontend/src/metabase/lib/data_grid.js
@@ -10,7 +10,7 @@ function compareNumbers(a, b) {
 export function pivot(data) {
   // find the lowest cardinality dimension and make it our "pivoted" column
   // TODO: we assume dimensions are in the first 2 columns, which is less than ideal
-  var pivotCol = 0,
+  let pivotCol = 0,
     normalCol = 1,
     cellCol = 2,
     pivotColValues = distinctValues(data, pivotCol),
@@ -19,7 +19,7 @@ export function pivot(data) {
     pivotCol = 1;
     normalCol = 0;
 
-    var tmp = pivotColValues;
+    let tmp = pivotColValues;
     pivotColValues = normalColValues;
     normalColValues = tmp;
   }
@@ -52,9 +52,9 @@ export function pivot(data) {
   });
 
   // fill it up with the data
-  for (var j = 0; j < data.rows.length; j++) {
-    var normalColIdx = normalColValues.lastIndexOf(data.rows[j][normalCol]);
-    var pivotColIdx = pivotColValues.lastIndexOf(data.rows[j][pivotCol]);
+  for (let j = 0; j < data.rows.length; j++) {
+    let normalColIdx = normalColValues.lastIndexOf(data.rows[j][normalCol]);
+    let pivotColIdx = pivotColValues.lastIndexOf(data.rows[j][pivotCol]);
 
     pivotedRows[normalColIdx][0] = data.rows[j][normalCol];
     // NOTE: we are hard coding the expectation that the metric is in the 3rd column
@@ -68,7 +68,7 @@ export function pivot(data) {
       return data.cols[normalCol];
     }
 
-    var colDef = _.clone(data.cols[cellCol]);
+    let colDef = _.clone(data.cols[cellCol]);
     colDef.name = colDef.display_name =
       formatValue(value, { column: data.cols[pivotCol] }) || "";
     // for onVisualizationClick:
@@ -88,7 +88,7 @@ export function pivot(data) {
 }
 
 export function distinctValues(data, colIdx) {
-  var vals = data.rows.map(function(r) {
+  let vals = data.rows.map(function(r) {
     return r[colIdx];
   });
 

--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -45,8 +45,8 @@ export function isObscured(element, offset) {
 
 // get the position of an element on the page
 export function findPosition(element, excludeScroll = false) {
-  var offset = { top: 0, left: 0 };
-  var scroll = { top: 0, left: 0 };
+  let offset = { top: 0, left: 0 };
+  let scroll = { top: 0, left: 0 };
   let offsetParent = element;
   while (offsetParent) {
     // we need to check every element for scrollTop/scrollLeft
@@ -173,7 +173,7 @@ function getTextNodeAtPosition(root, index) {
       return NodeFilter.FILTER_ACCEPT;
     },
   );
-  var c = treeWalker.nextNode();
+  let c = treeWalker.nextNode();
   return {
     node: c ? c : root,
     position: c ? index : 0,
@@ -181,9 +181,9 @@ function getTextNodeAtPosition(root, index) {
 }
 
 // https://davidwalsh.name/add-rules-stylesheets
-var STYLE_SHEET = (function() {
+let STYLE_SHEET = (function() {
   // Create the <style> tag
-  var style = document.createElement("style");
+  let style = document.createElement("style");
 
   // WebKit hack :(
   style.appendChild(document.createTextNode("/* dynamic stylesheet */"));

--- a/frontend/src/metabase/lib/greeting.js
+++ b/frontend/src/metabase/lib/greeting.js
@@ -14,7 +14,7 @@ const subheadPrefixes = [
   t`What do you want to find out?`,
 ];
 
-var Greeting = {
+const Greeting = {
   simpleGreeting: function() {
     // TODO - this can result in an undefined thing
     const randomIndex = Math.floor(
@@ -25,7 +25,7 @@ var Greeting = {
 
   sayHello: function(personalization) {
     if (personalization) {
-      var g = Greeting.simpleGreeting();
+      let g = Greeting.simpleGreeting();
       if (g === t`How's it going`) {
         return g + ", " + personalization + "?";
       } else {

--- a/frontend/src/metabase/lib/permissions.js
+++ b/frontend/src/metabase/lib/permissions.js
@@ -71,7 +71,7 @@ export function updatePermission(
   } else {
     newValue = value;
   }
-  for (var i = 0; i < fullPath.length; i++) {
+  for (let i = 0; i < fullPath.length; i++) {
     if (typeof getIn(permissions, fullPath.slice(0, i)) === "string") {
       permissions = setIn(permissions, fullPath.slice(0, i), {});
     }

--- a/frontend/src/metabase/lib/query.js
+++ b/frontend/src/metabase/lib/query.js
@@ -79,7 +79,7 @@ const SORTABLE_AGGREGATION_TYPES = new Set([
   "max",
 ]);
 
-var Query = {
+const Query = {
   isStructured(dataset_query) {
     return dataset_query && dataset_query.type === "query";
   },
@@ -211,7 +211,7 @@ var Query = {
   },
 
   canAddDimensions(query) {
-    var MAX_DIMENSIONS = 2;
+    let MAX_DIMENSIONS = 2;
     return query && query.breakout && query.breakout.length < MAX_DIMENSIONS;
   },
 
@@ -266,7 +266,7 @@ var Query = {
       return fields;
     } else if (Query.hasValidBreakout(query)) {
       // further filter field list down to only fields in our breakout clause
-      var breakoutFieldList = [];
+      let breakoutFieldList = [];
 
       const breakouts = Query.getBreakouts(query);
       breakouts.map(function(breakoutField) {
@@ -518,7 +518,7 @@ var Query = {
     filterFn = _.identity,
     usedFields = {},
   ) {
-    var results = {
+    let results = {
       count: 0,
       fields: null,
       fks: [],
@@ -532,7 +532,7 @@ var Query = {
       results.fks = fields
         .filter(f => isFK(f.special_type) && f.target)
         .map(joinField => {
-          var targetFields = filterFn(joinField.target.table.fields).filter(
+          let targetFields = filterFn(joinField.target.table.fields).filter(
             f =>
               (!Array.isArray(f.id) || f.id[0] !== "aggregation") &&
               !usedFields[f.id],

--- a/frontend/src/metabase/lib/redux.js
+++ b/frontend/src/metabase/lib/redux.js
@@ -12,7 +12,7 @@ export { handleActions, createAction } from "redux-actions";
 // the promise returned from the thunk resolves or rejects, similar to redux-promise
 export function createThunkAction(actionType, actionThunkCreator) {
   function fn(...actionArgs) {
-    var thunk = actionThunkCreator(...actionArgs);
+    let thunk = actionThunkCreator(...actionArgs);
     return async function(dispatch, getState) {
       try {
         let payload = await thunk(dispatch, getState);

--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -423,7 +423,7 @@ function dimensionFields(fields) {
   return _.filter(fields, isDimension);
 }
 
-var Aggregators = [
+let Aggregators = [
   {
     name: t`Raw data`,
     short: "rows",
@@ -506,7 +506,7 @@ var Aggregators = [
   },
 ];
 
-var BreakoutAggregator = {
+let BreakoutAggregator = {
   name: t`Break out by dimension`,
   short: "breakout",
   validFieldsFilters: [dimensionFields],
@@ -558,7 +558,7 @@ export const isCompatibleAggregatorForField = (aggregator, field) =>
   aggregator.validFieldsFilters.every(filter => filter([field]).length === 1);
 
 export function getBreakouts(fields) {
-  var result = populateFields(BreakoutAggregator, fields);
+  let result = populateFields(BreakoutAggregator, fields);
   result.fields = result.fields[0];
   result.validFieldsFilter = result.validFieldsFilters[0];
   return result;
@@ -623,8 +623,8 @@ export function getIconForField(field) {
 }
 
 export function computeMetadataStrength(table) {
-  var total = 0;
-  var completed = 0;
+  let total = 0;
+  let completed = 0;
   function score(value) {
     total++;
     if (value) {

--- a/frontend/src/metabase/lib/utils.js
+++ b/frontend/src/metabase/lib/utils.js
@@ -8,7 +8,7 @@ function s4() {
 }
 
 // provides functions for building urls to things we care about
-var MetabaseUtils = {
+let MetabaseUtils = {
   generatePassword: function(length, complexity) {
     const len = length || 14;
 
@@ -25,10 +25,10 @@ var MetabaseUtils = {
     }
 
     function isStrongEnough(password) {
-      var uc = password.match(/([A-Z])/g);
-      var lc = password.match(/([a-z])/g);
-      var di = password.match(/([\d])/g);
-      var sc = password.match(/([!@#\$%\^\&*\)\(+=._-{}])/g);
+      let uc = password.match(/([A-Z])/g);
+      let lc = password.match(/([a-z])/g);
+      let di = password.match(/([\d])/g);
+      let sc = password.match(/([!@#\$%\^\&*\)\(+=._-{}])/g);
 
       return (
         uc &&
@@ -50,7 +50,7 @@ var MetabaseUtils = {
 
   // pretty limited.  just does 0-9 for right now.
   numberToWord: function(num) {
-    var names = [
+    let names = [
       t`zero`,
       t`one`,
       t`two`,
@@ -113,7 +113,7 @@ var MetabaseUtils = {
   },
 
   validEmail: function(email) {
-    var re = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+    let re = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
     return re.test(email);
   },
 

--- a/frontend/src/metabase/public/lib/embed.js
+++ b/frontend/src/metabase/public/lib/embed.js
@@ -59,7 +59,7 @@ export function getUnsignedPreviewUrl(
 export function optionsToHashParams(options = {}) {
   options = { ...options };
   // filter out null, undefined, ""
-  for (var name in options) {
+  for (let name in options) {
     if (options[name] == null || options[name] === "") {
       delete options[name];
     }

--- a/frontend/src/metabase/qb/components/actions/GenerateDashboardAction.jsx
+++ b/frontend/src/metabase/qb/components/actions/GenerateDashboardAction.jsx
@@ -10,11 +10,11 @@ import { t } from "c-3po";
 export default ({ question, settings }: ClickActionProps): ClickAction[] => {
   // currently time series xrays require the maximum fidelity
   console.log(JSON.stringify(question.query().datasetQuery()));
-  var dashboard_url = "adhoc";
+  let dashboard_url = "adhoc";
   if (question.card().id) {
     dashboard_url = `/auto/dashboard/question/${question.card().id}`;
   } else {
-    var encodedQueryDict = utf8_to_b64url(
+    let encodedQueryDict = utf8_to_b64url(
       JSON.stringify(question.query().datasetQuery()),
     );
     dashboard_url = `/auto/dashboard/adhoc/${encodedQueryDict}`;

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -126,8 +126,8 @@ export const updateUrl = createThunkAction(
     if (!card) {
       return;
     }
-    var copy = cleanCopyCard(card);
-    var newState = {
+    let copy = cleanCopyCard(card);
+    let newState = {
       card: copy,
       cardId: copy.id,
       serializedCard: serializeCardForUrl(copy),
@@ -139,7 +139,7 @@ export const updateUrl = createThunkAction(
       return;
     }
 
-    var url = urlForCardState(newState, dirty);
+    let url = urlForCardState(newState, dirty);
 
     // if the serialized card is identical replace the previous state instead of adding a new one
     // e.x. when saving a new card we want to replace the state and URL with one with the new card ID
@@ -1319,8 +1319,8 @@ export const followForeignKey = createThunkAction(FOLLOW_FOREIGN_KEY, fk => {
     if (!queryResult || !fk) return false;
 
     // extract the value we will use to filter our new query
-    var originValue;
-    for (var i = 0; i < queryResult.data.cols.length; i++) {
+    let originValue;
+    for (let i = 0; i < queryResult.data.cols.length; i++) {
       if (isPK(queryResult.data.cols[i].special_type)) {
         originValue = queryResult.data.rows[0][i];
       }
@@ -1351,8 +1351,8 @@ export const loadObjectDetailFKReferences = createThunkAction(
       const { qb: { card, queryResult, tableForeignKeys } } = getState();
 
       function getObjectDetailIdValue(data) {
-        for (var i = 0; i < data.cols.length; i++) {
-          var coldef = data.cols[i];
+        for (let i = 0; i < data.cols.length; i++) {
+          let coldef = data.cols[i];
           if (isPK(coldef.special_type)) {
             return data.rows[0][i];
           }

--- a/frontend/src/metabase/query_builder/components/ExpandableString.jsx
+++ b/frontend/src/metabase/query_builder/components/ExpandableString.jsx
@@ -32,7 +32,7 @@ export default class ExpandableString extends Component {
   render() {
     if (!this.props.str) return false;
 
-    var truncated = Humanize.truncate(this.props.str || "", 140);
+    let truncated = Humanize.truncate(this.props.str || "", 140);
 
     if (this.state.expanded) {
       return (

--- a/frontend/src/metabase/query_builder/components/QueryHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryHeader.jsx
@@ -173,7 +173,7 @@ export default class QueryHeader extends Component {
 
   async onFetchRevisions({ entity, id }) {
     // TODO: reduxify
-    var revisions = await RevisionApi.list({ entity, id });
+    let revisions = await RevisionApi.list({ entity, id });
     this.setState({ revisions });
   }
 
@@ -203,7 +203,7 @@ export default class QueryHeader extends Component {
       id: card && card.dataset_query && card.dataset_query.database,
     });
 
-    var buttonSections = [];
+    let buttonSections = [];
 
     // A card that is either completely new or it has been derived from a saved question
     if (isNew && isDirty) {
@@ -437,7 +437,7 @@ export default class QueryHeader extends Component {
     ]);
 
     // data reference button
-    var dataReferenceButtonClasses = cx("transition-color", {
+    let dataReferenceButtonClasses = cx("transition-color", {
       "text-brand": this.props.isShowingDataReference,
       "text-brand-hover": !this.state.isShowingDataReference,
     });

--- a/frontend/src/metabase/query_builder/components/QueryModeButton.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryModeButton.jsx
@@ -41,7 +41,7 @@ export default class QueryModeButton extends Component {
     } = this.props;
 
     // determine the type to switch to based on the type
-    var targetType = mode === "query" ? "native" : "query";
+    let targetType = mode === "query" ? "native" : "query";
 
     const engine = tableMetadata && tableMetadata.db.engine;
     const nativeQueryName =

--- a/frontend/src/metabase/query_builder/components/SelectionModule.jsx
+++ b/frontend/src/metabase/query_builder/components/SelectionModule.jsx
@@ -16,7 +16,7 @@ export default class SelectionModule extends Component {
     this._toggleOpen = this._toggleOpen.bind(this);
     this.onClose = this.onClose.bind(this);
     // a selection module can be told to be open on initialization but otherwise is closed
-    var isInitiallyOpen = props.isInitiallyOpen || false;
+    let isInitiallyOpen = props.isInitiallyOpen || false;
 
     this.state = {
       open: isInitiallyOpen,
@@ -83,8 +83,8 @@ export default class SelectionModule extends Component {
       return true;
     }
     // if an item that is normally in the expansion is selected then show the expansion
-    for (var i = 0; i < this.props.items.length; i++) {
-      var item = this.props.items[i];
+    for (let i = 0; i < this.props.items.length; i++) {
+      let item = this.props.items[i];
       if (this._itemIsSelected(item) && !this.props.expandFilter(item, i)) {
         return true;
       }
@@ -93,9 +93,9 @@ export default class SelectionModule extends Component {
   }
 
   _displayCustom(values) {
-    var custom = [];
+    let custom = [];
     this.props.children.forEach(function(element) {
-      var newElement = element;
+      let newElement = element;
       newElement.props.children = values[newElement.props.content];
       custom.push(element);
     });
@@ -104,20 +104,20 @@ export default class SelectionModule extends Component {
 
   _listItems(selection) {
     if (this.props.items) {
-      var sourceItems = this.props.items;
+      let sourceItems = this.props.items;
 
-      var isExpanded = this._isExpanded();
+      let isExpanded = this._isExpanded();
       if (!isExpanded) {
         sourceItems = sourceItems.filter(this.props.expandFilter);
       }
 
-      var items = sourceItems.map(function(item, index) {
-        var display = item ? item[this.props.display] || item : item;
-        var itemClassName = cx({
+      let items = sourceItems.map(function(item, index) {
+        let display = item ? item[this.props.display] || item : item;
+        let itemClassName = cx({
           SelectionItem: true,
           "SelectionItem--selected": selection === display,
         });
-        var description = null;
+        let description = null;
         if (
           this.props.descriptionKey &&
           item &&
@@ -169,7 +169,7 @@ export default class SelectionModule extends Component {
   }
 
   _select(item) {
-    var index = this.props.index;
+    let index = this.props.index;
     // send back the item with the specified action
     if (this.props.action) {
       if (index !== undefined) {
@@ -197,12 +197,12 @@ export default class SelectionModule extends Component {
 
   renderPopover(selection) {
     if (this.state.open) {
-      var itemListClasses = cx("SelectionItems", {
+      let itemListClasses = cx("SelectionItems", {
         "SelectionItems--open": this.state.open,
         "SelectionItems--expanded": this.state.expanded,
       });
 
-      var searchBar;
+      let searchBar;
       if (this._enableSearch()) {
         searchBar = <SearchBar onFilter={this._filterSelections} />;
       }
@@ -224,18 +224,18 @@ export default class SelectionModule extends Component {
   }
 
   render() {
-    var selection;
+    let selection;
     this.props.items.forEach(function(item) {
       if (this._itemIsSelected(item)) {
         selection = item[this.props.display];
       }
     }, this);
 
-    var placeholder = selection || this.props.placeholder,
+    let placeholder = selection || this.props.placeholder,
       remove,
       removeable = !!this.props.remove;
 
-    var moduleClasses = cx({
+    let moduleClasses = cx({
       SelectionModule: true,
       selected: selection,
       removeable: removeable,

--- a/frontend/src/metabase/query_builder/components/SortWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/SortWidget.jsx
@@ -59,7 +59,7 @@ export default class SortWidget extends Component {
   }
 
   render() {
-    var directionOptions = [
+    let directionOptions = [
       { key: "ascending", val: "ascending" },
       { key: "descending", val: "descending" },
     ];

--- a/frontend/src/metabase/query_builder/components/VisualizationSettings.jsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationSettings.jsx
@@ -36,7 +36,7 @@ export default class VisualizationSettings extends React.Component {
       { card, data: result.data },
     ]);
 
-    var triggerElement = (
+    let triggerElement = (
       <span className="px2 py1 text-bold cursor-pointer text-default flex align-center">
         <Icon className="mr1" name={CardVisualization.iconName} size={12} />
         {CardVisualization.uiName}

--- a/frontend/src/metabase/query_builder/components/dataref/DataReference.jsx
+++ b/frontend/src/metabase/query_builder/components/dataref/DataReference.jsx
@@ -51,11 +51,11 @@ export default class DataReference extends Component {
   }
 
   render() {
-    var content;
+    let content;
     if (this.state.stack.length === 0) {
       content = <MainPane {...this.props} show={this.show} />;
     } else {
-      var page = this.state.stack[this.state.stack.length - 1];
+      let page = this.state.stack[this.state.stack.length - 1];
       if (page.type === "table") {
         content = (
           <TablePane {...this.props} show={this.show} table={page.item} />
@@ -75,7 +75,7 @@ export default class DataReference extends Component {
       }
     }
 
-    var backButton;
+    let backButton;
     if (this.state.stack.length > 0) {
       backButton = (
         <a
@@ -88,7 +88,7 @@ export default class DataReference extends Component {
       );
     }
 
-    var closeButton = (
+    let closeButton = (
       <a
         className="flex-align-right text-default text-brand-hover no-decoration"
         onClick={this.close}

--- a/frontend/src/metabase/query_builder/components/dataref/TablePane.jsx
+++ b/frontend/src/metabase/query_builder/components/dataref/TablePane.jsx
@@ -66,9 +66,9 @@ export default class TablePane extends Component {
   render() {
     const { table, error } = this.state;
     if (table) {
-      var queryButton;
+      let queryButton;
       if (table.rows != null) {
-        var text = t`See the raw data for ${table.display_name}`;
+        let text = t`See the raw data for ${table.display_name}`;
         queryButton = (
           <QueryButton
             className="border-bottom border-top mb3"
@@ -78,13 +78,13 @@ export default class TablePane extends Component {
           />
         );
       }
-      var panes = {
+      let panes = {
         fields: table.fields.length,
         // "metrics": table.metrics.length,
         // "segments": table.segments.length,
         connections: this.state.tableForeignKeys.length,
       };
-      var tabs = Object.entries(panes).map(([name, count]) => (
+      let tabs = Object.entries(panes).map(([name, count]) => (
         <a
           key={name}
           className={cx("Button Button--small", {
@@ -97,7 +97,8 @@ export default class TablePane extends Component {
         </a>
       ));
 
-      var pane;
+      let pane;
+      let description;
       if (this.state.pane === "connections") {
         const fkCountsByTable = foreignKeyCountsByOriginTable(
           this.state.tableForeignKeys,
@@ -140,12 +141,14 @@ export default class TablePane extends Component {
             ))}
           </ul>
         );
-      } else var descriptionClasses = cx({ "text-grey-3": !table.description });
-      var description = (
-        <p className={descriptionClasses}>
-          {table.description || t`No description set.`}
-        </p>
-      );
+      } else {
+        const descriptionClasses = cx({ "text-grey-3": !table.description });
+        description = (
+          <p className={descriptionClasses}>
+            {table.description || t`No description set.`}
+          </p>
+        );
+      }
 
       return (
         <div>

--- a/frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx
@@ -187,7 +187,7 @@ export default class FilterPopover extends Component {
       }
     }
     // arguments are non-null/undefined
-    for (var i = 2; i < filter.length; i++) {
+    for (let i = 2; i < filter.length; i++) {
       if (filter[i] == null) {
         return false;
       }

--- a/frontend/src/metabase/user/components/SetUserPassword.jsx
+++ b/frontend/src/metabase/user/components/SetUserPassword.jsx
@@ -34,7 +34,7 @@ export default class SetUserPassword extends Component {
     let isValid = true;
 
     // required: first_name, last_name, email
-    for (var fieldName in this.refs) {
+    for (let fieldName in this.refs) {
       let node = ReactDOM.findDOMNode(this.refs[fieldName]);
       if (node.required && MetabaseUtils.isEmpty(node.value)) isValid = false;
     }

--- a/frontend/src/metabase/user/components/UpdateUserDetails.jsx
+++ b/frontend/src/metabase/user/components/UpdateUserDetails.jsx
@@ -33,7 +33,7 @@ export default class UpdateUserDetails extends Component {
     let isValid = true;
 
     // required: first_name, last_name, email
-    for (var fieldName in this.refs) {
+    for (let fieldName in this.refs) {
       let node = ReactDOM.findDOMNode(this.refs[fieldName]);
       if (node.required && MetabaseUtils.isEmpty(node.value)) isValid = false;
     }

--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -228,7 +228,7 @@ export default class ChoroplethMap extends Component {
 
     const groups = ss.ckmeans(domain, heatMapColors.length);
 
-    var colorScale = d3.scale
+    let colorScale = d3.scale
       .quantile()
       .domain(groups.map(cluster => cluster[0]))
       .range(heatMapColors);

--- a/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
+++ b/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
@@ -70,7 +70,7 @@ export default class Funnel extends Component {
     const formatPercent = percent => `${(100 * percent).toFixed(2)} %`;
 
     // Initial infos (required for step calculation)
-    var infos: StepInfo[] = [
+    let infos: StepInfo[] = [
       {
         value: rows[0][metricIndex],
         graph: {
@@ -82,7 +82,7 @@ export default class Funnel extends Component {
       },
     ];
 
-    var remaining: number = rows[0][metricIndex];
+    let remaining: number = rows[0][metricIndex];
 
     rows.map((row, rowIndex) => {
       remaining -= infos[rowIndex].value - row[metricIndex];

--- a/frontend/src/metabase/visualizations/components/LegendVertical.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendVertical.jsx
@@ -30,7 +30,7 @@ export default class LegendVertical extends Component {
       this.setState({ overflowCount: 0, size });
     } else if (this.state.overflowCount === 0) {
       let overflowCount = 0;
-      for (var i = 0; i < this.props.titles.length; i++) {
+      for (let i = 0; i < this.props.titles.length; i++) {
         let itemSize = ReactDOM.findDOMNode(
           this.refs["item" + i],
         ).getBoundingClientRect();

--- a/frontend/src/metabase/visualizations/lib/graph/addons.js
+++ b/frontend/src/metabase/visualizations/lib/graph/addons.js
@@ -5,8 +5,8 @@ import moment from "moment";
 
 export const lineAddons = _chart => {
   _chart.fadeDeselectedArea = function() {
-    var dots = _chart.chartBodyG().selectAll(".dot");
-    var extent = _chart.brush().extent();
+    let dots = _chart.chartBodyG().selectAll(".dot");
+    let extent = _chart.brush().extent();
 
     if (_chart.isOrdinal()) {
       if (_chart.hasFilter()) {
@@ -22,8 +22,8 @@ export const lineAddons = _chart => {
       }
     } else {
       if (!_chart.brushIsEmpty(extent)) {
-        var start = extent[0];
-        var end = extent[1];
+        let start = extent[0];
+        let end = extent[1];
         const isSelected = d => {
           if (moment.isDate(start)) {
             return !(moment(d.x).isBefore(start) || moment(d.x).isAfter(end));

--- a/frontend/src/metabase/visualizations/lib/numeric.js
+++ b/frontend/src/metabase/visualizations/lib/numeric.js
@@ -13,7 +13,7 @@ export function precision(a) {
   if (!a) {
     return 0;
   }
-  var e = 1;
+  let e = 1;
   while (Math.round(a / e) !== a / e) {
     e /= 10;
   }
@@ -25,7 +25,7 @@ export function precision(a) {
 
 export function decimalCount(a) {
   if (!isFinite(a)) return 0;
-  var e = 1,
+  let e = 1,
     p = 0;
   while (Math.round(a * e) / e !== a) {
     e *= 10;

--- a/frontend/test/admin/permissions/selectors.unit.spec.js
+++ b/frontend/test/admin/permissions/selectors.unit.spec.js
@@ -80,7 +80,7 @@ const initialState = {
   metadata: normalizedMetadata,
 };
 
-var state = initialState;
+let state = initialState;
 const resetState = () => {
   state = initialState;
 };

--- a/frontend/test/karma.conf.js
+++ b/frontend/test/karma.conf.js
@@ -1,4 +1,4 @@
-var webpackConfig = require("../../webpack.config");
+let webpackConfig = require("../../webpack.config");
 console.dir(webpackConfig.module.rules, { depth: null });
 webpackConfig.module.rules.forEach(function(loader) {
   loader.use = loader.use.filter(

--- a/frontend/test/reference/databases.integ.spec.js
+++ b/frontend/test/reference/databases.integ.spec.js
@@ -58,7 +58,7 @@ describe("The Reference Section", () => {
     it("should see databases", async () => {
       const store = await createTestStore();
       store.pushPath("/reference/databases/");
-      var container = mount(store.connectContainer(<DatabaseListContainer />));
+      let container = mount(store.connectContainer(<DatabaseListContainer />));
       await store.waitForActions([FETCH_REAL_DATABASES, END_LOADING]);
 
       expect(container.find(ReferenceHeader).length).toBe(1);
@@ -71,10 +71,10 @@ describe("The Reference Section", () => {
 
     // database list
     it("should not see saved questions in the database list", async () => {
-      var card = await CardApi.create(cardDef);
+      let card = await CardApi.create(cardDef);
       const store = await createTestStore();
       store.pushPath("/reference/databases/");
-      var container = mount(store.connectContainer(<DatabaseListContainer />));
+      let container = mount(store.connectContainer(<DatabaseListContainer />));
       await store.waitForActions([FETCH_REAL_DATABASES, END_LOADING]);
 
       expect(container.find(ReferenceHeader).length).toBe(1);
@@ -144,7 +144,7 @@ describe("The Reference Section", () => {
       mount(store.connectContainer(<TableQuestionsContainer />));
       await store.waitForActions([FETCH_DATABASE_METADATA, END_LOADING]);
 
-      var card = await CardApi.create(cardDef);
+      let card = await CardApi.create(cardDef);
 
       expect(card.name).toBe(cardDef.name);
 

--- a/frontend/test/reference/guide.integ.spec.js
+++ b/frontend/test/reference/guide.integ.spec.js
@@ -78,9 +78,9 @@ describe("The Reference Section", () => {
 
     it("Adding metrics should to the guide should make them appear", async () => {
       expect(0).toBe(0);
-      var metric = await MetricApi.create(metricDef);
+      let metric = await MetricApi.create(metricDef);
       expect(1).toBe(1);
-      var metric2 = await MetricApi.create(anotherMetricDef);
+      let metric2 = await MetricApi.create(anotherMetricDef);
       expect(2).toBe(2);
       await MetricApi.delete({
         metricId: metric.id,
@@ -96,9 +96,9 @@ describe("The Reference Section", () => {
 
     it("Adding segments should to the guide should make them appear", async () => {
       expect(0).toBe(0);
-      var segment = await SegmentApi.create(segmentDef);
+      let segment = await SegmentApi.create(segmentDef);
       expect(1).toBe(1);
-      var anotherSegment = await SegmentApi.create(anotherSegmentDef);
+      let anotherSegment = await SegmentApi.create(anotherSegmentDef);
       expect(2).toBe(2);
       await SegmentApi.delete({
         segmentId: segment.id,

--- a/frontend/test/reference/metrics.integ.spec.js
+++ b/frontend/test/reference/metrics.integ.spec.js
@@ -67,12 +67,12 @@ describe("The Reference Section", () => {
     });
 
     describe("With Metrics State", async () => {
-      var metricIds = [];
+      let metricIds = [];
 
       beforeAll(async () => {
         // Create some metrics to have something to look at
-        var metric = await MetricApi.create(metricDef);
-        var metric2 = await MetricApi.create(anotherMetricDef);
+        let metric = await MetricApi.create(metricDef);
+        let metric2 = await MetricApi.create(anotherMetricDef);
 
         metricIds.push(metric.id);
         metricIds.push(metric2.id);
@@ -116,7 +116,7 @@ describe("The Reference Section", () => {
       });
 
       it("Should see a newly asked question in its questions list", async () => {
-        var card = await CardApi.create(metricCardDef);
+        let card = await CardApi.create(metricCardDef);
         expect(card.name).toBe(metricCardDef.name);
 
         try {

--- a/frontend/test/reference/segments.integ.spec.js
+++ b/frontend/test/reference/segments.integ.spec.js
@@ -80,12 +80,12 @@ describe("The Reference Section", () => {
     });
 
     describe("With Segments State", async () => {
-      var segmentIds = [];
+      let segmentIds = [];
 
       beforeAll(async () => {
         // Create some segments to have something to look at
-        var segment = await SegmentApi.create(segmentDef);
-        var anotherSegment = await SegmentApi.create(anotherSegmentDef);
+        let segment = await SegmentApi.create(segmentDef);
+        let anotherSegment = await SegmentApi.create(anotherSegmentDef);
         segmentIds.push(segment.id);
         segmentIds.push(anotherSegment.id);
       });
@@ -151,7 +151,7 @@ describe("The Reference Section", () => {
       });
 
       it("Should see a newly asked question in its questions list", async () => {
-        var card = await CardApi.create(segmentCardDef);
+        let card = await CardApi.create(segmentCardDef);
 
         expect(card.name).toBe(segmentCardDef.name);
 


### PR DESCRIPTION
`var` is basically deprecated. This requires use of `let`/`const` instead.

We could also enable `prefer-const` to force `const` when a variable isn't re-assigned https://eslint.org/docs/rules/prefer-const