### PR TITLE
Add support for binning of nested queries

### DIFF
--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -430,12 +430,10 @@
 
 (defn- build-query
   ([context bindings filters metrics dimensions limit order_by]
-   (walk/postwalk
-    (fn [subform]
-      (if (rules/dimension-form? subform)
-        (let [[_ identifier opts] subform]
-          (->reference :mbql (-> identifier bindings (merge opts))))
-        subform))
+   (qp.util/postwalk-pred
+    rules/dimension-form?
+    (fn [[_ identifier opts]]
+      (->reference :mbql (-> identifier bindings (merge opts))))
     {:type     :query
      :database (-> context :root :database)
      :query    (cond-> {:source_table (if (->> context :source (instance? (type Table)))

--- a/src/metabase/query_processor/interface.clj
+++ b/src/metabase/query_processor/interface.clj
@@ -177,11 +177,18 @@
   [unit]
   (contains? relative-datetime-value-units (keyword unit)))
 
+(def binning-strategies
+  "Valid binning strategies for a `BinnedField`"
+  #{:num-bins :bin-width :default})
+
 ;; TODO - maybe we should figure out some way to have the schema validate that the driver supports field literals,
 ;; like we do for some of the other clauses. Ideally we'd do that in a more generic way (perhaps in expand, we could
 ;; make the clauses specify required feature metadata and have that get checked automatically?)
-(s/defrecord FieldLiteral [field-name    :- su/NonBlankString
-                           base-type     :- su/FieldType]
+(s/defrecord FieldLiteral [field-name       :- su/NonBlankString
+                           base-type        :- su/FieldType
+                           binning-strategy :- (s/maybe (apply s/enum binning-strategies))
+                           binning-param    :- (s/maybe s/Num)
+                           fingerprint      :- (s/maybe i/Fingerprint)]
   nil
   :load-ns true
   clojure.lang.Named
@@ -210,11 +217,7 @@
   nil
   :load-ns true)
 
-(def binning-strategies
-  "Valid binning strategies for a `BinnedField`"
-  #{:num-bins :bin-width :default})
-
-(s/defrecord BinnedField [field     :- Field
+(s/defrecord BinnedField [field     :- (s/cond-pre Field FieldLiteral)
                           strategy  :- (apply s/enum binning-strategies)
                           num-bins  :- s/Int
                           min-value :- s/Num

--- a/src/metabase/query_processor/middleware/binning.clj
+++ b/src/metabase/query_processor/middleware/binning.clj
@@ -3,7 +3,8 @@
             [clojure.walk :as walk]
             [metabase
              [public-settings :as public-settings]
-             [util :as u]])
+             [util :as u]]
+            [metabase.query-processor.util :as qputil])
   (:import [metabase.query_processor.interface BetweenFilter BinnedField ComparisonFilter]))
 
 (defn- update!
@@ -162,8 +163,6 @@
   (fn [query]
     (let [filter-field-map (filter->field-map (get-in query [:query :filter]))]
       (qp
-       (walk/postwalk (fn [node]
-                        (if (instance? BinnedField node)
-                          (update-binned-field node filter-field-map)
-                          node))
-                      query)))))
+       (qputil/postwalk-pred #(instance? BinnedField %)
+                             #(update-binned-field % filter-field-map)
+                             query)))))

--- a/src/metabase/query_processor/middleware/expand.clj
+++ b/src/metabase/query_processor/middleware/expand.clj
@@ -225,7 +225,7 @@
 
 ;;; ## breakout & fields
 
-(s/defn ^:ql binning-strategy :- FieldPlaceholder
+(s/defn ^:ql binning-strategy :- (s/cond-pre FieldPlaceholder FieldLiteral)
   "Reference to a `BinnedField`. This is just a `Field` reference with an associated `STRATEGY-NAME` and
   `STRATEGY-PARAM`"
   ([f strategy-name & [strategy-param]]

--- a/src/metabase/query_processor/middleware/expand_macros.clj
+++ b/src/metabase/query_processor/middleware/expand_macros.clj
@@ -8,7 +8,6 @@
    TODO - this namespace is ancient and written with MBQL '95 in mind, e.g. it is case-sensitive.
    At some point this ought to be reworked to be case-insensitive and cleaned up."
   (:require [clojure.tools.logging :as log]
-            [clojure.walk :as walk]
             [metabase.models
              [metric :refer [Metric]]
              [segment :refer [Segment]]]
@@ -105,12 +104,9 @@
     (maybe-unnest-ag-clause ag-clause)))
 
 (defn- expand-metrics-in-ag-clause [query-dict filter-clauses-atom]
-  (walk/postwalk
-   (fn [form]
-     (if-not (metric? form)
-       form
-       (expand-metric form filter-clauses-atom)))
-   query-dict))
+  (qputil/postwalk-pred metric?
+                        #(expand-metric % filter-clauses-atom)
+                        query-dict))
 
 (defn merge-filter-clauses
   "Merge filter clauses."

--- a/src/metabase/query_processor/middleware/fetch_source_query.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query.clj
@@ -24,7 +24,7 @@
 (defn- card-id->source-query
   "Return the source query info for Card with CARD-ID."
   [card-id]
-  (let [card       (db/select-one ['Card :dataset_query :database_id] :id card-id)
+  (let [card       (db/select-one ['Card :dataset_query :database_id :result_metadata] :id card-id)
         card-query (:dataset_query card)]
     (assoc (or (:query card-query)
                (when-let [native (:native card-query)]
@@ -33,7 +33,8 @@
                (throw (Exception. (str "Missing source query in Card " card-id))))
       ;; include database ID as well; we'll pass that up the chain so it eventually gets put in its spot in the
       ;; outer-query
-      :database (:database card-query))))
+      :database        (:database card-query)
+      :result_metadata (:result_metadata card))))
 
 (defn- source-table-str->source-query
   "Given a SOURCE-TABLE-STR like `card__100` return the appropriate source query."
@@ -41,7 +42,10 @@
   (let [[_ card-id-str] (re-find #"^card__(\d+)$" source-table-str)]
     (u/prog1 (card-id->source-query (Integer/parseInt card-id-str))
       (when-not i/*disable-qp-logging*
-        (log/info "\nFETCHED SOURCE QUERY FROM CARD" card-id-str ":\n" (u/pprint-to-str 'yellow <>))))))
+        (log/infof "\nFETCHED SOURCE QUERY FROM CARD %s:\n%s"
+                   card-id-str
+                   ;; No need to include result metadata here, it can be large and will clutter the logs
+                   (u/pprint-to-str 'yellow (dissoc <> :result_metadata)))))))
 
 (defn- expand-card-source-tables
   "If `source-table` is a Card reference (a string like `card__100`) then replace that with appropriate
@@ -58,8 +62,9 @@
             ;; Add new `source-query` info in its place. Pass the database ID up the chain, removing it from the
             ;; source query
             (assoc
-              :source-query (dissoc source-query :database)
-              :database     (:database source-query)))))))
+              :source-query    (dissoc source-query :database :result_metadata)
+              :database        (:database source-query)
+              :result_metadata (:result_metadata source-query)))))))
 
 (defn- fetch-source-query* [{inner-query :query, :as outer-query}]
   (if-not inner-query
@@ -68,9 +73,11 @@
     ;; otherwise attempt to expand any source queries as needed
     (let [expanded-inner-query (expand-card-source-tables inner-query)]
       (merge outer-query
-             {:query (dissoc expanded-inner-query :database)}
+             {:query (dissoc expanded-inner-query :database :result_metadata)}
              (when-let [database (:database expanded-inner-query)]
-               {:database database})))))
+               {:database database})
+             (when-let [result-metadata (:result_metadata expanded-inner-query)]
+               {:result_metadata result-metadata})))))
 
 (defn fetch-source-query
   "Middleware that assocs the `:source-query` for this query if it was specified using the shorthand `:source-table`

--- a/src/metabase/query_processor/middleware/results_metadata.clj
+++ b/src/metabase/query_processor/middleware/results_metadata.clj
@@ -5,50 +5,12 @@
   (:require [buddy.core.hash :as hash]
             [cheshire.core :as json]
             [clojure.tools.logging :as log]
-            [metabase.models.humanization :as humanization]
             [metabase.query-processor.interface :as i]
+            [metabase.sync.analyze.query-results :as qr]
             [metabase.util :as u]
-            [metabase.util
-             [encryption :as encryption]
-             [schema :as su]]
+            [metabase.util.encryption :as encryption]
             [ring.util.codec :as codec]
-            [schema.core :as s]
             [toucan.db :as db]))
-
-(def ^:private DateTimeUnitKeywordOrString
-  "Schema for a valid datetime unit string like \"default\" or \"minute-of-hour\"."
-  (s/constrained su/KeywordOrString
-                 (fn [unit]
-                   (contains? i/datetime-field-units (keyword unit)))
-                 "Valid field datetime unit keyword or string"))
-
-(def ResultsMetadata
-  "Schema for valid values of the `result_metadata` column."
-  (su/with-api-error-message (s/named [{:name                          su/NonBlankString
-                                        :display_name                  su/NonBlankString
-                                        (s/optional-key :description)  (s/maybe su/NonBlankString)
-                                        :base_type                     su/FieldTypeKeywordOrString
-                                        (s/optional-key :special_type) (s/maybe su/FieldTypeKeywordOrString)
-                                        (s/optional-key :unit)         (s/maybe DateTimeUnitKeywordOrString)}]
-                                      "Valid array of results column metadata maps")
-    "value must be an array of valid results column metadata maps."))
-
-(s/defn ^:private results->column-metadata :- (s/maybe ResultsMetadata)
-  "Return the desired storage format for the column metadata coming back from RESULTS, or `nil` if no columns were returned."
-  [results]
-  ;; rarely certain queries will return columns with no names, for example `SELECT COUNT(*)` in SQL Server seems to come back with no name
-  ;; since we can't use those as field literals in subsequent queries just filter them out
-  (seq (for [col   (:cols results)
-             :when (seq (:name col))]
-         (merge
-          ;; if base-type isn't set put a default one in there. Similarly just use humanized value of `:name` for `:display_name` if one isn't set
-          {:base_type    :type/*
-           :display_name (humanization/name->human-readable-name (name (:name col)))}
-          (u/select-non-nil-keys col [:name :display_name :description :base_type :special_type :unit])
-          ;; since years are actually returned as text they can't be used for breakout purposes so don't advertise them as DateTime columns
-          (when (= (:unit col) :year)
-            {:base_type :type/Text
-             :unit      nil})))))
 
 ;; TODO - is there some way we could avoid doing this every single time a Card is ran? Perhaps by passing the current Card
 ;; metadata as part of the query context so we can compare for changes
@@ -88,7 +50,7 @@
   (fn [{{:keys [card-id nested?]} :info, :as query}]
     (let [results (qp query)]
       (try
-        (let [metadata (results->column-metadata results)]
+        (let [metadata (seq (qr/results->column-metadata results))]
           ;; At the very least we can skip the Extra DB call to update this Card's metadata results
           ;; if its DB doesn't support nested queries in the first place
           (when (i/driver-supports? :nested-queries)

--- a/src/metabase/sync/analyze/classify.clj
+++ b/src/metabase/sync/analyze/classify.clj
@@ -69,7 +69,7 @@
   "Various classifier functions available. These should all take two args, a `FieldInstance` and a possibly `nil`
   `Fingerprint`, and return `FieldInstance` with any inferred property changes, or `nil` if none could be inferred.
   Order is important!"
-  [name/infer-special-type
+  [name/infer-and-assoc-special-type
    category/infer-is-category-or-list
    no-preview-display/infer-no-preview-display
    text-fingerprint/infer-special-type])

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -21,18 +21,22 @@
             [schema.core :as s]
             [toucan.db :as db]))
 
+(def ^:private FieldOrColumn
+  {:base_type s/Keyword
+   s/Any      s/Any})
+
 (s/defn ^:private type-specific-fingerprint :- (s/maybe i/TypeSpecificFingerprint)
   "Return type-specific fingerprint info for FIELD AND. a FieldSample of Values if it has an elligible base type"
-  [field :- i/FieldInstance, values :- i/FieldSample]
+  [field :- FieldOrColumn, values :- i/FieldSample]
   (condp #(isa? %2 %1) (:base_type field)
     :type/Text     {:type/Text (text/text-fingerprint values)}
     :type/Number   {:type/Number (number/number-fingerprint values)}
     :type/DateTime {:type/DateTime (datetime/datetime-fingerprint values)}
     nil))
 
-(s/defn ^:private fingerprint :- i/Fingerprint
+(s/defn fingerprint :- i/Fingerprint
   "Generate a 'fingerprint' from a FieldSample of VALUES."
-  [field :- i/FieldInstance, values :- i/FieldSample]
+  [field :- FieldOrColumn, values :- i/FieldSample]
   (merge
    (when-let [global-fingerprint (global/global-fingerprint values)]
      {:global global-fingerprint})

--- a/src/metabase/sync/analyze/query_results.clj
+++ b/src/metabase/sync/analyze/query_results.clj
@@ -1,0 +1,91 @@
+(ns metabase.sync.analyze.query-results
+  "Analysis similar to what we do as part of the Sync process, but aimed at analyzing and introspecting query
+  results. The current focus of this namespace is around column metadata from the results of a query. Going forward
+  this is likely to extend beyond just metadata about columns but also about the query results as a whole and over
+  time."
+  (:require [metabase.models.humanization :as humanization]
+            [metabase.query-processor.interface :as i]
+            [metabase.sync.analyze.classifiers.name :as classify-name]
+            [metabase.sync.analyze.fingerprint :as f]
+            [metabase.sync.interface :as si]
+            [metabase.util :as u]
+            [metabase.util.schema :as su]
+            [schema.core :as s]))
+
+(def ^:private DateTimeUnitKeywordOrString
+  "Schema for a valid datetime unit string like \"default\" or \"minute-of-hour\"."
+  (s/constrained su/KeywordOrString
+                 (fn [unit]
+                   (contains? i/datetime-field-units (keyword unit)))
+                 "Valid field datetime unit keyword or string"))
+
+(def ^:private ResultColumnMetadata
+  "Result metadata for a single column"
+  {:name                          su/NonBlankString
+   :display_name                  su/NonBlankString
+   (s/optional-key :description)  (s/maybe su/NonBlankString)
+   :base_type                     su/FieldTypeKeywordOrString
+   (s/optional-key :special_type) (s/maybe su/FieldTypeKeywordOrString)
+   (s/optional-key :unit)         (s/maybe DateTimeUnitKeywordOrString)
+   (s/optional-key :fingerprint)  (s/maybe si/Fingerprint)})
+
+(def ResultsMetadata
+  "Schema for valid values of the `result_metadata` column."
+  (su/with-api-error-message (s/named [ResultColumnMetadata]
+                                      "Valid array of results column metadata maps")
+    "value must be an array of valid results column metadata maps."))
+
+(s/defn ^:private maybe-infer-special-type :- ResultColumnMetadata
+  "Infer the special type and add it to the result metadata. If the inferred special type is nil, don't override the
+  special type with a nil special type"
+  [result-metadata col]
+  (update result-metadata :special_type (fn [original-value]
+                                          ;; If the original special type is a PK or FK, we don't want to use a new
+                                          ;; computed special type because it'll just be confusing as we can't do any
+                                          ;; meaningful binning etc on it. If it's not of that type and we are able to
+                                          ;; compute a special type based on the results, use that
+                                          (if-let [new-special-type (and (not (isa? original-value :type/PK))
+                                                                         (not (isa? original-value :type/FK))
+                                                                         (classify-name/infer-special-type col))]
+                                            new-special-type
+                                            original-value))))
+
+(s/defn ^:private maybe-compute-fingerprint :- ResultColumnMetadata
+  "If we already have a fingerprint from our stored metadata, use that. Queries that we don't have fingerprint data
+  on, such as native queries, we'll need to run the fingerprint code similar to what sync does."
+  [result-metadata col results-for-column]
+  (if-let [values (and (not (contains? result-metadata :fingerprint))
+                       (seq (remove nil? results-for-column)))]
+    (assoc result-metadata :fingerprint (f/fingerprint col values))
+    result-metadata))
+
+(s/defn ^:private stored-column-metadata->result-column-metadata :- ResultColumnMetadata
+  "The metadata in the column of our resultsets come from the metadata we store in the `Field` associated with the
+  column. It is cheapest and easiest to just use that. This function takes what it can from the column metadata to
+  populate the ResultColumnMetadata"
+  [column]
+  (merge
+   ;; if base-type isn't set put a default one in there. Similarly just use humanized value of `:name` for `:display_name` if one isn't set
+   {:base_type    :type/*
+    :display_name (humanization/name->human-readable-name (name (:name column)))}
+   (u/select-non-nil-keys column [:name :display_name :description :base_type :special_type :unit :fingerprint])
+   ;; since years are actually returned as text they can't be used for breakout purposes so don't advertise them as DateTime columns
+   (when (= (:unit column) :year)
+     {:base_type :type/Text
+      :unit      nil})))
+
+(s/defn results->column-metadata :- ResultsMetadata
+  "Return the desired storage format for the column metadata coming back from RESULTS, or `nil` if no columns were returned."
+  [results]
+  ;; rarely certain queries will return columns with no names, for example `SELECT COUNT(*)` in SQL Server seems to come back with no name
+  ;; since we can't use those as field literals in subsequent queries just filter them out
+  (for [[index col] (map-indexed vector (:cols results))
+        :when       (seq (:name col))
+        ;; TODO: This is really inefficient. This will make one pass over the data for each column returned, which
+        ;; could be bad. The fingerprinting code expects to have a list of values to fingerprint, rather than more of
+        ;; an accumulator style that will take one value at a time as we make a single pass over the data. Once we can
+        ;; get the fingerprint code changed to support this, we should apply that change here
+        :let        [results-for-column (map #(nth % index) (:rows results))]]
+    (-> (stored-column-metadata->result-column-metadata col)
+        (maybe-infer-special-type col)
+        (maybe-compute-fingerprint col results-for-column))))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -320,11 +320,13 @@
   [{:base_type    "type/Integer"
     :display_name "count"
     :name         "count"
-    :special_type "type/Number"}]
-  (let [metadata [{:base_type    :type/Integer
-                   :display_name "Count Chocula"
-                   :name         "count_chocula"
-                   :special_type :type/Number}]
+    :special_type "type/Quantity"
+    :fingerprint  {:global {:distinct-count 1},
+                   :type   {:type/Number {:min 100, :max 100, :avg 100.0}}}}]
+  (let [metadata  [{:base_type    :type/Integer
+                    :display_name "Count Chocula"
+                    :name         "count_chocula"
+                    :special_type :type/Quantity}]
         card-name (tu/random-name)]
     (tt/with-temp Collection [collection]
       (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
@@ -521,11 +523,13 @@
   [{:base_type    "type/Integer"
     :display_name "count"
     :name         "count"
-    :special_type "type/Number"}]
+    :special_type "type/Quantity"
+    :fingerprint  {:global {:distinct-count 1},
+                   :type   {:type/Number {:min 100, :max 100, :avg 100.0}}}}]
   (let [metadata [{:base_type    :type/Integer
                    :display_name "Count Chocula"
                    :name         "count_chocula"
-                   :special_type :type/Number}]]
+                   :special_type :type/Quantity}]]
     (tt/with-temp Card [card]
       (with-cards-in-writeable-collection card
         ;; update the Card's query

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -478,12 +478,11 @@
                                :base_type    "type/Text"
                                :special_type "type/Name"
                                :fingerprint  (:name mutil/venue-fingerprints)}
-                              (with-numeric-dimension-options
-                                {:name         "ID"
-                                 :display_name "ID"
-                                 :base_type    "type/Integer"
-                                 :special_type nil
-                                 :fingerprint  (:id mutil/venue-fingerprints)})
+                              {:name         "ID"
+                               :display_name "ID"
+                               :base_type    "type/Integer"
+                               :special_type nil
+                               :fingerprint  (:id mutil/venue-fingerprints)}
                               (with-numeric-dimension-options
                                 {:name         "PRICE"
                                  :display_name "Price"

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -18,6 +18,7 @@
              [permissions :as perms]
              [permissions-group :as perms-group]
              [table :as table :refer [Table]]]
+            [metabase.query-processor.util :as qputil]
             [metabase.test
              [data :as data]
              [util :as tu :refer [match-$]]]
@@ -25,6 +26,7 @@
              [dataset-definitions :as defs]
              [datasets :as datasets]
              [users :refer [user->client]]]
+            [metabase.test.mock.util :as mutil]
             [metabase.timeseries-query-processor-test.util :as tqpt]
             [toucan
              [db :as db]
@@ -437,6 +439,25 @@
                                                           :fields_hash  $}))))}])
   ((user->client :rasta) :get 200 (format "table/%d/fks" (data/id :users))))
 
+(defn- with-field-literal-id [{field-name :name, base-type :base_type :as field}]
+  (assoc field :id ["field-literal" field-name base-type]))
+
+(defn- default-card-field-for-venues [table-id]
+  {:table_id                 table-id
+   :special_type             nil
+   :default_dimension_option nil
+   :dimension_options        []})
+
+(defn- with-numeric-dimension-options [field]
+  (assoc field
+    :default_dimension_option (var-get #'table-api/numeric-default-index)
+    :dimension_options (var-get #'table-api/numeric-dimension-indexes)))
+
+(defn- with-coordinate-dimension-options [field]
+  (assoc field
+    :default_dimension_option (var-get #'table-api/coordinate-default-index)
+    :dimension_options (var-get #'table-api/coordinate-dimension-indexes)))
+
 ;; Make sure metadata for 'virtual' tables comes back as expected from GET /api/table/:id/query_metadata
 (tt/expect-with-temp [Card [card {:name          "Go Dubs!"
                                   :database_id   (data/id)
@@ -450,23 +471,36 @@
      :id                card-virtual-table-id
      :description       nil
      :dimension_options (default-dimension-options)
-     :fields            (for [[field-name display-name base-type] [["NAME"     "Name"     "type/Text"]
-                                                                   ["ID"       "ID"       "type/Integer"]
-                                                                   ["PRICE"    "Price"    "type/Integer"]
-                                                                   ["LATITUDE" "Latitude" "type/Float"]]]
-                          {:name                     field-name
-                           :display_name             display-name
-                           :base_type                base-type
-                           :table_id                 card-virtual-table-id
-                           :id                       ["field-literal" field-name base-type]
-                           :special_type             nil
-                           :default_dimension_option nil
-                           :dimension_options        []})})
+     :fields            (map (comp #(merge (default-card-field-for-venues card-virtual-table-id) %)
+                                   with-field-literal-id)
+                             [{:name         "NAME"
+                               :display_name "Name"
+                               :base_type    "type/Text"
+                               :special_type "type/Name"
+                               :fingerprint  (:name mutil/venue-fingerprints)}
+                              (with-numeric-dimension-options
+                                {:name         "ID"
+                                 :display_name "ID"
+                                 :base_type    "type/Integer"
+                                 :special_type nil
+                                 :fingerprint  (:id mutil/venue-fingerprints)})
+                              (with-numeric-dimension-options
+                                {:name         "PRICE"
+                                 :display_name "Price"
+                                 :base_type    "type/Integer"
+                                 :special_type nil
+                                 :fingerprint  (:price mutil/venue-fingerprints)})
+                              (with-coordinate-dimension-options
+                                {:name         "LATITUDE"
+                                 :display_name "Latitude"
+                                 :base_type    "type/Float"
+                                 :special_type "type/Latitude"
+                                 :fingerprint  (:latitude mutil/venue-fingerprints)})])})
   (do
     ;; run the Card which will populate its result_metadata column
     ((user->client :crowberto) :post 200 (format "card/%d/query" (u/get-id card)))
     ;; Now fetch the metadata for this "table"
-    ((user->client :crowberto) :get 200 (format "table/card__%d/query_metadata" (u/get-id card)))))
+    (tu/round-all-decimals 2 ((user->client :crowberto) :get 200 (format "table/card__%d/query_metadata" (u/get-id card))))))
 
 ;; Test date dimensions being included with a nested query
 (tt/expect-with-temp [Card [card {:name          "Users"
@@ -486,9 +520,12 @@
                           :base_type                "type/Text"
                           :table_id                 card-virtual-table-id
                           :id                       ["field-literal" "NAME" "type/Text"]
-                          :special_type             nil
+                          :special_type             "type/Name"
                           :default_dimension_option nil
-                          :dimension_options        []}
+                          :dimension_options        []
+                          :fingerprint              {:global {:distinct-count 15},
+                                                     :type   {:type/Text {:percent-json  0.0, :percent-url    0.0,
+                                                                          :percent-email 0.0, :average-length 13.27}}}}
                          {:name                     "LAST_LOGIN"
                           :display_name             "Last Login"
                           :base_type                "type/DateTime"
@@ -496,12 +533,15 @@
                           :id                       ["field-literal" "LAST_LOGIN" "type/DateTime"]
                           :special_type             nil
                           :default_dimension_option (var-get #'table-api/date-default-index)
-                          :dimension_options        (var-get #'table-api/datetime-dimension-indexes)}]})
+                          :dimension_options        (var-get #'table-api/datetime-dimension-indexes)
+                          :fingerprint              {:global {:distinct-count 15},
+                                                     :type   {:type/DateTime {:earliest "2014-01-01T08:30:00.000Z",
+                                                                              :latest   "2014-12-05T15:15:00.000Z"}}}}]})
   (do
     ;; run the Card which will populate its result_metadata column
     ((user->client :crowberto) :post 200 (format "card/%d/query" (u/get-id card)))
     ;; Now fetch the metadata for this "table"
-    ((user->client :crowberto) :get 200 (format "table/card__%d/query_metadata" (u/get-id card)))))
+    (tu/round-all-decimals 2 ((user->client :crowberto) :get 200 (format "table/card__%d/query_metadata" (u/get-id card))))))
 
 
 ;; make sure GET /api/table/:id/fks just returns nothing for 'virtual' tables
@@ -606,11 +646,10 @@
           :dimension_options))))
 
 (defn- dimension-options-for-field [response field-name]
-  (let [formatted-field-name (data/format-name field-name)]
-    (->> response
-         :fields
-         (m/find-first #(= formatted-field-name (:name %)))
-         :dimension_options)))
+  (->> response
+       :fields
+       (m/find-first #(.equalsIgnoreCase field-name (:name %)))
+       :dimension_options))
 
 (defn- extract-dimension-options
   "For the given `FIELD-NAME` find it's dimension_options following
@@ -667,3 +706,29 @@
 (expect
   #{:metrics :segments :linked-from :linking-to :tables}
   (-> ((user->client :crowberto) :get 200 (format "table/%s/related" (data/id :venues))) keys set))
+
+;; Nested queries with a fingerprint should have dimension options for binning
+(datasets/expect-with-engines (qpt/non-timeseries-engines-with-feature :binning :nested-queries)
+  (repeat 2 (var-get #'table-api/coordinate-dimension-indexes))
+  (tt/with-temp Card [card {:database_id   (data/id)
+                            :dataset_query {:database (data/id)
+                                            :type    :query
+                                            :query    {:source-query {:source-table (data/id :venues)}}}}]
+    ;; run the Card which will populate its result_metadata column
+    ((user->client :crowberto) :post 200 (format "card/%d/query" (u/get-id card)))
+    (let [response ((user->client :crowberto) :get 200 (format "table/card__%d/query_metadata" (u/get-id card)))]
+      (map #(dimension-options-for-field response %)
+           ["latitude" "longitude"]))))
+
+;; Nested queries missing a fingerprint should not show binning-options
+(datasets/expect-with-engines (qpt/non-timeseries-engines-with-feature :binning :nested-queries)
+  [nil nil]
+  (tt/with-temp Card [card {:database_id   (data/id)
+                            :dataset_query {:database (data/id)
+                                            :type    :query
+                                            :query    {:source-query {:source-table (data/id :venues)}}}}]
+    ;; By default result_metadata will be nil (and no fingerprint). Just asking for query_metadata after the card was
+    ;; created but before it was ran should not allow binning
+    (let [response ((user->client :crowberto) :get 200 (format "table/card__%d/query_metadata" (u/get-id card)))]
+      (map #(dimension-options-for-field response %)
+           ["latitude" "longitude"]))))

--- a/test/metabase/query_processor/middleware/fetch_source_query_test.clj
+++ b/test/metabase/query_processor/middleware/fetch_source_query_test.clj
@@ -76,21 +76,22 @@
                        :query    {:source-table (str "card__" (u/get-id card))}})))
 
 (expect
-  (default-expanded-results
-   {:source-query {:source-table {:schema "PUBLIC" :name "CHECKINS" :id (data/id :checkins)}, :join-tables nil}
-    :filter {:filter-type :between,
-             :field {:field-name "date", :base-type :type/Date},
-             :min-val {:value (tcoerce/to-timestamp (du/str->date-time "2015-01-01"))
-                       :field {:field {:field-name "date", :base-type :type/Date}, :unit :default}},
-             :max-val {:value (tcoerce/to-timestamp (du/str->date-time "2015-02-01"))
-                       :field {:field {:field-name "date", :base-type :type/Date}, :unit :default}}}})
+  (let [date-field-literal {:field-name "date", :base-type :type/Date, :binning-strategy nil, :binning-param nil, :fingerprint nil}]
+    (default-expanded-results
+     {:source-query {:source-table {:schema "PUBLIC" :name "CHECKINS" :id (data/id :checkins)}, :join-tables nil}
+      :filter       {:filter-type :between,
+                     :field       date-field-literal
+                     :min-val     {:value (tcoerce/to-timestamp (du/str->date-time "2015-01-01"))
+                                   :field {:field date-field-literal, :unit :default}},
+                     :max-val     {:value (tcoerce/to-timestamp (du/str->date-time "2015-02-01"))
+                                   :field {:field date-field-literal, :unit :default}}}}))
   (tt/with-temp Card [card {:dataset_query {:database (data/id)
                                             :type     :query
                                             :query    {:source-table (data/id :checkins)}}}]
     (expand-and-scrub {:database database/virtual-id
                        :type     :query
                        :query    {:source-table (str "card__" (u/get-id card))
-                                  :filter ["BETWEEN" ["field-id" ["field-literal" "date" "type/Date"]] "2015-01-01" "2015-02-01"]}})))
+                                  :filter       ["BETWEEN" ["field-id" ["field-literal" "date" "type/Date"]] "2015-01-01" "2015-02-01"]}})))
 
 ;; make sure that nested nested queries work as expected
 (expect

--- a/test/metabase/query_processor/middleware/results_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/results_metadata_test.clj
@@ -10,8 +10,11 @@
              [permissions :as perms]
              [permissions-group :as group]]
             [metabase.query-processor.middleware.results-metadata :as results-metadata]
-            [metabase.test.data :as data]
+            [metabase.test
+             [data :as data]
+             [util :as tu]]
             [metabase.test.data.users :as users]
+            [metabase.test.mock.util :as mutil]
             [toucan.db :as db]
             [toucan.util.test :as tt]))
 
@@ -23,19 +26,33 @@
 (defn- card-metadata [card]
   (db/select-one-field :result_metadata Card :id (u/get-id card)))
 
+(defn- round-all-decimals'
+  "Defaults `tu/round-all-decimals` to 2 digits"
+  [data]
+  (tu/round-all-decimals 2 data))
+
+(def ^:private default-card-results
+  [{:name         "ID",      :display_name "ID", :base_type "type/Integer",
+    :special_type "type/PK", :fingerprint  (:id mutil/venue-fingerprints)}
+   {:name         "NAME",      :display_name "Name", :base_type "type/Text",
+    :special_type "type/Name", :fingerprint  (:name mutil/venue-fingerprints)}
+   {:name         "PRICE", :display_name "Price", :base_type "type/Integer",
+    :special_type nil,     :fingerprint  (:price mutil/venue-fingerprints)}
+   {:name         "CATEGORY_ID", :display_name "Category ID", :base_type "type/Integer",
+    :special_type nil,           :fingerprint  (:category_id mutil/venue-fingerprints)}
+   {:name         "LATITUDE",      :display_name "Latitude", :base_type "type/Float",
+    :special_type "type/Latitude", :fingerprint  (:latitude mutil/venue-fingerprints)}
+   {:name         "LONGITUDE",      :display_name "Longitude", :base_type "type/Float"
+    :special_type "type/Longitude", :fingerprint  (:longitude mutil/venue-fingerprints)}])
+
 ;; test that Card result metadata is saved after running a Card
 (expect
-  [{:name "ID",          :display_name "ID",          :base_type "type/Integer"}
-   {:name "NAME",        :display_name "Name",        :base_type "type/Text"}
-   {:name "PRICE",       :display_name "Price",       :base_type "type/Integer"}
-   {:name "CATEGORY_ID", :display_name "Category ID", :base_type "type/Integer"}
-   {:name "LATITUDE",    :display_name "Latitude",    :base_type "type/Float"}
-   {:name "LONGITUDE",   :display_name "Longitude",   :base_type "type/Float"}]
+  default-card-results
   (tt/with-temp Card [card]
     (qp/process-query (assoc (native-query "SELECT ID, NAME, PRICE, CATEGORY_ID, LATITUDE, LONGITUDE FROM VENUES")
                         :info {:card-id    (u/get-id card)
                                :query-hash (byte-array 0)}))
-    (card-metadata card)))
+    (round-all-decimals' (card-metadata card))))
 
 ;; check that using a Card as your source doesn't overwrite the results metadata...
 (expect
@@ -73,17 +90,17 @@
 ;; make sure that queries come back with metadata
 (expect
   {:checksum java.lang.String
-   :columns [{:base_type :type/Integer, :display_name "ID",          :name "ID"}
-             {:base_type :type/Text,    :display_name "Name",        :name "NAME"}
-             {:base_type :type/Integer, :display_name "Price",       :name "PRICE"}
-             {:base_type :type/Integer, :display_name "Category ID", :name "CATEGORY_ID"}
-             {:base_type :type/Float,   :display_name "Latitude",    :name "LATITUDE"}
-             {:base_type :type/Float,   :display_name "Longitude",   :name "LONGITUDE"}]}
+   :columns  (map (fn [col]
+                    (-> col
+                        (update :special_type keyword)
+                        (update :base_type keyword)))
+                  default-card-results)}
   (-> (qp/process-query {:database (data/id)
                          :type     :native
                          :native   {:query "SELECT ID, NAME, PRICE, CATEGORY_ID, LATITUDE, LONGITUDE FROM VENUES"}})
       (get-in [:data :results_metadata])
-      (update :checksum class)))
+      (update :checksum class)
+      round-all-decimals'))
 
 ;; make sure that a Card where a DateTime column is broken out by year advertises that column as Text, since you can't
 ;; do datetime breakouts on years
@@ -91,11 +108,16 @@
   [{:base_type    "type/Text"
     :display_name "Date"
     :name         "DATE"
-    :unit         nil}
+    :unit         nil
+    :special_type nil
+    :fingerprint  {:global {:distinct-count 618}, :type {:type/DateTime {:earliest "2013-01-03T00:00:00.000Z"
+                                                                         :latest   "2015-12-29T00:00:00.000Z"}}}}
    {:base_type    "type/Integer"
     :display_name "count"
     :name         "count"
-    :special_type "type/Number"}]
+    :special_type "type/Quantity"
+    :fingerprint  {:global {:distinct-count 3},
+                   :type {:type/Number {:min 235, :max 498, :avg 333.33}}}}]
   (tt/with-temp Card [card]
     (qp/process-query {:database (data/id)
                        :type     :query
@@ -104,4 +126,4 @@
                                   :breakout     [[:datetime-field [:field-id (data/id :checkins :date)] :year]]}
                        :info     {:card-id    (u/get-id card)
                                   :query-hash (byte-array 0)}})
-    (card-metadata card)))
+    (round-all-decimals' (card-metadata card))))

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -32,11 +32,13 @@
   (set/difference datasets/all-valid-engines timeseries-engines))
 
 (defn non-timeseries-engines-with-feature
-  "Set of engines that support a given FEATURE."
-  [feature]
-  (set (for [engine non-timeseries-engines
-             :when  (contains? (driver/features (driver/engine->driver engine)) feature)]
-         engine)))
+  "Set of engines that support a given `feature`. If additional features are given, it will ensure all features are
+  supported."
+  [feature & more-features]
+  (let [features (set (cons feature more-features))]
+    (set (for [engine non-timeseries-engines
+               :when  (set/subset? features (driver/features (driver/engine->driver engine)))]
+           engine))))
 
 (defn non-timeseries-engines-without-feature
   "Return a set of all non-timeseries engines (e.g., everything except Druid) that DO NOT support `feature`."

--- a/test/metabase/query_processor_test/breakout_test.clj
+++ b/test/metabase/query_processor_test/breakout_test.clj
@@ -5,9 +5,11 @@
              [query-processor-test :refer :all]
              [util :as u]]
             [metabase.models
+             [card :refer [Card]]
              [dimension :refer [Dimension]]
              [field :refer [Field]]
              [field-values :refer [FieldValues]]]
+            [metabase.query-processor :as qp]
             [metabase.query-processor.middleware
              [add-dimension-projections :as add-dim-projections]
              [expand :as ql]]
@@ -17,7 +19,8 @@
             [metabase.test.data
              [dataset-definitions :as defs]
              [datasets :as datasets]]
-            [toucan.db :as db]))
+            [toucan.db :as db]
+            [toucan.util.test :as tt]))
 
 ;;; single column
 (qp-expect-with-all-engines
@@ -245,3 +248,35 @@
                         (ql/aggregation (ql/count))
                         (ql/breakout (ql/binning-strategy $latitude :default)))
         (select-keys [:status :class :error]))))
+
+(defn- field->result-metadata [field]
+  (select-keys field [:name :display_name :description :base_type :special_type :unit :fingerprint]))
+
+(defn- nested-venues-query [card-or-card-id]
+  {:database metabase.models.database/virtual-id
+   :type :query
+   :query {:source-table (str "card__" (u/get-id card-or-card-id))
+           :aggregation  [:count]
+           :breakout     [(ql/binning-strategy (ql/field-literal (data/format-name :latitude) :type/Float) :num-bins 20)]}})
+
+;; Binning should be allowed on nested queries that have result metadata
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :binning :nested-queries)
+  [[10.0 1] [32.0 4] [34.0 57] [36.0 29] [40.0 9]]
+  (tt/with-temp Card [card {:dataset_query {:database (data/id)
+                                            :type :query
+                                            :query {:source-query {:source-table (data/id :venues)}}}
+                            :result_metadata (mapv field->result-metadata (db/select Field :table_id (data/id :venues)))}]
+    (->> (nested-venues-query card)
+         qp/process-query
+         rows
+         (format-rows-by [(partial u/round-to-decimals 1) int]))))
+
+;; Binning is not supported when there is no fingerprint to determine boundaries
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :binning :nested-queries)
+  Exception
+  (tt/with-temp Card [card {:dataset_query {:database (data/id)
+                                            :type :query
+                                            :query {:source-query {:source-table (data/id :venues)}}}}]
+    (-> (nested-venues-query card)
+        qp/process-query
+        rows)))

--- a/test/metabase/sync/analyze/classifiers/name_test.clj
+++ b/test/metabase/sync/analyze/classifiers/name_test.clj
@@ -37,7 +37,7 @@
                                          :special_type :type/FK
                                          :name         "City"
                                          :base_type    :type/Text}]]
-    (-> field-id Field (infer-special-type nil) :special_type)))
+    (-> field-id Field (infer-and-assoc-special-type nil) :special_type)))
 
 ;; ... but overwrite other types to alow evolution of our type system
 (expect
@@ -47,4 +47,4 @@
                                          :special_type :type/Category
                                          :name         "City"
                                          :base_type    :type/Text}]]
-    (-> field-id Field (infer-special-type nil) :special_type)))
+    (-> field-id Field (infer-and-assoc-special-type nil) :special_type)))

--- a/test/metabase/sync/analyze/fingerprint_test.clj
+++ b/test/metabase/sync/analyze/fingerprint_test.clj
@@ -135,7 +135,7 @@
 ;; Make sure that the above functions are used correctly to determine which Fields get (re-)fingerprinted
 (defn- field-was-fingerprinted? {:style/indent 0} [fingerprint-versions field-properties]
   (let [fingerprinted? (atom false)
-        fake-field     (field/map->FieldInstance {:name "Fake Field"})]
+        fake-field     (field/map->FieldInstance {:name "Fake Field", :base_type :type/Number})]
     (with-redefs [i/fingerprint-version->types-that-should-be-re-fingerprinted fingerprint-versions
                   sample/sample-fields                                         (constantly [[fake-field [1 2 3 4 5]]])
                   fingerprint/save-fingerprint!                                (fn [& _] (reset! fingerprinted? true))]

--- a/test/metabase/sync/analyze/query_results_test.clj
+++ b/test/metabase/sync/analyze/query_results_test.clj
@@ -1,0 +1,111 @@
+(ns metabase.sync.analyze.query-results-test
+  (:require [clojure.string :as str]
+            [expectations :refer :all]
+            [metabase
+             [query-processor :as qp]
+             [util :as u]]
+            [metabase.models
+             [card :refer [Card]]
+             [database :as database]]
+            [metabase.sync.analyze
+             [fingerprint :as fprint]
+             [query-results :as qr :refer :all]]
+            [metabase.sync.analyze.classifiers.name :as classify-name]
+            [metabase.test
+             [data :as data]
+             [util :as tu]]
+            [metabase.test.mock.util :as mutil]
+            [toucan.util.test :as tt]))
+
+(defn- column->name-keyword [field-or-column-metadata]
+  (-> field-or-column-metadata
+      :name
+      str/lower-case
+      keyword))
+
+(defn- name->fingerprints [field-or-metadata]
+  (zipmap (map column->name-keyword field-or-metadata)
+          (map :fingerprint field-or-metadata)))
+
+(defn- name->special-type [field-or-metadata]
+  (zipmap (map column->name-keyword field-or-metadata)
+          (map :special_type field-or-metadata)))
+
+(defn- query->result-metadata
+  [query-map]
+  (->> query-map
+       qp/process-query
+       :data
+       results->column-metadata
+       (tu/round-all-decimals 2)))
+
+(defn- query-for-card [card]
+  {:database database/virtual-id
+   :type     :query
+   :query    {:source-table (str "card__" (u/get-id card))}})
+
+(def ^:private venue-name->special-types
+  {:id          :type/PK,
+   :name        :type/Name,
+   :price       :type/Category,
+   :category_id :type/FK,
+   :latitude    :type/Latitude,
+   :longitude   :type/Longitude})
+
+;; Getting the result metadata for a card backed by an MBQL query should use the fingerprints from the related fields
+(expect
+  mutil/venue-fingerprints
+  (tt/with-temp Card [card {:dataset_query   {:database (data/id)
+                                              :type     :query
+                                              :query    {:source-table (data/id :venues)}}}]
+    (tu/throw-if-called fprint/fingerprint
+      (name->fingerprints
+       (query->result-metadata (query-for-card card))))))
+
+;; Getting the result metadata for a card backed by an MBQL query should just infer the types of all the fields
+(expect
+  venue-name->special-types
+  (tt/with-temp Card [card {:dataset_query   {:database (data/id)
+                                              :type     :query
+                                              :query    {:source-table (data/id :venues)}}}]
+    (name->special-type (query->result-metadata (query-for-card card)))))
+
+;; Native queries don't know what the associated Fields are for the results, we need to compute the fingerprints, but
+;; they should sill be the same
+(expect
+  mutil/venue-fingerprints
+  (tt/with-temp Card [card {:dataset_query   {:database (data/id)
+                                              :type     :native
+                                              :native   {:query "select * from venues"}}}]
+    (name->fingerprints
+     (query->result-metadata (query-for-card card)))))
+
+;; Similarly, check that we computed the correct special types. Note that we don't know that the category_id is an FK
+;; as it's just an integer flowing through, similarly Price isn't found to be a category as we're inferring by name
+;; only
+(expect
+  (assoc venue-name->special-types :category_id nil, :price nil)
+  (tt/with-temp Card [card {:dataset_query   {:database (data/id)
+                                              :type     :native
+                                              :native   {:query "select * from venues"}}}]
+    (name->special-type
+     (query->result-metadata (query-for-card card)))))
+
+;; Limiting to just 1 column on an MBQL query should still get the result metadata from the Field
+(expect
+  (select-keys mutil/venue-fingerprints [:longitude])
+  (tt/with-temp Card [card {:dataset_query   {:database (data/id)
+                                              :type     :query
+                                              :query    {:source-table (data/id :venues)}}}]
+    (tu/throw-if-called fprint/fingerprint
+      (name->fingerprints
+       (query->result-metadata (assoc-in (query-for-card card) [:query :fields] (data/id :venues :longitude)))))))
+
+;; Similar query as above, just native so that we need to calculate the fingerprint
+(expect
+  (select-keys mutil/venue-fingerprints [:longitude])
+  (tt/with-temp Card [card {:dataset_query   {:database (data/id)
+                                              :type     :native
+                                              :native   {:query "select longitude from venues"}}}]
+    (name->fingerprints
+     (query->result-metadata (query-for-card card)))))

--- a/test/metabase/sync/sync_metadata/fields_test.clj
+++ b/test/metabase/sync/sync_metadata/fields_test.clj
@@ -12,7 +12,9 @@
              [field :refer [Field]]
              [table :refer [Table]]]
             [metabase.sync.util-test :as sut]
-            [metabase.test.data :as data]
+            [metabase.test
+             [data :as data]
+             [util :as tu]]
             [metabase.test.data.one-off-dbs :as one-off-dbs]
             [toucan
              [db :as db]
@@ -181,11 +183,6 @@
   (doseq [statement statements]
     (jdbc/execute! one-off-dbs/*conn* [statement])))
 
-(defmacro ^:private throw-if-called {:style/indent 1} [fn-var & body]
-  `(with-redefs [~fn-var (fn [& args#]
-                           (throw (RuntimeException. "Should not be called!")))]
-     ~@body))
-
 ;; Validate the changing of a column's type triggers a hash miss and sync
 (expect
   [ ;; Original column type
@@ -212,7 +209,7 @@
             {new-db-type :database_type} (get-field)]
 
         ;; Syncing again with no change should not call sync-field-instances! or update the hash
-        (throw-if-called metabase.sync.sync-metadata.fields/sync-field-instances!
+        (tu/throw-if-called metabase.sync.sync-metadata.fields/sync-field-instances!
           (sync/sync-database! (data/db))
           [old-db-type
            new-db-type

--- a/test/metabase/test/mock/util.clj
+++ b/test/metabase/test/mock/util.clj
@@ -43,6 +43,22 @@
    :schedule_day   nil
    :enabled        true})
 
+(def venue-fingerprints
+  "Fingerprints for the full venues table"
+  {:name        {:global {:distinct-count 100},
+                 :type   {:type/Text {:percent-json  0.0, :percent-url    0.0,
+                                      :percent-email 0.0, :average-length 15.63}}}
+   :id          {:global {:distinct-count 100},
+                 :type   {:type/Number {:min 1, :max 100, :avg 50.5}}}
+   :price       {:global {:distinct-count 4},
+                 :type   {:type/Number {:min 1, :max 4, :avg 2.03}}}
+   :latitude    {:global {:distinct-count 94},
+                 :type   {:type/Number {:min 10.06, :max 40.78, :avg 35.51}}}
+   :category_id {:global {:distinct-count 28},
+                 :type   {:type/Number {:min 2, :max 74, :avg 29.98}}}
+   :longitude   {:global {:distinct-count 84},
+                 :type   {:type/Number {:min -165.37, :max -73.95, :avg -116.0}}}})
+
 ;; This is just a fake implementation that just swoops in and returns somewhat-correct looking results for different
 ;; queries we know will get ran as part of sync
 (defn- is-table-row-count-query? [expanded-query]


### PR DESCRIPTION
To support this Cards now include fingerprints in the
result_metadata. That fingerprint is included in the query dictionary
and is available to the query pipeline. The expand/resolve/binning
middleware can make use of that fingerprint data to build the binned
query. Dimension options for these kinds of queries will also now be
available.

Note that binning is only available on questions that have result
metadata. If no result metadata (and thus no fingerprint) is
available, no dimensions options will be included and an exception
will be thrown if a binned query is attempted. In most cases, just
running a card once will populate that data.