### PR TITLE
Add :type/ID

### DIFF
--- a/frontend/src/metabase/lib/core.js
+++ b/frontend/src/metabase/lib/core.js
@@ -225,6 +225,11 @@ export const field_special_types = [
     name: t`Birthday`,
     section: t`Common`,
   },
+  {
+    id: TYPE.ID,
+    name: t`ID`,
+    section: t`Common`,
+  },
 ];
 
 export const field_special_types_map = field_special_types.reduce(

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -283,13 +283,8 @@
 
 (defn- key-col?
   "Workaround for our leaky type system which conflates types with properties."
-  [{:keys [base_type special_type name]}]
-  (and (isa? base_type :type/Number)
-       (or (#{:type/PK :type/FK} special_type)
-           (let [name (str/lower-case name)]
-             (or (= name "id")
-                 (str/starts-with? name "id_")
-                 (str/ends-with? name "_id"))))))
+  [{:keys [special_type]}]
+  (isa? special_type :type/ID))
 
 (def ^:private field-filters
   {:fieldspec       (fn [fieldspec]
@@ -299,7 +294,7 @@
                         (fn [{:keys [special_type target] :as field}]
                           (cond
                             ;; This case is mostly relevant for native queries
-                            (#{:type/PK :type/FK} fieldspec)
+                            (isa? fieldspec :type/ID)
                             (isa? special_type fieldspec)
 
                             target

--- a/src/metabase/types.clj
+++ b/src/metabase/types.clj
@@ -132,8 +132,9 @@
 
 (derive :type/Special :type/*)
 
-(derive :type/FK :type/Special)
-(derive :type/PK :type/Special)
+(derive :type/ID :type/Special)
+(derive :type/FK :type/ID)
+(derive :type/PK :type/ID)
 
 (derive :type/Category :type/Special)
 


### PR DESCRIPTION
Primarily used as a negative filter, this removes some scar tissue from xray heuristics into type system where it makes more sense.