### PR TITLE
Refactor and externalize driver details strings

### DIFF
--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -54,6 +54,53 @@
    :username-incorrect                 (tru "Looks like your username is incorrect.")
    :username-or-password-incorrect     (tru "Looks like the username or password is incorrect.")})
 
+(def default-host-details
+  "Map of the db host details field, useful for `details-fields` implementations"
+  {:name         "host"
+   :display-name (tru "Host")
+   :default      "localhost"})
+
+(def default-port-details
+  "Map of the db port details field, useful for `details-fields` implementations. Implementations should assoc a
+  `:default` key."
+  {:name         "port"
+   :display-name (tru "Port")
+   :type         :integer})
+
+(def default-user-details
+  "Map of the db user details field, useful for `details-fields` implementations"
+  {:name         "user"
+   :display-name (tru "Database username")
+   :placeholder  (tru "What username do you use to login to the database?")
+   :required     true})
+
+(def default-password-details
+  "Map of the db password details field, useful for `details-fields` implementations"
+  {:name         "password"
+   :display-name (tru "Database password")
+   :type         :password
+   :placeholder  "*******"})
+
+(def default-dbname-details
+  "Map of the db name details field, useful for `details-fields` implementations"
+  {:name         "dbname"
+   :display-name (tru "Database name")
+   :placeholder  (tru "birds_of_the_world")
+   :required     true})
+
+(def default-ssl-details
+  "Map of the db ssl details field, useful for `details-fields` implementations"
+  {:name         "ssl"
+   :display-name (tru "Use a secure connection (SSL)?")
+   :type         :boolean
+   :default      false})
+
+(def default-additional-options-details
+  "Map of the db `additional-options` details field, useful for `details-fields` implementations. Should assoc a
+  `:placeholder` key"
+  {:name         "additional-options"
+   :display-name (tru "Additional JDBC connection string options")})
+
 (defprotocol IDriver
   "Methods that Metabase drivers must implement. Methods marked *OPTIONAL* have default implementations in
    `IDriverDefaultsMixin`. Drivers should also implement `getName` form `clojure.lang.Named`, so we can call `name` on

--- a/src/metabase/driver/bigquery.clj
+++ b/src/metabase/driver/bigquery.clj
@@ -561,23 +561,23 @@
           :describe-database        (u/drop-first-arg describe-database)
           :describe-table           (u/drop-first-arg describe-table)
           :details-fields           (constantly [{:name         "project-id"
-                                                  :display-name "Project ID"
-                                                  :placeholder  "praxis-beacon-120871"
+                                                  :display-name (tru "Project ID")
+                                                  :placeholder  (tru "praxis-beacon-120871")
                                                   :required     true}
                                                  {:name         "dataset-id"
-                                                  :display-name "Dataset ID"
-                                                  :placeholder  "toucanSightings"
+                                                  :display-name (tru "Dataset ID")
+                                                  :placeholder  (tru "toucanSightings")
                                                   :required     true}
                                                  {:name         "client-id"
-                                                  :display-name "Client ID"
+                                                  :display-name (tru "Client ID")
                                                   :placeholder  "1201327674725-y6ferb0feo1hfssr7t40o4aikqll46d4.apps.googleusercontent.com"
                                                   :required     true}
                                                  {:name         "client-secret"
-                                                  :display-name "Client Secret"
+                                                  :display-name (tru "Client Secret")
                                                   :placeholder  "dJNi4utWgMzyIFo2JbnsK6Np"
                                                   :required     true}
                                                  {:name         "auth-code"
-                                                  :display-name "Auth Code"
+                                                  :display-name (tru "Auth Code")
                                                   :placeholder  "4/HSk-KtxkSzTt61j5zcbee2Rmm5JHkRFbL5gD5lgkXek"
                                                   :required     true}])
           :execute-query            (u/drop-first-arg execute-query)

--- a/src/metabase/driver/crate.clj
+++ b/src/metabase/driver/crate.clj
@@ -6,7 +6,8 @@
              [driver :as driver]
              [util :as u]]
             [metabase.driver.crate.util :as crate-util]
