### PR TITLE
Search type filters should match width of results

### DIFF
--- a/frontend/src/metabase/home/containers/SearchApp.jsx
+++ b/frontend/src/metabase/home/containers/SearchApp.jsx
@@ -27,15 +27,15 @@ export default class SearchApp extends React.Component {
             <Subhead>{jt`Results for "${location.query.q}"`}</Subhead>
           </Flex>
         )}
-        <ItemTypeFilterBar
-          analyticsContext={`Search Results`}
-          filters={FILTERS.concat({
-            name: t`Collections`,
-            filter: "collection",
-            icon: "all",
-          })}
-        />
         <Box w={[1, 2 / 3]}>
+          <ItemTypeFilterBar
+            analyticsContext={`Search Results`}
+            filters={FILTERS.concat({
+              name: t`Collections`,
+              filter: "collection",
+              icon: "all",
+            })}
+          />
           <EntityListLoader
             entityType="search"
             entityQuery={location.query}


### PR DESCRIPTION
Old:
<img width="1495" alt="screen shot 2018-08-03 at 9 16 05 am" src="https://user-images.githubusercontent.com/5248953/43653761-dfe58e28-96fd-11e8-8421-9afc099aeab9.png">

New:
<img width="1498" alt="screen shot 2018-08-03 at 9 15 50 am" src="https://user-images.githubusercontent.com/5248953/43653762-dffe6498-96fd-11e8-9d13-100c28b175c9.png">
