### PR TITLE
Fix mystery sample dataset failures (?)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -52,7 +52,7 @@
                  [com.google.apis/google-api-services-bigquery        ; Google BigQuery Java Client Library
                    "v2-rev368-1.23.0"]
                  [com.jcraft/jsch "0.1.54"]                           ; SSH client for tunnels
-                 [com.h2database/h2 "1.4.194"]                        ; embedded SQL database
+                 [com.h2database/h2 "1.4.197"]                        ; embedded SQL database
                  [com.mattbertolini/liquibase-slf4j "2.0.0"]          ; Java Migrations lib
                  [com.mchange/c3p0 "0.9.5.2"]                         ; connection pooling library
                  [com.microsoft.sqlserver/mssql-jdbc "6.2.1.jre7"]    ; SQLServer JDBC driver. TODO - Switch this to `.jre8` once we officially switch to Java 8
@@ -102,7 +102,7 @@
                  [ring/ring-jetty-adapter "1.6.0"]                    ; Ring adapter using Jetty webserver (used to run a Ring server for unit tests)
                  [ring/ring-json "0.4.0"]                             ; Ring middleware for reading/writing JSON automatically
                  [stencil "0.5.0"]                                    ; Mustache templates for Clojure
-                 [toucan "1.1.4"                                      ; Model layer, hydration, and DB utilities
+                 [toucan "1.1.5"                                      ; Model layer, hydration, and DB utilities
                   :exclusions [honeysql]]]
   :repositories [["bintray" "https://dl.bintray.com/crate/crate"]     ; Repo for Crate JDBC driver
                  ["redshift" "https://s3.amazonaws.com/redshift-driver-downloads"]]

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -346,9 +346,8 @@
         (parse formatter time-str))))
 
 (defn make-current-db-time-fn
-  "Takes a clj-time date formatter `DATE-FORMATTER` and a native query
-  for the current time. Returns a function that executes the query and
-  parses the date returned preserving it's timezone"
+  "Takes a clj-time date formatter `DATE-FORMATTER` and a native query for the current time. Returns a function that
+  executes the query and parses the date returned preserving it's timezone"
   [native-query date-formatters]
   (fn [driver database]
     (let [settings (when-let [report-tz (report-timezone-if-supported driver)]

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -288,9 +288,8 @@
 (defmacro with-metadata
   "Execute BODY with `java.sql.DatabaseMetaData` for DATABASE."
   [[binding _ database] & body]
-  `(with-open [^java.sql.Connection conn# (jdbc/get-connection (db->jdbc-connection-spec ~database))]
-     (let [~binding (.getMetaData conn#)]
-       ~@body)))
+  `(jdbc/with-db-metadata [~binding (db->jdbc-connection-spec ~database)]
+     ~@body))
 
 (defn- get-tables
   "Fetch a JDBC Metadata ResultSet of tables in the DB, optionally limited to ones belonging to a given schema."


### PR DESCRIPTION
So this seemed to be an H2 bug. I updated to the latest version of the H2 JDBC driver and it seemed to resolve our issues?

However the new version of H2 started returning newly inserted rows with `:id` keys instead of `:scope_identity()`, which broke Toucan, so I had to go update that really quick as well.
