### PR TITLE
Fix not being able to type a negative number in conditional field formatting

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx
@@ -420,6 +420,6 @@ const NumericInput = ({ value, onChange }) => (
     className="AdminSelect input mt1 full"
     type="number"
     value={value}
-    onChange={e => onChange(parseFloat(e.target.value))}
+    onChange={e => onChange(e.target.value)}
   />
 );


### PR DESCRIPTION
Fixes #8014 

the console log messages were complaining that it couldn't parse `NaN` as a number which suggested it was attempting to parse the value twice. The first parse failed because `-` by itself is not a valid number... removing it seems to do the trick and things are working as expected (manually verified).