### PR TITLE
Fix SparkSQL driver registration

### DIFF
--- a/src/metabase/driver/sparksql.clj
+++ b/src/metabase/driver/sparksql.clj
@@ -223,4 +223,7 @@
           :string-length-fn          (u/drop-first-arg hive-like/string-length-fn)
           :unix-timestamp->timestamp (u/drop-first-arg hive-like/unix-timestamp->timestamp)}))
 
-(driver/register-driver! :sparksql (SparkSQLDriver.))
+(defn -init-driver
+  "Register the SparkSQL driver."
+  []
+  (driver/register-driver! :sparksql (SparkSQLDriver.)))


### PR DESCRIPTION
I just realized the new SparkSQL driver was using the old pattern of registering itself when its namespace gets loaded rather than the new pattern which waits for an init function to be called. This doesn't make a real difference here but we were getting a warning about it in the logs so I'm going to go ahead and fixx