### PR TITLE
Fix `Unauthenticated` nested query test failures

### DIFF
--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -525,7 +525,7 @@
   (tt/with-temp Card [card {:dataset_query {:database db-id
                                             :type     :native
                                             :native   {:query "SELECT * FROM VENUES"}}}]
-    ((user->client :rasta) :post "card"
+    ((user->client :rasta) :post expected-status-code "card"
      {:name                   (tu/random-name)
       :display                "scalar"
       :visualization_settings {}


### PR DESCRIPTION
This test has been failing seemingly randomly with a message like this:
```
failure in (nested_queries_test.clj:549) : metabase.query-processor-test.nested-queries-test
(expect
 "You don't have permissions to do that."
 (do-with-temp-copy-of-test-db (fn [db] (perms/revoke-permissions! (perms-group/all-users) (u/get-id db)) (save-card-via-API-with-native-source-query! 403 (u/get-id db)))))

           expected: "You don't have permissions to do that." 
                was: "Unauthenticated"

            matches: ""
           diverges: "You don't have permissions to do that."
                  &: "Unauthenticated"
ERROR metabase.http-client :: "Unauthenticated"
```
This PR prevents that test failure. Gory details to follow:

The change is very subtle and it took me a while to track down the issue. The issue is very easy to reproduce when you control the order the tests are ran (which we don't). In the REPL, I was able to run the `metabase.api.session-test` test namespace, then right after run the `metabase.query-processor-test.nested-queries-test` test namespace and reproduce the issue every time. The tests in `session-test` put the Session store (in memory atom) and the Session table in the database in a weird state. After the session tests run, our test user has a session that exists in memory but not in the database, causing an authentication failure. We already have code that [deals with this issue](https://github.com/metabase/metabase/blob/master/test/metabase/test/data/users.clj#L146) but it's only triggered when the HTTP client code throws an exception. The nested queries tests [don't include the status code](https://github.com/metabase/metabase/blob/master/test/metabase/query_processor_test/nested_queries_test.clj#L528) which causes our HTTP client code to [not throw an error](https://github.com/metabase/metabase/blob/master/test/metabase/http_client.clj#L91).

By including the status code, authentication failures throw which will cause the in-memory session store to be flushed and go back through the session creation flow. This allows the tests to recover even if previous tests have put the session store in a bad state.