### PR TITLE
Clean up navbar on smaller screens.

### DIFF
--- a/frontend/src/metabase/nav/containers/Navbar.jsx
+++ b/frontend/src/metabase/nav/containers/Navbar.jsx
@@ -270,10 +270,11 @@ export default class Navbar extends Component {
           </Box>
         </Flex>
         <Flex ml="auto" align="center" className="relative z2">
-          <Link to={Urls.newQuestion()} mx={2}>
+          <Link to={Urls.newQuestion()} mx={2} className="hide sm-show">
             <Button medium>{t`Ask a question`}</Button>
           </Link>
           <EntityMenu
+            className="hide sm-show"
             triggerIcon="add"
             items={[
               {


### PR DESCRIPTION
Hides ask a question and the action to create a new dashboard and new pulse on mobile as we'd previously done since those experiences aren't really set up to be used in that context.