### PR TITLE
Add page titles to auto dashboards

### DIFF
--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
@@ -6,6 +6,7 @@ import { connect } from "react-redux";
 import { Link } from "react-router";
 
 import { withBackground } from "metabase/hoc/Background";
+import title from "metabase/hoc/Title";
 import ActionButton from "metabase/components/ActionButton";
 import Button from "metabase/components/Button";
 import Icon from "metabase/components/Icon";
@@ -41,6 +42,7 @@ const mapStateToProps = (state, props) => ({
 
 @connect(mapStateToProps, { addUndo, createUndo })
 @DashboardData
+@title(({ dashboard }) => dashboard && dashboard.name)
 class AutomaticDashboardApp extends React.Component {
   state = {
     savedDashboardId: null,


### PR DESCRIPTION
Currently using `name` rather than `transient_name` since they tend to be shorter, but that's easy to change if anyone strongly disagrees.