### PR TITLE
Fix dashboard archive redirect

### DIFF
--- a/frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx
+++ b/frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx
@@ -1,16 +1,14 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { t } from "c-3po";
+
+import Button from "metabase/components/Button";
 import ModalContent from "metabase/components/ModalContent.jsx";
 
 export default class ArchiveDashboardModal extends Component {
-  constructor(props, context) {
-    super(props, context);
-
-    this.state = {
-      error: null,
-    };
-  }
+  state = {
+    error: null,
+  };
 
   static propTypes = {
     dashboard: PropTypes.object.isRequired,
@@ -43,23 +41,15 @@ export default class ArchiveDashboardModal extends Component {
 
     return (
       <ModalContent title={t`Archive Dashboard`} onClose={this.props.onClose}>
-        <div className="Form-inputs mb4">
-          <p>{t`Are you sure you want to do this?`}</p>
-        </div>
+        <p>{t`Are you sure you want to do this?`}</p>
 
-        <div className="Form-actions">
-          <button
-            className="Button Button--danger"
-            onClick={() => this.archiveDashboard()}
-          >
+        <div>
+          <Button danger onClick={() => this.archiveDashboard()}>
             Yes
-          </button>
-          <button
-            className="Button Button--primary ml1"
-            onClick={this.props.onClose}
-          >
+          </Button>
+          <Button primary ml={1} onClick={this.props.onClose}>
             No
-          </button>
+          </Button>
           {formError}
         </div>
       </ModalContent>

--- a/frontend/src/metabase/dashboard/components/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader.jsx
@@ -3,20 +3,21 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { t } from "c-3po";
-import ActionButton from "metabase/components/ActionButton.jsx";
-import AddToDashSelectQuestionModal from "./AddToDashSelectQuestionModal.jsx";
-import ArchiveDashboardModal from "./ArchiveDashboardModal.jsx";
-import Header from "metabase/components/Header.jsx";
-import Icon from "metabase/components/Icon.jsx";
-import ModalWithTrigger from "metabase/components/ModalWithTrigger.jsx";
-import Tooltip from "metabase/components/Tooltip.jsx";
+import ActionButton from "metabase/components/ActionButton";
+import AddToDashSelectQuestionModal from "./AddToDashSelectQuestionModal";
+import ArchiveDashboardModal from "./ArchiveDashboardModal";
+import Header from "metabase/components/Header";
+import Icon from "metabase/components/Icon";
+import ModalWithTrigger from "metabase/components/ModalWithTrigger";
+import Tooltip from "metabase/components/Tooltip";
 import DashboardEmbedWidget from "../containers/DashboardEmbedWidget";
 
 import { getDashboardActions } from "./DashboardActions";
 
-import ParametersPopover from "./ParametersPopover.jsx";
-import Popover from "metabase/components/Popover.jsx";
+import ParametersPopover from "./ParametersPopover";
+import Popover from "metabase/components/Popover";
 
+import * as Urls from "metabase/lib/urls";
 import MetabaseSettings from "metabase/lib/settings";
 
 import cx from "classnames";
@@ -144,8 +145,10 @@ export default class DashboardHeader extends Component {
   }
 
   async onArchive() {
-    await this.props.archiveDashboard(this.props.dashboard.id);
-    this.props.onChangeLocation("/dashboards");
+    const { dashboard } = this.props;
+    // TODO - this should use entity action
+    await this.props.archiveDashboard(dashboard.id);
+    this.props.onChangeLocation(Urls.collection(dashboard.collection_id));
   }
 
   getEditingButtons() {

--- a/frontend/src/metabase/meta/types/Dashboard.js
+++ b/frontend/src/metabase/meta/types/Dashboard.js
@@ -18,6 +18,7 @@ export type Dashboard = {
   show_in_getting_started?: boolean,
   // incomplete
   parameters: Array<Parameter>,
+  collection_id: ?number,
 };
 
 // TODO Atte Keinänen 4/5/16: After upgrading Flow, use spread operator `...Dashboard`
@@ -28,6 +29,7 @@ export type DashboardWithCards = {
   ordered_cards: Array<DashCard>,
   // incomplete
   parameters: Array<Parameter>,
+  collection_id: ?number,
 };
 
 export type DashCardId = number;


### PR DESCRIPTION
When archiving a dashboard from the dashboard itself the app would redirect to the old dashboard listing page which no longer exists. This also cleans up the archive modal.