### PR TITLE
Homepage visual tweaks

### DIFF
--- a/frontend/src/metabase/components/CollectionItem.jsx
+++ b/frontend/src/metabase/components/CollectionItem.jsx
@@ -1,45 +1,87 @@
 import React from "react";
 import { Flex } from "grid-styled";
+
+import Card from "metabase/components/Card";
 import Ellipsified from "metabase/components/Ellipsified";
 import Icon from "metabase/components/Icon";
 import Link from "metabase/components/Link";
 
 import colors from "metabase/lib/colors";
 
-const CollectionItem = ({
-  collection,
-  color,
-  iconName = "all",
-  highlighted,
-  hovered,
-  event,
-}) => (
+const ItemLink = props => (
   <Link
-    to={`collection/${collection.id}`}
+    to={`collection/${props.collection.id}`}
     bg={
-      hovered
+      props.hovered
         ? colors["brand"]
-        : highlighted ? colors["bg-light"] : colors["bg-medium"]
+        : props.highlighted ? colors["bg-light"] : colors["bg-medium"]
     }
-    color={hovered ? "white" : colors["text-medium"]}
+    color={props.hovered ? "white" : colors["text-medium"]}
     className="block rounded relative text-brand-hover"
-    data-metabase-event={event}
+    data-metabase-event={props.event}
     style={{
       borderSize: 1,
-      borderColor: hovered
+      borderColor: props.hovered
         ? colors["brand"]
-        : highlighted ? colors["bg-medium"] : "transparent",
-      borderStyle: hovered ? "solid" : highlighted ? "dotted" : "solid",
+        : props.highlighted ? colors["bg-medium"] : "transparent",
+      borderStyle: props.hovered
+        ? "solid"
+        : props.highlighted ? "dotted" : "solid",
     }}
-    p={[1, 2]}
+    hover={{ color: colors["brand"] }}
   >
-    <Flex align="center" py={1} key={`collection-${collection.id}`}>
-      <Icon name={iconName} mx={1} />
-      <h4 className="overflow-hidden">
-        <Ellipsified>{collection.name}</Ellipsified>
-      </h4>
-    </Flex>
+    {props.children}
   </Link>
 );
+
+const ItemInfo = props => (
+  <h4 className="overflow-hidden">
+    <Ellipsified>{props.collection.name}</Ellipsified>
+  </h4>
+);
+
+const CollectionItem = props => {
+  const icon = (
+    <Icon
+      name={props.iconName}
+      mx={props.asCard ? 0 : 1}
+      color={props.asCard ? "white" : colors["bg-dark"]}
+    />
+  );
+
+  const content = (
+    <Flex
+      align="center"
+      py={props.asCard ? 1 : 2}
+      px={props.asCard ? 1 : 0}
+      key={`collection-${props.collection.id}`}
+    >
+      {props.asCard ? (
+        <Flex
+          align="center"
+          justify="center"
+          w="42px"
+          bg={colors["bg-dark"]}
+          style={{ height: 42, borderRadius: 6, flexShrink: 0 }}
+          mr={1}
+        >
+          {icon}
+        </Flex>
+      ) : (
+        icon
+      )}
+      <ItemInfo {...props} />
+    </Flex>
+  );
+  return (
+    <ItemLink {...props}>
+      {props.asCard ? <Card hoverable>{content}</Card> : content}
+    </ItemLink>
+  );
+};
+
+CollectionItem.defaultProps = {
+  iconName: "all",
+};
 
 export default CollectionItem;

--- a/frontend/src/metabase/components/CollectionList.jsx
+++ b/frontend/src/metabase/components/CollectionList.jsx
@@ -24,6 +24,7 @@ class CollectionList extends React.Component {
       currentCollection,
       isRoot,
       w,
+      asCards,
     } = this.props;
     return (
       <Box className="relative">
@@ -43,6 +44,7 @@ class CollectionList extends React.Component {
                         highlighted={highlighted}
                         hovered={hovered}
                         event={`${analyticsContext};Collection List;Collection click`}
+                        asCard={asCards}
                       />
                     </ItemDragSource>
                   )}
@@ -64,6 +66,7 @@ class CollectionList extends React.Component {
                     highlighted={highlighted}
                     hovered={hovered}
                     event={`${analyticsContext};Collection List;Personal collection click`}
+                    asCard={asCards}
                   />
                 )}
               </CollectionDropTarget>
@@ -82,6 +85,7 @@ class CollectionList extends React.Component {
                   }}
                   iconName="person"
                   event={`${analyticsContext};Collection List;All user collecetions click`}
+                  asCard={asCards}
                 />
               </GridItem>
             )}
