### PR TITLE
Consolidate some strings

### DIFF
--- a/frontend/src/metabase/containers/UserCollectionList.jsx
+++ b/frontend/src/metabase/containers/UserCollectionList.jsx
@@ -23,7 +23,7 @@ const UserCollectionList = () => (
       <BrowserCrumbs
         crumbs={[
           { title: t`Our analytics`, to: Urls.collection() },
-          { title: t`Everyone else’s personal collections` },
+          { title: t`Everyone else's personal collections` },
         ]}
       />
     </Box>

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -632,9 +632,9 @@
   ;; You also can't archive a Personal Collection
   (when (api/column-will-change? :archived collection-before-updates collection-updates)
     (throw
-     (ex-info (tru "You cannot archive a Personal Collection!")
+     (ex-info (tru "You cannot archive a Personal Collection.")
        {:status-code 400
-        :errors      {:archived (tru "You cannot archive a Personal Collection!")}}))))
+        :errors      {:archived (tru "You cannot archive a Personal Collection.")}}))))
 
 (s/defn ^:private maybe-archive-or-unarchive!
   "If `:archived` specified in the updates map, archive/unarchive as needed."

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -147,7 +147,7 @@
           (db/simple-insert! Setting :key settings-last-updated-key, :value current-timestamp-as-string-honeysql)
           (catch java.sql.SQLException e
             ;; go ahead and log the Exception anyway on the off chance that it *wasn't* just a race condition issue
-            (log/error (tru "Error inserting new Setting:") (with-out-str (jdbc/print-sql-exception-chain e)))))))
+            (log/error (tru "Error inserting a new Setting:") (with-out-str (jdbc/print-sql-exception-chain e)))))))
   ;; Now that we updated the value in the DB, go ahead and update our cached value as well, because we know about the
   ;; changes
   (swap! cache assoc settings-last-updated-key (db/select-one-field :value Setting :key settings-last-updated-key)))


### PR DESCRIPTION
Address 2 out of the 3 comments in https://github.com/metabase/metabase/issues/8194:
- [this one](https://github.com/metabase/metabase/issues/8194#issuecomment-409981186)
- and [this one](https://github.com/metabase/metabase/issues/8194#issuecomment-409987742)

I couldn't figure out what need to be done to address [the problem in the initial issue description](https://github.com/metabase/metabase/issues/8194#issue-346966762): those strings are identical, so I guess the problem is that they're somehow being put into the pot file twice or something? 