-            [metabase.driver.generic-sql :as sql])
+            [metabase.driver.generic-sql :as sql]
+            [puppetlabs.i18n.core :refer [tru]])
   (:import java.sql.DatabaseMetaData))
 
 (def ^:private ^:const column->base-type
@@ -109,7 +110,7 @@
           :date-interval   crate-util/date-interval
           :describe-table  describe-table
           :details-fields  (constantly [{:name         "hosts"
-                                         :display-name "Hosts"
+                                         :display-name (tru "Hosts")
                                          :default      "localhost:5432/"}])
           :features        (comp (u/rpartial disj :foreign-keys) sql/features)
           :current-db-time (driver/make-current-db-time-fn crate-db-time-query crate-date-formatters)})

--- a/src/metabase/driver/druid.clj
+++ b/src/metabase/driver/druid.clj
@@ -7,7 +7,8 @@
              [driver :as driver]
              [util :as u]]
             [metabase.driver.druid.query-processor :as qp]
-            [metabase.util.ssh :as ssh]))
+            [metabase.util.ssh :as ssh]
+            [puppetlabs.i18n.core :refer [tru]]))
 
 ;;; ### Request helper fns
 
@@ -151,13 +152,10 @@
           :describe-database (u/drop-first-arg describe-database)
           :describe-table    (u/drop-first-arg describe-table)
           :details-fields    (constantly (ssh/with-tunnel-config
-                                           [{:name         "host"
-                                             :display-name "Host"
-                                             :default      "http://localhost"}
-                                            {:name         "port"
-                                             :display-name "Broker node port"
-                                             :type         :integer
-                                             :default      8082}]))
+                                           [(assoc driver/default-host-details :default "http://localhost")
+                                            (assoc driver/default-port-details
+                                              :display-name (tru "Broker node port")
+                                              :default      8082)]))
           :execute-query     (fn [_ query] (qp/execute-query do-query-with-cancellation query))
           :features          (constantly #{:basic-aggregations :set-timezone :expression-aggregations})
           :mbql->native      (u/drop-first-arg qp/mbql->native)}))

--- a/src/metabase/driver/googleanalytics.clj
+++ b/src/metabase/driver/googleanalytics.clj
@@ -245,19 +245,19 @@
           :describe-database                 (u/drop-first-arg describe-database)
           :describe-table                    (u/drop-first-arg describe-table)
           :details-fields                    (constantly [{:name         "account-id"
-                                                           :display-name "Google Analytics Account ID"
+                                                           :display-name (tru "Google Analytics Account ID")
                                                            :placeholder  "1234567"
                                                            :required     true}
                                                           {:name         "client-id"
-                                                           :display-name "Client ID"
+                                                           :display-name (tru "Client ID")
                                                            :placeholder  "1201327674725-y6ferb0feo1hfssr7t40o4aikqll46d4.apps.googleusercontent.com"
                                                            :required     true}
                                                           {:name         "client-secret"
-                                                           :display-name "Client Secret"
+                                                           :display-name (tru "Client Secret")
                                                            :placeholder  "dJNi4utWgMzyIFo2JbnsK6Np"
                                                            :required     true}
                                                           {:name         "auth-code"
-                                                           :display-name "Auth Code"
+                                                           :display-name (tru "Auth Code")
                                                            :placeholder  "4/HSk-KtxkSzTt61j5zcbee2Rmm5JHkRFbL5gD5lgkXek"
                                                            :required     true}])
           :execute-query                     (u/drop-first-arg (partial qp/execute-query do-query))

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -218,8 +218,9 @@
   (merge (sql/IDriverSQLDefaultsMixin)
          {:date-interval                     (u/drop-first-arg date-interval)
           :details-fields                    (constantly [{:name         "db"
-                                                           :display-name "Connection String"
-                                                           :placeholder  "file:/Users/camsaul/bird_sightings/toucans"
+                                                           :display-name (tru "Connection String")
+                                                           :placeholder  (str "file:/"
+                                                                              (tru "Users/camsaul/bird_sightings/toucans"))
                                                            :required     true}])
           :humanize-connection-error-message (u/drop-first-arg humanize-connection-error-message)
           :process-query-in-context          (u/drop-first-arg process-query-in-context)

--- a/src/metabase/driver/mongo.clj
+++ b/src/metabase/driver/mongo.clj
@@ -15,6 +15,7 @@
              [command :as cmd]
              [conversion :as conv]
              [db :as mdb]]
+            [puppetlabs.i18n.core :refer [tru]]
             [schema.core :as s]
             [toucan.db :as db])
   (:import com.mongodb.DB))
