### PR TITLE
Metabot needs to include `collection_id` when pulling cards

### DIFF
--- a/src/metabase/metabot.clj
+++ b/src/metabase/metabot.clj
@@ -206,7 +206,7 @@
   "Implementation of the `metabot list cards` command."
   [& _]
   (let [cards (with-metabot-permissions
-                (filterv mi/can-read? (db/select [Card :id :name :dataset_query], {:order-by [[:id :desc]], :limit 20})))]
+                (filterv mi/can-read? (db/select [Card :id :name :dataset_query :collection_id], {:order-by [[:id :desc]], :limit 20})))]
     (tru "Here''s your {0} most recent cards:\n{1}" (count cards) (format-cards cards))))
 
 (defn- card-with-name [card-name]

--- a/test/metabase/metabot_test.clj
+++ b/test/metabase/metabot_test.clj
@@ -1,7 +1,9 @@
 (ns metabase.metabot-test
   (:require [expectations :refer :all]
             [metabase.metabot :as metabot]
-            [metabase.util.date :as du]))
+            [metabase.models.card :refer [Card]]
+            [metabase.util.date :as du]
+            [toucan.util.test :as tt]))
 
 ;; test that if we're not the MetaBot based on Settings, our function to check is working correctly
 (expect
@@ -35,3 +37,10 @@
     (#'metabot/metabot-instance-last-checkin (#'metabot/current-timestamp-from-db))
     (#'metabot/check-and-update-instance-status!)
     (#'metabot/am-i-the-metabot?)))
+
+;; Check that `metabot/list` returns a string with card information and passes the permissions checks
+(expect
+  #"2 most recent cards"
+  (tt/with-temp* [Card [_]
+                  Card [_]]
+    (metabot/list)))


### PR DESCRIPTION
The collection_id is needed to check the permissions of the card,
added it an a test that will catch this kind of problem in the future.

Fixes #8210