### PR TITLE
Single pass fingerprinting fixes

### DIFF
--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -491,6 +491,6 @@
                                :fields       (vec (for [field fields]
                                                     [:field-id (u/get-id field)]))
                                :limit        max-sample-rows}
-                  :middleware {:format-rows?        false
+                  :middleware {:format-rows?         false
                                :skip-fingerprinting? true}})]
     (get-in results [:data :rows])))

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -491,6 +491,6 @@
                                :fields       (vec (for [field fields]
                                                     [:field-id (u/get-id field)]))
                                :limit        max-sample-rows}
-                  :middleware {:format-rows?           false
-                               :skip-results-metadata? true}})]
+                  :middleware {:format-rows?        false
+                               :skip-fingerprinting? true}})]
     (get-in results [:data :rows])))

--- a/src/metabase/query_processor/middleware/results_metadata.clj
+++ b/src/metabase/query_processor/middleware/results_metadata.clj
@@ -49,22 +49,22 @@
   [qp]
   (fn [{{:keys [card-id nested?]} :info, :as query}]
     (let [results (qp query)]
-      (if (-> query :middleware :skip-results-metadata?)
-        results
-        (try
-          (let [metadata (seq (qr/results->column-metadata results))]
-            ;; At the very least we can skip the Extra DB call to update this Card's metadata results
-            ;; if its DB doesn't support nested queries in the first place
-            (when (and (i/driver-supports? :nested-queries)
-                       card-id
-                       (not nested?))
-              (record-metadata! card-id metadata))
-            ;; add the metadata and checksum to the response
-            (assoc results :results_metadata {:checksum (metadata-checksum metadata)
-                                              :columns  metadata}))
-          ;; if for some reason we weren't able to record results metadata for this query then just proceed as normal
-          ;; rather than failing the entire query
-          (catch Throwable e
-            (log/error "Error recording results metadata for query:" (.getMessage e) "\n"
-                       (u/pprint-to-str (u/filtered-stacktrace e)))
-            results))))))
+      (try
+        (let [metadata (seq (if (-> query :middleware :skip-fingerprinting?)
+                              (qr/results->column-metadata results)
+                              (qr/results->column-metadata+fingerprint results)))]
+          ;; At the very least we can skip the Extra DB call to update this Card's metadata results
+          ;; if its DB doesn't support nested queries in the first place
+          (when (and (i/driver-supports? :nested-queries)
+                     card-id
+                     (not nested?))
+            (record-metadata! card-id metadata))
+          ;; add the metadata and checksum to the response
+          (assoc results :results_metadata {:checksum (metadata-checksum metadata)
+                                            :columns  metadata}))
+        ;; if for some reason we weren't able to record results metadata for this query then just proceed as normal
+        ;; rather than failing the entire query
+        (catch Throwable e
+          (log/error "Error recording results metadata for query:" (.getMessage e) "\n"
+                     (u/pprint-to-str (u/filtered-stacktrace e)))
+          results)))))

--- a/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+++ b/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
@@ -140,10 +140,9 @@
                :latest   latest}))
 
 (deffingerprinter :type/Number
-  ((remove nil?)
-   (redux/fuse {:min stats/min
-                :max stats/max
-                :avg stats/mean})))
+  (redux/fuse {:min stats/min
+               :max stats/max
+               :avg stats/mean}))
 
 (defn- valid-serialized-json?
   "Is x a serialized JSON dictionary or array."

--- a/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+++ b/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
@@ -1,6 +1,7 @@
 (ns metabase.sync.analyze.fingerprint.fingerprinters
   "Non-identifying fingerprinters for various field types."
   (:require [cheshire.core :as json]
+            [clj-time.coerce :as t.coerce]
             [kixi.stats.core :as stats]
             [metabase.sync.util :as sync-util]
             [metabase.util :as u]
@@ -136,8 +137,12 @@
      acc)))
 
 (deffingerprinter :type/DateTime
-  (redux/fuse {:earliest earliest
-               :latest   latest}))
+  ((map (fn [dt]
+          (if (string? dt)
+            (-> dt du/str->date-time t.coerce/to-date-time)
+            dt)))
+   (redux/fuse {:earliest earliest
+                :latest   latest})))
 
 (deffingerprinter :type/Number
   (redux/fuse {:min stats/min

--- a/src/metabase/sync/analyze/query_results.clj
+++ b/src/metabase/sync/analyze/query_results.clj
@@ -68,10 +68,15 @@
 (s/defn results->column-metadata :- ResultsMetadata
   "Return the desired storage format for the column metadata coming back from RESULTS."
   [results]
-  (let [result-metadata (for [col (:cols results)]
-                          (-> col
-                              stored-column-metadata->result-column-metadata
-                              (maybe-infer-special-type col)))]
+  (for [col (:cols results)]
+    (-> col
+        stored-column-metadata->result-column-metadata
+        (maybe-infer-special-type col))))
+
+(s/defn results->column-metadata+fingerprint :- ResultsMetadata
+  "Return the desired storage format for the column metadata coming back from RESULTS and fingerprint the RESULTS."
+  [results]
+  (let [result-metadata (results->column-metadata results)]
     (transduce identity
                (redux/post-complete
                 (apply f/col-wise (for [metadata result-metadata]

--- a/test/metabase/sync/analyze/query_results_test.clj
+++ b/test/metabase/sync/analyze/query_results_test.clj
@@ -35,7 +35,7 @@
   (->> query-map
        qp/process-query
        :data
-       results->column-metadata
+       results->column-metadata+fingerprint
        (tu/round-all-decimals 2)))
 
 (defn- query-for-card [card]


### PR DESCRIPTION
This fixes the recent test failures.  I think there were 2 issues: 
1) I didn't take into account that sync is run asynchronously and it might be that type classification hadn't run yet when we start fingerprinting. 
2) some drivers apparently return dates as strings. I've added an optional cast, but a better solution would be to dispatch based on engine. Do we have some flag or something that indicates whether we're returning strings or Dates?