### PR TITLE
add new custom-stylesheet setting for public sharing

### DIFF
--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -313,6 +313,12 @@ const SECTIONS = [
         type: "boolean",
       },
       {
+        key: "custom-stylesheet",
+        display_name: t`Custom CSS URL`,
+        type: "string",
+        getHidden: settings => !settings["enable-public-sharing"],
+      },
+      {
         key: "-public-sharing-dashboards",
         display_name: t`Shared Dashboards`,
         widget: PublicLinksDashboardListing,

--- a/src/metabase/middleware.clj
+++ b/src/metabase/middleware.clj
@@ -181,8 +181,9 @@
   the original request was HTTPS; if sent in response to an HTTP request, this is simply ignored)"
   {"Strict-Transport-Security" "max-age=31536000"})
 
-(def ^:private ^:const content-security-policy-header
+(defn- content-security-policy-header
   "`Content-Security-Policy` header. See https://content-security-policy.com for more details."
+  []
   {"Content-Security-Policy"
    (apply str (for [[k vs] {:default-src ["'none'"]
                             :script-src  ["'unsafe-inline'"
@@ -200,6 +201,11 @@
                                           "https://accounts.google.com"]
                             :style-src   ["'unsafe-inline'"
                                           "'self'"
+                                          ;; STATE: test this
+                                          (when-let
+                                              [^java.net.URL url (u/ignore-exceptions
+                                                                  (java.net.URL. (public-settings/custom-stylesheet)))]
+                                            (.getHost url))
                                           "fonts.googleapis.com"]
                             :font-src    ["'self'"
                                           "fonts.gstatic.com"
@@ -233,7 +239,7 @@
   (merge
    (cache-prevention-headers)
    strict-transport-security-header
-   content-security-policy-header
+   (content-security-policy-header)
    #_(public-key-pins-header)
    (when-not allow-iframes?
      ;; Tell browsers not to render our site as an iframe (prevent clickjacking)

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -76,6 +76,10 @@
   :type    :boolean
   :default false)
 
+(defsetting custom-stylesheet
+  (tru "If provided, Metabase will include a <link> to this stylesheet in embedded dashboards and questions.")
+  :default "")
+
 (defsetting enable-embedding
   (tru "Allow admins to securely embed questions and dashboards within other applications?")
   :type    :boolean
@@ -171,6 +175,7 @@
    :password_complexity   password/active-password-complexity
    :premium_token         (metastore/premium-embedding-token)
    :public_sharing        (enable-public-sharing)
+   :custom_stylesheet     (custom-stylesheet)
    :report_timezone       (setting/get :report-timezone)
    :setup_token           ((resolve 'metabase.setup/token-value))
    :site_name             (site-name)

--- a/src/metabase/routes.clj
+++ b/src/metabase/routes.clj
@@ -60,6 +60,7 @@
                         :localization_json (escape-script (load-localization))
                         :uri               (escape-script (json/generate-string uri))
                         :base_href         (escape-script (json/generate-string (base-href)))
+                        :custom_stylesheet (escape-script (json/generate-string (public-settings/custom-stylesheet)))
                         :embed_code        (when embeddable? (embed/head uri))})
         (load-file-at-path "frontend_client/init.html"))
       resp/response

--- a/src/metabase/util/embed.clj
+++ b/src/metabase/util/embed.clj
@@ -37,10 +37,18 @@
   "A `<meta>` tag for `Embed.ly` support."
   (html [:meta {:name "generator", :content "Metabase"}]))
 
+(defn- custom-stylesheet-link
+  "Returns a `<link>` tag for the custom stylesheet, if any."
+  ^String []
+  (when-not (str/blank? (setting/get :custom-stylesheet))
+    (html [:link {:rel   "stylesheet"
+                  :type  "text/css"
+                  :href  (public-settings/custom-stylesheet)}])))
+
 (defn head
   "Returns the `<meta>`/`<link>` tags for an embeddable public page."
   ^String [^String url]
-  (str embedly-meta (oembed-link url)))
+  (str embedly-meta (oembed-link url) (custom-stylesheet-link)))
 
 (defn iframe
   "Return an `<iframe>` HTML fragment to embed a public page."


### PR DESCRIPTION
happy monday all! here's a [#YOLO JUST SUBMIT A PR](https://github.com/metabase/metabase/blob/master/docs/contributing.md#yolo-just-submit-a-pr). i'm starting to play with this internally. totally understand if you all don't want to merge, but i figured i'd let you know.

this optionally adds a user-defined CSS `<link>` to publicly shared dashboards and questions.

i originally added a `Access-Control-Allow-Origin: *` HTTP response header and tried to style into the iframe from JS in the outer HTML, but that didn't work. idk, i'm not a web developer, i just play one on TV.

related to:
https://discourse.metabase.com/t/is-it-possible-to-inject-a-custom-css-to-change-metabases-ui/1702
https://discourse.metabase.com/t/idiots-guide-to-modifying-visualisations/2771
https://discourse.metabase.com/t/ui-customization-in-dashboards/3278


-  [x] If there are changes to the backend codebase, run the backend tests with `lein test && lein eastwood && lein bikeshed && lein docstring-checker && ./bin/reflection-linter`
-  [ ] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).