### PR TITLE
Change the Pulse API to accept a CardRef or HybridPulseCard

### DIFF
--- a/src/metabase/api/pulse.clj
+++ b/src/metabase/api/pulse.clj
@@ -46,7 +46,7 @@
   "Create a new `Pulse`."
   [:as {{:keys [name cards channels skip_if_empty collection_id collection_position]} :body}]
   {name                su/NonBlankString
-   cards               (su/non-empty [pulse/CardRef])
+   cards               (su/non-empty [pulse/CoercibleToCardRef])
    channels            (su/non-empty [su/Map])
    skip_if_empty       (s/maybe s/Bool)
    collection_id       (s/maybe su/IntGreaterThanZero)
@@ -79,7 +79,7 @@
   "Update a Pulse with `id`."
   [id :as {{:keys [name cards channels skip_if_empty collection_id], :as pulse-updates} :body}]
   {name          (s/maybe su/NonBlankString)
-   cards         (s/maybe (su/non-empty [pulse/CardRef]))
+   cards         (s/maybe (su/non-empty [pulse/CoercibleToCardRef]))
    channels      (s/maybe (su/non-empty [su/Map]))
    skip_if_empty (s/maybe s/Bool)
    collection_id (s/maybe su/IntGreaterThanZero)}


### PR DESCRIPTION
The pulse GET responses include a PulseCard that isn't exactly a
PulseCard. It includes some extra information from the underlying card
useful for the FE to include in the display. When adding a card to an
existing pulse that has one or more cards already, the PUT include a
mixture of these HybridPulseCards (the existing cards for the pulse)
and CardRefs (for newly added cards). This commit changes the schema
to allow either and updates the tests accordingly.

This also adds similar flexibility to the POST so that it is
consistent with the PUT.

Fixes #7789