### PR TITLE
make sure auth views are full screen

### DIFF
--- a/frontend/src/metabase/auth/AuthApp.jsx
+++ b/frontend/src/metabase/auth/AuthApp.jsx
@@ -1,0 +1,6 @@
+import fitViewPort from "metabase/hoc/FitViewPort";
+
+// Auth components expect a full viewport experience to center most of the pages
+const AuthApp = ({ children }) => children;
+
+export default fitViewPort(AuthApp);

--- a/frontend/src/metabase/auth/containers/LoginApp.jsx
+++ b/frontend/src/metabase/auth/containers/LoginApp.jsx
@@ -112,7 +112,7 @@ export default class LoginApp extends Component {
     const ldapEnabled = Settings.ldapEnabled();
 
     return (
-      <div className="viewport-height full bg-white flex flex-column flex-full md-layout-centered">
+      <div className="full bg-white flex flex-column flex-full md-layout-centered">
         <div className="Login-wrapper wrapper Grid Grid--full md-Grid--1of2 relative z2">
           <div className="Grid-cell flex layout-centered text-brand">
             <LogoIcon className="Logo my4 sm-my0" width={66} height={85} />

--- a/frontend/src/metabase/css/core/layout.css
+++ b/frontend/src/metabase/css/core/layout.css
@@ -33,11 +33,6 @@
   height: 100%;
 }
 
-/* set height to that of the viewport */
-.viewport-height {
-  height: 100vh;
-}
-
 /* display utilities */
 .block,
 :local(.block) {

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -16,6 +16,7 @@ import App from "metabase/App.jsx";
 import HomepageApp from "metabase/home/containers/HomepageApp";
 
 // auth containers
+import AuthApp from "metabase/auth/AuthApp";
 import ForgotPasswordApp from "metabase/auth/containers/ForgotPasswordApp.jsx";
 import LoginApp from "metabase/auth/containers/LoginApp.jsx";
 import LogoutApp from "metabase/auth/containers/LogoutApp.jsx";
@@ -177,7 +178,7 @@ export const getRoutes = store => (
       }}
     >
       {/* AUTH */}
-      <Route path="/auth">
+      <Route path="/auth" component={AuthApp}>
         <IndexRedirect to="/auth/login" />
         <Route component={IsNotAuthenticated}>
           <Route path="login" title={t`Login`} component={LoginApp} />


### PR DESCRIPTION
When we switched things around to not have the app root include full viewport classes by default I think we (read: me) forgot that the auth pages have that expectation and forgot to check some of the lesser used password reset, etc routes. This ensures that everything under the auth routes will behave as expected.

Fixes #8076