### PR TITLE
Respect :active flag in related and xrays

### DIFF
--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -646,7 +646,8 @@
   (for [{:keys [id target]} (field/with-targets
                               (db/select Field
                                 :table_id           (u/get-id table)
-                                :fk_target_field_id [:not= nil]))
+                                :fk_target_field_id [:not= nil]
+                                :active             true))
         :when (some-> target mi/can-read?)]
     (-> target field/table (assoc :link id))))
 
@@ -700,7 +701,8 @@
         table->fields (if (instance? (type Table) source)
                         (comp (->> (db/select Field
                                      :table_id        [:in (map u/get-id tables)]
-                                     :visibility_type "normal")
+                                     :visibility_type "normal"
+                                     :active          true)
                                    field/with-targets
                                    (map #(assoc % :engine engine))
                                    (group-by :table_id))
@@ -1184,7 +1186,8 @@
   (when (not-empty tables)
     (let [field-count (->> (db/query {:select   [:table_id [:%count.* "count"]]
                                       :from     [Field]
-                                      :where    [:in :table_id (map u/get-id tables)]
+                                      :where    [:and [:in :table_id (map u/get-id tables)]
+                                                 [:= :active true]]
                                       :group-by [:table_id]})
                            (into {} (map (juxt :table_id :count))))
           list-like?  (->> (when-let [candidates (->> field-count
@@ -1194,6 +1197,7 @@
                              (db/query {:select   [:table_id]
                                         :from     [Field]
                                         :where    [:and [:in :table_id candidates]
+                                                   [:= :active true]
                                                    [:or [:not= :special_type "type/PK"]
                                                     [:= :special_type nil]]]
                                         :group-by [:table_id]
@@ -1202,6 +1206,7 @@
           link-table? (->> (db/query {:select   [:table_id [:%count.* "count"]]
                                       :from     [Field]
                                       :where    [:and [:in :table_id (keys field-count)]
+                                                 [:= :active true]
                                                  [:in :special_type ["type/PK" "type/FK"]]]
                                       :group-by [:table_id]})
                            (filter (fn [{:keys [table_id count]}]
@@ -1232,7 +1237,8 @@
    (let [rules (rules/get-rules ["table"])]
      (->> (apply db/select [Table :id :schema :display_name :entity_type :db_id]
                  (cond-> [:db_id           (u/get-id database)
-                          :visibility_type nil]
+                          :visibility_type nil
+                          :active          true]
                    schema (concat [:schema schema])))
           (filter mi/can-read?)
           enhance-table-stats

--- a/src/metabase/related.clj
+++ b/src/metabase/related.clj
@@ -93,29 +93,31 @@
     (concat best (->> rest shuffle (take max-serendipity-matches)))))
 
 (def ^:private ^{:arglists '([entities])} filter-visible
-  (partial filter (fn [{:keys [archived visibility_type] :as entity}]
+  (partial filter (fn [{:keys [archived visibility_type active] :as entity}]
                     (and (or (nil? visibility_type)
-                             (= (name visibility_type) "normal"))
+                             (= (qp.util/normalize-token visibility_type) :normal))
                          (not archived)
+                         (not= active false)
                          (mi/can-read? entity)))))
 
 (defn- metrics-for-table
   [table]
   (filter-visible (db/select Metric
-                    :table_id  (:id table)
+                    :table_id (:id table)
                     :archived false)))
 
 (defn- segments-for-table
   [table]
   (filter-visible (db/select Segment
-                    :table_id  (:id table)
+                    :table_id (:id table)
                     :archived false)))
 
 (defn- linking-to
   [table]
   (->> (db/select-field :fk_target_field_id Field
-         :table_id (:id table)
-         :fk_target_field_id [:not= nil])
+         :table_id           (:id table)
+         :fk_target_field_id [:not= nil]
+         :active             true)
        (map (comp Table :table_id Field))
        distinct
        filter-visible
@@ -123,9 +125,12 @@
 
 (defn- linked-from
   [table]
-  (if-let [fields (not-empty (db/select-field :id Field :table_id (:id table)))]
+  (if-let [fields (not-empty (db/select-field :id Field
+                               :table_id (:id table)
+                               :active   true))]
     (->> (db/select-field :table_id Field
-           :fk_target_field_id [:in fields])
+           :fk_target_field_id [:in fields]
+           :active             true)
          (map Table)
          filter-visible
          (take max-matches))
@@ -134,10 +139,10 @@
 (defn- cards-sharing-dashboard
   [card]
   (if-let [dashboards (not-empty (db/select-field :dashboard_id DashboardCard
-                                     :card_id (:id card)))]
+                                   :card_id (:id card)))]
     (->> (db/select-field :card_id DashboardCard
            :dashboard_id [:in dashboards]
-           :card_id [:not= (:id card)])
+           :card_id      [:not= (:id card)])
          (map Card)
          filter-visible
          (take max-matches))
@@ -165,8 +170,8 @@
 (defn- recently-modified-dashboards
   []
   (->> (db/select-field :model_id 'Revision
-         :model   "Dashboard"
-         :user_id api/*current-user-id*
+         :model     "Dashboard"
+         :user_id   api/*current-user-id*
          {:order-by [[:timestamp :desc]]})
        (map Dashboard)
        filter-visible
@@ -266,7 +271,8 @@
                          :db_id           (:db_id table)
                          :schema          (:schema table)
                          :id              [:not= (:id table)]
-                         :visibility_type nil)
+                         :visibility_type nil
+                         :active          true)
                        (remove (set (concat linking-to linked-from)))
                        filter-visible
                        interesting-mix)}))
@@ -287,7 +293,8 @@
      :fields   (->> (db/select Field
                       :table_id        (:id table)
                       :id              [:not= (:id field)]
-                      :visibility_type "normal")
+                      :visibility_type "normal"
+                      :active          true)
                     filter-visible
                     interesting-mix)}))
 

--- a/test/metabase/related_test.clj
+++ b/test/metabase/related_test.clj
@@ -1,14 +1,18 @@
 (ns metabase.related-test
-  (:require [expectations :refer :all]
+  (:require [clojure.java.jdbc :as jdbc]
+            [expectations :refer :all]
+            [metabase
+             [related :as r :refer :all]
+             [sync :as sync]]
             [metabase.models
              [card :refer [Card]]
              [collection :refer [Collection]]
              [metric :refer [Metric]]
              [segment :refer [Segment]]]
-            [metabase.related :as r :refer :all]
             [metabase.test.data :as data]
             [metabase.test.data.users :as users]
-            [toucan.util.test :as tt]))
+            [toucan.util.test :as tt]
+            [metabase.test.data.one-off-dbs :as one-off-dbs]))
 
 (expect
   #{[:field-id 1] [:metric 1] [:field-id 2] [:segment 1]}
@@ -128,6 +132,28 @@
    :tables      [(data/id :users)]}
   (->> ((users/user->client :crowberto) :get 200 (format "table/%s/related" (data/id :venues)))
        result-mask))
+
+
+;; We should ignore non-active entities
+
+(defn- exec! [& statements]
+  (doseq [statement statements]
+    (jdbc/execute! one-off-dbs/*conn* [statement])))
+
+(expect
+  [1 0]
+  (one-off-dbs/with-blank-db
+    (exec! "CREATE TABLE blueberries_consumed (num SMALLINT NOT NULL, weight FLOAT)")
+    (one-off-dbs/insert-rows-and-sync! (range 50))
+    (let [count-related-fields (fn []
+                                 (->> ((users/user->client :crowberto) :get 200
+                                       (format "field/%s/related" (data/id :blueberries_consumed :num)))
+                                      :fields
+                                      count))
+          before               (count-related-fields)]
+      (exec! "ALTER TABLE blueberries_consumed DROP COLUMN weight")
+      (sync/sync-database! (data/db))
+      [before (count-related-fields)])))
 
 
 ;; Test transitive similarity:

--- a/test/metabase/related_test.clj
+++ b/test/metabase/related_test.clj
@@ -10,9 +10,9 @@
              [metric :refer [Metric]]
              [segment :refer [Segment]]]
             [metabase.test.data :as data]
-            [metabase.test.data.users :as users]
-            [toucan.util.test :as tt]
-            [metabase.test.data.one-off-dbs :as one-off-dbs]))
+            [metabase.test.data.one-off-dbs :as one-off-dbs]
+            [toucan.util.test :as tt][metabase.test.data.users :as users]
+            [toucan.util.test :as tt]))
 
 (expect
   #{[:field-id 1] [:metric 1] [:field-id 2] [:segment 1]}


### PR DESCRIPTION
Fixes a bug where xrays either directly or via related would dig up tables and fields that were no longer there. 