### PR TITLE
Instrument entity actions

### DIFF
--- a/frontend/src/metabase/entities/collections.js
+++ b/frontend/src/metabase/entities/collections.js
@@ -128,7 +128,7 @@ export const canonicalCollectionId = (
     ? null
     : parseInt(collectionId, 10);
 
-export const getCollectionType = (collectionId, state) =>
+export const getCollectionType = (collectionId: string, state: {}) =>
   collectionId === null || collectionId === "root"
     ? "root"
     : collectionId === getUserPersonalCollectionId(state)

--- a/frontend/src/metabase/entities/collections.js
+++ b/frontend/src/metabase/entities/collections.js
@@ -5,7 +5,11 @@ import colors from "metabase/lib/colors";
 import { CollectionSchema } from "metabase/schema";
 import { createSelector } from "reselect";
 
-import { getUser, getUserDefaultCollectionId } from "metabase/selectors/user";
+import {
+  getUser,
+  getUserDefaultCollectionId,
+  getUserPersonalCollectionId,
+} from "metabase/selectors/user";
 
 import { t } from "c-3po";
 
@@ -106,6 +110,11 @@ const Collections = createEntity({
       },
     ],
   },
+
+  getAnalyticsMetadata(action, object, getState) {
+    const type = object && getCollectionType(object.parent_id, getState());
+    return type && `collection=${type}`;
+  },
 });
 
 export default Collections;
@@ -118,6 +127,13 @@ export const canonicalCollectionId = (
   collectionId == null || collectionId === "root"
     ? null
     : parseInt(collectionId, 10);
+
+export const getCollectionType = (collectionId, state) =>
+  collectionId === null || collectionId === "root"
+    ? "root"
+    : collectionId === getUserPersonalCollectionId(state)
+      ? "personal"
+      : collectionId !== undefined ? "other" : null;
 
 export const ROOT_COLLECTION = {
   id: "root",

--- a/frontend/src/metabase/entities/dashboards.js
+++ b/frontend/src/metabase/entities/dashboards.js
@@ -7,7 +7,10 @@ import { assocIn } from "icepick";
 import { t } from "c-3po";
 
 import { POST, DELETE } from "metabase/lib/api";
-import { canonicalCollectionId } from "metabase/entities/collections";
+import {
+  canonicalCollectionId,
+  getCollectionType,
+} from "metabase/entities/collections";
 
 const FAVORITE_ACTION = `metabase/entities/dashboards/FAVORITE`;
 const UNFAVORITE_ACTION = `metabase/entities/dashboards/UNFAVORITE`;
@@ -108,6 +111,11 @@ const Dashboards = createEntity({
           colelctionId === undefined ? "Collection is required" : null,
       },
     ],
+  },
+
+  getAnalyticsMetadata(action, object, getState) {
+    const type = object && getCollectionType(object.collection_id, getState());
+    return type && `collection=${type}`;
   },
 });
 

--- a/frontend/src/metabase/entities/pulses.js
+++ b/frontend/src/metabase/entities/pulses.js
@@ -2,7 +2,10 @@ import { createEntity, undo } from "metabase/lib/entities";
 import * as Urls from "metabase/lib/urls";
 import { normal } from "metabase/lib/colors";
 
-import { canonicalCollectionId } from "metabase/entities/collections";
+import {
+  canonicalCollectionId,
+  getCollectionType,
+} from "metabase/entities/collections";
 
 const Pulses = createEntity({
   name: "pulses",
@@ -50,6 +53,11 @@ const Pulses = createEntity({
         type: "collection",
       },
     ],
+  },
+
+  getAnalyticsMetadata(action, object, getState) {
+    const type = object && getCollectionType(object.collection_id, getState());
+    return type && `collection=${type}`;
   },
 });
 

--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -6,7 +6,10 @@ import { createEntity, undo } from "metabase/lib/entities";
 import * as Urls from "metabase/lib/urls";
 import colors from "metabase/lib/colors";
 
-import { canonicalCollectionId } from "metabase/entities/collections";
+import {
+  canonicalCollectionId,
+  getCollectionType,
+} from "metabase/entities/collections";
 
 import { POST, DELETE } from "metabase/lib/api";
 
@@ -103,6 +106,11 @@ const Questions = createEntity({
     "result_metadata",
     "metadata_checksum",
   ],
+
+  getAnalyticsMetadata(action, object, getState) {
+    const type = object && getCollectionType(object.collection_id, getState());
+    return type && `collection=${type}`;
+  },
 });
 
 export default Questions;

