### PR TITLE
Add fuzzy search for categories filters with a list

### DIFF
--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -250,6 +250,32 @@ export class FieldValuesWidget extends Component {
       }
     }
 
+    let filterOption = (option, filterString) =>
+      (option[0] != null &&
+        String(option[0])
+          .toLowerCase()
+          .indexOf(filterString.toLowerCase()) === 0) ||
+      (option[1] != null &&
+        String(option[1])
+          .toLowerCase()
+          .indexOf(filterString.toLowerCase()) === 0);
+
+    if (field.isString() && this.hasList()) {
+      // fuzzy search
+      filterOption = (option, filterString) => {
+        return (
+          (option[0] != null &&
+            String(option[0])
+              .toLowerCase()
+              .indexOf(filterString.toLowerCase()) >= 0) ||
+          (option[1] != null &&
+            String(option[1])
+              .toLowerCase()
+              .indexOf(filterString.toLowerCase()) >= 0)
+        );
+      };
+    }
+
     let options = [];
     if (this.hasList()) {
       options = field.values;
@@ -307,16 +333,7 @@ export class FieldValuesWidget extends Component {
               {this.renderOptions(props)}
             </div>
           )}
-          filterOption={(option, filterString) =>
-            (option[0] != null &&
-              String(option[0])
-                .toLowerCase()
-                .indexOf(filterString.toLowerCase()) === 0) ||
-            (option[1] != null &&
-              String(option[1])
-                .toLowerCase()
-                .indexOf(filterString.toLowerCase()) === 0)
-          }
+          filterOption={filterOption}
           onInputChange={this.onInputChange}
           parseFreeformValue={v => {
             // trim whitespace

--- a/frontend/test/components/FieldValuesWidget.unit.spec.js
+++ b/frontend/test/components/FieldValuesWidget.unit.spec.js
@@ -59,6 +59,28 @@ describe("FieldValuesWidget", () => {
         expect(component.find(TokenField).props().placeholder).toEqual(
           "Search the list",
         );
+
+        it("should have a fuzzy search", () => {
+          const component = mountFieldValuesWidget({ ...props });
+          expect(
+            component
+              .find(TokenField)
+              .props()
+              .filterOption(["test"], "test"),
+          ).toBe(true);
+          expect(
+            component
+              .find(TokenField)
+              .props()
+              .filterOption(["test"], "st"),
+          ).toBe(true);
+          expect(
+            component
+              .find(TokenField)
+              .props()
+              .filterOption(["test"], "sfsf"),
+          ).toBe(false);
+        });
       });
     });
     describe("has_field_values = search", () => {
@@ -105,6 +127,33 @@ describe("FieldValuesWidget", () => {
         expect(component.find(TokenField).props().placeholder).toEqual(
           "Search the list",
         );
+      });
+      it("shouldn't have a fuzzy search", () => {
+        const component = mountFieldValuesWidget({
+          field: mock(metadata.field(ORDERS_PRODUCT_FK_FIELD_ID), {
+            has_field_values: "list",
+            values: [[1234]],
+          }),
+        });
+
+        expect(
+          component
+            .find(TokenField)
+            .props()
+            .filterOption(["test"], "test"),
+        ).toBe(true);
+        expect(
+          component
+            .find(TokenField)
+            .props()
+            .filterOption(["test"], "st"),
+        ).toBe(false);
+        expect(
+          component
+            .find(TokenField)
+            .props()
+            .filterOption(["test"], "sfsf"),
+        ).toBe(false);
       });
     });
     describe("has_field_values = search", () => {


### PR DESCRIPTION
Hi, 

For a list of values in a categories filter, when you have 20+ categories available in the list, it's handy to have a fuzzy search instead of an order dependent search.

The idea is to help the user to find faster what they are looking for even if they are typing a part of the categorie's name.
