### PR TITLE
Fix data browsing long name overflow

### DIFF
--- a/frontend/src/metabase/components/BrowseApp.jsx
+++ b/frontend/src/metabase/components/BrowseApp.jsx
@@ -103,6 +103,7 @@ export class SchemaBrowser extends React.Component {
                         mb={1}
                         hover={{ color: normal.purple }}
                         data-metabase-event={`${ANALYTICS_CONTEXT};Schema Click`}
+                        className="overflow-hidden"
                       >
                         <Card hoverable px={1}>
                           <Flex align="center">
@@ -173,6 +174,7 @@ export class TableBrowser extends React.Component {
                               ml={1}
                               hover={{ color: normal.purple }}
                               data-metabase-event={`${ANALYTICS_CONTEXT};Table Click`}
+                              className="overflow-hidden"
                             >
                               <EntityItem
                                 item={table}


### PR DESCRIPTION
EntityItem already handles ellipsis on long names but since it's used in a flex context alongside the hover items that link to x-rays and the data reference in these cards we need to add `overflow: hidden` on these links so it knows how wide it can be.

<img width="1668" alt="screen shot 2018-08-11 at 8 06 06 pm" src="https://user-images.githubusercontent.com/5248953/43998097-8969ec1e-9da2-11e8-8a5f-847064a4fd74.png">

Fixes #8276 