### PR TITLE
xray: better field analysis

### DIFF
--- a/resources/automagic_dashboards/field/Country.yaml
+++ b/resources/automagic_dashboards/field/Country.yaml
@@ -1,6 +1,6 @@
-title: A look at your [[this]] per country
-transient_title: Here's a closer look at your [[this]] per country
-description: Which countries are represented the most and least.
+title: A look at your [[this]]
+transient_title: Here's a closer look at your [[this]] field
+description: How [[GenericTable]] are distributed across [[this]], and how each country is represented in different categories.
 applies_to: GenericTable.Country
 metrics:
 - Sum: [sum, [dimension, GenericNumber]]

--- a/resources/automagic_dashboards/field/Country.yaml
+++ b/resources/automagic_dashboards/field/Country.yaml
@@ -1,6 +1,6 @@
 title: A look at your [[this]]
 transient_title: Here's a closer look at your [[this]] field
-description: How [[GenericTable]] are distributed across [[this]], and how each country is represented in different categories.
+description: The number of [[GenericTable]] per country, and how each country is represented in different categories.
 applies_to: GenericTable.Country
 metrics:
 - Sum: [sum, [dimension, GenericNumber]]

--- a/resources/automagic_dashboards/field/DateTime.yaml
+++ b/resources/automagic_dashboards/field/DateTime.yaml
@@ -6,6 +6,7 @@ metrics:
 - Sum: [sum, [dimension, GenericNumber]]
 - Avg: [avg, [dimension, GenericNumber]]
 - Count: [count]
+- Distinct: [distinct, [dimension, this]]
 dimensions:
   - GenericNumber: GenericTable.Number
   - GenericCategoryMedium:
@@ -20,6 +21,8 @@ dimensions:
       field_type: GenericTable.Country
   - State:
       field_type: GenericTable.State
+filters:
+  - Nils: [is-null, [dimension, this]]
 dashboard_filters:
   - this
   - State
@@ -29,10 +32,29 @@ groups:
   - Overview:
       title: Overview
   - Breakdowns:
-      title: Different numbers across [[this]]
-  - Seasonality:
       title: How [[this]] is distributed
+  - Seasonality:
+      title: Seasonal components of [[this]]
 cards:
+  - Count:
+      title: Count
+      visualization: scalar
+      metrics: Count
+      group: Overview
+      width: 6
+  - Nils:
+      title: Null values
+      visualization: scalar
+      metrics: Count
+      filters: Nils
+      group: Overview
+      width: 6
+  - Distinct:
+      title: Distinct values
+      visualization: scalar
+      metrics: Distinct
+      group: Overview
+      width: 6
   - Distribution:
       title: "[[GenericTable]] by [[this]]"
       visualization: line
@@ -51,7 +73,9 @@ cards:
       group: Breakdowns
   - ByCategory:
       title: "Count of [[GenericCategoryMedium]] by [[this]]"
-      visualization: area
+      visualization:
+        area:
+          stackable.stack_type: stacked
       metrics: Count
       dimensions:
         - this

--- a/resources/automagic_dashboards/field/DateTime.yaml
+++ b/resources/automagic_dashboards/field/DateTime.yaml
@@ -1,6 +1,6 @@
 title: A look at your [[this]]
 transient_title: Here's a closer look at your [[this]]
-description: See how [[GenericTable]] are distributed across this field, and if it has any seasonal patterns.
+description: How [[GenericTable]] are distributed across this time field, and if it has any seasonal patterns.
 applies_to: GenericTable.DateTime
 metrics:
 - Sum: [sum, [dimension, GenericNumber]]

--- a/resources/automagic_dashboards/field/DateTime.yaml
+++ b/resources/automagic_dashboards/field/DateTime.yaml
@@ -1,6 +1,6 @@
-title: A look at your [[this]] over time
-transient_title: Here's a closer look at your [[this]] over time
-description: How [[this]] is distributed, and how different numbers change across it.
+title: A look at your [[this]]
+transient_title: Here's a closer look at your [[this]]
+description: See how [[GenericTable]] are distributed across this field, and if it has any seasonal patterns.
 applies_to: GenericTable.DateTime
 metrics:
 - Sum: [sum, [dimension, GenericNumber]]

--- a/resources/automagic_dashboards/field/DateTime.yaml
+++ b/resources/automagic_dashboards/field/DateTime.yaml
@@ -34,7 +34,7 @@ groups:
   - Breakdowns:
       title: How [[this]] is distributed
   - Seasonality:
-      title: Seasonal components of [[this]]
+      title: Seasonal patterns in [[this]]
 cards:
   - Count:
       title: Count

