### PR TITLE
Hide collection color field on collection forms.

### DIFF
--- a/frontend/src/metabase/components/form/FormField.jsx
+++ b/frontend/src/metabase/components/form/FormField.jsx
@@ -12,6 +12,7 @@ export default class FormField extends Component {
     visited: PropTypes.bool,
     active: PropTypes.bool,
 
+    hidden: PropTypes.bool,
     displayName: PropTypes.string,
     children: PropTypes.element,
 
@@ -21,7 +22,7 @@ export default class FormField extends Component {
   };
 
   render() {
-    const { displayName, offset, formError, children } = this.props;
+    const { displayName, offset, formError, children, hidden } = this.props;
     const name = this.props.name || this.props.fieldName;
 
     let error = this.props.error || getIn(formError, ["data", "errors", name]);
@@ -34,6 +35,7 @@ export default class FormField extends Component {
       <div
         className={cx("Form-field", {
           "Form--fieldError": !!error,
+          hide: hidden,
         })}
       >
         {displayName && (

--- a/frontend/src/metabase/components/form/FormWidget.jsx
+++ b/frontend/src/metabase/components/form/FormWidget.jsx
@@ -5,6 +5,7 @@ import FormTextAreaWidget from "./widgets/FormTextAreaWidget";
 import FormPasswordWidget from "./widgets/FormPasswordWidget";
 import FormColorWidget from "./widgets/FormColorWidget";
 import FormSelectWidget from "./widgets/FormSelectWidget";
+import FormHiddenWidget from "./widgets/FormHiddenWidget";
 
 const WIDGETS = {
   input: FormInputWidget,
@@ -12,6 +13,7 @@ const WIDGETS = {
   color: FormColorWidget,
   password: FormPasswordWidget,
   select: FormSelectWidget,
+  hidden: FormHiddenWidget,
 };
 
 const FormWidget = ({ type, ...props }) => {

--- a/frontend/src/metabase/components/form/StandardForm.jsx
+++ b/frontend/src/metabase/components/form/StandardForm.jsx
@@ -21,7 +21,7 @@ const StandardForm = ({
 
   form,
   className,
-  resetButton = true,
+  resetButton = false,
   newForm = true,
 
   ...props

--- a/frontend/src/metabase/components/form/StandardForm.jsx
+++ b/frontend/src/metabase/components/form/StandardForm.jsx
@@ -39,6 +39,7 @@ const StandardForm = ({
             }
             offset={!newForm}
             {...field}
+            hidden={formField.type === "hidden"}
           >
             <FormWidget field={field} offset={!newForm} {...formField} />
             {!newForm && <span className="Form-charm" />}

--- a/frontend/src/metabase/components/form/widgets/FormHiddenWidget.jsx
+++ b/frontend/src/metabase/components/form/widgets/FormHiddenWidget.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+import { formDomOnlyProps } from "metabase/lib/redux";
+
+const FormHiddenWidget = ({ type = "hidden", field }) => (
+  <input type={type} {...formDomOnlyProps(field)} />
+);
+
+export default FormHiddenWidget;

--- a/frontend/src/metabase/containers/Form.jsx
+++ b/frontend/src/metabase/containers/Form.jsx
@@ -76,7 +76,10 @@ export default class Form_ extends React.Component {
   _updateFormComponent(props: Props) {
     if (this.props.form) {
       const form = makeForm(this.props.form);
-      const initialValues = this.props.initialValues || form.initial();
+      const initialValues = {
+        ...form.initial(),
+        ...(this.props.initialValues || {}),
+      };
       // redux-form config:
       const formConfig = {
         form: this._formName,

--- a/frontend/src/metabase/entities/collections.js
+++ b/frontend/src/metabase/entities/collections.js
@@ -47,9 +47,11 @@ const Collections = createEntity({
   },
 
   form: {
-    fields: (values = {
-      color: colors.brand
-    }) => [
+    fields: (
+      values = {
+        color: colors.brand,
+      },
+    ) => [
       {
         name: "name",
         placeholder: "My new fantastic collection",
@@ -64,7 +66,8 @@ const Collections = createEntity({
         normalize: description => description || null, // expected to be nil or non-empty string
       },
       {
-        name: 'color',
+        name: "color",
+        type: "hidden",
         initial: () => colors.brand,
         validate: color => !color && t`Color is required`,
       },

--- a/frontend/src/metabase/entities/collections.js
+++ b/frontend/src/metabase/entities/collections.js
@@ -1,7 +1,7 @@
 /* @flow weak */
 
 import { createEntity, undo } from "metabase/lib/entities";
-import { normal, getRandomColor } from "metabase/lib/colors";
+import colors from "metabase/lib/colors";
 import { CollectionSchema } from "metabase/schema";
 import { createSelector } from "reselect";
 
@@ -47,7 +47,9 @@ const Collections = createEntity({
   },
 
   form: {
-    fields: (values = {}) => [
+    fields: (values = {
+      color: colors.brand
+    }) => [
       {
         name: "name",
         placeholder: "My new fantastic collection",
@@ -62,9 +64,8 @@ const Collections = createEntity({
         normalize: description => description || null, // expected to be nil or non-empty string
       },
       {
-        name: "color",
-        type: "color",
-        initial: () => getRandomColor(normal),
+        name: 'color',
+        initial: () => colors.brand,
         validate: color => !color && t`Color is required`,
       },
       {


### PR DESCRIPTION
Turns the color field into a hidden field for now so users creating collections don't need to make color choices until we decide what we'd like to do with collection colors more broadly.

@tlrobinson I could use some help figuring out why it's not setting an initialValue despite color having an `initial` function in the entity definition.