@@ -110,6 +114,7 @@ class CollectionList extends React.Component {
 
 CollectionList.defaultProps = {
   w: [1, 1 / 2, 1 / 4],
+  asCards: false,
 };
 
 export default CollectionList;

--- a/frontend/src/metabase/components/ExplorePane.jsx
+++ b/frontend/src/metabase/components/ExplorePane.jsx
@@ -8,6 +8,8 @@ import MetabotLogo from "metabase/components/MetabotLogo";
 import Select, { Option } from "metabase/components/Select";
 import { Grid, GridItem } from "metabase/components/Grid";
 import Card from "metabase/components/Card";
+import { Flex } from "grid-styled";
+import colors from "metabase/lib/colors";
 
 import { t } from "c-3po";
 import _ from "underscore";
@@ -71,7 +73,7 @@ export class ExplorePane extends React.Component {
     }
 
     return (
-      <div className="pt4 pb2">
+      <div>
         {title && (
           <div className="flex align-center mb2">
             {withMetabot && <MetabotLogo />}
@@ -156,15 +158,21 @@ export const ExploreList = ({
 export const ExploreOption = ({ option }: { option: Candidate }) => (
   <Link
     to={option.url}
-    className="flex align-center text-bold no-decoration text-medium text-brand-hover bg-light p2 py3"
+    className="flex align-center no-decoration text-medium text-brand-hover"
   >
-    <Icon
-      name="bolt"
-      size={20}
-      className="flex-no-shrink mr1 justify-center text-gold"
-    />
+    <Flex
+      align="center"
+      justify="center"
+      bg={colors["accent4"]}
+      w="42px"
+      style={{ borderRadius: 6, height: 42 }}
+      mr={1}
+    >
+      <Icon name="bolt" size={20} className="flex-no-shrink text-white" />
+    </Flex>
     <div>
-      <span className="text-normal">{t`A look at your`}</span> {option.title}
+      {t`A look at your`}{" "}
+      <span className="text-bold text-dark">{option.title}</span>
     </div>
   </Link>
 );

--- a/frontend/src/metabase/components/ExplorePane.jsx
+++ b/frontend/src/metabase/components/ExplorePane.jsx
@@ -171,8 +171,7 @@ export const ExploreOption = ({ option }: { option: Candidate }) => (
       <Icon name="bolt" size={20} className="flex-no-shrink text-white" />
     </Flex>
     <div>
-      {t`A look at your`}{" "}
-      <span className="text-bold text-dark">{option.title}</span>
+      {t`A look at your`} <span className="text-bold">{option.title}</span>
     </div>
   </Link>
 );

--- a/frontend/src/metabase/containers/Overworld.jsx
+++ b/frontend/src/metabase/containers/Overworld.jsx
@@ -73,10 +73,11 @@ class Overworld extends React.Component {
     return (
       <Box>
         <Flex px={PAGE_PADDING} pt={3} pb={1} align="center">
-          <MetabotLogo />
+          <Tooltip tooltip={t`Don't tell anyone, but you're my favorite.`}>
+            <MetabotLogo />
+          </Tooltip>
           <Box ml={2}>
             <Subhead>{Greeting.sayHello(user.first_name)}</Subhead>
-            <p className="text-paragraph m0 text-medium">{t`Don't tell anyone, but you're my favorite.`}</p>
           </Box>
         </Flex>
         <CollectionItemsLoader collectionId="root">
@@ -94,24 +95,19 @@ class Overworld extends React.Component {
                       return null;
                     }
                     return (
-                      <Box mx={PAGE_PADDING} mt={2}>
+                      <Box mx={PAGE_PADDING} mt={[1, 3]}>
                         <SectionHeading>
-                          {t`Not sure where to start? Try these x-rays based on your data.`}
+                          {t`Try these x-rays based on your data.`}
                         </SectionHeading>
-                        <Card mt={2} px={3} pb={1}>
+                        <Box>
                           <ExplorePane
                             candidates={candidates}
                             withMetabot={false}
                             title=""
                             gridColumns={[1, 1 / 3]}
-                            asCards={false}
-                            description={
-                              isSample
-                                ? t`Once you connect your own data, I can show you some automatic explorations called x-rays. Here are some examples with sample data.`
-                                : ``
-                            }
+                            asCards={true}
                           />
-                        </Card>
+                        </Box>
                       </Box>
                     );
                   }}
@@ -163,13 +159,14 @@ class Overworld extends React.Component {
 
         <Box px={PAGE_PADDING} my={3}>
           <SectionHeading>{t`Our analytics`}</SectionHeading>
-          <Card p={[1, 2]} mt={2}>
+          <Box p={[1, 2]} mt={2} bg={colors["bg-medium"]}>
             {this.props.collections.filter(
               c => c.id !== user.personal_collection_id,
             ).length > 0 ? (
               <CollectionList
                 collections={this.props.collections}
                 analyticsContext="Homepage"
+                asCards={true}
               />
             ) : (
               <Box className="text-centered">
@@ -201,7 +198,7 @@ class Overworld extends React.Component {
                 </Box>
               </Flex>
             </Link>
-          </Card>
+          </Box>
         </Box>
 
         <DatabaseListLoader>


### PR DESCRIPTION
Things were a bit flat and dull here especially in cases where you didn't have anything pinned, so I wanted to try and make this page feel like a nicer place to land.

<img width="1503" alt="screen shot 2018-08-07 at 10 39 41 am" src="https://user-images.githubusercontent.com/5248953/43792660-37572db4-9a2e-11e8-8a90-3ab8d7bfda53.png">

vs:

<img width="1498" alt="screen shot 2018-08-07 at 10 40 40 am" src="https://user-images.githubusercontent.com/5248953/43792694-593385ea-9a2e-11e8-9071-282ea404ee61.png">
