### PR TITLE
xrays: Better related using per-entity/dashboard type recommendations

### DIFF
--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
@@ -13,7 +13,6 @@ import Icon from "metabase/components/Icon";
 
 import cxs from "cxs";
 import { t } from "c-3po";
-import _ from "underscore";
 
 import { Dashboard } from "metabase/dashboard/containers/Dashboard";
 import DashboardData from "metabase/dashboard/hoc/DashboardData";
@@ -240,7 +239,7 @@ const SuggestionsSidebar = ({ related }) => (
     <div className="py2 text-centered my3">
       <h3 className="text-grey-3">More X-rays</h3>
     </div>
-     <SuggestionsList section="related" suggestions={related} />
+    <SuggestionsList section="related" suggestions={related} />
   </div>
 );
 

--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
@@ -89,7 +89,7 @@ class AutomaticDashboardApp extends React.Component {
     // pull out "more" related items for displaying as a button at the bottom of the dashboard
     const more = dashboard && dashboard.more;
     const related = dashboard && dashboard.related;
-    const hasSidebar = _.any(related || {}, list => list.length > 0);
+    const hasSidebar = related && related.length > 0;
 
     return (
       <div className="relative">
@@ -240,9 +240,7 @@ const SuggestionsSidebar = ({ related }) => (
     <div className="py2 text-centered my3">
       <h3 className="text-grey-3">More X-rays</h3>
     </div>
-    {Object.entries(related).map(([section, suggestions]) => (
-      <SuggestionsList section={section} suggestions={suggestions} />
-    ))}
+     <SuggestionsList section="related" suggestions={related} />
   </div>
 );
 

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -752,50 +752,29 @@
           :else
           (recur remaining-selectors related selected))))))
 
-(defmulti
-  ^{:private true
-    :arglists '([root])}
-  related-selectors (comp type :entity))
-
-(defmethod related-selectors (type Table)
-  [_]
-  (let [down     [[:indepth] [:segments :metrics] [:drilldown-fields]]
-        sideways [[:linking-to :linked-from] [:tables]]]
-    [down down down down sideways sideways]))
-
-(defmethod related-selectors (type Segment)
-  [_]
-  (let [down     [[:indepth] [:segments :metrics] [:drilldown-fields]]
-        sideways [[:linking-to] [:tables]]
-        up       [[:table]]]
-    [down down down sideways sideways up]))
-
-(defmethod related-selectors (type Metric)
-  [_]
-  (let [down     [[:drilldown-fields]]
-        sideways [[:metrics :segments]]
-        up       [[:table]]]
-    [sideways sideways sideways down down up]))
-
-(defmethod related-selectors (type Field)
-  [_]
-  (let [sideways [[:fields]]
-        up       [[:table] [:metrics :segments]]]
-    [sideways sideways up]))
-
-(defmethod related-selectors (type Card)
-  [_]
-  (let [down     [[:drilldown-fields]]
-        sideways [[:metrics] [:similar-questions :dashboard-mates]]
-        up       [[:table]]]
-    [sideways sideways sideways down down up]))
-
-(defmethod related-selectors (type Query)
-  [_]
-  (let [down     [[:drilldown-fields]]
-        sideways [[:metrics] [:similar-questions]]
-        up       [[:table]]]
-    [sideways sideways sideways down down up]))
+(def ^:private related-selectors
+  {(type Table)   (let [down     [[:indepth] [:segments :metrics] [:drilldown-fields]]
+                        sideways [[:linking-to :linked-from] [:tables]]]
+                    [down down down down sideways sideways])
+   (type Segment) (let [down     [[:indepth] [:segments :metrics] [:drilldown-fields]]
+                        sideways [[:linking-to] [:tables]]
+                        up       [[:table]]]
+                    [down down down sideways sideways up])
+   (type Metric)  (let [down     [[:drilldown-fields]]
+                        sideways [[:metrics :segments]]
+                        up       [[:table]]]
+                    [sideways sideways sideways down down up])
+   (type Field)   (let [sideways [[:fields]]
+                        up       [[:table] [:metrics :segments]]]
+                    [sideways sideways up])
+   (type Card)    (let [down     [[:drilldown-fields]]
+                        sideways [[:metrics] [:similar-questions :dashboard-mates]]
+                        up       [[:table]]]
+                    [sideways sideways sideways down down up])
+   (type Query)   (let [down     [[:drilldown-fields]]
+                        sideways [[:metrics] [:similar-questions]]
+                        up       [[:table]]]
+                    [sideways sideways sideways down down up])})
 
 (s/defn ^:private related
   "Build a balancee list of related X-rays. General composition of the list is determined for each
@@ -805,7 +784,7 @@
     (->> (merge (indepth root rule)
                 (drilldown-fields dashboard)
                 (related-entities root))
-         (fill-related max-related (related-selectors root))
+         (fill-related max-related (related-selectors (-> root :entity type)))
          (group-by :selector)
          (m/map-vals (partial map :entity)))))
 

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -807,7 +807,7 @@
                           (drilldown-fields dashboard)
                           (related-entities root))
         selectors  (related-selectors root)]
-    (mapcat (fill-related max-related selectors candidates) (distinct path))))
+    (mapcat (fill-related max-related selectors candidates) (distinct selectors))))
 
 (defn- automagic-dashboard
   "Create dashboards for table `root` using the best matching heuristics."

--- a/src/metabase/related.clj
+++ b/src/metabase/related.clj
@@ -146,7 +146,7 @@
 (defn- similar-questions
   [card]
   (->> (db/select Card
-         :table_id (:table_id card)
+         :table_id (qp.util/get-normalized card :table-id)
          :archived false)
        filter-visible
        (rank-by-similarity card)
@@ -155,7 +155,7 @@
 (defn- canonical-metric
   [card]
   (->> (db/select Metric
-         :table_id (:table_id card)
+         :table_id (qp.util/get-normalized card :table-id)
          :archived false)
        filter-visible
        (m/find-first (comp #{(-> card :dataset_query :query :aggregation)}
@@ -206,7 +206,7 @@
 
 (defmethod related (type Card)
   [card]
-  (let [table             (Table (:table_id card))
+  (let [table             (Table (qp.util/get-normalized card :table-id))
         similar-questions (similar-questions card)]
     {:table             table
      :metrics           (->> table


### PR DESCRIPTION
Better related using per-entity/dashboard type recommendations. The idea is to have semi-crafted paths through your data. 

Open questions:
- Should there be more structure? Grouping by type or in intent (down/up/sideways)?

TODO:
- [x] instrument and track which option was clicked (we already have provisional tracking in place, but now more context would be good)