### PR TITLE
 Allow positive numeric values for text fingerprint average lengths 

### DIFF
--- a/src/metabase/sync/analyze/fingerprint/text.clj
+++ b/src/metabase/sync/analyze/fingerprint/text.clj
@@ -3,9 +3,10 @@
   (:require [cheshire.core :as json]
             [metabase.sync.interface :as i]
             [metabase.util :as u]
+            [metabase.util.schema :as su]
             [schema.core :as s]))
 
-(s/defn ^:private average-length :- (s/constrained Double #(>= % 0))
+(s/defn ^:private average-length :- su/PositiveNum
   "Return the average length of VALUES."
   [values :- i/FieldSample]
   (let [total-length (reduce + (for [value values]

--- a/src/metabase/sync/interface.clj
+++ b/src/metabase/sync/interface.clj
@@ -104,7 +104,7 @@
   {(s/optional-key :percent-json)   Percent
    (s/optional-key :percent-url)    Percent
    (s/optional-key :percent-email)  Percent
-   (s/optional-key :average-length) (s/constrained Double #(>= % 0) "Valid number greater than or equal to zero")})
+   (s/optional-key :average-length) su/PositiveNum})
 
 (def DateTimeFingerprint
   "Schema for fingerprint information for Fields deriving from `:type/DateTime`."

--- a/src/metabase/util/schema.clj
+++ b/src/metabase/util/schema.clj
@@ -118,6 +118,12 @@
       (s/constrained s/Int (partial < 0) (tru "Integer greater than zero"))
     (tru "value must be an integer greater than zero.")))
 
+(def PositiveNum
+  "Schema representing a numeric value greater than zero. This allows floating point numbers and integers."
+  (with-api-error-message
+      (s/constrained s/Num (partial < 0) (tru "Number greater than zero"))
+    (tru "value must be a number greater than zero.")))
+
 (def KeywordOrString
   "Schema for something that can be either a `Keyword` or a `String`."
   (s/named (s/cond-pre s/Keyword s/Str) (tru "Keyword or string")))


### PR DESCRIPTION
Previously this only allowed double values. If the average length
happened to be something like `13.0` some Javascript implementations
trim the `.0` and when the frontend POSTs the data, it includes `13`
instead. This was causing our schema validation to break as it was
looking for a `Double`.

This commit changes the schema to look for a positive numeric value,
not just a positive double which covers both cases.