### PR TITLE
query builder entity menus + edit bar [wip]

### DIFF
--- a/frontend/src/metabase/components/EditBar.jsx
+++ b/frontend/src/metabase/components/EditBar.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
+import { Flex } from "rebass"
 
 class EditBar extends Component {
   static propTypes = {
@@ -18,8 +19,11 @@ class EditBar extends Component {
   render() {
     const { admin, buttons, subtitle, title } = this.props;
     return (
-      <div
-        className={cx("EditHeader wrapper py1 flex align-center", {
+      <Flex
+        align='center'
+        py={1}
+        px={4}
+        className={cx("EditHeader", {
           "EditHeader--admin": admin,
         })}
         ref="editHeader"
@@ -29,7 +33,7 @@ class EditBar extends Component {
           <span className="EditHeader-subtitle mx1">{subtitle}</span>
         )}
         <span className="flex-align-right flex">{buttons}</span>
-      </div>
+      </Flex>
     );
   }
 }

--- a/frontend/src/metabase/components/Header.jsx
+++ b/frontend/src/metabase/components/Header.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
+import { Box, Flex } from "rebass"
 
 import Input from "metabase/components/Input.jsx";
 import HeaderModal from "metabase/components/HeaderModal.jsx";
@@ -14,15 +15,11 @@ export default class Header extends Component {
     editingTitle: "",
     editingSubtitle: "",
     editingButtons: [],
-    headerClassName: "py1 lg-py2 xl-py3 wrapper",
+    headerClassName: "",
   };
 
-  constructor(props, context) {
-    super(props, context);
-
-    this.state = {
-      headerHeight: 0,
-    };
+  state = {
+    headerHeight: 0,
   }
 
   componentDidMount() {
@@ -126,43 +123,41 @@ export default class Header extends Component {
         return (
           section &&
           section.length > 0 && (
-            <span
+            <Box
               key={sectionIndex}
-              className="Header-buttonSection flex align-center"
+              mx={1}
             >
               {section.map((button, buttonIndex) => (
                 <span key={buttonIndex} className="Header-button">
                   {button}
                 </span>
               ))}
-            </span>
+            </Box>
           )
         );
       },
     );
 
     return (
-      <div>
+      <Box>
         {this.renderEditHeader()}
         {this.renderHeaderModal()}
-        <div
-          className={
-            "QueryBuilder-section flex align-center " +
-            this.props.headerClassName
-          }
+        <Flex
+          align='center'
           ref="header"
+          px={4}
         >
-          <div className="Entity py3">
+          <Box className="Entity py3">
             {titleAndDescription}
             {attribution}
-          </div>
+          </Box>
 
-          <div className="flex align-center flex-align-right">
+          <Flex align='center' ml='auto'>
             {headerButtons}
-          </div>
-        </div>
+          </Flex>
+        </Flex>
         {this.props.children}
-      </div>
+      </Box>
     );
   }
 }

--- a/frontend/src/metabase/dashboard/components/DashboardHistoryModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHistoryModal.jsx
@@ -1,52 +1,12 @@
 import React from "react";
 import HistoryModal from "metabase/components/HistoryModal";
 import { withRouter } from "react-router";
-import { Component } from "react/lib/ReactBaseClasses";
-import * as dashboardActions from "../dashboard";
-import { connect } from "react-redux";
-import { getRevisions } from "metabase/dashboard/selectors";
-import type { EntityType, EntityId } from "metabase/meta/types";
-import type { RevisionId } from "metabase/meta/types/Revision";
 
-const mapStateToProps = (state, props) => {
-  return { revisions: getRevisions(state, props) };
-};
-
-const mapDispatchToProps = {
-  ...dashboardActions,
-};
-
-@connect(mapStateToProps, mapDispatchToProps)
 @withRouter
-export class DashboardHistoryModal extends Component {
+export class DashboardHistoryModal extends React.Component {
   props: {
     location: Object,
     onClose: () => any,
-    revisions: { [key: string]: Revision[] },
-    fetchRevisions: ({ entity: string, id: number }) => void,
-    revertToRevision: ({
-      entity: string,
-      id: number,
-      revision_id: RevisionId,
-    }) => void,
-  };
-
-  // 1. fetch revisions
-  onFetchRevisions = ({ entity, id }: { entity: EntityType, id: EntityId }) => {
-    return this.props.fetchRevisions({ entity, id });
-  };
-
-  // 2. revert to a revision
-  onRevertToRevision = ({
-    entity,
-    id,
-    revision_id,
-  }: {
-    entity: EntityType,
-    id: EntityId,
-    revision_id: RevisionId,
-  }) => {
-    return this.props.revertToRevision({ entity, id, revision_id });
   };
 
   // 3. finished reverting to a revision
@@ -59,18 +19,10 @@ export class DashboardHistoryModal extends Component {
   render() {
     const { params, onClose } = this.props;
 
-    // NOTE Atte Keinänen 1/17/18: While we still use react-router v3,
-    // we have to read the dashboard id from parsed route via `params`.
-    // Migrating to react-router v4 will make this easier because can
-    // have the route definition and the component in `<DashboardHeader>`
-    // which already knows the dashboard id
     return (
       <HistoryModal
         entityType="dashboard"
-        entityId={parseInt(params.dashboardId)}
-        revisions={this.props.revisions["dashboard-" + params.dashboardId]}
-        onFetchRevisions={this.onFetchRevisions}
-        onRevertToRevision={this.onRevertToRevision}
+        entityId={params.dashboardId}
         onReverted={this.onRevertedRevision}
         onClose={onClose}
       />

--- a/frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx
@@ -5,29 +5,19 @@ import { t } from "c-3po";
 import { parse as urlParse } from "url";
 import querystring from "querystring";
 
-import PopoverWithTrigger from "metabase/components/PopoverWithTrigger.jsx";
-import Icon from "metabase/components/Icon.jsx";
+import ModalContent from "metabase/components/ModalContent"
 import DownloadButton from "metabase/components/DownloadButton.jsx";
-import Tooltip from "metabase/components/Tooltip.jsx";
 
 import FieldSet from "metabase/components/FieldSet.jsx";
 
 import * as Urls from "metabase/lib/urls";
 
 import _ from "underscore";
-import cx from "classnames";
 
 const EXPORT_FORMATS = ["csv", "xlsx", "json"];
 
 const QueryDownloadWidget = ({ className, card, result, uuid, token }) => (
-  <PopoverWithTrigger
-    triggerElement={
-      <Tooltip tooltip={t`Download full results`}>
-        <Icon title={t`Download this data`} name="downarrow" size={16} />
-      </Tooltip>
-    }
-    triggerClasses={cx(className, "text-brand-hover")}
-  >
+  <ModalContent>
     <div className="p2" style={{ maxWidth: 320 }}>
       <h4>{t`Download full results`}</h4>
       {result.data.rows_truncated != null && (
@@ -74,7 +64,7 @@ const QueryDownloadWidget = ({ className, card, result, uuid, token }) => (
         )}
       </div>
     </div>
-  </PopoverWithTrigger>
+  </ModalContent>
 );
 
 const UnsavedQueryButton = ({

--- a/frontend/src/metabase/query_builder/components/QueryHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryHeader.jsx
@@ -23,7 +23,7 @@ import SaveQuestionModal from "metabase/containers/SaveQuestionModal.jsx";
 
 import { clearRequestState } from "metabase/redux/requests";
 
-import { CardApi, RevisionApi } from "metabase/services";
+import { CardApi } from "metabase/services";
 
 import MetabaseAnalytics from "metabase/lib/analytics";
 import * as Urls from "metabase/lib/urls";
@@ -74,9 +74,6 @@ export default class QueryHeader extends Component {
       "onDelete",
       "onFollowBreadcrumb",
       "onToggleDataReference",
-      "onFetchRevisions",
-      "onRevertToRevision",
-      "onRevertedRevision",
     );
   }
 
@@ -172,21 +169,6 @@ export default class QueryHeader extends Component {
     this.props.onChangeLocation(this.props.fromUrl || "/");
   }
 
-  async onFetchRevisions({ entity, id }) {
-    // TODO: reduxify
-    let revisions = await RevisionApi.list({ entity, id });
-    this.setState({ revisions });
-  }
-
-  onRevertToRevision({ entity, id, revision_id }) {
-    // TODO: reduxify
-    return RevisionApi.revert({ entity, id, revision_id });
-  }
-
-  onRevertedRevision() {
-    this.props.reloadCardFn();
-    this.refs.cardHistory.toggle();
-  }
 
   getHeaderButtons() {
     const {

--- a/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
@@ -15,7 +15,6 @@ import VisualizationError from "./VisualizationError.jsx";
 import VisualizationResult from "./VisualizationResult.jsx";
 
 import Warnings from "./Warnings.jsx";
-import QueryDownloadWidget from "./QueryDownloadWidget.jsx";
 import QuestionEmbedWidget from "../containers/QuestionEmbedWidget";
 
 import { formatNumber, duration } from "metabase/lib/formatting";
@@ -200,13 +199,6 @@ export default class QueryVisualization extends Component {
               size={18}
             />
           )}
-          {!isResultDirty && result && !result.error ? (
-            <QueryDownloadWidget
-              className="mx1 hide sm-show"
-              card={question.card()}
-              result={result}
-            />
-          ) : null}
           {question.isSaved() &&
           ((isPublicLinksEnabled && (isAdmin || question.publicUUID())) ||
             (isEmbeddingEnabled && isAdmin)) ? (

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -6,6 +6,7 @@ import { connect } from "react-redux";
 import { t } from "c-3po";
 import cx from "classnames";
 import _ from "underscore";
+import { Box } from "rebass"
 
 import { loadTableAndForeignKeys } from "metabase/lib/table";
 
@@ -259,26 +260,27 @@ class LegacyQueryBuilder extends Component {
                 datasetQuery={card && card.dataset_query}
               />
             ) : query instanceof StructuredQuery ? (
-              <div className="wrapper">
+              <Box mx={4} width='100%'>
                 <GuiQueryEditor
                   {...this.props}
                   datasetQuery={card && card.dataset_query}
                 />
-              </div>
+              </Box>
             ) : null}
           </div>
 
-          <div
+          <Box
+            mx={4}
             ref="viz"
             id="react_qb_viz"
-            className="flex z1"
+            className="z1"
             style={{ transition: "opacity 0.25s ease-in-out" }}
           >
             <QueryVisualization
               {...this.props}
-              className="full wrapper mb2 z1"
+              className="full mb2 z1"
             />
-          </div>
+          </Box>
 
           {ModeFooter && (
             <ModeFooter {...this.props} className="flex-no-shrink" />

--- a/frontend/src/metabase/questions/QuestionHistoryModal.jsx
+++ b/frontend/src/metabase/questions/QuestionHistoryModal.jsx
@@ -1,0 +1,23 @@
+import React from "react"
+// TODO - modal route should pass this instead
+import { withRouter } from "react-router"
+
+import HistoryModal from "metabase/components/HistoryModal";
+
+@withRouter
+class QuestionHistoryModal extends React.Component {
+
+  render () {
+    const { params, onClose } = this.props
+    return (
+      <HistoryModal
+        entityType="card"
+        entityId={params.cardId}
+        onClose={onClose}
+      />
+    )
+  }
+}
+
+export default QuestionHistoryModal
+

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -35,7 +35,9 @@ import {
   TableBrowser,
 } from "metabase/components/BrowseApp";
 
-import QueryBuilder from "metabase/query_builder/containers/QueryBuilder.jsx";
+import QueryBuilder from "metabase/query_builder/containers/QueryBuilder";
+import QueryDownloadWidget from "metabase/query_builder/components/QueryDownloadWidget";
+import HistoryModal from "metabase/components/HistoryModal";
 
 import CollectionEdit from "metabase/questions/containers/CollectionEdit.jsx";
 import CollectionCreate from "metabase/questions/containers/CollectionCreate.jsx";
@@ -227,7 +229,11 @@ export const getRoutes = store => (
             />
           </Route>
         </Route>
-        <Route path="/question/:cardId" component={QueryBuilder} />
+        <Route path="/question/:cardId" component={QueryBuilder}>
+          <ModalRoute path="history" modal={HistoryModal} />
+          <ModalRoute path="move" modal={HistoryModal} />
+          <ModalRoute path="download" modal={QueryDownloadWidget} />
+        </Route>
         <Route path="/question/:cardId/entity" component={EntityPage} />
 
         <Route path="/ready" component={PostSetupApp} />

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -37,7 +37,7 @@ import {
 
 import QueryBuilder from "metabase/query_builder/containers/QueryBuilder";
 import QueryDownloadWidget from "metabase/query_builder/components/QueryDownloadWidget";
-import HistoryModal from "metabase/components/HistoryModal";
+import QuestionHistoryModal from "metabase/questions/QuestionHistoryModal"
 
 import CollectionEdit from "metabase/questions/containers/CollectionEdit.jsx";
 import CollectionCreate from "metabase/questions/containers/CollectionCreate.jsx";
@@ -230,8 +230,9 @@ export const getRoutes = store => (
           </Route>
         </Route>
         <Route path="/question/:cardId" component={QueryBuilder}>
-          <ModalRoute path="history" modal={HistoryModal} />
-          <ModalRoute path="move" modal={HistoryModal} />
+          <ModalRoute path="history" modal={QuestionHistoryModal} />
+          { // <ModalRoute path="move" modal={HistoryModal} />
+          }
           <ModalRoute path="download" modal={QueryDownloadWidget} />
         </Route>
         <Route path="/question/:cardId/entity" component={EntityPage} />


### PR DESCRIPTION
Applies entity menus to the query builder to help clean up and more logically group the different actions. Also uses the edit bar like we do on dashboards when editing to keep the "edit" experience a little more consistent. 

Implements #5113 and part of #6170