### PR TITLE
Update `->Timestamp` to include `report-timezone`

### DIFF
--- a/src/metabase/driver/bigquery.clj
+++ b/src/metabase/driver/bigquery.clj
@@ -149,21 +149,13 @@
                    (.setQuery query-string))]
      (google/execute (.query (.jobs client) project-id request)))))
 
-(def ^:private ^java.util.TimeZone default-timezone
-  (java.util.TimeZone/getDefault))
-
 (defn- parse-timestamp-str [s]
   ;; Timestamp strings either come back as ISO-8601 strings or Unix timestamps in µs, e.g. "1.3963104E9"
   (or
-   (du/->Timestamp s)
-   ;; If parsing as ISO-8601 fails parse as a double then convert to ms. Add the appropriate number of milliseconds to
-   ;; the number to convert it to the local timezone. We do this because the dates come back in UTC but we want the
-   ;; grouping to match the local time (HUH?) This gives us the same results as the other
-   ;; `has-questionable-timezone-support?` drivers. Not sure if this is actually desirable, but if it's not, it
-   ;; probably means all of those other drivers are doing it wrong
-   (du/->Timestamp (- (* (Double/parseDouble s) 1000)
-                      (.getDSTSavings default-timezone)
-                      (.getRawOffset  default-timezone)))))
+   (du/->Timestamp s time/utc)
+   ;; If parsing as ISO-8601 fails parse as a double then convert to ms. This is ms since epoch in UTC. By using
+   ;; `->Timestamp`, it will convert from ms in UTC to a timestamp object in the JVM timezone
+   (du/->Timestamp (* (Double/parseDouble s) 1000))))
 
 (def ^:private bigquery-time-format (tformat/formatter "HH:mm:SS" time/utc))
 

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -19,11 +19,13 @@
             metabase.query-processor.interface
             [metabase.util
              [honeysql-extensions :as hx]
-             [ssh :as ssh]])
+             [ssh :as ssh]]
+            [schema.core :as s])
   (:import [clojure.lang Keyword PersistentVector]
            com.mchange.v2.c3p0.ComboPooledDataSource
+           honeysql.types.SqlCall
            [java.sql DatabaseMetaData ResultSet]
-           java.util.Map
+           [java.util Date Map]
            metabase.models.field.FieldInstance
            [metabase.query_processor.interface Field Value]))
 
@@ -89,20 +91,6 @@
      calls `name`, which returns the *unqualified* name of `Field`.
 
      Return `nil` to prevent FIELD from being aliased.")
-
-  (prepare-sql-param [this obj]
-    "*OPTIONAL*. Do any neccesary type conversions, etc. to an object being passed as a prepared statment argument in
-     a parameterized raw SQL query. For example, a raw SQL query with a date param, `x`, e.g. `WHERE date > {{x}}`, is
-     converted to SQL like `WHERE date > ?`, and the value of `x` is passed as a `java.sql.Timestamp`. Some databases,
-     notably SQLite, don't work with `Timestamps`, and dates must be passed as string literals instead; the SQLite
-     driver overrides this method to convert dates as needed.
-
-  The default implementation is `identity`.
-
-  NOTE - This method is only used for parameters in raw SQL queries. It's not needed for MBQL queries because
-  the multimethod `metabase.driver.generic-sql.query-processor/->honeysql` provides an opportunity for drivers to do
-  type conversions as needed. In the future we may simplify a bit and combine them into a single method used in both
-  places.")
 
   (quote-style ^clojure.lang.Keyword [this]
     "*OPTIONAL*. Return the quoting style that should be used by [HoneySQL](https://github.com/jkk/honeysql) when
@@ -382,6 +370,62 @@
                                :schema (:pktable_schem result)}
             :dest-column-name (:pkcolumn_name result)}))))
 
+;;; ## Native SQL parameter functions
+
+(def PreparedStatementSubstitution
+  "Represents the SQL string replace value (usually ?) and the typed parameter value"
+  {:sql-string   s/Str
+   :param-values [s/Any]})
+
+(s/defn make-stmt-subs :- PreparedStatementSubstitution
+  "Create a `PreparedStatementSubstitution` map for `sql-string` and the `param-seq`"
+  [sql-string param-seq]
+  {:sql-string   sql-string
+   :param-values param-seq})
+
+(defmulti ^{:doc          (str "Returns a `PreparedStatementSubstitution` for `x` and the given driver. "
+                               "This allows driver specific parameters and SQL replacement text (usually just ?). "
+                               "The param value is already prepared and ready for inlcusion in the query, such as "
+                               "what's needed for SQLite and timestamps.")
+            :arglists     '([driver x])
+            :style/indent 1}
+  ->prepared-substitution
+  (fn [driver x]
+    [(class driver) (class x)]))
+
+(s/defn ^:private honeysql->prepared-stmt-subs
+  "Convert X to a replacement snippet info map by passing it to HoneySQL's `format` function."
+  [driver x]
+  (let [[snippet & args] (hsql/format x, :quoting (quote-style driver))]
+    (make-stmt-subs snippet args)))
+
+(s/defmethod ->prepared-substitution [Object nil] :- PreparedStatementSubstitution
+  [driver _]
+  (honeysql->prepared-stmt-subs driver nil))
+
+(s/defmethod ->prepared-substitution [Object Object] :- PreparedStatementSubstitution
+  [driver obj]
+  (honeysql->prepared-stmt-subs driver (str obj)))
+
+(s/defmethod ->prepared-substitution [Object Number] :- PreparedStatementSubstitution
+  [driver num]
+  (honeysql->prepared-stmt-subs driver num))
+
+(s/defmethod ->prepared-substitution [Object Boolean] :- PreparedStatementSubstitution
+  [driver b]
+  (honeysql->prepared-stmt-subs driver b))
+
+(s/defmethod ->prepared-substitution [Object Keyword] :- PreparedStatementSubstitution
+  [driver kwd]
+  (honeysql->prepared-stmt-subs driver kwd))
+
+(s/defmethod ->prepared-substitution [Object SqlCall] :- PreparedStatementSubstitution
+  [driver sql-call]
+  (honeysql->prepared-stmt-subs driver sql-call))
+
+(s/defmethod ->prepared-substitution [Object Date] :- PreparedStatementSubstitution
+  [driver date]
+  (make-stmt-subs "?" [date]))
 
 (defn ISQLDriverDefaultsMixin
   "Default implementations for methods in `ISQLDriver`."
@@ -404,7 +448,6 @@
    :excluded-schemas     (constantly nil)
    :field->identifier    (u/drop-first-arg (comp (partial apply hsql/qualify) field/qualified-name-components))
    :field->alias         (u/drop-first-arg name)
-   :prepare-sql-param    (u/drop-first-arg identity)
    :quote-style          (constantly :ansi)
    :set-timezone-sql     (constantly nil)
    :stddev-fn            (constantly :STDDEV)})

