### PR TITLE
Simple admin string spacing fix

### DIFF
--- a/src/metabase/models/humanization.clj
+++ b/src/metabase/models/humanization.clj
@@ -114,7 +114,7 @@
 
 (defsetting ^{:added "0.28.0"} humanization-strategy
   (str (tru "Metabase can attempt to transform your table and field names into more sensible, human-readable versions, e.g. \"somehorriblename\" becomes \"Some Horrible Name\".")
-       (tru "This doesn’t work all that well if the names are in a language other than English, however.")
-       (tru "Do you want us to take a guess?"))
+       (tru " This doesn’t work all that well if the names are in a language other than English, however.")
+       (tru " Do you want us to take a guess?"))
   :default "advanced"
   :setter  set-humanization-strategy!)

--- a/src/metabase/models/humanization.clj
+++ b/src/metabase/models/humanization.clj
@@ -114,7 +114,9 @@
 
 (defsetting ^{:added "0.28.0"} humanization-strategy
   (str (tru "Metabase can attempt to transform your table and field names into more sensible, human-readable versions, e.g. \"somehorriblename\" becomes \"Some Horrible Name\".")
-       (tru " This doesn’t work all that well if the names are in a language other than English, however.")
-       (tru " Do you want us to take a guess?"))
+       " "
+       (tru "This doesn’t work all that well if the names are in a language other than English, however.")
+       " "
+       (tru "Do you want us to take a guess?"))
   :default "advanced"
   :setter  set-humanization-strategy!)


### PR DESCRIPTION
Adds spaces after periods in the table name humanization text, so

Metabase can attempt to transform your table and field names into more sensible, human-readable versions, e.g. "somehorriblename" becomes "Some Horrible Name".This doesn’t work all that well if the names are in a language other than English, however.Do you want us to take a guess?

becomes

Metabase can attempt to transform your table and field names into more sensible, human-readable versions, e.g. "somehorriblename" becomes "Some Horrible Name". This doesn’t work all that well if the names are in a language other than English, however. Do you want us to take a guess?

I feel like a bad contributor but due to my current setup and environment I'm unable to test this myself, but dare I say testing it won't be hard?

###### Before submitting the PR, please make sure you do the following 
-  [ ] If there are changes to the backend codebase, run the backend tests with `lein test && lein eastwood && lein bikeshed && lein docstring-checker && ./bin/reflection-linter`
-  [ ] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [ ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
