### PR TITLE
Enable Eastwood unused namespaces linter

### DIFF
--- a/src/metabase/api/alert.clj
+++ b/src/metabase/api/alert.clj
@@ -5,8 +5,7 @@
             [medley.core :as m]
             [metabase
              [email :as email]
-             [events :as events]
-             [util :as u]]
+             [events :as events]]
             [metabase.api
              [common :as api]
              [pulse :as pulse-api]]

--- a/src/metabase/api/automagic_dashboards.clj
+++ b/src/metabase/api/automagic_dashboards.clj
@@ -4,25 +4,23 @@
             [compojure.core :refer [GET POST]]
             [metabase.api.common :as api]
             [metabase.automagic-dashboards
-             [core :as magic]
              [comparison :as magic.comparison]
+             [core :as magic]
              [rules :as rules]]
             [metabase.models
              [card :refer [Card]]
-             [dashboard :refer [Dashboard] :as dashboard]
+             [dashboard :as dashboard :refer [Dashboard]]
              [database :refer [Database]]
              [field :refer [Field]]
              [metric :refer [Metric]]
-             [query :refer [Query] :as query]
+             [query :as query]
              [segment :refer [Segment]]
              [table :refer [Table]]]
             [metabase.util.schema :as su]
             [puppetlabs.i18n.core :refer [tru]]
             [ring.util.codec :as codec]
             [schema.core :as s]
-            [toucan
-             [db :as db]
-             [hydrate :refer [hydrate]]]))
+            [toucan.hydrate :refer [hydrate]]))
 
 (def ^:private Show
   (su/with-api-error-message (s/maybe (s/enum "all"))

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -7,15 +7,14 @@
             [medley.core :as m]
             [metabase
              [events :as events]
-             [middleware :as middleware]
              [public-settings :as public-settings]
              [query-processor :as qp]
+             [related :as related]
              [util :as u]]
             [metabase.api
              [common :as api]
              [dataset :as dataset-api]
              [label :as label-api]]
-            [metabase.api.common.internal :refer [route-fn-name]]
             [metabase.email.messages :as messages]
             [metabase.models
              [card :as card :refer [Card]]
@@ -36,7 +35,6 @@
             [metabase.query-processor.middleware
              [cache :as cache]
              [results-metadata :as results-metadata]]
-            [metabase.related :as related]
             [metabase.util.schema :as su]
             [ring.util.codec :as codec]
             [schema.core :as s]

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -251,6 +251,7 @@
 ;;; --------------------------------------- DEFENDPOINT AND RELATED FUNCTIONS ----------------------------------------
 
 ;; TODO - several of the things `defendpoint` does could and should just be done by custom Ring middleware instead
+;; e.g. `catch-api-exceptions` and `auto-parse`
 (defmacro defendpoint
   "Define an API function.
    This automatically does several things:

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -5,10 +5,9 @@
             [metabase
              [events :as events]
              [query-processor :as qp]
+             [related :as related]
              [util :as u]]
-            [metabase.api
-             [common :as api]
-             [dataset :as dataset]]
+            [metabase.api.common :as api]
             [metabase.models
              [card :refer [Card]]
              [dashboard :as dashboard :refer [Dashboard]]
@@ -18,7 +17,6 @@
              [query :as query :refer [Query]]
              [revision :as revision]]
             [metabase.query-processor.util :as qp-util]
-            [metabase.related :as related]
             [metabase.util.schema :as su]
             [schema.core :as s]
             [toucan

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -1,22 +1,16 @@
 (ns metabase.api.dataset
   "/api/dataset endpoints."
   (:require [cheshire.core :as json]
-            [clj-time.format :as tformat]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [compojure.core :refer [POST]]
-            [metabase
-             [middleware :as middleware]
-             [query-processor :as qp]
-             [util :as u]]
             [metabase.api.common :as api]
-            [metabase.api.common.internal :refer [route-fn-name]]
             [metabase.models
              [card :refer [Card]]
              [database :as database :refer [Database]]
              [query :as query]]
+            [metabase.query-processor :as qp]
             [metabase.query-processor.util :as qputil]
-            [metabase.util :as util]
             [metabase.util
              [date :as du]
              [export :as ex]

--- a/src/metabase/api/ldap.clj
+++ b/src/metabase/api/ldap.clj
@@ -1,10 +1,9 @@
 (ns metabase.api.ldap
   "/api/ldap endpoints"
-  (:require [clojure.tools.logging :as log]
-            [clojure.set :as set]
+  (:require [clojure.set :as set]
+            [clojure.tools.logging :as log]
             [compojure.core :refer [PUT]]
             [metabase.api.common :refer :all]
-            [metabase.config :as config]
             [metabase.integrations.ldap :as ldap]
             [metabase.models.setting :as setting]
             [metabase.util.schema :as su]))

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -11,24 +11,21 @@
             [metabase.api
              [card :as card-api]
              [common :as api]
-             [dataset :as dataset-api]
              [dashboard :as dashboard-api]
+             [dataset :as dataset-api]
              [field :as field-api]]
             [metabase.models
-             [card :refer [Card] :as card]
+             [card :as card :refer [Card]]
              [dashboard :refer [Dashboard]]
              [dashboard-card :refer [DashboardCard]]
              [dashboard-card-series :refer [DashboardCardSeries]]
              [dimension :refer [Dimension]]
              [field :refer [Field]]
-             [field-values :refer [FieldValues]]
              [params :as params]]
-            [metabase.query-processor :as qp]
-            metabase.query-processor.interface ; because we refer to Field
             [metabase.util
              [embed :as embed]
              [schema :as su]]
-            [puppetlabs.i18n.core :refer [trs tru]]
+            [puppetlabs.i18n.core :refer [tru]]
             [schema.core :as s]
             [toucan
              [db :as db]

--- a/src/metabase/api/pulse.clj
+++ b/src/metabase/api/pulse.clj
@@ -3,7 +3,6 @@
   (:require [compojure.core :refer [DELETE GET POST PUT]]
             [hiccup.core :refer [html]]
             [metabase
-             [driver :as driver]
              [email :as email]
              [events :as events]
              [pulse :as p]
@@ -17,12 +16,12 @@
              [pulse :as pulse :refer [Pulse]]
              [pulse-channel :refer [channel-types]]]
             [metabase.pulse.render :as render]
-            [metabase.util.schema :as su]
-            [metabase.util.urls :as urls]
+            [metabase.util
+             [schema :as su]
+             [urls :as urls]]
             [schema.core :as s]
             [toucan.db :as db])
-  (:import java.io.ByteArrayInputStream
-           java.util.TimeZone))
+  (:import java.io.ByteArrayInputStream))
 
 (api/defendpoint GET "/"
   "Fetch all `Pulses`"

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -136,7 +136,7 @@
 
 (defn- create-dim-index-seq [dim-type]
   (->> dimension-options
-       (m/filter-kv (fn [k v] (= (:type v) dim-type)))
+       (m/filter-vals (fn [v] (= (:type v) dim-type)))
        keys
        sort
        (map str)))

--- a/src/metabase/api/x_ray.clj
+++ b/src/metabase/api/x_ray.clj
@@ -7,8 +7,7 @@
              [core :as fe]
              [costs :as costs]]
             [metabase.models
-             [card :refer [Card] :as card]
-             [database :refer [Database] :as database]
+             [card :as card :refer [Card]]
              [field :refer [Field]]
              [metric :refer [Metric]]
              [query :as query]

--- a/src/metabase/automagic_dashboards/comparison.clj
+++ b/src/metabase/automagic_dashboards/comparison.clj
@@ -1,8 +1,8 @@
 (ns metabase.automagic-dashboards.comparison
-  (:require [clojure.string :as str]
-            [metabase.api.common :as api]
-            [metabase.automagic-dashboards
-             [populate :as populate]]))
+  #_(:require [clojure.string :as str]
+              [metabase.api.common :as api]
+              [metabase.automagic-dashboards
+               [populate :as populate]]))
 
 ;; (defn- dashboard->cards
 ;;   [dashboard]

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -109,7 +109,7 @@
     :day))
 
 (defmethod ->reference [:mbql (type Field)]
-  [_ {:keys [fk_target_field_id id link aggregation base_type fingerprint name base_type] :as field}]
+  [_ {:keys [fk_target_field_id id link aggregation fingerprint name base_type] :as field}]
   (let [reference (cond
                     link               [:fk-> link id]
                     fk_target_field_id [:fk-> id fk_target_field_id]

--- a/src/metabase/automagic_dashboards/populate.clj
+++ b/src/metabase/automagic_dashboards/populate.clj
@@ -9,13 +9,15 @@
             [puppetlabs.i18n.core :as i18n :refer [trs]]
             [toucan.db :as db]))
 
-(def ^Long ^:const grid-width
+(def ^Long grid-width
   "Total grid width."
   18)
-(def ^Long ^:const default-card-width
+
+(def ^Long default-card-width
   "Default card width."
   6)
-(def ^Long ^:const default-card-height
+
+(def ^Long default-card-height
   "Default card height"
   4)
 

--- a/src/metabase/automagic_dashboards/rules.clj
+++ b/src/metabase/automagic_dashboards/rules.clj
@@ -4,7 +4,6 @@
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [metabase.automagic-dashboards.populate :as populate]
-            [metabase.types]
             [metabase.util :as u]
             [metabase.util.schema :as su]
             [puppetlabs.i18n.core :as i18n :refer [trs]]
@@ -12,8 +11,7 @@
              [coerce :as sc]
              [core :as s]]
             [yaml.core :as yaml])
-  (:import java.nio.file.Path java.nio.file.FileSystems java.nio.file.FileSystem
-           java.nio.file.Files))
+  (:import [java.nio.file Files FileSystem FileSystems Path]))
 
 (def ^Long ^:const max-score
   "Maximal (and default) value for heuristics scores."

--- a/src/metabase/cmd/refresh_integration_test_db_metadata.clj
+++ b/src/metabase/cmd/refresh_integration_test_db_metadata.clj
@@ -3,13 +3,11 @@
             [environ.core :refer [env]]
             [metabase
              [db :as mdb]
-             [util :as u]]
+             [sample-data :as sample-data]
+             [sync :as sync]]
             [metabase.models
              [database :refer [Database]]
-             [field :refer [Field]]
-             [table :refer [Table]]]
-            [metabase.sample-data :as sample-data]
-            [metabase.sync :as sync]
+             [field :refer [Field]]]
             [toucan.db :as db]))
 
 (defn- test-fixture-db-path

--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -1,6 +1,7 @@
 (ns metabase.config
-  (:require (clojure.java [io :as io]
-                          [shell :as shell])
+  (:require [clojure.java
+             [io :as io]
+             [shell :as shell]]
             [clojure.string :as s]
             [environ.core :as environ])
   (:import clojure.lang.Keyword))
@@ -49,9 +50,9 @@
 (defn ^Boolean config-bool "Fetch a configuration key and parse it as a boolean."  [k] (some-> k config-str Boolean/parseBoolean))
 (defn ^Keyword config-kw   "Fetch a configuration key and parse it as a keyword."  [k] (some-> k config-str keyword))
 
-(def ^:const ^Boolean is-dev?  "Are we running in `dev` mode (i.e. in a REPL or via `lein ring server`)?" (= :dev  (config-kw :mb-run-mode)))
-(def ^:const ^Boolean is-prod? "Are we running in `prod` mode (i.e. from a JAR)?"                         (= :prod (config-kw :mb-run-mode)))
-(def ^:const ^Boolean is-test? "Are we running in `test` mode (i.e. via `lein test`)?"                    (= :test (config-kw :mb-run-mode)))
+(def ^Boolean is-dev?  "Are we running in `dev` mode (i.e. in a REPL or via `lein ring server`)?" (= :dev  (config-kw :mb-run-mode)))
+(def ^Boolean is-prod? "Are we running in `prod` mode (i.e. from a JAR)?"                         (= :prod (config-kw :mb-run-mode)))
+(def ^Boolean is-test? "Are we running in `test` mode (i.e. via `lein test`)?"                    (= :test (config-kw :mb-run-mode)))
 
 
 ;;; Version stuff
@@ -73,7 +74,7 @@
         (into {} (for [[k v] props]
                    [(keyword k) v]))))))
 
-(def ^:const mb-version-info
+(def mb-version-info
   "Information about the current version of Metabase.
    This comes from `resources/version.properties` for prod builds and is fetched from `git` via the `./bin/version` script for dev.
 
@@ -82,13 +83,13 @@
     (version-info-from-properties-file)
     (version-info-from-shell-script)))
 
-(def ^:const ^String mb-version-string
+(def ^String mb-version-string
   "A formatted version string representing the currently running application.
    Looks something like `v0.25.0-snapshot (1de6f3f nested-queries-icon)`."
   (let [{:keys [tag hash branch]} mb-version-info]
     (format "%s (%s %s)" tag hash branch)))
 
-(def ^:const ^String mb-app-id-string
+(def ^String mb-app-id-string
   "A formatted version string including the word 'Metabase' appropriate for passing along
    with database connections so admins can identify them as Metabase ones.
    Looks something like `Metabase v0.25.0.RC1`."

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -47,12 +47,12 @@
 ;; difference between this and `streaming-json-response`?
 (defn- streamed-json-response
   "Write `RESPONSE-SEQ` to a PipedOutputStream as JSON, returning the connected PipedInputStream"
-  [response-seq options]
+  [response-seq opts]
   (rui/piped-input-stream
    (fn [^OutputStream output-stream]
      (with-open [output-writer   (OutputStreamWriter. ^OutputStream output-stream ^Charset StandardCharsets/UTF_8)
                  buffered-writer (BufferedWriter. output-writer)]
-       (json/generate-stream response-seq buffered-writer)))))
+       (json/generate-stream response-seq buffered-writer opts)))))
 
 (defn- wrap-streamed-json-response
   "Similar to ring.middleware/wrap-json-response in that it will serialize the response's body to JSON if it's a

--- a/src/metabase/db/migrations.clj
+++ b/src/metabase/db/migrations.clj
@@ -10,9 +10,8 @@
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [metabase
-             [db :as mdb]
              [config :as config]
-             [driver :as driver]
+             [db :as mdb]
              [public-settings :as public-settings]
              [util :as u]]
             [metabase.events.activity-feed :refer [activity-feed-topics]]

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -16,24 +16,19 @@
              [format :as tformat]]
             [clojure.tools.logging :as log]
             [medley.core :as m]
-            [metabase.config :as config]
+            [metabase
+             [config :as config]
+             [util :as u]]
             [metabase.models
              [database :refer [Database]]
-             field
-             [setting :refer [defsetting]]
-             table]
+             [setting :refer [defsetting]]]
             [metabase.sync.interface :as si]
