### PR TITLE
Don't derive Date and Time from DateTime [WIP]

### DIFF
--- a/frontend/src/metabase/lib/core.js
+++ b/frontend/src/metabase/lib/core.js
@@ -126,6 +126,16 @@ export const field_special_types = [
     section: t`Common`,
   },
   {
+    id: TYPE.CreationDate,
+    name: t`Creation date`,
+    section: t`Common`,
+  },
+  {
+    id: TYPE.CreationTime,
+    name: t`Creation time`,
+    section: t`Common`,
+  },
+  {
     id: TYPE.Product,
     name: t`Product`,
     section: t`Common`,
@@ -148,6 +158,16 @@ export const field_special_types = [
   {
     id: TYPE.JoinTimestamp,
     name: t`Join timestamp`,
+    section: t`Common`,
+  },
+  {
+    id: TYPE.JoinDate,
+    name: t`Join date`,
+    section: t`Common`,
+  },
+  {
+    id: TYPE.JoinTime,
+    name: t`Join time`,
     section: t`Common`,
   },
   {

--- a/resources/automagic_dashboards/table/GenericTable.yaml
+++ b/resources/automagic_dashboards/table/GenericTable.yaml
@@ -35,13 +35,31 @@ dimensions:
       field_type: GenericTable.Category
       max_cardinality: 1
       score: 100
+  - Date:
+      field_type: GenericTable.Date
+      score: 50
+  - Time:
+      field_type: GenericTable.Time
+      score: 50
   - Timestamp:
       field_type: DateTime
       score: 60
   - JoinDate:
-      field_type: GenericTable.JoinTimestamp
+      field_type: GenericTable.JoinDate
       score: 50
   - CreateDate:
+      field_type: CreationDate
+      score: 80
+  - JoinTime:
+      field_type: GenericTable.JoinTime
+      score: 50
+  - CreateTime:
+      field_type: CreationTime
+      score: 80
+  - JoinTimestamp:
+      field_type: GenericTable.JoinTimestamp
+      score: 50
+  - CreateTimestamp:
       field_type: CreationTimestamp
       score: 80
   - FK: FK
@@ -52,14 +70,23 @@ dimensions:
   - ZIP: ZipCode
 filters:
   - Last30Days:
-      filter: ["time-interval", [dimension, CreateDate], -30, day]
+      filter: ["time-interval", [dimension, CreateTimestamp], -30, day]
       score: 100
   - Last30Days:
-      filter: ["time-interval", [dimension, JoinDate], -30, day]
+      filter: ["time-interval", [dimension, CreateDate], -30, day]
+      score: 99
+  - Last30Days:
+      filter: ["time-interval", [dimension, JoinTimestamp], -30, day]
       score: 90
+  - Last30Days:
+      filter: ["time-interval", [dimension, JoinDate], -30, day]
+      score: 89
   - Last30Days:
       filter: ["time-interval", [dimension, Timestamp], -30, day]
       score: 80
+  - Last30Days:
+      filter: ["time-interval", [dimension, Date], -30, day]
+      score: 79
 groups:
 - Overview:
     title: Summary
@@ -73,8 +100,11 @@ groups:
     title: How [[this]] are distributed
 dashboard_filters:
 - Timestamp
+- Date
 - JoinDate
+- JoinTimestamp
 - CreateDate
+- CreateTimestamp
 - GenericCategoryMedium
 - Source
 - Country
@@ -167,7 +197,21 @@ cards:
   - CountByJoinDate:
       title: "[[this]] that have joined over time"
       visualization: line
+      dimensions: JoinTimestamp
+      metrics: Count
+      score: 90
+      group: ByTime
+  - CountByJoinDate:
+      title: "[[this]] that have joined over time"
+      visualization: line
       dimensions: JoinDate
+      metrics: Count
+      score: 90
+      group: ByTime
+  - CountByCreateDate:
+      title: New [[this]] over time
+      visualization: line
+      dimensions: CreateTimestamp
       metrics: Count
       score: 90
       group: ByTime
@@ -185,6 +229,13 @@ cards:
       metrics: Count
       score: 20
       group: ByTime
+  - CountByTimestamp:
+      title: "[[this]] by [[Timestamp]]"
+      visualization: line
+      dimensions: Date
+      metrics: Count
+      score: 20
+      group: ByTime
   - NumberOverTime:
       title: "[[GenericNumber]] over time"
       visualization: line
@@ -194,6 +245,24 @@ cards:
         - Avg
       score: 70
       group: ByTime
+  - NumberOverTime:
+      title: "[[GenericNumber]] over time"
+      visualization: line
+      dimensions: Date
+      metrics:
+        - Sum
+        - Avg
+      score: 70
+      group: ByTime
+  - NumberOverJoinDate:
+      title: "[[GenericNumber]] by join date"
+      visualization: line
+      dimensions: JoinTimestamp
+      metrics:
+        - Sum
+        - Avg
+      score: 80
+      group: ByTime
   - NumberOverJoinDate:
       title: "[[GenericNumber]] by join date"
       visualization: line
@@ -202,6 +271,15 @@ cards:
         - Sum
         - Avg
       score: 80
+      group: ByTime
+  - NumberOverCreateDate:
+      title: "[[GenericNumber]] over time"
+      visualization: line
+      dimensions: CreateTimestamp
+      metrics:
+        - Sum
+        - Avg
+      score: 90
       group: ByTime
   - NumberOverCreateDate:
       title: "[[GenericNumber]] over time"
@@ -222,11 +300,31 @@ cards:
       score: 60
       group: ByTime
       x_label: "[[Timestamp]]"
+  - DayOfWeekTimestamp:
+      title: "[[Timestamp]] by day of the week"
+      visualization: bar
+      dimensions:
+        - Date:
+            aggregation: day-of-week
+      metrics: Count
+      score: 60
+      group: ByTime
+      x_label: "[[Timestamp]]"
   - HourOfDayTimestamp:
       title: "[[Timestamp]] by hour of the day"
       visualization: bar
       dimensions:
       - Timestamp:
+          aggregation: hour-of-day
+      metrics: Count
+      score: 50
+      group: ByTime
+      x_label: "[[Timestamp]]"
+  - HourOfDayTimestamp:
+      title: "[[Timestamp]] by hour of the day"
+      visualization: bar
+      dimensions:
+      - Time:
           aggregation: hour-of-day
       metrics: Count
       score: 50
@@ -242,6 +340,16 @@ cards:
       score: 40
       group: ByTime
       x_label: "[[Timestamp]]"
+  - MonthOfYearTimestamp:
+      title: "[[Timestamp]] by month of the year"
+      visualization: bar
+      dimensions:
+        - Date:
+            aggregation: month-of-year
+      metrics: Count
+      score: 40
+      group: ByTime
+      x_label: "[[Timestamp]]"
   - QuarterOfYearTimestamp:
       title: "[[Timestamp]] by quarter of the year"
       visualization: bar
@@ -252,6 +360,26 @@ cards:
       score: 40
       group: ByTime
       x_label: "[[Timestamp]]"
+  - QuarterOfYearTimestamp:
+      title: "[[Timestamp]] by quarter of the year"
+      visualization: bar
+      dimensions:
+        - Date:
+            aggregation: quarter-of-year
+      metrics: Count
+      score: 40
+      group: ByTime
+      x_label: "[[Timestamp]]"
+  - DayOfWeekCreateDate:
+      title: Weekdays when new [[this]] were added
+      visualization: bar
+      dimensions:
+        - CreateTimestamp:
+            aggregation: day-of-week
+      metrics: Count
+      score: 60
+      group: ByTime
+      x_label: Created At by day of the week
   - DayOfWeekCreateDate:
       title: Weekdays when new [[this]] were added
       visualization: bar
@@ -266,12 +394,32 @@ cards:
       title: Hours when new [[this]] were added
       visualization: bar
       dimensions:
-      - CreateDate:
+      - CreateTimestamp:
           aggregation: hour-of-day
       metrics: Count
       score: 50
       group: ByTime
       x_label: Created At by hour of the day
+  - HourOfDayCreateDate:
+      title: Hours when new [[this]] were added
+      visualization: bar
+      dimensions:
+      - CreateTime:
+          aggregation: hour-of-day
+      metrics: Count
+      score: 50
+      group: ByTime
+      x_label: Created At by hour of the day
+  - DayOfMonthCreateDate:
+      title: Days when new [[this]] were added
+      visualization: bar
+      dimensions:
+        - CreateTimestamp:
+            aggregation: day-of-month
+      metrics: Count
+      score: 40
+      group: ByTime
+      x_label: Created At by day of the month
   - DayOfMonthCreateDate:
       title: Days when new [[this]] were added
       visualization: bar
@@ -286,12 +434,32 @@ cards:
       title: Months when new [[this]] were added
       visualization: bar
       dimensions:
+        - CreateTimestamp:
+            aggregation: month-of-year
+      metrics: Count
+      score: 40
+      group: ByTime
+      x_label: Created At by month of the year
+  - MonthOfYearCreateDate:
+      title: Months when new [[this]] were added
+      visualization: bar
+      dimensions:
         - CreateDate:
             aggregation: month-of-year
       metrics: Count
       score: 40
       group: ByTime
       x_label: Created At by month of the year
+  - QuerterOfYearCreateDate:
+      title: Quarters when new [[this]] were added
+      visualization: bar
+      dimensions:
+        - CreateTimestamp:
+            aggregation: quarter-of-year
+      metrics: Count
+      score: 40
+      group: ByTime
+      x_label: Created At by quarter of the year
   - QuerterOfYearCreateDate:
       title: Quarters when new [[this]] were added
       visualization: bar
@@ -306,6 +474,16 @@ cards:
       title: Weekdays when [[this]] joined
       visualization: bar
       dimensions:
+        - JoinTimestamp:
+            aggregation: day-of-week
+      metrics: Count
+      score: 60
+      group: ByTime
+      x_label: Join date by day of the week
+  - DayOfWeekJoinDate:
+      title: Weekdays when [[this]] joined
+      visualization: bar
+      dimensions:
         - JoinDate:
             aggregation: day-of-week
       metrics: Count
@@ -316,12 +494,32 @@ cards:
       title: Hours when [[this]] joined
       visualization: bar
       dimensions:
-      - JoinDate:
+      - JoinTimestamp:
           aggregation: hour-of-day
       metrics: Count
       score: 50
       group: ByTime
       x_label: Join date by hour of the day
+  - HourOfDayJoinDate:
+      title: Hours when [[this]] joined
+      visualization: bar
+      dimensions:
+      - JoinTime:
+          aggregation: hour-of-day
+      metrics: Count
+      score: 50
+      group: ByTime
+      x_label: Join date by hour of the day
+  - DayOfMonthJoinDate:
+      title: Days of the month when [[this]] joined
+      visualization: bar
+      dimensions:
+        - JoinTimestamp:
+            aggregation: day-of-month
+      metrics: Count
+      score: 40
+      group: ByTime
+      x_label: Join date by day of the month
   - DayOfMonthJoinDate:
       title: Days of the month when [[this]] joined
       visualization: bar
@@ -336,12 +534,32 @@ cards:
       title: Months when [[this]] joined
       visualization: bar
       dimensions:
+        - JoinTimestamp:
+            aggregation: month-of-year
+      metrics: Count
+      score: 40
+      group: ByTime
+      x_label: Join date by month of the year
+  - MonthOfYearJoinDate:
+      title: Months when [[this]] joined
+      visualization: bar
+      dimensions:
         - JoinDate:
             aggregation: month-of-year
       metrics: Count
       score: 40
       group: ByTime
       x_label: Join date by month of the year
+  - QuerterOfYearJoinDate:
+      title: Quarters when [[this]] joined
+      visualization: bar
+      dimensions:
+        - JoinTimestamp:
+            aggregation: quarter-of-year
+      metrics: Count
+      score: 40
+      group: ByTime
+      x_label: Join date by quarter of the year
   - QuerterOfYearJoinDate:
       title: Quarters when [[this]] joined
       visualization: bar

--- a/resources/automagic_dashboards/table/TransactionTable.yaml
+++ b/resources/automagic_dashboards/table/TransactionTable.yaml
@@ -20,8 +20,16 @@ metrics:
 dimensions:
 - Timestamp:
     field_type: CreationTimestamp
+    score: 100
+- Timestamp:
+    field_type: CreationDate
+    score: 100
 - Timestamp:
     field_type: DateTime
+    score: 90
+- Timestamp:
+    field_type: Date
+    score: 90
 - State:
     field_type: GenericTable.State
 - Country: GenericTable.Country

--- a/resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
+++ b/resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
@@ -13,8 +13,16 @@ metrics:
 dimensions:
 - Timestamp:
     field_type: CreationTimestamp
+    score: 100
+- Timestamp:
+    field_type: CreationDate
+    score: 100
 - Timestamp:
     field_type: DateTime
+    score: 90
+- Timestamp:
+    field_type: Date
+    score: 90
 - Country:
     field_type: UserTable.Country
 - Income: Income

--- a/resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
+++ b/resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
@@ -15,8 +15,16 @@ dimensions:
 - State: GenericTable.State
 - Timestamp:
     field_type: CreationTimestamp
+    score: 100
+- Timestamp:
+    field_type: CreationDate
+    score: 100
 - Timestamp:
     field_type: DateTime
+    score: 90
+- Timestamp:
+    field_type: Date
+    score: 90
 - Source:
     field_type: UserTable.Source
     max_cardinality: 10

--- a/resources/automagic_dashboards/table/TransactionTable/BySource.yaml
+++ b/resources/automagic_dashboards/table/TransactionTable/BySource.yaml
@@ -13,8 +13,16 @@ metrics:
 dimensions:
 - Timestamp:
     field_type: CreationTimestamp
+    score: 100
+- Timestamp:
+    field_type: CreationDate
+    score: 100
 - Timestamp:
     field_type: DateTime
+    score: 90
+- Timestamp:
+    field_type: Date
+    score: 90
 - SourceMedium:
     field_type: UserTable.Source
     max_cardinality: 10

--- a/resources/automagic_dashboards/table/TransactionTable/ByState.yaml
+++ b/resources/automagic_dashboards/table/TransactionTable/ByState.yaml
@@ -13,8 +13,16 @@ metrics:
 dimensions:
 - Timestamp:
     field_type: CreationTimestamp
+    score: 100
+- Timestamp:
+    field_type: CreationDate
+    score: 100
 - Timestamp:
     field_type: DateTime
+    score: 90
+- Timestamp:
+    field_type: Date
+    score: 90
 - State:
     field_type: UserTable.State
 - Income: Income

--- a/resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
+++ b/resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
@@ -9,6 +9,14 @@ dimensions:
     field_type: CreationTimestamp
 - Timestamp:
     field_type: DateTime
+- Datetime:
+    field_type: CreationDate
+- Date:
+    field_type: Date
+- Time:
+    field_type: CreationTime
+- Time:
+    field_type: DateTime
 - Country: GenericTable.Country
 - State: GenericTable.State
 - Source:
@@ -20,6 +28,7 @@ dimensions:
 dashboard_filters:
 - Source
 - Timestamp
+- Date
 - State
 - Country
 - ProductCategory
@@ -32,6 +41,14 @@ cards:
       score: 100
       width: 18
       height: 6
+  - CountByTimestamp:
+      title: Transactions over time
+      visualization: line
+      dimensions: Date
+      metrics: Count
+      score: 90
+      width: 18
+      height: 6
   - DayOfWeekTimestamp:
       title: Transactions per day of the week
       visualization: bar
@@ -40,6 +57,17 @@ cards:
             aggregation: day-of-week
       metrics: Count
       score: 60
+      width: 9
+      height: 6
+      x_label: "[[Timestamp]] by day of week"
+  - DayOfWeekTimestamp:
+      title: Transactions per day of the week
+      visualization: bar
+      dimensions:
+        - Date:
+            aggregation: day-of-week
+      metrics: Count
+      score: 50
       width: 9
       height: 6
       x_label: "[[Timestamp]] by day of week"
@@ -54,6 +82,17 @@ cards:
       width: 9
       height: 6
       x_label: "[[Timestamp]] by hour of day"
+  - HourOfDayTimestamp:
+      title: Transactions per hour of the day
+      visualization: bar
+      dimensions:
+      - Time:
+          aggregation: hour-of-day
+      metrics: Count
+      score: 40
+      width: 9
+      height: 6
+      x_label: "[[Timestamp]] by hour of day"
   - MonthOfYearTimestamp:
       title: Transactions per month of the year
       visualization: bar
@@ -65,6 +104,17 @@ cards:
       width: 9
       height: 6
       x_label: "[[Timestamp]] by month of year"
+  - MonthOfYearTimestamp:
+      title: Transactions per month of the year
+      visualization: bar
+      dimensions:
+        - Date:
+            aggregation: month-of-year
+      metrics: Count
+      score: 30
+      width: 9
+      height: 6
+      x_label: "[[Timestamp]] by month of year"
   - QuarterOfYearTimestamp:
       title: Transactions per quarter of the year
       visualization: bar
@@ -73,6 +123,17 @@ cards:
             aggregation: quarter-of-year
       metrics: Count
       score: 40
+      width: 9
+      height: 6
+      x_label: "[[Timestamp]] by quarter of year"
+  - QuarterOfYearTimestamp:
+      title: Transactions per quarter of the year
+      visualization: bar
+      dimensions:
+        - Date:
+            aggregation: quarter-of-year
+      metrics: Count
+      score: 30
       width: 9
       height: 6
       x_label: "[[Timestamp]] by quarter of year"

--- a/resources/automagic_dashboards/table/UserTable.yaml
+++ b/resources/automagic_dashboards/table/UserTable.yaml
@@ -9,10 +9,19 @@ dimensions:
     field_type: JoinTimestamp
     score: 100
 - JoinDate:
+    field_type: JoinDate
+    score: 100
+- JoinDate:
     field_type: CreationTimestamp
     score: 90
 - JoinDate:
+    field_type: CreationDate
+    score: 90
+- JoinDate:
     field_type: DateTime
+    score: 30
+- JoinDate:
+    field_type: Date
     score: 30
 - Source:
     field_type: Source

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -87,7 +87,9 @@
   "Given `column-metadata` find the `:type/Date` columns"
   [column-metadata]
   (transduce (comp (map-indexed (fn [idx col-map] [idx (:base_type col-map)]))
-                   (filter (fn [[idx base-type]] (isa? base-type :type/Date)))
+                   (filter (fn [[idx base-type]]
+                             (and (isa? base-type :type/Date)
+                                  (not (isa? base-type :type/DateTime)))))
                    (map first))
              conj [] column-metadata))
 

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -87,7 +87,7 @@
              (map (fn [[name param]]
                     {:name name
                      :mbql ["datetime-field" nil param]
-                     :type "type/DateTime"})
+                     :type "type/Date"})
                   ;; note the order of these options corresponds to the order they will be shown to the user in the UI
                   [[(tru "Minute") "minute"]
                    [(tru "Hour") "hour"]
@@ -141,8 +141,8 @@
        sort
        (map str)))
 
