### PR TITLE
Fix invalid queries in aggregate card with joins x-ray

### DIFF
--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -152,8 +152,7 @@
      :rules-prefix ["field"]}))
 
 (def ^:private ^{:arglists '([card-or-question])} nested-query?
-  (comp (every-pred string? #(str/starts-with? % "card__"))
-        #(qp.util/get-in-normalized % [:dataset_query :query :source_table])))
+  (comp qp.util/query->source-card-id :dataset_query))
 
 (def ^:private ^{:arglists '([card-or-question])} native-query?
   (comp #{:native} qp.util/normalize-token #(qp.util/get-in-normalized % [:dataset_query :type])))
@@ -573,19 +572,23 @@
 
 (defmethod inject-root (type Field)
   [context field]
-  (update context :dimensions
-          (fn [dimensions]
-            (->> dimensions
-                 (keep (fn [[identifier definition]]
-                         (when-let [matches (->> definition
-                                                 :matches
-                                                 (remove (comp #{(id-or-name field)} id-or-name))
-                                                 not-empty)]
-                           [identifier (assoc definition :matches matches)])))
-                 (concat [["this" {:matches [field]
-                                   :name    (:display_name field)
-                                   :score   rules/max-score}]])
-                 (into {})))))
+  (let [field (assoc field :link (->> context
+                                      :tables
+                                      (m/find-first (comp #{(:table_id field)} u/get-id))
+                                      :link))]
+    (update context :dimensions
+            (fn [dimensions]
+              (->> dimensions
+                   (keep (fn [[identifier definition]]
+                           (when-let [matches (->> definition
+                                                   :matches
+                                                   (remove (comp #{(id-or-name field)} id-or-name))
+                                                   not-empty)]
+                             [identifier (assoc definition :matches matches)])))
+                   (concat [["this" {:matches [field]
+                                     :name    (:display_name field)
+                                     :score   rules/max-score}]])
+                   (into {}))))))
 
 (defmethod inject-root (type Metric)
   [context metric]

--- a/src/metabase/models/query.clj
+++ b/src/metabase/models/query.clj
@@ -60,9 +60,8 @@
               (throw e))))))
 
 
-(defn- native-query? [query-type]
-  (or (= query-type "native")
-      (= query-type :native)))
+(def ^:private ^{:arglists '([query-type])} native-query?
+  (comp #{:native} qputil/normalize-token))
 
 (defn query->database-and-table-ids
   "Return a map with `:database-id` and source `:table-id` that should be saved for a Card. Handles queries that use


### PR DESCRIPTION
When generating the breakout (field) part of the aggregate card x-ray, we did not account correctly for joins, or rather what the source table is. This PR fixes this and adds testing for valid generated query for all xrays.