### PR TITLE
Less aggressive entity type inference

### DIFF
--- a/src/metabase/sync/analyze/classifiers/name.clj
+++ b/src/metabase/sync/analyze/classifiers/name.clj
@@ -123,23 +123,27 @@
                        inferred-special-type))
     (assoc field :special_type inferred-special-type)))
 
+(defn- prefix-or-postfix
+  [s]
+  (re-pattern (format "(?:^%s)|(?:%ss?$)" s s)))
+
 (def ^:private entity-types-patterns
-  [[#"order"        :entity/TransactionTable]
-   [#"transaction"  :entity/TransactionTable]
-   [#"sale"         :entity/TransactionTable]
-   [#"product"      :entity/ProductTable]
-   [#"user"         :entity/UserTable]
-   [#"account"      :entity/UserTable]
-   [#"people"       :entity/UserTable]
-   [#"person"       :entity/UserTable]
-   [#"employee"     :entity/UserTable]
-   [#"event"        :entity/EventTable]
-   [#"checkin"      :entity/EventTable]
-   [#"log"          :entity/EventTable]
-   [#"subscription" :entity/SubscriptionTable]
-   [#"company"      :entity/CompanyTable]
-   [#"companies"    :entity/CompanyTable]
-   [#"vendor"       :entity/CompanyTable]])
+  [[(prefix-or-postfix "order")        :entity/TransactionTable]
+   [(prefix-or-postfix "transaction")  :entity/TransactionTable]
+   [(prefix-or-postfix "sale")         :entity/TransactionTable]
+   [(prefix-or-postfix "product")      :entity/ProductTable]
+   [(prefix-or-postfix "user")         :entity/UserTable]
+   [(prefix-or-postfix "account")      :entity/UserTable]
+   [(prefix-or-postfix "people")       :entity/UserTable]
+   [(prefix-or-postfix "person")       :entity/UserTable]
+   [(prefix-or-postfix "employee")     :entity/UserTable]
+   [(prefix-or-postfix "event")        :entity/EventTable]
+   [(prefix-or-postfix "checkin")      :entity/EventTable]
+   [(prefix-or-postfix "log")          :entity/EventTable]
+   [(prefix-or-postfix "subscription") :entity/SubscriptionTable]
+   [(prefix-or-postfix "company")      :entity/CompanyTable]
+   [(prefix-or-postfix "companies")    :entity/CompanyTable]
+   [(prefix-or-postfix "vendor")       :entity/CompanyTable]])
 
 (s/defn infer-entity-type :- i/TableInstance
   "Classifer that infers the special type of a TABLE based on its name."

--- a/test/metabase/sync/analyze/classifiers/name_test.clj
+++ b/test/metabase/sync/analyze/classifiers/name_test.clj
@@ -5,20 +5,20 @@
 
 ;; Postfix + pluralization
 (expect
-  :type/TransactionTable
+  :entity/TransactionTable
   (-> {:name "MY_ORDERS"} table/map->TableInstance infer-entity-type :entity_type))
 
 ;; Prefix
 (expect
-  :type/ProductTable
+  :entity/ProductTable
   (-> {:name "productcatalogue"} table/map->TableInstance infer-entity-type :entity_type))
 
 ;; Don't match in the middle of the name
 (expect
-  :type/GenericTable
+  :entity/GenericTable
   (-> {:name "myproductcatalogue"} table/map->TableInstance infer-entity-type :entity_type))
 
 ;; Not-match/default
 (expect
-  :type/GenericTable
+  :entity/GenericTable
   (-> {:name "foo"} table/map->TableInstance infer-entity-type :entity_type))

--- a/test/metabase/sync/analyze/classifiers/name_test.clj
+++ b/test/metabase/sync/analyze/classifiers/name_test.clj
@@ -1,0 +1,24 @@
+(ns metabase.automagic-dashboards.core-test
+  (:require [expectations :refer :all]
+            [metabase.models.table :as table]
+            [metabase.sync.analyze.classifiers.name :refer :all]))
+
+;; Postfix + pluralization
+(expect
+  :type/TransactionTable
+  (-> {:name "MY_ORDERS"} table/map->TableInstance infer-entity-type :entity_type))
+
+;; Prefix
+(expect
+  :type/ProductTable
+  (-> {:name "productcatalogue"} table/map->TableInstance infer-entity-type :entity_type))
+
+;; Don't match in the middle of the name
+(expect
+  :type/GenericTable
+  (-> {:name "myproductcatalogue"} table/map->TableInstance infer-entity-type :entity_type))
+
+;; Not-match/default
+(expect
+  :type/GenericTable
+  (-> {:name "foo"} table/map->TableInstance infer-entity-type :entity_type))

--- a/test/metabase/sync/analyze/classifiers/name_test.clj
+++ b/test/metabase/sync/analyze/classifiers/name_test.clj
@@ -1,4 +1,4 @@
-(ns metabase.automagic-dashboards.core-test
+(ns metabase.sync.analyze.classifiers.name-test
   (:require [expectations :refer :all]
             [metabase.models.table :as table]
             [metabase.sync.analyze.classifiers.name :refer :all]))


### PR DESCRIPTION
Only match table names where entity keyword is a prefix or postfix (including plural). 

The "occurs anywhere in the name" strategy turned out to be too aggressive. This seems like a better compromise. 