### PR TITLE
Replace "users" with table name in UserTable.yaml

### DIFF
--- a/resources/automagic_dashboards/table/UserTable.yaml
+++ b/resources/automagic_dashboards/table/UserTable.yaml
@@ -1,5 +1,5 @@
 title: A look at your [[this]] table
-transient_title: "Here's an overview of your [[this]] table"
+transient_title: "Here's an overview of the people in your [[this]] table"
 description: An exploration of your users to get you started.
 metrics:
 - Count:

--- a/resources/automagic_dashboards/table/UserTable.yaml
+++ b/resources/automagic_dashboards/table/UserTable.yaml
@@ -45,9 +45,9 @@ groups:
 - Overview:
     title: Overview
 - Geographical:
-    title: Where your users are
+    title: Where these [[this]] are
 - General:
-    title: How your users are distributed
+    title: How these [[this]] are distributed
 dashboard_filters:
 - JoinDate
 - GenericCategoryMedium
@@ -57,7 +57,7 @@ dashboard_filters:
 cards:
 # Overview
   - Rowcount:
-      title: Total users
+      title: Total [[this]]
       visualization: scalar
       metrics: Count
       score: 100
@@ -65,7 +65,7 @@ cards:
       width: 5
       height: 3
   - RowcountLast30Days:
-      title: New users in the last 30 days
+      title: New [[this]] in the last 30 days
       visualization: scalar
       metrics: Count
       score: 100
@@ -75,8 +75,8 @@ cards:
       height: 3
   - NewUsersByMonth:
       visualization: line
-      title: New users per month
-      description: How many new users we've acquired each month
+      title: New [[this]] per month
+      description: The number of new [[this]] each month
       dimensions: JoinDate
       metrics: Count
       score: 100
@@ -85,7 +85,7 @@ cards:
       height: 7
 # Geographical
   - CountByCountry:
-      title: Count of users per country
+      title: Number of [[this]] per country
       metrics: Count
       dimensions: Country
       score: 90
@@ -95,7 +95,7 @@ cards:
           map.region: world_countries
       group: Geographical
   - CountByState:
-      title: Users per state
+      title: "[[this]] per state"
       metrics: Count
       dimensions: State
       score: 90
@@ -106,7 +106,7 @@ cards:
           map.region: us_states
       group: Geographical
   - CountByCoords:
-      title: Users by coordinates
+      title: "[[this]] by coordinates"
       metrics: Count
       dimensions:
         - Long
@@ -126,7 +126,7 @@ cards:
       score: 90
       group: General
   - CountByCategoryMedium:
-      title: Users per [[GenericCategoryMedium]]
+      title: "[[this]] per [[GenericCategoryMedium]]"
       dimensions: GenericCategoryMedium
       metrics: Count
       visualization: row
@@ -136,7 +136,7 @@ cards:
       order_by:
         - Count: descending
   - CountByCategoryLarge:
-      title: Users per [[GenericCategoryLarge]]
+      title: "[[this]] per [[GenericCategoryLarge]]"
       dimensions: GenericCategoryLarge
       metrics: Count
       visualization: table


### PR DESCRIPTION
- [ ] Need @sbelak's help to get references to [[this]] in chart titles to render the table name

In x-rays, some tables are being classified as a "user" table because they seem to contain people, but this means that tables with things like employees, patients, clients, etc. were getting labeled "users" throughout:

![screen shot 2018-04-25 at 3 17 59 pm](https://user-images.githubusercontent.com/2223916/39276353-81300c9a-489d-11e8-8a57-defc6e43703f.png)

This PR is meant to replace "users" throughout with the name of the table so that it'll say things like "New Employees in the last 30 days." 

But @sbelak, there seems to be a problem with referring to `[[this]]` in the UserTable.yaml file, because it's rendering the word literally in chart titles:

![screen shot 2018-04-25 at 3 30 51 pm](https://user-images.githubusercontent.com/2223916/39276394-aea9622a-489d-11e8-9d55-63aa32940e91.png)
