### PR TITLE
Update `/pulse/test` to accept HybridCards

### DIFF
--- a/src/metabase/api/pulse.clj
+++ b/src/metabase/api/pulse.clj
@@ -180,11 +180,13 @@
 
 (api/defendpoint POST "/test"
   "Test send an unsaved pulse."
-  [:as {{:keys [name cards channels skip_if_empty] :as body} :body}]
-  {name          su/NonBlankString
-   cards         (su/non-empty [pulse/CardRef])
-   channels      (su/non-empty [su/Map])
-   skip_if_empty s/Bool}
+  [:as {{:keys [name cards channels skip_if_empty collection_id collection_position] :as body} :body}]
+  {name                su/NonBlankString
+   cards               (su/non-empty [pulse/CoercibleToCardRef])
+   channels            (su/non-empty [su/Map])
+   skip_if_empty       (s/maybe s/Bool)
+   collection_id       (s/maybe su/IntGreaterThanZero)
+   collection_position (s/maybe su/IntGreaterThanZero)}
   (check-card-read-permissions cards)
   (p/send-pulse! body)
   {:ok true})


### PR DESCRIPTION
The other endpoints in the pulse API have switch over to
accepting/returning HybridCards but `/pulse/test` was still expecting
a `CardRef`. This caused issues when the UI which was using the
results of the GET request in the body of the `/pulse/test` POST.

Fixes #8228
