### PR TITLE
Nested collections

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -4107,6 +4107,25 @@ databaseChangeLog:
               - column:
                   name: collection_id
   - changeSet:
+      id: 80
+      author: camsaul
+      changes:
+        - addColumn:
+            tableName: collection
+            columns:
+              name: location
+              type: varchar(254)
+              remarks: 'Directory-structure path of ancestor Collections. e.g. "/1/2/" means our Parent is Collection 2, and their parent is Collection 1.'
+              constraints:
+                nullable: false
+              defaultValue: "/"
+        - createIndex:
+            tableName: collection
+            indexName: idx_collection_location
+            columns:
+              - column:
+                  name: location
+  - changeSet:
       id: 81
       author: camsaul
       comment: 'Added 0.30.0'

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -1,15 +1,18 @@
 (ns metabase.models.collection
+  (:refer-clojure :exclude [ancestors descendants])
   (:require [clojure
              [data :as data]
              [string :as str]]
-            [metabase.api.common :refer [*current-user-id* *current-user-permissions-set*] :as api]
+            [clojure.tools.logging :as log]
+            [honeysql.core :as hsql]
+            [metabase.api.common :as api :refer [*current-user-id* *current-user-permissions-set*]]
             [metabase.models
              [collection-revision :as collection-revision :refer [CollectionRevision]]
              [interface :as i]
              [permissions :as perms]]
             [metabase.util :as u]
             [metabase.util.schema :as su]
-            [puppetlabs.i18n.core :refer [tru]]
+            [puppetlabs.i18n.core :refer [trs tru]]
             [schema.core :as s]
             [toucan
              [db :as db]
@@ -20,6 +23,11 @@
   254)
 
 (models/defmodel Collection :collection)
+
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                         Slug & Hex Color & Validation                                          |
+;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defn- assert-unique-slug [slug]
   (when (db/exists? Collection :slug slug)
@@ -43,12 +51,309 @@
              {:status-code 400, :errors {:name (tru "cannot be blank")}})))
   (u/slugify collection-name collection-slug-max-length))
 
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                       Nested Collections: Location Paths                                       |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+;; "Location Paths" are strings that keep track of where a Colllection lives in a filesystem-like hierarchy. Almost
+;; all of our backend code does not need to know this and can act as if there is no Collection hierarchy; it is,
+;; however, presented as such in the UI. Perhaps it is best to think of the hierarchy as a façade.
+;;
+;; For example, Collection 30 might have a `location` like `/10/20/`, which means it's the child of Collection 20, who
+;; itself is the child of Collection 10. Note that the `location` does not include the ID of Collection 30 itself.
+;;
+;; Storing the relationship in this manner, rather than with foreign keys such as `:parent_id`, allows us to
+;; efficiently fetch all ancestors or descendants of a Collection without having to make multiple DB calls (e.g. to
+;; fetch a grandparent, you'd first have to fetch its parent to get their `parent_id`).
+;;
+;; The following functions are useful for working with the Collection `location`, breaking it out into component IDs,
+;; assembling IDs into a location path, and so forth.
+
+(defn- unchecked-location-path->ids
+  "*** Don't use this directly! Instead use `location-path->ids`. ***
+
+  'Explode' a `location-path` into a sequence of Collection IDs, and parse them as integers. THIS DOES NOT VALIDATE
+  THAT THE PATH OR RESULTS ARE VALID. This unchecked version exists solely to power the other version below."
+  [location-path]
+  (for [^String id-str (rest (str/split location-path #"/"))]
+    (Integer/parseInt id-str)))
+
+(defn- valid-location-path? [s]
+  (and (string? s)
+       (seq s)
+       (or (= s "/")
+           (and (re-matches #"/(\d+/)*" s)
+                (apply distinct? (unchecked-location-path->ids s))))))
+
+(def LocationPath
+  "Schema for a directory-style 'path' to the location of a Collection."
+  (s/pred valid-location-path?))
+
+(s/defn location-path :- LocationPath
+  "Build a 'location path' from a sequence of `collections-or-ids`.
+
+     (location-path 10 20) ; -> \"/10/20/\""
+  [& collections-or-ids :- [(s/cond-pre su/IntGreaterThanZero su/Map)]]
+  (if-not (seq collections-or-ids)
+    "/"
+    (str
+     "/"
+     (str/join "/" (for [collection-or-id collections-or-ids]
+                     (u/get-id collection-or-id)))
+     "/")))
+
+(s/defn location-path->ids :- [su/IntGreaterThanZero]
+  "'Explode' a `location-path` into a sequence of Collection IDs, and parse them as integers.
+
+     (location-path->ids \"/10/20/\") ; -> [10 20]"
+  [location-path :- LocationPath]
+  (unchecked-location-path->ids location-path))
+
+(s/defn location-path->parent-id :- (s/maybe su/IntGreaterThanZero)
+  "Given a `location-path` fetch the ID of the direct of a Collection.
+
+     (location-path->parent-id \"/10/20/\") ; -> 20"
+  [location-path :- LocationPath]
+  (last (location-path->ids location-path)))
+
+(s/defn all-ids-in-location-path-are-valid? :- s/Bool
+  "Do all the IDs in `location-path` belong to actual Collections? (This requires a DB call to check this, so this
+  should only be used when creating/updating a Collection. Don't use this for casual schema validation.)"
+  [location-path :- LocationPath]
+  (or
+   ;; if location is just the root Collection there are no IDs in the path, so nothing to check
+   (= location-path "/")
+   ;; otherwise get all the IDs in the path and then make sure the count Collections with those IDs matches the number
+   ;; of IDs
+   (let [ids (location-path->ids location-path)]
+     (= (count ids)
+        (db/count Collection :id [:in ids])))))
+
+(defn- assert-valid-location
+  "Assert that the `location` property of a `collection`, if specified, is valid. This checks that it is valid both from
+  a schema standpoint, and from a 'do the referenced Collections exist' standpoint. Intended for use as part of
+  `pre-update` and `pre-insert`."
+  [{:keys [location], :as collection}]
+  (when (contains? collection :location)
+    (when-not (valid-location-path? location)
+      (throw
+       (ex-info (tru "Invalid Collection location: path is invalid.")
+         {:status-code 400
+          :errors      {:location (tru "Invalid Collection location: path is invalid.")}})))
+    (when-not (all-ids-in-location-path-are-valid? location)
+      (throw
+       (ex-info (tru "Invalid Collection location: some or all ancestors do not exist.")
+         {:status-code 404
+          :errors      {:location (tru "Invalid Collection location: some or all ancestors do not exist.")}})))))
+
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                 Nested Collections: "Effective" Location Paths                                 |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+;; "Effective" Location Paths are location paths for Collections that exclude the IDs of Collections the current user
+;; isn't allowed to see.
+;;
+;; For example, if a Collection has a `location` of `/10/20/30/`, and the current User is allowed to see Collections
+;; 10 and 30, but not 20, we will show them an "effective" location path of `/10/30/`. This is used for things like
+;; breadcrumbing in the frontend.
+
+(s/defn permissions-set->visible-collection-ids :- (s/cond-pre (s/eq :all) #{su/IntGreaterThanZero})
+  "Given a `permissions-set` (presumably those of the current user), return a set of IDs of Collections that the
+  permissions set allows you to view. For those with *root* permissions (e.g., an admin), this function will return
+  `:all`, signifying that you are allowed to view all Collections.
+
+    (permissions-set->visible-collection-ids #{\"/collection/10/\"}) ; -> #{10}
+    (permissions-set->visible-collection-ids #{\"/\"})               ; -> :all"
+  [permissions-set :- #{perms/UserPath}]
+  (if (contains? permissions-set "/")
+    :all
+    (set (for [path  permissions-set
+               :let  [[_ id-str] (re-matches #"/collection/(\d+)/(read/)?" path)]
+               :when id-str]
+           (Integer/parseInt id-str)))))
+
+(s/defn effective-location-path :- LocationPath
+  "Given a `location-path` and a set of Collection IDs one is allowed to view (obtained from
+  `permissions-set->visibile-collection-ids` above), calculate the 'effective' location path (excluding IDs of
+  Collections for which we do not have read perms) we should show to the User.
+
+  When called with a single argument, `collection`, this is used as a hydration function to hydrate
+  `:effective_location`."
+  {:hydrate :effective_location}
+  ([collection :- su/Map]
+   (effective-location-path (:location collection)
+                            (permissions-set->visible-collection-ids @*current-user-permissions-set*)))
+
+  ([real-location-path :- LocationPath, allowed-collection-ids :- (s/cond-pre (s/eq :all) #{su/IntGreaterThanZero})]
+   (if (= allowed-collection-ids :all)
+     real-location-path
+     (apply location-path (for [id    (location-path->ids real-location-path)
+                                :when (contains? allowed-collection-ids id)]
+                            id)))))
+
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                          Nested Collections: Ancestors, Childrens, Child Collections                           |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(s/defn ^:private ^:hydrate ancestors :- [CollectionInstance]
+  "Fetch ancestors (parent, grandparent, etc.) of a `collection`. These are returned in order starting with the
+  highest-level (e.g. most distant) ancestor."
+  [{:keys [location]}]
+  (when-let [ancestor-ids (seq (location-path->ids location))]
+    (db/select [Collection :name :id] :id [:in ancestor-ids] {:order-by [:%lower.name]})))
+
+(s/defn effective-ancestors :- [CollectionInstance]
+  "Fetch the ancestors of a `collection`, filtering out any ones the current User isn't allowed to see. This is used
+  in the UI to power the 'breadcrumb' path to the location of a given Collection. For example, suppose we have four
+  Collections, nested like:
+
+    A > B > C > D
+
+  The ancestors of D are:
+
+    A > B > C
+
+  If the current User is allowed to see A and C, but not B, `effective-ancestors` of D will be:
+
+    A > C
+
+  Thus the existence of C will be kept hidden from the current User, and for all intents and purposes the current User
+  can effectively treat A as the parent of C."
+  {:hydrate :effective_ancestors}
+  [collection]
+  (filter i/can-read? (ancestors collection)))
+
+(def root-collection
+  "Special placeholder map representing the Root Collection, which isn't really a real Collection."
+  {::is-root? true})
+
+(defn- is-root-collection? [m]
+  (boolean (::is-root? m)))
+
+(s/defn children-location :- LocationPath
+  "Given a `collection` return a location path that should match the `:location` value of all the children of the
+  Collection.
+
+     (children-location collection) ; -> \"/10/20/30/;
+
+     ;; To get children of this collection:
+     (db/select Collection :location \"/10/20/30/\")"
+  [{:keys [location], :as collection} :- su/Map]
+  (if (is-root-collection? collection)
+    "/"
+    (str location (u/get-id collection) "/")))
+
+(def ^:private Children
+  (s/both
+   CollectionInstance
+   {:children #{(s/recursive #'Children)}
+    s/Keyword s/Any}))
+
+(s/defn ^:private descendants :- #{Children}
+  "Return all descendants of a `collection`, including children, grandchildren, and so forth. This is done primarily
+  to power the `effective-children` feature below, and thus the descendants are returned in a hierarchy, rather than
+  as a flat set. e.g. results will be something like:
+
+       +-> B
+       |
+    A -+-> C -+-> D -> E
+              |
+              +-> F -> G
+
+  where each letter represents a Collection, and the arrows represent values of its respective `:children`
+  set."
+  [collection :- su/Map]
+  ;; first, fetch all the descendants of the `collection`, and build a map of location -> children. This will be used
+  ;; so we can fetch the immediate children of each Collection
+  (let [location->children (group-by :location (db/select [Collection :name :id :location]
+                                                 :location [:like (str (children-location collection) "%")]))
+        ;; Next, build a function to add children to a given `coll`. This function will recursively call itself to add
+        ;; children to each child
+        add-children       (fn add-children [coll]
+                             (let [children (get location->children (children-location coll))]
+                               (assoc coll :children (set (map add-children children)))))]
+    ;; call the `add-children` function we just built on the root `collection` that was passed in.
+    (-> (add-children collection)
+        ;; since this function will be used for hydration (etc.), return only the newly produced `:children`
+        ;; key
+        :children)))
+
+
+(s/defn effective-children ;; :- #{CollectionInstance}
+  "Return the descendants of a `collection` that should be presented to the current user as the children of this
+  Collection. This takes into account descendants that get filtered out when the current user can't see them. For
+  example, suppose we have some Collections with a hierarchy like this:
+
+       +-> B
+       |
+    A -+-> C -+-> D -> E
+              |
+              +-> F -> G
+
+   Suppose the current User can see A, B, E, F, and G, but not C, or D. The 'effective' children of A would be C and
+   E, and the current user would be presented with a hierarchy like:
+
+       +-> B
+       |
+    A -+-> E
+       |
+       +-> F -> G
+
+   You can think of this process as 'collapsing' the Collection hierarchy and removing nodes that aren't visible to
+   the current User. This needs to be done so we can give a User a way to navigate to nodes that are children of
+   Collections they cannot access; in the example above, E and F are such nodes."
+  {:hydrate :effective_children}
+  [collection :- su/Map]
+  ;; Hydrate `:children` if it's not already done
+  (-> (for [child (if (contains? collection :children)
+                    (:children collection)
+                    (descendants collection))]
+        ;; if we can read this `child` then we can go ahead and keep it as is. Discard its `children` and `location`
+        (if (i/can-read? child)
+          (dissoc child :children :location)
+          ;; otherwise recursively call on each of the grandchildren. Make it a `vec` so flatten works on it
+          (vec (effective-children child))))
+      ;; since the results will be nested once for each recursive call, un-nest the results and convert back to a set
+      flatten
+      set))
+
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                               Moving Collections                                               |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(s/defn move-collection!
+  "Move a Collection and all its descendant Collections from its current `location` to a `new-location`."
+  [collection :- su/Map, new-location :- LocationPath]
+  (let [orig-children-location (children-location collection)
+        new-children-location  (children-location (assoc collection :location new-location))]
+    ;; first move this Collection
+    (log/info (trs "Moving Collection {0} and its descendants from {1} to {2}"
+                   (u/get-id collection) (:location collection) new-location))
+    (db/transaction
+      (db/update! Collection (u/get-id collection) :location new-location)
+      ;; we need to update all the descendant collections as well...
+      (db/execute!
+       {:update Collection
+        :set    {:location (hsql/call :replace :location orig-children-location new-children-location)}
+        :where  [:like :location (str orig-children-location "%")]}))))
+
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                       Toucan IModel & Perms Method Impls                                       |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
 (defn- pre-insert [{collection-name :name, color :color, :as collection}]
+  (assert-valid-location collection)
   (assert-valid-hex-color color)
   (assoc collection :slug (u/prog1 (slugify collection-name)
                             (assert-unique-slug <>))))
 
 (defn- pre-update [{collection-name :name, id :id, color :color, archived? :archived, :as collection}]
+  (assert-valid-location collection)
   ;; make sure hex color is valid
   (when (contains? collection :color)
     (assert-valid-hex-color color))
@@ -69,7 +374,9 @@
   ;; shouldn't be deleting Collections, but rather archiving them instead
   (doseq [model ['Card 'Pulse 'Dashboard]]
     (db/update-where! model {:collection_id (u/get-id collection)}
-      :collection_id nil)))
+      :collection_id nil))
+  ;; Now delete all the Children of this Collection
+  (db/delete! Collection :location (children-location collection)))
 
 (defn perms-objects-set
   "Return the required set of permissions to READ-OR-WRITE COLLECTION-OR-ID."
@@ -148,7 +455,9 @@
 ;;; -------------------------------------------------- Update Graph --------------------------------------------------
 
 (s/defn ^:private update-collection-permissions!
-  [group-id :- su/IntGreaterThanZero, collection-id :- su/IntGreaterThanZero, new-collection-perms :- CollectionPermissions]
+  [group-id             :- su/IntGreaterThanZero
+   collection-id        :- su/IntGreaterThanZero
+   new-collection-perms :- CollectionPermissions]
   ;; remove whatever entry is already there (if any) and add a new entry if applicable
   (perms/revoke-collection-permissions! group-id collection-id)
   (case new-collection-perms
@@ -156,7 +465,8 @@
     :read  (perms/grant-collection-read-permissions! group-id collection-id)
     :none  nil))
 
-(s/defn ^:private update-group-permissions! [group-id :- su/IntGreaterThanZero, new-group-perms :- GroupPermissionsGraph]
+(s/defn ^:private update-group-permissions!
+  [group-id :- su/IntGreaterThanZero, new-group-perms :- GroupPermissionsGraph]
   (doseq [[collection-id new-perms] new-group-perms]
     (update-collection-permissions! group-id collection-id new-perms)))
 
@@ -193,7 +503,9 @@
    (update-graph! (assoc-in (graph) (cons :groups ks) new-value))))
 
 
-;;; ------------------------------------------- Perms Checking Helper Fns --------------------------------------------
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                           Perms Checking Helper Fns                                            |
+;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defn check-write-perms-for-collection
   "Check that we have write permissions for Collection with `collection-id`, or throw a 403 Exception. If

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -57,6 +57,15 @@
              (some (u/rpartial re-matches object-path)
                    valid-object-path-patterns))))
 
+(def ObjectPath
+  "Schema for a valid permissions path to an object."
+  (s/pred valid-object-path? "Valid permissions object path."))
+
+(def UserPath
+  "Schema for a valid permissions path that a user might possess in their `*current-user-permissions-set*`. This is the
+  same as what's allowed for `ObjectPath` but also includes root permissions, which admins will have."
+  (s/pred #(or (= % "/") (valid-object-path? %))
+          "Valid user permissions path."))
 
 (defn- assert-not-admin-group
   "Check to make sure the `:group_id` for PERMISSIONS entry isn't the admin group."

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -6,7 +6,8 @@
              [util :as u]]
             [metabase.models
              [card :refer [Card]]
-             [collection :refer [Collection]]
+             [collection :as collection :refer [Collection]]
+             [collection-test :as collection-test]
              [dashboard :refer [Dashboard]]
              [database :refer [Database]]
              [permissions :as perms]
@@ -74,14 +75,23 @@
   (tt/with-temp Collection [collection]
     ((user->client :rasta) :get 403 (str "collection/" (u/get-id collection)))))
 
+
+;;; ----------------------------------------- Cards, Dashboards, and Pulses ------------------------------------------
+
 ;; check that cards are returned with the collections detail endpoint
 (tt/expect-with-temp [Collection [collection]
                       Card       [card        {:collection_id (u/get-id collection)}]]
-  (tu/obj->json->obj (assoc collection
-                       :cards      [(select-keys card [:name :id :collection_position])]
-                       :dashboards []
-                       :pulses     []))
-  (tu/obj->json->obj ((user->client :crowberto) :get 200 (str "collection/" (u/get-id collection)))))
+  (tu/obj->json->obj
+    (assoc collection
+      :cards               [(select-keys card [:name :id :collection_position])]
+      :dashboards          []
+      :pulses              []
+      :effective_ancestors []
+      :effective_location  "/"
+      :effective_children  []
+      :can_write           true))
+  (tu/obj->json->obj
+    ((user->client :crowberto) :get 200 (str "collection/" (u/get-id collection)))))
 
 ;; check that collections detail doesn't return archived collections
 (expect
@@ -133,6 +143,96 @@
           remove-ids-from-collection-detail))))
 
 
+;;; ------------------------------------ Effective Ancestors & Effective Children ------------------------------------
+
+(defmacro ^:private with-collection-hierarchy
+  "Totally-rad macro that creates a Collection hierarchy and grants the All Users group perms for all the Collections
+  you've bound."
+  {:style/indent 1}
+  [collection-bindings & body]
+  {:pre [(vector? collection-bindings)
+         (every? symbol? collection-bindings)]}
+  `(collection-test/with-collection-hierarchy [{:keys ~collection-bindings}]
+     ~@(for [collection-symb collection-bindings]
+         `(perms/grant-collection-read-permissions! (group/all-users) ~collection-symb))
+     ~@body))
+
+(defn- format-ancestors-and-children
+  "Nicely format the `:effective_` results from an API call."
+  [results]
+  (-> results
+      (select-keys [:effective_children :effective_ancestors :effective_location])
+      (update :effective_children  (comp set (partial map #(update % :id integer?))))
+      (update :effective_ancestors (partial map #(update % :id integer?)))
+      (update :effective_location collection-test/location-path-ids->names)))
+
+(defn- api-get-collection-ancestors-and-children
+  "Call the API with Rasta to fetch `collection-or-id` and put the `:effective_` results in a nice format for the tests
+  below."
+  [collection-or-id]
+  (-> ((user->client :rasta) :get 200 (str "collection/" (u/get-id collection-or-id)))
+      format-ancestors-and-children))
+
+;; does a top-level Collection like A have the correct Children?
+(expect
+  {:effective_children  #{{:name "B", :id true} {:name "C", :id true}}
+   :effective_ancestors []
+   :effective_location  "/"}
+  (with-collection-hierarchy [a b c d g]
+    (api-get-collection-ancestors-and-children a)))
+
+;; ok, does a second-level Collection have its parent and its children?
+(expect
+  {:effective_children  #{{:name "D", :id true} {:name "G", :id true}}
+   :effective_ancestors [{:name "A", :id true}]
+   :effective_location  "/A/"}
+  (with-collection-hierarchy [a b c d g]
+    (api-get-collection-ancestors-and-children c)))
+
+;; what about a third-level Collection?
+(expect
+  {:effective_children #{}
+   :effective_ancestors [{:name "A", :id true} {:name "C", :id true}]
+   :effective_location "/A/C/"}
+  (with-collection-hierarchy [a b c d g]
+    (api-get-collection-ancestors-and-children d)))
+
+;; for D: if we remove perms for C we should only have A as an ancestor; effective_location should lie and say we are
+;; a child of A
+(expect
+  {:effective_children #{}
+   :effective_ancestors [{:name "A", :id true}]
+   :effective_location "/A/"}
+  (with-collection-hierarchy [a b d g]
+    (api-get-collection-ancestors-and-children d)))
+
+;; for D: If, on the other hand, we remove A, we should see C as the only ancestor and as a root-level Collection.
+(expect
+  {:effective_children #{},
+   :effective_ancestors [{:name "C", :id true}]
+   :effective_location "/C/"}
+  (with-collection-hierarchy [b c d g]
+    (api-get-collection-ancestors-and-children d)))
+
+;; for C: if we remove D we should get E and F as effective children
+(expect
+  {:effective_children #{{:name "E", :id true} {:name "F", :id true}}
+   :effective_ancestors [{:name "A", :id true}]
+   :effective_location "/A/"}
+  (with-collection-hierarchy [a b c e f g]
+    (api-get-collection-ancestors-and-children c)))
+
+;; Make sure we can collapse multiple generations. For A: removing C and D should move up E and F
+(expect
+  {:effective_children #{{:name "B", :id true}
+                         {:name "E", :id true}
+                         {:name "F", :id true}}
+   :effective_ancestors []
+   :effective_location "/"}
+  (with-collection-hierarchy [a b e f g]
+    (api-get-collection-ancestors-and-children a)))
+
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                              GET /collection/root                                              |
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -180,6 +280,34 @@
         (remove-ids-from-collection-detail :keep-collection-id? true))))
 
 
+;;; ----------------------------------- Effective Children, Ancestors, & Location ------------------------------------
+
+(defn- api-get-root-collection-ancestors-and-children
+  "Call the API with Rasta to fetch the 'Root' Collection and put the `:effective_` results in a nice format for the
+  tests below."
+  []
+  (-> ((user->client :rasta) :get 200 "collection/root")
+      format-ancestors-and-children))
+
+;; Do top-level collections show up as children of the Root Collection?
+(expect
+  {:effective_children #{{:name "A", :id true}}
+   :effective_ancestors []
+   :effective_location "/"}
+  (with-collection-hierarchy [a b c d e f g]
+    (api-get-root-collection-ancestors-and-children)))
+
+;; ...and collapsing children should work for the Root Collection as well
+(expect
+  {:effective_children #{{:name "B", :id true}
+                         {:name "D", :id true}
+                         {:name "F", :id true}}
+   :effective_ancestors []
+   :effective_location "/"}
+  (with-collection-hierarchy [b d e f g]
+    (api-get-root-collection-ancestors-and-children)))
+
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                              POST /api/collection                                              |
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -190,12 +318,12 @@
    :slug        "stamp_collection"
    :description nil
    :color       "#123456"
-   :archived    false}
-  (dissoc (u/prog1 ((user->client :crowberto) :post 200 "collection"
-                    {:name "Stamp Collection", :color "#123456"})
-            ;; make sure we clean up after ourselves
-            (db/delete! Collection :id (u/get-id <>)))
-          :id))
+   :archived    false
+   :location    "/"}
+  (tu/with-model-cleanup [Collection]
+    (-> ((user->client :crowberto) :post 200 "collection"
+         {:name "Stamp Collection", :color "#123456"})
+        (dissoc :id))))
 
 ;; test that non-admins aren't allowed to create a collection
 (expect
@@ -203,6 +331,24 @@
   ((user->client :rasta) :post 403 "collection"
    {:name "Stamp Collection", :color "#123456"}))
 
+;; Can I create a Collection as a child of an existing collection?
+(expect
+  {:id          true
+   :name        "Trading Card Collection"
+   :slug        "trading_card_collection"
+   :description "Collection of basketball cards including limited-edition holographic Draymond Green"
+   :color       "#ABCDEF"
+   :archived    false
+   :location    "/A/C/D/"}
+  (tu/with-model-cleanup [Collection]
+    (with-collection-hierarchy [a c d]
+      (-> ((user->client :crowberto) :post 200 "collection"
+           {:name        "Trading Card Collection"
+            :color       "#ABCDEF"
+            :description "Collection of basketball cards including limited-edition holographic Draymond Green"
+            :parent_id   (u/get-id d)})
+          (update :location collection-test/location-path-ids->names)
+          (update :id integer?)))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                            PUT /api/collection/:id                                             |
@@ -215,7 +361,8 @@
    :slug        "my_beautiful_collection"
    :description nil
    :color       "#ABCDEF"
-   :archived    false}
+   :archived    false
+   :location    "/"}
   ((user->client :crowberto) :put 200 (str "collection/" (u/get-id collection))
    {:name "My Beautiful Collection", :color "#ABCDEF"}))
 
