### PR TITLE
Fix /explore sample data candidates sometimes not appearing

### DIFF
--- a/frontend/src/metabase/setup/containers/PostSetupApp.jsx
+++ b/frontend/src/metabase/setup/containers/PostSetupApp.jsx
@@ -15,7 +15,9 @@ import cx from "classnames";
 import { t } from "c-3po";
 
 const CANDIDATES_POLL_INTERVAL = 2000;
-const CANDIDATES_TIMEOUT = 10000;
+// ensure this is 1 second offset from CANDIDATES_POLL_INTERVAL due to
+// concurrency issue in candidates endpoint
+const CANDIDATES_TIMEOUT = 11000;
 
 const QUOTES = [
   t`Metabot is admiring your integers…`,


### PR DESCRIPTION
This is the simplest fix.

We could also poll for the sample dataset candidates if we think there's a chance `/candidates` might still error (e.x. 1 second isn't long enough, sample dataset takes longer than 10 seconds to sync, ???)