-            [metabase.util :as u]
             [metabase.util.date :as du]
-            [puppetlabs.i18n.core :refer [tru]]
-            [schema.core :as s]
             [puppetlabs.i18n.core :refer [trs tru]]
+            [schema.core :as s]
             [toucan.db :as db])
   (:import clojure.lang.Keyword
            java.text.SimpleDateFormat
-           metabase.models.database.DatabaseInstance
-           metabase.models.field.FieldInstance
-           metabase.models.table.TableInstance
            org.joda.time.DateTime
            org.joda.time.format.DateTimeFormatter))
 
@@ -80,17 +75,17 @@
 
        (date-interval (PostgresDriver.) :month 1) -> (hsql/call :+ :%now (hsql/raw \"INTERVAL '1 month'\"))")
 
-  (describe-database ^java.util.Map [this, ^DatabaseInstance database]
+  (describe-database ^java.util.Map [this database]
     "Return a map containing information that describes all of the schema settings in DATABASE, most notably a set of
      tables. It is expected that this function will be peformant and avoid draining meaningful resources of the
      database. Results should match the `DatabaseMetadata` schema.")
 
-  (describe-table ^java.util.Map [this, ^DatabaseInstance database, ^TableInstance table]
+  (describe-table ^java.util.Map [this database table]
     "Return a map containing information that describes the physical schema of TABLE.
      It is expected that this function will be peformant and avoid draining meaningful resources of the database.
      Results should match the `TableMetadata` schema.")
 
-  (describe-table-fks ^java.util.Set [this, ^DatabaseInstance database, ^TableInstance table]
+  (describe-table-fks ^java.util.Set [this database table]
     "*OPTIONAL*, BUT REQUIRED FOR DRIVERS THAT SUPPORT `:foreign-keys`*
      Results should match the `FKMetadata` schema.")
 
@@ -194,7 +189,7 @@
        {:query \"-- [Contents of `(query->remark query)`]
                  SELECT * FROM my_table\"}")
 
-  (notify-database-updated [this, ^DatabaseInstance database]
+  (notify-database-updated [this database]
     "*OPTIONAL*. Notify the driver that the attributes of the DATABASE have changed. This is specifically relevant in
      the event that the driver was doing some caching or connection pooling.")
 
@@ -209,7 +204,7 @@
          (fn [query]
            (qp query)))")
 
-  (^{:style/indent 2} sync-in-context [this, ^DatabaseInstance database, ^clojure.lang.IFn f]
+  (^{:style/indent 2} sync-in-context [this database ^clojure.lang.IFn f]
     "*OPTIONAL*. Drivers may provide this function if they need to do special setup before a sync operation such as
      `sync-database!`. The sync operation itself is encapsulated as the lambda F, which must be called with no
      arguments.
@@ -218,7 +213,7 @@
          (with-connection [_ database]
            (f)))")
 
-  (table-rows-seq ^clojure.lang.Sequential [this, ^DatabaseInstance database, ^java.util.Map table]
+  (table-rows-seq ^clojure.lang.Sequential [this database ^java.util.Map table]
     "*OPTIONAL*. Return a sequence of *all* the rows in a given TABLE, which is guaranteed to have at least `:name`
      and `:schema` keys. (It is guaranteed too satisfy the `DatabaseMetadataTable` schema in
      `metabase.sync.interface`.) Currently, this is only used for iterating over the values in a `_metabase_metadata`
@@ -226,7 +221,7 @@
      table. As such, the results are not expected to be returned lazily. There is no expectation that the results be
      returned in any given order.")
 
-  (current-db-time ^org.joda.time.DateTime [this ^DatabaseInstance database]
+  (current-db-time ^org.joda.time.DateTime [this database]
     "Returns the current time and timezone from the perspective of `DATABASE`.")
 
   (default-to-case-sensitive? ^Boolean [this]
@@ -324,6 +319,7 @@
 ;; as it's not threadsafe. This will always create a new SimpleDateFormat instance and discard it after parsing the
 ;; date
 (defrecord ^:private ThreadSafeSimpleDateFormat [format-str]
+  :load-ns true
   ParseDateTimeString
   (parse [_ date-time-str]
     (let [sdf         (SimpleDateFormat. format-str)

--- a/src/metabase/driver/bigquery.clj
+++ b/src/metabase/driver/bigquery.clj
@@ -39,6 +39,7 @@
            [metabase.query_processor.interface AggregationWithField AggregationWithoutField DateTimeValue Expression TimeValue Value]))
 
 (defrecord BigQueryDriver []
+  :load-ns true
   clojure.lang.Named
   (getName [_] "BigQuery"))
 

--- a/src/metabase/driver/crate.clj
+++ b/src/metabase/driver/crate.clj
@@ -60,7 +60,7 @@
   (hsql/call :char_length field-key))
 
 (defn- describe-table-fields
-  [database, driver, {:keys [schema name]}]
+  [database _ {:keys [schema name]}]
   (let [columns (jdbc/query
                  (sql/db->jdbc-connection-spec database)
                  [(format "select column_name, data_type as type_name
@@ -95,6 +95,7 @@
          (add-table-pks metadata))))
 
 (defrecord CrateDriver []
+  :load-ns true
   clojure.lang.Named
   (getName [_] "Crate"))
 

--- a/src/metabase/driver/crate/util.clj
+++ b/src/metabase/driver/crate/util.clj
@@ -1,9 +1,9 @@
 (ns metabase.driver.crate.util
   (:refer-clojure :exclude [second])
-  (:require (honeysql [core :as hsql]
-                      [format :as hformat])
+  (:require [honeysql
+             [core :as hsql]
+             [format :as hformat]]
             [metabase.driver.generic-sql.query-processor :as qp]
-            [metabase.util :as u]
             [metabase.util
              [date :as du]
              [honeysql-extensions :as hx]])

--- a/src/metabase/driver/druid.clj
+++ b/src/metabase/driver/druid.clj
@@ -7,12 +7,7 @@
              [driver :as driver]
              [util :as u]]
             [metabase.driver.druid.query-processor :as qp]
-            [metabase.models
-             [database :refer [Database]]
-             [field :as field]
-             [table :as table]]
-            [metabase.util.ssh :as ssh]
-            [toucan.db :as db]))
+            [metabase.util.ssh :as ssh]))
 
 ;;; ### Request helper fns
 
@@ -145,6 +140,7 @@
 ;;; ### DruidrDriver Class Definition
 
 (defrecord DruidDriver []
+  :load-ns true
   clojure.lang.Named
   (getName [_] "Druid"))
 

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -16,9 +16,9 @@
              [util :as qputil]]
             [metabase.util
              [date :as du]
-             [honeysql-extensions :as hx]])
-  (:import clojure.lang.Keyword
-           [java.sql PreparedStatement ResultSet ResultSetMetaData SQLException]
+             [honeysql-extensions :as hx]]
+            [puppetlabs.i18n.core :refer [trs]])
+  (:import [java.sql PreparedStatement ResultSet ResultSetMetaData SQLException]
            [java.util Calendar Date TimeZone]
            [metabase.query_processor.interface AgFieldRef BinnedField DateTimeField DateTimeValue Expression
             ExpressionRef Field FieldLiteral RelativeDateTimeValue TimeField TimeValue Value]))
@@ -534,19 +534,21 @@
     (log/debug (u/format-color 'green "Setting timezone with statement: %s" sql))
     (jdbc/db-do-prepared connection [sql])))
 
-(defn- run-query-without-timezone [driver settings connection query]
+(defn- run-query-without-timezone [_ _ connection query]
   (do-in-transaction connection (partial run-query query nil)))
 
 (defn- run-query-with-timezone [driver {:keys [^String report-timezone] :as settings} connection query]
   (try
     (do-in-transaction connection (fn [transaction-connection]
                                     (set-timezone! driver settings transaction-connection)
-                                    (run-query query (some-> report-timezone TimeZone/getTimeZone) transaction-connection)))
+                                    (run-query query
+                                               (some-> report-timezone TimeZone/getTimeZone)
+                                               transaction-connection)))
     (catch SQLException e
-      (log/error "Failed to set timezone:\n" (with-out-str (jdbc/print-sql-exception-chain e)))
+      (log/error (trs "Failed to set timezone:") "\n" (with-out-str (jdbc/print-sql-exception-chain e)))
       (run-query-without-timezone driver settings connection query))
     (catch Throwable e
-      (log/error "Failed to set timezone:\n" (.getMessage e))
+      (log/error (trs "Failed to set timezone:") "\n" (.getMessage e))
       (run-query-without-timezone driver settings connection query))))
 
 

--- a/src/metabase/driver/generic_sql/util/unprepare.clj
+++ b/src/metabase/driver/generic_sql/util/unprepare.clj
@@ -2,7 +2,6 @@
   "Utility functions for converting a prepared statement with `?` into a plain SQL query."
   (:require [clojure.string :as str]
             [honeysql.core :as hsql]
-            [metabase.util :as u]
             [metabase.util
              [date :as du]
              [honeysql-extensions :as hx]])
@@ -16,7 +15,7 @@
   (hsql/call iso-8601-fn (hx/literal (du/date->iso-8601 date-or-time))))
 
 (extend-protocol IUnprepare
-  nil     (unprepare-arg [this _] "NULL")
+  nil     (unprepare-arg [_ _] "NULL")
   String  (unprepare-arg [this {:keys [quote-escape]}] (str \' (str/replace this "'" (str quote-escape "'")) \')) ; escape single-quotes
   Boolean (unprepare-arg [this _] (if this "TRUE" "FALSE"))
   Number  (unprepare-arg [this _] (str this))

--- a/src/metabase/driver/googleanalytics.clj
+++ b/src/metabase/driver/googleanalytics.clj
@@ -234,6 +234,7 @@
 
 
 (defrecord GoogleAnalyticsDriver []
+  :load-ns true
   clojure.lang.Named
   (getName [_] "Google Analytics"))
 

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -209,6 +209,7 @@
 (def ^:private h2-db-time-query  (format "select formatdatetime(current_timestamp(),'%s') AS VARCHAR" date-format-str))
 
 (defrecord H2Driver []
+  :load-ns true
   clojure.lang.Named
   (getName [_] "H2"))
 

--- a/src/metabase/driver/hive_like.clj
+++ b/src/metabase/driver/hive_like.clj
@@ -124,7 +124,7 @@
 
 (defn run-query-without-timezone
   "Runs the given query without trying to set a timezone"
-  [driver settings connection query]
+  [_ _ connection query]
   (run-query query connection))
 
 (defmethod hformat/fn-handler "hive-like-from-unixtime" [_ datetime-literal]

--- a/src/metabase/driver/mongo.clj
+++ b/src/metabase/driver/mongo.clj
@@ -1,27 +1,20 @@
 (ns metabase.driver.mongo
   "MongoDB Driver."
   (:require [cheshire.core :as json]
-            [clojure.string :as str]
             [clojure.tools.logging :as log]
             [metabase
              [driver :as driver]
              [util :as u]]
             [metabase.driver.mongo
              [query-processor :as qp]
-             [util :refer [*mongo-connection* with-mongo-connection]]]
-            [metabase.models
-             [database :refer [Database]]
-             [field :as field]]
-            [metabase.sync.interface :as si]
-            [metabase.util
-             [schema :as su]
-             [ssh :as ssh]]
+             [util :refer [with-mongo-connection]]]
+            [metabase.models.database :refer [Database]]
+            [metabase.util.ssh :as ssh]
             [monger
              [collection :as mc]
              [command :as cmd]
              [conversion :as conv]
-             [db :as mdb]
-             [query :as mq]]
+             [db :as mdb]]
             [schema.core :as s]
             [toucan.db :as db])
   (:import com.mongodb.DB))
@@ -57,7 +50,7 @@
 
 (defn- process-query-in-context [qp]
   (fn [{database-id :database, :as query}]
-    (with-mongo-connection [^DB conn, (db/select-one [Database :details], :id database-id)]
+    (with-mongo-connection [_ (db/select-one [Database :details], :id database-id)]
       (qp query))))
 
 
@@ -166,6 +159,7 @@
 
 
 (defrecord MongoDriver []
+  :load-ns true
   clojure.lang.Named
   (getName [_] "MongoDB"))
 

--- a/src/metabase/driver/mongo/query_processor.clj
+++ b/src/metabase/driver/mongo/query_processor.clj
@@ -14,7 +14,7 @@
              [interface :as i]]
             [metabase.util :as u]
             [metabase.util.date :as du]
-            [monger joda-time
+            [monger
              [collection :as mc]
              [operators :refer :all]])
   (:import java.sql.Timestamp

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -23,6 +23,7 @@
            org.joda.time.format.DateTimeFormatter))
 
 (defrecord MySQLDriver []
+  :load-ns true
   clojure.lang.Named
   (getName [_] "MySQL"))
 

--- a/src/metabase/driver/oracle.clj
+++ b/src/metabase/driver/oracle.clj
@@ -15,6 +15,7 @@
              [ssh :as ssh]]))
 
 (defrecord OracleDriver []
+  :load-ns true
   clojure.lang.Named
   (getName [_] "Oracle"))
 

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -12,15 +12,15 @@
             [metabase.db.spec :as dbspec]
             [metabase.driver.generic-sql :as sql]
             [metabase.driver.generic-sql.query-processor :as sqlqp]
-            metabase.query-processor.interface
             [metabase.util
              [honeysql-extensions :as hx]
              [ssh :as ssh]])
-  (:import java.util.UUID
-           java.sql.Time
+  (:import java.sql.Time
+           java.util.UUID
            metabase.query_processor.interface.Value))
 
 (defrecord PostgresDriver []
+  :load-ns true
   clojure.lang.Named
   (getName [_] "PostgreSQL"))
 
@@ -97,7 +97,7 @@
 
 (defn- column->special-type
   "Attempt to determine the special-type of a Field given its name and Postgres column type."
-  [column-name column-type]
+  [_ column-type]
   ;; this is really, really simple right now.  if its postgres :json type then it's :type/SerializedJSON special-type
   (case column-type
     :json :type/SerializedJSON
@@ -201,7 +201,7 @@
       :else                               (sqlqp/->honeysql driver value))))
 
 (defmethod sqlqp/->honeysql [PostgresDriver Time]
-  [driver time-value]
+  [_ time-value]
   (hx/->time time-value))
 
 (defn- string-length-fn [field-key]

--- a/src/metabase/driver/presto.clj
+++ b/src/metabase/driver/presto.clj
@@ -28,6 +28,7 @@
            [metabase.query_processor.interface TimeValue]))
 
 (defrecord PrestoDriver []
+  :load-ns true
   clojure.lang.Named
   (getName [_] "Presto"))
 

--- a/src/metabase/driver/redshift.clj
+++ b/src/metabase/driver/redshift.clj
@@ -67,6 +67,7 @@
           :dest-column-name (:dest-column-name fk)})))
 
 (defrecord RedshiftDriver []
+  :load-ns true
   clojure.lang.Named
   (getName [_] "Amazon Redshift"))
 

