### PR TITLE
Fix metabot alignment

### DIFF
--- a/frontend/src/metabase/setup/containers/PostSetupApp.jsx
+++ b/frontend/src/metabase/setup/containers/PostSetupApp.jsx
@@ -139,7 +139,9 @@ export default class PostSetupApp extends Component {
                   just a few minutes.`}
                 </h2>
                 <BorderedPanel className="p4 my4 flex">
-                  <MetabotLogo />
+                  <div className="mt1">
+                    <MetabotLogo />
+                  </div>
                   <div className="flex-full ml3 mt1">
                     <div className="mb1">
                       <Quotes quotes={QUOTES} period={2000} />


### PR DESCRIPTION
Micro PR to make Metabot line up more nicely with the loading text and bar:

**Before**

<img width="635" alt="screen shot 2018-04-25 at 1 25 39 pm" src="https://user-images.githubusercontent.com/2223916/39273428-a0f49514-4893-11e8-9771-237fedf1463f.png">

**After**

<img width="676" alt="screen shot 2018-04-25 at 1 25 47 pm" src="https://user-images.githubusercontent.com/2223916/39273441-a6b308d2-4893-11e8-85c5-99dc25194d43.png">
