### PR TITLE
remove trailing commas

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -229,7 +229,7 @@ if (NODE_ENV === "hot") {
   config.plugins.unshift(
     new webpack.NoEmitOnErrorsPlugin(),
     new webpack.NamedModulesPlugin(),
-    new webpack.HotModuleReplacementPlugin(),
+    new webpack.HotModuleReplacementPlugin()
   );
 }
 
@@ -264,7 +264,7 @@ if (NODE_ENV !== "production") {
           }),
         },
       },
-    }),
+    })
   );
 
   config.devtool = "source-map";


### PR DESCRIPTION
Prettier added these, and whatever version of node the alpine base image has doesn't care for these. 