### PR TITLE
Fix GSG now that Dashboards require collection_id for read perms check

### DIFF
--- a/src/metabase/api/getting_started.clj
+++ b/src/metabase/api/getting_started.clj
@@ -1,10 +1,12 @@
 (ns metabase.api.getting-started
+  "/api/getting_started routes."
   (:require [compojure.core :refer [GET]]
             [medley.core :as m]
             [metabase.api.common :as api]
             [metabase.models
              [interface :as mi]
              [setting :refer [defsetting]]]
+            [metabase.util :as u]
             [puppetlabs.i18n.core :refer [tru]]
             [toucan.db :as db]))
 
@@ -27,9 +29,10 @@
     {:things_to_know           (getting-started-things-to-know)
      :contact                  {:name  (getting-started-contact-name)
                                 :email (getting-started-contact-email)}
-     :most_important_dashboard (when-let [dashboard (db/select-one ['Dashboard :id] :show_in_getting_started true)]
+     :most_important_dashboard (when-let [dashboard (db/select-one ['Dashboard :id :collection_id]
+                                                      :show_in_getting_started true)]
                                  (when (mi/can-read? dashboard)
-                                   (:id dashboard)))
+                                   (u/get-id dashboard)))
      :important_metrics        metric-ids
      :important_tables         table-ids
      :important_segments       segment-ids

--- a/test/metabase/api/getting_started_test.clj
+++ b/test/metabase/api/getting_started_test.clj
@@ -1,0 +1,40 @@
+(ns metabase.api.getting-started-test
+  (:require [expectations :refer [expect]]
+            [metabase.models
+             [collection :refer [Collection]]
+             [dashboard :refer [Dashboard]]
+             [permissions :as perms]
+             [permissions-group :as group]]
+            [metabase.test.data.users :as test-users]
+            [metabase.util :as u]
+            [toucan.util.test :as tt]))
+
+;; make sure that we can fetch the GSG stuff with a 'show in getting started' Dashboard
+;; ...but you shouldn't know about it if you don't have read perms for it
+(expect
+  {:things_to_know           nil
+   :contact                  {:name nil, :email nil}
+   :most_important_dashboard false
+   :important_metrics        []
+   :important_tables         []
+   :important_segments       []
+   :metric_important_fields  {}}
+  (tt/with-temp Dashboard [_ {:show_in_getting_started true}]
+    (-> ((test-users/user->client :rasta) :get 200 "getting_started")
+        (update :most_important_dashboard integer?))))
+
+;; ...but if you do have read perms, then you should get to see it!
+(expect
+  {:things_to_know           nil
+   :contact                  {:name nil, :email nil}
+   :most_important_dashboard true
+   :important_metrics        []
+   :important_tables         []
+   :important_segments       []
+   :metric_important_fields  {}}
+  (tt/with-temp* [Collection [collection]
+                  Dashboard  [_ {:collection_id           (u/get-id collection)
+                                 :show_in_getting_started true}]]
+    (perms/grant-collection-read-permissions! (group/all-users) collection)
+    (-> ((test-users/user->client :rasta) :get 200 "getting_started")
+        (update :most_important_dashboard integer?))))


### PR DESCRIPTION
endpoint was failing because it couldn't calcluate read perms for the dashboard because we weren't fetching its `collection_id`, which is now required. Fixed & added tests