### PR TITLE
fix up ProgressBar in flex context on the table metadata page

### DIFF
--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx
@@ -8,6 +8,8 @@ import { t } from "c-3po";
 import Input from "metabase/components/Input.jsx";
 import ProgressBar from "metabase/components/ProgressBar.jsx";
 
+import { normal } from "metabase/lib/colors";
+
 import _ from "underscore";
 import cx from "classnames";
 
@@ -120,7 +122,12 @@ export default class MetadataTable extends Component {
           {this.renderVisibilityWidget()}
           <span className="flex-align-right flex align-center">
             <span className="text-uppercase mr1">{t`Metadata Strength`}</span>
-            <ProgressBar percentage={tableMetadata.metadataStrength} />
+            <span style={{ width: 64 }}>
+              <ProgressBar
+                percentage={tableMetadata.metadataStrength}
+                color={normal.grey2}
+              />
+            </span>
           </span>
         </div>
         <div className={"mt2 " + (this.isHidden() ? "disabled" : "")}>


### PR DESCRIPTION
Missed one spot in the conversion over to the new progress bar. Needs an explicit width here since it's in a flex context since we're not hard-coding the progress bar size anymore in the component itself.

Fixes #7537 