### PR TITLE
Turn "create new dashboard" button in add-question-to-dashboard modal into a link

### DIFF
--- a/frontend/src/metabase/containers/AddToDashSelectDashModal.jsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal.jsx
@@ -2,8 +2,10 @@
 
 import React, { Component } from "react";
 import { t } from "c-3po";
+import { Flex } from "grid-styled";
 
-import Button from "metabase/components/Button";
+import Icon from "metabase/components/Icon";
+import Link from "metabase/components/Link";
 import ModalContent from "metabase/components/ModalContent.jsx";
 import DashboardForm from "metabase/containers/DashboardForm.jsx";
 import DashboardPicker from "metabase/containers/DashboardPicker";
@@ -46,16 +48,19 @@ export default class AddToDashSelectDashModal extends Component {
       return (
         <ModalContent
           id="AddToDashSelectDashModal"
-          title={t`Add Question to Dashboard`}
+          title={t`Add this question to a dashboard`}
           onClose={this.props.onClose}
         >
           <DashboardPicker onChange={this.addToDashboard} />
-          <Button
+          <Link
             mt={1}
             onClick={() => this.setState({ shouldCreateDashboard: true })}
           >
-            {t`Create New Dashboard`}
-          </Button>
+            <Flex align="center" className="text-brand" py={2}>
+              <Icon name="add" mx={1} bordered />
+              <h4>{t`Create a new dashboard`}</h4>
+            </Flex>
+          </Link>
         </ModalContent>
       );
     }


### PR DESCRIPTION
The current button feels like it draws a bit more attention than it deserves, and might even be mistaken for a confirmation button:

<img width="670" alt="screen shot 2018-08-02 at 3 14 14 pm" src="https://user-images.githubusercontent.com/2223916/43614057-c0593100-9666-11e8-996e-0c5f3b401182.png">

**After:**

<img width="711" alt="screen shot 2018-08-02 at 2 49 10 pm" src="https://user-images.githubusercontent.com/2223916/43614028-9a90c9e2-9666-11e8-884d-af4450c3da42.png">

Personally I think this makes the empty state a little nicer on the eyes, too:

<img width="680" alt="screen shot 2018-08-02 at 2 48 46 pm" src="https://user-images.githubusercontent.com/2223916/43614033-9dbdf112-9666-11e8-8af9-f20557e5450e.png">
