### PR TITLE
Don't needlessly re-sort results

### DIFF
--- a/src/metabase/query_processor/annotate.clj
+++ b/src/metabase/query_processor/annotate.clj
@@ -378,17 +378,17 @@
   2.  Resolves the Fields returned in the results and adds information like `:columns` and `:cols` expected by the
       frontend."
   [query {:keys [columns rows], :as results}]
-  (let [cols                   (resolve-sort-and-format-columns (:query query)
-                                                                (distinct columns)
-                                                                (for [row (take 10 rows)]
-                                                                  (zipmap columns row)))
-        sorted-columns         (mapv :name cols)
-        sorted-column-ordering (pre-sort-index->post-sort-index columns sorted-columns)]
+  (let [cols           (resolve-sort-and-format-columns (:query query)
+                                                        (distinct columns)
+                                                        (for [row (take 10 rows)]
+                                                          (zipmap columns row)))
+        sorted-columns (mapv :name cols)]
     (assoc results
       :cols    (vec (for [col cols]
                       (update col :name name)))
       :columns (mapv name sorted-columns)
-      :rows    (if (not= sorted-column-ordering (sort sorted-column-ordering))
-                 (for [row rows]
-                   (mapv (partial nth (vec row)) sorted-column-ordering))
+      :rows    (if (not= columns sorted-columns)
+                 (let [sorted-column-ordering (pre-sort-index->post-sort-index columns sorted-columns)]
+                   (for [row rows]
+                     (mapv (partial nth (vec row)) sorted-column-ordering)))
                  rows))))

--- a/src/metabase/query_processor/annotate.clj
+++ b/src/metabase/query_processor/annotate.clj
@@ -366,8 +366,7 @@
 
 (defn- pre-sort-index->post-sort-index
   "Return a  mapping of how columns should be sorted:
-   [2 1 0] means the 1st column should be 3rd, 2nd should remain 2nd, and  3rd
-   should become the 1st."
+   [2 1 0] means the 1st column should be 3rd, 2nd remain 2nd, and 3rd should come 1st."
   [unsorted-columns sorted-columns]
   (let [column-index (zipmap unsorted-columns (range))]
     (map column-index sorted-columns)))
@@ -384,7 +383,6 @@
                                                                 (for [row (take 10 rows)]
                                                                   (zipmap columns row)))
         sorted-columns         (mapv :name cols)
-
         sorted-column-ordering (pre-sort-index->post-sort-index columns sorted-columns)]
     (assoc results
       :cols    (vec (for [col cols]


### PR DESCRIPTION
This short-circuits sorting of resultset columns when the ordering is already correct and generates slightly less garbage otherwise. 