### PR TITLE
Fix issues with remappings and FKs with nested queries

### DIFF
--- a/src/metabase/query_processor/middleware/add_dimension_projections.clj
+++ b/src/metabase/query_processor/middleware/add_dimension_projections.clj
@@ -1,6 +1,8 @@
 (ns metabase.query-processor.middleware.add-dimension-projections
   "Middleware for adding remapping and other dimension related projections"
-  (:require [metabase.query-processor.interface :as i]))
+  (:require [metabase.query-processor
+             [interface :as i]
+             [util :as qputil]]))
 
 (defn- create-remapped-col [col-name remapped-from]
   {:description     nil
@@ -97,11 +99,13 @@
   "Function that will include FK references needed for external remappings. This will then flow through to the resolver
   to get the new tables included in the join."
   [query]
-  (let [remap-col-pairs (create-remap-col-pairs (get-in query [:query :fields]))]
+  (let [remap-col-pairs (create-remap-col-pairs (qputil/get-in-query query [:fields]))]
     (if (seq remap-col-pairs)
-      (-> query
-          (update-in [:query :order-by] #(update-remapped-order-by (into {} remap-col-pairs) %))
-          (update-in [:query :fields] concat (map second remap-col-pairs)))
+      (let [order-by (qputil/get-in-query query [:order-by])
+            fields   (qputil/get-in-query query [:fields])]
+        (-> query
+            (qputil/assoc-in-query [:order-by] (update-remapped-order-by (into {} remap-col-pairs) order-by))
+            (qputil/assoc-in-query [:fields] (concat fields (map second remap-col-pairs)))))
       query)))
 
 (defn- remap-results

--- a/src/metabase/query_processor/middleware/resolve.clj
+++ b/src/metabase/query_processor/middleware/resolve.clj
@@ -377,24 +377,62 @@
                               ;; the first 30 here
                               :join-alias  (apply str (take 30 (str target-table-name "__via__" source-field-name)))})))))
 