-(def ^:private datetime-dimension-indexes
-  (create-dim-index-seq "type/DateTime"))
+(def ^:private date-dimension-indexes
+  (create-dim-index-seq "type/Date"))
 
 (def ^:private numeric-dimension-indexes
   (create-dim-index-seq "type/Number"))
@@ -156,7 +156,7 @@
                               (pred v))) dimension-options-for-response)))
 
 (def ^:private date-default-index
-  (dimension-index-for-type "type/DateTime" #(= day-str (:name %))))
+  (dimension-index-for-type "type/Date" #(= day-str (:name %))))
 
 (def ^:private numeric-default-index
   (dimension-index-for-type "type/Number" #(.contains ^String (:name %) auto-bin-str)))
@@ -168,18 +168,17 @@
   (and driver (contains? (driver/features driver) :binning)))
 
 (defn- supports-date-binning?
-  "Time fields don't support binning, returns true if it's a DateTime field and not a time field"
+  "Time fields don't support binning, returns true if it's a Date (or DateTime) field."
   [{:keys [base_type special_type]}]
-  (and (or (isa? base_type :type/DateTime)
-           (isa? special_type :type/DateTime))
-       (not (isa? base_type :type/Time))))
+  (or (isa? base_type :type/Date)
+      (isa? special_type :type/Date)))
 
 (defn- assoc-field-dimension-options [driver {:keys [base_type special_type fingerprint] :as field}]
   (let [{min_value :min, max_value :max} (get-in fingerprint [:type :type/Number])
         [default-option all-options] (cond
 
                                        (supports-date-binning? field)
-                                       [date-default-index datetime-dimension-indexes]
+                                       [date-default-index date-dimension-indexes]
 
                                        (and min_value max_value
                                             (isa? special_type :type/Coordinate)

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -91,7 +91,7 @@
   ->reference (fn [template-type model]
                 [template-type (type model)]))
 
-(defn- optimal-datetime-resolution
+(defn- optimal-date-resolution
   [field]
   (if-let [[earliest latest] (some->> field
                                       :fingerprint
@@ -115,9 +115,9 @@
                     id                 [:field-id id]
                     :else              [:field-literal name base_type])]
     (cond
-      (isa? base_type :type/DateTime)
+      (isa? base_type :type/Date)
       [:datetime-field reference (or aggregation
-                                     (optimal-datetime-resolution field))]
+                                     (optimal-date-resolution field))]
 
       (and aggregation
            ; We don't handle binning on non-analyzed fields gracefully

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -47,7 +47,8 @@
          (contains? field :base_type)
          (contains? field :has_field_values)]}
   (and (not (contains? #{:retired :sensitive :hidden :details-only} (keyword visibility-type)))
-       (not (isa? (keyword base-type) :type/DateTime))
+       (not (isa? (keyword base-type) :type/Date))
+       (not (isa? (keyword base-type) :type/Time))
        (= has-field-values "list")))
 
 

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -137,10 +137,10 @@
    (or (ui-logic/y-axis-rowfn card data)
        second)])
 
-(defn- datetime-field?
+(defn- date-field?
   [field]
-  (or (isa? (:base_type field)    :type/DateTime)
-      (isa? (:special_type field) :type/DateTime)))
+  (or (isa? (:base_type field)    :type/Date)
+      (isa? (:special_type field) :type/Date)))
 
 (defn- number-field?
   [field]
@@ -165,7 +165,7 @@
            (= row-count 1))                                        :scalar
       (and (= col-count 2)
            (> row-count 1)
-           (datetime-field? col-1)
+           (date-field? col-1)
            (number-field? col-2))                                  :sparkline
       (and (= col-count 2)
            (number-field? col-2))                                  :bar
@@ -278,8 +278,8 @@
 (defn- format-cell
   [timezone value col]
   (cond
-    (datetime-field? col) (format-timestamp timezone value col)
-    (and (number? value) (not (datetime-field? col))) (format-number value)
+    (date-field? col) (format-timestamp timezone value col)
+    (and (number? value) (not (date-field? col))) (format-number value)
     :else (str value)))
 
 (defn- render-img-data-uri
@@ -648,7 +648,7 @@
 (s/defn ^:private render:sparkline :- RenderedPulseCard
   [render-type timezone card {:keys [rows cols] :as data}]
   (let [[x-axis-rowfn y-axis-rowfn] (graphing-columns card data)
-        ft-row (if (datetime-field? (x-axis-rowfn cols))
+        ft-row (if (date-field? (x-axis-rowfn cols))
                  #(.getTime ^Date (u/->Timestamp %))
                  identity)
         rows   (if (> (ft-row (x-axis-rowfn (first rows)))

--- a/src/metabase/query_processor/middleware/expand.clj
+++ b/src/metabase/query_processor/middleware/expand.clj
@@ -111,7 +111,8 @@
     (instance? DateTimeValue v)         v
     (instance? RelativeDatetime v)      (i/map->RelativeDateTimeValue (assoc v :unit (datetime-unit f v), :field (datetime-field f (datetime-unit f v))))
     (instance? DateTimeField f)         (i/map->DateTimeValue {:value (u/->Timestamp v), :field f})
-    (instance? FieldLiteral f)          (if (isa? (:base-type f) :type/DateTime)
+    (instance? FieldLiteral f)          (if (clojure.core/or (isa? (:base-type f) :type/Date)
+                                                             (isa? (:base-type f) :type/Time))
                                           (i/map->DateTimeValue {:value (u/->Timestamp v)
                                                                  :field (i/map->DateTimeField {:field f :unit :default})})
                                           (i/map->Value {:value v, :field f}))

--- a/src/metabase/query_processor/middleware/resolve.clj
+++ b/src/metabase/query_processor/middleware/resolve.clj
@@ -190,9 +190,8 @@
                                                                (merge-non-nils (select-keys this [:fk-field-id :remapped-from :remapped-to :field-display-name])))]
     ;; try to resolve the Field with the ones available in field-id->field
     (cond
-      (and (or (isa? base-type :type/DateTime)
-               (isa? special-type :type/DateTime))
-           (not (isa? base-type :type/Time)))
+      (and (or (isa? base-type :type/Date)
+               (isa? special-type :type/Date)))
       (i/map->DateTimeField {:field field
                              :unit  (or datetime-unit :day)}) ; default to `:day` if a unit wasn't specified
 

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -17,8 +17,10 @@
 (defn datetime-field?
   "Is FIELD a `DateTime` field?"
   [{:keys [base-type special-type]}]
-  (or (isa? base-type :type/DateTime)
-      (isa? special-type :type/DateTime)))
+  (or (isa? base-type :type/Date)
+      (isa? base-type :type/Time)
+      (isa? special-type :type/Date)
+      (isa? special-type :type/Time)))
 
 (defn query-without-aggregations-or-limits?
   "Is the given query an MBQL query without a `:limit`, `:aggregation`, or `:page` clause?"

--- a/src/metabase/sync/analyze/classifiers/category.clj
+++ b/src/metabase/sync/analyze/classifiers/category.clj
@@ -21,7 +21,8 @@
 
 (s/defn ^:private cannot-be-category-or-list? :- s/Bool
   [base-type :- su/FieldType, special-type :- (s/maybe su/FieldType)]
-  (or (isa? base-type    :type/DateTime)
+  (or (isa? base-type    :type/Date)
+      (isa? base-type    :type/Time)
       (isa? base-type    :type/Collection)
       ;; Don't let IDs become list Fields (they already can't become categories, because they already have a special
       ;; type). It just doesn't make sense to cache a sequence of numbers since they aren't inherently meaningful

--- a/src/metabase/sync/analyze/classifiers/name.clj
+++ b/src/metabase/sync/analyze/classifiers/name.clj
@@ -20,7 +20,9 @@
 (def ^:private int-type         #{:type/Integer})
 (def ^:private int-or-text-type #{:type/Integer :type/Text})
 (def ^:private text-type        #{:type/Text})
-(def ^:private timestamp-type   #{:type/DateTime})
+(def ^:private datetime-type    #{:type/DateTime})
+(def ^:private time-type        #{:type/Time})
+(def ^:private date-type        #{:type/Date})
 (def ^:private number-type      #{:type/Number})
 
 
@@ -70,8 +72,12 @@
    [#"count$"                      int-type         :type/Quantity]
    [#"number"                      int-type         :type/Quantity]
    [#"^num_"                       int-type         :type/Quantity]
-   [#"join"                        timestamp-type   :type/JoinTimestamp]
-   [#"create"                      timestamp-type   :type/CreationTimestamp]
+   [#"join"                        datetime-type    :type/JoinTimestamp]
+   [#"join"                        date-type        :type/JoinDate]
+   [#"join"                        time-type        :type/JoinTime]
+   [#"create"                      datetime-type    :type/CreationTimestamp]
+   [#"create"                      date-type        :type/CreationDate]
+   [#"create"                      time-type        :type/CreationTime]
    [#"source"                      int-or-text-type :type/Source]
    [#"channel"                     int-or-text-type :type/Source]
    [#"share"                       float-type       :type/Share]
@@ -93,8 +99,8 @@
    [#"description"                 text-type        :type/Description]
    [#"title"                       text-type        :type/Title]
    [#"comment"                     text-type        :type/Comment]
-   [#"birthda(?:te|y)"             timestamp-type   :type/Birthdate]
-   [#"(?:te|y)(?:_?)or(?:_?)birth" timestamp-type   :type/Birthdate]])
+   [#"birthda(?:te|y)"             date-type        :type/Birthdate]
+   [#"(?:te|y)(?:_?)or(?:_?)birth" date-type        :type/Birthdate]])
 
 ;; Check that all the pattern tuples are valid
 (when-not config/is-prod?

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -25,7 +25,7 @@
   (condp #(isa? %2 %1) (:base_type field)
     :type/Text     {:type/Text (text/text-fingerprint values)}
     :type/Number   {:type/Number (number/number-fingerprint values)}
-    :type/DateTime {:type/DateTime (datetime/datetime-fingerprint values)}
+    :type/Date     {:type/DateTime (datetime/datetime-fingerprint values)}
     nil))
 
 (s/defn ^:private fingerprint :- i/Fingerprint

--- a/src/metabase/sync/analyze/fingerprint/datetime.clj
+++ b/src/metabase/sync/analyze/fingerprint/datetime.clj
@@ -10,7 +10,7 @@
             [schema.core :as s]))
 
 (s/defn datetime-fingerprint :- i/DateTimeFingerprint
-  "Generate a fingerprint containing information about values that belong to a `DateTime` Field."
+  "Generate a fingerprint containing information about values that belong to a `Date` Field."
   [values :- i/FieldSample]
   (transduce (map u/str->date-time)
              (redux/post-complete

--- a/src/metabase/sync/interface.clj
+++ b/src/metabase/sync/interface.clj
@@ -109,7 +109,7 @@
    (s/optional-key :average-length) (s/constrained Double #(>= % 0) "Valid number greater than or equal to zero")})
 
 (def DateTimeFingerprint
-  "Schema for fingerprint information for Fields deriving from `:type/DateTime`."
+  "Schema for fingerprint information for Fields deriving from `:type/Date`."
   {(s/optional-key :earliest) s/Str
    (s/optional-key :latest)   s/Str})
 

--- a/src/metabase/types.clj
+++ b/src/metabase/types.clj
@@ -78,17 +78,26 @@
 
 ;;; DateTime Types
 
-(derive :type/DateTime :type/*)
+(derive :type/Time :type/*)
+(derive :type/Date :type/*)
 
-(derive :type/Time :type/DateTime)
-(derive :type/Date :type/DateTime)
+(derive :type/DateTime :type/Date)
+(derive :type/DateTime :type/Time)
 
 (derive :type/UNIXTimestamp :type/DateTime)
 (derive :type/UNIXTimestamp :type/Integer)
 (derive :type/UNIXTimestampSeconds :type/UNIXTimestamp)
 (derive :type/UNIXTimestampMilliseconds :type/UNIXTimestamp)
 
+(derive :type/CreationTime :type/Time)
+(derive :type/CreationDate :type/Date)
+(derive :type/CreationTimestamp :type/CreationTime)
+(derive :type/CreationTimestamp :type/CreationDate)
 (derive :type/CreationTimestamp :type/DateTime)
+(derive :type/JoinTime :type/Time)
+(derive :type/JoinDate :type/Date)
+(derive :type/JoinTimestamp :type/JoinTime)
+(derive :type/JoinTimestamp :type/JoinDate)
 (derive :type/JoinTimestamp :type/DateTime)
 (derive :type/Birthdate :type/Date)
 

--- a/src/metabase/util/ui_logic.clj
+++ b/src/metabase/util/ui_logic.clj
@@ -14,7 +14,7 @@
   (and (or (isa? base_type :type/Number)
            (isa? special_type :type/Number))
        (not (isa? special_type :type/Special))
-       (not (isa? special_type :type/DateTime))))
+       (not (isa? special_type :type/Date))))
 
 (defn- metric-column?
   "A metric column is any non-breakout column that is summable (numeric that isn't a special type like an FK/PK/Unix

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -248,7 +248,7 @@
                              :database_type            "TIMESTAMP"
                              :base_type                "type/DateTime"
                              :visibility_type          "normal"
-                             :dimension_options        (var-get #'table-api/datetime-dimension-indexes)
+                             :dimension_options        (var-get #'table-api/date-dimension-indexes)
                              :default_dimension_option (var-get #'table-api/date-default-index)
                              :has_field_values         "none")
                            (assoc (field-details (Field (data/id :users :name)))
@@ -301,7 +301,7 @@
                              :display_name             "Last Login"
                              :database_type            "TIMESTAMP"
                              :base_type                "type/DateTime"
-                             :dimension_options        (var-get #'table-api/datetime-dimension-indexes)
+                             :dimension_options        (var-get #'table-api/date-dimension-indexes)
                              :default_dimension_option (var-get #'table-api/date-default-index)
                              :has_field_values         "none")
                            (assoc (field-details (Field (data/id :users :name)))
@@ -491,7 +491,7 @@
                           :id                       ["field-literal" "LAST_LOGIN" "type/DateTime"]
                           :special_type             nil
                           :default_dimension_option (var-get #'table-api/date-default-index)
-                          :dimension_options        (var-get #'table-api/datetime-dimension-indexes)}]})
+                          :dimension_options        (var-get #'table-api/date-dimension-indexes)}]})
   (do
     ;; run the Card which will populate its result_metadata column
     ((user->client :crowberto) :post 200 (format "card/%d/query" (u/get-id card)))
@@ -580,8 +580,8 @@
 
 ;; Ensure dimensions options are sorted numerically, but returned as strings
 (expect
-  (map str (sort (map #(Long/parseLong %) (var-get #'table-api/datetime-dimension-indexes))))
-  (var-get #'table-api/datetime-dimension-indexes))
+  (map str (sort (map #(Long/parseLong %) (var-get #'table-api/date-dimension-indexes))))
+  (var-get #'table-api/date-dimension-indexes))
 
 (expect
   (map str (sort (map #(Long/parseLong %) (var-get #'table-api/numeric-dimension-indexes))))
@@ -635,20 +635,20 @@
 
 ;; Ensure unix timestamps show date binning options, not numeric binning options
 (expect
-  (var-get #'table-api/datetime-dimension-indexes)
+  (var-get #'table-api/date-dimension-indexes)
   (data/dataset sad-toucan-incidents
     (let [response ((user->client :rasta) :get 200 (format "table/%d/query_metadata" (data/id :incidents)))]
       (dimension-options-for-field response "timestamp"))))
 
 ;; Datetime binning options should showup whether the backend supports binning of numeric values or not
 (datasets/expect-with-engines #{:druid}
-  (var-get #'table-api/datetime-dimension-indexes)
+  (var-get #'table-api/date-dimension-indexes)
   (tqpt/with-flattened-dbdef
     (let [response ((user->client :rasta) :get 200 (format "table/%d/query_metadata" (data/id :checkins)))]
       (dimension-options-for-field response "timestamp"))))
 
 (qpt/expect-with-non-timeseries-dbs
- (var-get #'table-api/datetime-dimension-indexes)
+ (var-get #'table-api/date-dimension-indexes)
  (let [response ((user->client :rasta) :get 200 (format "table/%d/query_metadata" (data/id :checkins)))]
    (dimension-options-for-field response "date")))
 

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -279,30 +279,30 @@
 
 (expect
   :month
-  (#'magic/optimal-datetime-resolution
+  (#'magic/optimal-date-resolution
    {:fingerprint {:type {:type/DateTime {:earliest "2015"
                                          :latest   "2017"}}}}))
 
 (expect
   :day
-  (#'magic/optimal-datetime-resolution
+  (#'magic/optimal-date-resolution
    {:fingerprint {:type {:type/DateTime {:earliest "2017-01-01"
                                          :latest   "2017-03-04"}}}}))
 
 (expect
   :year
-  (#'magic/optimal-datetime-resolution
+  (#'magic/optimal-date-resolution
    {:fingerprint {:type {:type/DateTime {:earliest "2005"
                                          :latest   "2017"}}}}))
 
 (expect
   :hour
-  (#'magic/optimal-datetime-resolution
+  (#'magic/optimal-date-resolution
    {:fingerprint {:type {:type/DateTime {:earliest "2017-01-01"
                                          :latest   "2017-01-02"}}}}))
 
 (expect
   :minute
-  (#'magic/optimal-datetime-resolution
+  (#'magic/optimal-date-resolution
    {:fingerprint {:type {:type/DateTime {:earliest "2017-01-01T00:00:00"
                                          :latest   "2017-01-01T00:02:00"}}}}))


### PR DESCRIPTION
Adds date and time specific heuristics. This became quite involved as our type system previously derived Date from DateTime which doesn't really make sense. I've now switched them around. The whole thing does expose 2 areas we should address very soon:
* writing heuristics has way too much repetition
* our type system is stretched to the breaking point. Tracking semantic meaning (eg. "Joined*") down both Date and Time path is crying for a refactor. 
