### PR TITLE
Add a shadow to toggle switches

### DIFF
--- a/frontend/src/metabase/components/Toggle.css
+++ b/frontend/src/metabase/components/Toggle.css
@@ -25,6 +25,7 @@
   left: 1px;
   background-color: white;
   transition: all 0.3s;
+  box-shadow: 2px 2px 6px var(--color-shadow);
 }
 
 :local(.toggle.selected):after {


### PR DESCRIPTION
Tiny little change to make toggles have better contrast.

**Before**

![screen shot 2018-07-09 at 2 12 03 pm](https://user-images.githubusercontent.com/2223916/42476307-621cf276-8382-11e8-971e-815b35abe949.png)

**After**

![screen shot 2018-07-09 at 2 12 00 pm](https://user-images.githubusercontent.com/2223916/42476311-65981b06-8382-11e8-8af9-d5520c037680.png)

