### PR TITLE
Clean up padding for x-rays and text card titles

### DIFF
--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
@@ -124,7 +124,7 @@ class AutomaticDashboardApp extends React.Component {
             </div>
           </div>
 
-          <div className="px3 pb4">
+          <div className="wrapper pb4">
             {parameters &&
               parameters.length > 0 && (
                 <div className="px1 pt1">

--- a/frontend/src/metabase/visualizations/visualizations/Text.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text.jsx
@@ -180,7 +180,7 @@ export default class Text extends Component {
             styles[isSmall ? "small" : "large"],
             /* if the card is not showing a background we should adjust the left
              * padding to help align the titles with the wrapper */
-            { pl1: !settings["dashcard.background"] },
+            { pl0: !settings["dashcard.background"] },
           )}
         >
           <ReactMarkdown

--- a/frontend/src/metabase/visualizations/visualizations/Text.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text.jsx
@@ -178,6 +178,9 @@ export default class Text extends Component {
             className,
             styles.Text,
             styles[isSmall ? "small" : "large"],
+            /* if the card is not showing a background we should adjust the left
+             * padding to help align the titles with the wrapper */
+            { pl1: !settings["dashcard.background"] },
           )}
         >
           <ReactMarkdown


### PR DESCRIPTION
In cases where text cards have no backgrounds the overall padding of the content inside was staying the same as when there's a card around the content. 

Without the background this meant that there was a bit of excessive left padding, which was messing with alignment of the title with the other cards and creating more work than necessary for your eye to parse the title and content with all these different alignments.

As part of this I also added our wrapper to help align the content on x-ray pages with the page title and parts of the navbar to help unify things even more.

### Before: 
<img width="2503" alt="screen shot 2018-04-24 at 9 41 37 am" src="https://user-images.githubusercontent.com/5248953/39201559-3b98d9ae-47a4-11e8-880e-425afd2b0b52.png">

### After:
<img width="2503" alt="screen shot 2018-04-24 at 9 41 22 am" src="https://user-images.githubusercontent.com/5248953/39201575-46a60cae-47a4-11e8-8b79-584fac7df617.png">