+(defn- create-fk-id+table-id->table
+  "Create the `fk-id+table-id->table` map used in resolving table names in `resolve-table` calls"
+  [{source-table-id :id :as source-table} joined-tables]
+  (into {[nil source-table-id] source-table}
+        (for [{:keys [source-field table-id join-alias]} joined-tables]
+          {[(:field-id source-field) table-id] {:name join-alias
+                                                :id   table-id}})))
+
+(defn- append-new-fields
+  "Returns a vector fields that have all `existing-fields` and any field in `new-fields` not already found in
+  `existing-fields`"
+  [existing-fields new-fields]
+  (let [existing-field-names (set (map name existing-fields))]
+    (vec (concat existing-fields
+                 (remove (comp existing-field-names name) new-fields)))))
+
+;; Needed as `resolve-tables-in-nested-query` and `resolved-tables` are mutually recursive
+(declare resolve-tables)
+
+(defn- resolve-tables-in-nested-query
+  "This function is pull up a nested query found in `expanded-query-dict` and run it through
+  `resolve-tables`. Unfortunately our work isn't done there. If `expanded-query-dict` has a breakout that refers to a
+  column from the nested query we will need to resolve the fields in that breakout after the nested query has been
+  resolved. More comments in-line that breakout the work for that."
+  [expanded-query-dict]
+  (let [source-query (qputil/get-in-normalized expanded-query-dict [:query :source-query])]
+    ;; No need to try and resolve a nested native query
+    (if (:native source-query)
+      expanded-query-dict
+      (let [ ;; Resolve the nested query as if it were a top level query
+            {nested-q :query :as nested-qd} (resolve-tables (assoc expanded-query-dict :query source-query))
+            nested-source-table             (qputil/get-in-normalized nested-qd [:query :source-table])
+            ;; Build a list of join tables found from the newly resolved nested query
+            nested-joined-tables            (fk-field-ids->joined-tables (:id nested-source-table)
+                                                                         (:fk-field-ids nested-qd))
+            ;; Create the map of fk to table info from the resolved nested query
+            fk-id+table-id->table           (create-fk-id+table-id->table nested-source-table nested-joined-tables)
+            ;; Resolve the top level (original) breakout fields with the join information from the resolved nested query
+            resolved-breakout               (for [breakout (get-in expanded-query-dict [:query :breakout])]
+                                              (resolve-table breakout fk-id+table-id->table))]
+        (assoc-in expanded-query-dict [:query :source-query]
+                  (if (and (contains? nested-q :fields)
+                           (seq resolved-breakout))
+                    (update nested-q :fields append-new-fields resolved-breakout)
+                    nested-q))))))
+
 (defn- resolve-tables
   "Resolve the `Tables` in an EXPANDED-QUERY-DICT."
-  [{:keys [table-ids fk-field-ids], :as expanded-query-dict}]
+  [{:keys [fk-field-ids], :as expanded-query-dict}]
   (let [{source-table-id :id :as source-table} (qputil/get-in-normalized expanded-query-dict [:query :source-table])]
     (if-not source-table-id
       ;; if we have a `source-query`, recurse and resolve tables in that
-      (update-in expanded-query-dict [:query :source-query] (fn [source-query]
-                                                              (if (:native source-query)
-                                                                source-query
-                                                                (:query (resolve-tables (assoc expanded-query-dict
-                                                                                          :query source-query))))))
+      (resolve-tables-in-nested-query expanded-query-dict)
       ;; otherwise we can resolve tables in the (current) top-level
-      (let [table-ids             (conj table-ids source-table-id)
-            joined-tables         (fk-field-ids->joined-tables source-table-id fk-field-ids)
-            fk-id+table-id->table (into {[nil source-table-id] source-table}
-                                        (for [{:keys [source-field table-id join-alias]} joined-tables]
-                                          {[(:field-id source-field) table-id] {:name join-alias
-                                                                                :id   table-id}}))]
+      (let [joined-tables         (fk-field-ids->joined-tables source-table-id fk-field-ids)
+            fk-id+table-id->table (create-fk-id+table-id->table source-table joined-tables)]
         (as-> expanded-query-dict <>
           (assoc-in <> [:query :join-tables]  joined-tables)
           (walk/postwalk #(resolve-table % fk-id+table-id->table) <>))))))

--- a/test/metabase/query_processor/util_test.clj
+++ b/test/metabase/query_processor/util_test.clj
@@ -207,3 +207,50 @@
   (qputil/postwalk-collect set?
                            identity
                            test-tree))
+
+(def ^:private test-inner-map
+  {:test {:value 10}})
+
+;; get-in-query should work for a nested query
+(expect
+  10
+  (qputil/get-in-query {:query {:source-query test-inner-map}} [:test :value]))
+
+;; Not currently supported, but get-in-query should work for a double nested query
+(expect
+  10
+  (qputil/get-in-query {:query {:source-query {:source-query test-inner-map}}} [:test :value]))
+
+;; get-in-query should also work with non-nested queries
+(expect
+  10
+  (qputil/get-in-query {:query test-inner-map} [:test :value]))
+
+;; Not providing a `not-found` value should just return nil
+(expect
+  nil
+  (qputil/get-in-query {} [:test]))
+
+;; Providing a `not-found` value should return that
+(let [not-found (gensym)]
+  (expect
+    not-found
+    (qputil/get-in-query {} [:test] not-found)))
+
+(def ^:private updated-test-map
+  {:test {:value 11}})
+
+;; assoc-in-query works with a non-nested query
+(expect
+  {:query updated-test-map}
+  (qputil/assoc-in-query {:query test-inner-map} [:test :value] 11))
+
+;; assoc-in-query works with a nested query
+(expect
+  {:query {:source-query updated-test-map}}
+  (qputil/assoc-in-query {:query {:source-query test-inner-map}} [:test :value] 11))
+
+;; Not supported yet, but assoc-in-query should do the right thing with a double nested query
+(expect
+  {:query {:source-query {:source-query updated-test-map}}}
+  (qputil/assoc-in-query {:query {:source-query {:source-query test-inner-map}}} [:test :value] 11))

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -134,9 +134,9 @@
                     :breakout     [[:field-literal (keyword (data/format-name :price)) :type/Integer]]}}))))
 
 ;; Test including a breakout of a nested query column that follows an FK
-(datasets/expect-with-engines (non-timeseries-engines-with-feature :nested-queries)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :nested-queries :foreign-keys)
   {:rows [[1 174] [2 474] [3 78] [4 39]]
-   :cols [{:name "price", :base_type :type/Integer}
+   :cols [{:name "price", :base_type (data/expected-base-type->actual :type/Integer)}
           {:name "count", :base_type :type/Integer}]}
   (rows+cols
     (format-rows-by [int int]
@@ -150,13 +150,13 @@
                     :breakout     [(ql/fk-> (data/id :checkins :venue_id) (data/id :venues :price))]}}))))
 
 ;; Test two breakout columns from the nested query, both following an FK
-(datasets/expect-with-engines (non-timeseries-engines-with-feature :nested-queries)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :nested-queries :foreign-keys)
   {:rows [[2 33.7701 7]
           [2 33.8894 8]
           [2 33.9997 7]
           [3 10.0646 2]
           [4 33.983 2]],
-   :cols [{:name "price", :base_type :type/Integer}
+   :cols [{:name "price", :base_type (data/expected-base-type->actual :type/Integer)}
           {:name "latitude", :base_type :type/Float}
           {:name "count", :base_type :type/Integer}]}
   (rows+cols
@@ -173,13 +173,13 @@
                                    (ql/fk-> (data/id :checkins :venue_id) (data/id :venues :latitude))]}}))))
 
 ;; Test two breakout columns from the nested query, one following an FK the other from the source table
