### PR TITLE
Fix i18n loading

### DIFF
--- a/frontend/src/metabase/app.js
+++ b/frontend/src/metabase/app.js
@@ -12,18 +12,11 @@ import "number-to-locale-string";
 // strings/elements to assist in finding untranslated strings.
 import "metabase/lib/i18n-debug";
 
-import "metabase/lib/colors";
-
-// make the i18n function "t" global so we don't have to import it in basically every file
-import { t, jt } from "c-3po";
-global.t = t;
-global.jt = jt;
-
 // set the locale before loading anything else
-import { setLocalization } from "metabase/lib/i18n";
-if (window.MetabaseLocalization) {
-  setLocalization(window.MetabaseLocalization);
-}
+import "metabase/lib/i18n";
+
+// NOTE: why do we need to load this here?
+import "metabase/lib/colors";
 
 import React from "react";
 import ReactDOM from "react-dom";

--- a/frontend/src/metabase/lib/i18n.js
+++ b/frontend/src/metabase/lib/i18n.js
@@ -1,11 +1,16 @@
 import { addLocale, useLocale } from "c-3po";
-import { I18NApi } from "metabase/services";
 
-export async function loadLocalization(locale) {
-  // load and parse the locale
-  const translationsObject = await I18NApi.locale({ locale });
-  setLocalization(translationsObject);
-}
+// NOTE: loadLocalization not currently used, and we need to be sure to set the
+// initial localization before loading any files, so don't load metabase/services
+// just in case
+
+// import { I18NApi } from "metabase/services";
+//
+// export async function loadLocalization(locale) {
+//   // load and parse the locale
+//   const translationsObject = await I18NApi.locale({ locale });
+//   setLocalization(translationsObject);
+// }
 
 export function setLocalization(translationsObject) {
   const locale = translationsObject.headers.language;
@@ -26,4 +31,9 @@ function addMsgIds(translationsObject) {
       msgs[msgid].msgid = msgid;
     }
   }
+}
+
+// set the initial localization
+if (window.MetabaseLocalization) {
+  setLocalization(window.MetabaseLocalization);
 }

--- a/frontend/test/__support__/integrated_tests.js
+++ b/frontend/test/__support__/integrated_tests.js
@@ -55,18 +55,8 @@ let simulateOfflineMode = false;
 let apiRequestCompletedCallback = null;
 let skippedApiRequests = [];
 
-// These i18n settings are same is beginning of app.js
-
-// make the i18n function "t" global so we don't have to import it in basically every file
-import { t, jt } from "c-3po";
-global.t = t;
-global.jt = jt;
-
-// set the locale before loading anything else
-import { setLocalization } from "metabase/lib/i18n";
-if (window.MetabaseLocalization) {
-  setLocalization(window.MetabaseLocalization);
-}
+// load files that are loaded at the top if app.js
+import "metabase/lib/i18n";
 
 const warnAboutCreatingStoreBeforeLogin = () => {
   if (!loginSession && hasStartedCreatingStore) {


### PR DESCRIPTION
It turns out ES modules are hoisted such that dependencies are loaded and executed before the dependent module, so `setLocalization` was not getting called before attempting to translate strings defined statically in various modules. This just moves the call to `setLocalization` into `metabase/lib/i18n`, and couple other bits of cleanup.

Resolves #8209