### PR TITLE
xray: don't capitalize items in the sidebar

### DIFF
--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -572,7 +572,7 @@
                        first)
         dashboard (make-dashboard root rule)]
     {:url         (:url root)
-     :title       (-> root :full-name str/capitalize)
+     :title       (:full-name root)
      :description (:description dashboard)}))
 
 (defn- others


### PR DESCRIPTION
We were being too aggressive with capitalisation. This leaves items in the sidebar alone, rather than forcing capitalisation.