@@ -173,34 +174,19 @@
           :describe-database                 (u/drop-first-arg describe-database)
           :describe-table                    (u/drop-first-arg describe-table)
           :details-fields                    (constantly (ssh/with-tunnel-config
-                                                           [{:name         "host"
-                                                             :display-name "Host"
-                                                             :default      "localhost"}
-                                                            {:name         "port"
-                                                             :display-name "Port"
-                                                             :type         :integer
-                                                             :default      27017}
-                                                            {:name         "dbname"
-                                                             :display-name "Database name"
-                                                             :placeholder  "carrierPigeonDeliveries"
-                                                             :required     true}
-                                                            {:name         "user"
-                                                             :display-name "Database username"
-                                                             :placeholder  "What username do you use to login to the database?"}
-                                                            {:name         "pass"
-                                                             :display-name "Database password"
-                                                             :type         :password
-                                                             :placeholder  "******"}
+                                                           [driver/default-host-details
+                                                            (assoc driver/default-port-details :default 27017)
+                                                            (assoc driver/default-dbname-details
+                                                              :placeholder  (tru "carrierPigeonDeliveries"))
+                                                            driver/default-user-details
+                                                            (assoc driver/default-password-details :name "pass")
                                                             {:name         "authdb"
-                                                             :display-name "Authentication Database"
-                                                             :placeholder  "Optional database to use when authenticating"}
-                                                            {:name         "ssl"
-                                                             :display-name "Use a secure connection (SSL)?"
-                                                             :type         :boolean
-                                                             :default      false}
-                                                            {:name         "additional-options"
-                                                             :display-name "Additional Mongo connection string options"
-                                                             :placeholder  "readPreference=nearest&replicaSet=test"}]))
+                                                             :display-name (tru "Authentication Database")
+                                                             :placeholder  (tru "Optional database to use when authenticating")}
+                                                            driver/default-ssl-details
+                                                            (assoc driver/default-additional-options-details
+                                                              :display-name (tru "Additional Mongo connection string options")
+                                                              :placeholder  "readPreference=nearest&replicaSet=test")]))
           :execute-query                     (u/drop-first-arg qp/execute-query)
           :features                          (constantly #{:basic-aggregations :nested-fields})
           :humanize-connection-error-message (u/drop-first-arg humanize-connection-error-message)

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -269,28 +269,13 @@
    (sql/IDriverSQLDefaultsMixin)
    {:date-interval                     (u/drop-first-arg date-interval)
     :details-fields                    (constantly (ssh/with-tunnel-config
-                                                     [{:name         "host"
-                                                       :display-name "Host"
-                                                       :default      "localhost"}
-                                                      {:name         "port"
-                                                       :display-name "Port"
-                                                       :type         :integer
-                                                       :default      3306}
-                                                      {:name         "dbname"
-                                                       :display-name "Database name"
-                                                       :placeholder  "birds_of_the_word"
-                                                       :required     true}
-                                                      {:name         "user"
-                                                       :display-name "Database username"
-                                                       :placeholder  "What username do you use to login to the database?"
-                                                       :required     true}
-                                                      {:name         "password"
-                                                       :display-name "Database password"
-                                                       :type         :password
-                                                       :placeholder  "*******"}
-                                                      {:name         "additional-options"
-                                                       :display-name "Additional JDBC connection string options"
-                                                       :placeholder  "tinyInt1isBit=false"}]))
+                                                     [driver/default-host-details
+                                                      (assoc driver/default-port-details :default 3306)
+                                                      driver/default-dbname-details
+                                                      driver/default-user-details
+                                                      driver/default-password-details
+                                                      (assoc driver/default-additional-options-details
+                                                        :placeholder  "tinyInt1isBit=false")]))
     :humanize-connection-error-message (u/drop-first-arg humanize-connection-error-message)
     :current-db-time                   (driver/make-current-db-time-fn mysql-db-time-query mysql-date-formatters)
     :features                          (fn [this]

--- a/src/metabase/driver/oracle.clj
+++ b/src/metabase/driver/oracle.clj
@@ -12,7 +12,8 @@
             [metabase.driver.generic-sql.query-processor :as sqlqp]
             [metabase.util
              [honeysql-extensions :as hx]
-             [ssh :as ssh]]))
+             [ssh :as ssh]]
+            [puppetlabs.i18n.core :refer [tru]]))
 
 (defrecord OracleDriver []
   :load-ns true
@@ -265,27 +266,18 @@
          {:can-connect?                      (u/drop-first-arg can-connect?)
           :date-interval                     (u/drop-first-arg date-interval)
           :details-fields                    (constantly (ssh/with-tunnel-config
-                                                           [{:name         "host"
-                                                             :display-name "Host"
-                                                             :default      "localhost"}
-                                                            {:name         "port"
-                                                             :display-name "Port"
-                                                             :type         :integer
-                                                             :default      1521}
+                                                           [driver/default-host-details
+                                                            (assoc driver/default-port-details :default 1521)
                                                             {:name         "sid"
-                                                             :display-name "Oracle system ID (SID)"
-                                                             :placeholder  "Usually something like ORCL or XE. Optional if using service name"}
+                                                             :display-name (tru "Oracle system ID (SID)")
+                                                             :placeholder  (str (tru "Usually something like ORCL or XE.")
+                                                                                " "
+                                                                                (tru "Optional if using service name"))}
                                                             {:name         "service-name"
-                                                             :display-name "Oracle service name"
-                                                             :placeholder  "Optional TNS alias"}
-                                                            {:name         "user"
-                                                             :display-name "Database username"
-                                                             :placeholder  "What username do you use to login to the database?"
-                                                             :required     true}
-                                                            {:name         "password"
-                                                             :display-name "Database password"
-                                                             :type         :password
-                                                             :placeholder  "*******"}]))
+                                                             :display-name (tru "Oracle service name")
+                                                             :placeholder  (tru "Optional TNS alias")}
+                                                            driver/default-user-details
+                                                            driver/default-password-details]))
           :execute-query                     (comp remove-rownum-column sqlqp/execute-query)
           :humanize-connection-error-message (u/drop-first-arg humanize-connection-error-message)
           :current-db-time                   (driver/make-current-db-time-fn oracle-db-time-query oracle-date-formatters)})

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -251,32 +251,14 @@
           :date-interval                     (u/drop-first-arg date-interval)
           :describe-table                    describe-table
           :details-fields                    (constantly (ssh/with-tunnel-config
-                                                           [{:name         "host"
-                                                             :display-name "Host"
-                                                             :default      "localhost"}
-                                                            {:name         "port"
-                                                             :display-name "Port"
-                                                             :type         :integer
-                                                             :default      5432}
-                                                            {:name         "dbname"
-                                                             :display-name "Database name"
-                                                             :placeholder  "birds_of_the_word"
-                                                             :required     true}
-                                                            {:name         "user"
-                                                             :display-name "Database username"
-                                                             :placeholder  "What username do you use to login to the database?"
-                                                             :required     true}
-                                                            {:name         "password"
-                                                             :display-name "Database password"
-                                                             :type         :password
-                                                             :placeholder  "*******"}
-                                                            {:name         "ssl"
-                                                             :display-name "Use a secure connection (SSL)?"
-                                                             :type         :boolean
-                                                             :default      false}
-                                                            {:name         "additional-options"
-                                                             :display-name "Additional JDBC connection string options"
-                                                             :placeholder  "prepareThreshold=0"}]))
+                                                           [driver/default-host-details
+                                                            (assoc driver/default-port-details :default 5432)
+                                                            driver/default-dbname-details
+                                                            driver/default-user-details
+                                                            driver/default-password-details
+                                                            driver/default-ssl-details
+                                                            (assoc driver/default-additional-options-details
+                                                              :placeholder "prepareThreshold=0")]))
           :humanize-connection-error-message (u/drop-first-arg humanize-connection-error-message)})
 
   sql/ISQLDriver PostgresISQLDriverMixin)

