### PR TITLE
Don't create binned cards if the driver does not support binning

### DIFF
--- a/resources/automagic_dashboards/comparison/FK.yaml
+++ b/resources/automagic_dashboards/comparison/FK.yaml
@@ -1,0 +1,12 @@
+title: A look at your [[this]]
+transient_title: Here's an overview of your [[this]]
+description: How [[this]] is distributed and more.
+applies_to: GenericTable.FK
+metrics:
+- Count: [count]
+cards:
+  - Distribution:
+      title: How [[this]] is distributed
+      visualization: bar
+      metrics: Count
+      dimensions: this

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -557,8 +557,9 @@
       (u/update-when :visualization #(instantate-visualization % bindings (:metrics context)))))
 
 (defn- valid-breakout-dimension?
-  [{:keys [base_type engine fingerprint]}]
-  (or (not (isa? base_type :type/Number))
+  [{:keys [base_type engine fingerprint aggregation]}]
+  (or (nil? aggregation)
+      (not (isa? base_type :type/Number))
       (and (driver/driver-supports? (driver/engine->driver engine) :binning)
            (-> fingerprint :type :type/Number :min))))
 
@@ -601,7 +602,8 @@
          (map (partial zipmap used-dimensions))
          (filter (fn [bindings]
                    (->> dimensions
-                        (map (comp bindings second))
+                        (map (fn [[_ identifier opts]]
+                               (merge (bindings identifier) opts)))
                         (every? (every-pred valid-breakout-dimension?
                                             (complement (comp cell-dimension? id-or-name)))))))
          (map (fn [bindings]

--- a/test/metabase/driver/mongo_test.clj
+++ b/test/metabase/driver/mongo_test.clj
@@ -2,6 +2,7 @@
   "Tests for Mongo driver."
   (:require [expectations :refer :all]
             [medley.core :as m]
+            [metabase.automagic-dashboards.core :as magic]
             [metabase
              [driver :as driver]
              [query-processor :as qp]
@@ -267,3 +268,11 @@
 (expect
   nil
   (#'mongo/most-common-object-type [[Float 20] [nil 40] [Integer 10] [String 30]]))
+
+
+;; make sure x-rays don't use features that the driver doesn't support
+(expect
+  (->> (magic/automagic-analysis (Field (data/id :venues :price)) {})
+       :ordered_cards
+       (mapcat (comp :breakout :query :dataset_query :card))
+       (not-any? #{[:binning-strategy [:field-id (data/id :venues :price)] "default"]})))

--- a/test/metabase/driver/mongo_test.clj
+++ b/test/metabase/driver/mongo_test.clj
@@ -272,6 +272,7 @@
 
 ;; make sure x-rays don't use features that the driver doesn't support
 (datasets/expect-with-engine :mongo
+  true
   (->> (magic/automagic-analysis (Field (data/id :venues :price)) {})
        :ordered_cards
        (mapcat (comp :breakout :query :dataset_query :card))

--- a/test/metabase/driver/mongo_test.clj
+++ b/test/metabase/driver/mongo_test.clj
@@ -271,7 +271,7 @@
 
 
 ;; make sure x-rays don't use features that the driver doesn't support
-(expect
+(datasets/expect-with-engine :mongo
   (->> (magic/automagic-analysis (Field (data/id :venues :price)) {})
        :ordered_cards
        (mapcat (comp :breakout :query :dataset_query :card))


### PR DESCRIPTION
Currently we generate xray cards that bin numerical values even if our driver does not support it. This results in potentially huge resultset. This patch fixes this by checking for driver features and skipping such cards.