### PR TITLE
xrays: keep rules in memory

### DIFF
--- a/docs/users-guide/14-x-rays.md
+++ b/docs/users-guide/14-x-rays.md
@@ -12,7 +12,13 @@ Click on one of these to see an x-ray.
 
 ![X-ray example](.images/x-rays/example.png)
 
-You can see more suggested x-rays over on the right-hand side of the screen. If you come across an x-ray that's particularly interesting, you can save it as a dashboard by clicking the green Save button.
+You can see more suggested x-rays over on the right-hand side of the screen. Browsing through x-rays like this is a pretty fun way of getting a quick overview of your data.
+
+### Saving x-rays
+
+If you're logged in as an Administrator and you come across an x-ray that's particularly interesting, you can save it as a dashboard by clicking the green Save button. Metabase will create a new dashboard for you and put all of its charts in a new collection. The new collection and dashboard will only be visible to other Administrators by default.
+
+To quickly make your new dashboard visible to other users, go to the collection with its charts, click the lock icon to edit the collection's permissions, and choose which groups should be allowed to view the charts in this collection. Note that this might allow users to see charts and data that they might not normally have access to. For more about how Metabase handles permissions, check out these posts about [collection permissions](../administration-guide/06-collections.md) and [data access permissions](../administration-guide/05-setting-permissions.md).
 
 ### Creating x-rays by clicking on charts or tables
 

--- a/project.clj
+++ b/project.clj
@@ -10,8 +10,7 @@
             "test" ["with-profile" "+expectations" "expectations"]
             "generate-sample-dataset" ["with-profile" "+generate-sample-dataset" "run"]
             "profile" ["with-profile" "+profile" "run" "profile"]
-            "h2" ["with-profile" "+h2-shell" "run" "-url" "jdbc:h2:./metabase.db" "-user" "" "-password" "" "-driver" "org.h2.Driver"]
-            "validate-automagic-dashboards" ["with-profile" "+validate-automagic-dashboards" "run"]}
+            "h2" ["with-profile" "+h2-shell" "run" "-url" "jdbc:h2:./metabase.db" "-user" "" "-password" "" "-driver" "org.h2.Driver"]}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/core.async "0.3.442"]
                  [org.clojure/core.match "0.3.0-alpha4"]              ; optimized pattern matching library for Clojure
@@ -195,5 +194,4 @@
              :profile {:jvm-opts ["-XX:+CITime"                       ; print time spent in JIT compiler
                                   "-XX:+PrintGC"]}                    ; print a message when garbage collection takes place
              ;; get the H2 shell with 'lein h2'
-             :h2-shell {:main org.h2.tools.Shell}
-             :validate-automagic-dashboards {:main metabase.automagic-dashboards.rules}})
+             :h2-shell {:main org.h2.tools.Shell}})

--- a/src/metabase/automagic_dashboards/rules.clj
+++ b/src/metabase/automagic_dashboards/rules.clj
@@ -329,20 +329,20 @@
        (let [~identifier (.getPath (FileSystems/getDefault) (.getPath ~path) (into-array String []))]
          ~@body))))
 
-(def ^:private rules
-  (with-resource [path (-> rules-dir io/resource .toURI)]
-    (into {} (load-rule-dir path))))
+(def ^:private rules (delay
+                      (with-resource [path (-> rules-dir io/resource .toURI)]
+                        (into {} (load-rule-dir path)))))
 
 (defn get-rules
-  "Get all rules with prefix `path`.
-   Path needs to match the entire prefix, so [\"table\"] will match table/TransactionTable.yaml,
-   but not table/TransactionTable/ByCountry.yaml"
-  [path]
-  (->> path
-       (get-in rules)
+  "Get all rules with prefix `prefix`.
+   prefix is greedy, so [\"table\"] will match table/TransactionTable.yaml, but not
+   table/TransactionTable/ByCountry.yaml"
+  [prefix]
+  (->> prefix
+       (get-in @rules)
        (keep (comp ::leaf val))))
 
 (defn get-rule
   "Get rule at path `path`."
   [path]
-  (get-in rules (concat path [::leaf])))
+  (get-in @rules (concat path [::leaf])))

--- a/src/metabase/automagic_dashboards/rules.clj
+++ b/src/metabase/automagic_dashboards/rules.clj
@@ -280,7 +280,7 @@
   (comp (partial re-find #".+(?=\.yaml)") str (memfn ^Path getFileName)))
 
 (defn- load-rule
-  [f]
+  [^Path f]
   (try
     (let [entity-type (file->entity-type f)]
       (-> f

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -50,7 +50,7 @@
   (->> (data/id :users)
        Table
        (#'magic/->root)
-       (#'magic/matching-rules (rules/load-rules "table"))
+       (#'magic/matching-rules (rules/get-rules ["table"]))
        (map (comp first :applies_to))))
 
 (defn- collect-urls

--- a/test/metabase/automagic_dashboards/rules_test.clj
+++ b/test/metabase/automagic_dashboards/rules_test.clj
@@ -14,9 +14,12 @@
 (expect "ga:foo"  (#'rules/->type "ga:foo"))
 (expect :type/Foo (#'rules/->type "Foo"))
 
-(expect (every? some? (load-rules "table")))
-(expect (every? some? (load-rules "metrics")))
-(expect (every? some? (load-rules "fields")))
+;; This also tests that all the rules are valid (else there would be nils returned)
+(expect (every? some? (get-rules ["table"])))
+(expect (every? some? (get-rules ["metrics"])))
+(expect (every? some? (get-rules ["fields"])))
+
+(expect (some? (get-rules ["table" "GenericTable" "ByCountry"]))
 
 (expect true  (dimension-form? [:dimension "Foo"]))
 (expect true  (dimension-form? ["dimension" "Foo"]))

--- a/test/metabase/automagic_dashboards/rules_test.clj
+++ b/test/metabase/automagic_dashboards/rules_test.clj
@@ -19,7 +19,7 @@
 (expect (every? some? (get-rules ["metrics"])))
 (expect (every? some? (get-rules ["fields"])))
 
-(expect (some? (get-rules ["table" "GenericTable" "ByCountry"]))
+(expect (some? (get-rules ["table" "GenericTable" "ByCountry"])))
 
 (expect true  (dimension-form? [:dimension "Foo"]))
 (expect true  (dimension-form? ["dimension" "Foo"]))


### PR DESCRIPTION
An actual fix to the problem identified in #7510.

I went with loading all the rules in memory (alternative: in app DB) because:
* the access patterns are such that we'd usually end up with the whole thing in memory anyway and just create a lot of trash. 
* feels less messy than to track changes to the heuristics and update the DB plus doing custom serialization of ordered maps.