-(datasets/expect-with-engines (non-timeseries-engines-with-feature :nested-queries)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :nested-queries :foreign-keys)
   {:rows  [[1 1 6]
            [1 2 14]
            [1 3 13]
            [1 4 8]
            [1 5 10]],
-   :cols [{:name "price", :base_type :type/Integer}
+   :cols [{:name "price", :base_type (data/expected-base-type->actual :type/Integer)}
           {:name "user_id", :base_type :type/Integer}
           {:name "count", :base_type :type/Integer}]}
   (rows+cols

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -18,6 +18,7 @@
              [segment :refer [Segment]]
              [table :refer [Table]]]
             [metabase.models.query.permissions :as query-perms]
+            [metabase.query-processor.middleware.expand :as ql]
             [metabase.test
              [data :as data]
              [util :as tu]]
@@ -131,6 +132,69 @@
          :query    {:source-query {:source-table (data/id :venues)}
                     :aggregation  [:count]
                     :breakout     [[:field-literal (keyword (data/format-name :price)) :type/Integer]]}}))))
+
+;; Test including a breakout of a nested query column that follows an FK
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :nested-queries)
+  {:rows [[1 174] [2 474] [3 78] [4 39]]
+   :cols [{:name "price", :base_type :type/Integer}
+          {:name "count", :base_type :type/Integer}]}
+  (rows+cols
+    (format-rows-by [int int]
+      (qp/process-query
+        {:database (data/id)
+         :type     :query
+         :query    {:source-query {:source_table (data/id :checkins)
+                                   :filter [">" (data/id :checkins :date) "2014-01-01"]}
+                    :aggregation  [:count]
+                    :order-by     [[:asc (ql/fk-> (data/id :checkins :venue_id) (data/id :venues :price))]]
+                    :breakout     [(ql/fk-> (data/id :checkins :venue_id) (data/id :venues :price))]}}))))
+
+;; Test two breakout columns from the nested query, both following an FK
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :nested-queries)
+  {:rows [[2 33.7701 7]
+          [2 33.8894 8]
+          [2 33.9997 7]
+          [3 10.0646 2]
+          [4 33.983 2]],
+   :cols [{:name "price", :base_type :type/Integer}
+          {:name "latitude", :base_type :type/Float}
+          {:name "count", :base_type :type/Integer}]}
+  (rows+cols
+    (format-rows-by [int (partial u/round-to-decimals 4) int]
+      (qp/process-query
+        {:database (data/id)
+         :type     :query
+         :query    {:source-query {:source_table (data/id :checkins)
+                                   :filter [">" (data/id :checkins :date) "2014-01-01"]}
+                    :filter [["<" (ql/fk-> (data/id :checkins :venue_id) (data/id :venues :latitude)) 34]]
+                    :aggregation  [:count]
+                    :order-by     [[:asc (ql/fk-> (data/id :checkins :venue_id) (data/id :venues :price))]]
+                    :breakout     [(ql/fk-> (data/id :checkins :venue_id) (data/id :venues :price))
+                                   (ql/fk-> (data/id :checkins :venue_id) (data/id :venues :latitude))]}}))))
+
+;; Test two breakout columns from the nested query, one following an FK the other from the source table
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :nested-queries)
+  {:rows  [[1 1 6]
+           [1 2 14]
+           [1 3 13]
+           [1 4 8]
+           [1 5 10]],
+   :cols [{:name "price", :base_type :type/Integer}
+          {:name "user_id", :base_type :type/Integer}
+          {:name "count", :base_type :type/Integer}]}
+  (rows+cols
+    (format-rows-by [int int int]
+      (qp/process-query
+        {:database (data/id)
+         :type     :query
+         :query    {:source-query {:source_table (data/id :checkins)
+                                   :filter [">" (data/id :checkins :date) "2014-01-01"]}
+                    :aggregation  [:count]
+                    :filter       [["=" (ql/fk-> (data/id :checkins :venue_id) (data/id :venues :price)) 1]]
+                    :order-by     [[:asc (ql/fk-> (data/id :checkins :venue_id) (data/id :venues :price))]]
+                    :breakout     [(ql/fk-> (data/id :checkins :venue_id) (data/id :venues :price))
+                                   [:field-literal (keyword (data/format-name :user_id)) :type/Integer]]
+                    :limit        5}}))))
 
 ;; make sure we can do a query with breakout and aggregation using a SQL source query
 (datasets/expect-with-engines (non-timeseries-engines-with-feature :nested-queries)
@@ -285,9 +349,15 @@
                                :order-by     [[[:aggregate-field 0] :descending]]}
                 :aggregation  [[:avg [:field-literal "stddev" :type/Integer]]]}}))
 
