### PR TITLE
Lets use HTTP2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -93,7 +93,7 @@
                  [puppetlabs/i18n "0.8.0"]                            ; Internationalization library
                  [redux "0.1.4"]                                      ; Utility functions for building and composing transducers
                  [ring/ring-core "1.6.0"]
-                 [ring/ring-jetty-adapter "1.6.0"]                    ; Ring adapter using Jetty webserver (used to run a Ring server for unit tests)
+                 [info.sunng/ring-jetty9-adapter "0.11.1"]            ; Ring adapter using Jetty webserver (used to run a Ring server for unit tests)
                  [ring/ring-json "0.4.0"]                             ; Ring middleware for reading/writing JSON automatically
                  [stencil "0.5.0"]                                    ; Mustache templates for Clojure
                  [toucan "1.1.7"                                      ; Model layer, hydration, and DB utilities

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -24,7 +24,7 @@
              [user :refer [User]]]
             [metabase.util.i18n :refer [set-locale]]
             [puppetlabs.i18n.core :refer [locale-negotiator trs]]
-            [ring.adapter.jetty :as ring-jetty]
+            [ring.adapter.jetty9 :as ring-jetty]
             [ring.middleware
              [cookies :refer [wrap-cookies]]
              [gzip :refer [wrap-gzip]]
@@ -207,7 +207,9 @@
                                                             :max-threads   (config/config-int :mb-jetty-maxthreads)
                                                             :min-threads   (config/config-int :mb-jetty-minthreads)
                                                             :max-queued    (config/config-int :mb-jetty-maxqueued)
-                                                            :max-idle-time (config/config-int :mb-jetty-maxidletime)})
+                                                            :max-idle-time (config/config-int :mb-jetty-maxidletime)
+                                                            :h2c?          true
+                                                            :h2?           true})
                              (config/config-str :mb-jetty-daemon) (assoc :daemon? (config/config-bool :mb-jetty-daemon))
                              (config/config-str :mb-jetty-ssl)    (-> (assoc :ssl? true)
                                                                       (merge jetty-ssl-config)))]


### PR DESCRIPTION
For now metabase uses HTTP 1.1

This change makes HTTP 2 requests possible.

### Before
```
% curl -vso /dev/null --http2 http://localhost:3000                                                                                  18-06-04 - 18:03:31
* Rebuilt URL to: http://localhost:3000/
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 3000 (#0)
> GET / HTTP/1.1
> Host: localhost:3000
> User-Agent: curl/7.54.0
> Accept: */*
> Connection: Upgrade, HTTP2-Settings
> Upgrade: h2c
> HTTP2-Settings: AAMAAABkAARAAAAAAAIAAAAA
>
< HTTP/1.1 200 OK
< X-Frame-Options: DENY
< X-XSS-Protection: 1; mode=block
< Last-Modified: Mon, 04 Jun 2018 21:03:40 +0000
< Strict-Transport-Security: max-age=31536000
< X-Permitted-Cross-Domain-Policies: none
< Cache-Control: max-age=0, no-cache, must-revalidate, proxy-revalidate
< X-Content-Type-Options: nosniff
< Content-Security-Policy: default-src 'none'; script-src 'unsafe-inline' 'unsafe-eval' 'self' https://maps.google.com https://apis.google.com https://www.google-analytics.com https://*.googleapis.com *.gstatic.com https://js-agent.newrelic.com https://*.nr-data.net ; child-src 'self' https://accounts.google.com; style-src 'unsafe-inline' 'self' fonts.googleapis.com; font-src 'self' fonts.gstatic.com themes.googleusercontent.com ; img-src * 'self' data:; connect-src 'self' metabase.us10.list-manage.com https://*.nr-data.net ;
< Content-Type: text/html;charset=utf-8
< Expires: Tue, 03 Jul 2001 06:00:00 GMT
< Transfer-Encoding: chunked
< Server: Jetty(9.4.z-SNAPSHOT)
<
{ [15401 bytes data]
* Connection #0 to host localhost left intact
```


### After
```
% curl -vso /dev/null --http2 http://localhost:3000                                                                                  18-06-04 - 18:03:40
* Rebuilt URL to: http://localhost:3000/
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 3000 (#0)
> GET / HTTP/1.1
> Host: localhost:3000
> User-Agent: curl/7.54.0
> Accept: */*
> Connection: Upgrade, HTTP2-Settings
> Upgrade: h2c
> HTTP2-Settings: AAMAAABkAARAAAAAAAIAAAAA
>
< HTTP/1.1 101 Switching Protocols
* Received 101
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Connection state changed (MAX_CONCURRENT_STREAMS updated)!
< HTTP/2 200
< server: Jetty(9.4.z-SNAPSHOT)
< x-frame-options: DENY
< x-xss-protection: 1; mode=block
< last-modified: Mon, 04 Jun 2018 21:10:23 +0000
< strict-transport-security: max-age=31536000
< x-permitted-cross-domain-policies: none
< cache-control: max-age=0, no-cache, must-revalidate, proxy-revalidate
< x-content-type-options: nosniff
< content-security-policy: default-src 'none'; script-src 'unsafe-inline' 'unsafe-eval' 'self' https://maps.google.com https://apis.google.com https://www.google-analytics.com https://*.googleapis.com *.gstatic.com https://js-agent.newrelic.com https://*.nr-data.net ; child-src 'self' https://accounts.google.com; style-src 'unsafe-inline' 'self' fonts.googleapis.com; font-src 'self' fonts.gstatic.com themes.googleusercontent.com ; img-src * 'self' data:; connect-src 'self' metabase.us10.list-manage.com https://*.nr-data.net ;
< content-type: text/html;charset=utf-8
< expires: Tue, 03 Jul 2001 06:00:00 GMT
<
{ [16384 bytes data]
* 16366 data bytes written
{ [16366 bytes data]
* Connection #0 to host localhost left intact
```

Possibly
Fixes #6385

###### Before submitting the PR, please make sure you do the following 
-  [x] If there are changes to the backend codebase, run the backend tests with `lein test && lein eastwood && lein bikeshed && lein docstring-checker && ./bin/reflection-linter`
-  [x] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
