### PR TITLE
Add an endpoint to get schemas and tables for a schema

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -548,5 +548,21 @@
   (delete-all-field-values-for-database! id)
   {:status :ok})
 
+;;; ------------------------------------------ GET /api/database/:id/schemas -----------------------------------------
+
+(api/defendpoint GET "/:id/schemas"
+  "Returns a list of all the schemas found for the database `id`"
+  [id]
+  (let [db (api/read-check Database id)]
+    (sort (db/select-field :schema Table :db_id id))))
+
+;;; ------------------------------------- GET /api/database/:id/schema/:schema ---------------------------------------
+
+(api/defendpoint GET "/:id/schema/:schema"
+  "Returns a list of tables for the given database `id` and `schema`"
+  [id schema]
+  (let [db (api/read-check Database id)]
+    (api/let-404 [tables (seq (db/select Table :db_id id :schema schema {:order-by [[:name :asc]]}))]
+      tables)))
 
 (api/define-routes)

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -10,6 +10,8 @@
              [database :as database :refer [Database]]
              [field :refer [Field]]
              [field-values :refer [FieldValues]]
+             [permissions :as perms]
+             [permissions-group :as perms-group]
              [table :refer [Table]]]
             [metabase.sync
              [analyze :as analyze]
@@ -649,3 +651,57 @@
   (with-redefs [database-api/test-database-connection test-database-connection]
     ((user->client :crowberto) :post 200 "database/validate"
      {:details {:engine :h2, :details {:db "ABC"}}})))
+
+;; Tests for GET /api/database/:id/schemas
+(expect
+  ["schema1"]
+  (tt/with-temp* [Database [{db-id :id}]
+                  Table    [t1          {:db_id db-id, :schema "schema1"}]
+                  Table    [t2          {:db_id db-id, :schema "schema1"}]]
+    ((user->client :crowberto) :get 200 (format "database/%d/schemas" db-id))))
+
+;; Multiple schemas are ordered by name
+(expect
+  ["schema1" "schema2" "schema3"]
+  (tt/with-temp* [Database [{db-id :id}]
+                  Table    [t1          {:db_id db-id, :schema "schema3"}]
+                  Table    [t2          {:db_id db-id, :schema "schema2"}]
+                  Table    [t3          {:db_id db-id, :schema "schema1"}]]
+    ((user->client :crowberto) :get 200 (format "database/%d/schemas" db-id))))
+
+;; Multiple schemas are ordered by name
+(expect
+  ["t1" "t3"]
+  (tt/with-temp* [Database [{db-id :id}]
+                  Table    [{t1-id :id} {:db_id db-id, :schema "schema1", :name "t1"}]
+                  Table    [t2          {:db_id db-id, :schema "schema2"}]
+                  Table    [{t3-id :id} {:db_id db-id, :schema "schema1", :name "t3"}]]
+    (map :name ((user->client :crowberto) :get 200 (format "database/%d/schema/%s" db-id "schema1")))))
+
+;; GET /api/database/:id/schemas should return a 403 for a user that doesn't have read permissions
+(expect
+  "You don't have permissions to do that."
+  (tt/with-temp* [Database [{database-id :id}]
+                  Table    [{table-id :id} {:db_id database-id, :schema "test"}]]
+    (perms/delete-related-permissions! (perms-group/all-users) (perms/object-path database-id))
+    ((user->client :rasta) :get 403 (format "database/%s/schemas" database-id))))
+
+;; GET /api/database/:id/schemas should return a 403 for a user that doesn't have read permissions
+(expect
+  "You don't have permissions to do that."
+  (tt/with-temp* [Database [{database-id :id}]
+                  Table    [{table-id :id} {:db_id database-id, :schema "test"}]]
+    (perms/delete-related-permissions! (perms-group/all-users) (perms/object-path database-id))
+    ((user->client :rasta) :get 403 (format "database/%s/schema/%s" database-id "test"))))
+
+;; Looking for a database that doesn't exist should return a 404
+(expect
+  "Not found."
+  ((user->client :rasta) :get 404 (format "database/%s/schemas" Integer/MAX_VALUE)))
+
+;; Check that a 404 returns if the schema isn't found
+(expect
+  "Not found."
+  (tt/with-temp* [Database [{db-id :id}]
+                  Table    [{t1-id :id} {:db_id db-id, :schema "schema1"}]]
+    ((user->client :crowberto) :get 404 (format "database/%d/schema/%s" db-id "not schema1"))))


### PR DESCRIPTION
The new endpoints `/api/database/:id/schemas` returns a list of schema
strings. The schema endpoint is `/api/database/:id/schema/:schema` and
returns a list of table entities.