--- a/src/metabase/driver/mongo/query_processor.clj
+++ b/src/metabase/driver/mongo/query_processor.clj
@@ -18,7 +18,7 @@
              [collection :as mc]
              [operators :refer :all]])
   (:import java.sql.Timestamp
-           java.util.Date
+           [java.util Date TimeZone]
            [metabase.query_processor.interface AgFieldRef DateTimeField DateTimeValue Field FieldLiteral
             RelativeDateTimeValue Value]
            org.bson.types.ObjectId
@@ -425,7 +425,7 @@
     (into {} (for [[k v] row]
                {k (if (and (map? v)
                            (:___date v))
-                    (du/->Timestamp (:___date v))
+                    (du/->Timestamp (:___date v) (TimeZone/getDefault))
                     v)}))))
 
 

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -6,7 +6,7 @@
              [format :as time]]
             [clojure
              [set :as set]
-             [string :as s]]
+             [string :as str]]
             [honeysql.core :as hsql]
             [metabase
              [driver :as driver]
@@ -17,9 +17,11 @@
             [metabase.util
              [date :as du]
              [honeysql-extensions :as hx]
-             [ssh :as ssh]])
+             [ssh :as ssh]]
+            [schema.core :as s])
   (:import java.sql.Time
            [java.util Date TimeZone]
+           metabase.util.honeysql_extensions.Literal
            org.joda.time.format.DateTimeFormatter))
 
 (defrecord MySQLDriver []
@@ -62,7 +64,7 @@
     :TINYTEXT   :type/Text
     :VARBINARY  :type/*
     :VARCHAR    :type/Text
-    :YEAR       :type/Integer} (keyword (s/replace (name column-type) #"\sUNSIGNED$" "")))) ; strip off " UNSIGNED" from end if present
+    :YEAR       :type/Integer} (keyword (str/replace (name column-type) #"\sUNSIGNED$" "")))) ; strip off " UNSIGNED" from end if present
 
 (def ^:private ^:const default-connection-args
   "Map of args for the MySQL JDBC connection string.
@@ -79,8 +81,8 @@
    :useJDBCCompliantTimezoneShift :true})
 
 (def ^:private ^:const ^String default-connection-args-string
-  (s/join \& (for [[k v] default-connection-args]
-               (str (name k) \= (name v)))))
+  (str/join \& (for [[k v] default-connection-args]
+                 (str (name k) \= (name v)))))
 
 (defn- append-connection-args
   "Append `default-connection-args-string` to the connection string in CONNECTION-DETAILS, and an additional option to
@@ -128,11 +130,14 @@
   [date-time]
   (timezone-id->offset-str (.getID (TimeZone/getDefault)) date-time))
 
-;; MySQL doesn't seem to correctly want to handle timestamps no matter how nicely we ask. SAD! Thus we will just
-;; convert them to appropriate timestamp literals and include functions to convert timezones as needed
-(defmethod sqlqp/->honeysql [MySQLDriver Date]
-  [_ date]
-  (let [date-as-dt                 (tcoerce/from-date date)
+(s/defn ^:private create-hsql-for-date
+  "Returns an HoneySQL structure representing the date for MySQL. If there's a report timezone, we need to ensure the
+  timezone conversion is wrapped around the `date-literal-or-string`. It supports both an `hx/literal` and a plain
+  string depending on whether or not the date value should be emedded in the statement or separated as a prepared
+  statement parameter. Use a string for prepared statement values, a literal if you want it embedded in the statement"
+  [date-obj :- java.util.Date
+   date-literal-or-string :- (s/either s/Str Literal)]
+  (let [date-as-dt                 (tcoerce/from-date date-obj)
         report-timezone-offset-str (timezone-id->offset-str (driver/report-timezone) date-as-dt)
         system-timezone-offset-str (system-timezone->offset-str date-as-dt)]
     (if (and report-timezone-offset-str
@@ -151,12 +156,29 @@
       ;; preferable to have timezones slightly wrong in these rare theoretical situations, instead of all the time, as
       ;; was the previous behavior.
       (hsql/call :convert_tz
-        (hx/literal (du/format-date :date-hour-minute-second-ms date))
+        date-literal-or-string
         (hx/literal system-timezone-offset-str)
         (hx/literal report-timezone-offset-str))
       ;; otherwise if we don't have a report timezone we can continue to pass the object as-is, e.g. as a prepared
       ;; statement param
-      date)))
+      date-obj)))
+
+;; MySQL doesn't seem to correctly want to handle timestamps no matter how nicely we ask. SAD! Thus we will just
+;; convert them to appropriate timestamp literals and include functions to convert timezones as needed
+(defmethod sqlqp/->honeysql [MySQLDriver Date]
+  [_ date]
+  (create-hsql-for-date date (hx/literal (du/format-date :date-hour-minute-second-ms date))))
+
+;; The sqlqp/->honeysql entrypoint is used by MBQL, but native queries with field filters have the same issue. Below
+;; will return a map that will be used in the prepared statement to correctly convert and parameterize the date
+(s/defmethod sql/->prepared-substitution [MySQLDriver Date] :- sql/PreparedStatementSubstitution
+  [_ date]
+  (let [date-str (du/format-date :date-hour-minute-second-ms date)]
+    (sql/make-stmt-subs (-> (create-hsql-for-date date date-str)
+                            hx/->date
+                            (hsql/format :quoting (sql/quote-style (MySQLDriver.)))
+                            first)
+                        [(du/format-date :date-hour-minute-second-ms date)])))
 
 (defmethod sqlqp/->honeysql [MySQLDriver Time]
   [_ time-value]

--- a/src/metabase/driver/sqlite.clj
+++ b/src/metabase/driver/sqlite.clj
@@ -14,7 +14,8 @@
             [metabase.driver.generic-sql.query-processor :as sqlqp]
             [metabase.util
              [date :as du]
-             [honeysql-extensions :as hx]])
+             [honeysql-extensions :as hx]]
+            [schema.core :as s])
   (:import [java.sql Time Timestamp]))
 
 (defrecord SQLiteDriver []
@@ -139,20 +140,17 @@
     :seconds      (->datetime expr (hx/literal "unixepoch"))
     :milliseconds (recur (hx// expr 1000) :seconds)))
 
-
 ;; SQLite doesn't like things like Timestamps getting passed in as prepared statement args, so we need to convert them
 ;; to date literal strings instead to get things to work
 ;;
 ;; TODO - not sure why this doesn't need to be done in `->honeysql` as well? I think it's because the MBQL date values
 ;; are funneled through the `date` family of functions above
-(defn- prepare-sql-param [obj]
-  (if (instance? java.util.Date obj)
-    ;; for anything that's a Date (usually a java.sql.Timestamp) convert it to a yyyy-MM-dd formatted date literal
-    ;; string For whatever reason the SQL generated from parameters ends up looking like `WHERE date(some_field) = ?`
-    ;; sometimes so we need to use just the date rather than a full ISO-8601 string
-    (du/format-date "yyyy-MM-dd" obj)
-    ;; every other prepared statement arg can be returned as-is
-    obj))
+(s/defmethod sql/->prepared-substitution [SQLiteDriver java.util.Date] :- sql/PreparedStatementSubstitution
+  [_ date]
+  ;; for anything that's a Date (usually a java.sql.Timestamp) convert it to a yyyy-MM-dd formatted date literal
+  ;; string For whatever reason the SQL generated from parameters ends up looking like `WHERE date(some_field) = ?`
+  ;; sometimes so we need to use just the date rather than a full ISO-8601 string
+  (sql/make-stmt-subs "?" [(du/format-date "yyyy-MM-dd" date)]))
 
 ;; SQLite doesn't support `TRUE`/`FALSE`; it uses `1`/`0`, respectively; convert these booleans to numbers.
 (defmethod sqlqp/->honeysql [SQLiteDriver Boolean]
@@ -206,7 +204,6 @@
     :connection-details->spec  (u/drop-first-arg connection-details->spec)
     :current-datetime-fn       (constantly (hsql/call :datetime (hx/literal :now)))
     :date                      (u/drop-first-arg date)
-    :prepare-sql-param         (u/drop-first-arg prepare-sql-param)
     :string-length-fn          (u/drop-first-arg string-length-fn)
     :unix-timestamp->timestamp (u/drop-first-arg unix-timestamp->timestamp)}))
 

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -646,7 +646,7 @@
   [render-type timezone card {:keys [rows cols] :as data}]
   (let [[x-axis-rowfn y-axis-rowfn] (graphing-columns card data)
         ft-row (if (datetime-field? (x-axis-rowfn cols))
-                 #(.getTime ^Date (du/->Timestamp %))
+                 #(.getTime ^Date (du/->Timestamp % timezone))
                  identity)
         rows   (if (> (ft-row (x-axis-rowfn (first rows)))
                       (ft-row (x-axis-rowfn (last rows))))

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -15,6 +15,7 @@
              [add-settings :as add-settings]
              [annotate-and-sort :as annotate-and-sort]
              [binning :as binning]
+             [bind-effective-timezone :as bind-timezone]
              [cache :as cache]
              [catch-exceptions :as catch-exceptions]
              [cumulative-aggregations :as cumulative-ags]
@@ -108,6 +109,7 @@
       driver-specific/process-query-in-context         ; (drivers can inject custom middleware if they implement IDriver's `process-query-in-context`)
       add-settings/add-settings
       resolve-driver/resolve-driver                    ; ▲▲▲ DRIVER RESOLUTION POINT ▲▲▲ All functions *above* will have access to the driver during PRE- *and* POST-PROCESSING
+      bind-timezone/bind-effective-timezone
       fetch-source-query/fetch-source-query
       log-query/log-initial-query
       cache/maybe-return-cached-results
@@ -142,7 +144,8 @@
        expand-macros/expand-macros
        driver-specific/process-query-in-context
        resolve-driver/resolve-driver
-       fetch-source-query/fetch-source-query))
+       fetch-source-query/fetch-source-query
+       bind-timezone/bind-effective-timezone))
 ;; ▲▲▲ This only does PRE-PROCESSING, so it happens from bottom to top, eventually returning the preprocessed query
 ;; instead of running it
 

--- a/src/metabase/query_processor/middleware/bind_effective_timezone.clj
+++ b/src/metabase/query_processor/middleware/bind_effective_timezone.clj
@@ -1,0 +1,9 @@
+(ns metabase.query-processor.middleware.bind-effective-timezone
+  (:require [metabase.util.date :as ud]))
+
+(defn bind-effective-timezone
+  "Middlware that ensures the report-timezone and data-timezone are bound based on the database being queried against"
+  [qp]
+  (fn [query]
+    (ud/with-effective-timezone (:database query)
+      (qp query))))

--- a/src/metabase/query_processor/middleware/parameters/sql.clj
+++ b/src/metabase/query_processor/middleware/parameters/sql.clj
@@ -20,6 +20,7 @@
            honeysql.types.SqlCall
            java.text.NumberFormat
            java.util.regex.Pattern
+           java.util.TimeZone
            metabase.models.field.FieldInstance))
 
 ;; The Basics:
@@ -44,9 +45,6 @@
 ;; TODO - we have dynamic *driver* variables like this in several places; it probably makes more sense to see if we
 ;; can share one used somewhere else instead
 (def ^:private ^:dynamic *driver* nil)
-
-(def ^:private ^:dynamic *timezone* nil)
-
 
 ;; various record types below are used as a convenience for differentiating the different param types.
 
@@ -299,7 +297,7 @@
 (s/defn ^:private relative-date-dimension-value->replacement-snippet-info :- ParamSnippetInfo
   [value]
   ;; TODO - get timezone from query dict
-  (-> (date-params/date-string->range value *timezone*)
+  (-> (date-params/date-string->range value (.getID du/*report-timezone*))
       map->DateRange
       ->replacement-snippet-info))
 
@@ -528,8 +526,7 @@
 (defn expand
   "Expand parameters inside a *SQL* QUERY."
   [query]
-  (binding [*driver*   (ensure-driver query)
-            *timezone* (get-in query [:settings :report-timezone])]
+  (binding [*driver*   (ensure-driver query)]
     (if (driver/driver-supports? *driver* :native-query-params)
       (update query :native expand-query-params (query->params-map query))
       query)))

--- a/src/metabase/query_processor/middleware/parameters/sql.clj
+++ b/src/metabase/query_processor/middleware/parameters/sql.clj
@@ -8,6 +8,7 @@
             [medley.core :as m]
             [metabase.driver :as driver]
             [metabase.models.field :as field :refer [Field]]
+            [metabase.driver.generic-sql :as sql]
             [metabase.query-processor.middleware.expand :as ql]
             [metabase.query-processor.middleware.parameters.dates :as date-params]
             [metabase.util
@@ -328,7 +329,7 @@
 (s/defn ^:private honeysql->replacement-snippet-info :- ParamSnippetInfo
   "Convert X to a replacement snippet info map by passing it to HoneySQL's `format` function."
   [x]
-  (let [[snippet & args] (hsql/format x, :quoting ((resolve 'metabase.driver.generic-sql/quote-style) *driver*))]
+  (let [[snippet & args] (hsql/format x, :quoting (sql/quote-style *driver*))]
     {:replacement-snippet     snippet
      :prepared-statement-args args}))
 
@@ -337,9 +338,9 @@
    For non-date Fields, this is just a quoted identifier; for dates, the SQL includes appropriately bucketing based on
    the PARAM-TYPE."
   [field param-type]
-  (-> (honeysql->replacement-snippet-info (let [identifier ((resolve 'metabase.driver.generic-sql/field->identifier) *driver* field)]
+  (-> (honeysql->replacement-snippet-info (let [identifier (sql/field->identifier *driver* field)]
                                             (if (date-param-type? param-type)
-                                              ((resolve 'metabase.driver.generic-sql/date) *driver* :day identifier)
+                                              (sql/date *driver* :day identifier)
                                               identifier)))
       :replacement-snippet))
 
@@ -349,13 +350,23 @@
   {:replacement-snippet     (str \( (str/join " AND " (map :replacement-snippet replacement-snippet-maps)) \))
    :prepared-statement-args (reduce concat (map :prepared-statement-args replacement-snippet-maps))})
 
+(defn- create-replacement-snippet [nil-or-obj]
+  (let [{:keys [sql-string param-values]} (sql/->prepared-substitution *driver* nil-or-obj)]
+    {:replacement-snippet sql-string
+     :prepared-statement-args param-values}))
+
+(defn- prepared-ts-subs [operator date-str]
+  (let [{:keys [sql-string param-values]} (sql/->prepared-substitution *driver* (du/->Timestamp date-str))]
+    {:replacement-snippet (str operator " " sql-string)
+     :prepared-statement-args param-values}))
+
 (extend-protocol ISQLParamSubstituion
-  nil     (->replacement-snippet-info [this] (honeysql->replacement-snippet-info this))
-  Object  (->replacement-snippet-info [this] (honeysql->replacement-snippet-info (str this)))
-  Number  (->replacement-snippet-info [this] (honeysql->replacement-snippet-info this))
-  Boolean (->replacement-snippet-info [this] (honeysql->replacement-snippet-info this))
-  Keyword (->replacement-snippet-info [this] (honeysql->replacement-snippet-info this))
-  SqlCall (->replacement-snippet-info [this] (honeysql->replacement-snippet-info this))
+  nil     (->replacement-snippet-info [this] (create-replacement-snippet this))
+  Object  (->replacement-snippet-info [this] (create-replacement-snippet (str this)))
+  Number  (->replacement-snippet-info [this] (create-replacement-snippet this))
+  Boolean (->replacement-snippet-info [this] (create-replacement-snippet this))
+  Keyword (->replacement-snippet-info [this] (create-replacement-snippet this))
+  SqlCall (->replacement-snippet-info [this] (create-replacement-snippet this))
   NoValue (->replacement-snippet-info [_]    {:replacement-snippet ""})
 
   CommaSeparatedNumbers
@@ -370,15 +381,24 @@
 
   Date
   (->replacement-snippet-info [{:keys [s]}]
-    (honeysql->replacement-snippet-info (du/->Timestamp s)))
+    (create-replacement-snippet (du/->Timestamp s)))
 
   DateRange
   (->replacement-snippet-info [{:keys [start end]}]
     (cond
-      (= start end) {:replacement-snippet "= ?",             :prepared-statement-args [(du/->Timestamp start)]}
-      (nil? start)  {:replacement-snippet "< ?",             :prepared-statement-args [(du/->Timestamp end)]}
-      (nil? end)    {:replacement-snippet "> ?",             :prepared-statement-args [(du/->Timestamp start)]}
-      :else         {:replacement-snippet "BETWEEN ? AND ?", :prepared-statement-args [(du/->Timestamp start) (du/->Timestamp end)]}))
+      (= start end)
+      (prepared-ts-subs \= start)
+
+      (nil? start)
+      (prepared-ts-subs \< end)
+
+      (nil? end)
+      (prepared-ts-subs \> start)
+
+      :else
+      (let [params (map (comp #(sql/->prepared-substitution *driver* %) du/->Timestamp) [start end])]
+        {:replacement-snippet     (apply format "BETWEEN %s AND %s" (map :sql-string params)),
+         :prepared-statement-args (vec (mapcat :param-values params))})))
 
   ;; TODO - clean this up if possible!
   Dimension
@@ -506,14 +526,9 @@
 ;;; |                                            PUTTING IT ALL TOGETHER                                             |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(defn- prepare-sql-param-for-driver [param]
-  ((resolve 'metabase.driver.generic-sql/prepare-sql-param) *driver* param))
-
 (s/defn ^:private expand-query-params
   [{sql :query, :as native}, param-key->value :- ParamValues]
-  (merge native
-         ;; `prepare-sql-param-for-driver` can't be lazy as it needs `*driver*` to be bound
-         (update (parse-template sql param-key->value) :params #(mapv prepare-sql-param-for-driver %))))
+  (merge native (parse-template sql param-key->value)))
 
 (defn- ensure-driver
   "Depending on where the query came from (the user, permissions check etc) there might not be an driver associated to

--- a/src/metabase/query_processor/middleware/resolve.clj
+++ b/src/metabase/query_processor/middleware/resolve.clj
@@ -10,6 +10,7 @@
             [metabase
              [db :as mdb]
              [util :as u]]
+            [metabase.util.date :as du]
             [metabase.models
              [database :refer [Database]]
              [field :as field]
@@ -229,11 +230,7 @@
 
   DateTimeField
   (parse-value [this value]
-    (let [tz                 (when-let [tz-id ^String (setting/get :report-timezone)]
-                               (TimeZone/getTimeZone tz-id))
-          parsed-string-date (some-> value
-                                     (du/str->date-time tz)
-                                     du/->Timestamp)]
+    (let [parsed-string-date (some-> value du/->Timestamp)]
       (cond
         parsed-string-date
         (s/validate DateTimeValue (i/map->DateTimeValue {:field this, :value parsed-string-date}))

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -15,7 +15,9 @@
              [sample :as sample]
              [text :as text]]
             [metabase.util :as u]
-            [metabase.util.schema :as su]
+            [metabase.util
+             [date :as du]
+             [schema :as su]]
             [schema.core :as s]
             [toucan.db :as db]))
 
@@ -176,8 +178,9 @@
   [database :- i/DatabaseInstance
    tables :- [i/TableInstance]
    log-progress-fn]
-  (apply merge-with + (for [table tables
-                            :let [result (fingerprint-fields! table)]]
-                        (do
-                          (log-progress-fn "fingerprint-fields" table)
-                          result))))
+  (du/with-effective-timezone database
+    (apply merge-with + (for [table tables
+                              :let [result (fingerprint-fields! table)]]
+                          (do
+                            (log-progress-fn "fingerprint-fields" table)
+                            result)))))

--- a/src/metabase/types.clj
+++ b/src/metabase/types.clj
@@ -82,6 +82,7 @@
 
 (derive :type/Time :type/DateTime)
 (derive :type/Date :type/DateTime)
+(derive :type/DateTimeWithTZ :type/DateTime)
 
 (derive :type/UNIXTimestamp :type/DateTime)
 (derive :type/UNIXTimestamp :type/Integer)

--- a/src/metabase/util/date.clj
+++ b/src/metabase/util/date.clj
@@ -197,7 +197,8 @@
   (->Timestamp (System/currentTimeMillis)))
 
 (defn format-date
-  "Format DATE using a given DATE-FORMAT.
+  "Format DATE using a given DATE-FORMAT. NOTE: This will create a date string in the JVM's timezone, not the report
+  timezone.
 
    DATE is anything that can coerced to a `Timestamp` via `->Timestamp`, such as a `Date`, `Timestamp`,
    `Long` (ms since the epoch), or an ISO-8601 `String`. DATE defaults to the current moment in time.

--- a/src/metabase/util/date.clj
+++ b/src/metabase/util/date.clj
@@ -4,38 +4,122 @@
              [core :as t]
              [format :as time]]
             [clojure.math.numeric-tower :as math]
-            [metabase.util :as u])
+            [clojure.tools.logging :as log]
+            [metabase.util :as u]
+            [puppetlabs.i18n.core :refer [trs]])
   (:import clojure.lang.Keyword
            [java.sql Time Timestamp]
            [java.util Calendar Date TimeZone]
-           org.joda.time.DateTime
+           [org.joda.time DateTime DateTimeZone]
            org.joda.time.format.DateTimeFormatter))
+
+(def ^{:tag     TimeZone
+       :dynamic true
+       :doc     "Timezone to be used when formatting timestamps for display or for the data (pre aggregation)"}
+  *report-timezone*)
+
+(def ^{:dynamic true
+       :doc     "The timezone of the data being queried. Today this is the same as the database timezone."
+       :tag     TimeZone}
+  *data-timezone*)
+
+(defprotocol ITimeZoneCoercible
+  "Coerce object to `java.util.TimeZone`"
+  (coerce-to-timezone ^TimeZone [this]
+    "Coerce `this` to `java.util.TimeZone`"))
+
+(extend-protocol ^:private ITimeZoneCoercible
+  String       (coerce-to-timezone [this]
+                 (TimeZone/getTimeZone this))
+  TimeZone     (coerce-to-timezone [this]
+                 this)
+  DateTimeZone (coerce-to-timezone [this]
+                 (.toTimeZone this)))
+
+(def ^TimeZone utc
+  "UTC TimeZone"
+  (coerce-to-timezone "UTC"))
+
+(def ^:private jvm-timezone
+  (delay (coerce-to-timezone (System/getProperty "user.timezone"))))
+
+(defn- warn-on-timezone-conflict
+  "Attempts to check the combination of report-timezone, jvm-timezone and data-timezone to determine of we have a
+  possible conflict. If one is found, warn the user."
+  [driver db ^TimeZone report-timezone ^TimeZone jvm-timezone ^TimeZone data-timezone]
+  ;; No need to check this if we don't have a data-timezone
+  (when (and data-timezone driver)
+    (let [jvm-data-tz-conflict? (not (.hasSameRules jvm-timezone data-timezone))]
+      (if ((resolve 'metabase.driver/driver-supports?) driver :set-timezone)
+        ;; This database could have a report-timezone configured, if it doesn't and the JVM and data timezones don't
+        ;; match, we should suggest that the user configure a report timezone
+        (when (and (not report-timezone)
+                   jvm-data-tz-conflict?)
+          (log/warn (str (trs "Possible imezone conflict found on database {0}." (:name db))
+                         (trs "JVM timezone is {0} and detected database timezone is {1}."
+                              (.getID jvm-timezone) (.getID data-timezone))
+                         (trs "Configure a report timezone to ensure proper date and time conversions."))))
+        ;; This database doesn't support a report timezone, check the JVM and data timezones, if they don't match,
+        ;; warn the user
+        (when jvm-data-tz-conflict?
+          (log/warn (str (trs "Possible timezone conflict found on database {0}." (:name db))
+                         (trs "JVM timezone is {0} and detected database timezone is {1}."
+                              (.getID jvm-timezone) (.getID data-timezone)))))))))
+
+(defn call-with-effective-timezone
+  "Invokes `f` with `*report-timezone*` and `*data-timezone*` bound for the given `db`"
+  [db f]
+  (let [driver    ((resolve 'metabase.driver/->driver) db)
+        report-tz (when-let [report-tz-id (and driver ((resolve 'metabase.driver/report-timezone-if-supported) driver))]
+                    (coerce-to-timezone report-tz-id))
+        data-tz   (some-> db :timezone coerce-to-timezone)
+        jvm-tz    @jvm-timezone]
+    (warn-on-timezone-conflict driver db report-tz jvm-tz data-tz)
+    (binding [*report-timezone* (or report-tz jvm-tz)
+              *data-timezone*   data-tz]
+      (f))))
+
+(defmacro with-effective-timezone
+  "Runs `body` with `*report-timezone*` and `*data-timezone*` configured using the given `db`"
+  [db & body]
+  `(call-with-effective-timezone ~db (fn [] ~@body)))
 
 (defprotocol ITimestampCoercible
   "Coerce object to a `java.sql.Timestamp`."
-  (->Timestamp ^java.sql.Timestamp [this]
+  (coerce-to-timestamp ^java.sql.Timestamp [this] [this timezone-coercible]
     "Coerce this object to a `java.sql.Timestamp`. Strings are parsed as ISO-8601."))
+
+(extend-protocol ^:private ITimestampCoercible
+  nil       (coerce-to-timestamp [_]
+              nil)
+  Timestamp (coerce-to-timestamp [this]
+              this)
+  Date      (coerce-to-timestamp
+              [this]
+              (coerce/to-timestamp (coerce/from-date this)))
+  ;; Number is assumed to be a UNIX timezone in milliseconds (UTC)
+  Number    (coerce-to-timestamp [this]
+              (coerce/to-timestamp (coerce/from-long (long this))))
+  Calendar  (coerce-to-timestamp [this]
+              (coerce-to-timestamp (.getTime this)))
+  DateTime  (coerce-to-timestamp [this]
+              (coerce/to-timestamp this)))
 
 (declare str->date-time)
 
-(extend-protocol ITimestampCoercible
-  nil       (->Timestamp [_]
-              nil)
-  Timestamp (->Timestamp [this]
-              this)
-  Date       (->Timestamp [this]
-               (Timestamp. (.getTime this)))
-  ;; Number is assumed to be a UNIX timezone in milliseconds (UTC)
-  Number    (->Timestamp [this]
-              (Timestamp. this))
-  Calendar  (->Timestamp [this]
-              (->Timestamp (.getTime this)))
-  ;; Strings are expected to be in ISO-8601 format. `YYYY-MM-DD` strings *are* valid ISO-8601 dates.
-  String    (->Timestamp [this]
-              (->Timestamp (str->date-time this)))
-  DateTime  (->Timestamp [this]
-              (->Timestamp (.getMillis this))))
-
+(defn ^Timestamp ->Timestamp
+  "Converts `coercible-to-ts` to a `java.util.Timestamp`. Requires a `coercible-to-tz` if converting a string. Leans
+  on clj-time to ensure correct conversions between the various types"
+  ([coercible-to-ts]
+   {:pre [(or (not (string? coercible-to-ts))
+              (and (string? coercible-to-ts) (bound? #'*report-timezone*)))]}
+   (->Timestamp coercible-to-ts *report-timezone*))
+  ([coercible-to-ts timezone]
+   {:pre [(or (not (string? coercible-to-ts))
+              (and (string? coercible-to-ts) timezone))]}
+   (if (string? coercible-to-ts)
+     (coerce-to-timestamp (str->date-time coercible-to-ts (coerce-to-timezone timezone)))
+     (coerce-to-timestamp coercible-to-ts))))
 
 (defprotocol IDateTimeFormatterCoercible
   "Protocol for converting objects to `DateTimeFormatters`."
@@ -61,7 +145,6 @@
      (parse-date :date-time \"2016-02-01T00:00:00.000Z\") -> #inst \"2016-02-01\""
   ^java.sql.Timestamp [date-format, ^String s]
   (->Timestamp (time/parse (->DateTimeFormatter date-format) s)))
-
 
 (defprotocol ISO8601
   "Protocol for converting objects to ISO8601 formatted strings."
@@ -141,7 +224,9 @@
   [^String s]
   (boolean (when (string? s)
              (u/ignore-exceptions
-               (->Timestamp s)))))
+               ;; Using UTC as the timezone here as it's `def`'d and the result of the parse is discarded, any
+               ;; timezone is fine here
+               (->Timestamp s utc)))))
 
 (defn ->Date
   "Coerece DATE to a `java.util.Date`."
@@ -149,7 +234,6 @@
    (java.util.Date.))
   (^java.util.Date [date]
    (java.util.Date. (.getTime (->Timestamp date)))))
-
 
 (defn ->Calendar
   "Coerce DATE to a `java.util.Calendar`."
@@ -162,7 +246,6 @@
   (^java.util.Calendar [date, ^String timezone-id]
    (doto (->Calendar date)
      (.setTimeZone (TimeZone/getTimeZone timezone-id)))))
-
 
 (defn relative-date
   "Return a new `Timestamp` relative to the current time using a relative date UNIT.
@@ -184,7 +267,6 @@
      (.set cal unit (+ (.get cal unit)
                        (* amount multiplier)))
      (->Timestamp cal))))
-
 
 (def ^:private ^:const date-extract-units
   #{:minute-of-hour :hour-of-day :day-of-week :day-of-month :day-of-year :week-of-year :month-of-year :quarter-of-year
@@ -215,14 +297,14 @@
                                   3)))
        :year            (.get cal Calendar/YEAR)))))
 
-
 (def ^:private ^:const date-trunc-units
   #{:minute :hour :day :week :month :quarter :year})
 
 (defn- trunc-with-format [format-string date timezone-id]
   (->Timestamp (format-date (time/with-zone (time/formatter format-string)
                               (t/time-zone-for-id timezone-id))
-                            date)))
+                            date)
+               timezone-id))
 
 (defn- trunc-with-floor [date amount-ms]
   (->Timestamp (* (math/floor (/ (.getTime (->Timestamp date))
@@ -258,7 +340,6 @@
      :month   (trunc-with-format "yyyy-MM-01'T'ZZ" date timezone-id)
      :quarter (trunc-with-format (format-string-for-quarter date timezone-id) date timezone-id)
      :year    (trunc-with-format "yyyy-01-01'T'ZZ" date timezone-id))))
-
 
 (defn date-trunc-or-extract
   "Apply date bucketing with UNIT to DATE. DATE defaults to now."

--- a/test/metabase/api/activity_test.clj
+++ b/test/metabase/api/activity_test.clj
@@ -23,19 +23,19 @@
 ;; NOTE: timestamp matching was being a real PITA so I cheated a bit.  ideally we'd fix that
 (tt/expect-with-temp [Activity [activity1 {:topic     "install"
                                            :details   {}
-                                           :timestamp (du/->Timestamp "2015-09-09T12:13:14.888Z")}]
+                                           :timestamp (du/->Timestamp #inst "2015-09-09T12:13:14.888Z")}]
                       Activity [activity2 {:topic     "dashboard-create"
                                            :user_id   (user->id :crowberto)
                                            :model     "dashboard"
                                            :model_id  1234
                                            :details   {:description  "Because I can!"
                                                        :name         "Bwahahaha"}
-                                           :timestamp (du/->Timestamp "2015-09-10T18:53:01.632Z")}]
+                                           :timestamp (du/->Timestamp #inst "2015-09-10T18:53:01.632Z")}]
                       Activity [activity3 {:topic     "user-joined"
                                            :user_id   (user->id :rasta)
                                            :model     "user"
                                            :details   {}
-                                           :timestamp (du/->Timestamp "2015-09-10T05:33:43.641Z")}]]
+                                           :timestamp (du/->Timestamp #inst "2015-09-10T05:33:43.641Z")}]]
   [(match-$ (Activity (:id activity2))
      {:id           $
       :topic        "dashboard-create"

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -141,15 +141,15 @@
                       ;; 3 was viewed most recently, followed by 4, then 1. Card 2 was viewed by a different user so
                       ;; shouldn't be returned
                       ViewLog  [_ {:model "card", :model_id card-1-id, :user_id (user->id :rasta)
-                                   :timestamp (du/->Timestamp "2015-12-01")}]
+                                   :timestamp (du/->Timestamp #inst "2015-12-01")}]
                       ViewLog  [_ {:model "card", :model_id card-2-id, :user_id (user->id :trashbird)
-                                   :timestamp (du/->Timestamp "2016-01-01")}]
+                                   :timestamp (du/->Timestamp #inst "2016-01-01")}]
                       ViewLog  [_ {:model "card", :model_id card-3-id, :user_id (user->id :rasta)
-                                   :timestamp (du/->Timestamp "2016-02-01")}]
+                                   :timestamp (du/->Timestamp #inst "2016-02-01")}]
                       ViewLog  [_ {:model "card", :model_id card-4-id, :user_id (user->id :rasta)
-                                   :timestamp (du/->Timestamp "2016-03-01")}]
+                                   :timestamp (du/->Timestamp #inst "2016-03-01")}]
                       ViewLog  [_ {:model "card", :model_id card-3-id, :user_id (user->id :rasta)
-                                   :timestamp (du/->Timestamp "2016-04-01")}]]
+                                   :timestamp (du/->Timestamp #inst "2016-04-01")}]]
   [card-3-id card-4-id card-1-id]
   (mapv :id ((user->client :rasta) :get 200 "card", :f :recent)))
 

--- a/test/metabase/driver/bigquery_test.clj
+++ b/test/metabase/driver/bigquery_test.clj
@@ -44,7 +44,6 @@
        (sort-by first)
        (take 5)))
 
-
 ;; make sure that BigQuery native queries maintain the column ordering specified in the SQL -- post-processing
 ;; ordering shouldn't apply (Issue #2821)
 (expect-with-engine :bigquery

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -99,8 +99,8 @@
     (tu/db-timezone-id)))
 
 
-(def before-daylight-savings (du/str->date-time "2018-03-10 10:00:00"))
-(def after-daylight-savings (du/str->date-time "2018-03-12 10:00:00"))
+(def before-daylight-savings (du/str->date-time "2018-03-10 10:00:00" du/utc))
+(def after-daylight-savings (du/str->date-time "2018-03-12 10:00:00" du/utc))
 
 (expect (#'mysql/timezone-id->offset-str "US/Pacific" before-daylight-savings) "-08:00")
 (expect (#'mysql/timezone-id->offset-str "US/Pacific" after-daylight-savings)  "-07:00")
@@ -114,18 +114,18 @@
 ;; make sure DateTime types generate appropriate SQL...
 ;; ...with no report-timezone set
 (expect
-  ["?" (du/->Timestamp "2018-01-03")]
+  ["?" (du/->Timestamp #inst "2018-01-03")]
   (tu/with-temporary-setting-values [report-timezone nil]
-    (hsql/format (sqlqp/->honeysql (MySQLDriver.) (du/->Timestamp "2018-01-03")))))
+    (hsql/format (sqlqp/->honeysql (MySQLDriver.) (du/->Timestamp #inst "2018-01-03")))))
 
 ;; ...with a report-timezone set
 (expect
   ["convert_tz('2018-01-03T00:00:00.000', '+00:00', '-08:00')"]
   (tu/with-temporary-setting-values [report-timezone "US/Pacific"]
-    (hsql/format (sqlqp/->honeysql (MySQLDriver.) (du/->Timestamp "2018-01-03")))))
+    (hsql/format (sqlqp/->honeysql (MySQLDriver.) (du/->Timestamp #inst "2018-01-03")))))
 
 ;; ...with a report-timezone set to the same as the system timezone (shouldn't need to do TZ conversion)
 (expect
   ["?" (du/->Timestamp #inst "2018-01-03")]
   (tu/with-temporary-setting-values [report-timezone "UTC"]
-    (hsql/format (sqlqp/->honeysql (MySQLDriver.) (du/->Timestamp "2018-01-03")))))
+    (hsql/format (sqlqp/->honeysql (MySQLDriver.) (du/->Timestamp #inst "2018-01-03")))))

--- a/test/metabase/driver/oracle_test.clj
+++ b/test/metabase/driver/oracle_test.clj
@@ -5,6 +5,7 @@
             [metabase.driver
              [generic-sql :as sql]
              [oracle :as oracle]]
+            [metabase.models.setting :as setting]
             [metabase.test.data.datasets :refer [expect-with-engine]]
             [metabase.test.util :as tu])
   (:import metabase.driver.oracle.OracleDriver))
@@ -67,4 +68,6 @@
 
 (expect-with-engine :oracle
   "UTC"
-  (tu/db-timezone-id))
+  (do
+    (setting/set! :report-timezone "")
+    (tu/db-timezone-id)))

--- a/test/metabase/driver/oracle_test.clj
+++ b/test/metabase/driver/oracle_test.clj
@@ -5,8 +5,13 @@
             [metabase.driver
              [generic-sql :as sql]
              [oracle :as oracle]]
-            [metabase.models.setting :as setting]
-            [metabase.test.data.datasets :refer [expect-with-engine]]
+            [metabase.models
+             [database :refer [Database]]
+             [setting :as setting]]
+            [metabase.test.data :as data]
+            [metabase.test.data
+             [dataset-definitions :as defs]
+             [datasets :refer [expect-with-engine]]]
             [metabase.test.util :as tu])
   (:import metabase.driver.oracle.OracleDriver))
 
@@ -68,6 +73,4 @@
 
 (expect-with-engine :oracle
   "UTC"
-  (do
-    (setting/set! :report-timezone "")
-    (tu/db-timezone-id)))
+  (tu/db-timezone-id))

--- a/test/metabase/http_client.clj
+++ b/test/metabase/http_client.clj
@@ -41,7 +41,8 @@
         (map? response) (->> response
                              (map (fn [[k v]]
                                     {k (cond
-                                         (contains? auto-deserialize-dates-keys k) (du/->Timestamp v)
+                                         ;; Our tests only run in UTC, parsing timestamp strings as UTC
+                                         (contains? auto-deserialize-dates-keys k) (du/->Timestamp v du/utc)
                                          (coll? v) (auto-deserialize-dates v)
                                          :else v)}))
                              (into {}))

--- a/test/metabase/models/session_test.clj
+++ b/test/metabase/models/session_test.clj
@@ -19,16 +19,16 @@
     (db/simple-insert-many! Session
       [{:id         "the-greatest-day-ever"
         :user_id    user-id
-        :created_at (du/->Timestamp "1980-10-19T05:05:05.000Z")}
+        :created_at (du/->Timestamp #inst "1980-10-19T05:05:05.000Z")}
        {:id         "even-more-greatness"
         :user_id    user-id
-        :created_at (du/->Timestamp "1980-10-19T05:08:05.000Z")}
+        :created_at (du/->Timestamp #inst "1980-10-19T05:08:05.000Z")}
        {:id         "the-world-of-bi-changes-forever"
         :user_id    user-id
-        :created_at (du/->Timestamp "2015-10-21")}
+        :created_at (du/->Timestamp #inst "2015-10-21")}
        {:id         "something-could-have-happened"
         :user_id    user-id
-        :created_at (du/->Timestamp "1999-12-31")}
+        :created_at (du/->Timestamp #inst "1999-12-31")}
        {:id         "now"
         :user_id    user-id
         :created_at (du/new-sql-timestamp)}])

--- a/test/metabase/query_processor/expand_resolve_test.clj
+++ b/test/metabase/query_processor/expand_resolve_test.clj
@@ -9,6 +9,7 @@
              [expand :as ql]
              [resolve :as resolve]
              [source-table :as source-table]]
+            [metabase.query-processor-test :as qpt]
             [metabase.test
              [data :as data :refer :all]
              [util :as tu]]
@@ -240,7 +241,7 @@
                                                                                     :type   {:type/DateTime {:earliest "2014-01-01T00:00:00.000Z"
                                                                                                              :latest   "2014-12-05T00:00:00.000Z"}}}})
                                                 :unit  :year}
-                                  :value       {:value (du/->Timestamp "1980-01-01")
+                                  :value       {:value (du/->Timestamp #inst "1980-01-01")
                                                 :field {:field
                                                         (merge field-defaults
                                                                {:field-id           (id :users :last_login)
@@ -267,11 +268,11 @@
                                    :join-alias   "USERS__via__USER_ID"}]}
     :fk-field-ids #{(id :checkins :user_id)}
     :table-ids    #{(id :users)}}]
-  (let [expanded-form (ql/expand (wrap-inner-query (query checkins
-                                                     (ql/filter (ql/> (ql/datetime-field $user_id->users.last_login :year)
-                                                                      "1980-01-01")))))]
-    (mapv obj->map [expanded-form
-                    (resolve' expanded-form)])))
+  (qpt/with-h2-db-timezone
+    (let [expanded-form (ql/expand (wrap-inner-query (query checkins
+                                                       (ql/filter (ql/> (ql/datetime-field $user_id->users.last_login :year)
+                                                                        "1980-01-01")))))]
+      (mapv obj->map [expanded-form (resolve' expanded-form)]))))
 
 
 ;; sum aggregation w/ datetime breakout

--- a/test/metabase/query_processor/middleware/parameters/sql_test.clj
+++ b/test/metabase/query_processor/middleware/parameters/sql_test.clj
@@ -5,9 +5,13 @@
             [metabase
              [driver :as driver]
              [query-processor :as qp]
-             [query-processor-test :refer [non-timeseries-engines-with-feature first-row format-rows-by]]]
+             [query-processor-test :as qpt :refer [first-row format-rows-by]]]
+            [metabase.models.database :refer [Database]]
+            [metabase.util.date :as du]
             [metabase.query-processor.middleware.parameters.sql :as sql :refer :all]
-            [metabase.test.data :as data]
+            [metabase.test
+             [data :as data]
+             [util :as tu]]
             [metabase.test.data
              [datasets :as datasets]
              [generic-sql :as generic-sql]]
@@ -329,15 +333,17 @@
 ;;; ------------------------------------------- expansion tests: variables -------------------------------------------
 
 (defn- expand* [query]
-  (-> (expand (assoc query :driver (driver/engine->driver :h2)))
-      :native
-      (select-keys [:query :params])))
+  (qpt/with-h2-db-timezone
+    (-> (expand (assoc query :driver (driver/engine->driver :h2)))
+        :native
+        (select-keys [:query :params :template_tags]))))
 
 ;; unspecified optional param
 (expect
-  {:query  "SELECT * FROM orders ;"
-   :params []}
-  (expand* {:native     {:query "SELECT * FROM orders [[WHERE id = {{id}}]];"
+  {:query         "SELECT * FROM orders ;"
+   :params        []
+   :template_tags {:id {:name "id", :display_name "ID", :type "number"}}}
+  (expand* {:native     {:query         "SELECT * FROM orders [[WHERE id = {{id}}]];"
                          :template_tags {:id {:name "id", :display_name "ID", :type "number"}}}
             :parameters []}))
 
@@ -350,33 +356,37 @@
 
 ;; default value
 (expect
-  {:query  "SELECT * FROM orders WHERE id = 100;"
-   :params []}
-  (expand* {:native     {:query "SELECT * FROM orders WHERE id = {{id}};"
+  {:query         "SELECT * FROM orders WHERE id = 100;"
+   :params        []
+   :template_tags {:id {:name "id", :display_name "ID", :type "number", :required true, :default "100"}}}
+  (expand* {:native     {:query         "SELECT * FROM orders WHERE id = {{id}};"
                          :template_tags {:id {:name "id", :display_name "ID", :type "number", :required true, :default "100"}}}
             :parameters []}))
 
 ;; specified param (numbers)
 (expect
-  {:query  "SELECT * FROM orders WHERE id = 2;"
-   :params []}
-  (expand* {:native     {:query "SELECT * FROM orders WHERE id = {{id}};"
+  {:query         "SELECT * FROM orders WHERE id = 2;"
+   :params        []
+   :template_tags {:id {:name "id", :display_name "ID", :type "number", :required true, :default "100"}}}
+  (expand* {:native     {:query         "SELECT * FROM orders WHERE id = {{id}};"
                          :template_tags {:id {:name "id", :display_name "ID", :type "number", :required true, :default "100"}}}
             :parameters [{:type "category", :target ["variable" ["template-tag" "id"]], :value "2"}]}))
 
 ;; specified param (date/single)
 (expect
-  {:query  "SELECT * FROM orders WHERE created_at > ?;"
-   :params [#inst "2016-07-19T00:00:00.000000000-00:00"]}
-  (expand* {:native     {:query "SELECT * FROM orders WHERE created_at > {{created_at}};"
+  {:query         "SELECT * FROM orders WHERE created_at > ?;"
+   :params        [#inst "2016-07-19T00:00:00.000000000-00:00"]
+   :template_tags {:created_at {:name "created_at", :display_name "Created At", :type "date"}}}
+  (expand* {:native     {:query         "SELECT * FROM orders WHERE created_at > {{created_at}};"
                          :template_tags {:created_at {:name "created_at", :display_name "Created At", :type "date"}}}
             :parameters [{:type "date/single", :target ["variable" ["template-tag" "created_at"]], :value "2016-07-19"}]}))
 
 ;; specified param (text)
 (expect
-  {:query  "SELECT * FROM products WHERE category = ?;"
-   :params ["Gizmo"]}
-  (expand* {:native     {:query "SELECT * FROM products WHERE category = {{category}};"
+  {:query         "SELECT * FROM products WHERE category = ?;"
+   :params        ["Gizmo"]
+   :template_tags {:category {:name "category", :display_name "Category", :type "text"}}}
+  (expand* {:native     {:query         "SELECT * FROM products WHERE category = {{category}};"
                          :template_tags {:category {:name "category", :display_name "Category", :type "text"}}}
             :parameters [{:type "category", :target ["variable" ["template-tag" "category"]], :value "Gizmo"}]}))
 
@@ -385,11 +395,13 @@
 
 (defn- expand-with-dimension-param [dimension-param]
   (with-redefs [t/now (constantly (t/date-time 2016 06 07 12 0 0))]
-    (expand* {:native     {:query "SELECT * FROM checkins WHERE {{date}};"
-                           :template_tags {:date {:name "date", :display_name "Checkin Date", :type "dimension", :dimension ["field-id" (data/id :checkins :date)]}}}
-              :parameters (when dimension-param
-                            [(merge {:target ["dimension" ["template-tag" "date"]]}
-                                    dimension-param)])})))
+    (-> {:native     {:query "SELECT * FROM checkins WHERE {{date}};"
+                      :template_tags {:date {:name "date", :display_name "Checkin Date", :type "dimension", :dimension ["field-id" (data/id :checkins :date)]}}}
+         :parameters (when dimension-param
+                       [(merge {:target ["dimension" ["template-tag" "date"]]}
+                               dimension-param)])}
+        expand*
+        (dissoc :template_tags))))
 
 ;; dimension (date/single)
 (expect
@@ -529,11 +541,12 @@
 
 ;; as with the MBQL parameters tests Redshift and Crate fail for unknown reasons; disable their tests for now
 (def ^:private ^:const sql-parameters-engines
-  (disj (non-timeseries-engines-with-feature :native-parameters) :redshift :crate))
+  (disj (qpt/non-timeseries-engines-with-feature :native-parameters) :redshift :crate))
 
 (defn- process-native {:style/indent 0} [& kvs]
-  (qp/process-query
-    (apply assoc {:database (data/id), :type :native} kvs)))
+  (du/with-effective-timezone (Database (data/id))
+    (qp/process-query
+      (apply assoc {:database (data/id), :type :native, :settings {:report-timezone "UTC"}} kvs))))
 
 (datasets/expect-with-engines sql-parameters-engines
   [29]
@@ -577,6 +590,18 @@
        :parameters [{:type "date/range",  :target ["dimension" ["template-tag" "checkin_date"]], :value "2015-01-01~2016-09-01"}
                     {:type "date/single", :target ["dimension" ["template-tag" "checkin_date"]], :value "2015-07-01"}]))))
 
+;; Test that native dates are parsed with the report timezone (when supported)
+(datasets/expect-with-engines (disj sql-parameters-engines :sqlite)
+  [(if (qpt/supports-report-timezone? datasets/*engine*)
+     "2018-04-18T00:00:00.000-07:00"
+     "2018-04-18T00:00:00.000Z")]
+  (tu/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
+    (first-row
+      (process-native
+        :native     {:query         "SELECT cast({{date}} as date)"
+                     :template_tags {:date {:name "date" :display_name "Date" :type "date" }}}
+        :parameters [{:type "date/single" :target ["variable" ["template-tag" "date"]] :value "2018-04-18"}]))))
+
 
 ;;; -------------------------------------------- SQL PARAMETERS 2.0 TESTS --------------------------------------------
 
@@ -587,56 +612,50 @@
    :template_tags {:created_at {:name "created_at", :display_name "Created At", :type "dimension", :dimension ["field-id" (data/id :checkins :date)]}},
    :params        [#inst "2017-03-01T00:00:00.000000000-00:00"
                    #inst "2017-03-31T00:00:00.000000000-00:00"]}
-  (:native (expand {:driver     (driver/engine->driver :h2)
-                    :native     {:query         "SELECT count(*) FROM CHECKINS WHERE {{created_at}}"
-                                 :template_tags {:created_at {:name "created_at", :display_name "Created At", :type "dimension", :dimension ["field-id" (data/id :checkins :date)]}}}
-                    :parameters [{:type "date/month-year", :target ["dimension" ["template-tag" "created_at"]], :value "2017-03"}]})))
+  (expand* {:native     {:query         "SELECT count(*) FROM CHECKINS WHERE {{created_at}}"
+                         :template_tags {:created_at {:name "created_at", :display_name "Created At",
+                                                      :type "dimension", :dimension ["field-id" (data/id :checkins :date)]}}}
+            :parameters [{:type "date/month-year", :target ["dimension" ["template-tag" "created_at"]], :value "2017-03"}]}))
 
 (expect
   {:query         "SELECT count(*) FROM ORDERS"
    :template_tags {:price {:name "price", :display_name "Price", :type "number", :required false}}
    :params        []}
-  (:native (expand {:driver     (driver/engine->driver :h2)
-                    :native     {:query         "SELECT count(*) FROM ORDERS [[WHERE price > {{price}}]]"
-                                 :template_tags {:price {:name "price", :display_name "Price", :type "number", :required false}}}
-                    :parameters []})))
+  (expand* {:native {:query         "SELECT count(*) FROM ORDERS [[WHERE price > {{price}}]]"
+                     :template_tags {:price {:name "price", :display_name "Price", :type "number", :required false}}}}))
 
 (expect
   {:query         "SELECT count(*) FROM ORDERS WHERE price > 100"
    :template_tags {:price {:name "price", :display_name "Price", :type "number", :required false}}
    :params        []}
-  (:native (expand {:driver     (driver/engine->driver :h2)
-                    :native     {:query         "SELECT count(*) FROM ORDERS [[WHERE price > {{price}}]]"
-                                 :template_tags {:price {:name "price", :display_name "Price", :type "number", :required false}}}
-                    :parameters [{:type "category", :target ["variable" ["template-tag" "price"]], :value "100"}]})))
+  (expand* {:native      {:query         "SELECT count(*) FROM ORDERS [[WHERE price > {{price}}]]"
+                          :template_tags {:price {:name "price", :display_name "Price", :type "number", :required false}}}
+            :parameters   [{:type "category", :target ["variable" ["template-tag" "price"]], :value "100"}]}))
 
 (expect
   {:query         "SELECT count(*) FROM PRODUCTS WHERE TITLE LIKE ?"
    :template_tags {:x {:name "x", :display_name "X", :type "text", :required true, :default "%Toucan%"}}
    :params        ["%Toucan%"]}
-  (:native (expand {:driver     (driver/engine->driver :h2)
-                    :native     {:query         "SELECT count(*) FROM PRODUCTS WHERE TITLE LIKE {{x}}",
-                                 :template_tags {:x {:name "x", :display_name "X", :type "text", :required true, :default "%Toucan%"}}},
-                    :parameters [{:type "category", :target ["variable" ["template-tag" "x"]]}]})))
+  (expand* {:native     {:query         "SELECT count(*) FROM PRODUCTS WHERE TITLE LIKE {{x}}",
+                         :template_tags {:x {:name "x", :display_name "X", :type "text", :required true, :default "%Toucan%"}}},
+            :parameters [{:type "category", :target ["variable" ["template-tag" "x"]]}]}))
 
 ;; make sure that you can use the same parameter multiple times (#4659)
 (expect
   {:query         "SELECT count(*) FROM products WHERE title LIKE ? AND subtitle LIKE ?"
    :template_tags {:x {:name "x", :display_name "X", :type "text", :required true, :default "%Toucan%"}}
    :params        ["%Toucan%" "%Toucan%"]}
-  (:native (expand {:driver     (driver/engine->driver :h2)
-                    :native     {:query         "SELECT count(*) FROM products WHERE title LIKE {{x}} AND subtitle LIKE {{x}}",
-                                 :template_tags {:x {:name "x", :display_name "X", :type "text", :required true, :default "%Toucan%"}}},
-                    :parameters [{:type "category", :target ["variable" ["template-tag" "x"]]}]})))
+  (expand* {:native     {:query         "SELECT count(*) FROM products WHERE title LIKE {{x}} AND subtitle LIKE {{x}}",
+                         :template_tags {:x {:name "x", :display_name "X", :type "text", :required true, :default "%Toucan%"}}},
+            :parameters [{:type "category", :target ["variable" ["template-tag" "x"]]}]}))
 
 (expect
   {:query         "SELECT * FROM ORDERS WHERE true  AND ID = ? OR USER_ID = ?"
    :template_tags {:id {:name "id", :display_name "ID", :type "text"}}
    :params        ["2" "2"]}
-  (:native (expand {:driver     (driver/engine->driver :h2)
-                    :native     {:query         "SELECT * FROM ORDERS WHERE true [[ AND ID = {{id}} OR USER_ID = {{id}} ]]"
-                                 :template_tags {:id {:name "id", :display_name "ID", :type "text"}}}
-                    :parameters [{:type "category", :target ["variable" ["template-tag" "id"]], :value "2"}]})))
+  (expand* {:native     {:query         "SELECT * FROM ORDERS WHERE true [[ AND ID = {{id}} OR USER_ID = {{id}} ]]"
+                         :template_tags {:id {:name "id", :display_name "ID", :type "text"}}}
+            :parameters [{:type "category", :target ["variable" ["template-tag" "id"]], :value "2"}]}))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -656,18 +675,17 @@
    :params        [#inst "2017-10-31T00:00:00.000000000-00:00"
                    #inst "2017-11-04T00:00:00.000000000-00:00"]}
   (with-redefs [t/now (constantly (t/date-time 2017 11 05 12 0 0))]
-    (:native (expand {:driver     (driver/engine->driver :h2)
-                      :native     {:query         (str "SELECT count(*) AS \"count\", \"DATE\" "
-                                                       "FROM CHECKINS "
-                                                       "WHERE {{checkin_date}} "
-                                                       "GROUP BY \"DATE\"")
-                                   :template_tags {:checkin_date {:name         "checkin_date"
-                                                                  :display_name "Checkin Date"
-                                                                  :type         "dimension"
-                                                                  :dimension    ["field-id" (data/id :checkins :date)]}}}
-                      :parameters [{:type   "date/range"
-                                    :target ["dimension" ["template-tag" "checkin_date"]]
-                                    :value  "past5days"}]}))))
+    (expand* {:native     {:query         (str "SELECT count(*) AS \"count\", \"DATE\" "
+                                               "FROM CHECKINS "
+                                               "WHERE {{checkin_date}} "
+                                               "GROUP BY \"DATE\"")
+                           :template_tags {:checkin_date {:name         "checkin_date"
+                                                          :display_name "Checkin Date"
+                                                          :type         "dimension"
+                                                          :dimension    ["field-id" (data/id :checkins :date)]}}}
+              :parameters [{:type   "date/range"
+                            :target ["dimension" ["template-tag" "checkin_date"]]
+                            :value  "past5days"}]})))
 
 ;; Make sure defaults values get picked up for field filter clauses
 (expect
@@ -700,17 +718,16 @@
    :params        [#inst "2017-10-31T00:00:00.000000000-00:00"
                    #inst "2017-11-04T00:00:00.000000000-00:00"]}
   (with-redefs [t/now (constantly (t/date-time 2017 11 05 12 0 0))]
-    (:native (expand {:driver (driver/engine->driver :h2)
-                      :native {:query         (str "SELECT count(*) AS \"count\", \"DATE\" "
-                                                   "FROM CHECKINS "
-                                                   "WHERE {{checkin_date}} "
-                                                   "GROUP BY \"DATE\"")
-                               :template_tags {:checkin_date {:name         "checkin_date"
-                                                              :display_name "Checkin Date"
-                                                              :type         "dimension"
-                                                              :dimension    ["field-id" (data/id :checkins :date)]
-                                                              :default      "past5days"
-                                                              :widget_type  "date/all-options"}}}}))))
+    (expand* {:native {:query         (str "SELECT count(*) AS \"count\", \"DATE\" "
+                                           "FROM CHECKINS "
+                                           "WHERE {{checkin_date}} "
+                                           "GROUP BY \"DATE\"")
+                       :template_tags {:checkin_date {:name         "checkin_date"
+                                                      :display_name "Checkin Date"
+                                                      :type         "dimension"
+                                                      :dimension    ["field-id" (data/id :checkins :date)]
+                                                      :default      "past5days"
+                                                      :widget_type  "date/all-options"}}}})))
 
 ;; Check that it works with absolute dates as well
 (expect
@@ -725,17 +742,16 @@
                                   :default      "2017-11-14"
                                   :widget_type  "date/all-options"}}
    :params        [#inst "2017-11-14T00:00:00.000000000-00:00"]}
-  (:native (expand {:driver (driver/engine->driver :h2)
-                    :native {:query         (str "SELECT count(*) AS \"count\", \"DATE\" "
-                                                 "FROM CHECKINS "
-                                                 "WHERE {{checkin_date}} "
-                                                 "GROUP BY \"DATE\"")
-                             :template_tags {:checkin_date {:name         "checkin_date"
-                                                            :display_name "Checkin Date"
-                                                            :type         "dimension"
-                                                            :dimension    ["field-id" (data/id :checkins :date)]
-                                                            :default      "2017-11-14"
-                                                            :widget_type  "date/all-options"}}}})))
+  (expand* {:native {:query         (str "SELECT count(*) AS \"count\", \"DATE\" "
+                                         "FROM CHECKINS "
+                                         "WHERE {{checkin_date}} "
+                                         "GROUP BY \"DATE\"")
+                     :template_tags {:checkin_date {:name         "checkin_date"
+                                                    :display_name "Checkin Date"
+                                                    :type         "dimension"
+                                                    :dimension    ["field-id" (data/id :checkins :date)]
+                                                    :default      "2017-11-14"
+                                                    :widget_type  "date/all-options"}}}}))
 
 
 ;;; ------------------------------- Multiple Value Support (comma-separated or array) --------------------------------
@@ -761,15 +777,14 @@
   {:query         "SELECT * FROM CATEGORIES where name IN (?, ?, ?)"
    :template_tags {:names_list {:name "names_list", :display_name "Names List", :type "text"}}
    :params        ["BBQ" "Bakery" "Bar"]}
-  (:native (expand
-            {:driver     (driver/engine->driver :h2)
-             :native     {:query         "SELECT * FROM CATEGORIES [[where name IN ({{names_list}})]]"
-                          :template_tags {:names_list {:name         "names_list"
-                                                       :display_name "Names List"
-                                                       :type         "text"}}}
-             :parameters [{:type   "category"
-                           :target ["variable" ["template-tag" "names_list"]]
-                           :value  ["BBQ", "Bakery", "Bar"]}]})))
+  (expand*
+   {:native     {:query         "SELECT * FROM CATEGORIES [[where name IN ({{names_list}})]]"
+                 :template_tags {:names_list {:name         "names_list"
+                                              :display_name "Names List"
+                                              :type         "text"}}}
+    :parameters [{:type   "category"
+                  :target ["variable" ["template-tag" "names_list"]]
+                  :value  ["BBQ", "Bakery", "Bar"]}]}))
 
 ;; Make sure arrays of values also work for 'field filter' params
 (expect
@@ -779,13 +794,12 @@
                                 :type         "dimension"
                                 :dimension    ["field-id" (data/id :users :id)]}}
    :params        ["BBQ" "Bakery" "Bar"]}
-  (:native (expand
-            {:driver     (driver/engine->driver :h2)
-             :native     {:query         "SELECT * FROM CATEGORIES WHERE {{names_list}}"
-                          :template_tags {:names_list {:name         "names_list"
-                                                       :display_name "Names List"
-                                                       :type         "dimension"
-                                                       :dimension    ["field-id" (data/id :users :id)]}}}
-             :parameters [{:type   "text"
-                           :target ["dimension" ["template-tag" "names_list"]]
-                           :value  ["BBQ", "Bakery", "Bar"]}]})))
+  (expand*
+   {:native     {:query         "SELECT * FROM CATEGORIES WHERE {{names_list}}"
+                 :template_tags {:names_list {:name         "names_list"
+                                              :display_name "Names List"
+                                              :type         "dimension"
+                                              :dimension    ["field-id" (data/id :users :id)]}}}
+    :parameters [{:type   "text"
+                  :target ["dimension" ["template-tag" "names_list"]]
+                  :value  ["BBQ", "Bakery", "Bar"]}]}))

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -9,7 +9,8 @@
              [driver :as driver]
              [util :as u]]
             [metabase.test.data :as data]
-            [metabase.test.data.datasets :as datasets]))
+            [metabase.test.data.datasets :as datasets]
+            [metabase.util.date :as du]))
 
 ;; make sure all the driver test extension namespaces are loaded <3 if this isn't done some things will get loaded at
 ;; the wrong time which can end up causing test databases to be created more than once, which fails
@@ -358,3 +359,13 @@
       driver/engine->driver
       driver/features
       (contains? :set-timezone)))
+
+(defmacro with-h2-db-timezone
+  "This macro is useful when testing pieces of the query pipeline (such as expand) where it's a basic unit test not
+  involving a database, but does need to parse dates"
+  [& body]
+  `(du/with-effective-timezone {:engine   :h2
+                                :timezone "UTC"
+                                :name     "mock_db"
+                                :id       1}
+    ~@body))

--- a/test/metabase/query_processor_test/timezones_test.clj
+++ b/test/metabase/query_processor_test/timezones_test.clj
@@ -1,0 +1,204 @@
+(ns metabase.query-processor-test.timezones-test
+  (:require [clojure.java.jdbc :as jdbc]
+            [expectations :refer :all]
+            [metabase
+             [query-processor :as qp]
+             [query-processor-test :as qptest]]
+            [metabase.query-processor.middleware.expand :as ql]
+            [metabase.query-processor-test :as qpt]
+            [metabase.test
+             [data :as data]
+             [util :as tu]]
+            [metabase.test.data.interface :as i]
+            [metabase.test.data.mysql :as mysql-data]
+            [metabase.driver.generic-sql :as sql]
+            [metabase.test.data.generic-sql :as generic-sql]
+            [metabase.test.data.datasets :refer [expect-with-engine expect-with-engines *engine* *driver*]]
+            [metabase.test.data.dataset-definitions :as defs]
+            [toucan.db :as db])
+  (:import metabase.driver.mysql.MySQLDriver))
+
+(def ^:private mysql-driver (MySQLDriver.))
+
+(defn- fix-mysql-timestamps?
+  "Returns true if the database at `db-spec` needs to have it's timestamps fixed. See the `update-mysql-timestamps
+  comment for more information on why these are being fixed"
+  [db-spec]
+  (empty? (jdbc/query db-spec "select 1 from users where id=1 and last_login='2014-04-01 01:30:00'")))
+
+(defn- update-mysql-timestamps
+  "Unfortunately the timestamps we insert in this dataset are in UTC, but MySQL is inserting them as if they were in
+  pacific time. This means that they are rolling them forward 7 (or 8) hours. Instead of inserting 08:30 it's
+  inserting 15:30. This is wrong, rather than hack something together that weaves through all of the data loading
+  code, this function just fixes up the timestamps after the data is loaded using MySQL's `convert_tz` function"
+  []
+  (when (= :mysql *engine*)
+    (let [details (i/database->connection-details mysql-driver :db {:database-name "test-data-with-timezones"})
+          db-spec (sql/connection-details->spec mysql-driver details)]
+      (when (fix-mysql-timestamps? db-spec)
+        (jdbc/execute! db-spec "update users set last_login=convert_tz(last_login,'UTC','America/Los_Angeles')")))))
+
+(defn- call-with-timezones-db [f]
+  ;; Does the database exist?
+  (when-not (i/metabase-instance defs/test-data-with-timezones *engine*)
+    ;; The database doesn't exist, so we need to create it
+    (data/get-or-create-database! defs/test-data-with-timezones)
+    ;; The db has been created but the timestamps are wrong on MySQL, fix them up
+    (update-mysql-timestamps))
+  ;; The database can now be used in tests
+  (data/with-db (data/get-or-create-database! defs/test-data-with-timezones)
+    (f)))
+
+(defmacro ^:private with-tz-db
+  "Calls `with-db` on the `test-data-with-timezones` dataset and ensures the timestamps are fixed up on MySQL"
+  [& body]
+  `(call-with-timezones-db (fn [] ~@body)))
+
+(def ^:private default-utc-results
+  #{[6 "Shad Ferdynand" "2014-08-02T12:30:00.000Z"]
+    [7 "Conchúr Tihomir" "2014-08-02T09:30:00.000Z"]})
+
+(def ^:private default-pacific-results
+  #{[6 "Shad Ferdynand" "2014-08-02T05:30:00.000-07:00"]
+    [7 "Conchúr Tihomir" "2014-08-02T02:30:00.000-07:00"]})
+
+;; Test querying a database that does NOT support report timezones
+;;
+;; The report-timezone of Europe/Brussels is UTC+2, our tests use a JVM timezone of UTC. If the timestamps below are
+;; interpretted incorrectly as Europe/Brussels, it would adjust that back 2 hours to UTC
+;; (i.e. 2014-07-01T22:00:00.000Z). We then cast that time to a date, which truncates it to 2014-07-01, which is then
+;; querying the day before. This reproduces the bug found in https://github.com/metabase/metabase/issues/7584
+(expect-with-engine :bigquery
+  #{[10 "Frans Hevel" "2014-07-03T19:30:00.000Z"]
+    [12 "Kfir Caj" "2014-07-03T01:30:00.000Z"]}
+  (with-tz-db
+    (tu/with-temporary-setting-values [report-timezone "Europe/Brussels"]
+      (-> (data/run-query users
+            (ql/filter (ql/between $last_login
+                                   "2014-07-02"
+                                   "2014-07-03")))
+          qptest/rows
+          set))))
+
+;; Query PG using a report-timezone set to pacific time. Should adjust the query parameter using that report timezone
+;; and should return the timestamp in pacific time as well
+(expect-with-engines [:postgres :mysql]
+  default-pacific-results
+  (with-tz-db
+    (tu/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
+      (-> (data/run-query users
+            (ql/filter (ql/between $last_login
+                                   "2014-08-02T03:00:00.000000"
+                                   "2014-08-02T06:00:00.000000")))
+          qptest/rows
+          set))))
+
+(defn- quote-name [identifier]
+  (generic-sql/quote-name *driver* identifier))
+
+(defn- users-table-identifier []
+  ;; HACK ! I don't have all day to write protocol methods to make this work the "right" way so for BigQuery and
+  (if (= *engine* :bigquery)
+    "[test_data_with_timezones.users]"
+    (let [{table-name :name, schema :schema} (db/select-one ['Table :name :schema], :id (data/id :users))]
+      (str (when (seq schema)
+             (str (quote-name schema) \.))
+           (quote-name table-name)))))
+
+(defn- field-identifier [& kwds]
+  (let [field (db/select-one ['Field :name :table_id] :id (apply data/id kwds))
+        {table-name :name, schema :schema} (db/select-one ['Table :name :schema] :id (:table_id field))]
+    (str (when (seq schema)
+           (str (quote-name schema) \.))
+         (quote-name table-name) \. (quote-name (:name field)))))
+
+(def ^:private process-query' (comp set qpt/rows qp/process-query))
+
+;; Test that native dates are parsed with the report timezone (when supported)
+(expect-with-engines [:postgres :mysql]
+  default-pacific-results
+  (with-tz-db
+    (tu/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
+      (process-query'
+       {:database (data/id)
+        :type :native
+        :native     {:query         (format "select %s, %s, %s from %s where cast(last_login as date) between {{date1}} and {{date2}}"
+                                            (field-identifier :users :id)
+                                            (field-identifier :users :name)
+                                            (field-identifier :users :last_login)
+                                            (users-table-identifier))
+                     :template_tags {:date1 {:name "date1" :display_name "Date1" :type "date" }
+                                     :date2 {:name "date2" :display_name "Date2" :type "date" }}}
+        :parameters [{:type "date/single" :target ["variable" ["template-tag" "date1"]] :value "2014-08-02T02:00:00.000000"}
+                     {:type "date/single" :target ["variable" ["template-tag" "date2"]] :value "2014-08-02T06:00:00.000000"}]}))))
+
+;; This does not currently work for MySQL
+(expect-with-engines [:postgres :mysql]
+  default-pacific-results
+  (with-tz-db
+    (tu/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
+      (process-query'
+       {:database (data/id)
+        :type :native
+        :native     {:query         (format "select %s, %s, %s from %s where {{ts_range}}"
+                                            (field-identifier :users :id)
+                                            (field-identifier :users :name)
+                                            (field-identifier :users :last_login)
+                                            (users-table-identifier))
+                     :template_tags {:ts_range {:name "ts_range", :display_name "Timestamp Range", :type "dimension",
+                                                :dimension ["field-id" (data/id :users :last_login)]}}}
+        :parameters [{:type "date/range", :target ["dimension" ["template-tag" "ts_range"]], :value "2014-08-02~2014-08-03"}]}))))
+
+;; Querying using a single date
+(expect-with-engines [:postgres :mysql]
+  default-pacific-results
+  (with-tz-db
+    (tu/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
+      (process-query'
+       {:database (data/id)
+        :type :native
+        :native     {:query         (format "select %s, %s, %s from %s where {{just_a_date}}"
+                                            (field-identifier :users :id)
+                                            (field-identifier :users :name)
+                                            (field-identifier :users :last_login)
+                                            (users-table-identifier))
+                     :template_tags {:just_a_date {:name "just_a_date", :display_name "Just A Date", :type "dimension",
+                                                   :dimension ["field-id" (data/id :users :last_login)]}}}
+        :parameters [{:type "date/single", :target ["dimension" ["template-tag" "just_a_date"]], :value "2014-08-02"}]}))))
+
+;; This is the same answer as above but uses timestamp with the timezone included. The report timezone is still
+;; pacific though, so it should return as pacific regardless of how the filter was specified
+(expect-with-engines [:postgres :mysql]
+  default-pacific-results
+  (with-tz-db
+    (tu/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
+      (-> (data/run-query users
+            (ql/filter (ql/between $last_login
+                                   "2014-08-02T10:00:00.000000Z"
+                                   "2014-08-02T13:00:00.000000Z")))
+          qptest/rows
+          set))))
+
+;; Checking UTC report timezone filtering and responses
+(expect-with-engines [:postgres :bigquery :mysql]
+  default-utc-results
+  (with-tz-db
+    (tu/with-temporary-setting-values [report-timezone "UTC"]
+      (-> (data/run-query users
+            (ql/filter (ql/between $last_login
+                                   "2014-08-02T10:00:00.000000"
+                                   "2014-08-02T13:00:00.000000")))
+          qptest/rows
+          set))))
+
+;; With no report timezone, the JVM timezone is used. For our tests this is UTC so this should be the same as
+;; specifying UTC for a report timezone
+(expect-with-engines [:postgres :bigquery :mysql]
+  default-utc-results
+  (with-tz-db
+    (-> (data/run-query users
+          (ql/filter (ql/between $last_login
+                                 "2014-08-02T10:00:00.000000"
+                                 "2014-08-02T13:00:00.000000")))
+        qptest/rows
+        set)))

--- a/test/metabase/sync/analyze/classify_test.clj
+++ b/test/metabase/sync/analyze/classify_test.clj
@@ -22,7 +22,7 @@
                     Field [_ {:table_id            (u/get-id table)
                               :name                "Current fingerprint, already analzed"
                               :fingerprint_version Short/MAX_VALUE
-                              :last_analyzed       (du/->Timestamp "2017-08-09")}]
+                              :last_analyzed       (du/->Timestamp #inst "2017-08-09")}]
                     Field [_ {:table_id            (u/get-id table)
                               :name                "Old fingerprint, not analyzed"
                               :fingerprint_version (dec Short/MAX_VALUE)
@@ -30,6 +30,6 @@
                     Field [_ {:table_id            (u/get-id table)
                               :name                "Old fingerprint, already analzed"
                               :fingerprint_version (dec Short/MAX_VALUE)
-                              :last_analyzed       (du/->Timestamp "2017-08-09")}]]
+                              :last_analyzed       (du/->Timestamp #inst "2017-08-09")}]]
       (for [field (#'classify/fields-to-classify table)]
         (:name field)))))

--- a/test/metabase/sync/analyze/fingerprint_test.clj
+++ b/test/metabase/sync/analyze/fingerprint_test.clj
@@ -226,7 +226,7 @@
                               :table_id            (data/id :venues)
                               :fingerprint         nil
                               :fingerprint_version 1
-                              :last_analyzed       (du/->Timestamp "2017-08-09")}]
+                              :last_analyzed       (du/->Timestamp #inst "2017-08-09")}]
     (with-redefs [i/latest-fingerprint-version 3
                   sample/sample-fields         (constantly [[field [1 2 3 4 5]]])
                   fingerprint/fingerprint      (constantly {:experimental {:fake-fingerprint? true}})]

--- a/test/metabase/sync/analyze_test.clj
+++ b/test/metabase/sync/analyze_test.clj
@@ -15,7 +15,7 @@
             [toucan.util.test :as tt]))
 
 (def ^:private fake-analysis-completion-date
-  (du/->Timestamp "2017-08-01"))
+  (du/->Timestamp #inst "2017-08-01"))
 
 ;; Check that Fields do *not* get analyzed if they're not newly created and fingerprint version is current
 (expect
@@ -62,7 +62,7 @@
 (expect
   #{"Current fingerprint, not analyzed"}
   (with-redefs [i/latest-fingerprint-version Short/MAX_VALUE
-                du/new-sql-timestamp         (constantly (du/->Timestamp "1999-01-01"))]
+                du/new-sql-timestamp         (constantly (du/->Timestamp #inst "1999-01-01"))]
     (tt/with-temp* [Table [table]
                     Field [_ {:table_id            (u/get-id table)
                               :name                "Current fingerprint, not analyzed"
@@ -71,7 +71,7 @@
                     Field [_ {:table_id            (u/get-id table)
                               :name                "Current fingerprint, already analzed"
                               :fingerprint_version Short/MAX_VALUE
-                              :last_analyzed       (du/->Timestamp "2017-08-09")}]
+                              :last_analyzed       (du/->Timestamp #inst "2017-08-09")}]
                     Field [_ {:table_id            (u/get-id table)
                               :name                "Old fingerprint, not analyzed"
                               :fingerprint_version (dec Short/MAX_VALUE)
@@ -79,6 +79,6 @@
                     Field [_ {:table_id            (u/get-id table)
                               :name                "Old fingerprint, already analzed"
                               :fingerprint_version (dec Short/MAX_VALUE)
-                              :last_analyzed       (du/->Timestamp "2017-08-09")}]]
+                              :last_analyzed       (du/->Timestamp #inst "2017-08-09")}]]
       (#'analyze/update-fields-last-analyzed! table)
       (db/select-field :name Field :last_analyzed (du/new-sql-timestamp)))))

--- a/test/metabase/test/data/bigquery.clj
+++ b/test/metabase/test/data/bigquery.clj
@@ -130,16 +130,17 @@
 
 
 (def ^:private ^:const base-type->bigquery-type
-  {:type/BigInteger :INTEGER
-   :type/Boolean    :BOOLEAN
-   :type/Date       :TIMESTAMP
-   :type/DateTime   :TIMESTAMP
-   :type/Decimal    :FLOAT
-   :type/Dictionary :RECORD
-   :type/Float      :FLOAT
-   :type/Integer    :INTEGER
-   :type/Text       :STRING
-   :type/Time       :TIME})
+  {:type/BigInteger     :INTEGER
+   :type/Boolean        :BOOLEAN
+   :type/Date           :TIMESTAMP
+   :type/DateTime       :TIMESTAMP
+   :type/DateTimeWithTZ :TIMESTAMP
+   :type/Decimal        :FLOAT
+   :type/Dictionary     :RECORD
+   :type/Float          :FLOAT
+   :type/Integer        :INTEGER
+   :type/Text           :STRING
+   :type/Time           :TIME})
 
 (defn- fielddefs->field-name->base-type
   "Convert FIELD-DEFINITIONS to a format appropriate for passing to `create-table!`."
@@ -200,7 +201,7 @@
 
 (defn- create-db! [{:keys [database-name table-definitions]}]
   {:pre [(seq database-name) (sequential? table-definitions)]}
-  ;; fetch existing datasets if we haven't done so yet
+    ;; fetch existing datasets if we haven't done so yet
   (when-not (seq @existing-datasets)
     (reset! existing-datasets (set (existing-dataset-names)))
     (println "These BigQuery datasets have already been loaded:\n" (u/pprint-to-str (sort @existing-datasets))))

--- a/test/metabase/test/data/dataset_definitions.clj
+++ b/test/metabase/test/data/dataset_definitions.clj
@@ -1,7 +1,8 @@
 (ns metabase.test.data.dataset-definitions
   "Definitions of various datasets for use in tests with `with-temp-db`."
   (:require [clojure.tools.reader.edn :as edn]
-            [metabase.test.data.interface :as di])
+            [metabase.test.data.interface :as di]
+            [metabase.util.date :as du])
   (:import java.sql.Time
            java.util.Calendar))
 
@@ -75,6 +76,15 @@
                        #(vec (concat % [{:field-name "null_only_date" :base-type :type/Date}]))
                        (fn [rows]
                          (mapv #(conj % nil) rows))
+                       (di/slurp-edn-table-def "test-data")))
+
+(di/def-database-definition test-data-with-timezones
+  (di/update-table-def "users"
+                       (fn [table-def]
+                         [(first table-def)
+                          {:field-name "last_login", :base-type :type/DateTimeWithTZ}
+                          (peek table-def)])
+                       identity
                        (di/slurp-edn-table-def "test-data")))
 
 (def test-data-map

--- a/test/metabase/test/data/generic_sql.clj
+++ b/test/metabase/test/data/generic_sql.clj
@@ -175,7 +175,7 @@
       (zipmap fields-for-insert (for [v row]
                                   (if (and (not (instance? java.sql.Time v))
                                            (instance? java.util.Date v))
-                                    (du/->Timestamp v)
+                                    (du/->Timestamp v du/utc)
                                     v))))))
 
 (defn load-data-add-ids

--- a/test/metabase/test/data/mysql.clj
+++ b/test/metabase/test/data/mysql.clj
@@ -1,27 +1,32 @@
 (ns metabase.test.data.mysql
   "Code for creating / destroying a MySQL database from a `DatabaseDefinition`."
-  (:require [metabase.driver.mysql :as mysql]
+  (:require [clojure.java.jdbc :as jdbc]
+            [metabase.driver.generic-sql :as gsql]
+            [metabase.driver.mysql :as mysql]
             [metabase.test.data
              [generic-sql :as generic]
              [interface :as i]]
             [metabase.util :as u]))
 
 (def ^:private ^:const field-base-type->sql-type
-  {:type/BigInteger "BIGINT"
-   :type/Boolean    "BOOLEAN" ; Synonym of TINYINT(1)
-   :type/Date       "DATE"
-   :type/DateTime   "TIMESTAMP"
-   :type/Decimal    "DECIMAL"
-   :type/Float      "DOUBLE"
-   :type/Integer    "INTEGER"
-   :type/Text       "TEXT"
-   :type/Time       "TIME"})
+  {:type/BigInteger     "BIGINT"
+   :type/Boolean        "BOOLEAN" ; Synonym of TINYINT(1)
+   :type/Date           "DATE"
+   :type/DateTime       "TIMESTAMP"
+   :type/DateTimeWithTZ "TIMESTAMP"
+   :type/Decimal        "DECIMAL"
+   :type/Float          "DOUBLE"
+   :type/Integer        "INTEGER"
+   :type/Text           "TEXT"
+   :type/Time           "TIME"})
 
 (defn- database->connection-details [context {:keys [database-name]}]
   (merge {:host         (i/db-test-env-var-or-throw :mysql :host "localhost")
           :port         (i/db-test-env-var-or-throw :mysql :port 3306)
           :user         (i/db-test-env-var :mysql :user "root")
-          :timezone     :America/Los_Angeles}
+          :timezone     :America/Los_Angeles
+;;          :serverTimezone "UTC"
+          }
          (when-let [password (i/db-test-env-var :mysql :password)]
            {:password password})
          (when (= context :db)
@@ -33,6 +38,7 @@
 
 (defn- quote-name [nm]
   (str \` nm \`))
+
 
 (u/strict-extend (class (mysql/->MySQLDriver))
   generic/IGenericSQLTestExtensions

--- a/test/metabase/test/data/postgres.clj
+++ b/test/metabase/test/data/postgres.clj
@@ -7,17 +7,18 @@
   (:import metabase.driver.postgres.PostgresDriver))
 
 (def ^:private ^:const field-base-type->sql-type
-  {:type/BigInteger "BIGINT"
-   :type/Boolean    "BOOL"
-   :type/Date       "DATE"
-   :type/DateTime   "TIMESTAMP"
-   :type/Decimal    "DECIMAL"
-   :type/Float      "FLOAT"
-   :type/Integer    "INTEGER"
-   :type/IPAddress  "INET"
-   :type/Text       "TEXT"
-   :type/Time       "TIME"
-   :type/UUID       "UUID"})
+  {:type/BigInteger     "BIGINT"
+   :type/Boolean        "BOOL"
+   :type/Date           "DATE"
+   :type/DateTime       "TIMESTAMP"
+   :type/DateTimeWithTZ "TIMESTAMP WITH TIME ZONE"
+   :type/Decimal        "DECIMAL"
+   :type/Float          "FLOAT"
+   :type/Integer        "INTEGER"
+   :type/IPAddress      "INET"
+   :type/Text           "TEXT"
+   :type/Time           "TIME"
+   :type/UUID           "UUID"})
 
 (defn- database->connection-details [context {:keys [database-name]}]
   (merge {:host     (i/db-test-env-var-or-throw :postgresql :host "localhost")

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -10,6 +10,7 @@
              [driver :as driver]
              [task :as task]
              [util :as u]]
+            [metabase.driver.generic-sql :as sql]
             [metabase.models
              [card :refer [Card]]
              [collection :refer [Collection]]
@@ -436,16 +437,27 @@
                                   {:cron-schedule (.getCronExpression ^CronTrigger trigger)
                                    :data          (into {} (.getJobDataMap trigger))}))))}))))))
 
+(defn- clear-connection-pool
+  "It's possible that a previous test ran and set the session's timezone to something, then returned the session to
+  the pool. Sometimes that connection's session can remain intact and subsequent queries will continue in that
+  timezone. That causes problems for tests that we can determine the database's timezone. This function will reset the
+  connections in the connection pool for `db` to ensure that we get fresh session with no timezone specified"
+  [db]
+  (when-let [conn-pool (:datasource (sql/db->pooled-connection-spec db))]
+    (.softResetAllUsers conn-pool)))
+
 (defn db-timezone-id
   "Return the timezone id from the test database. Must be called with `metabase.test.data.datasets/*driver*` bound,
   such as via `metabase.test.data.datasets/with-engine`"
   []
   (assert (bound? #'*driver*))
-  (data/dataset test-data
-    (-> (driver/current-db-time *driver* (data/db))
-        .getChronology
-        .getZone
-        .getID)))
+  (let [db (data/db)]
+    (clear-connection-pool db)
+    (data/dataset test-data
+      (-> (driver/current-db-time *driver* db)
+          .getChronology
+          .getZone
+          .getID))))
 
 (defn call-with-jvm-tz
   "Invokes the thunk `F` with the JVM timezone set to `DTZ`, puts the various timezone settings back the way it found

--- a/test/metabase/util/date_test.clj
+++ b/test/metabase/util/date_test.clj
@@ -18,7 +18,7 @@
 (expect saturday-the-31st (->Timestamp (->Calendar saturday-the-31st)))
 (expect saturday-the-31st (->Timestamp (->Calendar (.getTime saturday-the-31st))))
 (expect saturday-the-31st (->Timestamp (.getTime saturday-the-31st)))
-(expect saturday-the-31st (->Timestamp "2005-12-31T19:05:55+00:00"))
+(expect saturday-the-31st (->Timestamp "2005-12-31T19:05:55+00:00" utc))
 
 (expect nil (->iso-8601-datetime nil nil))
 (expect "2005-12-31T19:05:55.000Z" (->iso-8601-datetime saturday-the-31st nil))


### PR DESCRIPTION
Specifically this change fixes an issue where `->Timestamp` was
parsing a date string without the `report-timezone` and thus
interpretting the date string in the JVM's timezone instead of the
report timezone.

Although this fixes an important issue, there are several things I don't like about the solution. These conversions are somewhat nuanced and surprisingly complicated. It would be great if there was a way to encapsulate this nuance and make the correct decision automatic.

## Conversion from
Depending on what we're converting from we might or might not need an associated timezone. As an example, if we're converting from an integer/long we don't. Integer/long values are assumed to be in UTC. If we're converting from a `java.util.Date` the date will already be in the JVM's timezone, so no need to have a timezone there either. If we have a String we probably do need a timezone. JodaTime will parse the date as UTC unless the string includes the timezone. This difference makes the much simpler `->Timestamp` function signature more complicated. To facilitate this, I've made a 1-arity and 2-arity version of the function, with a `:pre` condition that will fail if trying to convert a String without a timezone. Not great, but does enforce the constraint.

## Where do I get the timezone
Unfortunately this is somewhat nuanced and we solve this in different ways in different areas of the app. The rules are, if we are parsing a datetime that is part of a query, the database we're querying against supports a `report-timezone` and the user has configured one, we should use that. That `report-timezone` could be coming from the query map (one of our middleware functions add it) or it might be coming from call to the settings table. Sometimes it's bound to a dynamic var, sometimes used directly. If we have no report timezone (or the database doesn't support it) we should use the JVM timezone. Typically this comes from the system property `user.timezone`. Finally the third way is some databases are always in UTC (i.e. BigQuery), for that we always just include the UTC timezone.

## Converting to
I'm not entirely sure that we should be using a Timestamp everywhere that we're using it. We aren't really using the features of the Timestamp (support for nanos) but rather we are basically leaning on the fact that Timestamp is a subclass of Date. I'm not aware of any specific problems that this is causing us, however the [docs say not to do that](https://docs.oracle.com/javase/7/docs/api/java/sql/Timestamp.html) :man_shrugging:.