### PR TITLE
Add collection_position column to Card/Dashboard/Notification [WIP]

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -4106,3 +4106,26 @@ databaseChangeLog:
             columns:
               - column:
                   name: collection_id
+  - changeSet:
+      id: 81
+      author: camsaul
+      comment: 'Added 0.30.0'
+      changes:
+        - addColumn:
+            tableName: report_dashboard
+            columns:
+              name: collection_position
+              type: smallint
+              remarks: 'Optional pinned position for this item in its Collection. NULL means item is not pinned.'
+        - addColumn:
+            tableName: report_card
+            columns:
+              name: collection_position
+              type: smallint
+              remarks: 'Optional pinned position for this item in its Collection. NULL means item is not pinned.'
+        - addColumn:
+            tableName: pulse
+            columns:
+              name: collection_position
+              type: smallint
+              remarks: 'Optional pinned position for this item in its Collection. NULL means item is not pinned.'

--- a/test/metabase/events/revision_test.clj
+++ b/test/metabase/events/revision_test.clj
@@ -10,7 +10,7 @@
              [revision :refer [Revision]]
              [segment :refer [Segment]]
              [table :refer [Table]]]
-            [metabase.test.data :refer :all]
+            [metabase.test.data :as data :refer :all]
             [metabase.test.data.users :refer :all]
             [metabase.util :as u]
             [toucan.db :as db]
@@ -20,18 +20,19 @@
   "Some default properties for `Cards` for use in tests in this namespace."
   []
   {:display                "table"
-   :dataset_query          {:database (id)
+   :dataset_query          {:database (data/id)
                             :type     "query"
                             :query    {:aggregation ["rows"]
-                                       :source_table (id :categories)}}
+                                       :source_table (data/id :categories)}}
    :visualization_settings {}
    :creator_id             (user->id :crowberto)})
 
 (defn- card->revision-object [card]
   {:archived               false
    :collection_id          nil
+   :collection_position    nil
    :creator_id             (:creator_id card)
-   :database_id            (id)
+   :database_id            (data/id)
    :dataset_query          (:dataset_query card)
    :read_permissions       (vec (:read_permissions card))
    :description            nil
@@ -44,7 +45,7 @@
    :public_uuid            nil
    :cache_ttl              nil
    :query_type             "query"
-   :table_id               (id :categories)
+   :table_id               (data/id :categories)
    :visualization_settings {}
    :result_metadata        nil})
 

--- a/test/metabase/models/pulse_test.clj
+++ b/test/metabase/models/pulse_test.clj
@@ -53,8 +53,9 @@
       remove-uneeded-pulse-keys))
 
 (def ^:private pulse-defaults
-  {:skip_if_empty false
-   :collection_id nil})
+  {:collection_id       nil
+   :collection_position nil
+   :skip_if_empty       false})
 
 ;; retrieve-pulse
 ;; this should cover all the basic Pulse attributes


### PR DESCRIPTION
Add new `collection_position` column to Card, Dashboard, and Notification models. `NULL` means object is not "pinned". Non-NULL value is its pinned position.

Can be set via normal POST/PUT endpoints.

TODO:
- [x] DB Migrations
- [x] perms checking
- [x] edit from Card endpoints
- [x] edit from Dashboard endpoints
- [x] edit from Pulse endpoints
- [x] edit from Alert endpoints
- [x] test edit from Card endpoints
- [x] test edit from Dashboard endpoints
- [x] test edit from Pulse endpoints
- [x] test edit from Alert endpoints