--- a/src/metabase/driver/sqlite.clj
+++ b/src/metabase/driver/sqlite.clj
@@ -18,6 +18,7 @@
   (:import [java.sql Time Timestamp]))
 
 (defrecord SQLiteDriver []
+  :load-ns true
   clojure.lang.Named
   (getName [_] "SQLite"))
 

--- a/src/metabase/driver/sqlserver.clj
+++ b/src/metabase/driver/sqlserver.clj
@@ -13,6 +13,7 @@
   (:import java.sql.Time))
 
 (defrecord SQLServerDriver []
+  :load-ns true
   clojure.lang.Named
   (getName [_] "SQL Server"))
 

--- a/src/metabase/driver/vertica.clj
+++ b/src/metabase/driver/vertica.clj
@@ -108,6 +108,7 @@
 
 
 (defrecord VerticaDriver []
+  :load-ns true
   clojure.lang.Named
   (getName [_] "Vertica"))
 

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -218,7 +218,7 @@
                       (export/export-to-csv-writer temp-file result)
                       (create-result-attachment-map "csv" card-name temp-file))
 
-                    (when-let [temp-file (and (render/include-xls-attachment? card result-data)
+                    (when-let [temp-file (and (:include_xls card)
                                               (create-temp-file "xlsx"))]
                       (export/export-to-xlsx-file temp-file result)
                       (create-result-attachment-map "xlsx" card-name temp-file))]))))

