### PR TITLE
Finally drop RawTable & RawColumn tables. Bye Felicia! :wave:

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -4284,3 +4284,14 @@ databaseChangeLog:
       changes:
         - sql:
             sql: DELETE FROM permissions WHERE object LIKE '%/native/read/'
+
+# Time to finally get rid of the RawTable and RawColumn tables. Bye Felicia!
+  - changeSet:
+      id: 87
+      author: camsaul
+      comment: 'Added 0.30.0'
+      changes:
+        - dropTable:
+            tableName: raw_column
+        - dropTable:
+            tableName: raw_table


### PR DESCRIPTION
The models were moved into the dustbin of history a year ago in #5510, but I didn't actually drop the tables from the DB so as to avoid breaking things for people who downgrade. But we've waited long enough at this point IMO. Implements #3448