### PR TITLE
Bump to Toucan 1.1.9

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -96,7 +96,7 @@
                  [ring/ring-jetty-adapter "1.6.0"]                    ; Ring adapter using Jetty webserver (used to run a Ring server for unit tests)
                  [ring/ring-json "0.4.0"]                             ; Ring middleware for reading/writing JSON automatically
                  [stencil "0.5.0"]                                    ; Mustache templates for Clojure
-                 [toucan "1.1.7"                                      ; Model layer, hydration, and DB utilities
+                 [toucan "1.1.9"                                      ; Model layer, hydration, and DB utilities
                   :exclusions [honeysql]]]
   :repositories [["bintray" "https://dl.bintray.com/crate/crate"]     ; Repo for Crate JDBC driver
                  ["redshift" "https://s3.amazonaws.com/redshift-driver-downloads"]]


### PR DESCRIPTION
This upgrade removes some unecessary classpath scanning from
Toucan. This slowness only affected the first query, which would
typically show up as a really slow call to the `/api/user/current`
endpoint (sometimes 10+ seconds).

