### PR TITLE
Restore previous minimum generated password length of 14

### DIFF
--- a/frontend/src/metabase/lib/utils.js
+++ b/frontend/src/metabase/lib/utils.js
@@ -48,8 +48,9 @@ let MetabaseUtils = {
   generatePassword: function(complexity) {
     complexity =
       complexity || MetabaseSettings.passwordComplexityRequirements() || {};
-    // fall back to length of 14 if the password_complexity Setting isn't set or total isn't passed in
-    const len = complexity.total || 14;
+    // generated password must be at least `complexity.total`, but can be longer
+    // so hard code a minimum of 14
+    const len = Math.max(complexity.total || 0, 14);
 
     let password = "";
     let tries = 0;

--- a/frontend/test/lib/utils.unit.spec.js
+++ b/frontend/test/lib/utils.unit.spec.js
@@ -3,9 +3,14 @@ import MetabaseSettings from "metabase/lib/settings";
 
 describe("utils", () => {
   describe("generatePassword", () => {
-    it("defaults to complexity requirements from Settings", () => {
+    it("defaults to at least 14 characters even if password_complexity requirements are lower", () => {
       MetabaseSettings.set("password_complexity", { total: 10 });
-      expect(MetabaseUtils.generatePassword().length).toBe(10);
+      expect(MetabaseUtils.generatePassword().length).toBe(14);
+    });
+
+    it("defaults to complexity requirements if greater than 14", () => {
+      MetabaseSettings.set("password_complexity", { total: 20 });
+      expect(MetabaseUtils.generatePassword().length).toBe(20);
     });
 
     it("falls back to length 14 passwords", () => {


### PR DESCRIPTION
#8079 inadvertently reduced our default generated password length to 6 which isn't very strong. The complexity requirements are the minimums but there's no reason not to generate longer passwords, so restore the previous minimum length of 14.