### PR TITLE
[Fix] - Date columns formatted as timestamp #7494

### DIFF
--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -387,12 +387,19 @@
       parsed-date
       (throw (Exception. (format "Unable to parse date '%s'" date-string))))))
 
-(defn- get-date [^TimeZone tz]
-  (fn [^ResultSet rs _ ^Integer i]
-    (try
-      (.getDate rs i (Calendar/getInstance tz))
-      (catch SQLException e
-        (parse-date-as-string tz rs i)))))
+(defn- get-date 
+  ([]
+    (fn [^ResultSet rs _ ^Integer i]
+      (try
+        (str (.getDate rs i))
+        (catch SQLException e
+          (parse-date-as-string rs i)))))
+  ([^TimeZone tz]
+    (fn [^ResultSet rs _ ^Integer i]
+      (try
+        (.getDate rs i (Calendar/getInstance tz))
+        (catch SQLException e
+          (parse-date-as-string tz rs i))))))
 
 (defn- get-timestamp [^TimeZone tz]
   (fn [^ResultSet rs _ ^Integer i]
@@ -413,6 +420,9 @@
 
     (and tz (= column-type java.sql.Types/TIMESTAMP))
     (get-timestamp tz)
+
+    (= column-type java.sql.Types/DATE)
+    (get-date)
 
     :else
     get-object))


### PR DESCRIPTION
## Background
This is a fix for [Issue 7494](https://github.com/metabase/metabase/issues/7494).
Database dates do not contain timezone information, and thus `timezone` is nil when it is parsed.

## Fix
Added an implementation where if `get-date` does not receive any time zones it will be parsed as-is such that it matches the expected behavior.

## Remarks
No tests has been written for this change because I don't know where should I place tests for this.
