### PR TITLE
Collections project bg sync

### DIFF
--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { Route } from "metabase/hoc/Title";
+import { IndexRoute, IndexRedirect } from "react-router";
+import { t } from "c-3po";
+
+// Settings
+import SettingsEditorApp from "metabase/admin/settings/containers/SettingsEditorApp.jsx";
+
+//  DB Add / list
+import DatabaseListApp from "metabase/admin/databases/containers/DatabaseListApp.jsx";
+import DatabaseEditApp from "metabase/admin/databases/containers/DatabaseEditApp.jsx";
+
+// Metadata / Data model
+import MetadataEditorApp from "metabase/admin/datamodel/containers/MetadataEditorApp.jsx";
+import MetricApp from "metabase/admin/datamodel/containers/MetricApp.jsx";
+import SegmentApp from "metabase/admin/datamodel/containers/SegmentApp.jsx";
+import RevisionHistoryApp from "metabase/admin/datamodel/containers/RevisionHistoryApp.jsx";
+import AdminPeopleApp from "metabase/admin/people/containers/AdminPeopleApp.jsx";
+import FieldApp from "metabase/admin/datamodel/containers/FieldApp.jsx";
+import TableSettingsApp from "metabase/admin/datamodel/containers/TableSettingsApp.jsx";
+
+// People
+import PeopleListingApp from "metabase/admin/people/containers/PeopleListingApp.jsx";
+import GroupsListingApp from "metabase/admin/people/containers/GroupsListingApp.jsx";
+import GroupDetailApp from "metabase/admin/people/containers/GroupDetailApp.jsx";
+
+import getAdminPermissionsRoutes from "metabase/admin/permissions/routes.jsx";
+
+const getRoutes = (store, IsAdmin) => (
+  <Route path="/admin" title={t`Admin`} component={IsAdmin}>
+    <IndexRedirect to="/admin/settings" />
+
+    <Route path="databases" title={t`Databases`}>
+      <IndexRoute component={DatabaseListApp} />
+      <Route path="create" component={DatabaseEditApp} />
+      <Route path=":databaseId" component={DatabaseEditApp} />
+    </Route>
+
+    <Route path="datamodel" title={t`Data Model`}>
+      <IndexRedirect to="database" />
+      <Route path="database" component={MetadataEditorApp} />
+      <Route path="database/:databaseId" component={MetadataEditorApp} />
+      <Route path="database/:databaseId/:mode" component={MetadataEditorApp} />
+      <Route
+        path="database/:databaseId/:mode/:tableId"
+        component={MetadataEditorApp}
+      />
+      <Route
+        path="database/:databaseId/:mode/:tableId/settings"
+        component={TableSettingsApp}
+      />
+      <Route
+        path="database/:databaseId/:mode/:tableId/:fieldId"
+        component={FieldApp}
+      />
+      <Route path="metric/create" component={MetricApp} />
+      <Route path="metric/:id" component={MetricApp} />
+      <Route path="segment/create" component={SegmentApp} />
+      <Route path="segment/:id" component={SegmentApp} />
+      <Route path=":entity/:id/revisions" component={RevisionHistoryApp} />
+    </Route>
+
+    {/* PEOPLE */}
+    <Route path="people" title={t`People`} component={AdminPeopleApp}>
+      <IndexRoute component={PeopleListingApp} />
+      <Route path="groups" title={t`Groups`}>
+        <IndexRoute component={GroupsListingApp} />
+        <Route path=":groupId" component={GroupDetailApp} />
+      </Route>
+    </Route>
+
+    {/* SETTINGS */}
+    <Route path="settings" title={t`Settings`}>
+      <IndexRedirect to="/admin/settings/setup" />
+      {/* <IndexRoute component={SettingsEditorApp} /> */}
+      <Route path=":section/:authType" component={SettingsEditorApp} />
+      <Route path=":section" component={SettingsEditorApp} />
+    </Route>
+
+    {getAdminPermissionsRoutes(store)}
+  </Route>
+);
+
+export default getRoutes;

--- a/frontend/src/metabase/components/BrowseApp.jsx
+++ b/frontend/src/metabase/components/BrowseApp.jsx
@@ -6,7 +6,6 @@ import EntityItem from "metabase/components/EntityItem";
 import EntityListLoader from "metabase/entities/containers/EntityListLoader";
 import EntityObjectLoader from "metabase/entities/containers/EntityObjectLoader";
 
-import { withBackground } from "metabase/hoc/Background";
 import { normal } from "metabase/lib/colors";
 import Question from "metabase-lib/lib/Question";
 
@@ -145,7 +144,6 @@ export class TableBrowser extends React.Component {
   }
 }
 
