### PR TITLE
Search results should not include alerts

### DIFF
--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -166,7 +166,9 @@
   (when-not archived?
     (-> (make-honeysql-search-query Pulse "pulse" pulse-columns-without-type)
         (merge-name-search search-ctx)
-        (add-collection-criteria :collection_id search-ctx))))
+        (add-collection-criteria :collection_id search-ctx)
+        ;; We don't want alerts included in pulse results
+        (h/merge-where [:= :alert_condition nil]))))
 
 (s/defmethod ^:private create-search-query :metric
   [_ search-ctx :- SearchContext]

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -217,3 +217,13 @@
                     Metric     [_ (archived {:name "metric test metric"})]
                     Segment    [_ (archived {:name "segment test segment"})]]
       (search-request :crowberto :q "test", :archived "true"))))
+
+;; Search should not return alerts
+(expect
+  []
+  (with-search-items-in-root-collection "test"
+    (tt/with-temp* [Pulse [pulse {:alert_condition  "rows"
+                                  :alert_first_only false
+                                  :alert_above_goal nil
+                                  :name             nil}]]
+      (filter #(= (u/get-id pulse) (:id %)) ((user->client :crowberto) :get 200 "search")))))


### PR DESCRIPTION
These were coming back with pulses, needed to include another query
clause to remove them.
