### PR TITLE
Rework xray candidates to use only 4 queries

### DIFF
--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -878,7 +878,7 @@
                                                    [:or [:not= :special_type "type/PK"]
                                                     [:= :special_type nil]]]
                                         :group-by [:table_id]
-                                        :having   [:= :count 1]}))
+                                        :having   [:= :%count.* 1]}))
                            (into #{} (map :table_id)))
           link-table? (->> (db/query {:select   [:table_id [:%count.* "count"]]
                                       :from     [:metabase_field]

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -874,7 +874,7 @@
                                                       not-empty)]
                              (db/query {:select   [:table_id [:%count.* "count"]]
                                         :from     [:metabase_field]
-                                        :where    [:and [:in :table_id ]
+                                        :where    [:and [:in :table_id candidates]
                                                    [:or [:not= :special_type "type/PK"]
                                                     [:= :special_type nil]]]
                                         :group-by [:table_id]

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -863,7 +863,7 @@
   [tables]
   (when (not-empty tables)
     (let [field-count (->> (db/query {:select   [:table_id [:%count.* "count"]]
-                                      :from     [:metabase_field]
+                                      :from     [Field]
                                       :where    [:in :table_id (map u/get-id tables)]
                                       :group-by [:table_id]})
                            (into {} (map (fn [{:keys [count table_id]}]
@@ -872,8 +872,8 @@
                                                       (filter (comp (partial >= 2) val))
                                                       (map key)
                                                       not-empty)]
-                             (db/query {:select   [:table_id [:%count.* "count"]]
-                                        :from     [:metabase_field]
+                             (db/query {:select   [:table_id]
+                                        :from     [Field]
                                         :where    [:and [:in :table_id candidates]
                                                    [:or [:not= :special_type "type/PK"]
                                                     [:= :special_type nil]]]
@@ -881,7 +881,7 @@
                                         :having   [:= :%count.* 1]}))
                            (into #{} (map :table_id)))
           link-table? (->> (db/query {:select   [:table_id [:%count.* "count"]]
-                                      :from     [:metabase_field]
+                                      :from     [Field]
                                       :where    [:and [:in :table_id (keys field-count)]
                                                  [:in :special_type ["type/PK" "type/FK"]]]
                                       :group-by [:table_id]})

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -861,13 +861,13 @@
 
 (defn- enhance-table-stats
   [tables]
-  (let [field-count (->> (db/query {:select   [:table_id [:%count.* :count]]
+  (let [field-count (->> (db/query {:select   [:table_id [:%count.* "count"]]
                                     :from     [:metabase_field]
                                     :where    [:in :table_id (map u/get-id tables)]
                                     :group-by [:table_id]})
                          (into {} (map (fn [{:keys [count table_id]}]
                                          [table_id count]))))
-        list-like?  (->> (db/query {:select   [:table_id [:%count.* :count]]
+        list-like?  (->> (db/query {:select   [:table_id [:%count.* "count"]]
                                     :from     [:metabase_field]
                                     :where    [:and [:in :table_id (->> field-count
                                                                         (filter (comp #{2} val))
@@ -877,7 +877,7 @@
                                     :group-by [:table_id]
                                     :having   [:= :count 1]})
                          (into #{} (map :table_id)))
-        link-table? (->> (db/query {:select   [:table_id [:%count.* :count]]
+        link-table? (->> (db/query {:select   [:table_id [:%count.* "count"]]
                                     :from     [:metabase_field]
                                     :where    [:and [:in :table_id (keys field-count)]
                                                     [:in :special_type ["type/PK" "type/FK"]]]

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -911,7 +911,7 @@
   ([database] (candidate-tables database nil))
   ([database schema]
    (let [rules (rules/get-rules ["table"])]
-     (->> (apply db/select Table
+     (->> (apply db/select [Table :id :schema :display_name :entity_type :db_id]
                  (cond-> [:db_id           (u/get-id database)
                           :visibility_type nil]
                    schema (concat [:schema schema])))

--- a/src/metabase/automagic_dashboards/rules.clj
+++ b/src/metabase/automagic_dashboards/rules.clj
@@ -189,6 +189,7 @@
   (constrained-all
    {(s/required-key :title)             s/Str
     (s/required-key :rule)              s/Str
+    (s/required-key :specificity)       s/Int
     (s/optional-key :cards)             [Card]
     (s/optional-key :dimensions)        [Dimension]
     (s/optional-key :applies_to)        AppliesTo
@@ -278,6 +279,10 @@
 (def ^:private ^{:arglists '([f])} file->entity-type
   (comp (partial re-find #".+(?=\.yaml$)") str (memfn ^Path getFileName)))
 
+(defn- specificity
+  [rule]
+  (transduce (map (comp count ancestors)) + (:applies_to rule)))
+
 (defn- load-rule
   [^Path f]
   (try
@@ -288,6 +293,7 @@
           yaml/parse-string
           (assoc :rule entity-type)
           (update :applies_to #(or % entity-type))
+          (as-> rule (assoc rule :specificity (specificity rule)))
           rules-validator))
     (catch Exception e
       (log/errorf (trs "Error parsing %s:\n%s")

--- a/src/metabase/automagic_dashboards/rules.clj
+++ b/src/metabase/automagic_dashboards/rules.clj
@@ -291,10 +291,11 @@
           .toUri
           slurp
           yaml/parse-string
-          (assoc :rule entity-type)
+          (assoc :rule        entity-type
+                 :specificity 0)
           (update :applies_to #(or % entity-type))
-          (as-> rule (assoc rule :specificity (specificity rule)))
-          rules-validator))
+          rules-validator
+          (as-> rule (assoc rule :specificity (specificity rule)))))
     (catch Exception e
       (log/errorf (trs "Error parsing %s:\n%s")
                   (.getFileName f)

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -253,8 +253,8 @@
   1
   (tt/with-temp* [Database [{db-id :id}]
                   Table    [{table-id :id} {:db_id db-id}]
-                  Field    [{} {:table_id table-id}]
-                  Field    [{} {:table_id table-id}]]
+                  Field    [_ {:table_id table-id}]
+                  Field    [_ {:table_id table-id}]]
     (with-rasta
       (with-dashboard-cleanup
         (count (candidate-tables (Database db-id)))))))
@@ -263,8 +263,8 @@
   4
   (tt/with-temp* [Database [{db-id :id}]
                   Table    [{table-id :id} {:db_id db-id}]
-                  Field    [{} {:table_id table-id}]
-                  Field    [{} {:table_id table-id}]]
+                  Field    [_ {:table_id table-id}]
+                  Field    [_ {:table_id table-id}]]
     (with-rasta
       (with-dashboard-cleanup
         (let [database (Database db-id)]
@@ -278,8 +278,8 @@
    :num-fields 2}
   (tt/with-temp* [Database [{db-id :id}]
                   Table    [{table-id :id} {:db_id db-id}]
-                  Field    [{} {:table_id table-id :special_type :type/PK}]
-                  Field    [{} {:table_id table-id}]]
+                  Field    [_ {:table_id table-id :special_type :type/PK}]
+                  Field    [_ {:table_id table-id}]]
     (with-rasta
       (with-dashboard-cleanup
         (-> (#'magic/enhance-table-stats [(Table table-id)])
@@ -292,9 +292,9 @@
    :num-fields 3}
   (tt/with-temp* [Database [{db-id :id}]
                   Table    [{table-id :id} {:db_id db-id}]
-                  Field    [{} {:table_id table-id :special_type :type/PK}]
-                  Field    [{} {:table_id table-id :special_type :type/FK}]
-                  Field    [{} {:table_id table-id :special_type :type/FK}]]
+                  Field    [_ {:table_id table-id :special_type :type/PK}]
+                  Field    [_ {:table_id table-id :special_type :type/FK}]
+                  Field    [_ {:table_id table-id :special_type :type/FK}]]
     (with-rasta
       (with-dashboard-cleanup
         (-> (#'magic/enhance-table-stats [(Table table-id)])

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -275,7 +275,7 @@
 (expect
   {:list-like?  true
    :link-table? false
-   :num.-fields 2}
+   :num-fields 2}
   (tt/with-temp* [Database [{db-id :id}]
                   Table    [{table-id :id} {:db_id db-id}]
                   Field    [{} {:table_id table-id :special_type :type/PK}]
@@ -289,7 +289,7 @@
 (expect
   {:list-like?  false
    :link-table? true
-   :num.-fields 3}
+   :num-fields 3}
   (tt/with-temp* [Database [{db-id :id}]
                   Table    [{table-id :id} {:db_id db-id}]
                   Field    [{} {:table_id table-id :special_type :type/PK}]

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -28,6 +28,13 @@
                                                     atom)]
      ~@body))
 
+(defmacro ^:private with-dashboard-cleanup
+  [& body]
+  `(tu/with-model-cleanup ['~'Card '~'Dashboard '~'Collection '~'DashboardCard]
+     ~@body))
+
+
+;;; ------------------- `->reference` -------------------
 
 (expect
   [:field-id 1]
@@ -44,6 +51,8 @@
   (->> 42
        (#'magic/->reference :mbql)))
 
+
+;;; ------------------- Rule matching  -------------------
 
 (expect
   [:entity/UserTable :entity/GenericTable :entity/*]
@@ -63,6 +72,8 @@
        (#'magic/matching-rules (rules/get-rules ["table"]))
        (map (comp first :applies_to))))
 
+
+;;; ------------------- `automagic-anaysis` -------------------
 
 (defn- collect-urls
   [dashboard]
@@ -86,11 +97,6 @@
   (assert (-> dashboard :ordered_cards count pos?))
   (assert (valid-urls? dashboard))
   true)
-
-(defmacro ^:private with-dashboard-cleanup
-  [& body]
-  `(tu/with-model-cleanup ['~'Card '~'Dashboard '~'Collection '~'DashboardCard]
-     ~@body))
 
 (expect
   (with-rasta
@@ -235,6 +241,8 @@
             valid-dashboard?)))))
 
 
+;;; ------------------- /candidates -------------------
+
 (expect
   3
   (with-rasta
@@ -251,6 +259,50 @@
       (with-dashboard-cleanup
         (count (candidate-tables (Database db-id)))))))
 
+(expect
+  4
+  (tt/with-temp* [Database [{db-id :id}]
+                  Table    [{table-id :id} {:db_id db-id}]
+                  Field    [{} {:table_id table-id}]
+                  Field    [{} {:table_id table-id}]]
+    (with-rasta
+      (with-dashboard-cleanup
+        (let [database (Database db-id)]
+          (db/with-call-counting [call-count]
+            (candidate-tables database)
+            (call-count)))))))
+
+(expect
+  {:list-like?  true
+   :link-table? false
+   :num.-fields 2}
+  (tt/with-temp* [Database [{db-id :id}]
+                  Table    [{table-id :id} {:db_id db-id}]
+                  Field    [{} {:table_id table-id :special_type :type/PK}]
+                  Field    [{} {:table_id table-id}]]
+    (with-rasta
+      (with-dashboard-cleanup
+        (-> (#'magic/enhance-table-stats [(Table table-id)])
+            first
+            :stats)))))
+
+(expect
+  {:list-like?  false
+   :link-table? true
+   :num.-fields 3}
+  (tt/with-temp* [Database [{db-id :id}]
+                  Table    [{table-id :id} {:db_id db-id}]
+                  Field    [{} {:table_id table-id :special_type :type/PK}]
+                  Field    [{} {:table_id table-id :special_type :type/FK}]
+                  Field    [{} {:table_id table-id :special_type :type/FK}]]
+    (with-rasta
+      (with-dashboard-cleanup
+        (-> (#'magic/enhance-table-stats [(Table table-id)])
+            first
+            :stats)))))
+
+
+;;; ------------------- Definition overloading -------------------
 
 ;; Identity
 (expect
@@ -303,6 +355,8 @@
       first
       key))
 
+
+;;; ------------------- Datetime resolution inference -------------------
 
 (expect
   :month


### PR DESCRIPTION
/candidates now only use 4 queries no matter the DB size. Additionally all the aggregation is pushed into the DB, so the only full select is for tables which is unavoidable. 

Hot path is optimized. Now /candidates for our Redshift DB takes ~200ms.

Also adds a couple additional tests.

Fixes #7866