-@withBackground("bg-slate-extra-light")
 export class BrowseApp extends React.Component {
   render() {
     return <Box mx={4}>{this.props.children}</Box>;

--- a/frontend/src/metabase/components/CollectionLanding.jsx
+++ b/frontend/src/metabase/components/CollectionLanding.jsx
@@ -3,7 +3,6 @@ import { Box, Flex, Subhead, Truncate } from "rebass";
 import { t } from "c-3po";
 import { connect } from "react-redux";
 import { withRouter } from "react-router";
-import { withBackground } from "metabase/hoc/Background";
 
 import Question from "metabase/entities/questions";
 import Dashboard from "metabase/entities/dashboards";
@@ -282,7 +281,6 @@ class DefaultLanding extends React.Component {
 }
 
 @connect(mapStateToProps)
-@withBackground("bg-slate-extra-light")
 class CollectionLanding extends React.Component {
   render() {
     const { params, currentCollection } = this.props;

--- a/frontend/src/metabase/components/LoadingAndErrorWrapper.jsx
+++ b/frontend/src/metabase/components/LoadingAndErrorWrapper.jsx
@@ -29,7 +29,7 @@ export default class LoadingAndErrorWrapper extends Component {
   static defaultProps = {
     error: false,
     loading: false,
-    noBackground: false,
+    noBackground: true,
     noWrapper: false,
     showSpinner: true,
     loadingMessages: [t`Loading...`],

--- a/frontend/src/metabase/containers/Overworld.jsx
+++ b/frontend/src/metabase/containers/Overworld.jsx
@@ -8,7 +8,6 @@ import { DatabaseListLoader } from "metabase/components/BrowseApp";
 
 import * as Urls from "metabase/lib/urls";
 import { normal } from "metabase/lib/colors";
-import { withBackground } from "metabase/hoc/Background";
 
 import Card from "metabase/components/Card";
 import { Grid, GridItem } from "metabase/components/Grid";
@@ -25,7 +24,6 @@ const mapStateToProps = state => ({
 
 //class Overworld extends Zelda
 @connect(mapStateToProps)
-@withBackground("bg-slate-extra-light")
 class Overworld extends React.Component {
   render() {
     return (

--- a/frontend/src/metabase/css/core/base.css
+++ b/frontend/src/metabase/css/core/base.css
@@ -2,6 +2,7 @@
   --default-font-family: "Lato";
   --default-font-size: 0.875em;
   --default-font-color: #2e353b;
+  --default-bg-color: #f9fbfc;
 }
 
 html {
@@ -19,6 +20,7 @@ body {
   height: 100%; /* ensure the entire page will fill the window */
   display: flex;
   flex-direction: column;
+  background-color: var(--default-bg-color);
 
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
@@ -5,7 +5,6 @@ import React from "react";
 import { connect } from "react-redux";
 import { Link } from "react-router";
 
-import { withBackground } from "metabase/hoc/Background";
 import title from "metabase/hoc/Title";
 import ActionButton from "metabase/components/ActionButton";
 import Button from "metabase/components/Button";
@@ -254,4 +253,4 @@ const SuggestionsSidebar = ({ related }) => (
   </div>
 );
 
-export default withBackground("bg-slate-extra-light")(AutomaticDashboardApp);
+export default AutomaticDashboardApp;

--- a/frontend/src/metabase/home/containers/ArchiveApp.jsx
+++ b/frontend/src/metabase/home/containers/ArchiveApp.jsx
@@ -8,7 +8,6 @@ import HeaderWithBack from "metabase/components/HeaderWithBack";
 import Card from "metabase/components/Card";
 import ArchivedItem from "../../components/ArchivedItem";
 
-import { withBackground } from "metabase/hoc/Background";
 import { entityListLoader } from "metabase/entities/containers/EntityListLoader";
 import listSearch from "metabase/hoc/ListSearch";
 
@@ -26,7 +25,6 @@ const mapStateToProps = (state, props) => ({
 })
 @listSearch()
 @connect(mapStateToProps, null)
-@withBackground("bg-slate-extra-light")
 export default class ArchiveApp extends Component {
   render() {
     const { isAdmin, list, reload } = this.props;

--- a/frontend/src/metabase/home/containers/HomepageApp.jsx
+++ b/frontend/src/metabase/home/containers/HomepageApp.jsx
@@ -16,8 +16,6 @@ import NextStep from "../components/NextStep";
 import * as homepageActions from "../actions";
 import { getActivity, getRecentViews, getUser } from "../selectors";
 
-import { withBackground } from "metabase/hoc/Background";
-
 import { Box, Flex, Subhead } from "rebass";
 
 const mapStateToProps = (state, props) => ({
@@ -33,7 +31,6 @@ const mapDispatchToProps = {
 };
 
 @connect(mapStateToProps, mapDispatchToProps)
-@withBackground("bg-slate-extra-light")
 export default class HomepageApp extends Component {
   static propTypes = {
     onChangeLocation: PropTypes.func.isRequired,

--- a/frontend/src/metabase/home/containers/SearchApp.jsx
+++ b/frontend/src/metabase/home/containers/SearchApp.jsx
@@ -6,13 +6,11 @@ import Link from "metabase/components/Link";
 
 import { Box, Flex, Subhead, Text } from "rebass";
 
-import { withBackground } from "metabase/hoc/Background";
 import EntityListLoader from "metabase/entities/containers/EntityListLoader";
 
 import Card from "metabase/components/Card";
 import EntityItem from "metabase/components/EntityItem";
 
-@withBackground("bg-slate-extra-light")
 export default class SearchApp extends React.Component {
   render() {
     return (

--- a/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
+++ b/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
@@ -9,7 +9,6 @@ import {
   fetchSegments,
 } from "metabase/redux/metadata";
 
-import { withBackground } from "metabase/hoc/Background";
 import { determineWhichOptionsToShow, resetQuery } from "../new_query";
 import { t } from "c-3po";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
@@ -177,6 +176,4 @@ export class NewQueryOptions extends Component {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(
-  withBackground("bg-slate-extra-light")(NewQueryOptions),
-);
+export default connect(mapStateToProps, mapDispatchToProps)(NewQueryOptions);

--- a/frontend/src/metabase/new_query/router_wrappers.js
+++ b/frontend/src/metabase/new_query/router_wrappers.js
@@ -2,13 +2,10 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import { push } from "react-router-redux";
 
-import { withBackground } from "metabase/hoc/Background";
-
 import NewQueryOptions from "./containers/NewQueryOptions";
 import MetricSearch from "./containers/MetricSearch";
 
 @connect(null, { onChangeLocation: push })
-@withBackground("bg-slate-extra-light")
 export class NewQuestionStart extends Component {
   getUrlForQuery = query => {
     return query.question().getUrl();
@@ -26,7 +23,6 @@ export class NewQuestionStart extends Component {
 }
 
 @connect(null, { onChangeLocation: push })
-@withBackground("bg-slate-extra-light")
 export class NewQuestionMetricSearch extends Component {
   getUrlForQuery = query => {
     return query.question().getUrl();

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -13,6 +13,8 @@ import MetabaseSettings from "metabase/lib/settings";
 
 import App from "metabase/App.jsx";
 
+import { withBackground } from "metabase/hoc/Background";
+
 import HomepageApp from "metabase/home/containers/HomepageApp";
 
 // auth containers
@@ -53,18 +55,6 @@ import {
   NewQuestionMetricSearch,
 } from "metabase/new_query/router_wrappers";
 
-// admin containers
-import DatabaseListApp from "metabase/admin/databases/containers/DatabaseListApp.jsx";
-import DatabaseEditApp from "metabase/admin/databases/containers/DatabaseEditApp.jsx";
-import MetadataEditorApp from "metabase/admin/datamodel/containers/MetadataEditorApp.jsx";
-import MetricApp from "metabase/admin/datamodel/containers/MetricApp.jsx";
-import SegmentApp from "metabase/admin/datamodel/containers/SegmentApp.jsx";
-import RevisionHistoryApp from "metabase/admin/datamodel/containers/RevisionHistoryApp.jsx";
-import AdminPeopleApp from "metabase/admin/people/containers/AdminPeopleApp.jsx";
-import SettingsEditorApp from "metabase/admin/settings/containers/SettingsEditorApp.jsx";
-import FieldApp from "metabase/admin/datamodel/containers/FieldApp.jsx";
-import TableSettingsApp from "metabase/admin/datamodel/containers/TableSettingsApp.jsx";
-
 import NotFound from "metabase/components/NotFound.jsx";
 import Unauthorized from "metabase/components/Unauthorized.jsx";
 
@@ -91,11 +81,7 @@ import TableQuestionsContainer from "metabase/reference/databases/TableQuestions
 import FieldListContainer from "metabase/reference/databases/FieldListContainer.jsx";
 import FieldDetailContainer from "metabase/reference/databases/FieldDetailContainer.jsx";
 
-import getAdminPermissionsRoutes from "metabase/admin/permissions/routes.jsx";
-
-import PeopleListingApp from "metabase/admin/people/containers/PeopleListingApp.jsx";
-import GroupsListingApp from "metabase/admin/people/containers/GroupsListingApp.jsx";
-import GroupDetailApp from "metabase/admin/people/containers/GroupDetailApp.jsx";
+import getAdminRoutes from "metabase/admin/routes";
 
 import PublicQuestion from "metabase/public/containers/PublicQuestion.jsx";
 import PublicDashboard from "metabase/public/containers/PublicDashboard.jsx";
@@ -155,8 +141,8 @@ const UserIsNotAuthenticated = UserAuthWrapper({
 const IsAuthenticated = MetabaseIsSetup(
   UserIsAuthenticated(({ children }) => children),
 );
-const IsAdmin = MetabaseIsSetup(
-  UserIsAuthenticated(UserIsAdmin(({ children }) => children)),
+const IsAdmin = withBackground("bg-white")(
+  MetabaseIsSetup(UserIsAuthenticated(UserIsAdmin(({ children }) => children))),
 );
 const IsNotAuthenticated = MetabaseIsSetup(
   UserIsNotAuthenticated(({ children }) => children),
@@ -337,61 +323,7 @@ export const getRoutes = store => (
       <Route path="/user/edit_current" component={UserSettingsApp} />
 
       {/* ADMIN */}
-      <Route path="/admin" title={t`Admin`} component={IsAdmin}>
-        <IndexRedirect to="/admin/settings" />
-
-        <Route path="databases" title={t`Databases`}>
-          <IndexRoute component={DatabaseListApp} />
-          <Route path="create" component={DatabaseEditApp} />
-          <Route path=":databaseId" component={DatabaseEditApp} />
-        </Route>
-
-        <Route path="datamodel" title={t`Data Model`}>
-          <IndexRedirect to="database" />
-          <Route path="database" component={MetadataEditorApp} />
-          <Route path="database/:databaseId" component={MetadataEditorApp} />
-          <Route
-            path="database/:databaseId/:mode"
-            component={MetadataEditorApp}
-          />
-          <Route
-            path="database/:databaseId/:mode/:tableId"
-            component={MetadataEditorApp}
-          />
-          <Route
-            path="database/:databaseId/:mode/:tableId/settings"
-            component={TableSettingsApp}
-          />
-          <Route
-            path="database/:databaseId/:mode/:tableId/:fieldId"
-            component={FieldApp}
-          />
-          <Route path="metric/create" component={MetricApp} />
-          <Route path="metric/:id" component={MetricApp} />
-          <Route path="segment/create" component={SegmentApp} />
-          <Route path="segment/:id" component={SegmentApp} />
-          <Route path=":entity/:id/revisions" component={RevisionHistoryApp} />
-        </Route>
-
-        {/* PEOPLE */}
-        <Route path="people" title={t`People`} component={AdminPeopleApp}>
-          <IndexRoute component={PeopleListingApp} />
-          <Route path="groups" title={t`Groups`}>
-            <IndexRoute component={GroupsListingApp} />
-            <Route path=":groupId" component={GroupDetailApp} />
-          </Route>
-        </Route>
-
-        {/* SETTINGS */}
-        <Route path="settings" title={t`Settings`}>
-          <IndexRedirect to="/admin/settings/setup" />
-          {/* <IndexRoute component={SettingsEditorApp} /> */}
-          <Route path=":section/:authType" component={SettingsEditorApp} />
-          <Route path=":section" component={SettingsEditorApp} />
-        </Route>
-
-        {getAdminPermissionsRoutes(store)}
-      </Route>
+      {getAdminRoutes(store, IsAdmin)}
     </Route>
 
     {/* INTERNAL */}

--- a/frontend/src/metabase/setup/containers/PostSetupApp.jsx
+++ b/frontend/src/metabase/setup/containers/PostSetupApp.jsx
@@ -7,7 +7,6 @@ import ExplorePane from "metabase/components/ExplorePane";
 import MetabotLogo from "metabase/components/MetabotLogo";
 import ProgressBar from "metabase/components/ProgressBar";
 import Quotes from "metabase/components/Quotes";
-import { withBackground } from "metabase/hoc/Background";
 import fitViewport from "metabase/hoc/FitViewPort";
 
 import { MetabaseApi, AutoApi } from "metabase/services";
@@ -45,7 +44,6 @@ type State = {
   sampleCandidates: ?DatabaseCandidates,
 };
 
-@withBackground("bg-slate-extra-light")
 @fitViewport
 export default class PostSetupApp extends Component {
   props: Props;


### PR DESCRIPTION
Since we're using a different background color in most spots now, rather than use `withBackground` a bunch of places, this changes things to just default to the new bg, and override in spots that are supposed to be different still.

Since the admin routes are the main spot there's still a stock white background I separated those routes out into a route partial to make them a bit easier to digest and make the routes file a little less intense.