### PR TITLE
Possible fix for "Cannot read property '_location' of null" CI errors

### DIFF
--- a/frontend/src/metabase/components/ErrorDetails.jsx
+++ b/frontend/src/metabase/components/ErrorDetails.jsx
@@ -28,7 +28,12 @@ export default class ErrorDetails extends React.Component {
             style={{ fontFamily: "monospace" }}
             className="QueryError2-detailBody bordered rounded bg-grey-0 text-bold p2 mt1"
           >
-            {details}
+            {/* ensure we don't try to render anything except a string */}
+            {typeof details === "string"
+              ? details
+              : typeof details.message === "string"
+                ? details.message
+                : String(details)}
           </div>
         </div>
       </div>


### PR DESCRIPTION
`Cannot read property '_location' of null` CI errors are always proceeded by the following error, which should be fixed by this PR. It may not fix the underlying transient failures but hopefully will at least result in better stack traces / test failure reports.

```
(node:12980) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 8): Invariant Violation: Objects are not valid as a React child (found: TypeError: Cannot read property 'createElement' of undefined). If you meant to render a collection of children, use an array instead or wrap the object using createFragment(object) from the React add-ons. Check the render method of `ErrorDetails`.
/home/ubuntu/metabase/node_modules/jsdom/lib/jsdom/browser/Window.js:148
      return idlUtils.wrapperForImpl(idlUtils.implForWrapper(window._document)._location);
                                                                              ^

TypeError: Cannot read property '_location' of null
    at Window.get location [as location] (/home/ubuntu/metabase/node_modules/jsdom/lib/jsdom/browser/Window.js:148:79)
    at Timeout.callback [as _onTimeout] (/home/ubuntu/metabase/node_modules/jsdom/lib/jsdom/browser/Window.js:525:41)
    at ontimeout (timers.js:475:11)
    at tryOnTimeout (timers.js:310:5)
    at Timer.listOnTimeout (timers.js:270:5)
```