### PR TITLE
Add missing LDAP special chars to escape function

### DIFF
--- a/src/metabase/integrations/ldap.clj
+++ b/src/metabase/integrations/ldap.clj
@@ -98,7 +98,7 @@
 (defn- escape-value
   "Escapes a value for use in an LDAP filter expression."
   [value]
-  (str/replace value #"[\*\(\)\\\\0]" (comp (partial format "\\%02X") int first)))
+  (str/replace value #"(?:^\s|\s$|[,\\\#\+<>;\"=\*\(\)\\0])" (comp (partial format "\\%02X") int first)))
 
 (defn- get-connection
   "Connects to LDAP with the currently set settings and returns the connection."

--- a/test/metabase/integrations/ldap_test.clj
+++ b/test/metabase/integrations/ldap_test.clj
@@ -15,8 +15,12 @@
 ;; See test_resources/ldap.ldif for fixtures
 
 (expect
-  "\\2AJohn \\28Dude\\29 Doe\\5C"
-  (#'ldap/escape-value "*John (Dude) Doe\\"))
+  "\\20\\2AJohn \\28Dude\\29 Doe\\5C"
+  (#'ldap/escape-value " *John (Dude) Doe\\"))
+
+(expect
+  "John\\2BSmith@metabase.com"
+  (#'ldap/escape-value "John+Smith@metabase.com"))
 
 ;; The connection test should pass with valid settings
 (expect-with-ldap-server


### PR DESCRIPTION
Resolves #7592 
I also added other missing special characters, not only the plus (+) sign from that issue.

###### Before submitting the PR, please make sure you do the following 
-  [x] If there are changes to the backend codebase, run the backend tests with `lein test && lein eastwood && lein bikeshed && lein docstring-checker && ./bin/reflection-linter`
-  [x] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
