### PR TITLE
Update admin checklist curate link

### DIFF
--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -142,7 +142,7 @@
      {:title       (tru "Organize questions")
       :group       (tru "Curate your data")
       :description (tru "Have a lot of saved questions in {0}? Create collections to help manage them and add context." (tru "Metabase"))
-      :link        "/questions/"
+      :link        "/collection/root"
       :completed   has-collections?
       :triggered   (>= num-cards 30)}
      {:title       (tru "Create metrics")


### PR DESCRIPTION
Fixes #8264.

Looks like we forgot that this link pointed to `/questions/.`This changes that to point to the root collection where the user can create new collections and manage things.