### PR TITLE
Change microcopy and spacing for items in the nav, overworld, and collections

### DIFF
--- a/frontend/src/metabase/admin/permissions/selectors.js
+++ b/frontend/src/metabase/admin/permissions/selectors.js
@@ -657,7 +657,7 @@ export const getDatabasesPermissionsGrid = createSelector(
 );
 
 // "root" collection we should include in the grid even though it's not listed by the endpoints
-const ROOT_COLLECTION = { id: "root", name: "Saved Items" };
+const ROOT_COLLECTION = { id: "root", name: "Home collection" };
 
 const getCollections = state => state.admin.permissions.collections;
 const getCollectionPermission = (permissions, groupId, { collectionId }) =>

--- a/frontend/src/metabase/components/CollectionLanding.jsx
+++ b/frontend/src/metabase/components/CollectionLanding.jsx
@@ -157,7 +157,7 @@ class DefaultLanding extends React.Component {
       <Flex>
         {showCollectionList && (
           <Box w={1 / 3} mr={3}>
-            <Box>
+            <Box mb={2}>
               <h4>{t`Collections`}</h4>
             </Box>
             <CollectionList />
@@ -199,7 +199,7 @@ class DefaultLanding extends React.Component {
 
                 return (
                   <Box>
-                    <Box mb={2}>
+                    <Box mb={3}>
                       {pinned.length > 0 && (
                         <Box mb={2}>
                           <h4>{t`Pinned items`}</h4>
@@ -251,8 +251,8 @@ class DefaultLanding extends React.Component {
                     </Box>
                     <Flex align="center" mb={2}>
                       {pinned.length > 0 && (
-                        <Box>
-                          <h4>{t`Saved here`}</h4>
+                        <Box mb={1}>
+                          <h4>{t`Dashboards, saved questions, and pulses`}</h4>
                         </Box>
                       )}
                     </Flex>
@@ -310,7 +310,7 @@ class CollectionLanding extends React.Component {
                       to={`/collection/${collectionId}`}
                       hover={{ color: normal.blue }}
                     >
-                      {isRoot ? "Saved items" : currentCollection.name}
+                      {isRoot ? "Home collection" : currentCollection.name}
                     </Link>
                   </Flex>
                 )}

--- a/frontend/src/metabase/containers/Overworld.jsx
+++ b/frontend/src/metabase/containers/Overworld.jsx
@@ -84,7 +84,7 @@ class Overworld extends React.Component {
             return (
               <Box>
                 <Box mt={3} mb={1}>
-                  <h4>{t`Pinned dashboards`}</h4>
+                  <h4>{t`Start here`}</h4>
                 </Box>
                 <Grid>
                   {pinnedDashboards.map(pin => {
@@ -122,7 +122,7 @@ class Overworld extends React.Component {
                           name="all"
                         />
                         <Flex align="center">
-                          <h3>See more items</h3>
+                          <h3>See everything we've saved</h3>
                           <Icon name="chevronright" size={14} ml={1} />
                         </Flex>
                       </Card>
@@ -135,20 +135,20 @@ class Overworld extends React.Component {
         </CollectionItemsLoader>
 
         <Box mb={3} mt={3}>
-          <h4>{t`Pinned items`}</h4>
+          <h4 className="mb2">{t`Start here`}</h4>
           <OverworldSectionEmptyState>
-            { jt`Click on the star ${<Icon name='pin' mx={1} color={normal.red} />}next to an item’s name to mark it as a personal favorite`}
+            { jt`If you pin ${<Icon name='pin' mx={1} color={normal.red} />}some things in the home collection, they’ll show up here for everyone`}
           </OverworldSectionEmptyState>
         </Box>
 
         <Box mb={3}>
-          <h4>{t`Favorites`}</h4>
+          <h4 className="mb2">{t`My personal favorites`}</h4>
           <OverworldSectionEmptyState>
             { jt`Click on the star ${<Icon name='star' mx={1} color={normal.yellow} />}next to an item’s name to mark it as a personal favorite`}
           </OverworldSectionEmptyState>
         </Box>
 
-        <Box mt={4}>
+        <Box my={4}>
           <h4>{t`Our data`}</h4>
           <Box mt={2}>
             <DatabaseListLoader>

--- a/frontend/src/metabase/nav/containers/Navbar.jsx
+++ b/frontend/src/metabase/nav/containers/Navbar.jsx
@@ -247,8 +247,8 @@ export default class Navbar extends Component {
             </Button>
           </Link>
           <Link to="collection/root" mx={1}>
-            <Box p={1} bg="#69ABE6" className="text-bold rounded">
-              Saved items
+            <Box py={1} px={2} bg="#69ABE6" className="text-bold rounded">
+              Collections
             </Box>
           </Link>
           <Tooltip tooltip={t`Reference`}>


### PR DESCRIPTION
Nav:
- "Saved items" => "Collections"

Overworld:
- "Pinned dashboards" => "Start here" (Trying to clarify that it's not _all_ pinned dashboards from every collection.)
- "See more items" => "See everything we've saved"
- "Favorites" => "My personal favorites" (Reinforcing that only you see these specific items.)

Root folder:
- "Saved items" => "Home collection" (Probably contentious, but what I'm trying to do is emphasize that this view is itself a collection. I think it also makes it clearer when editing its permissions, vs. calling it "Everything we've saved.")
- "Saved here" => "Dashboards, saved questions, and pulses" 

