### PR TITLE
Change dashboard grid with to 24 units wide (experimental-ish)

### DIFF
--- a/frontend/src/metabase/lib/dashboard_grid.js
+++ b/frontend/src/metabase/lib/dashboard_grid.js
@@ -2,7 +2,7 @@
 
 import type { DashCard } from "metabase/meta/types/Dashboard";
 
-export const GRID_WIDTH = 18;
+export const GRID_WIDTH = 24;
 export const GRID_ASPECT_RATIO = 4 / 3;
 export const GRID_MARGIN = 6;
 


### PR DESCRIPTION
This was proposed in https://github.com/metabase/metabase/issues/6218 (with a number of great reasons included there) and I wanted to try it out and see how it felt. It feels to me like this gives a lot more flexibility in dashboard layout, and as @vi-vsn pointed out, now you can have four equally-sized charts in the same row, like this:

![screen shot 2018-05-01 at 5 07 50 pm](https://user-images.githubusercontent.com/2223916/39499425-b5d77400-4d62-11e8-838b-55395e38e0fa.png)

![screen shot 2018-05-01 at 5 08 03 pm](https://user-images.githubusercontent.com/2223916/39499426-b835ad2a-4d62-11e8-82c9-955d79a396f0.png)

**Questions/concerns**
- Does this feel more, or less friendly? It feels less restrictive to me.
- This allows for smaller cards, which seems like a plus to me, but we'll want to make sure none of these are too small now.