### PR TITLE
Add collection to DashboardForm, and port CreateDashboardModal to use it

### DIFF
--- a/frontend/src/metabase/components/CreateDashboardModal.jsx
+++ b/frontend/src/metabase/components/CreateDashboardModal.jsx
@@ -1,20 +1,13 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { t } from "c-3po";
 import { connect } from "react-redux";
 import { withRouter } from "react-router";
 import { push } from "react-router-redux";
 
 import * as Urls from "metabase/lib/urls";
 
-import FormField from "metabase/components/form/FormField.jsx";
-import ModalContent from "metabase/components/ModalContent.jsx";
-
-import Button from "metabase/components/Button.jsx";
-import CollectionSelect from "metabase/containers/CollectionSelect.jsx";
-
-import Dashboards from "metabase/entities/dashboards";
 import Collections from "metabase/entities/collections";
+import DashboardForm from "metabase/containers/DashboardForm";
 
 const mapStateToProps = (state, props) => ({
   initialCollectionId: Collections.selectors.getInitialCollectionId(
@@ -24,133 +17,29 @@ const mapStateToProps = (state, props) => ({
 });
 
 const mapDispatchToProps = {
-  createDashboard: Dashboards.actions.create,
-  push,
+  onChangeLocation: push,
 };
 
 @withRouter
 @connect(mapStateToProps, mapDispatchToProps)
 export default class CreateDashboardModal extends Component {
-  constructor(props, context) {
-    super(props, context);
-
-    this.state = {
-      name: null,
-      description: null,
-      errors: null,
-      collection_id: props.initialCollectionId,
-    };
-  }
-
   static propTypes = {
-    createDashboard: PropTypes.func.isRequired,
     onClose: PropTypes.func,
   };
 
-  setName = event => {
-    this.setState({ name: event.target.value });
-  };
-
-  setDescription = event => {
-    this.setState({ description: event.target.value });
-  };
-
-  createNewDash = async event => {
-    event.preventDefault();
-
-    let name = this.state.name && this.state.name.trim();
-    let description = this.state.description && this.state.description.trim();
-
-    // populate a new Dash object
-    let newDash = {
-      name: name && name.length > 0 ? name : null,
-      description: description && description.length > 0 ? description : null,
-      collection_id: this.state.collection_id,
-    };
-
-    const { payload } = await this.props.createDashboard(newDash);
-    this.props.push(Urls.dashboard(payload.result));
-    this.props.onClose();
-  };
-
   render() {
-    let formError;
-    if (this.state.errors) {
-      let errorMessage = t`Server error encountered`;
-      if (this.state.errors.data && this.state.errors.data.message) {
-        errorMessage = this.state.errors.data.message;
-      }
-
-      // TODO: timeout display?
-      formError = <span className="text-error px2">{errorMessage}</span>;
-    }
-
-    let name = this.state.name && this.state.name.trim();
-
-    let formReady = name !== null && name !== "";
-
+    const { initialCollectionId, onClose, onChangeLocation } = this.props;
     return (
-      <ModalContent
-        id="CreateDashboardModal"
-        title={t`Create dashboard`}
-        footer={[
-          formError,
-          <Button
-            mr={1}
-            onClick={() => this.props.onClose()}
-          >{t`Cancel`}</Button>,
-          <Button
-            primary={formReady}
-            disabled={!formReady}
-            onClick={this.createNewDash}
-          >{t`Create`}</Button>,
-        ]}
-        onClose={this.props.onClose}
-      >
-        <form className="Modal-form" onSubmit={this.createNewDash}>
-          <div>
-            <FormField
-              name="name"
-              displayName={t`Name`}
-              formError={this.state.errors}
-            >
-              <input
-                className="Form-input full"
-                name="name"
-                placeholder={t`What is the name of your dashboard?`}
-                value={this.state.name}
-                onChange={this.setName}
-                autoFocus
-              />
-            </FormField>
-
-            <FormField
-              name="description"
-              displayName={t`Description`}
-              formError={this.state.errors}
-            >
-              <input
-                className="Form-input full"
-                name="description"
-                placeholder={t`It's optional but oh, so helpful`}
-                value={this.state.description}
-                onChange={this.setDescription}
-              />
-            </FormField>
-
-            <FormField
-              displayName={t`Which collection should this go in?`}
-              fieldName="collection_id"
-              errors={this.state.errors}
-            >
-              <CollectionSelect
-                value={this.state.collection_id}
-                onChange={collection_id => this.setState({ collection_id })}
-              />
-            </FormField>
-          </div>
-        </form>
-      </ModalContent>
+      <DashboardForm
+        dashboard={{ collection_id: initialCollectionId }}
+        onClose={onClose}
+        onSaved={dashboard => {
+          onChangeLocation(Urls.dashboard(dashboard.id));
+          if (onClose) {
+            onClose();
+          }
+        }}
+      />
     );
   }
 }

--- a/frontend/src/metabase/components/form/StandardForm.jsx
+++ b/frontend/src/metabase/components/form/StandardForm.jsx
@@ -6,6 +6,7 @@ import FormMessage from "metabase/components/form/FormMessage";
 
 import Button from "metabase/components/Button";
 
+import { t } from "c-3po";
 import cx from "classnames";
 import { getIn } from "icepick";
 
@@ -23,11 +24,12 @@ const StandardForm = ({
   className,
   resetButton = false,
   newForm = true,
+  onClose = null,
 
   ...props
 }) => (
   <form onSubmit={handleSubmit} className={cx(className, { NewForm: newForm })}>
-    <div className="m1">
+    <div>
       {form.fields(values).map(formField => {
         const nameComponents = formField.name.split(".");
         const field = getIn(fields, nameComponents);
@@ -47,25 +49,30 @@ const StandardForm = ({
         );
       })}
     </div>
-    <div className={cx("m1", { "Form-offset": !newForm })}>
-      <Button
-        type="submit"
-        primary
-        disabled={submitting || invalid}
-        className="mr1"
-      >
-        {values.id != null ? "Update" : "Create"}
-      </Button>
-      {resetButton && (
+    <div className={cx("flex", { "Form-offset": !newForm })}>
+      <div className="ml-auto flex align-center">
+        {onClose && (
+          <Button className="mr1" onClick={onClose}>{t`Cancel`}</Button>
+        )}
         <Button
-          type="button"
-          disabled={submitting || !dirty}
-          onClick={resetForm}
+          type="submit"
+          primary={!(submitting || invalid)}
+          disabled={submitting || invalid}
+          className="mr1"
         >
-          Reset
+          {values.id != null ? t`Update` : t`Create`}
         </Button>
-      )}
-      {error && <FormMessage message={error} formError />}
+        {resetButton && (
+          <Button
+            type="button"
+            disabled={submitting || !dirty}
+            onClick={resetForm}
+          >
+            {t`Reset`}
+          </Button>
+        )}
+        {error && <FormMessage message={error} formError />}
+      </div>
     </div>
   </form>
 );

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal.jsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal.jsx
@@ -39,6 +39,7 @@ export default class AddToDashSelectDashModal extends Component {
         <DashboardForm
           dashboard={{ collection_id: this.props.card.collection_id }}
           onSaved={dashboard => this.addToDashboard(dashboard.id)}
+          onClose={() => this.setState({ shouldCreateDashboard: false })}
         />
       );
     } else {

--- a/frontend/src/metabase/containers/DashboardForm.jsx
+++ b/frontend/src/metabase/containers/DashboardForm.jsx
@@ -6,11 +6,16 @@ import ModalContent from "metabase/components/ModalContent";
 const DashboardForm = ({ dashboard, onClose, ...props }) => (
   <ModalContent
     title={
-      dashboard && dashboard.id != null ? dashboard.name : t`New dashboard`
+      dashboard && dashboard.id != null ? dashboard.name : t`Create dashboard`
     }
     onClose={onClose}
   >
-    <EntityForm entityType="dashboards" entityObject={dashboard} {...props} />
+    <EntityForm
+      entityType="dashboards"
+      entityObject={dashboard}
+      onClose={onClose}
+      {...props}
+    />
   </ModalContent>
 );
 

--- a/frontend/src/metabase/entities/containers/EntityType.jsx
+++ b/frontend/src/metabase/entities/containers/EntityType.jsx
@@ -34,6 +34,16 @@ export default (entityType?: string) => (
         }
       }
 
+      shouldComponentUpdate(nextProps, nextState) {
+        if (
+          nextProps.entityDef !== this.props.entityDef ||
+          nextProps.dispatch !== this.props.dispatch
+        ) {
+          return true;
+        }
+        return false;
+      }
+
       _bindActionCreators({ entityDef, dispatch }) {
         this._boundActionCreators = bindActionCreators(
           entityDef.actions,

--- a/frontend/src/metabase/entities/dashboards.js
+++ b/frontend/src/metabase/entities/dashboards.js
@@ -4,6 +4,7 @@ import { createEntity, undo } from "metabase/lib/entities";
 import * as Urls from "metabase/lib/urls";
 import { normal } from "metabase/lib/colors";
 import { assocIn } from "icepick";
+import { t } from "c-3po";
 
 import { POST, DELETE } from "metabase/lib/api";
 import { canonicalCollectionId } from "metabase/entities/collections";
@@ -86,7 +87,25 @@ const Dashboards = createEntity({
   },
 
   form: {
-    fields: [{ name: "name" }, { name: "description", type: "text" }],
+    fields: [
+      {
+        name: "name",
+        placeholder: t`What is the name of your dashboard?`,
+        validate: name => (!name ? "Name is required" : null),
+      },
+      {
+        name: "description",
+        type: "text",
+        placeholder: t`It's optional but oh, so helpful`,
+      },
+      {
+        name: "collection_id",
+        title: t`Which collection should this go in?`,
+        type: "collection",
+        validate: colelctionId =>
+          colelctionId === undefined ? "Collection is required" : null,
+      },
+    ],
   },
 });
 

--- a/frontend/src/metabase/lib/redux.js
+++ b/frontend/src/metabase/lib/redux.js
@@ -8,6 +8,9 @@ import { setRequestState, clearRequestState } from "metabase/redux/requests";
 export { combineReducers } from "redux";
 export { handleActions, createAction } from "redux-actions";
 
+import { createSelectorCreator } from "reselect";
+import memoize from "lodash.memoize";
+
 // similar to createAction but accepts a (redux-thunk style) thunk and dispatches based on whether
 // the promise returned from the thunk resolves or rejects, similar to redux-promise
 export function createThunkAction(actionType, actionThunkCreator) {
@@ -192,3 +195,8 @@ export const formDomOnlyProps = ({
   defaultValue,
   ...domProps
 }) => domProps;
+
+export const createMemoizedSelector = createSelectorCreator(
+  memoize,
+  (...args) => JSON.stringify(args),
+);

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "leaflet": "^1.2.0",
     "leaflet-draw": "^0.4.9",
     "leaflet.heat": "^0.2.0",
+    "lodash.memoize": "^4.1.2",
     "moment": "2.19.3",
     "node-libs-browser": "^2.0.0",
     "normalizr": "^3.0.2",


### PR DESCRIPTION
Resolves #8136 by adding the `collection_id` to the `DashboardForm` (via the `dashboards` entity's default form definition)

Also ports `CreateDashboardModal` to use `DashboardForm`. We should try to use the Form/EntityForm/StandardForm stuff for basic forms like that since it's got validation etc built in.

This also optimizes EntityType and EntityListLoader a bit. They were re-rendering much more often than necessary (e.x. basically the whole app was re-rendering on every character typed into a form)