### PR TITLE
Fix database card hover effect on overworld and tweak card bg color

### DIFF
--- a/frontend/src/metabase/containers/Overworld.jsx
+++ b/frontend/src/metabase/containers/Overworld.jsx
@@ -91,11 +91,13 @@ class Overworld extends React.Component {
                   <Grid w={1 / 3}>
                     {databases.map(database => (
                       <GridItem>
-                        <Link to={`browse/${database.id}`}>
+                        <Link
+                          to={`browse/${database.id}`}
+                          hover={{ color: normal.blue }}
+                        >
                           <Box
                             p={3}
-                            hover={{ color: normal.blue }}
-                            bg="#f5f5f5"
+                            bg="#F5F7FA"
                           >
                             <Icon
                               name="database"

--- a/frontend/src/metabase/containers/Overworld.jsx
+++ b/frontend/src/metabase/containers/Overworld.jsx
@@ -97,7 +97,7 @@ class Overworld extends React.Component {
                         >
                           <Box
                             p={3}
-                            bg="#F5F7FA"
+                            bg="#F2F5F7"
                           >
                             <Icon
                               name="database"

--- a/frontend/src/metabase/containers/Overworld.jsx
+++ b/frontend/src/metabase/containers/Overworld.jsx
@@ -95,10 +95,7 @@ class Overworld extends React.Component {
                           to={`browse/${database.id}`}
                           hover={{ color: normal.blue }}
                         >
-                          <Box
-                            p={3}
-                            bg="#F2F5F7"
-                          >
+                          <Box p={3} bg="#F2F5F7">
                             <Icon
                               name="database"
                               color={normal.green}


### PR DESCRIPTION
The bg gray on the db cards had a hue that wasn't jiving with the page bg color, and the text hover wasn't correctly taking effect.

**Before:**

![current](https://user-images.githubusercontent.com/2223916/40568796-9c0ddbae-6031-11e8-84db-01c8d0370df8.png)


**After:**

![screen shot 2018-05-25 at 3 38 35 pm](https://user-images.githubusercontent.com/2223916/40568815-b66b60ca-6031-11e8-9ccf-25114eb81ce5.png)

