### PR TITLE
Fix a couple more horizontal scaling issues [WIP]

### DIFF
--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -71,7 +71,7 @@
                     (database-api/schedule-map->cron-strings schedules))))]
         (events/publish-event! :database-create db)))
     ;; clear the setup token now, it's no longer needed
-    (setup/clear-token!)
+    (setup/mark-setup-token-as-used!)
     ;; then we create a session right away because we want our new user logged in to continue the setup process
     (db/insert! Session
       :id      session-id

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -112,15 +112,18 @@
 ;;; --------------------------------------------------- Lifecycle ----------------------------------------------------
 
 (defn- -init-create-setup-token
-  "Create and set a new setup token and log it."
+  "Create and set a new setup token (as a side-effect of calling `setup-token`), and log a message telling people to
+  visit the setup URL to set up their instance."
   []
-  (let [setup-token (setup/create-token!)                    ; we need this here to create the initial token
-        hostname    (or (config/config-str :mb-jetty-host) "localhost")
-        port        (config/config-int :mb-jetty-port)
-        setup-url   (str "http://"
-                         (or hostname "localhost")
-                         (when-not (= 80 port) (str ":" port))
-                         "/setup/")]
+  ;; create token if needed...
+  (setup/setup-token)
+  ;; log the message
+  (let [hostname  (or (config/config-str :mb-jetty-host) "localhost")
+        port      (config/config-int :mb-jetty-port)
+        setup-url (str "http://"
+                       (or hostname "localhost")
+                       (when-not (= 80 port) (str ":" port))
+                       "/setup/")]
     (log/info (u/format-color 'green
                   (str (trs "Please use the following URL to setup your Metabase installation:")
                        "\n\n"

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -172,7 +172,7 @@
    :premium_token         (metastore/premium-embedding-token)
    :public_sharing        (enable-public-sharing)
    :report_timezone       (setting/get :report-timezone)
-   :setup_token           ((resolve 'metabase.setup/token-value))
+   :setup_token           ((resolve 'metabase.setup/setup-token))
    :site_name             (site-name)
    :site_url              (site-url)
    :timezone_short        (short-timezone-name (setting/get :report-timezone))

--- a/src/metabase/setup.clj
+++ b/src/metabase/setup.clj
@@ -1,27 +1,47 @@
-(ns metabase.setup)
+(ns metabase.setup
+  "Functionality used for setting up Metabase on first launch, such as the unique setup token (which authorizes you to
+  create the initial User.)"
+  (:require [metabase.models.setting :as setting :refer [defsetting Setting]]
+            [metabase.util :as u]
+            [puppetlabs.i18n.core :refer [trs]]
+            [toucan.db :as db]))
 
-(defonce ^:private setup-token
-  (atom nil))
+(defsetting ^:private setup-token-used?
+  "Has the setup token been used to create the initial user?"
+  :internal? true
+  :type      :boolean)
 
-(defn token-value
-  "Return the value of the setup token, if any."
-  []
-  @setup-token)
+(defsetting setup-token
+  "Token used to authorize the person who first launches this Metabase instance to create the first User. Magic getter
+  automatically creates and saves the value the first time this is fetched."
+  :internal? true
+  :getter  (fn []
+             ;; if the setup token has already been used, return `nil` from now on
+             (when-not (setup-token-used?)
+               ;; ok, double check that this setup token has *DEFINITELY NOT* BEEN USED! Fetch the actual value of the
+               ;; `setup-token-used?` setting in the DB, to make sure we're not seeing it as `false` because an old
+               ;; value is cached. (We still want it to be a cached Setting, however, because `setup-token` gets
+               ;; called on a fairly regular basis, as part of the `session/properties` endpoint ("public Settings"),
+               ;; so we would like to avoid the extra DB call.)
+               (when-not (db/select-one Setting :key "setup-token-used?", :value "true")
+                 (or
+                  ;; otherwise, if not 'used', return existing setup token if applicable
+                  (setting/get-string "setup-token")
+                  ;; if no value is in the DB, create a new value, save it, and return it
+                  (u/prog1 (str (java.util.UUID/randomUUID))
+                    (setting/set-string! "setup-token" <>))))))
+  ;; people shouldn't be changing the setup token themselves; the magic getter will set a value for it when appropriate.
+  :setter  (fn [_]
+             (throw (Exception. (str (trs "You cannot change setup-token."))))))
 
 (defn token-match?
   "Function for checking if the supplied string matches our setup token.
-   Returns boolean `true` if supplied token matches `@setup-token`, `false` otherwise."
+   Returns boolean `true` if supplied token matches `setup-token`, `false` otherwise."
   [token]
   {:pre [(string? token)]}
-  (= token @setup-token))
+  (= token (setup-token)))
 
-(defn create-token!
-  "Create and set a new `@setup-token`.
-   Returns the newly created token."
+(defn mark-setup-token-as-used!
+  "Mark the setup token as used; this means it can no longer be used to create Users."
   []
-  (reset! setup-token (str (java.util.UUID/randomUUID))))
-
-(defn clear-token!
-  "Clear the `@setup-token` if it exists and reset it to nil."
-  []
-  (reset! setup-token nil))
+  (setup-token-used? true))

--- a/test/metabase/api/setup_test.clj
+++ b/test/metabase/api/setup_test.clj
@@ -5,7 +5,15 @@
              [http-client :as http]
              [public-settings :as public-settings]
              [setup :as setup]]
+            [metabase.models.setting :as setting]
             [metabase.test.util :as tu]))
+
+(defn- new-setup-token!
+  "Return the setup token state to what is is upon launch, and return a new setup token."
+  []
+  (#'setup/setup-token-used? false)
+  (setting/set-string! "setup-token" nil)
+  (setup/setup-token))
 
 ;; ## POST /api/setup/user
 ;; Check that we can create a new superuser via setup-token
@@ -14,7 +22,7 @@
     [true
      email]
     (tu/with-temporary-setting-values [admin-email nil]
-      [(tu/is-uuid-string? (:id (http/client :post 200 "setup" {:token (setup/create-token!)
+      [(tu/is-uuid-string? (:id (http/client :post 200 "setup" {:token (new-setup-token!)
                                                                 :prefs {:site_name "Metabase Test"}
                                                                 :user  {:first_name (tu/random-name)
                                                                         :last_name  (tu/random-name)
@@ -22,7 +30,7 @@
                                                                         :password   "anythingUP12!!"}})))
        (do
          ;; reset our setup token
-         (setup/create-token!)
+         (new-setup-token!)
          (public-settings/admin-email))])))
 
 
@@ -34,25 +42,25 @@
   (http/client :post 400 "setup" {:token "foobar"}))
 
 (expect {:errors {:site_name "value must be a non-blank string."}}
-  (http/client :post 400 "setup" {:token (setup/token-value)}))
+  (http/client :post 400 "setup" {:token (new-setup-token!)}))
 
 (expect {:errors {:first_name "value must be a non-blank string."}}
-  (http/client :post 400 "setup" {:token (setup/token-value)
+  (http/client :post 400 "setup" {:token (new-setup-token!)
                                   :prefs {:site_name "awesomesauce"}}))
 
 (expect {:errors {:last_name "value must be a non-blank string."}}
-  (http/client :post 400 "setup" {:token (setup/token-value)
+  (http/client :post 400 "setup" {:token (new-setup-token!)
                                   :prefs {:site_name "awesomesauce"}
                                   :user {:first_name "anything"}}))
 
 (expect {:errors {:email "value must be a valid email address."}}
-  (http/client :post 400 "setup" {:token (setup/token-value)
+  (http/client :post 400 "setup" {:token (new-setup-token!)
                                   :prefs {:site_name "awesomesauce"}
                                   :user {:first_name "anything"
                                          :last_name "anything"}}))
 
 (expect {:errors {:password "Insufficient password strength"}}
-  (http/client :post 400 "setup" {:token (setup/token-value)
+  (http/client :post 400 "setup" {:token (new-setup-token!)
                                   :prefs {:site_name "awesomesauce"}
                                   :user {:first_name "anything"
                                          :last_name "anything"
@@ -60,7 +68,7 @@
 
 ;; valid email + complex password
 (expect {:errors {:email "value must be a valid email address."}}
-  (http/client :post 400 "setup" {:token (setup/token-value)
+  (http/client :post 400 "setup" {:token (new-setup-token!)
                                   :prefs {:site_name "awesomesauce"}
                                   :user {:token "anything"
                                          :first_name "anything"
@@ -69,7 +77,7 @@
                                          :password "anything"}}))
 
 (expect {:errors {:password "Insufficient password strength"}}
-  (http/client :post 400 "setup" {:token (setup/token-value)
+  (http/client :post 400 "setup" {:token (new-setup-token!)
                                   :prefs {:site_name "awesomesauce"}
                                   :user {:token "anything"
                                          :first_name "anything"
@@ -86,4 +94,4 @@
   (http/client :post 400 "setup/validate" {:token "foobar"}))
 
 (expect {:errors {:engine "value must be a valid database engine."}}
-  (http/client :post 400 "setup/validate" {:token (setup/token-value)}))
+  (http/client :post 400 "setup/validate" {:token (new-setup-token!)}))


### PR DESCRIPTION
Fix a couple smaller issues that prevented things from working "flawlessly" on initial launch of a new horizontal Metabase cluster:

*  `setup-token` was process-unqiue and stored in memory, meaning if two or more new instances were launched at the same time, they would each have their own setup token, and completing setup on one instance would leave the others stuck in setup-mode until restarted. Fixed by storing `setup-token` as a Setting.
*  DB migrations had a weird race condition where multiple instances could acquire migration locks simultaneously and both attempt to run migrations at the same time. Only one would ultimately succeed, causing the other instance to throw an Exception and quit. (Yes, I know, the locks sort of don't work right if this was allowed to happen; this is Liquibase, however...). 