### PR TITLE
xray: add fallback to GenericTable

### DIFF
--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -428,7 +428,7 @@
    Most specific is defined as entity type specification the longest ancestor
    chain."
   [rules {:keys [source entity]}]
-  (let [table-type (:entity_type source)]
+  (let [table-type (or (:entity_type source) :entity/GenericTable)]
     (->> rules
          (filter (fn [{:keys [applies_to]}]
                    (let [[entity-type field-type] applies_to]

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -768,9 +768,7 @@
    (let [rules (rules/load-rules "table")]
      (->> (apply db/select Table
                  (cond-> [:db_id           (u/get-id database)
-                          :visibility_type nil
-                          :entity_type     [:not= nil]] ; only consider tables that have alredy
-                                                        ; been analyzed
+                          :visibility_type nil]
                    schema (concat [:schema schema])))
           (filter mi/can-read?)
           (map enhanced-table-stats)

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -206,18 +206,6 @@
 
 
 (expect
-  [true true]
-  (tt/with-temp* [Table [{table-id :id}]]
-    (with-rasta
-      (with-dashboard-cleanup
-        (let [table               (Table table-id)
-              not-analyzed-result (automagic-analysis table {})
-              analyzed-result     (-> table
-                                      (assoc :entity_type :entity/GenericTable)
-                                      (automagic-analysis {}))]
-          [(nil? not-analyzed-result) (some? analyzed-result)])))))
-
-(expect
   (tt/with-temp* [Database [{db-id :id}]
                   Table    [{table-id :id} {:db_id db-id}]
                   Field    [{} {:table_id table-id}]

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -53,6 +53,17 @@
        (#'magic/matching-rules (rules/load-rules "table"))
        (map (comp first :applies_to))))
 
+;; Test fallback to GenericTable
+(expect
+  [:entity/GenericTable :entity/*]
+  (->> (-> (data/id :users)
+           Table
+           (assoc :entity_type nil)
+           (#'magic/->root))
+       (#'magic/matching-rules (rules/load-rules "table"))
+       (map (comp first :applies_to))))
+
+
 (defn- collect-urls
   [dashboard]
   (->> dashboard

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -206,22 +206,20 @@
 
 
 (expect
+  3
+  (with-rasta
+    (->> (Database (data/id)) candidate-tables first :tables count)))
+
+;; /candidates should work with unanalyzed tables
+(expect
+  1
   (tt/with-temp* [Database [{db-id :id}]
                   Table    [{table-id :id} {:db_id db-id}]
                   Field    [{} {:table_id table-id}]
                   Field    [{} {:table_id table-id}]]
     (with-rasta
       (with-dashboard-cleanup
-        (let [database           (Database db-id)
-              not-analyzed-count (count (candidate-tables database))]
-          (db/update! Table table-id :entity_type :entity/GenericTable)
-          (= (inc not-analyzed-count) (count (candidate-tables database))))))))
-
-
-(expect
-  3
-  (with-rasta
-    (->> (Database (data/id)) candidate-tables first :tables count)))
+        (count (candidate-tables (Database db-id)))))))
 
 
 ;; Identity


### PR DESCRIPTION
Somewhat alleviates the upgrade problem: if you update it might be you hit xrays before analysis has run with the new code, hence no table type inference. This changes the rule matching so that `:entity/GenericTable` is assumed if `:entity_type` is not set.

Also changes /candidates to return (using GenericTable fallback) as soon as we see some tables (ie. after sync is done with at least one table).