### PR TITLE
Update archive question redirect

### DIFF
--- a/frontend/src/metabase/components/Archived.jsx
+++ b/frontend/src/metabase/components/Archived.jsx
@@ -3,6 +3,8 @@ import EmptyState from "metabase/components/EmptyState";
 import Link from "metabase/components/Link";
 import { t } from "c-3po";
 
+import fitViewport from "metabase/hoc/FitViewPort";
+
 // TODO: port to ErrorMessage for more consistent style
 
 const Archived = ({ entityName, linkTo }) => (
@@ -23,4 +25,4 @@ const Archived = ({ entityName, linkTo }) => (
   </div>
 );
 
-export default Archived;
+export default fitViewport(Archived);

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -8,6 +8,8 @@ import { createAction } from "redux-actions";
 import _ from "underscore";
 import { assocIn } from "icepick";
 
+import * as Urls from "metabase/lib/urls";
+
 import { createThunkAction } from "metabase/lib/redux";
 import { push, replace } from "react-router-redux";
 import { setErrorPage } from "metabase/redux/app";
@@ -1432,7 +1434,7 @@ export const archiveQuestion = createThunkAction(
       ),
     );
 
-    dispatch(push("/questions"));
+    dispatch(push(Urls.collection(card.collection_id)));
     return response;
   },
 );


### PR DESCRIPTION
Fixes #7696. Redirects to the collection the question belonged to. Also properly centers the archive message when viewing an archived question.