### PR TITLE
Fix NullPointerException when not including a search string

### DIFF
--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -196,7 +196,7 @@
 (s/defn ^:private make-search-context :- SearchContext
   [search-string :- (s/maybe su/NonBlankString)
    archived-string :- (s/maybe su/BooleanString)]
-  {:search-string       (str "%" (str/lower-case search-string) "%")
+  {:search-string       search-string
    :archived?           (Boolean/parseBoolean archived-string)
    :visible-collections (coll/permissions-set->visible-collection-ids @*current-user-permissions-set*)})
 

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.api.search-test
-  (:require [clojure.string :as str]
+  (:require [clojure.set :as set]
+            [clojure.string :as str]
             [expectations :refer :all]
             [metabase.models
              [card :refer [Card]]
@@ -84,6 +85,14 @@
   default-search-results
   (with-search-items-in-root-collection "test"
     (search-request :crowberto :q "test")))
+
+;; Search with no search string. Note this search everything in the DB, including any stale data left behind from
+;; previous tests. Instead of an = comparison here, just ensure our default results are included
+(expect
+  (set/subset?
+   default-search-results
+   (with-search-items-in-root-collection "test"
+     (search-request :crowberto))))
 
 ;; Ensure that users without perms for the root collection don't get results
 ;; NOTE: Metrics and segments don't have collections, so they'll be returned


### PR DESCRIPTION
This is an issue resulting from the merge with the
collections-project-bulk-actions branch. A missing search string was
allowed in the form validation, but would fail as it tried to
lower-case the nil string.