--- a/src/metabase/events.clj
+++ b/src/metabase/events.clj
@@ -1,13 +1,13 @@
 (ns metabase.events
-  "Provides a very simply event bus using `core.async` to allow publishing and subscribing to intersting
-   topics happening throughout the Metabase system in a decoupled way.
+  "Provides a very simply event bus using `core.async` to allow publishing and subscribing to interesting topics
+  happening throughout the Metabase system in a decoupled way.
 
-   ## Regarding Events Initialization:
+  ## Regarding Events Initialization:
 
-   The most appropriate way to initialize event listeners in any `metabase.events.*` namespace is to implement the
-   `events-init` function which accepts zero arguments.  This function is dynamically resolved and called exactly
-   once when the application goes through normal startup procedures.  Inside this function you can do any work
-   needed and add your events subscribers to the bus as usual via `start-event-listener!`."
+  The most appropriate way to initialize event listeners in any `metabase.events.*` namespace is to implement the
+  `events-init` function which accepts zero arguments. This function is dynamically resolved and called exactly once
+  when the application goes through normal startup procedures. Inside this function you can do any work needed and add
+  your events subscribers to the bus as usual via `start-event-listener!`."
   (:require [clojure.core.async :as async]
             [clojure.string :as s]
             [clojure.tools.logging :as log]
@@ -15,14 +15,15 @@
                       [util :as u])))
 
 
-;;; ## ---------------------------------------- LIFECYCLE ----------------------------------------
+;;; --------------------------------------------------- LIFECYCLE ----------------------------------------------------
 
 
 (defonce ^:private events-initialized?
   (atom nil))
 
 (defn- find-and-load-event-handlers!
-  "Search Classpath for namespaces that start with `metabase.events.`, and call their `events-init` function if it exists."
+  "Search Classpath for namespaces that start with `metabase.events.`, and call their `events-init` function if it
+  exists."
   []
   (when-not config/is-test?
     (doseq [ns-symb @u/metabase-namespace-symbols
@@ -41,7 +42,7 @@
     (reset! events-initialized? true)))
 
 
-;;; ## ---------------------------------------- PUBLICATION ----------------------------------------
+;;; -------------------------------------------------- PUBLICATION ---------------------------------------------------
 
 
 (def ^:private events-channel
@@ -49,25 +50,22 @@
   (async/chan))
 
 (def ^:private events-publication
-  "Publication for general events channel.
-   Expects a map as input and the map must have a `:topic` key."
+  "Publication for general events channel. Expects a map as input and the map must have a `:topic` key."
   (async/pub events-channel :topic))
 
 (defn publish-event!
-  "Publish an item into the events stream.
-  Returns the published item to allow for chaining."
+  "Publish an item into the events stream. Returns the published item to allow for chaining."
   [topic event-item]
   {:pre [(keyword topic)]}
-  (async/go (async/>! events-channel {:topic (keyword topic) :item event-item}))
+  (async/go (async/>! events-channel {:topic (keyword topic), :item event-item}))
   event-item)
 
 
-;;; ## ---------------------------------------- SUBSCRIPTION ----------------------------------------
+;;; -------------------------------------------------- SUBSCRIPTION --------------------------------------------------
 
 (defn- subscribe-to-topic!
-  "Subscribe to a given topic of the general events stream.
-   Expects a topic to subscribe to and a `core.async` channel.
-   Returns the channel to allow for chaining."
+  "Subscribe to a given topic of the general events stream. Expects a topic to subscribe to and a `core.async` channel.
+  Returns the channel to allow for chaining."
   [topic channel]
   {:pre [(keyword topic)]}
   (async/sub events-publication (keyword topic) channel)
@@ -96,8 +94,7 @@
     (recur)))
 
 
-;;; ## ---------------------------------------- HELPER FUNCTIONS ----------------------------------------
-
+;;; ------------------------------------------------ HELPER FUNCTIONS ------------------------------------------------
 
 (defn topic->model
   "Determine a valid `model` identifier for the given TOPIC."

--- a/src/metabase/events/last_login.clj
+++ b/src/metabase/events/last_login.clj
@@ -1,9 +1,7 @@
 (ns metabase.events.last-login
   (:require [clojure.core.async :as async]
             [clojure.tools.logging :as log]
-            [metabase
-             [events :as events]
-             [util :as u]]
+            [metabase.events :as events]
             [metabase.models.user :refer [User]]
             [metabase.util.date :as du]
             [toucan.db :as db]))

--- a/src/metabase/feature_extraction/async.clj
+++ b/src/metabase/feature_extraction/async.clj
@@ -2,11 +2,10 @@
   (:require [cheshire.core :as json]
             [clojure.tools.logging :as log]
             [metabase.api.common :as api]
-            [metabase.public-settings :as public-settings]
             [metabase.models
              [computation-job :refer [ComputationJob]]
              [computation-job-result :refer [ComputationJobResult]]]
-            [metabase.util :as u]
+            [metabase.public-settings :as public-settings]
             [metabase.util.date :as du]
             [toucan.db :as db]))
 

--- a/src/metabase/feature_extraction/comparison.clj
+++ b/src/metabase/feature_extraction/comparison.clj
@@ -69,15 +69,15 @@
                         t a b)}))
 
 (defmethod difference [nil Object]
-  [a b]
+  [_ _]
   {:difference nil})
 
 (defmethod difference [Object nil]
-  [a b]
+  [_ _]
   {:difference nil})
 
 (defmethod difference [nil nil]
-  [a b]
+  [_ _]
   {:difference nil})
 
 (defn- unify-categories

--- a/src/metabase/feature_extraction/core.clj
+++ b/src/metabase/feature_extraction/core.clj
@@ -1,8 +1,8 @@
 (ns metabase.feature-extraction.core
   "Feature extraction for various models."
   (:require [clojure
-             [walk :refer [postwalk]]
-             [string :as s]]
+             [string :as s]
+             [walk :refer [postwalk]]]
             [medley.core :as m]
             [metabase.db.metadata-queries :as metadata]
             [metabase.feature-extraction
@@ -16,12 +16,10 @@
              [card :refer [Card]]
              [field :refer [Field]]
              [metric :refer [Metric]]
-             [query :refer [Query] :as query]
+             [query :as query :refer [Query]]
              [segment :refer [Segment]]
              [table :refer [Table]]]
-            [metabase.query-processor :as qp]
             [metabase.util :as u]
-            [redux.core :as redux]
             [toucan
              [db :as db]
              [hydrate :refer [hydrate]]]))

--- a/src/metabase/feature_extraction/feature_extractors.clj
+++ b/src/metabase/feature_extraction/feature_extractors.clj
@@ -12,9 +12,7 @@
              [values :as values]]
             [metabase.models.field :as field]
             [metabase.query-processor.middleware.binning :as binning]
-            [metabase
-             [query-processor :as qp]
-             [util :as u]]
+            [metabase.util :as u]
             [net.cgrand.xforms :as x]
             [redux.core :as redux]
             [toucan.db :as db])

--- a/src/metabase/middleware.clj
+++ b/src/metabase/middleware.clj
@@ -7,8 +7,7 @@
              [db :as mdb]
              [public-settings :as public-settings]
              [util :as u]]
-            [metabase.api.common :refer [*current-user* *current-user-id* *current-user-permissions-set*
-                                         *is-superuser?*]]
+            [metabase.api.common :refer [*current-user* *current-user-id* *current-user-permissions-set* *is-superuser?*]]
             [metabase.api.common.internal :refer [*automatically-catch-api-exceptions*]]
             [metabase.core.initialization-status :as init-status]
             [metabase.models
@@ -16,13 +15,11 @@
              [setting :refer [defsetting]]
              [user :as user :refer [User]]]
             [metabase.util.date :as du]
-            monger.json
             [puppetlabs.i18n.core :refer [tru]]
             [toucan
              [db :as db]
              [models :as models]])
-  (:import com.fasterxml.jackson.core.JsonGenerator
-           java.io.OutputStream))
+  (:import com.fasterxml.jackson.core.JsonGenerator))
 
 ;;; ---------------------------------------------------- UTIL FNS ----------------------------------------------------
 