@@ -254,3 +401,18 @@
        {:name "My Beautiful Collection", :color "#ABCDEF", :archived true}))
     [(et/regex-email-bodies #"the question was archived by Crowberto Corv")
      (Pulse pulse-id)]))
+
+;; Can I *change* the `location` of a Collection? (i.e. move it into a different parent Colleciton)
+(expect
+  {:id          true
+   :name        "E"
+   :slug        "e"
+   :description nil
+   :color       "#ABCDEF"
+   :archived    false
+   :location    "/A/B/"}
+  (with-collection-hierarchy [a b e]
+    (-> ((user->client :crowberto) :put 200 (str "collection/" (u/get-id e))
+         {:parent_id (u/get-id b)})
+        (update :location collection-test/location-path-ids->names)
+        (update :id integer?))))

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -1,8 +1,13 @@
 (ns metabase.models.collection-test
-  (:require [expectations :refer :all]
+  (:refer-clojure :exclude [ancestors descendants])
+  (:require [clojure.string :as str]
+            [expectations :refer :all]
+            [metabase.api.common :refer [*current-user-permissions-set*]]
             [metabase.models
              [card :refer [Card]]
-             [collection :refer [Collection]]]
+             [collection :as collection :refer [Collection]]
+             [permissions :as perms]]
+            [metabase.test.util :as tu]
             [metabase.util :as u]
             [toucan.db :as db]
             [toucan.util.test :as tt]))