--- a/resources/automagic_dashboards/field/GenericField.yaml
+++ b/resources/automagic_dashboards/field/GenericField.yaml
@@ -1,6 +1,6 @@
 title: A look at your [[this]]
 transient_title: Here's an overview of your [[this]]
-description: How [[GenericTable]] are distributed across this field, and how it changes over time.
+description: A look at [[GenericTable]] across your [[this]], and how it changes over time.
 applies_to: GenericTable.*
 metrics:
 - Sum: [sum, [dimension, GenericNumber]]

--- a/resources/automagic_dashboards/field/GenericField.yaml
+++ b/resources/automagic_dashboards/field/GenericField.yaml
@@ -6,8 +6,13 @@ metrics:
 - Sum: [sum, [dimension, GenericNumber]]
 - Avg: [avg, [dimension, GenericNumber]]
 - Count: [count]
+- Distinct: [distinct, [dimension, this]]
 dimensions:
   - GenericNumber: GenericTable.Number
+  - GenericCategoryMedium:
+      field_type: GenericTable.Category
+      max_cardinality: 12
+      score: 90
 # bind just so they don't get used
   - LongLat: GenericTable.Coordinate
   - ZipCode: GenericTable.ZipCode
@@ -16,16 +21,14 @@ dimensions:
       field_type: GenericTable.Country
   - State:
       field_type: GenericTable.State
-  - GenericCategoryMedium:
-      field_type: GenericTable.Category
-      max_cardinality: 12
-      score: 90
   - Timestamp:
       field_type: CreationTimestamp
       score: 100
   - Timestamp:
       field_type: DateTime
       score: 90
+filters:
+  - Nils: [is-null, [dimension, this]]
 dashboard_filters:
   - Timestamp
   - State
@@ -35,8 +38,27 @@ groups:
   - Overview:
       title: Overview
   - Breakdowns:
-      title: "How different numbers are distributed across [[this]]"
+      title: How [[this]] are distributed
 cards:
+  - Count:
+      title: Count
+      visualization: scalar
+      metrics: Count
+      group: Overview
+      width: 6
+  - Nils:
+      title: Null values
+      visualization: scalar
+      metrics: Count
+      filters: Nils
+      group: Overview
+      width: 6
+  - Distinct:
+      title: Distinct values
+      visualization: scalar
+      metrics: Distinct
+      group: Overview
+      width: 6
   - Distribution:
       title: How [[this]] is distributed
       visualization: bar
@@ -52,3 +74,13 @@ cards:
       - Avg
       dimensions: this
       group: Breakdowns
+  - Crosstab:
+      title: "[[this]] by [[GenericCategoryMedium]]"
+      visualization: table
+      metrics: Count
+      dimensions:
+      - this
+      - GenericCategoryMedium
+      group: Breakdowns
+      width: 9
+      height: 8

--- a/resources/automagic_dashboards/field/GenericField.yaml
+++ b/resources/automagic_dashboards/field/GenericField.yaml
@@ -1,6 +1,6 @@
 title: A look at your [[this]]
 transient_title: Here's an overview of your [[this]]
-description: How [[this]] is distributed and more.
+description: How this field is distributed, how many distinct values it has, and how it changes over time.
 applies_to: GenericTable.*
 metrics:
 - Sum: [sum, [dimension, GenericNumber]]

--- a/resources/automagic_dashboards/field/GenericField.yaml
+++ b/resources/automagic_dashboards/field/GenericField.yaml
@@ -1,6 +1,6 @@
 title: A look at your [[this]]
 transient_title: Here's an overview of your [[this]]
-description: How this field is distributed, how many distinct values it has, and how it changes over time.
+description: How [[GenericTable]] are distributed across this field, and how it changes over time.
 applies_to: GenericTable.*
 metrics:
 - Sum: [sum, [dimension, GenericNumber]]

--- a/resources/automagic_dashboards/field/Number.yaml
+++ b/resources/automagic_dashboards/field/Number.yaml
@@ -1,6 +1,6 @@
 title: A look at your [[this]]
-transient_title: Here's an overview of your [[this]]
-description: How [[this]] is distributed and more.
+transient_title: We crunched the numbers for your [[this]]
+description: A breakdown of your [[this]] over time, and its min, max, average and more.
 applies_to: GenericTable.Number
 metrics:
 - Sum: [sum, [dimension, this]]

--- a/resources/automagic_dashboards/field/Number.yaml
+++ b/resources/automagic_dashboards/field/Number.yaml
@@ -1,10 +1,13 @@
-title: A look at your [[this]] per country
-transient_title: Here's a closer look at your [[this]] per country
-description: Which countries are represented the most and least.
-applies_to: GenericTable.Country
+title: A look at your [[this]]
+transient_title: Here's an overview of your [[this]]
+description: How [[this]] is distributed and more.
+applies_to: GenericTable.Number
 metrics:
-- Sum: [sum, [dimension, GenericNumber]]
-- Avg: [avg, [dimension, GenericNumber]]
+- Sum: [sum, [dimension, this]]
+- Avg: [avg, [dimension, this]]
+- Min: [min, [dimension, this]]
+- Max: [max, [dimension, this]]
+- SD: [stddev, [dimension, this]]
 - Count: [count]
 - Distinct: [distinct, [dimension, this]]
 dimensions:
@@ -12,6 +15,9 @@ dimensions:
   - GenericCategoryMedium:
       field_type: GenericTable.Category
       max_cardinality: 12
+      score: 90
+  - Timestamp:
+      field_type: DateTime
       score: 90
 # bind just so they don't get used
   - LongLat: GenericTable.Coordinate
@@ -21,12 +27,6 @@ dimensions:
       field_type: GenericTable.Country
   - State:
       field_type: GenericTable.State
-  - Timestamp:
-      field_type: CreationTimestamp
-      score: 100
-  - Timestamp:
-      field_type: DateTime
-      score: 90
 filters:
   - Nils: [is-null, [dimension, this]]
 dashboard_filters:
@@ -59,50 +59,43 @@ cards:
       metrics: Distinct
       group: Overview
       width: 6
-  - Distribution:
-      title: Distribution of [[this]]
-      visualization:
-        map:
-          map.type: region
-          map.region: world_countries
-      metrics: Count
-      dimensions: this
-      group: Overview
-  - Top5:
-      title: Top 5 [[this]]
-      visualization: row
-      metrics: Count
-      dimensions: this
-      limit: 5
-      order_by:
-        - Count: descending
-      group: Overview
-  - Bottom5:
-      title: Bottom 5 [[this]]
-      visualization: row
-      metrics: Count
-      dimensions: this
-      limit: 5
-      order_by:
-        - Count: ascending
-      group: Overview
-  - ByNumber:
-      title: "Sum of [[GenericNumber]] by [[this]]"
-      visualization:
-        map:
-          map.type: region
-          map.region: world_countries
+  - Stats:
+      title: Summary statistics
+      visualization: table
       metrics:
       - Sum
-      dimensions: this
-      group: Breakdowns
-  - Crosstab:
-      title: "[[this]] by [[GenericCategoryMedium]]"
-      visualization: table
+      - Avg
+      - Min
+      - Max
+      - SD
+      group: Overview
+      width: 9
+  - Distribution:
+      title: How [[this]] is distributed
+      visualization: bar
       metrics: Count
       dimensions:
-      - this
-      - GenericCategoryMedium
+        - this:
+            aggregation: default
+      group: Overview
+      width: 9
+  - ByDateTime:
+      title: "[[this]] by [[Timestamp]]"
+      visualization: line
+      metrics:
+      - Sum
+      - Avg
+      dimensions: Timestamp
       group: Breakdowns
       width: 9
-      height: 8
+      height: 6
+  - ByCategory:
+      title: "[[this]] by [[GenericCategoryMedium]]"
+      visualization: bar
+      metrics:
+      - Sum
+      - Avg
+      dimensions: GenericCategoryMedium
+      group: Breakdowns
+      height: 6
+      width: 9

--- a/resources/automagic_dashboards/field/Number.yaml
+++ b/resources/automagic_dashboards/field/Number.yaml
@@ -38,7 +38,11 @@ groups:
   - Overview:
       title: Overview
   - Breakdowns:
-      title: How [[this]] are distributed
+      title: How [[this]] is distributed across categories
+  - Seasonality:
+      title: How [[this]] changes with time
+  - Geographical:
+      title: How [[this]] is distributed geographically
 cards:
   - Count:
       title: Count
@@ -86,9 +90,8 @@ cards:
       - Sum
       - Avg
       dimensions: Timestamp
-      group: Breakdowns
+      group: Seasonality
       width: 9
-      height: 6
   - ByCategory:
       title: "[[this]] by [[GenericCategoryMedium]]"
       visualization: bar
@@ -99,3 +102,43 @@ cards:
       group: Breakdowns
       height: 6
       width: 9
+  - ByCountrySum:
+      title: "Sum of [[this]] by [[Country]]"
+      visualization:
+        map:
+          map.type: region
+          map.region: world_countries
+      metrics:
+      - Sum
+      dimensions: Country
+      group: Geographical
+  - ByCountryAvg:
+      title: "Average of [[this]] by [[Country]]"
+      visualization:
+        map:
+          map.type: region
+          map.region: world_countries
+      metrics:
+      - Avg
+      dimensions: Country
+      group: Geographical
+  - ByStateSum:
+      title: "Sum of [[this]] by [[State]]"
+      visualization:
+        map:
+          map.type: region
+          map.region: us_states
+      metrics:
+      - Sum
+      dimensions: State
+      group: Geographical
+  - ByStateAvg:
+      title: "Average of [[this]] by [[State]]"
+      visualization:
+        map:
+          map.type: region
+          map.region: us_states
+      metrics:
+      - Avg
+      dimensions: State
+      group: Geographical

