### PR TITLE
Ensure base type in result metadata

### DIFF
--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -449,7 +449,7 @@
   [values]
   (->> values
        (take 100)                                   ; take up to 100 values
-       (filter (complement nil?))                   ; filter out `nil` values
+       (remove nil?)                                ; filter out `nil` values
        (group-by (comp class->base-type class))     ; now group by their base-type
        (sort-by (comp (partial * -1) count second)) ; sort the map into pairs of [base-type count] with highest count as first pair
        ffirst))                                     ; take the base-type from the first pair

--- a/src/metabase/query_processor/annotate.clj
+++ b/src/metabase/query_processor/annotate.clj
@@ -197,9 +197,8 @@
   "Return a set of bare-bones metadata for a Field named K when all else fails.
    Scan the INITIAL-VALUES of K in an attempt to determine the `base-type`."
   [k & [initial-values]]
-  {:base-type          (if (seq initial-values)
-                         (driver/values->base-type initial-values)
-                         :type/*)
+  {:base-type          (or (driver/values->base-type initial-values)
+                           :type/*)
    :preview-display    true
    :special-type       nil
    :field-name         k

--- a/src/metabase/query_processor/middleware/annotate_and_sort.clj
+++ b/src/metabase/query_processor/middleware/annotate_and_sort.clj
@@ -26,8 +26,9 @@
                         :let [col (nth columns i)]]
                     {:name         (name col)
                      :display_name (humanization/name->human-readable-name (name col))
-                     :base_type    (driver/values->base-type (for [row rows]
-                                                               (nth row i)))}))))
+                     :base_type    (or (driver/values->base-type (for [row rows]
+                                                                   (nth row i)))
+                                       :type/*)}))))
 
 
 ;;; +------------------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/sync/analyze/query_results.clj
+++ b/src/metabase/sync/analyze/query_results.clj
@@ -3,8 +3,7 @@
   results. The current focus of this namespace is around column metadata from the results of a query. Going forward
   this is likely to extend beyond just metadata about columns but also about the query results as a whole and over
   time."
-  (:require [metabase.models.humanization :as humanization]
-            [metabase.query-processor.interface :as qp.i]
+  (:require [metabase.query-processor.interface :as qp.i]
             [metabase.sync.interface :as i]
             [metabase.sync.analyze.classifiers.name :as classify-name]
             [metabase.sync.analyze.fingerprint.fingerprinters :as f]
@@ -58,17 +57,10 @@
      {:base_type :type/Text
       :unit      nil})))
 
-(defn- ensure-base-fields
-  "If base-type isn't set put a default one in there. Similarly just use humanized value of `:name` for `:display_name` if one isn't set."
-  [column]
-  (merge {:base_type    :type/*
-          :display_name (humanization/name->human-readable-name (name (:name column)))}
-         column))
-
 (s/defn results->column-metadata :- ResultsMetadata
   "Return the desired storage format for the column metadata coming back from RESULTS and fingerprint the RESULTS."
   [results]
-  (let [result-metadata (for [col (map ensure-base-fields (:cols results))]
+  (let [result-metadata (for [col (:cols results)]
                           (-> col
                               stored-column-metadata->result-column-metadata
                               (maybe-infer-special-type col)))]

--- a/test/metabase/query_processor/middleware/annotate_and_sort_test.clj
+++ b/test/metabase/query_processor/middleware/annotate_and_sort_test.clj
@@ -11,3 +11,9 @@
                                                                            [3 nil]
                                                                            [4   5]
                                                                            [6   7]]})))
+
+;; make sure that `infer-column-types` defaults `base_type` to `type/*` if there are no non-nil
+;; values when we peek.
+(expect
+  [{:name "a", :display_name "A", :base_type :type/*}]
+  (:cols (#'annotate-and-sort/infer-column-types {:columns [:a], :rows [[nil]]})))


### PR DESCRIPTION
In rare cases where the first 100 values returned are all nils, annotate middleware set the base_type as nil. While the main code-path corrected for this in a subsequent QP there was a bug where the metadata was used before being corrected resulting in a schema violation.
This changes defaulting to type/* in such cases to the point where we determine the type in the first place.

Should fix error mentioned in https://github.com/metabase/metabase/issues/8284#issuecomment-412949166 (but not the main issue).