### PR TITLE
0.29 Instrumentation

### DIFF
--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
@@ -26,6 +26,7 @@ import { getUserIsAdmin } from "metabase/selectors/user";
 
 import { DashboardApi } from "metabase/services";
 import * as Urls from "metabase/lib/urls";
+import MetabaseAnalytics from "metabase/lib/analytics";
 
 import { getParameterIconName } from "metabase/meta/Parameter";
 
@@ -78,6 +79,7 @@ class AutomaticDashboardApp extends React.Component {
       }),
     );
     this.setState({ savedDashboardId: newDashboard.id });
+    MetabaseAnalytics.trackEvent("AutoDashboard", "Save");
   };
 
   render() {
@@ -145,7 +147,13 @@ class AutomaticDashboardApp extends React.Component {
           {more && (
             <div className="flex justify-end px4 pb4">
               {more.map(item => (
-                <Link to={item.url} className="ml2">
+                <Link
+                  to={item.url}
+                  className="ml2"
+                  onClick={() =>
+                    MetabaseAnalytics.trackEvent("AutoDashboard", "ClickMore")
+                  }
+                >
                   <Button iconRight="chevronright">{item.title}</Button>
                 </Link>
               ))}
@@ -204,13 +212,20 @@ const suggestionClasses = cxs({
   },
 });
 
-const SuggestionsList = ({ suggestions }) => (
+const SuggestionsList = ({ suggestions, section }) => (
   <ol className="px2">
     {suggestions.map((s, i) => (
       <li key={i} className={suggestionClasses}>
         <Link
           to={s.url}
           className="bordered rounded bg-white shadowed mb2 p2 flex no-decoration"
+          onClick={() =>
+            MetabaseAnalytics.trackEvent(
+              "AutoDashboard",
+              "ClickRelated",
+              section,
+            )
+          }
         >
           <div
             className="bg-slate-extra-light rounded flex align-center justify-center text-slate mr1 flex-no-shrink"
@@ -233,8 +248,8 @@ const SuggestionsSidebar = ({ related }) => (
     <div className="py2 text-centered my3">
       <h3 className="text-grey-3">More X-rays</h3>
     </div>
-    {Object.values(related).map(suggestions => (
-      <SuggestionsList suggestions={suggestions} />
+    {Object.entries(related).map(([section, suggestions]) => (
+      <SuggestionsList section={section} suggestions={suggestions} />
     ))}
   </div>
 );

--- a/frontend/src/metabase/lib/analytics.js
+++ b/frontend/src/metabase/lib/analytics.js
@@ -25,9 +25,9 @@ const MetabaseAnalytics = {
   // track an event
   trackEvent: function(
     category: string,
-    action?: string,
-    label?: string | number | boolean,
-    value?: number,
+    action?: ?string,
+    label?: ?(string | number | boolean),
+    value?: ?number,
   ) {
     const { tag } = MetabaseSettings.get("version");
 

--- a/frontend/src/metabase/query_builder/components/AlertModals.jsx
+++ b/frontend/src/metabase/query_builder/components/AlertModals.jsx
@@ -119,7 +119,7 @@ export class CreateAlertModalContent extends Component {
     // (maybe check how other modals are implemented)
     onAlertCreated();
 
-    MetabaseAnalytics.trackEvent("Alert", "Create", alert.alert_condition)
+    MetabaseAnalytics.trackEvent("Alert", "Create", alert.alert_condition);
   };
 
   proceedFromEducationalScreen = () => {
@@ -292,7 +292,11 @@ export class UpdateAlertModalContent extends Component {
     await updateAlert(modifiedAlert);
     onAlertUpdated();
 
-    MetabaseAnalytics.trackEvent("Alert", "Update", modifiedAlert.alert_condition)
+    MetabaseAnalytics.trackEvent(
+      "Alert",
+      "Update",
+      modifiedAlert.alert_condition,
+    );
   };
 
   onDeleteAlert = async () => {

--- a/frontend/src/metabase/query_builder/components/AlertModals.jsx
+++ b/frontend/src/metabase/query_builder/components/AlertModals.jsx
@@ -39,6 +39,7 @@ import cxs from "cxs";
 import ChannelSetupModal from "metabase/components/ChannelSetupModal";
 import ButtonWithStatus from "metabase/components/ButtonWithStatus";
 import { apiUpdateQuestion } from "metabase/query_builder/actions";
+import MetabaseAnalytics from "metabase/lib/analytics";
 
 const getScheduleFromChannel = channel =>
   _.pick(
@@ -117,6 +118,8 @@ export class CreateAlertModalContent extends Component {
     // OR should the modal visibility be part of QB redux state
     // (maybe check how other modals are implemented)
     onAlertCreated();
+
+    MetabaseAnalytics.trackEvent("Alert", "Create", alert.alert_condition)
   };
 
   proceedFromEducationalScreen = () => {
@@ -288,6 +291,8 @@ export class UpdateAlertModalContent extends Component {
 
     await updateAlert(modifiedAlert);
     onAlertUpdated();
+
+    MetabaseAnalytics.trackEvent("Alert", "Update", modifiedAlert.alert_condition)
   };
 
   onDeleteAlert = async () => {

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -57,6 +57,9 @@ Object.values(SECTIONS).map((section, index) => {
   section.index = index;
 });
 
+const getGALabelForAction = action =>
+  `${action.section || ""}:${action.name || ""}`;
+
 type Props = {
   clicked: ?ClickObject,
   clickActions: ?(ClickAction[]),
@@ -84,6 +87,11 @@ export default class ChartClickActions extends Component {
   handleClickAction = (action: ClickAction) => {
     const { onChangeCardAndRun } = this.props;
     if (action.popover) {
+      MetabaseAnalytics.trackEvent(
+        "Actions",
+        "Open Click Action Popover",
+        getGALabelForAction(action),
+      );
       this.setState({ popoverAction: action });
     } else if (action.question) {
       const nextQuestion = action.question();
@@ -91,7 +99,7 @@ export default class ChartClickActions extends Component {
         MetabaseAnalytics.trackEvent(
           "Actions",
           "Executed Click Action",
-          `${action.section || ""}:${action.name || ""}`,
+          getGALabelForAction(action),
         );
         onChangeCardAndRun({ nextCard: nextQuestion.card() });
       }
@@ -117,7 +125,7 @@ export default class ChartClickActions extends Component {
               MetabaseAnalytics.trackEvent(
                 "Action",
                 "Executed Click Action",
-                `${popoverAction.section || ""}:${popoverAction.name || ""}`,
+                getGALabelForAction(popoverAction),
               );
             }
             onChangeCardAndRun({ nextCard });
@@ -126,6 +134,7 @@ export default class ChartClickActions extends Component {
             MetabaseAnalytics.trackEvent(
               "Action",
               "Dismissed Click Action Menu",
+              getGALabelForAction(popoverAction),
             );
             this.close();
           }}
@@ -209,7 +218,17 @@ export const ChartClickAction = ({
   // } else
   if (action.url) {
     return (
-      <Link to={action.url()} className={className}>
+      <Link
+        to={action.url()}
+        className={className}
+        onClick={() =>
+          MetabaseAnalytics.trackEvent(
+            "Actions",
+            "Executed Click Action",
+            getGALabelForAction(action),
+          )
+        }
+      >
         {action.title}
       </Link>
     );

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -58,7 +58,7 @@ Object.values(SECTIONS).map((section, index) => {
 });
 
 const getGALabelForAction = action =>
-  `${action.section || ""}:${action.name || ""}`;
+  action ? `${action.section || ""}:${action.name || ""}` : null;
 
 type Props = {
   clicked: ?ClickObject,


### PR DESCRIPTION
Resolves #7465

Auto dashboards

- [x] Automatic dashboard views
- [ ] Which table types each dashboard view relates to
- [x] How many are saved
- [x] Clicks in the "related x-rays" pane
- [x] Dashboard drill-through clicks
- [ ] Where the x-ray originated from:
  - post app setup
  - post DB connection
  - drill through
  - data reference
  - bottom-right bauble (if we end up implementing that)
  - side pane (which you already listed)
- [ ] X-ray filters usage (i.e. are people using the filters we're automatically putting there), and maybe what type of field the filter is
- [x] "See more" button clicks

For the tables in pulses feature:

- [ ] number of pulses that include a table question
- [ ] total table questions in all pulses
- [ ] number of columns and rows in attached questions

FieldValuesWidget:

- [ ] Count of filters that are a list vs autocomplete vs an input box

Alerts

- [x] When an alert gets created
- [x] When an alert gets edited
- [x] How many goal-based alerts get made
- [x] How many has-results alerts get made
- [ ] Whether the channel is email, pulse, or both
- [ ] Whether goal-based alerts are set to one-time or repeating, and above or below the goal
