### PR TITLE
check for data access to display new questions and data reference nav items

### DIFF
--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -57,7 +57,6 @@ export default class App extends Component {
       return <div>😢</div>;
     }
 
-    console.log("app props", this.props);
     return (
       <ScrollToTop>
         <div className="relative">

--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -14,6 +14,7 @@ import GenericError from "metabase/components/GenericError.jsx";
 
 const mapStateToProps = (state, props) => ({
   errorPage: state.app.errorPage,
+  currentUser: state.currentUser,
 });
 
 const getErrorComponent = ({ status, data, context }) => {
@@ -50,16 +51,17 @@ export default class App extends Component {
   }
 
   render() {
-    const { children, location, errorPage } = this.props;
+    const { children, currentUser, location, errorPage } = this.props;
 
     if (this.state.hasError) {
       return <div>😢</div>;
     }
 
+    console.log("app props", this.props);
     return (
       <ScrollToTop>
         <div className="relative">
-          <Navbar location={location} />
+          {currentUser && <Navbar location={location} />}
           {errorPage ? getErrorComponent(errorPage) : children}
           <UndoListing />
         </div>

--- a/frontend/src/metabase/nav/containers/Navbar.jsx
+++ b/frontend/src/metabase/nav/containers/Navbar.jsx
@@ -28,6 +28,7 @@ import CreateDashboardModal from "metabase/components/CreateDashboardModal";
 import ProfileLink from "metabase/nav/components/ProfileLink.jsx";
 
 import { getPath, getContext, getUser } from "../selectors";
+import { entityListLoader } from "metabase/entities/containers/EntityListLoader";
 
 const mapStateToProps = (state, props) => ({
   path: getPath(state, props),
@@ -146,6 +147,9 @@ class SearchBar extends React.Component {
 
 const MODAL_NEW_DASHBOARD = "MODAL_NEW_DASHBOARD";
 
+@entityListLoader({
+  entityType: "databases",
+})
 @connect(mapStateToProps, mapDispatchToProps)
 export default class Navbar extends Component {
   state = {
@@ -246,6 +250,7 @@ export default class Navbar extends Component {
   }
 
   renderMainNav() {
+    const hasDataAccess = this.props.databases.length > 0;
     return (
       <Flex
         // NOTE: DO NOT REMOVE `Nav` CLASS FOR NOW, USED BY MODALS, FULLSCREEN DASHBOARD, ETC
@@ -278,14 +283,16 @@ export default class Navbar extends Component {
           </Box>
         </Flex>
         <Flex ml="auto" align="center" className="relative z2">
-          <Link
-            to={Urls.newQuestion()}
-            mx={2}
-            className="hide sm-show"
-            data-metabase-event={`NavBar;New Question`}
-          >
-            <Button medium>{t`Ask a question`}</Button>
-          </Link>
+          {hasDataAccess && (
+            <Link
+              to={Urls.newQuestion()}
+              mx={2}
+              className="hide sm-show"
+              data-metabase-event={`NavBar;New Question`}
+            >
+              <Button medium>{t`Ask a question`}</Button>
+            </Link>
+          )}
           <EntityMenu
             tooltip={t`Create`}
             className="hide sm-show"
@@ -305,13 +312,15 @@ export default class Navbar extends Component {
               },
             ]}
           />
-          <Tooltip tooltip={t`Reference`}>
-            <Link to="reference" data-metabase-event={`NavBar;Reference`}>
-              <IconWrapper>
-                <Icon name="reference" />
-              </IconWrapper>
-            </Link>
-          </Tooltip>
+          {hasDataAccess && (
+            <Tooltip tooltip={t`Reference`}>
+              <Link to="reference" data-metabase-event={`NavBar;Reference`}>
+                <IconWrapper>
+                  <Icon name="reference" />
+                </IconWrapper>
+              </Link>
+            </Tooltip>
+          )}
           <Tooltip tooltip={t`Activity`}>
             <Link to="activity" data-metabase-event={`NavBar;Activity`}>
               <IconWrapper>

--- a/frontend/src/metabase/nav/containers/Navbar.jsx
+++ b/frontend/src/metabase/nav/containers/Navbar.jsx
@@ -149,6 +149,8 @@ const MODAL_NEW_DASHBOARD = "MODAL_NEW_DASHBOARD";
 
 @entityListLoader({
   entityType: "databases",
+  // set this to false to prevent a potential spinner on the main nav
+  loadingAndErrorWrapper: false,
 })
 @connect(mapStateToProps, mapDispatchToProps)
 export default class Navbar extends Component {
@@ -250,7 +252,8 @@ export default class Navbar extends Component {
   }
 
   renderMainNav() {
-    const hasDataAccess = this.props.databases.length > 0;
+    const hasDataAccess =
+      this.props.databases && this.props.databases.length > 0;
     return (
       <Flex
         // NOTE: DO NOT REMOVE `Nav` CLASS FOR NOW, USED BY MODALS, FULLSCREEN DASHBOARD, ETC


### PR DESCRIPTION
Checks whether the user has data access by looking at the list of DBs and if its empty (no access) then hides nav items that require data access to work.

Resolves #8214 

ToDo(s)

- [x] Make sure the request only happens for the main nav not all nav states (the nav bar component render methods are kinda wack)