### PR TITLE
Don't decrypt obviously not encrypted strings

### DIFF
--- a/src/metabase/util/encryption.clj
+++ b/src/metabase/util/encryption.clj
@@ -6,6 +6,7 @@
              [crypto :as crypto]
              [kdf :as kdf]
              [nonce :as nonce]]
+            [clojure.string :as str]
             [clojure.tools.logging :as log]
             [environ.core :as env]
             [metabase.util :as u]
@@ -73,21 +74,37 @@
        (encrypt secret-key s))
      s)))
 
+(def ^:private ^:const aes256-tag-length 32)
+(def ^:private ^:const aes256-block-size 16)
+
+(defn- possibly-encrypted-string?
+  "Returns true if it's likely that `s` is an encrypted string. Specifically we need `s` to be a non-blank, base64
+  encoded string of the correct length. The correct length is determined by the cipher's type tag and the cipher's
+  block size (AES+CBC). To compute this, we need the number of bytes in the input, subtract the bytes used by the
+  cipher type tag (`aes256-tag-length`) and what is left should be divisible by the cipher's block size
+  (`aes256-block-size`). If it's not divisible by that number it is either not encrypted or it has been corrupted as
+  it must always have a multiple of the block size or it won't decrypt."
+  [s]
+  (when-let [str-byte-length (and (not (str/blank? s))
+                                  (u/base64-string? s)
+                                  (alength ^bytes (codec/base64-decode s)))]
+    (zero? (mod (- str-byte-length aes256-tag-length)
+                aes256-block-size))))
+
 (defn maybe-decrypt
   "If `MB_ENCRYPTION_SECRET_KEY` is set and `s` is encrypted, decrypt `s`; otherwise return `s` as-is."
   (^String [^String s]
    (maybe-decrypt default-secret-key s))
   (^String [secret-key, ^String s]
-   (if (and secret-key (seq s))
+   (if (and secret-key (possibly-encrypted-string? s))
      (try
        (decrypt secret-key s)
        (catch Throwable e
-         (if (u/base64-string? s)
-           ;; if we can't decrypt `s`, but it *is* encrypted, log an error message and return `nil`
-           (log/error
-            (trs "Cannot decrypt encrypted credentials. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?")
-            (.getMessage e)
-            (u/pprint-to-str (u/filtered-stacktrace e)))
-           ;; otherwise return S without decrypting. It's probably not decrypted in the first place
-           s)))
+         ;; if we can't decrypt `s`, but it *is* probably encrypted, log a warning
+         (log/warn
+          (trs "Cannot decrypt encrypted string. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?")
+          (.getMessage e)
+          (u/pprint-to-str (u/filtered-stacktrace e)))
+         s))
+     ;; otherwise return `s` without decrypting. It's probably not decrypted in the first place
      s)))

--- a/test/metabase/util/encryption_test.clj
+++ b/test/metabase/util/encryption_test.clj
@@ -54,14 +54,49 @@
   "{\"a\":100}"
   (encryption/maybe-decrypt secret "{\"a\":100}"))
 
-;; trying to decrypt something that is encrypted with the wrong key with `maybe-decrypt` should return `nil`...
-(expect
-  nil
-  (encryption/maybe-decrypt secret-2 (encryption/encrypt secret "WOW")))
+;; trying to decrypt something that is encrypted with the wrong key with `maybe-decrypt` should return the ciphertext...
+(let [original-ciphertext (encryption/encrypt secret "WOW")]
+  (expect
+    original-ciphertext
+    (encryption/maybe-decrypt secret-2 original-ciphertext)))
+
+(defn- includes-encryption-warning? [log-messages]
+  (some (fn [[level _ message]]
+          (and (= level :warn)
+               (str/includes? message (str "Cannot decrypt encrypted string. Have you changed or forgot to set "
+                                           "MB_ENCRYPTION_SECRET_KEY? Message seems corrupt or manipulated."))))
+        log-messages))
 
 (expect
-  (some (fn [[_ _ message]]
-          (str/includes? message (str "Cannot decrypt encrypted credentials. Have you changed or forgot to set "
-                                      "MB_ENCRYPTION_SECRET_KEY? Message seems corrupt or manipulated.")))
-        (tu/with-log-messages
-          (encryption/maybe-decrypt secret-2 (encryption/encrypt secret "WOW")))))
+  (includes-encryption-warning?
+   (tu/with-mb-log-messages-at-level :warn
+     (encryption/maybe-decrypt secret-2 (encryption/encrypt secret "WOW")))))
+
+;; Something obviously not encrypted should avoiding trying to decrypt it (and thus not log an error)
+(expect
+  []
+  (tu/with-mb-log-messages-at-level :warn
+    (encryption/maybe-decrypt secret "abc")))
+
+;; Something obviously not encrypted should return the original string
+(expect
+  "abc"
+  (encryption/maybe-decrypt secret "abc"))
+
+(def ^:private fake-ciphertext
+  "AES+CBC's block size is 16 bytes and the tag length is 32 bytes. This is a string of characters that is the same
+  length as would be expected for something that has been encrypted, but it is not encrypted, just unlucky enough to
+  have the same size"
+  (apply str (repeat 64 "a")))
+
+;; Something that is not encrypted, but might be (is the correct shape etc) should attempt to be decrypted. If unable
+;; to decrypt it, log a warning.
+(expect
+  (includes-encryption-warning?
+   (tu/with-mb-log-messages-at-level :warn
+     (encryption/maybe-decrypt secret fake-ciphertext))))
+
+;; Something that is not encrypted, but might be should return the original text
+(expect
+  fake-ciphertext
+  (encryption/maybe-decrypt secret fake-ciphertext))


### PR DESCRIPTION
When `MB_ENCRYPTION_SECRET_KEY` is set, we assume that all settings
have been encrypted. If a setting has not been encrypted, decryption
fails, but the original setting is returned. This causes Metabase to
behave correctly but have very noisy logging as when the decrypt fails
an error is logged.

This commit changes the `maybe-decrypt` behavior to more closely
examine the ciphertext to ensure it is something that can be
decrypted. If it looks like something that can be decrypted, but
decription fails (i.e. what if an unencrypted string is multiple of
the cipher block size) then log a warning as it's probably not an
issue, but could be.

Fixes #8151