+(def ^:private ^:const ^String venues-source-with-category-sql
+  (str "(SELECT \"PUBLIC\".\"VENUES\".\"ID\" AS \"ID\", \"PUBLIC\".\"VENUES\".\"NAME\" AS \"NAME\", "
+       "\"PUBLIC\".\"VENUES\".\"CATEGORY_ID\" AS \"CATEGORY_ID\", \"PUBLIC\".\"VENUES\".\"LATITUDE\" AS \"LATITUDE\", "
+       "\"PUBLIC\".\"VENUES\".\"LONGITUDE\" AS \"LONGITUDE\", \"PUBLIC\".\"VENUES\".\"PRICE\" AS \"PRICE\", \"category_id\" AS \"category_id\" "
+       "FROM \"PUBLIC\".\"VENUES\") \"source\""))
+
 ;; make sure that we handle [field-id [field-literal ...]] forms gracefully, despite that not making any sense
 (expect
-  {:query  (format "SELECT \"category_id\" AS \"category_id\" FROM %s GROUP BY \"category_id\" ORDER BY \"category_id\" ASC LIMIT 10" venues-source-sql)
+  {:query  (format "SELECT \"category_id\" AS \"category_id\" FROM %s GROUP BY \"category_id\" ORDER BY \"category_id\" ASC LIMIT 10" venues-source-with-category-sql)
    :params nil}
   (qp/query->native
     {:database (data/id)

--- a/test/metabase/query_processor_test/remapping_test.clj
+++ b/test/metabase/query_processor_test/remapping_test.clj
@@ -85,7 +85,7 @@
          :data)))
 
 ;; Test that we can remap inside an MBQL nested query
-(datasets/expect-with-engines (non-timeseries-engines-with-feature :foreign-keys)
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :foreign-keys :nested-queries)
   ["Kinaree Thai Bistro" "Ruen Pair Thai Restaurant" "Yamashiro Hollywood" "Spitz Eagle Rock" "The Gumbo Pot"]
   (data/with-data
     (fn []
@@ -96,8 +96,8 @@
     (->> (qp/process-query
            {:database (data/id)
             :type :query
-            :query {:source-query {:source-table (data/id :checkins)
-                                   :order-by [[(data/id :checkins :date) :ascending]]}
+            :query {:source-query {:source-table (data/id :checkins)}
+                    :order-by [[(data/id :checkins :date) :ascending]]
                     :limit 5}})
          rows
          (map last))))

--- a/test/metabase/query_processor_test/remapping_test.clj
+++ b/test/metabase/query_processor_test/remapping_test.clj
@@ -1,13 +1,17 @@
 (ns metabase.query-processor-test.remapping-test
   "Tests for the remapping results"
-  (:require [metabase.query-processor-test :refer :all]
+  (:require [metabase
+             [query-processor :as qp]
+             [query-processor-test :refer :all]]
+            [metabase.models.dimension :refer [Dimension]]
             [metabase.query-processor.middleware
              [add-dimension-projections :as add-dimension-projections]
              [expand :as ql]]
             [metabase.test
              [data :as data]
              [util :as tu]]
-            [metabase.test.data.datasets :as datasets]))
+            [metabase.test.data.datasets :as datasets]
+            [toucan.db :as db]))
 
 (qp-expect-with-all-engines
   {:rows  [["20th Century Cafe" 12 "Café Sweets"]
@@ -79,3 +83,21 @@
          (select-columns (set (map data/format-name ["name" "price" "name_2"])))
          tu/round-fingerprint-cols
          :data)))
+
+;; Test that we can remap inside an MBQL nested query
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :foreign-keys)
+  ["Kinaree Thai Bistro" "Ruen Pair Thai Restaurant" "Yamashiro Hollywood" "Spitz Eagle Rock" "The Gumbo Pot"]
+  (data/with-data
+    (fn []
+      [(db/insert! Dimension {:field_id (data/id :checkins :venue_id)
+                              :name "venue-remapping"
+                              :type :external
+                              :human_readable_field_id (data/id :venues :name)})])
+    (->> (qp/process-query
+           {:database (data/id)
+            :type :query
+            :query {:source-query {:source-table (data/id :checkins)
+                                   :order-by [[(data/id :checkins :date) :ascending]]}
+                    :limit 5}})
+         rows
+         (map last))))


### PR DESCRIPTION
This PR adds support for remappings and breakouts on FK related fields in nested MBQL queries.