### PR TITLE
replace delay with eventually in FieldApp integration tests

### DIFF
--- a/frontend/test/admin/datamodel/FieldApp.integ.spec.js
+++ b/frontend/test/admin/datamodel/FieldApp.integ.spec.js
@@ -309,9 +309,12 @@ describe("FieldApp", () => {
       click(useFKButton);
       store.waitForActions([UPDATE_FIELD_DIMENSION, FETCH_TABLE_METADATA]);
 
-      const fkFieldSelect = section.find(SelectButton);
+      let fkFieldSelect;
 
-      await eventually(() => expect(fkFieldSelect.text()).toBe("Name"));
+      await eventually(() => {
+        fkFieldSelect = section.find(SelectButton);
+        expect(fkFieldSelect.text()).toBe("Name");
+      });
 
       click(fkFieldSelect);
 
@@ -326,7 +329,11 @@ describe("FieldApp", () => {
 
       click(sourceField);
       store.waitForActions([FETCH_TABLE_METADATA]);
-      await eventually(() => expect(fkFieldSelect.text()).toBe("Source"));
+
+      await eventually(() => {
+        fkFieldSelect = section.find(SelectButton);
+        expect(fkFieldSelect.text()).toBe("Source");
+      });
     });
 
     it("doesn't show date fields in fk options", async () => {

--- a/frontend/test/admin/datamodel/FieldApp.integ.spec.js
+++ b/frontend/test/admin/datamodel/FieldApp.integ.spec.js
@@ -1,6 +1,7 @@
 import {
   useSharedAdminLogin,
   createTestStore,
+  eventually,
 } from "__support__/integrated_tests";
 
 import {
@@ -307,12 +308,11 @@ describe("FieldApp", () => {
         .first();
       click(useFKButton);
       store.waitForActions([UPDATE_FIELD_DIMENSION, FETCH_TABLE_METADATA]);
-      // TODO: Figure out a way to avoid using delay – the use of delays may lead to occasional CI failures
-      await delay(500);
 
       const fkFieldSelect = section.find(SelectButton);
 
-      expect(fkFieldSelect.text()).toBe("Name");
+      await eventually(() => expect(fkFieldSelect.text()).toBe("Name"));
+
       click(fkFieldSelect);
 
       const sourceField = fkFieldSelect
@@ -326,9 +326,7 @@ describe("FieldApp", () => {
 
       click(sourceField);
       store.waitForActions([FETCH_TABLE_METADATA]);
-      // TODO: Figure out a way to avoid using delay – the use of delays may lead to occasional CI failures
-      await delay(500);
-      expect(fkFieldSelect.text()).toBe("Source");
+      await eventually(() => expect(fkFieldSelect.text()).toBe("Source"));
     });
 
     it("doesn't show date fields in fk options", async () => {


### PR DESCRIPTION
Should help with some of these intermittent test failures.
