### PR TITLE
xrays: Ensure stable series ordering

### DIFF
--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -93,6 +93,13 @@
     (saved-metric? metric)        (-> args first Metric :name)
     :else                         (second args)))
 
+(defn metric-op
+  "Return the name op of the metric"
+  [[op & args :as metric]]
+  (if (saved-metric? metric)
+    (-> args first Metric (get-in [:definition :aggregation 0 0]))
+    op))
+
 (defn- join-enumeration
   [xs]
   (if (next xs)
@@ -266,7 +273,7 @@
                                       :type
                                       :type/DateTime
                                       ((juxt :earliest :latest))
-                                      (map t.format/parse))]
+                                      (map date/str->date-time))]
     (condp > (t/in-hours (t/interval earliest latest))
       3               :minute
       (* 24 7)        :hour
@@ -621,7 +628,10 @@
                                                          (zipmap (:metrics card))
                                                          (merge bindings)))
                       (assoc :dataset_query query
-                             :metrics       (map (some-fn :name (comp metric-name :metric)) metrics)
+                             :metrics       (for [metric metrics]
+                                              {:name ((some-fn :name (comp metric-name :metric)) metric)
+                                               :op   (-> metric :metric metric-op)})
+                             :dimensions    (map (comp :name bindings second) dimensions)
                              :score         score))))))))
 
 (defn- matching-rules

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -76,7 +76,8 @@
    :cum-sum   (tru "cumulative sum")})
 
 (def ^:private ^{:arglists '([metric])} saved-metric?
-  (comp #{:metric} qp.util/normalize-token first))
+  (every-pred (comp #{:metric} qp.util/normalize-token first)
+              (complement qp.expand/ga-metric?)))
 
 (def ^:private ^{:arglists '([metric])} custom-expression?
   (comp #{:named} qp.util/normalize-token first))

--- a/src/metabase/automagic_dashboards/populate.clj
+++ b/src/metabase/automagic_dashboards/populate.clj
@@ -100,7 +100,9 @@
   (let [[display visualization-settings] visualization]
     {:display display
      :visualization_settings (-> visualization-settings
-                                 (assoc :graph.series_labels metrics)
+                                 (assoc :graph.series_labels (map :name metrics)
+                                        :graph.metrics       (map :op metrics)
+                                        :graph.dimensions    dimensions)
                                  (merge (colorize card))
                                  (cond->
                                      series_labels (assoc :graph.series_labels series_labels)


### PR DESCRIPTION
Adds `graph.metrics` and `graph.dimensions` to `visualization_settings` for all x-ray generated cards to ensure stable series ordering of multiseries cards.

Fixes #8294 