### PR TITLE
Fix is_not filters causing errors on generating dashboards

### DIFF
--- a/src/metabase/automagic_dashboards/filters.clj
+++ b/src/metabase/automagic_dashboards/filters.clj
@@ -181,7 +181,7 @@
                (format "is on %s" (humanize-datetime value))
                (format "is %s" (apply either value values)))}]))
 
-(defmethod humanize-filter-value :not=
+(defmethod humanize-filter-value :!=
   [[_ field-reference value]]
   [{:field field-reference
     :value (format "is not %s" value)}])

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -127,6 +127,22 @@
             (automagic-analysis {:cell-query [:= [:field-id (data/id :venues :category_id) 2]]})
             valid-dashboard?)))))
 
+
+(expect
+  true
+  (tt/with-temp* [Card [{card-id :id} {:table_id      (data/id :venues)
+                                       :dataset_query {:query {:filter [:> [:field-id (data/id :venues :price)] 10]
+                                                               :source_table (data/id :venues)}
+                                                       :type :query
+                                                       :database (data/id)}}]]
+    (with-rasta
+      (with-dashboard-cleanup
+        (-> card-id
+            Card
+            (automagic-analysis {:cell-query [:!= [:field-id (data/id :venues :category_id) 2]]})
+            valid-dashboard?)))))
+
+
 (expect
   true
   (with-rasta


### PR DESCRIPTION
This seems to fix the reported issue by @mazameli in #7414