--- a/src/metabase/driver/presto.clj
+++ b/src/metabase/driver/presto.clj
@@ -22,7 +22,8 @@
             [metabase.util
              [date :as du]
              [honeysql-extensions :as hx]
-             [ssh :as ssh]])
+             [ssh :as ssh]]
+            [puppetlabs.i18n.core :refer [tru]])
   (:import java.sql.Time
            java.util.Date
            [metabase.query_processor.interface TimeValue]))
@@ -326,29 +327,14 @@
           :describe-table                    (u/drop-first-arg describe-table)
           :describe-table-fks                (constantly nil) ; no FKs in Presto
           :details-fields                    (constantly (ssh/with-tunnel-config
-                                                           [{:name         "host"
-                                                             :display-name "Host"
-                                                             :default      "localhost"}
-                                                            {:name         "port"
-                                                             :display-name "Port"
-                                                             :type         :integer
-                                                             :default      8080}
-                                                            {:name         "catalog"
-                                                             :display-name "Database name"
-                                                             :placeholder  "hive"
-                                                             :required     true}
-                                                            {:name         "user"
-                                                             :display-name "Database username"
-                                                             :placeholder  "What username do you use to login to the database"
-                                                             :default      "metabase"}
-                                                            {:name         "password"
-                                                             :display-name "Database password"
-                                                             :type         :password
-                                                             :placeholder  "*******"}
-                                                            {:name         "ssl"
-                                                             :display-name "Use a secure connection (SSL)?"
-                                                             :type         :boolean
-                                                             :default      false}]))
+                                                           [driver/default-host-details
+                                                            (assoc driver/default-port-details :default 8080)
+                                                            (assoc driver/default-dbname-details
+                                                              :name         "catalog"
+                                                              :placeholder  (tru "hive"))
+                                                            driver/default-user-details
+                                                            driver/default-password-details
+                                                            driver/default-ssl-details]))
           :execute-query                     (u/drop-first-arg execute-query)
           :features                          (constantly (set/union #{:set-timezone
                                                                       :basic-aggregations

--- a/src/metabase/driver/redshift.clj
+++ b/src/metabase/driver/redshift.clj
@@ -12,7 +12,8 @@
              [postgres :as postgres]]
             [metabase.util
              [honeysql-extensions :as hx]
-             [ssh :as ssh]]))
+             [ssh :as ssh]]
+            [puppetlabs.i18n.core :refer [tru]]))
 
 (defn- connection-details->spec
   "Create a database specification for a redshift database. Opts should include
@@ -82,27 +83,14 @@
          {:date-interval            (u/drop-first-arg date-interval)
           :describe-table-fks       (u/drop-first-arg describe-table-fks)
           :details-fields           (constantly (ssh/with-tunnel-config
-                                                  [{:name         "host"
-                                                    :display-name "Host"
-                                                    :placeholder  "my-cluster-name.abcd1234.us-east-1.redshift.amazonaws.com"
-                                                    :required     true}
-                                                   {:name         "port"
-                                                    :display-name "Port"
-                                                    :type         :integer
-                                                    :default      5439}
-                                                   {:name         "db"
-                                                    :display-name "Database name"
-                                                    :placeholder  "toucan_sightings"
-                                                    :required     true}
-                                                   {:name         "user"
-                                                    :display-name "Database username"
-                                                    :placeholder  "cam"
-                                                    :required     true}
-                                                   {:name         "password"
-                                                    :display-name "Database user password"
-                                                    :type         :password
-                                                    :placeholder  "*******"
-                                                    :required     true}]))
+                                                  [(assoc driver/default-host-details
+                                                     :placeholder (tru "my-cluster-name.abcd1234.us-east-1.redshift.amazonaws.com"))
+                                                   (assoc driver/default-port-details :default 5439)
+                                                   (assoc driver/default-dbname-details
+                                                     :name         "db"
+                                                     :placeholder  (tru "toucan_sightings"))
+                                                   driver/default-user-details
+                                                   driver/default-port-details]))
           :format-custom-field-name (u/drop-first-arg str/lower-case)
           :current-db-time          (driver/make-current-db-time-fn redshift-db-time-query redshift-date-formatters)})
 