@@ -13,7 +18,8 @@
    :slug        "my_favorite_cards"
    :description nil
    :color       "#ABCDEF"
-   :archived    false}
+   :archived    false
+   :location    "/"}
   (tt/with-temp Collection [collection {:name "My Favorite Cards", :color "#ABCDEF"}]
     (dissoc collection :id)))
 
@@ -74,3 +80,591 @@
   (tt/with-temp Collection [collection]
     (db/update! Collection (u/get-id collection)
       :name "")))
+
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                     Nested Collections Helper Fns & Macros                                     |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defn do-with-collection-hierarchy [a-fn]
+  (tt/with-temp* [Collection [a {:name "A"}]
+                  Collection [b {:name "B", :location (collection/location-path a)}]
+                  Collection [c {:name "C", :location (collection/location-path a)}]
+                  Collection [d {:name "D", :location (collection/location-path a c)}]
+                  Collection [e {:name "E", :location (collection/location-path a c d)}]
+                  Collection [f {:name "F", :location (collection/location-path a c)}]
+                  Collection [g {:name "G", :location (collection/location-path a c f)}]]
+    (a-fn {:a a, :b b, :c c, :d d, :e e, :f f, :g g})))
+
+(defmacro with-collection-hierarchy
+  "Run `body` with a hierarchy of Collections that looks like:
+
+        +-> B
+        |
+     A -+-> C -+-> D -> E
+               |
+               +-> F -> G
+
+     Bind only the collections you need by using `:keys`:
+
+     (with-collection-hierarchy [{:keys [a b c]}]
+       ...)"
+  {:style/indent 1}
+  [[collections-binding] & body]
+  `(do-with-collection-hierarchy (fn [~collections-binding] ~@body)))
+
+(defmacro with-current-user-perms-for-collections
+  "Run `body` with the current User permissions for `collections-or-ids`.
+
+     (with-current-user-perms-for-collections [a b c]
+       ...)"
+  {:style/indent 1}
+  [collections-or-ids & body]
+  `(binding [*current-user-permissions-set* (atom #{~@(for [collection-or-id collections-or-ids]
+                                                        `(perms/collection-read-path ~collection-or-id))})]
+     ~@body))
+
+(defn location-path-ids->names
+  "Given a Collection location `path` replace all the IDs with the names of the Collections they represent. Done to make
+  it possible to compare Collection location paths in tests without having to know the randomly-generated IDs."
+  [path]
+  ;; split the path into IDs and then fetch a map of ID -> Name for each ID
+  (let [ids     (collection/location-path->ids path)
+        id->name (when (seq ids)
+                   (db/select-field->field :id :name Collection :id [:in ids]))]
+    ;; now loop through each ID and replace the ID part like (ex. /10/) with a name (ex. /A/)
+    (loop [path path, [id & more] ids]
+      (if-not id
+        path
+        (recur
+         (str/replace path (re-pattern (str "/" id "/")) (str "/" (id->name id) "/"))
+         more)))))
+
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                       Nested Collections: Location Paths                                       |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+;; Does our handy utility function for working with `location` paths work as expected?
+(expect "/1/2/3/" (collection/location-path 1 2 3))
+(expect "/"       (collection/location-path))
+(expect "/1/"     (collection/location-path {:id 1}))
+(expect "/1/2/3/" (collection/location-path {:id 1} {:id 2} {:id 3}))
+(expect "/1/337/" (collection/location-path 1 {:id 337}))
+(expect Exception (collection/location-path "1"))
+(expect Exception (collection/location-path nil))
+(expect Exception (collection/location-path -1))
+(expect Exception (collection/location-path 1 2 1)) ; shouldn't allow duplicates
+
+(expect [1 2 3]   (collection/location-path->ids "/1/2/3/"))
+(expect []        (collection/location-path->ids "/"))
+(expect [1]       (collection/location-path->ids "/1/"))
+(expect [1 337]   (collection/location-path->ids "/1/337/"))
+(expect Exception (collection/location-path->ids "/a/"))
+(expect Exception (collection/location-path->ids nil))
+(expect Exception (collection/location-path->ids "/-1/"))
+(expect Exception (collection/location-path->ids "/1/2/1/"))
+
+(expect 3         (collection/location-path->parent-id "/1/2/3/"))
+(expect nil       (collection/location-path->parent-id "/"))
+(expect 1         (collection/location-path->parent-id "/1/"))
+(expect 337       (collection/location-path->parent-id "/1/337/"))
+(expect Exception (collection/location-path->parent-id "/a/"))
+(expect Exception (collection/location-path->parent-id nil))
+(expect Exception (collection/location-path->parent-id "/-1/"))
+(expect Exception (collection/location-path->parent-id "/1/2/1/"))
+
+(expect "/1/2/3/1000/" (collection/children-location {:id 1000, :location "/1/2/3/"}))
+(expect "/1000/"       (collection/children-location {:id 1000, :location "/"}))
+(expect "/1/1000/"     (collection/children-location {:id 1000, :location "/1/"}))
+(expect "/1/337/1000/" (collection/children-location {:id 1000, :location "/1/337/"}))
+(expect Exception      (collection/children-location {:id 1000, :location "/a/"}))
+(expect Exception      (collection/children-location {:id 1000, :location nil}))
+(expect Exception      (collection/children-location {:id 1000, :location "/-1/"}))
+(expect Exception      (collection/children-location {:id nil,  :location "/1/"}))
+(expect Exception      (collection/children-location {:id "a",  :location "/1/"}))
+(expect Exception      (collection/children-location {:id 1,    :location "/1/2/"}))
+
+;; Make sure we can look at the current user's permissions set and figure out which Collections they're allowed to see
+(expect
+  #{8 9}
+  (collection/permissions-set->visible-collection-ids
+   #{"/db/1/"
+     "/db/2/native/"
+     "/db/3/native/read/"
+     "/db/4/schema/"
+     "/db/5/schema/PUBLIC/"
+     "/db/6/schema/PUBLIC/table/7/"
+     "/collection/8/"
+     "/collection/9/read/"}))
+
+;; If the current user has root permissions then make sure the function returns `:all`, which signifies that they are
+;; able to see all Collections
+(expect
+  :all
+  (collection/permissions-set->visible-collection-ids
+   #{"/"
+     "/db/2/native/"
+     "/collection/9/read/"}))
+
+;; Can we calculate `effective-location-path`?
+(expect "/10/20/"    (collection/effective-location-path "/10/20/30/" #{10 20}))
+(expect "/10/30/"    (collection/effective-location-path "/10/20/30/" #{10 30}))
+(expect "/"          (collection/effective-location-path "/10/20/30/" #{}))
+(expect "/10/20/30/" (collection/effective-location-path "/10/20/30/" #{10 20 30}))
+(expect "/10/20/30/" (collection/effective-location-path "/10/20/30/" :all))
+(expect Exception    (collection/effective-location-path "/10/20/30/" nil))
+(expect Exception    (collection/effective-location-path "/10/20/30/" [20]))
+(expect Exception    (collection/effective-location-path nil #{}))
+(expect Exception    (collection/effective-location-path [10 20] #{}))
+
+;; Does the function also work if we call the single-arity version that powers hydration?
+(expect
+  "/10/20/"
+  (binding [*current-user-permissions-set* (atom #{"/collection/10/" "/collection/20/read/"})]
+    (collection/effective-location-path {:location "/10/20/30/"})))
+
+(expect
+  "/10/30/"
+  (binding [*current-user-permissions-set* (atom #{"/collection/10/read/" "/collection/30/read/"})]
+    (collection/effective-location-path {:location "/10/20/30/"})))
+
+(expect
+  "/"
+  (binding [*current-user-permissions-set* (atom #{})]
+    (collection/effective-location-path {:location "/10/20/30/"})))
+
+(expect
+  "/10/20/30/"
+  (binding [*current-user-permissions-set* (atom #{"/collection/10/" "/collection/20/read/" "/collection/30/read/"})]
+    (collection/effective-location-path {:location "/10/20/30/"})))
+
+(expect
+  "/10/20/30/"
+  (binding [*current-user-permissions-set* (atom #{"/"})]
+    (collection/effective-location-path {:location "/10/20/30/"})))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                Nested Collections: CRUD Constraints & Behavior                                 |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+;; Can we INSERT a Collection with a valid path?
+(defn- insert-collection-with-location! [location]
+  (tu/with-model-cleanup [Collection]
+    (-> (db/insert! Collection :name (tu/random-name), :color "#ABCDEF", :location location)
+        :location
+        (= location))))
+
+(expect
+  (tt/with-temp Collection [parent]
+    (insert-collection-with-location! (collection/location-path parent))))
+
+;; Make sure we can't INSERT a Collection with an invalid path
+(defn- nonexistent-collection-id []
+  (inc (or (:max (db/select-one [Collection [:%max.id :max]]))
+           0)))
+
+(expect
+  Exception
+  (insert-collection-with-location! "/a/"))
+
+;; Make sure we can't INSERT a Collection with an non-existent ancestors
+(expect
+  Exception
+  (insert-collection-with-location! (collection/location-path (nonexistent-collection-id))))
+
+;; MAae sure we can UPDATE a Collection and give it a new, *valid* location
+(expect
+  (tt/with-temp* [Collection [collection-1]
+                  Collection [collection-2]]
+    (db/update! Collection (u/get-id collection-1) :location (collection/location-path collection-2))))
+
+;; Make sure we can't UPDATE a Collection to give it an valid path
+(expect
+  Exception
+  (tt/with-temp Collection [collection]
+    (db/update! Collection (u/get-id collection) :location "/a/")))
+
+;; Make sure we can't UPDATE a Collection to give it a non-existent ancestors
+(expect
+  Exception
+  (tt/with-temp Collection [collection]
+    (db/update! Collection (u/get-id collection) :location (collection/location-path (nonexistent-collection-id)))))
+
+
+;; When we delete a Collection do its descendants get deleted as well?
+;;
+;;    +-> B
+;;    |
+;; x -+-> C -+-> D -> E     ===>     x
+;;           |
+;;           +-> F -> G
+(expect
+  0
+  (with-collection-hierarchy [{:keys [a b c d e f g]}]
+    (db/delete! Collection :id (u/get-id a))
+    (db/count Collection :id [:in (map u/get-id [a b c d e f g])])))
+
+;; ...put parents & siblings should be untouched
+;;
+;;    +-> B                             +-> B
+;;    |                                 |
+;; A -+-> x -+-> D -> E     ===>     A -+
+;;           |
+;;           +-> F -> G
+(expect
+  2
+  (with-collection-hierarchy [{:keys [a b c d e f g]}]
+    (db/delete! Collection :id (u/get-id c))
+    (db/count Collection :id [:in (map u/get-id [a b c d e f g])])))
+
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                              Nested Collections: Ancestors & Effective Ancestors                               |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defn- ancestors [collection]
+  (map :name (#'collection/ancestors collection)))
+
+;; Can we hydrate `ancestors` the way we'd hope?
+(expect
+  ["A" "C"]
+  (with-collection-hierarchy [{:keys [d]}]
+    (ancestors d)))
+
+(expect
+  ["A" "C" "D"]
+  (with-collection-hierarchy [{:keys [e]}]
+    (ancestors e)))
+
+;; trying it on C should give us only A
+(expect
+  ["A"]
+  (with-collection-hierarchy [{:keys [c]}]
+    (ancestors c)))
+
+
+;;; ---------------------------------------------- Effective Ancestors -----------------------------------------------
+
+(defn- effective-ancestors [collection]
+  (map :name (collection/effective-ancestors collection)))
+
+;; For D: if we don't have permissions for C, we should only see A
+(expect
+  ["A"]
+  (with-collection-hierarchy [{:keys [a d]}]
+    (with-current-user-perms-for-collections [a d]
+      (effective-ancestors d))))
+
+;; For D: if we don't have permissions for A, we should only see C
+(expect
+  ["C"]
+  (with-collection-hierarchy [{:keys [c d]}]
+    (with-current-user-perms-for-collections [c d]
+      (effective-ancestors d))))
+
+;; For D: if we have perms for all ancestors we should see them all
+(expect
+  ["A" "C"]
+  (with-collection-hierarchy [{:keys [a c d]}]
+    (with-current-user-perms-for-collections [a c d]
+      (effective-ancestors d))))
+
+;; For D: if we have permissions for no ancestors, we should see nothing
+(expect
+  []
+  (with-collection-hierarchy [{:keys [a c d]}]
+    (with-current-user-perms-for-collections [d]
+      (effective-ancestors d))))
+
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                              Nested Collections: Descendants & Effective Children                              |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+;;; -------------------------------------------------- Descendants ---------------------------------------------------
+
+(defn- format-collections
+  "Put the results of `collection/descendants` (etc.) in a nice format that makes it easy to write our tests."
+  [collections]
+  (set (for [collection collections]
+         (-> (into {} collection)
+             (update :id integer?)
+             (update :location location-path-ids->names)
+             (update :children (comp set (partial format-collections)))))))
+
+(defn- descendants [collection]
+  (-> (#'collection/descendants collection)
+      format-collections))
+
+;; make sure we can fetch the descendants of a Collection in the hierarchy we'd expect
+(expect
+  #{{:name "B", :id true, :location "/A/", :children #{}}
+    {:name     "C"
+     :id       true
+     :location "/A/"
+     :children #{{:name     "D"
+                  :id       true
+                  :location "/A/C/"
+                  :children #{{:name "E", :id true, :location "/A/C/D/", :children #{}}}}
+                 {:name     "F"
+                  :id       true
+                  :location "/A/C/"
+                  :children #{{:name "G", :id true, :location "/A/C/F/", :children #{}}}}}}}
+  (with-collection-hierarchy [{:keys [a]}]
+    (descendants a)))
+
+;; try for one of the children, make sure we get just that subtree
+(expect
+  #{}
+  (with-collection-hierarchy [{:keys [b]}]
+    (descendants b)))
+
+;; try for the other child, we should get just that subtree!
+(expect
+  #{{:name     "D"
+     :id       true
+     :location "/A/C/"
+     :children #{{:name "E", :id true, :location "/A/C/D/", :children #{}}}}
+    {:name     "F"
+     :id       true
+     :location "/A/C/"
+     :children #{{:name "G", :id true, :location "/A/C/F/", :children #{}}}}}
+  (with-collection-hierarchy [{:keys [c]}]
+    (descendants c)))
+
+;; try for a grandchild
+(expect
+  #{{:name "E", :id true, :location "/A/C/D/", :children #{}}}
+  (with-collection-hierarchy [{:keys [d]}]
+    (descendants d)))
+
+;; For the *Root* Collection, can we get top-level Collections?
+(expect
+  #{{:name     "A"
+     :id       true
+     :location "/"
+     :children #{{:name     "C"
+                  :id       true
+                  :location "/A/"
+                  :children #{{:name     "D"
+                               :id       true
+                               :location "/A/C/"
+                               :children #{{:name     "E"
+                                            :id       true
+                                            :location "/A/C/D/"
+                                            :children #{}}}}
+                              {:name     "F"
+                               :id       true
+                               :location "/A/C/"
+                               :children #{{:name     "G"
+                                            :id       true
+                                            :location "/A/C/F/"
+                                            :children #{}}}}}}
+                 {:name "B", :id true, :location "/A/", :children #{}}}}
+    (with-collection-hierarchy [{:keys [a b c d e f g]}]
+      (descendants collection/root-collection))})
+
+
+;;; ----------------------------------------------- Effective Children -----------------------------------------------
+
+(defn- effective-children [collection]
+  (set (map :name (collection/effective-children collection))))
+
+;; If we *have* perms for everything we should just see B and C.
+(expect
+  #{"B" "C"}
+  (with-collection-hierarchy [{:keys [a b c d e f g]}]
+    (with-current-user-perms-for-collections [a b c d e f g]
+      (effective-children a))))
+
+;; make sure that `effective-children` isn't returning children or location of children! Those should get discarded.
+(expect
+  #{:name :id}
+  (with-collection-hierarchy [{:keys [a b c d e f g]}]
+    (with-current-user-perms-for-collections [a b c d e f g]
+      (set (keys (first (collection/effective-children a)))))))
+
+;; If we don't have permissions for C, C's children (D and F) should be moved up one level
+;;
+;;    +-> B                             +-> B
+;;    |                                 |
+;; A -+-> x -+-> D -> E     ===>     A -+-> D -> E
+;;           |                          |
+;;           +-> F -> G                 +-> F -> G
+(expect
+  #{"B" "D" "F"}
+  (with-collection-hierarchy [{:keys [a b d e f g]}]
+    (with-current-user-perms-for-collections [a b d e f g]
+      (effective-children a))))
+
+;; If we also remove D, its child (F) should get moved up, for a total of 2 levels.
+;;
+;;    +-> B                             +-> B
+;;    |                                 |
+;; A -+-> x -+-> x -> E     ===>     A -+-> E
+;;           |                          |
+;;           +-> F -> G                 +-> F -> G
+(expect
+  #{"B" "E" "F"}
+  (with-collection-hierarchy [{:keys [a b e f g]}]
+    (with-current-user-perms-for-collections [a b e f g]
+      (effective-children a))))
+
+;; If we remove C and both its children, both grandchildren should get get moved up
+;;
+;;    +-> B                             +-> B
+;;    |                                 |
+;; A -+-> x -+-> x -> E     ===>     A -+-> E
+;;           |                          |
+;;           +-> x -> G                 +-> G
+(expect
+  #{"B" "E" "G"}
+  (with-collection-hierarchy [{:keys [a b e g]}]
+    (with-current-user-perms-for-collections [a b e g]
+      (effective-children a))))
+
+;; Now try with one of the Children. `effective-children` for C should be D & F
+;;
+;; C -+-> D -> E              C -+-> D -> E
+;;    |              ===>        |
+;;    +-> F -> G                 +-> F -> G
+(expect
+  #{"D" "F"}
+  (with-collection-hierarchy [{:keys [b c d e f g]}]
+    (with-current-user-perms-for-collections [b c d e f g]
+      (effective-children c))))
+
+;; If we remove perms for D & F their respective children should get moved up
+;;
+;; C -+-> x -> E              C -+-> E
+;;    |              ===>        |
+;;    +-> x -> G                 +-> G
+(expect
+  #{"E" "G"}
+  (with-collection-hierarchy [{:keys [b c e g]}]
+    (with-current-user-perms-for-collections [b c e g]
+      (effective-children c))))
+
+;; For the Root Collection: can we fetch its effective children?
+(expect
+  #{"A"}
+  (with-collection-hierarchy [{:keys [a b c d e f g]}]
+    (with-current-user-perms-for-collections [a b c d e f g]
+      (effective-children collection/root-collection))))
+
+;; For the Root Collection: if we don't have perms for A, we should get B and C as effective children
+(expect
+  #{"B" "C"}
+  (with-collection-hierarchy [{:keys [b c d e f g]}]
+    (with-current-user-perms-for-collections [b c d e f g]
+      (effective-children collection/root-collection))))
+
+;; For the Root Collection: if we remove A and C we should get B, D and F
+(expect
+  #{"B" "D" "F"}
+  (with-collection-hierarchy [{:keys [b d e f g]}]
+    (with-current-user-perms-for-collections [b d e f g]
+      (effective-children collection/root-collection))))
+
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                     Nested Collections: Moving Collections                                     |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defn- combine
+  "Recursive `merge-with` that works on nested maps."
+  [& maps]
+  (->>
+   ;; recursively call `combine` to merge this map and its nested maps
+   (apply merge-with combine maps)
+   ;; now sort the map by its keys and put it back in as an array map to keep the order. Nice!
+   (sort-by first)
+   (into (array-map))))
+
+(defn- collection-locations
+  "Print out an amazingly useful map that charts the hierarchy of `collections`."
+  [collections]
+  (apply
+   merge-with combine
+   (for [collection (-> (db/select Collection :id [:in (map u/get-id collections)])
+                        format-collections)]
+     (assoc-in {} (concat (filter seq (str/split (:location collection) #"/"))
+                          [(:name collection)])
+               {}))))
+
+;; Make sure the util functions above actually work correctly
+;;
+;;    +-> B
+;;    |
+;; A -+-> C -+-> D -> E
+;;           |
+;;           +-> F -> G
+(expect
+  {"A" {"B" {}
+        "C" {"D" {"E" {}}
+             "F" {"G" {}}}}}
+  (with-collection-hierarchy [collections]
+    (collection-locations (vals collections))))
+
+;; Test that we can move a Collection
+;;
+;;    +-> B                        +-> B ---> E
+;;    |                            |
+;; A -+-> C -+-> D -> E   ===>  A -+-> C -+-> D
+;;           |                            |
+;;           +-> F -> G                   +-> F -> G
+(expect
+  {"A" {"B" {"E" {}}
+        "C" {"D" {}
+             "F" {"G" {}}}}}
+  (with-collection-hierarchy [{:keys [b e], :as collections}]
+    (collection/move-collection! e (collection/children-location b))
+    (collection-locations (vals collections))))
+
+;; Test that we can move a Collection and its descendants get moved as well
+;;
+;;    +-> B                       +-> B ---> D -> E
+;;    |                           |
+;; A -+-> C -+-> D -> E  ===>  A -+-> C -+
+;;           |                           |
+;;           +-> F -> G                  +-> F -> G
+(expect
+  {"A" {"B" {"D" {"E" {}}}
+        "C" {"F" {"G" {}}}}}
+  (with-collection-hierarchy [{:keys [b d], :as collections}]
+    (collection/move-collection! d (collection/children-location b))
+    (collection-locations (vals collections))))
+
+
+;; Test that we can move a Collection into the Root Collection
+;;
+;;    +-> B                        +-> B
+;;    |                            |
+;; A -+-> C -+-> D -> E   ===>  A -+-> C -> D -> E
+;;           |
+;;           +-> F -> G         F -> G
+(expect
+  {"A" {"B" {}
+        "C" {"D" {"E" {}}}}
+   "F" {"G" {}}}
+  (with-collection-hierarchy [{:keys [f], :as collections}]
+    (collection/move-collection! f (collection/children-location collection/root-collection))
+    (collection-locations (vals collections))))
+
+;; Test that we can move a Collection out of the Root Collection
+;;
+;;    +-> B                               +-> B
+;;    |                                   |
+;; A -+-> C -+-> D -> E   ===>  F -+-> A -+-> C -+-> D -> E
+;;           |                     |
+;;           +-> F -> G            +-> G
+
+(expect
+  {"F" {"A" {"B" {}
+             "C" {"D" {"E" {}}}}
+        "G" {}}}
+  (with-collection-hierarchy [{:keys [a f], :as collections}]
+    (collection/move-collection! f (collection/children-location collection/root-collection))
+    (collection/move-collection! a (collection/children-location (Collection (u/get-id f))))
+    (collection-locations (vals collections))))


### PR DESCRIPTION
Follow-on to #7358. Implements #7470

### TODOS

###### Backend

- [x] Migration
- [x] model-layer code for: 
  - [x] working with `location` paths
    - [x] tests
  - [x] fetching ancestors of a Collection
    - [x] tests
  - [x] calculating `effective_location` -- the location path excluding IDs of Collections for which we don't have read perms. e.g. if Collection 40 has a `location` of `/10/20/30/`, but we don't have Permissions to see 30, so its `effective_location` is `/10/20/`
    - [x] tests
  - [x] fetching `effective_children` -- any descendants of the Collection that would be children of this Collection based on their `effective_location`. 
    - [x] tests
  - [x] fetching `effective_ancestors`. (This is simple, just filter `ancestors` by `can-read?`)
    - [x] tests
- [x] Return `effective_children` collections in `GET /api/collection/:id` 
  - [x] tests
- [x] Return `effective_ancestors` in `GET /api/collection/:id`
   - [x] tests
- [x] Return `effective_children` collections in `GET /api/collection/root`
   - [x] tests
- [x] Allow setting `Collection.location` from Collection CRUD API endpoints
   - [x] tests
- [x] I think "moving" a Collection means we need to update all the descendant collections and "move" them as well (?)
- [ ] (un)archiving a Collection is recursive? or something like that. TBD

###### Frontend

- [ ] Show nested collections (and possibly parent collection) in the collections detail views
- [ ] UI to allow you to set parent collections
- [ ] tests