--- a/frontend/src/metabase/lib/entities.js
+++ b/frontend/src/metabase/lib/entities.js
@@ -17,6 +17,8 @@ import { normalize, denormalize, schema } from "normalizr";
 import { getIn, dissocIn, merge } from "icepick";
 import _ from "underscore";
 
+import MetabaseAnalytics from "metabase/lib/analytics";
+
 // entity defintions export the following properties (`name`, and `api` or `path` are required)
 //
 // name: plural, like "questions" or "dashboards"
@@ -141,6 +143,7 @@ export type Entity = {
   actionShouldInvalidateLists: (action: Action) => boolean,
 
   writableProperties?: string[],
+  getAnalyticsMetadata?: () => any,
 
   HACK_getObjectFromAction: (action: Action) => any,
 };
@@ -581,9 +584,8 @@ export function createEntity(def: EntityDefinition): Entity {
 
   function trackAction(action, object, getState) {
     try {
-      // MetabaseAnalytics.trackEvent
-      console.log(
-        "entity:" + entity.name,
+      MetabaseAnalytics.trackEvent(
+        entity.name,
         action,
         entity.getAnalyticsMetadata &&
           entity.getAnalyticsMetadata(action, object, getState),

--- a/frontend/src/metabase/lib/entities.js
+++ b/frontend/src/metabase/lib/entities.js
@@ -205,6 +205,7 @@ export function createEntity(def: EntityDefinition): Entity {
     create: createThunkAction(
       CREATE_ACTION,
       entityObject => async (dispatch, getState) => {
+        trackAction("create", entityObject, getState);
         const statePath = ["entities", entity.name, "create"];
         try {
           dispatch(setRequestState({ statePath, state: "LOADING" }));
@@ -249,6 +250,7 @@ export function createEntity(def: EntityDefinition): Entity {
         dispatch,
         getState,
       ) => {
+        trackAction("update", updatedObject, getState);
         // save the original object for undo
         const originalObject = entity.selectors.getObject(getState(), {
           entityId: entityObject.id,
@@ -305,6 +307,7 @@ export function createEntity(def: EntityDefinition): Entity {
     delete: createThunkAction(
       DELETE_ACTION,
       entityObject => async (dispatch, getState) => {
+        trackAction("delete", getState);
         const statePath = [...getObjectStatePath(entityObject.id), "delete"];
         try {
           dispatch(setRequestState({ statePath, state: "LOADING" }));
@@ -574,6 +577,16 @@ export function createEntity(def: EntityDefinition): Entity {
 
     entity.wrapEntity = (object, dispatch = null) =>
       new EntityWrapper(object, dispatch);
+  }
+
+  function trackAction(action, object, getState) {
+    // MetabaseAnalytics.trackEvent
+    console.log(
+      "entity:" + entity.name,
+      action,
+      entity.getAnalyticsMetadata &&
+        entity.getAnalyticsMetadata(action, object, getState),
+    );
   }
 
   return entity;

--- a/frontend/src/metabase/lib/entities.js
+++ b/frontend/src/metabase/lib/entities.js
@@ -580,13 +580,17 @@ export function createEntity(def: EntityDefinition): Entity {
   }
 
   function trackAction(action, object, getState) {
-    // MetabaseAnalytics.trackEvent
-    console.log(
-      "entity:" + entity.name,
-      action,
-      entity.getAnalyticsMetadata &&
-        entity.getAnalyticsMetadata(action, object, getState),
-    );
+    try {
+      // MetabaseAnalytics.trackEvent
+      console.log(
+        "entity:" + entity.name,
+        action,
+        entity.getAnalyticsMetadata &&
+          entity.getAnalyticsMetadata(action, object, getState),
+      );
+    } catch (e) {
+      console.warn("trackAction threw an error:", e);
+    }
   }
 
   return entity;

--- a/frontend/src/metabase/lib/entities.js
+++ b/frontend/src/metabase/lib/entities.js
@@ -585,6 +585,7 @@ export function createEntity(def: EntityDefinition): Entity {
   function trackAction(action, object, getState) {
     try {
       MetabaseAnalytics.trackEvent(
+        "entity actions",
         entity.name,
         action,
         entity.getAnalyticsMetadata &&


### PR DESCRIPTION
Adds trackEvent for `create`, `update`, and `delete` actions for entities. Also adds logic to check what type of collection something is (root, personal, other) to help us learn how often things are saved in the top level, personal, and other collections respectively.