### PR TITLE
CI frontend helpers

### DIFF
--- a/frontend/test/__support__/jest/console-aggregator.js
+++ b/frontend/test/__support__/jest/console-aggregator.js
@@ -1,0 +1,27 @@
+const CONSOLE_IGNORE_REGEX_DEFAULT = /Warning: (Accessing createClass|Accessing PropTypes|validateDOMNesting|Each child in an array or iterator should have a unique "key" prop|Failed prop type)/;
+const CONSOLE_IGNORE_METHODS_DEFAULT = ["warn", "error"];
+
+module.exports = (
+  regex = CONSOLE_IGNORE_REGEX_DEFAULT,
+  methods = CONSOLE_IGNORE_METHODS_DEFAULT,
+) => {
+  const CONSOLE = { ...global.console };
+  const CONSOLE_IGNORED = {};
+
+  for (const method of methods) {
+    jest.spyOn(global.console, method).mockImplementation(function(...args) {
+      const match = String(args[0]).match(regex);
+      if (match) {
+        CONSOLE_IGNORED[match[0]] = (CONSOLE_IGNORED[match[0]] || 0) + 1;
+      } else {
+        CONSOLE[method].apply(this, args);
+      }
+    });
+  }
+
+  afterAll(async () => {
+    if (Object.keys(CONSOLE_IGNORED).length > 0) {
+      CONSOLE.log("IGNORED LOGS:\n", CONSOLE_IGNORED);
+    }
+  });
+};

--- a/frontend/test/__support__/jest/state-diff.js
+++ b/frontend/test/__support__/jest/state-diff.js
@@ -1,0 +1,36 @@
+const { diffJson } = require("diff");
+require("colors");
+
+// default getSnapshot that gets the sample dataset metadata
+const { MetabaseApi } = require("metabase/services");
+const { useSharedAdminLogin } = require("__support__/integrated_tests");
+const GET_SNAPSHOT_DEFAULT = () => {
+  useSharedAdminLogin();
+  return Promise.all(
+    [1, 2, 3, 4].map(tableId => MetabaseApi.table_query_metadata({ tableId })),
+  );
+};
+
+module.exports = (getSnapshot = GET_SNAPSHOT_DEFAULT) => {
+  let beforeSnapshot;
+  beforeAll(async () => {
+    beforeSnapshot = await getSnapshot();
+  });
+  afterAll(async () => {
+    try {
+      const afterSnapshot = await getSnapshot();
+      const changes = diffJson(beforeSnapshot, afterSnapshot).filter(
+        c => (c.added || c.removed) && c.value.indexOf('"updated_at"') < 0,
+      );
+      if (changes.length > 0) {
+        process.stdout.write("WARNING: METADATA CHANGED\n".red);
+        for (const part of changes) {
+          const color = part.added ? "green" : part.removed ? "red" : "grey";
+          process.stdout.write(part.value[color]);
+        }
+      }
+    } catch (e) {
+      console.warn("ERROR", e);
+    }
+  });
+};

--- a/frontend/test/jest-setup-framework-integ.js
+++ b/frontend/test/jest-setup-framework-integ.js
@@ -1,0 +1,2 @@
+require("./__support__/jest/console-aggregator")();
+require("./__support__/jest/state-diff")();

--- a/frontend/test/jest-setup-framework-unit.js
+++ b/frontend/test/jest-setup-framework-unit.js
@@ -1,0 +1,1 @@
+require("./__support__/jest/console-aggregator")();

--- a/jest.integ.conf.json
+++ b/jest.integ.conf.json
@@ -19,6 +19,7 @@
     "<rootDir>/frontend/test/jest-setup.js",
     "<rootDir>/frontend/test/metabase-bootstrap.js"
   ],
+  "setupTestFrameworkScriptFile": "<rootDir>/frontend/test/jest-setup-framework-integ.js",
   "globals": {
     "ace": {},
     "ga": {},

--- a/jest.unit.conf.json
+++ b/jest.unit.conf.json
@@ -17,6 +17,7 @@
     "<rootDir>/frontend/test/jest-setup.js",
     "<rootDir>/frontend/test/metabase-bootstrap.js"
   ],
+  "setupTestFrameworkScriptFile": "<rootDir>/frontend/test/jest-setup-framework-unit.js",
   "globals": {
     "ace": {},
     "ga": {},


### PR DESCRIPTION
A couple ideas I've been playing with to make frontend CI more manageable:

1. A `console-aggregator` that hooks `console.*` and prevents certain messages from being logged  directly (primarily React warnings, by default). A summary is logged at the end of the test, like:

```
      IGNORED LOGS:
       { 'Warning: Accessing PropTypes': 1,
        'Warning: Accessing createClass': 1 }
```

I think this helps a lot to shorten the logs especially for integration tests, though a lot of the remaing ones are backend API logs. The goal is to get CircleCI to at least not truncate the logs on node 6 (integration tests)... we'll see once CI runs on this branch.

2. A `state-diff` for integration tests that can run a set of API calls before and after a test suite and show a diff. Useful to see if your test is accidentally not reseting the server state (e.x. modifying the metadata) which could cause other tests to fail because we don't reset the server completely for performance reasons.

We probably want a way to disable manually or based on whether it's running in CI.