--- a/resources/automagic_dashboards/field/State.yaml
+++ b/resources/automagic_dashboards/field/State.yaml
@@ -6,8 +6,13 @@ metrics:
 - Sum: [sum, [dimension, GenericNumber]]
 - Avg: [avg, [dimension, GenericNumber]]
 - Count: [count]
+- Distinct: [distinct, [dimension, this]]
 dimensions:
   - GenericNumber: GenericTable.Number
+  - GenericCategoryMedium:
+      field_type: GenericTable.Category
+      max_cardinality: 12
+      score: 90
 # bind just so they don't get used
   - LongLat: GenericTable.Coordinate
   - ZipCode: GenericTable.ZipCode
@@ -16,16 +21,14 @@ dimensions:
       field_type: GenericTable.Country
   - State:
       field_type: GenericTable.State
-  - GenericCategoryMedium:
-      field_type: GenericTable.Category
-      max_cardinality: 12
-      score: 90
   - Timestamp:
       field_type: CreationTimestamp
       score: 100
   - Timestamp:
       field_type: DateTime
       score: 90
+filters:
+  - Nils: [is-null, [dimension, this]]
 dashboard_filters:
   - Timestamp
   - State
@@ -35,8 +38,27 @@ groups:
   - Overview:
       title: Overview
   - Breakdowns:
-      title: Different numbers per state
+      title: How [[this]] are distributed
 cards:
+  - Count:
+      title: Count
+      visualization: scalar
+      metrics: Count
+      group: Overview
+      width: 6
+  - Nils:
+      title: Null values
+      visualization: scalar
+      metrics: Count
+      filters: Nils
+      group: Overview
+      width: 6
+  - Distinct:
+      title: Distinct values
+      visualization: scalar
+      metrics: Distinct
+      group: Overview
+      width: 6
   - Distribution:
       title: "[[GenericTable]] per [[this]]"
       visualization:
@@ -74,3 +96,13 @@ cards:
       - Sum
       dimensions: this
       group: Breakdowns
+  - Crosstab:
+      title: "[[this]] by [[GenericCategoryMedium]]"
+      visualization: table
+      metrics: Count
+      dimensions:
+      - this
+      - GenericCategoryMedium
+      group: Breakdowns
+      width: 9
+      height: 8

--- a/resources/automagic_dashboards/field/State.yaml
+++ b/resources/automagic_dashboards/field/State.yaml
@@ -1,6 +1,6 @@
 title: A look at your [[this]]
 transient_title: Here's an overview of your [[this]]
-description: How many [[GenericTable]] there are per state, and how [[this]] is distributed across other categories.
+description: How many [[GenericTable]] there are per state, and how each state is represented across other categories.
 applies_to: GenericTable.State
 metrics:
 - Sum: [sum, [dimension, GenericNumber]]

--- a/resources/automagic_dashboards/field/State.yaml
+++ b/resources/automagic_dashboards/field/State.yaml
@@ -1,6 +1,6 @@
-title: A look at your [[this]] per state
-transient_title: Here's a closer look at your [[this]] per state
-description: How [[this]] is distributed, and how different numbers are represented per state.
+title: A look at your [[this]]
+transient_title: Here's an overview of your [[this]]
+description: How many [[GenericTable]] there are per state, and how [[this]] is distributed across other categories.
 applies_to: GenericTable.State
 metrics:
 - Sum: [sum, [dimension, GenericNumber]]


### PR DESCRIPTION
This adds:
1) An overview row for all field dashboards:
<img width="1060" alt="screenshot 2018-06-05 00 40 56" src="https://user-images.githubusercontent.com/178038/40945496-62e9fc10-6859-11e8-8e69-6499fd529d25.png">
2) "crosstab" for category-vs-category breakdown
<img width="567" alt="screenshot 2018-06-05 00 40 49" src="https://user-images.githubusercontent.com/178038/40945515-78911012-6859-11e8-83fa-70b36e5271ff.png">
3) Number field heuristic
<img width="1440" alt="screenshot 2018-06-05 00 39 10" src="https://user-images.githubusercontent.com/178038/40945531-89e0ed38-6859-11e8-994e-89e95e262fa0.png">
The goal for number fields is that for metric-like fields (eg. "Total" in our sample db) the result is as good as if it were a metric.