@@ -337,9 +334,9 @@
                    (str "\n" (u/pprint-to-str body)))))))
 
 (defn log-api-call
-  "Takes a handler and a `jetty-stats-fn`. Logs `:request` and/or `:response` by passing corresponding
-  OPTIONS. `jetty-stats-fn` returns threadpool metadata that is included in the api request log"
-  [handler jetty-stats-fn & options]
+  "Takes a handler and a `jetty-stats-fn`. Logs info about request such as status code, number of DB calls, and time
+  taken to complete. `jetty-stats-fn` returns threadpool metadata that is included in the api request log"
+  [handler jetty-stats-fn]
   (fn [{:keys [uri], :as request}]
     (if (or (not (api-call? request))
             (= uri "/api/health")     ; don't log calls to /health or /util/logs because they clutter up

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -1,8 +1,7 @@
 (ns metabase.models.card
   "Underlying DB model for what is now most commonly referred to as a 'Question' in most user-facing situations. Card
   is a historical name, but is the same thing; both terms are used interchangeably in the backend codebase."
-  (:require [clojure.core.memoize :as memoize]
-            [clojure.set :as set]
+  (:require [clojure.set :as set]
             [clojure.tools.logging :as log]
             [metabase
              [public-settings :as public-settings]

--- a/src/metabase/models/computation_job_result.clj
+++ b/src/metabase/models/computation_job_result.clj
@@ -1,6 +1,5 @@
 (ns metabase.models.computation-job-result
-  (:require [metabase.models.interface :as i]
-            [metabase.util :as u]
+  (:require [metabase.util :as u]
             [toucan.models :as models]))
 
 (models/defmodel ComputationJobResult :computation_job_result)

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -187,9 +187,9 @@
 
 
 (defn- update-field-values-for-on-demand-dbs!
-  "If the parameters have changed since last time this dashboard was saved, we need to update the FieldValues
+  "If the parameters have changed since last time this Dashboard was saved, we need to update the FieldValues
    for any Fields that belong to an 'On-Demand' synced DB."
-  [dashboard-or-id old-param-field-ids new-param-field-ids]
+  [old-param-field-ids new-param-field-ids]
   (when (and (seq new-param-field-ids)
              (not= old-param-field-ids new-param-field-ids))
     (let [newly-added-param-field-ids (set/difference new-param-field-ids old-param-field-ids)]
@@ -214,7 +214,7 @@
                                 (update :series #(filter identity (map u/get-id %))))]
     (u/prog1 (dashboard-card/create-dashboard-card! dashboard-card)
       (let [new-param-field-ids (dashboard-id->param-field-ids dashboard-or-id)]
-        (update-field-values-for-on-demand-dbs! dashboard-or-id old-param-field-ids new-param-field-ids)))))
+        (update-field-values-for-on-demand-dbs! old-param-field-ids new-param-field-ids)))))
 
 (defn update-dashcards!
   "Update the DASHCARDS belonging to DASHBOARD-OR-ID.
@@ -230,7 +230,7 @@
       (when (contains? dashcard-ids dashcard-id)
         (dashboard-card/update-dashboard-card! (update dashboard-card :series #(filter identity (map :id %))))))
     (let [new-param-field-ids (dashboard-id->param-field-ids dashboard-or-id)]
-      (update-field-values-for-on-demand-dbs! dashboard-or-id old-param-field-ids new-param-field-ids))))
+      (update-field-values-for-on-demand-dbs! old-param-field-ids new-param-field-ids))))
 
 
 (defn- result-metadata-for-query

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -16,7 +16,7 @@
 ;;; --------------------------------------------------- Constants ---------------------------------------------------
 
 ;; TODO - should this be renamed `saved-cards-virtual-id`?
-(def ^:const ^Integer virtual-id
+(def ^Integer virtual-id
   "The ID used to signify that a database is 'virtual' rather than physical.
 
    A fake integer ID is used so as to minimize the number of changes that need to be made on the frontend -- by using

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -8,22 +8,22 @@
              [db :as db]
              [models :as models]]))
 
-(def ^:const ^Integer category-cardinality-threshold
+(def ^Integer category-cardinality-threshold
   "Fields with less than this many distinct values should automatically be given a special type of `:type/Category`.
   This no longer has any meaning whatsoever as far as the backend code is concerned; it is used purely to inform
   frontend behavior such as widget choices."
   (int 30))
 
-(def ^:const ^Integer auto-list-cardinality-threshold
+(def ^Integer auto-list-cardinality-threshold
   "Fields with less than this many distincy values should be given a `has_field_values` value of `list`, which means
   the Field should have FieldValues."
   (int 100))
 
-(def ^:private ^:const ^Integer entry-max-length
+(def ^:private ^Integer entry-max-length
   "The maximum character length for a stored `FieldValues` entry."
   (int 100))
 
-(def ^:private ^:const ^Integer total-max-length
+(def ^:private ^Integer total-max-length
   "Maximum total length for a `FieldValues` entry (combined length of all values for the field)."
   (int (* auto-list-cardinality-threshold entry-max-length)))
 

--- a/src/metabase/models/metric.clj
+++ b/src/metabase/models/metric.clj
@@ -69,7 +69,7 @@
 
 (defn metric-dependencies
   "Calculate any dependent objects for a given `Metric`."
-  [this id {:keys [definition]}]
+  [_ _ {:keys [definition]}]
   (when definition
     {:Segment (q/extract-segment-ids definition)}))
 

--- a/src/metabase/models/params.clj
+++ b/src/metabase/models/params.clj
@@ -1,11 +1,10 @@
 (ns metabase.models.params
   "Utility functions for dealing with parameters for Dashboards and Cards."
   (:require [clojure.set :as set]
-            [metabase.query-processor.middleware.expand :as ql]
-            metabase.query-processor.interface
             [metabase
              [db :as mdb]
              [util :as u]]
+            [metabase.query-processor.middleware.expand :as ql]
             [toucan
              [db :as db]
              [hydrate :refer [hydrate]]])

--- a/src/metabase/models/pulse_channel.clj
+++ b/src/metabase/models/pulse_channel.clj
@@ -13,7 +13,7 @@
 
 ;; ## Static Definitions
 
-(def ^:const days-of-week
+(def days-of-week
   "Simple `vector` of the days in the week used for reference and lookups.
 
    NOTE: order is important here!!
@@ -36,7 +36,7 @@
   [hour]
   (and (integer? hour) (<= 0 hour 23)))
 
-(def ^:private ^:const schedule-frames
+(def ^:private schedule-frames
   "Set of possible schedule-frames allowe for a pulse channel."
   #{:first :mid :last})
 
@@ -45,7 +45,7 @@
   [frame]
   (contains? schedule-frames frame))
 
-(def ^:private ^:const schedule-types
+(def ^:private schedule-types
   "Set of the possible schedule-types allowed for a pulse channel."
   #{:hourly :daily :weekly :monthly})
 
@@ -75,7 +75,7 @@
              (and (= :mid schedule-frame)
                   (nil? schedule-day))))))
 
-(def ^:const channel-types
+(def channel-types
   "Map which contains the definitions for each type of pulse channel we allow.  Each key is a channel type with a map
    which contains any other relevant information for defining the channel.  E.g.
 

--- a/src/metabase/models/revision/diff.clj
+++ b/src/metabase/models/revision/diff.clj
@@ -2,27 +2,27 @@
   (:require [clojure.core.match :refer [match]]
             [clojure.string :as s]))
 
-(defn- diff-string* [t k v1 v2]
-  (match [t k v1 v2]
-    [_ :name _ _]
+(defn- diff-string* [k v1 v2]
+  (match [k v1 v2]
+    [:name _ _]
     (format "renamed it from \"%s\" to \"%s\"" v1 v2)
 
-    [_ :private true false]
+    [:private true false]
     "made it public"
 
-    [_ :private false true]
+    [:private false true]
     "made it private"
 
-    [_ :updated_at _ _]
+    [:updated_at _ _]
     nil
 
-    [_ :dataset_query _ _]
+    [:dataset_query _ _]
     "modified the query"
 
-    [_ :visualization_settings _ _]
+    [:visualization_settings _ _]
     "changed the visualization settings"
 
-    [_ _ _ _]
+    [_ _ _]
     (format "changed %s from \"%s\" to \"%s\"" (name k) v1 v2)))
 
 (defn build-sentence
@@ -41,6 +41,6 @@
   (when before
     (let [ks (keys before)]
       (some-> (filter identity (for [k ks]
-                                 (diff-string* t k (k before) (k after))))
+                                 (diff-string* k (k before) (k after))))
               build-sentence
               (s/replace-first #" it " (format " this %s " t))))))

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -7,11 +7,12 @@
              [common :as common]
              [setting :as setting :refer [defsetting]]]
             [metabase.public-settings.metastore :as metastore]
-            [metabase.util.i18n :refer [available-locales-with-names set-locale]]
-            [metabase.util.password :as password]
+            [metabase.util
+             [i18n :refer [available-locales-with-names set-locale]]
+             [password :as password]]
             [puppetlabs.i18n.core :refer [tru]]
             [toucan.db :as db])
-  (:import [java.util Locale TimeZone UUID]))
+  (:import [java.util TimeZone UUID]))
 
 (defsetting check-for-updates
   (tru "Identify when new versions of Metabase are available.")

--- a/src/metabase/public_settings/metastore.clj
+++ b/src/metabase/public_settings/metastore.clj
@@ -3,11 +3,11 @@
   (:require [cheshire.core :as json]
             [clojure.core.memoize :as memoize]
             [clojure.tools.logging :as log]
-            [clj-http.client :as client]
             [environ.core :refer [env]]
+            [metabase
+             [config :as config]
+             [util :as u]]
             [metabase.models.setting :as setting :refer [defsetting]]
-            [metabase.config :as config]
-            [metabase.util :as u]
             [metabase.util.schema :as su]
             [puppetlabs.i18n.core :refer [trs tru]]
             [schema.core :as s]))

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -120,7 +120,7 @@
 
 (defmulti ^:private should-send-notification?
   "Returns true if given the pulse type and resultset a new notification (pulse or alert) should be sent"
-  (fn [pulse results] (alert-or-pulse pulse)))
+  (fn [pulse _results] (alert-or-pulse pulse)))
 
 (defmethod should-send-notification? :alert
   [{:keys [alert_condition] :as alert} results]

--- a/src/metabase/query_processor/annotate.clj
+++ b/src/metabase/query_processor/annotate.clj
@@ -1,10 +1,12 @@
 (ns metabase.query-processor.annotate
   "Code that analyzes the results of running a query and adds relevant type information about results (including
   foreign key information). This also does things like taking lisp-case keys used in the QP and converting them back
-  to snake_case ones used in the frontend."
-  ;; TODO - The code in this namespace could definitely use a little cleanup to make it a little easier to wrap one's
-  ;;        head around :)
-  ;; TODO - This namespace should be called something like `metabase.query-processor.middleware.annotate`
+  to snake_case ones used in the frontend.
+
+  TODO - The code in this namespace could definitely use a little cleanup to make it a little easier to wrap one's
+         head around :)
+
+  TODO - This namespace should be called something like `metabase.query-processor.middleware.annotate`"
   (:require [clojure
              [set :as set]
              [string :as str]]
@@ -18,8 +20,7 @@
              [humanization :as humanization]]
             [metabase.query-processor
              [interface :as i]
-             [sort :as sort]
-             [util :as qputil]]
+             [sort :as sort]]
             [toucan.db :as db])
   (:import [metabase.query_processor.interface Expression ExpressionRef]))
 
@@ -317,7 +318,7 @@
      (fk-field->dest-fn fields fk-ids id->dest-id (u/key-by :id (db/select [Field :id :name :display_name :table_id :description :base_type :special_type :visibility_type]
                                                                   :id [:in (vals id->dest-id)])))))
   ;; Return a function that will return the corresponding destination Field for a given Field
-  ([fields fk-ids id->dest-id dest-id->field]
+  ([_ _ id->dest-id dest-id->field]
    (fn [{:keys [id]}]
      (some-> id id->dest-id dest-id->field))))
 

--- a/src/metabase/query_processor/interface.clj
+++ b/src/metabase/query_processor/interface.clj
@@ -6,7 +6,6 @@
              [dimension :as dim]
              [field :as field]]
             [metabase.sync.interface :as i]
-            [metabase.util :as u]
             [metabase.util
              [date :as du]
              [schema :as su]]
@@ -16,7 +15,7 @@
 
 ;;; --------------------------------------------------- CONSTANTS ----------------------------------------------------
 
-(def ^:const absolute-max-results
+(def absolute-max-results
   "Maximum number of rows the QP should ever return.
 
    This is coming directly from the max rows allowed by Excel for now ...
@@ -67,14 +66,18 @@
 ;; These are just used by the QueryExpander to record information about how joins should occur.
 
 (s/defrecord JoinTableField [field-id   :- su/IntGreaterThanZero
-                             field-name :- su/NonBlankString])
+                             field-name :- su/NonBlankString]
+  nil
+  :load-ns true)
 
 (s/defrecord JoinTable [source-field :- JoinTableField
                         pk-field     :- JoinTableField
                         table-id     :- su/IntGreaterThanZero
                         table-name   :- su/NonBlankString
                         schema       :- (s/maybe su/NonBlankString)
-                        join-alias   :- su/NonBlankString])
+                        join-alias   :- su/NonBlankString]
+  nil
+  :load-ns true)
 
 ;;; --------------------------------------------------- PROTOCOLS ----------------------------------------------------
 
@@ -97,7 +100,9 @@
                           values                  :- (s/maybe (s/cond-pre [s/Any] {} []))
                           human-readable-values   :- (s/maybe (s/cond-pre [s/Any] {} []))
                           created-at              :- java.util.Date
-                          updated-at              :- java.util.Date])
+                          updated-at              :- java.util.Date]
+  nil
+  :load-ns true)
 
 (s/defrecord Dimensions [dimension-id            :- su/IntGreaterThanZero
                          field-id                :- su/IntGreaterThanZero
@@ -105,7 +110,9 @@
                          human-readable-field-id :- (s/maybe su/IntGreaterThanZero)
                          dimension-type          :- (apply s/enum dim/dimension-types)
                          created-at              :- java.util.Date
-                         updated-at              :- java.util.Date])
+                         updated-at              :- java.util.Date]
+  nil
+  :load-ns true)
 
 ;; Field is the "expanded" form of a Field ID (field reference) in MBQL
 (s/defrecord Field [field-id           :- su/IntGreaterThanZero
@@ -129,6 +136,8 @@
                     dimensions         :- (s/maybe (s/cond-pre Dimensions {} []))
                     values             :- (s/maybe (s/cond-pre FieldValues {} []))
                     fingerprint        :- (s/maybe i/Fingerprint)]
+  nil
+  :load-ns true
   clojure.lang.Named
   (getName [_] field-name) ; (name <field>) returns the *unqualified* name of the field, #obvi
 
@@ -141,12 +150,12 @@
 
 ;;; DateTimeField
 
-(def ^:const datetime-field-units
+(def datetime-field-units
   "Valid units for a `DateTimeField`."
   #{:default :minute :minute-of-hour :hour :hour-of-day :day :day-of-week :day-of-month :day-of-year
     :week :week-of-year :month :month-of-year :quarter :quarter-of-year :year})
 
-(def ^:const relative-datetime-value-units
+(def relative-datetime-value-units
   "Valid units for a `RelativeDateTimeValue`."
   #{:minute :hour :day :week :month :quarter :year})
 
@@ -173,6 +182,8 @@
 ;; make the clauses specify required feature metadata and have that get checked automatically?)
 (s/defrecord FieldLiteral [field-name    :- su/NonBlankString
                            base-type     :- su/FieldType]
+  nil
+  :load-ns true
   clojure.lang.Named
   (getName [_] field-name)
   IField
@@ -181,17 +192,23 @@
 ;; DateTimeField is just a simple wrapper around Field
 (s/defrecord DateTimeField [field :- (s/cond-pre Field FieldLiteral)
                             unit  :- DatetimeFieldUnit]
+  nil
+  :load-ns true
   clojure.lang.Named
   (getName [_] (name field)))
 
 ;; TimeField is just a field wrapper that indicates string should be interpretted as a time
 (s/defrecord TimeField [field :- (s/cond-pre Field FieldLiteral)]
+  nil
+  :load-ns true
   clojure.lang.Named
   (getName [_] (name field)))
 
 (s/defrecord TimeValue [value       :- Time
                         field       :- TimeField
-                        timezone-id :- (s/maybe String)])
+                        timezone-id :- (s/maybe String)]
+  nil
+  :load-ns true)
 
 (def binning-strategies
   "Valid binning strategies for a `BinnedField`"
@@ -203,10 +220,14 @@
                           min-value :- s/Num
                           max-value :- s/Num
                           bin-width :- s/Num]
+  nil
+  :load-ns true
   clojure.lang.Named
   (getName [_] (name field)))
 
 (s/defrecord ExpressionRef [expression-name :- su/NonBlankString]
+  nil
+  :load-ns true
   clojure.lang.Named
   (getName [_] expression-name)
   IField
@@ -234,13 +255,19 @@
                                remapped-to         :- (s/maybe s/Str)
                                field-display-name  :- (s/maybe s/Str)
                                binning-strategy    :- (s/maybe (apply s/enum binning-strategies))
-                               binning-param       :- (s/maybe s/Num)])
+                               binning-param       :- (s/maybe s/Num)]
+  nil
+  :load-ns true)
 