--- a/src/metabase/driver/sparksql.clj
+++ b/src/metabase/driver/sparksql.clj
@@ -18,7 +18,7 @@
             [metabase.models.table :refer [Table]]
             [metabase.query-processor.util :as qputil]
             [metabase.util.honeysql-extensions :as hx]
-            [puppetlabs.i18n.core :refer [trs]])
+            [puppetlabs.i18n.core :refer [trs tru]])
   (:import clojure.lang.Reflector
            java.sql.DriverManager
            metabase.query_processor.interface.Field))
@@ -168,26 +168,14 @@
           :describe-database  describe-database
           :describe-table     describe-table
           :describe-table-fks (constantly #{})
-          :details-fields     (constantly [{:name         "host"
-                                            :display-name "Host"
-                                            :default      "localhost"}
-                                           {:name         "port"
-                                            :display-name "Port"
-                                            :type         :integer
-                                            :default      10000}
-                                           {:name         "dbname"
-                                            :display-name "Database name"
-                                            :placeholder  "default"}
-                                           {:name         "user"
-                                            :display-name "Database username"
-                                            :placeholder  "What username do you use to login to the database?"}
-                                           {:name         "password"
-                                            :display-name "Database password"
-                                            :type         :password
-                                            :placeholder  "*******"}
-                                           {:name         "jdbc-flags"
-                                            :display-name "Additional JDBC settings, appended to the connection string"
-                                            :placeholder  ";transportMode=http"}])
+          :details-fields     (constantly [driver/default-host-details
+                                           (assoc driver/default-port-details :default 10000)
+                                           (assoc driver/default-dbname-details :placeholder (tru "default"))
+                                           driver/default-user-details
+                                           driver/default-password-details
+                                           (assoc driver/default-additional-options-details
+                                             :name        "jdbc-flags"
+                                             :placeholder ";transportMode=http")])
           :execute-query      execute-query
           :features           (constantly (set/union #{:basic-aggregations
                                                        :binning

--- a/src/metabase/driver/sqlite.clj
+++ b/src/metabase/driver/sqlite.clj
@@ -15,6 +15,7 @@
             [metabase.util
              [date :as du]
              [honeysql-extensions :as hx]]
+            [puppetlabs.i18n.core :refer [tru]]
             [schema.core :as s])
   (:import [java.sql Time Timestamp]))
 
@@ -178,8 +179,8 @@
    (sql/IDriverSQLDefaultsMixin)
    {:date-interval   (u/drop-first-arg date-interval)
     :details-fields  (constantly [{:name         "db"
-                                   :display-name "Filename"
-                                   :placeholder  "/home/camsaul/toucan_sightings.sqlite 😋"
+                                   :display-name (tru "Filename")
+                                   :placeholder  (tru "/home/camsaul/toucan_sightings.sqlite 😋")
                                    :required     true}])
     :features        (fn [this]
                        (-> (sql/features this)

--- a/src/metabase/driver/sqlserver.clj
+++ b/src/metabase/driver/sqlserver.clj
@@ -9,7 +9,8 @@
             [metabase.driver.generic-sql.query-processor :as sqlqp]
             [metabase.util
              [honeysql-extensions :as hx]
-             [ssh :as ssh]])
+             [ssh :as ssh]]
+            [puppetlabs.i18n.core :refer [tru]])
   (:import java.sql.Time))
 
 (defrecord SQLServerDriver []
@@ -176,38 +177,22 @@
    (sql/IDriverSQLDefaultsMixin)
    {:date-interval  (u/drop-first-arg date-interval)
     :details-fields (constantly (ssh/with-tunnel-config
-                                  [{:name         "host"
-                                    :display-name "Host"
-                                    :default      "localhost"}
-                                   {:name         "port"
-                                    :display-name "Port"
-                                    :placeholder  "1433"
-                                    :type         :integer}
-                                   {:name         "db"
-                                    :display-name "Database name"
-                                    :placeholder  "BirdsOfTheWorld"
-                                    :required     true}
+                                  [driver/default-host-details
+                                   (assoc driver/default-port-details :placeholder "1433")
+                                   (assoc driver/default-dbname-details
+                                     :name         "db"
+                                     :placeholder  (tru "BirdsOfTheWorld"))
                                    {:name         "instance"
-                                    :display-name "Database instance name"
-                                    :placeholder  "N/A"}
+                                    :display-name (tru "Database instance name")
+                                    :placeholder  (tru "N/A")}
                                    {:name         "domain"
-                                    :display-name "Windows domain"
-                                    :placeholder  "N/A"}
-                                   {:name         "user"
-                                    :display-name "Database username"
-                                    :placeholder  "What username do you use to login to the database?"
-                                    :required     true}
-                                   {:name         "password"
-                                    :display-name "Database password"
-                                    :type         :password
-                                    :placeholder  "*******"}
-                                   {:name         "ssl"
-                                    :display-name "Use a secure connection (SSL)?"
-                                    :type         :boolean
-                                    :default      false}
-                                   {:name         "additional-options"
-                                    :display-name "Additional JDBC connection string options"
-                                    :placeholder  "trustServerCertificate=false"}]))
+                                    :display-name (tru "Windows domain")
+                                    :placeholder  (tru "N/A")}
+                                   driver/default-user-details
+                                   driver/default-password-details
+                                   driver/default-ssl-details
+                                   (assoc driver/default-additional-options-details
+                                     :placeholder  "trustServerCertificate=false")]))
     :current-db-time (driver/make-current-db-time-fn sqlserver-db-time-query sqlserver-date-formatters)
     :features        (fn [this]
                        ;; SQLServer LIKE clauses are case-sensitive or not based on whether the collation of the

--- a/src/metabase/driver/vertica.clj
+++ b/src/metabase/driver/vertica.clj
@@ -121,28 +121,13 @@
          {:date-interval     (u/drop-first-arg date-interval)
           :describe-database describe-database
           :details-fields    (constantly (ssh/with-tunnel-config
-                                           [{:name         "host"
-                                             :display-name "Host"
-                                             :default      "localhost"}
-                                            {:name         "port"
-                                             :display-name "Port"
-                                             :type         :integer
-                                             :default      5433}
-                                            {:name         "dbname"
-                                             :display-name "Database name"
-                                             :placeholder  "birds_of_the_word"
-                                             :required     true}
-                                            {:name         "user"
-                                             :display-name "Database username"
-                                             :placeholder  "What username do you use to login to the database?"
-                                             :required     true}
-                                            {:name         "password"
-                                             :display-name "Database password"
-                                             :type         :password
-                                             :placeholder  "*******"}
-                                            {:name         "additional-options"
-                                             :display-name "Additional JDBC connection string options"
-                                             :placeholder  "ConnectionLoadBalance=1"}]))
+                                           [driver/default-host-details
+                                            (assoc driver/default-port-details :default 5433)
+                                            driver/default-dbname-details
+                                            driver/default-user-details
+                                            driver/default-password-details
+                                            (assoc driver/default-additional-options-details
+                                              :placeholder "ConnectionLoadBalance=1")]))
           :current-db-time   (driver/make-current-db-time-fn vertica-db-time-query vertica-date-formatters)})
   sql/ISQLDriver
   (merge (sql/ISQLDriverDefaultsMixin)


### PR DESCRIPTION
There was a lot of duplication in the definition of driver details for
most of the drivers. Some of the strings that needed externalized were
slightly different. This commit moves those common driver detail maps
into `metabase.driver` and each of the drivers just references the
defs from there.
