### PR TITLE
Small copy changes to collection create/edit modal and empty state

### DIFF
--- a/frontend/src/metabase/components/CollectionEmptyState.jsx
+++ b/frontend/src/metabase/components/CollectionEmptyState.jsx
@@ -30,7 +30,7 @@ const CollectionEmptyState = ({ params }) => {
           className="link text-bold"
           mt={2}
           to={Urls.newCollection(params.collectionId)}
-        >{t`Create a sub collection`}</Link>
+        >{t`Create another collection`}</Link>
       </Box>
     </Box>
   );

--- a/frontend/src/metabase/css/components/form.css
+++ b/frontend/src/metabase/css/components/form.css
@@ -198,6 +198,7 @@
 
 .NewForm .Form-label {
   text-transform: uppercase;
+  letter-spacing: 0.05em;
   color: var(--color-text-medium);
   margin-bottom: 0.5em;
 }

--- a/frontend/src/metabase/entities/collections.js
+++ b/frontend/src/metabase/entities/collections.js
@@ -98,7 +98,7 @@ const Collections = createEntity({
       },
       {
         name: "parent_id",
-        title: "Parent collection",
+        title: "Collection it's saved in",
         type: "collection",
       },
     ],


### PR DESCRIPTION
In collection create/edit form: "Parent collection" => "Collection it's saved in"
("Parent collection" seems too technical to me)

On collection empty state: "Create a sub collection" => "Create another collection"
(Seemed more colloquial to me.)

Also adds a small bit of letter spacing to all-caps form headings so they're easier to read:
<img width="301" alt="screen shot 2018-07-22 at 11 09 26 am" src="https://user-images.githubusercontent.com/2223916/43047020-bb33a91e-8d9f-11e8-9db0-add1483c1c81.png">

Before:

<img width="265" alt="screen shot 2018-07-22 at 11 09 54 am" src="https://user-images.githubusercontent.com/2223916/43047028-cc7bf1f4-8d9f-11e8-9ca1-1f618d2edf17.png">


