### PR TITLE
Fix memory leaks in dc.js and leaflet visualizations

### DIFF
--- a/frontend/src/metabase/meta/types/Visualization.js
+++ b/frontend/src/metabase/meta/types/Visualization.js
@@ -90,6 +90,7 @@ export type VisualizationProps = {
     yAxisSplit?: number[][],
     warnings?: string[],
   }) => void,
+  onRenderError: (error: ?Error) => void,
 
   hovered: ?HoverObject,
   onHoverChange: (?HoverObject) => void,

--- a/frontend/src/metabase/visualizations/components/CardRenderer.jsx
+++ b/frontend/src/metabase/visualizations/components/CardRenderer.jsx
@@ -1,3 +1,4 @@
+/* @flow */
 /* eslint "react/prop-types": "warn" */
 
 import React, { Component } from "react";
@@ -10,6 +11,16 @@ import { isSameSeries } from "metabase/visualizations/lib/utils";
 
 import dc from "dc";
 
+import type { VisualizationProps } from "metabase/meta/types/Visualization";
+
+type DeregisterFunction = () => void;
+
+type Props = VisualizationProps & {
+  width: number,
+  height: number,
+  renderer: (element: Element, props: VisualizationProps) => DeregisterFunction,
+};
+
 @ExplicitSize
 export default class CardRenderer extends Component {
   static propTypes = {
@@ -21,7 +32,9 @@ export default class CardRenderer extends Component {
     className: PropTypes.string,
   };
 
-  shouldComponentUpdate(nextProps, nextState) {
+  _deregister: ?DeregisterFunction;
+
+  shouldComponentUpdate(nextProps: Props) {
     // a chart only needs re-rendering when the result itself changes OR the chart type is different
     let sameSize =
       this.props.width === nextProps.width &&
@@ -43,10 +56,10 @@ export default class CardRenderer extends Component {
   }
 
   _deregisterChart() {
-    if (this._chart) {
+    if (this._deregister) {
       // Prevents memory leak
-      dc.chartRegistry.deregister(this._chart);
-      delete this._chart;
+      this._deregister();
+      delete this._deregister;
     }
   }
 
@@ -71,7 +84,7 @@ export default class CardRenderer extends Component {
     parent.appendChild(element);
 
     try {
-      this._chart = this.props.renderer(element, this.props);
+      this._deregister = this.props.renderer(element, this.props);
     } catch (err) {
       console.error(err);
       this.props.onRenderError(err.message || err);

--- a/frontend/src/metabase/visualizations/components/CardRenderer.jsx
+++ b/frontend/src/metabase/visualizations/components/CardRenderer.jsx
@@ -1,5 +1,4 @@
 /* @flow */
-/* eslint "react/prop-types": "warn" */
 
 import React, { Component } from "react";
 import PropTypes from "prop-types";

--- a/frontend/src/metabase/visualizations/components/CardRenderer.jsx
+++ b/frontend/src/metabase/visualizations/components/CardRenderer.jsx
@@ -9,27 +9,23 @@ import ExplicitSize from "metabase/components/ExplicitSize.jsx";
 
 import { isSameSeries } from "metabase/visualizations/lib/utils";
 
-import dc from "dc";
-
 import type { VisualizationProps } from "metabase/meta/types/Visualization";
 
 type DeregisterFunction = () => void;
 
 type Props = VisualizationProps & {
-  width: number,
-  height: number,
   renderer: (element: Element, props: VisualizationProps) => DeregisterFunction,
 };
 
 @ExplicitSize
 export default class CardRenderer extends Component {
+  props: Props;
+
   static propTypes = {
+    className: PropTypes.string,
     series: PropTypes.array.isRequired,
-    width: PropTypes.number,
-    height: PropTypes.number,
     renderer: PropTypes.func.isRequired,
     onRenderError: PropTypes.func.isRequired,
-    className: PropTypes.string,
   };
 
   _deregister: ?DeregisterFunction;
@@ -37,7 +33,9 @@ export default class CardRenderer extends Component {
   shouldComponentUpdate(nextProps: Props) {
     // a chart only needs re-rendering when the result itself changes OR the chart type is different
     let sameSize =
+      // $FlowFixMe: width/height provided by ExplicitSize
       this.props.width === nextProps.width &&
+      // $FlowFixMe: width/height provided by ExplicitSize
       this.props.height === nextProps.height;
     let sameSeries = isSameSeries(this.props.series, nextProps.series);
     return !(sameSize && sameSeries);
@@ -64,6 +62,7 @@ export default class CardRenderer extends Component {
   }
 
   renderChart() {
+    // $FlowFixMe: width/height provided by ExplicitSize
     if (this.props.width == null || this.props.height == null) {
       return;
     }

--- a/frontend/src/metabase/visualizations/components/LeafletChoropleth.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletChoropleth.jsx
@@ -99,6 +99,10 @@ const LeafletChoropleth = ({
 
       map.fitBounds(minimalBounds);
       // map.fitBounds(geoFeatureGroup.getBounds());
+
+      return () => {
+        map.remove();
+      };
     }}
   />
 );

--- a/frontend/src/metabase/visualizations/components/LeafletMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletMap.jsx
@@ -104,6 +104,10 @@ export default class LeafletMap extends Component {
     }
   }
 
+  componentWillUnmount() {
+    this.map.remove();
+  }
+
   startFilter() {
     this._filter = new L.Draw.Rectangle(
       this.map,

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -579,7 +579,12 @@ type LineAreaBarProps = VisualizationProps & {
   maxSeries: number,
 };
 
-export default function lineAreaBar(element: Element, props: LineAreaBarProps) {
+type DeregisterFunction = () => void;
+
+export default function lineAreaBar(
+  element: Element,
+  props: LineAreaBarProps,
+): DeregisterFunction {
   const { onRender, chartType, isScalarSeries, settings } = props;
 
   const warnings = {};
@@ -677,7 +682,10 @@ export default function lineAreaBar(element: Element, props: LineAreaBarProps) {
       warnings: Object.keys(warnings),
     });
 
-  return parent;
+  // return an unregister function
+  return () => {
+    dc.chartRegistry.deregister(parent);
+  };
 }
 
 export const lineRenderer = (element, props) =>

--- a/frontend/src/metabase/visualizations/lib/RowRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/RowRenderer.js
@@ -13,7 +13,7 @@ import { checkXAxisLabelOverlap } from "./LineAreaBarPostRender";
 export default function rowRenderer(
   element,
   { settings, series, onHoverChange, onVisualizationClick, height },
-) {
+): DeregisterFunction {
   const { cols } = series[0].data;
 
   if (series.length > 1) {
@@ -174,4 +174,8 @@ export default function rowRenderer(
   if (checkXAxisLabelOverlap(chart, ".axis text")) {
     chart.selectAll(".axis").remove();
   }
+
+  return () => {
+    dc.chartRegistry.deregister(chart);
+  };
 }


### PR DESCRIPTION
dc.js and leaflet both need their objects to be explicitly cleaned up to avoid memory leaks. We were previously doing it for line/area/bar/scatter charts, but not row charts or Leaflet maps. 

Resolves #7809