### PR TITLE
Don't overwrite PKs and FKs when infering special_type

### DIFF
--- a/src/metabase/sync/analyze/classifiers/name.clj
+++ b/src/metabase/sync/analyze/classifiers/name.clj
@@ -117,11 +117,14 @@
 (s/defn infer-special-type :- (s/maybe i/FieldInstance)
   "Classifer that infers the special type of a FIELD based on its name and base type."
   [field :- i/FieldInstance, _ :- (s/maybe i/Fingerprint)]
-  (when-let [inferred-special-type (special-type-for-name-and-base-type (:name field) (:base_type field))]
-    (log/debug (format "Based on the name of %s, we're giving it a special type of %s."
-                       (sync-util/name-for-logging field)
-                       inferred-special-type))
-    (assoc field :special_type inferred-special-type)))
+  ;; Don't overwrite keys, else we're ok with overwriting as a new more precise type might have
+  ;; been added.
+  (when (not-any? (partial isa? (:special_type field)) [:type/PK :type/FK])
+    (when-let [inferred-special-type (special-type-for-name-and-base-type (:name field) (:base_type field))]
+      (log/debug (format "Based on the name of %s, we're giving it a special type of %s."
+                         (sync-util/name-for-logging field)
+                         inferred-special-type))
+      (assoc field :special_type inferred-special-type))))
 
 (defn- prefix-or-postfix
   [s]

--- a/test/metabase/sync/analyze/classifiers/name_test.clj
+++ b/test/metabase/sync/analyze/classifiers/name_test.clj
@@ -29,7 +29,7 @@
   (-> {:name "foo"} table/map->TableInstance infer-entity-type :entity_type))
 
 
-;; Don't overwrite PK/FK `specail_type`s.
+;; Don't overwrite PK/FK `special_type`s.
 (expect
   nil
   (tt/with-temp* [Table [{table-id :id}]

--- a/test/metabase/sync/analyze/classifiers/name_test.clj
+++ b/test/metabase/sync/analyze/classifiers/name_test.clj
@@ -1,7 +1,12 @@
 (ns metabase.sync.analyze.classifiers.name-test
   (:require [expectations :refer :all]
-            [metabase.models.table :as table]
-            [metabase.sync.analyze.classifiers.name :refer :all]))
+            [metabase.models
+             [field :refer [Field]]
+             [table :as table :refer [Table]]]
+            [metabase.sync.analyze.classifiers.name :refer :all]
+            [metabase.test.data :as data]
+            [metabase.util :as u]
+            [toucan.util.test :as tt]))
 
 ;; Postfix + pluralization
 (expect
@@ -22,3 +27,24 @@
 (expect
   :entity/GenericTable
   (-> {:name "foo"} table/map->TableInstance infer-entity-type :entity_type))
+
+
+;; Don't overwrite PK/FK `specail_type`s.
+(expect
+  nil
+  (tt/with-temp* [Table [{table-id :id}]
+                  Field [{field-id :id} {:table_id     table-id
+                                         :special_type :type/FK
+                                         :name         "City"
+                                         :base_type    :type/Text}]]
+    (-> field-id Field (infer-special-type nil) :special_type)))
+
+;; ... but overwrite other types to alow evolution of our type system
+(expect
+  :type/City
+  (tt/with-temp* [Table [{table-id :id}]
+                  Field [{field-id :id} {:table_id     table-id
+                                         :special_type :type/Category
+                                         :name         "City"
+                                         :base_type    :type/Text}]]
+    (-> field-id Field (infer-special-type nil) :special_type)))


### PR DESCRIPTION
Not the ideal solution. A more long term fix would be to track whether a field is a key in a separate   dimension (maybe something like "traits" and include has_field_values and such there as well). 

Fixes #7618.