-(s/defrecord AgFieldRef [index :- s/Int])
+(s/defrecord AgFieldRef [index :- s/Int]
+  nil
+  :load-ns true)
 ;; TODO - add a method to get matching expression from the query?
 
 (s/defrecord RelativeDatetime [amount :- s/Int
-                               unit   :- DatetimeValueUnit])
+                               unit   :- DatetimeValueUnit]
+  nil
+  :load-ns true)
 
 (declare Aggregation AnyField AnyValueLiteral)
 
@@ -250,7 +277,9 @@
                          args       :- [(s/cond-pre (s/recursive #'AnyValueLiteral)
                                                     (s/recursive #'AnyField)
                                                     (s/recursive #'Aggregation))]
-                         custom-name :- (s/maybe su/NonBlankString)])
+                         custom-name :- (s/maybe su/NonBlankString)]
+  nil
+  :load-ns true)
 
 
 (def AnyField
@@ -298,16 +327,22 @@
 ;; Information about the associated Field is included for convenience
 ;; TODO - Value doesn't need the whole field, just the relevant type info / units
 (s/defrecord Value [value   :- AnyValueLiteral
-                    field   :- (s/recursive #'AnyField)])
+                    field   :- (s/recursive #'AnyField)]
+  nil
+  :load-ns true)
 
 (s/defrecord RelativeDateTimeValue [amount :- s/Int
                                     unit   :- DatetimeValueUnit
                                     field  :- (s/cond-pre DateTimeField
-                                                          FieldPlaceholder)])
+                                                          FieldPlaceholder)]
+  nil
+  :load-ns true)
 
 ;; e.g. an absolute point in time (literal)
 (s/defrecord DateTimeValue [value :- (s/maybe Timestamp)
-                            field :- DateTimeField])
+                            field :- DateTimeField]
+  nil
+  :load-ns true)
 
 (def OrderableValue
   "Schema for an instance of `Value` whose `:value` property is itself orderable (a datetime or number, i.e. a
@@ -347,7 +382,9 @@
 ;; Replace values with these during first pass over Query.
 ;; Include associated Field ID so appropriate the info can be found during Field resolution
 (s/defrecord ValuePlaceholder [field-placeholder :- AnyField
-                               value             :- AnyValueLiteral])
+                               value             :- AnyValueLiteral]
+  nil
+  :load-ns true)
 
 (def OrderableValuePlaceholder
   "`ValuePlaceholder` schema with the additional constraint that the value be orderable (a number or datetime)."
@@ -387,14 +424,18 @@
 
 (s/defrecord AggregationWithoutField [aggregation-type :- (s/named (s/enum :count :cumulative-count)
                                                                    "Valid aggregation type")
-                                      custom-name      :- (s/maybe su/NonBlankString)])
+                                      custom-name      :- (s/maybe su/NonBlankString)]
+  nil
+  :load-ns true)
 
 (s/defrecord AggregationWithField [aggregation-type :- (s/named (s/enum :avg :count :cumulative-sum :distinct :max
                                                                         :min :stddev :sum)
                                                                 "Valid aggregation type")
                                    field            :- (s/cond-pre AnyField
                                                                    Expression)
-                                   custom-name      :- (s/maybe su/NonBlankString)])
+                                   custom-name      :- (s/maybe su/NonBlankString)]
+  nil
+  :load-ns true)
 
 (defn- valid-aggregation-for-driver? [{:keys [aggregation-type]}]
   (when (= aggregation-type :stddev)
@@ -413,22 +454,30 @@
 
 (s/defrecord EqualityFilter [filter-type :- (s/enum := :!=)
                              field       :- AnyField
-                             value       :- AnyFieldOrValue])
+                             value       :- AnyFieldOrValue]
+  nil
+  :load-ns true)
 
 (s/defrecord ComparisonFilter [filter-type :- (s/enum :< :<= :> :>=)
                                field       :- AnyField
-                               value       :- OrderableValueOrPlaceholder])
+                               value       :- OrderableValueOrPlaceholder]
+  nil
+  :load-ns true)
 
 (s/defrecord BetweenFilter [filter-type  :- (s/eq :between)
                             min-val      :- OrderableValueOrPlaceholder
                             field        :- AnyField
-                            max-val      :- OrderableValueOrPlaceholder])
+                            max-val      :- OrderableValueOrPlaceholder]
+  nil
+  :load-ns true)
 
 (s/defrecord StringFilter [filter-type     :- (s/enum :starts-with :contains :ends-with)
                            field           :- AnyField
                            ;; TODO - not 100% sure why this is also allowed to accept a plain string
                            value           :- (s/cond-pre s/Str StringValueOrPlaceholder)
-                           case-sensitive? :- s/Bool])
+                           case-sensitive? :- s/Bool]
+  nil
+  :load-ns true)
 
 (def SimpleFilterClause
   "Schema for a non-compound, non-`not` MBQL `filter` clause."
@@ -436,12 +485,16 @@
            "Simple filter clause"))
 
 (s/defrecord NotFilter [compound-type :- (s/eq :not)
-                        subclause     :- SimpleFilterClause])
+                        subclause     :- SimpleFilterClause]
+  nil
+  :load-ns true)
 
 (declare Filter)
 
 (s/defrecord CompoundFilter [compound-type :- (s/enum :and :or)
-                             subclauses    :- [(s/recursive #'Filter)]])
+                             subclauses    :- [(s/recursive #'Filter)]]
+  nil
+  :load-ns true)
 
 (def Filter
   "Schema for top-level `filter` clause in an MBQL query."

--- a/src/metabase/query_processor/middleware/add_row_count_and_status.clj
+++ b/src/metabase/query_processor/middleware/add_row_count_and_status.clj
@@ -1,7 +1,8 @@
 (ns metabase.query-processor.middleware.add-row-count-and-status
   "Middleware for adding `:row_count` and `:status` info to QP results."
-  (:require (metabase.query-processor [interface :as i]
-                                      [util :as qputil])))
+  (:require [metabase.query-processor
+             [interface :as i]
+             [util :as qputil]]))
 
 (defn add-row-count-and-status
   "Wrap the results of a successfully processed query in the format expected by the frontend (add `row_count` and `status`)."

--- a/src/metabase/query_processor/middleware/cache_backend/db.clj
+++ b/src/metabase/query_processor/middleware/cache_backend/db.clj
@@ -1,11 +1,8 @@
 (ns metabase.query-processor.middleware.cache-backend.db
-  (:require [metabase
-             [public-settings :as public-settings]
-             [util :as u]]
-            [metabase.util.date :as du]
-            [metabase.models
+  (:require [metabase.models
              [interface :as models]
              [query-cache :refer [QueryCache]]]
+            [metabase.public-settings :as public-settings]
             [metabase.query-processor.middleware.cache-backend.interface :as i]
             [metabase.util.date :as du]
             [toucan.db :as db]))

--- a/src/metabase/query_processor/middleware/cumulative_aggregations.clj
+++ b/src/metabase/query_processor/middleware/cumulative_aggregations.clj
@@ -34,7 +34,7 @@
       (pred item) i
       (seq more)  (recur (inc i) more))))
 
-(defn- post-cumulative-aggregation [basic-ag-type ag-field {rows :rows, cols :cols, :as results}]
+(defn- post-cumulative-aggregation [basic-ag-type {rows :rows, cols :cols, :as results}]
   (let [ ;; Determine the index of the field we need to cumulative sum
         field-index (u/prog1 (first-index-satisfying (comp (partial = (name basic-ag-type)) :name)
                                cols)
@@ -54,7 +54,7 @@
         post-cumulative-ag   (partial post-cumulative-aggregation basic-ag-type)]
     (fn [query]
       (if-let [{ag-field :field} (cumulative-ag-clause query)]
-        (post-cumulative-ag ag-field (qp (pre-cumulative-ag ag-field query)))
+        (post-cumulative-ag (qp (pre-cumulative-ag ag-field query)))
         (qp query)))))
 
 

--- a/src/metabase/query_processor/middleware/expand.clj
+++ b/src/metabase/query_processor/middleware/expand.clj
@@ -234,7 +234,7 @@
      (assoc field :binning-strategy strategy, :binning-param strategy-param))))
 
 (defn- fields-list-clause
-  ([k query] query)
+  ([_ query] query)
   ([k query & fields] (assoc query k (mapv field fields))))
 
 (def ^:ql ^{:arglists '([query & fields])} breakout "Specify which fields to breakout by." (partial fields-list-clause :breakout))

--- a/src/metabase/query_processor/middleware/parameters/sql.clj
+++ b/src/metabase/query_processor/middleware/parameters/sql.clj
@@ -4,15 +4,12 @@
    The new implementation uses prepared statement args instead of substituting them directly into the query,
    and is much better-organized and better-documented."
   (:require [clojure.string :as str]
-            [clojure.tools.logging :as log]
             [honeysql.core :as hsql]
-            [instaparse.core :as insta]
             [medley.core :as m]
             [metabase.driver :as driver]
             [metabase.models.field :as field :refer [Field]]
-            [metabase.query-processor.middleware.parameters.dates :as date-params]
             [metabase.query-processor.middleware.expand :as ql]
-            [metabase.util :as u]
+            [metabase.query-processor.middleware.parameters.dates :as date-params]
             [metabase.util
              [date :as du]
              [schema :as su]]

--- a/src/metabase/query_processor/middleware/resolve.clj
+++ b/src/metabase/query_processor/middleware/resolve.clj
@@ -4,11 +4,9 @@
   `FieldPlaceholder` or similar. During this phase, we'll take those placeholder objects and fetch information from
   the DB and replace them with actual objects like `Field`."
   (:refer-clojure :exclude [resolve])
-  (:require [clj-time.coerce :as tcoerce]
-            [clojure
+  (:require [clojure
              [set :as set]
              [walk :as walk]]
-            [medley.core :as m]
             [metabase
              [db :as mdb]
              [util :as u]]

--- a/src/metabase/related.clj
+++ b/src/metabase/related.clj
@@ -1,7 +1,6 @@
 (ns metabase.related
   "Related entities recommendations."
   (:require [clojure.set :as set]
-            [clojure.string :as str]
             [medley.core :as m]
             [metabase.api.common :as api]
             [metabase.models

--- a/src/metabase/sync/analyze/classifiers/name.clj
+++ b/src/metabase/sync/analyze/classifiers/name.clj
@@ -5,15 +5,12 @@
             [metabase
              [config :as config]
              [util :as u]]
-            [metabase.models
-             [field :refer [Field]]
-             [database :refer [Database]]]
+            [metabase.models.database :refer [Database]]
             [metabase.sync
              [interface :as i]
              [util :as sync-util]]
             [metabase.util.schema :as su]
-            [schema.core :as s]
-            [toucan.db :as db]))
+            [schema.core :as s]))
 
 (def ^:private bool-or-int-type #{:type/Boolean :type/Integer})
 (def ^:private float-type       #{:type/Float})

--- a/src/metabase/sync/analyze/fingerprint/datetime.clj
+++ b/src/metabase/sync/analyze/fingerprint/datetime.clj
@@ -5,7 +5,6 @@
              [core :as t]]
             [medley.core :as m]
             [metabase.sync.interface :as i]
-            [metabase.util :as u]
             [metabase.util.date :as du]
             [redux.core :as redux]
             [schema.core :as s]))

--- a/src/metabase/sync/analyze/fingerprint/sample.clj
+++ b/src/metabase/sync/analyze/fingerprint/sample.clj
@@ -5,7 +5,6 @@
    Fields, or do a better job getting a more-random sample of rows."
   (:require [medley.core :as m]
             [metabase.driver :as driver]
-            [metabase.models.database :refer [Database]]
             [metabase.sync.interface :as i]
             [schema.core :as s]))
 

--- a/src/metabase/sync/interface.clj
+++ b/src/metabase/sync/interface.clj
@@ -5,11 +5,9 @@
              [database :refer [Database]]
              [field :refer [Field]]
              [table :refer [Table]]]
-            metabase.types
             [metabase.util :as u]
             [metabase.util.schema :as su]
             [schema.core :as s]))
-
 
 (def DatabaseMetadataTable
   "Schema for the expected output of `describe-database` for a Table."

--- a/src/metabase/sync/sync_metadata.clj
+++ b/src/metabase/sync/sync_metadata.clj
@@ -6,9 +6,7 @@
    2.  Sync fields (`metabase.sync.sync-metadata.fields`)
    3.  Sync FKs    (`metabase.sync.sync-metadata.fks`)
    4.  Sync Metabase Metadata table (`metabase.sync.sync-metadata.metabase-metadata`)"
-  (:require [clj-time.core :as time]
-            [clojure.tools.logging :as log]
-            [metabase.sync
+  (:require [metabase.sync
              [interface :as i]
              [util :as sync-util]]
             [metabase.sync.sync-metadata
@@ -17,7 +15,6 @@
              [metabase-metadata :as metabase-metadata]
              [sync-timezone :as sync-tz]
              [tables :as sync-tables]]
-            [metabase.util :as u]
             [puppetlabs.i18n.core :refer [trs]]
             [schema.core :as s]))
 

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -1,10 +1,6 @@
 (ns metabase.util
   "Common utility functions useful throughout the codebase."
-  (:require [clj-time
-             [coerce :as coerce]
-             [core :as t]
-             [format :as time]]
-            [clojure
+  (:require [clojure
              [data :as data]
              [pprint :refer [pprint]]
              [string :as s]]
@@ -14,17 +10,13 @@
             [clojure.math.numeric-tower :as math]
             [clojure.tools.logging :as log]
             [clojure.tools.namespace.find :as ns-find]
-            colorize.core ; this needs to be loaded for `format-color`
+            [colorize.core :as colorize]
             [metabase.config :as config]
             [puppetlabs.i18n.core :as i18n :refer [trs]]
             [ring.util.codec :as codec])
-  (:import clojure.lang.Keyword
-           [java.net InetAddress InetSocketAddress Socket]
-           [java.sql SQLException Time Timestamp]
-           [java.text Normalizer Normalizer$Form]
-           [java.util Calendar Date TimeZone]
-           org.joda.time.DateTime
-           org.joda.time.format.DateTimeFormatter))
+  (:import [java.net InetAddress InetSocketAddress Socket]
+           java.sql.SQLException
+           [java.text Normalizer Normalizer$Form]))
 
 ;; This is the very first log message that will get printed.  It's here because this is one of the very first
 ;; namespaces that gets loaded, and the first that has access to the logger It shows up a solid 10-15 seconds before
@@ -223,39 +215,38 @@
      ~'<>))
 
 (def ^String ^{:arglists '([emoji-string])} emoji
-  "Returns the EMOJI-STRING passed in if emoji in logs are enabled, otherwise always returns an empty string."
+  "Returns the `emoji-string` passed in if emoji in logs are enabled, otherwise always returns an empty string."
   (if (config/config-bool :mb-emoji-in-logs)
     identity
     (constantly "")))
 
 (def ^:private ^{:arglists '([color-symb x])} colorize
-  "Colorize string X with the function matching COLOR-SYMB, but only if `MB_COLORIZE_LOGS` is enabled (the default)."
+  "Colorize string `x` with the function matching `color` symbol or keyword, but only if `MB_COLORIZE_LOGS` is
+  enabled (the default)."
   (if (config/config-bool :mb-colorize-logs)
-    (fn [color-symb x]
-      (let [color-fn (or (ns-resolve 'colorize.core color-symb)
-                         (throw (Exception. (str "Invalid color symbol: " color-symb))))]
-        (color-fn x)))
+    (fn [color x]
+      (colorize/color (keyword color) x))
     (fn [_ x]
       x)))
 
 (defn format-color
-  "Like `format`, but uses a function in `colorize.core` to colorize the output.
-   COLOR-SYMB should be a quoted symbol like `green`, `red`, `yellow`, `blue`,
-   `cyan`, `magenta`, etc. See the entire list of avaliable colors
-   [here](https://github.com/ibdknox/colorize/blob/master/src/colorize/core.clj).
+  "Like `format`, but colorizes the output. `color` should be a symbol or keyword like `green`, `red`, `yellow`, `blue`,
+  `cyan`, `magenta`, etc. See the entire list of avaliable
+  colors [here](https://github.com/ibdknox/colorize/blob/master/src/colorize/core.clj).
 
-     (format-color 'red \"Fatal error: %s\" error-message)"
+     (format-color :red \"Fatal error: %s\" error-message)"
   {:style/indent 2}
-  (^String [color-symb x]
-   {:pre [(symbol? color-symb)]}
-   (colorize color-symb x))
-  (^String [color-symb format-string & args]
-   (colorize color-symb (apply format format-string args))))
+  (^String [color x]
+   {:pre [((some-fn symbol? keyword?) color)]}
+   (colorize color x))
+
+  (^String [color format-string & args]
+   (colorize color (apply format format-string args))))
 
 (defn pprint-to-str
-  "Returns the output of pretty-printing X as a string.
-   Optionally accepts COLOR-SYMB, which colorizes the output with the corresponding
-   function from `colorize.core`.
+  "Returns the output of pretty-printing `x` as a string.
+  Optionally accepts `color-symb`, which colorizes the output with the corresponding
+  function from `colorize.core`.
 
      (pprint-to-str 'green some-obj)"
   {:style/indent 1}

--- a/src/metabase/util/date.clj
+++ b/src/metabase/util/date.clj
@@ -3,16 +3,13 @@
              [coerce :as coerce]
              [core :as t]
              [format :as time]]
-            [clojure.tools.logging :as log]
             [clojure.math.numeric-tower :as math]
-            [metabase.util :as u]
-            [puppetlabs.i18n.core :refer [trs]])
-  (:import [clojure.lang Keyword]
-           [java.util Calendar Date TimeZone]
+            [metabase.util :as u])
+  (:import clojure.lang.Keyword
            [java.sql Time Timestamp]
-           [org.joda.time DateTime DateTimeZone]
-           [org.joda.time.format DateTimeFormatter]))
-
+           [java.util Calendar Date TimeZone]
+           org.joda.time.DateTime
+           org.joda.time.format.DateTimeFormatter))
 
 (defprotocol ITimestampCoercible
   "Coerce object to a `java.sql.Timestamp`."

--- a/src/metabase/util/honeysql_extensions.clj
+++ b/src/metabase/util/honeysql_extensions.clj
@@ -95,6 +95,7 @@
 
 ;; Single-quoted string literal
 (defrecord Literal [literal]
+  :load-ns true
   ToSql
   (to-sql [_]
     (str \' (name literal) \')))

--- a/src/metabase/util/password.clj
+++ b/src/metabase/util/password.clj
@@ -1,23 +1,25 @@
 (ns metabase.util.password
   (:require [cemerick.friend.credentials :as creds]
-            (metabase [config :as config]
-                      [util :as u])))
+            [metabase
+             [config :as config]
+             [util :as u]]))
 
 
 (defn- count-occurrences
-  "Return a map of the counts of each class of character for PASSWORD.
+  "Return a map of the counts of each class of character for `password`.
 
     (count-occurrences \"GoodPw!!\")
       -> {:total  8, :lower 4, :upper 2, :letter 6, :digit 0, :special 2}"
   [password]
-  (loop [[^Character c & more] password, {:keys [lower, upper, letter, digit, special], :as counts} {:total 0, :lower 0, :upper 0, :letter 0, :digit 0, :special 0}]
-    (if-not c counts
-      (recur more (merge (update counts :total inc)
-                         (cond
-                           (Character/isLowerCase c) {:lower   (inc lower), :letter (inc letter)}
-                           (Character/isUpperCase c) {:upper   (inc upper), :letter (inc letter)}
-                           (Character/isDigit     c) {:digit   (inc digit)}
-                           :else                     {:special (inc special)}))))))
+  (loop [[^Character c & more] password, counts {:total 0, :lower 0, :upper 0, :letter 0, :digit 0, :special 0}]
+    (if-not c
+      counts
+      (recur more (let [counts (update counts :total inc)]
+                    (cond
+                      (Character/isLowerCase c) (-> (update counts :letter inc) (update :lower inc))
+                      (Character/isUpperCase c) (-> (update counts :letter inc) (update :upper inc))
+                      (Character/isDigit     c) (update counts :digit   inc)
+                      :else                     (update counts :special inc)))))))
 
 (def ^:private ^:const complexity->char-type->min
   "Minimum counts of each class of character a password should have for a given password complexity level."
@@ -59,7 +61,8 @@
 
 
 (defn verify-password
-  "Verify if a given unhashed password + salt matches the supplied hashed-password. Returns `true` if matched, `false` otherwise."
+  "Verify if a given unhashed password + salt matches the supplied hashed-password. Returns `true` if matched, `false`
+  otherwise."
   ^Boolean [password salt hashed-password]
   ;; we wrap the friend/bcrypt-verify with this function specifically to avoid unintended exceptions getting out
   (boolean (u/ignore-exceptions

--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -3,7 +3,7 @@
             [metabase.driver :as driver]))
 
 
-(defrecord TestDriver []
+(defrecord ^:private TestDriver []
   clojure.lang.Named
   (getName [_] "TestDriver"))
 

--- a/test/metabase/query_processor/qp_middleware_test.clj
+++ b/test/metabase/query_processor/qp_middleware_test.clj
@@ -9,7 +9,7 @@
              [catch-exceptions :as catch-exceptions]
              [format-rows :as format-rows]]))
 
-(defrecord TestDriver []
+(defrecord ^:private TestDriver []
   clojure.lang.Named
   (getName [_] "TestDriver"))
 

--- a/test/metabase/related_test.clj
+++ b/test/metabase/related_test.clj
@@ -45,7 +45,7 @@
                  (#'r/similarity (Card card-id-1) (Card card-id-1))])))
 
 
-(defmacro ^:private with-world
+(defmacro ^:private expect-with-world
   [& body]
   `(tt/expect-with-temp [Collection [{~'collection-id :id}]
                          Metric     [{~'metric-id-a :id} {:table_id (data/id :venues)
@@ -75,7 +75,7 @@
                                                       :query {:source_table (data/id :venues)
                                                               :aggregation [:sum [:field-id (data/id :venues :longitude)]]
                                                               :breakout [[:field-id (data/id :venues :category_id)]]}}}]
-                         Card       [{card-id-c :id :as ~'card-c}
+                         Card       [{~'card-id-c :id :as ~'card-c}
                                      {:table_id (data/id :venues)
                                       :dataset_query {:type :query
                                                       :database (data/id)
@@ -93,7 +93,7 @@
                (sort (map :id v))
                (:id v))])))
 
-(with-world
+(expect-with-world
   {:table             (data/id :venues)
    :metrics           (sort [metric-id-a metric-id-b])
    :segments          (sort [segment-id-a segment-id-b])
@@ -105,14 +105,14 @@
   (->> ((users/user->client :crowberto) :get 200 (format "card/%s/related" card-id-a))
        result-mask))
 
-(with-world
+(expect-with-world
   {:table    (data/id :venues)
    :metrics  [metric-id-b]
    :segments (sort [segment-id-a segment-id-b])}
   (->> ((users/user->client :crowberto) :get 200 (format "metric/%s/related" metric-id-a))
        result-mask))
 
-(with-world
+(expect-with-world
   {:table       (data/id :venues)
    :metrics     (sort [metric-id-a metric-id-b])
    :segments    [segment-id-b]
@@ -120,7 +120,7 @@
   (->> ((users/user->client :crowberto) :get 200 (format "segment/%s/related" segment-id-a))
        result-mask))
 
-(with-world
+(expect-with-world
   {:metrics     (sort [metric-id-a metric-id-b])
    :segments    (sort [segment-id-a segment-id-b])
    :linking-to  [(data/id :categories)]
@@ -136,19 +136,19 @@
 ;; and for C B. Note that C is less similar to B than A is, as C has an additional
 ;; breakout dimension.
 
-(with-world
+(expect-with-world
   [card-id-b]
   (->> ((users/user->client :crowberto) :get 200 (format "card/%s/related" card-id-a))
        result-mask
        :similar-questions))
 
-(with-world
+(expect-with-world
   [card-id-a card-id-c] ; Ordering matters as C is less similar to B than A.
   (->> ((users/user->client :crowberto) :get 200 (format "card/%s/related" card-id-b))
        result-mask
        :similar-questions))
 
-(with-world
+(expect-with-world
   [card-id-b]
   (->> ((users/user->client :crowberto) :get 200 (format "card/%s/related" card-id-c))
        result-mask

--- a/test/metabase/sync/util_test.clj
+++ b/test/metabase/sync/util_test.clj
@@ -19,7 +19,7 @@
 
 (defonce ^:private calls-to-describe-database (atom 0))
 
-(defrecord ConcurrentSyncTestDriver []
+(defrecord ^:private ConcurrentSyncTestDriver []
   clojure.lang.Named
   (getName [_] "ConcurrentSyncTestDriver"))
 

--- a/test/metabase/sync_database_test.clj
+++ b/test/metabase/sync_database_test.clj
@@ -51,6 +51,7 @@
 
 ;; TODO - I'm 90% sure we could just reüse the "MovieDB" instead of having this subset of it used here
 (defrecord SyncTestDriver []
+  :load-ns true
   clojure.lang.Named
   (getName [_] "SyncTestDriver"))
 

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -23,14 +23,20 @@
                                                              su/FieldType)
                               special-type    :- (s/maybe su/FieldType)
                               visibility-type :- (s/maybe (apply s/enum field/visibility-types))
-                              fk              :- (s/maybe s/Keyword)])
+                              fk              :- (s/maybe s/Keyword)]
+  nil
+  :load-ns true)
 
 (s/defrecord TableDefinition [table-name        :- su/NonBlankString
                               field-definitions :- [FieldDefinition]
-                              rows              :- [[s/Any]]])
+                              rows              :- [[s/Any]]]
+  nil
+  :load-ns true)
 
 (s/defrecord DatabaseDefinition [database-name     :- su/NonBlankString
-                                 table-definitions :- [TableDefinition]])
+                                 table-definitions :- [TableDefinition]]
+  nil
+  :load-ns true)
 
 (defn escaped-name
   "Return escaped version of database name suitable for use as a filename / database name / etc."

--- a/test/metabase/test/mock/moviedb.clj
+++ b/test/metabase/test/mock/moviedb.clj
@@ -68,7 +68,7 @@
                :base-type :type/Text}}}})
 
 
-(defrecord MovieDbDriver []
+(defrecord ^:private MovieDbDriver []
   clojure.lang.Named
   (getName [_] "MovieDbDriver"))
 

--- a/test/metabase/test/mock/schema_per_customer.clj
+++ b/test/metabase/test/mock/schema_per_customer.clj
@@ -41,7 +41,7 @@
                                  {:name         "name"
                                   :base-type    :type/Text}}}}})
 
-(defrecord SchemaPerCustomerDriver []
+(defrecord ^:private SchemaPerCustomerDriver []
   clojure.lang.Named
   (getName [_] "SchemaPerCustomerDriver"))
 

--- a/test/metabase/test/mock/toucanery.clj
+++ b/test/metabase/test/mock/toucanery.clj
@@ -66,7 +66,7 @@
      {:keypath "movies.description", :value "A cinematic adventure."}]))
 
 
-(defrecord ToucaneryDriver []
+(defrecord ^:private ToucaneryDriver []
   clojure.lang.Named
   (getName [_] "ToucaneryDriver"))
 


### PR DESCRIPTION
I found out that Clojure 1.8 added a new `:load-ns` option for `defrecord` that will automatically ensure a namespace gets loaded when you `import` a record type defined therein. Awesome!

I was also able to enable the Eastwood unused namespaces linter as a result and cleaned up a bunch of things it caught