### PR TITLE
Add basic support for formatting markdown links in table cells

### DIFF
--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -5,6 +5,7 @@ import inflection from "inflection";
 import moment from "moment";
 import Humanize from "humanize-plus";
 import React from "react";
+import ReactMarkdown from "react-markdown";
 import { ngettext, msgid } from "c-3po";
 
 import ExternalLink from "metabase/components/ExternalLink.jsx";
@@ -317,11 +318,41 @@ export function formatUrl(value: Value, { jsx, rich }: FormattingOptions = {}) {
   }
 }
 
+const MARKDOWN_LINK_WHITELIST_REGEX = /^\[([^\]]+)\]\s*\((.*)\)$/;
+
+function formatMarkdown(value: Value, { jsx, rich }: FormattingOptions = {}) {
+  const markdown = String(value);
+  /*
+   * For now only allow markdown links that take up the whole string. When more functionality
+   * is added to control rich formatting this could be expanded. Control is needed or else
+   * we risk formatting strings incorectly due to parsing them as markup when instead they should
+   * be treated as raw strings.
+   */
+  if (jsx && rich && MARKDOWN_LINK_WHITELIST_REGEX.test(markdown)) {
+    return (
+      <ReactMarkdown
+        className="full flex-full flex flex-column"
+        skipHtml={true}
+        source={markdown}
+        renderers={{
+          link: ExternalLink,
+        }}
+        allowedTypes={["root", "text", "paragraph", "link", "linkReference"]} // TODO add "image" type
+      />
+    );
+  } else {
+    return value;
+  }
+}
+
 // fallback for formatting a string without a column special_type
 function formatStringFallback(value: Value, options: FormattingOptions = {}) {
   value = formatUrl(value, options);
   if (typeof value === "string") {
     value = formatEmail(value, options);
+  }
+  if (typeof value === "string") {
+    value = formatMarkdown(value, options);
   }
   return value;
 }


### PR DESCRIPTION
Strings that match `/^\[([^\]]+)\]\s*\((.*)\)$/` will be formatted as markdown links. Only links will be processed. Code could be expanded in the future if more configuration is added to rich formatting. Blanket markdown processing is not done to prevent false markdown interpretation.

I didn't tackle images since that requires handling resizing, caching, and whitelisting and I'm not sure how the Metabase team plans to handle image design.

Examples:
```
// These will get formatted
[Metabase](https://metabase.com)
[Github] (https://github.com)

// This will not get formatted
foo [Google](https://google.com] bar
```

Partially addresses #6873, #2529, #7188, #2791

###### Before submitting the PR, please make sure you do the following 
-  [x] If there are changes to the backend codebase, run the backend tests with `lein test && lein eastwood && lein bikeshed && lein docstring-checker && ./bin/reflection-linter`
-  [x] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [x] Sign the [Contributor License Agreement]
