### PR TITLE
We should not be storing/update passwords for LDAP users

### DIFF
--- a/src/metabase/integrations/ldap.clj
+++ b/src/metabase/integrations/ldap.clj
@@ -211,11 +211,8 @@
   (let [user (or (db/select-one [User :id :last_login] :email email)
                  (user/create-new-ldap-auth-user! {:first_name first-name
                                                    :last_name  last-name
-                                                   :email      email
-                                                   :password   password}))]
+                                                   :email      email}))]
     (u/prog1 user
-      (when password
-        (user/set-password! (:id user) password))
       (when (ldap-group-sync)
         (let [special-ids #{(:id (group/admin)) (:id (group/all-users))}
               current-ids (set (map :group_id (db/select ['PermissionsGroupMembership :group_id] :user_id (:id user))))

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -191,7 +191,10 @@
   "Convenience for creating a new user via LDAP. This account is considered active immediately; thus all active admins
   will recieve an email right away."
   [new-user :- NewUser]
-  (insert-new-user! (assoc new-user :ldap_auth true)))
+  (insert-new-user! (-> new-user
+                        ;; We should not store LDAP passwords
+                        (dissoc :password)
+                        (assoc :ldap_auth true))))
 
 (defn set-password!
   "Updates the stored password for a specified `User` by hashing the password with a random salt."


### PR DESCRIPTION
Previously when an LDAP-based account was first created, the password
was encrypted and stored. Also the password was updated after each
successful LDAP login. This commit no longer does that and just stores
a randomly generated password (similar to what we do for Google auth).

Fixes #7635