### PR TITLE
Don't add default collection to native query unless required

### DIFF
--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -46,7 +46,6 @@ import {
 } from "./selectors";
 
 import {
-  getDatabases,
   getTables,
   getDatabasesList,
   getMetadata,
@@ -977,7 +976,6 @@ export const setQueryDatabase = createThunkAction(
   databaseId => {
     return async (dispatch, getState) => {
       const { qb: { card, uiControls } } = getState();
-      const databases = getDatabases(getState());
 
       // picking the same database doesn't change anything
       if (databaseId === card.dataset_query.database) {

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -997,12 +997,12 @@ export const setQueryDatabase = createThunkAction(
 
         // set the initial collection for the query if this is a native query
         // this is only used for Mongo queries which need to be ran against a specific collection
-        if (updatedCard.dataset_query.type === "native") {
-          let database = databases[databaseId],
-            tables = database ? database.tables : [],
-            table = tables.length > 0 ? tables[0] : null;
-          if (table) {
-            updatedCard.dataset_query.native.collection = table.name;
+        const question = new Question(getMetadata(getState()), updatedCard);
+        const query = question.query();
+        if (query instanceof NativeQuery && query.requiresTable()) {
+          const tables = query.tables();
+          if (tables && tables.length > 0) {
+            updatedCard.dataset_query.native.collection = tables[0].name;
           }
         }
 


### PR DESCRIPTION
Fixes issue where native queries were given a `collection` property that wasn't required.