### PR TITLE
use transpiled version of icepick 2.x for ie 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "grid-styled": "^4.1.0",
     "history": "3",
     "humanize-plus": "^1.8.1",
-    "icepick": "2",
+    "icepick": "2.3.0",
     "iframe-resizer": "^3.5.11",
     "inflection": "^1.7.1",
     "isomorphic-fetch": "^2.2.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -104,6 +104,10 @@ var config = (module.exports = {
       __support__: TEST_SUPPORT_PATH,
       style: SRC_PATH + "/css/core/index",
       ace: __dirname + "/node_modules/ace-builds/src-min-noconflict",
+      // NOTE @kdoh - 7/24/18
+      // icepick 2.x is es6 by defalt, to maintain backwards compatability
+      // with ie11 point to the minified version
+      icepick: __dirname + "/node_modules/icepick/icepick.min"
     },
   },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4975,7 +4975,7 @@ humanize-plus@^1.8.1:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/humanize-plus/-/humanize-plus-1.8.2.tgz#a65b34459ad6367adbb3707a82a3c9f916167030"
 
-icepick@2:
+icepick@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/icepick/-/icepick-2.3.0.tgz#1d1b0b28b80c1ff720a1f62359dab46392806f5c"
 


### PR DESCRIPTION
When trying to summit IE 11 you're gonna want to bring your transpiled icepick.

Long story short the default lib got updated to use es6 by default and we didn't notice until we checked IE 11 and the app wouldn't even render because there was an arrow function playing around in there, simple switch to use the "built" version rather than the default export.