### PR TITLE
EXAMPLE ONLY: switches Google APIs (BQ, GA) to use app default creds

### DIFF
--- a/modules/drivers/google/src/metabase/driver/google.clj
+++ b/modules/drivers/google/src/metabase/driver/google.clj
@@ -15,7 +15,9 @@
            com.google.api.client.googleapis.services.AbstractGoogleClientRequest
            com.google.api.client.http.HttpTransport
            com.google.api.client.json.jackson2.JacksonFactory
-           com.google.api.client.json.JsonFactory))
+           com.google.api.client.json.JsonFactory
+           com.google.api.services.bigquery.BigqueryScopes
+           java.util.Collections))
 
 (driver/register! :google, :abstract? true)
 
@@ -63,51 +65,10 @@
   (create-application-name config/mb-version-info))
 
 
-(defn- fetch-access-and-refresh-tokens* [scopes, ^String client-id, ^String client-secret, ^String auth-code]
-  {:pre  [(seq client-id) (seq client-secret) (seq auth-code)]
-   :post [(seq (:access-token %)) (seq (:refresh-token %))]}
-  (log/info (u/format-color 'magenta "Fetching Google access/refresh tokens with auth-code '%s'..." auth-code))
-  (let [^GoogleAuthorizationCodeFlow flow (.build (doto (GoogleAuthorizationCodeFlow$Builder. http-transport json-factory client-id client-secret scopes)
-                                                    (.setAccessType "offline")))
-        ^GoogleTokenResponse response     (.execute (doto (.newTokenRequest flow auth-code) ; don't use `execute` here because this is a *different* type of Google request
-                                                      (.setRedirectUri redirect-uri)))]
-    {:access-token (.getAccessToken response), :refresh-token (.getRefreshToken response)}))
-
-(def ^{:arglists '([scopes client-id client-secret auth-code])} fetch-access-and-refresh-tokens
-  "Fetch Google access and refresh tokens. This function is memoized because you're only allowed to redeem an
-  auth-code once. This way we can redeem it the first time when `can-connect?` checks to see if the DB details are
-  viable; then the second time we go to redeem it we can save the access token and refresh token with the newly
-  created `Database` <3"
-  (memoize fetch-access-and-refresh-tokens*))
-
-(defn- database->credential*
-  [scopes, {{:keys [^String client-id, ^String client-secret, ^String auth-code, ^String access-token, ^String refresh-token], :as details} :details, id :id, :as db}]
-  {:pre [(map? db) (seq client-id) (seq client-secret) (or (seq auth-code)
-                                                           (and (seq access-token) (seq refresh-token)))]}
-  (if-not (and (seq access-token)
-               (seq refresh-token))
-    ;; If Database doesn't have access/refresh tokens fetch them and try again
-    (let [details (-> (merge details (fetch-access-and-refresh-tokens scopes client-id client-secret auth-code))
-                      (dissoc :auth-code))]
-      (when id
-        (db/update! Database id, :details details))
-      (recur scopes (assoc db :details details)))
-    ;; Otherwise return credential as normal
-    (doto (.build (doto (GoogleCredential$Builder.)
-                    (.setClientSecrets client-id client-secret)
-                    (.setJsonFactory json-factory)
-                    (.setTransport http-transport)))
-      (.setAccessToken  access-token)
-      (.setRefreshToken refresh-token))))
-
 (defn database->credential
   "Get a `GoogleCredential` for a `DatabaseInstance`."
   ^com.google.api.client.googleapis.auth.oauth2.GoogleCredential [scopes database-or-id]
-  (database->credential*
-   scopes
-   (if (integer? database-or-id)
-     (db/select-one [Database :id :details], :id database-or-id)
-     database-or-id)))
+  (.createScoped (GoogleCredential/getApplicationDefault) (Collections/singleton BigqueryScopes/BIGQUERY)))
 
 (defn -init-driver
   "Nothing to init as this is code used by the google drivers, but is not a driver itself"


### PR DESCRIPTION
eg when running on GCE, or when the `GOOGLE_APPLICATION_CREDENTIALS` environment variable is set and points to a service account JSON creds file.

for #4634. thanks to @igorwwwwwwwwwwwwwwwwwwww for his hints toward this in #7564!

NOT TO BE MERGED. this doesn't properly add app default creds as an option, it crudely replaces the current OAuth creds with them, but doesn't touch the user-visible db settings UI. it's just a proof of concept.

you can verify that this is using the app default creds by adding a BigQuery db with random strings for client id, secret, and auth code, and then running a query on it. after that, run:

```sh
gcloud auth activate-service-account [SERVICE_ACCOUNT_ID] --key-file [SERVICE_ACCOUNT.json]
bq ls -j
bq show -j [JOB_ID]
```

it should show that the user who ran the job is the service account.