### PR TITLE
clean up extra padding on QB modal content

### DIFF
--- a/frontend/src/metabase/components/QuestionSavedModal.jsx
+++ b/frontend/src/metabase/components/QuestionSavedModal.jsx
@@ -18,7 +18,7 @@ export default class QuestionSavedModal extends Component {
         onClose={this.props.onClose}
         className="Modal-content Modal-content--small NewForm"
       >
-        <div className="Form-inputs mb4">
+        <div>
           <button
             className="Button Button--primary"
             onClick={this.props.addToDashboardFn}

--- a/frontend/src/metabase/containers/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.jsx
@@ -198,7 +198,7 @@ export default class SaveQuestionModal extends Component {
         ]}
         onClose={this.props.onClose}
       >
-        <form className="Form-inputs" onSubmit={this.formSubmitted}>
+        <form onSubmit={this.formSubmitted}>
           {saveOrUpdate}
           <CSSTransitionGroup
             transitionName="saveQuestionModalFields"


### PR DESCRIPTION
After some of our recent modal content tweaks where we baked in default padding to modals some of the older ones in the QB were overly padded. 

- Save question modal
- Add to dash on save modal

There may be others but I'll do those as I find them.