### PR TITLE
Mongo: correctly unpack nil dates

### DIFF
--- a/src/metabase/driver/mongo/query_processor.clj
+++ b/src/metabase/driver/mongo/query_processor.clj
@@ -424,7 +424,7 @@
   (for [row results]
     (into {} (for [[k v] row]
                {k (if (and (map? v)
-                           (:___date v))
+                           (contains? v :___date))
                     (du/->Timestamp (:___date v) (TimeZone/getDefault))
                     v)}))))
 


### PR DESCRIPTION
Fixes a bug where Mongo qp did not unpack nils, returning {:___date nil} instead.