### PR TITLE
require recipient for test email in pulses

### DIFF
--- a/frontend/src/metabase/lib/pulse.js
+++ b/frontend/src/metabase/lib/pulse.js
@@ -25,7 +25,7 @@ export function channelIsValid(channel, channelSpec) {
       return false;
   }
   if (channelSpec.recipients) {
-    if (!channel.recipients /* || channel.recipients.length === 0*/) {
+    if (!channel.recipients || channel.recipients.length === 0) {
       return false;
     }
   }

--- a/frontend/src/metabase/lib/pulse.js
+++ b/frontend/src/metabase/lib/pulse.js
@@ -25,7 +25,7 @@ export function channelIsValid(channel, channelSpec) {
       return false;
   }
   if (channelSpec.recipients) {
-    if (!channel.recipients || channel.recipients.length === 0) {
+    if (!channel.recipients) {
       return false;
     }
   }

--- a/frontend/src/metabase/pulse/components/PulseEditChannels.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEditChannels.jsx
@@ -18,8 +18,6 @@ import MetabaseAnalytics from "metabase/lib/analytics";
 
 import { channelIsValid, createChannel } from "metabase/lib/pulse";
 
-import cx from "classnames";
-
 export const CHANNEL_ICONS = {
   email: "mail",
   slack: "slack",
@@ -231,7 +229,7 @@ export default class PulseEditChannels extends Component {
           <div className="pt2">
             <ActionButton
               actionFn={this.onTestPulseChannel.bind(this, channel)}
-              className={cx("Button", { disabled: !isValid })}
+              disabled={!isValid}
               normalText={
                 channelSpec.type === "email"
                   ? t`Send email now`

--- a/frontend/src/metabase/pulse/components/PulseEditChannels.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEditChannels.jsx
@@ -229,7 +229,12 @@ export default class PulseEditChannels extends Component {
           <div className="pt2">
             <ActionButton
               actionFn={this.onTestPulseChannel.bind(this, channel)}
-              disabled={!isValid}
+              disabled={
+                !isValid ||
+                /* require at least one email recipient to allow email pulse testing */
+                (channelSpec.type === "email" &&
+                  channel.recipients.length === 0)
+              }
               normalText={
                 channelSpec.type === "email"
                   ? t`Send email now`


### PR DESCRIPTION
Looks like we previously has a check for recipients as part of `channelSpec` but it got commented out for some reason.. Also tweaked things to use native disabled vs applying a class.

Fixes #8229