### PR TITLE
Handle Azure Cosmos DB connections

### DIFF
--- a/src/metabase/driver/mongo.clj
+++ b/src/metabase/driver/mongo.clj
@@ -23,9 +23,9 @@
 
 (defn- can-connect? [details]
   (with-mongo-connection [^DB conn, details]
-    (= (-> (cmd/db-stats conn)
-           (conv/from-db-object :keywordize)
-           :ok)
+    (= (float (-> (cmd/db-stats conn)
+                  (conv/from-db-object :keywordize)
+                  :ok))
        1.0)))
 
 (defn- humanize-connection-error-message [message]


### PR DESCRIPTION
When attempting to connect with an Azure Cosmos DB instance,
`can-connect` for Mongo driver returns false due to a mismatch in
returned data types.

Mongo DB instances using wire protocol versions prior to 3.4 return
an an integer value (1) as the value for the "ok" field in the
response for db.stats(). Newer versions respond with a float value
(1.0). Azure Cosmos DB uses wire protocol version 3.2 by default.

This changeset casts the response value to float to ensure expected
behaviour.

Resolves: #5571

###### Before submitting the PR, please make sure you do the following 
-  [x] If there are changes to the backend codebase, run the backend tests with `lein test && lein eastwood && lein bikeshed && lein docstring-checker && ./bin/reflection-linter`
-  [x] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
