### PR TITLE
embedded dashboards: send message to parent HTML doc when params change

### DIFF
--- a/frontend/src/metabase/parameters/components/Parameters.jsx
+++ b/frontend/src/metabase/parameters/components/Parameters.jsx
@@ -86,6 +86,16 @@ export default class Parameters extends Component {
           document.title,
           window.location.pathname + search + window.location.hash,
         );
+        // if we're in an iframe, notify the parent document that the parameters
+        // have changed.
+        window.parent.postMessage(
+          {
+            source: "Metabase",
+            name: "dashboard-parameters",
+            value: search,
+          },
+          "*",
+        );
       }
     }
   }


### PR DESCRIPTION
embedded dashboards: send message to parent HTML doc when params change

for #7811. this lets HTML pages that embed Metabase dashboards detect and handle when the user changes parameter values.

as an example, with this PR, you can add this JS to the outer HTML page to propagate parameter values in and out of the dashboard iframe, so you can share URLs to specific queries:

```js
<script type="text/javascript">
function receiveMessage(event) {
  if (event.origin == "http://localhost:3000" &&
      event.data.source == "Metabase" &&
      event.data.name == "dashboard-parameters") {
    window.location.hash = event.data.value.slice(1);  // strip leading ? char
  }
}
window.addEventListener("message", receiveMessage, false);

if (window.location.hash) {
  document.getElementById("metabase").src += "?" +
      window.location.hash.slice(1);  // strip leading # char
}
</script>
```

you can see this in action on https://data.color.com/v1/ . the browser url fragment updates dynamically as you change filter values. if you then open that url in a new tab, it automatically sets the same filter values.

-  [ ] No backend changes afaict. (If there are changes to the backend codebase, run the backend tests with `lein test && lein eastwood && lein bikeshed && lein docstring-checker && ./bin/reflection-linter`)
-  [x] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).