### PR TITLE
Use histograms for fingerprinting numbers

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,6 +28,7 @@
                  [amalloy/ring-gzip-middleware "0.1.3"]               ; Ring middleware to GZIP responses if client can handle it
                  [aleph "0.4.5-alpha2"                                ; Async HTTP library; WebSockets
                   :exclusions [org.clojure/tools.logging]]
+                 [bigml/histogram "4.1.3"]                            ; Histogram data structure
                  [buddy/buddy-core "1.2.0"]                           ; various cryptograhpic functions
                  [buddy/buddy-sign "1.5.0"]                           ; JSON Web Tokens; High-Level message signing library
                  [cheshire "5.7.0"]                                   ; fast JSON encoding (used by Ring JSON middleware)

--- a/src/metabase/sync/interface.clj
+++ b/src/metabase/sync/interface.clj
@@ -98,7 +98,9 @@
   "Schema for fingerprint information for Fields deriving from `:type/Number`."
   {(s/optional-key :min) (s/maybe s/Num)
    (s/optional-key :max) (s/maybe s/Num)
-   (s/optional-key :avg) (s/maybe s/Num)})
+   (s/optional-key :avg) (s/maybe s/Num)
+   (s/optional-key :q1)  (s/maybe s/Num)
+   (s/optional-key :q3)  (s/maybe s/Num)})
 
 (def TextFingerprint
   "Schema for fingerprint information for Fields deriving from `:type/Text`."
@@ -157,7 +159,7 @@
   "Map of fingerprint version to the set of Field base types that need to be upgraded to this version the next
    time we do analysis. The highest-numbered entry is considered the latest version of fingerprints."
   {1 #{:type/*}
-   2 #{:type/DateTime}})
+   2 #{:type/Number :type/DateTime}})
 
 (def latest-fingerprint-version
   "The newest (highest-numbered) version of our Field fingerprints."

--- a/src/metabase/sync/interface.clj
+++ b/src/metabase/sync/interface.clj
@@ -159,7 +159,8 @@
   "Map of fingerprint version to the set of Field base types that need to be upgraded to this version the next
    time we do analysis. The highest-numbered entry is considered the latest version of fingerprints."
   {1 #{:type/*}
-   2 #{:type/Number :type/DateTime}})
+   2 #{:type/Number}
+   3 #{:type/DateTime}})
 
 (def latest-fingerprint-version
   "The newest (highest-numbered) version of our Field fingerprints."

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -331,7 +331,7 @@
     :name         "count"
     :special_type "type/Quantity"
     :fingerprint  {:global {:distinct-count 1},
-                   :type   {:type/Number {:min 100.0, :max 100.0, :avg 100.0}}}}]
+                   :type   {:type/Number {:min 100.0, :max 100.0, :avg 100.0, :q1 100.0, :q3 100.0}}}}]
   (tu/with-non-admin-groups-no-root-collection-perms
     (let [metadata  [{:base_type    :type/Integer
                       :display_name "Count Chocula"
@@ -539,7 +539,7 @@
     :name         "count"
     :special_type "type/Quantity"
     :fingerprint  {:global {:distinct-count 1},
-                   :type   {:type/Number {:min 100.0, :max 100.0, :avg 100.0}}}}]
+                   :type   {:type/Number {:min 100.0, :max 100.0, :avg 100.0, :q1 100.0, :q3 100.0}}}}]
   (let [metadata [{:base_type    :type/Integer
                    :display_name "Count Chocula"
                    :name         "count_chocula"

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -493,7 +493,8 @@
     ;; Now fetch the metadata for this "table"
     (->> card
          u/get-id
-         ((user->client :crowberto) :get 200 (format "table/card__%d/query_metadata"))
+         (format "table/card__%d/query_metadata")
+         ((user->client :crowberto) :get 200)
          (tu/round-fingerprint-cols [:fields])
          (tu/round-all-decimals 2))))
 
@@ -538,7 +539,8 @@
     ;; Now fetch the metadata for this "table"
     (->> card
          u/get-id
-         ((user->client :crowberto) :get 200 (format "table/card__%d/query_metadata"))
+         (format "table/card__%d/query_metadata")
+         ((user->client :crowberto) :get 200)
          (tu/round-fingerprint-cols [:fields])
          (tu/round-all-decimals 2))))
 

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -491,7 +491,11 @@
     ;; run the Card which will populate its result_metadata column
     ((user->client :crowberto) :post 200 (format "card/%d/query" (u/get-id card)))
     ;; Now fetch the metadata for this "table"
-    (tu/round-all-decimals 2 ((user->client :crowberto) :get 200 (format "table/card__%d/query_metadata" (u/get-id card))))))
+    (->> card
+         u/get-id
+         ((user->client :crowberto) :get 200 (format "table/card__%d/query_metadata"))
+         (tu/round-fingerprint-cols [:fields])
+         (tu/round-all-decimals 2))))
 
 ;; Test date dimensions being included with a nested query
 (tt/expect-with-temp [Card [card {:name          "Users"
@@ -532,7 +536,11 @@
     ;; run the Card which will populate its result_metadata column
     ((user->client :crowberto) :post 200 (format "card/%d/query" (u/get-id card)))
     ;; Now fetch the metadata for this "table"
-    (tu/round-all-decimals 2 ((user->client :crowberto) :get 200 (format "table/card__%d/query_metadata" (u/get-id card))))))
+    (->> card
+         u/get-id
+         ((user->client :crowberto) :get 200 (format "table/card__%d/query_metadata"))
+         (tu/round-fingerprint-cols [:fields])
+         (tu/round-all-decimals 2))))
 
 
 ;; make sure GET /api/table/:id/fks just returns nothing for 'virtual' tables

--- a/test/metabase/query_processor/expand_resolve_test.clj
+++ b/test/metabase/query_processor/expand_resolve_test.clj
@@ -98,7 +98,7 @@
                                                    :table-name         "VENUES"
                                                    :values             price-field-values
                                                    :fingerprint        {:global {:distinct-count 4}
-                                                                        :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03}}}})
+                                                                        :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03, :q1 1.46, :q3 2.49}}}})
                               :value       {:value 1
                                             :field (merge field-defaults
                                                           {:field-id           true
@@ -112,17 +112,18 @@
                                                            :table-name         "VENUES"
                                                            :values             price-field-values
                                                            :fingerprint        {:global {:distinct-count 4}
-                                                                                :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03}}}})}}
+                                                                                :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03, :q1 1.46, :q3 2.49}}}})}}
 
 
                :join-tables nil}
     :fk-field-ids #{}
     :table-ids    #{(id :venues)}}]
   (let [expanded-form (ql/expand (wrap-inner-query (query venues
-                                                     (ql/filter (ql/and (ql/> $price 1))))))]
-    (tu/boolean-ids-and-timestamps
-     (mapv obj->map [expanded-form
-                     (resolve' expanded-form)]))))
+                                                          (ql/filter (ql/and (ql/> $price 1))))))]
+    (tu/round-all-decimals 2
+     (tu/boolean-ids-and-timestamps
+      (mapv obj->map [expanded-form
+                      (resolve' expanded-form)])))))
 
 (def category-field-values
   {:values                (defs/field-values defs/test-data-map "categories" "name")
@@ -309,7 +310,7 @@
                                                              :table-name         "VENUES__via__VENUE_ID"
                                                              :values             price-field-values
                                                              :fingerprint        {:global {:distinct-count 4}
-                                                                                  :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03}}}})}]
+                                                                                  :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03, :q1 1.46, :q3 2.49}}}})}]
                    :breakout     [{:field (merge field-defaults
                                                  {:database-type      "DATE"
                                                   :base-type          :type/Date
@@ -337,9 +338,10 @@
   (let [expanded-form (ql/expand (wrap-inner-query (query checkins
                                                           (ql/aggregation (ql/sum $venue_id->venues.price))
                                                           (ql/breakout (ql/datetime-field $checkins.date :day-of-week)))))]
-    (tu/boolean-ids-and-timestamps
-     (mapv obj->map [expanded-form
-                     (resolve' expanded-form)]))))
+    (tu/round-all-decimals 2
+     (tu/boolean-ids-and-timestamps
+      (mapv obj->map [expanded-form
+                      (resolve' expanded-form)])))))
 
 ;; check that a schema invalidation error produces a reasonably-sized exception, < 50 lines.
 ;; previously the entire schema was being dumped which resulted in a ~5200 line exception (#5978)

--- a/test/metabase/query_processor/expand_resolve_test.clj
+++ b/test/metabase/query_processor/expand_resolve_test.clj
@@ -98,7 +98,7 @@
                                                    :table-name         "VENUES"
                                                    :values             price-field-values
                                                    :fingerprint        {:global {:distinct-count 4}
-                                                                        :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03, :q1 1.0, :q3 2.0}}}})
+                                                                        :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03, :q1 1.46, :q3 2.49}}}})
                               :value       {:value 1
                                             :field (merge field-defaults
                                                           {:field-id           true
@@ -310,7 +310,7 @@
                                                              :table-name         "VENUES__via__VENUE_ID"
                                                              :values             price-field-values
                                                              :fingerprint        {:global {:distinct-count 4}
-                                                                                  :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03, :q1 1.0, :q3 2.0}}}})}]
+                                                                                  :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03, :q1 1.46, :q3 2.49}}}})}]
                    :breakout     [{:field (merge field-defaults
                                                  {:database-type      "DATE"
                                                   :base-type          :type/Date

--- a/test/metabase/query_processor/expand_resolve_test.clj
+++ b/test/metabase/query_processor/expand_resolve_test.clj
@@ -98,7 +98,7 @@
                                                    :table-name         "VENUES"
                                                    :values             price-field-values
                                                    :fingerprint        {:global {:distinct-count 4}
-                                                                        :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03, :q1 1.46, :q3 2.49}}}})
+                                                                        :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03, :q1 1.0, :q3 2.0}}}})
                               :value       {:value 1
                                             :field (merge field-defaults
                                                           {:field-id           true
@@ -112,7 +112,7 @@
                                                            :table-name         "VENUES"
                                                            :values             price-field-values
                                                            :fingerprint        {:global {:distinct-count 4}
-                                                                                :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03, :q1 1.46, :q3 2.49}}}})}}
+                                                                                :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03, :q1 1.0, :q3 2.0}}}})}}
 
 
                :join-tables nil}
@@ -310,7 +310,7 @@
                                                              :table-name         "VENUES__via__VENUE_ID"
                                                              :values             price-field-values
                                                              :fingerprint        {:global {:distinct-count 4}
-                                                                                  :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03, :q1 1.46, :q3 2.49}}}})}]
+                                                                                  :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03, :q1 1.0, :q3 2.0}}}})}]
                    :breakout     [{:field (merge field-defaults
                                                  {:database-type      "DATE"
                                                   :base-type          :type/Date

--- a/test/metabase/query_processor/expand_resolve_test.clj
+++ b/test/metabase/query_processor/expand_resolve_test.clj
@@ -112,7 +112,7 @@
                                                            :table-name         "VENUES"
                                                            :values             price-field-values
                                                            :fingerprint        {:global {:distinct-count 4}
-                                                                                :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03, :q1 1.0, :q3 2.0}}}})}}
+                                                                                :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03, :q1 1.46, :q3 2.49}}}})}}
 
 
                :join-tables nil}

--- a/test/metabase/query_processor/middleware/results_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/results_metadata_test.clj
@@ -55,7 +55,10 @@
     (qp/process-query (assoc (native-query "SELECT ID, NAME, PRICE, CATEGORY_ID, LATITUDE, LONGITUDE FROM VENUES")
                         :info {:card-id    (u/get-id card)
                                :query-hash (byte-array 0)}))
-    (round-all-decimals' (card-metadata card))))
+    (-> card
+        card-metadata
+        round-all-decimals'
+        tu/round-fingerprint-cols)))
 
 ;; check that using a Card as your source doesn't overwrite the results metadata...
 (expect
@@ -103,7 +106,8 @@
                          :native   {:query "SELECT ID, NAME, PRICE, CATEGORY_ID, LATITUDE, LONGITUDE FROM VENUES"}})
       (get-in [:data :results_metadata])
       (update :checksum class)
-      round-all-decimals'))
+      round-all-decimals'
+      tu/round-fingerprint-cols))
 
 ;; make sure that a Card where a DateTime column is broken out by year advertises that column as Text, since you can't
 ;; do datetime breakouts on years
@@ -129,4 +133,7 @@
                                   :breakout     [[:datetime-field [:field-id (data/id :checkins :date)] :year]]}
                        :info     {:card-id    (u/get-id card)
                                   :query-hash (byte-array 0)}})
-    (round-all-decimals' (card-metadata card))))
+    (-> card
+        card-metadata
+        round-all-decimals'
+        tu/round-fingerprint-cols)))

--- a/test/metabase/query_processor/middleware/results_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/results_metadata_test.clj
@@ -46,7 +46,7 @@
     :special_type "type/Longitude", :fingerprint  (:longitude mutil/venue-fingerprints)}])
 
 (def ^:private default-card-results-native
-  (update-in default-card-results [3 :fingerprint] assoc :type {:type/Number {:min 2.0, :max 74.0, :avg 29.98}}))
+  (update-in default-card-results [3 :fingerprint] assoc :type {:type/Number {:min 2.0, :max 74.0, :avg 29.98, :q1 6.9, :q3 49.24}}))
 
 ;; test that Card result metadata is saved after running a Card
 (expect
@@ -120,7 +120,7 @@
     :name         "count"
     :special_type "type/Quantity"
     :fingerprint  {:global {:distinct-count 3},
-                   :type {:type/Number {:min 235.0, :max 498.0, :avg 333.33}}}}]
+                   :type {:type/Number {:min 235.0, :max 498.0, :avg 333.33 :q1 243.0, :q3 440.25}}}}]
   (tt/with-temp Card [card]
     (qp/process-query {:database (data/id)
                        :type     :query

--- a/test/metabase/query_processor/middleware/results_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/results_metadata_test.clj
@@ -46,7 +46,7 @@
     :special_type "type/Longitude", :fingerprint  (:longitude mutil/venue-fingerprints)}])
 
 (def ^:private default-card-results-native
-  (update-in default-card-results [3 :fingerprint] assoc :type {:type/Number {:min 2.0, :max 74.0, :avg 29.98, :q1 6.9, :q3 49.24}}))
+  (update-in default-card-results [3 :fingerprint] assoc :type {:type/Number {:min 2.0, :max 74.0, :avg 29.98, :q1 7.0, :q3 49.0}}))
 
 ;; test that Card result metadata is saved after running a Card
 (expect
@@ -120,7 +120,7 @@
     :name         "count"
     :special_type "type/Quantity"
     :fingerprint  {:global {:distinct-count 3},
-                   :type {:type/Number {:min 235.0, :max 498.0, :avg 333.33 :q1 243.0, :q3 440.25}}}}]
+                   :type {:type/Number {:min 235.0, :max 498.0, :avg 333.33 :q1 243.0, :q3 440.0}}}}]
   (tt/with-temp Card [card]
     (qp/process-query {:database (data/id)
                        :type     :query

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -244,7 +244,7 @@
                 :display_name "Venue ID"
                 :fingerprint  (if (data/fks-supported?)
                                 {:global {:distinct-count 100}}
-                                {:global {:distinct-count 100}, :type {:type/Number {:min 1.0, :max 100.0, :avg 51.97, :q1 27.63, :q3 76.13}}})}
+                                {:global {:distinct-count 100}, :type {:type/Number {:min 1.0, :max 100.0, :avg 51.97, :q1 27.7, :q3 76.13}}})}
      :user_id  {:extra_info   (if (data/fks-supported?) {:target_table_id (data/id :users)}
                                   {})
                 :target       (target-field (users-col :id))

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -128,7 +128,7 @@
                            :type   {:type/Text {:percent-json   0.0
                                                 :percent-url    0.0
                                                 :percent-email  0.0
-                                                :average-length 8.333}}}})))
+                                                :average-length 8.33}}}})))
 
 ;; #### users
 (defn users-col
@@ -152,7 +152,7 @@
                                  :type   {:type/Text {:percent-json   0.0
                                                       :percent-url    0.0
                                                       :percent-email  0.0
-                                                      :average-length 13.267}}}}
+                                                      :average-length 13.27}}}}
      :last_login {:special_type nil
                   :base_type    (data/expected-base-type->actual :type/DateTime)
                   :name         (data/format-name "last_login")
@@ -193,22 +193,22 @@
                    :display_name "Category ID"
                    :fingerprint  (if (data/fks-supported?)
                                    {:global {:distinct-count 28}}
-                                   {:global {:distinct-count 28}, :type {:type/Number {:min 2.0, :max 74.0, :avg 29.98}}})}
+                                   {:global {:distinct-count 28}, :type {:type/Number {:min 2.0, :max 74.0, :avg 29.98, :q1 6.9, :q3 49.24}}})}
      :price       {:special_type :type/Category
                    :base_type    (data/expected-base-type->actual :type/Integer)
                    :name         (data/format-name "price")
                    :display_name "Price"
-                   :fingerprint  {:global {:distinct-count 4}, :type {:type/Number {:min 1.0, :max 4.0, :avg 2.03}}}}
+                   :fingerprint  {:global {:distinct-count 4}, :type {:type/Number {:min 1.0, :max 4.0, :avg 2.03, :q1 1.46, :q3 2.49 }}}}
      :longitude   {:special_type :type/Longitude
                    :base_type    (data/expected-base-type->actual :type/Float)
                    :name         (data/format-name "longitude")
-                   :fingerprint  {:global {:distinct-count 84}, :type {:type/Number {:min -165.374, :max -73.953, :avg -115.998}}}
+                   :fingerprint  {:global {:distinct-count 84}, :type {:type/Number {:min -165.37, :max -73.95, :avg -116.0 :q1 -122.41, :q3 -118.26}}}
                    :display_name "Longitude"}
      :latitude    {:special_type :type/Latitude
                    :base_type    (data/expected-base-type->actual :type/Float)
                    :name         (data/format-name "latitude")
                    :display_name "Latitude"
-                   :fingerprint  {:global {:distinct-count 94}, :type {:type/Number {:min 10.065, :max 40.779, :avg 35.506}}}}
+                   :fingerprint  {:global {:distinct-count 94}, :type {:type/Number {:min 10.06, :max 40.78, :avg 35.51, :q1 34.06, :q3 37.77}}}}
      :name        {:special_type :type/Name
                    :base_type    (data/expected-base-type->actual :type/Text)
                    :name         (data/format-name "name")
@@ -244,7 +244,7 @@
                 :display_name "Venue ID"
                 :fingerprint  (if (data/fks-supported?)
                                 {:global {:distinct-count 100}}
-                                {:global {:distinct-count 100}, :type {:type/Number {:min 1.0, :max 100.0, :avg 51.965}}})}
+                                {:global {:distinct-count 100}, :type {:type/Number {:min 1.0, :max 100.0, :avg 51.97}}})}
      :user_id  {:extra_info   (if (data/fks-supported?) {:target_table_id (data/id :users)}
                                   {})
                 :target       (target-field (users-col :id))
@@ -256,7 +256,7 @@
                 :display_name "User ID"
                 :fingerprint  (if (data/fks-supported?)
                                 {:global {:distinct-count 15}}
-                                {:global {:distinct-count 15}, :type {:type/Number {:min 1.0, :max 15.0, :avg 7.929}}})})))
+                                {:global {:distinct-count 15}, :type {:type/Number {:min 1.0, :max 15.0, :avg 7.93}}})})))
 
 
 ;;; #### aggregate columns

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -244,7 +244,7 @@
                 :display_name "Venue ID"
                 :fingerprint  (if (data/fks-supported?)
                                 {:global {:distinct-count 100}}
-                                {:global {:distinct-count 100}, :type {:type/Number {:min 1.0, :max 100.0, :avg 51.97}}})}
+                                {:global {:distinct-count 100}, :type {:type/Number {:min 1.0, :max 100.0, :avg 51.97, :q1 27.70, :q3 76.13}}})}
      :user_id  {:extra_info   (if (data/fks-supported?) {:target_table_id (data/id :users)}
                                   {})
                 :target       (target-field (users-col :id))
@@ -256,7 +256,7 @@
                 :display_name "User ID"
                 :fingerprint  (if (data/fks-supported?)
                                 {:global {:distinct-count 15}}
-                                {:global {:distinct-count 15}, :type {:type/Number {:min 1.0, :max 15.0, :avg 7.93}}})})))
+                                {:global {:distinct-count 15}, :type {:type/Number {:min 1.0, :max 15.0, :avg 7.93 :q1 4.47, :q3 11.25}}})})))
 
 
 ;;; #### aggregate columns

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -244,7 +244,7 @@
                 :display_name "Venue ID"
                 :fingerprint  (if (data/fks-supported?)
                                 {:global {:distinct-count 100}}
-                                {:global {:distinct-count 100}, :type {:type/Number {:min 1.0, :max 100.0, :avg 51.97, :q1 27.7, :q3 76.13}}})}
+                                {:global {:distinct-count 100}, :type {:type/Number {:min 1.0, :max 100.0, :avg 51.97, :q1 27.63, :q3 76.13}}})}
      :user_id  {:extra_info   (if (data/fks-supported?) {:target_table_id (data/id :users)}
                                   {})
                 :target       (target-field (users-col :id))

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -244,7 +244,7 @@
                 :display_name "Venue ID"
                 :fingerprint  (if (data/fks-supported?)
                                 {:global {:distinct-count 100}}
-                                {:global {:distinct-count 100}, :type {:type/Number {:min 1.0, :max 100.0, :avg 51.97, :q1 27.76, :q3 76.13}}})}
+                                {:global {:distinct-count 100}, :type {:type/Number {:min 1.0, :max 100.0, :avg 51.97, :q1 27.7, :q3 76.13}}})}
      :user_id  {:extra_info   (if (data/fks-supported?) {:target_table_id (data/id :users)}
                                   {})
                 :target       (target-field (users-col :id))

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -244,7 +244,7 @@
                 :display_name "Venue ID"
                 :fingerprint  (if (data/fks-supported?)
                                 {:global {:distinct-count 100}}
-                                {:global {:distinct-count 100}, :type {:type/Number {:min 1.0, :max 100.0, :avg 51.97, :q1 27.70, :q3 76.13}}})}
+                                {:global {:distinct-count 100}, :type {:type/Number {:min 1.0, :max 100.0, :avg 51.97, :q1 27.76, :q3 76.13}}})}
      :user_id  {:extra_info   (if (data/fks-supported?) {:target_table_id (data/id :users)}
                                   {})
                 :target       (target-field (users-col :id))

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -193,22 +193,22 @@
                    :display_name "Category ID"
                    :fingerprint  (if (data/fks-supported?)
                                    {:global {:distinct-count 28}}
-                                   {:global {:distinct-count 28}, :type {:type/Number {:min 2.0, :max 74.0, :avg 29.98, :q1 6.9, :q3 49.24}}})}
+                                   {:global {:distinct-count 28}, :type {:type/Number {:min 2.0, :max 74.0, :avg 29.98, :q1 7.0, :q3 49.0}}})}
      :price       {:special_type :type/Category
                    :base_type    (data/expected-base-type->actual :type/Integer)
                    :name         (data/format-name "price")
                    :display_name "Price"
-                   :fingerprint  {:global {:distinct-count 4}, :type {:type/Number {:min 1.0, :max 4.0, :avg 2.03, :q1 1.46, :q3 2.49 }}}}
+                   :fingerprint  {:global {:distinct-count 4}, :type {:type/Number {:min 1.0, :max 4.0, :avg 2.03, :q1 1.0, :q3 2.0 }}}}
      :longitude   {:special_type :type/Longitude
                    :base_type    (data/expected-base-type->actual :type/Float)
                    :name         (data/format-name "longitude")
-                   :fingerprint  {:global {:distinct-count 84}, :type {:type/Number {:min -165.37, :max -73.95, :avg -116.0 :q1 -122.41, :q3 -118.26}}}
+                   :fingerprint  {:global {:distinct-count 84}, :type {:type/Number {:min -165.37, :max -73.95, :avg -116.0 :q1 -122.0, :q3 -118.0}}}
                    :display_name "Longitude"}
      :latitude    {:special_type :type/Latitude
                    :base_type    (data/expected-base-type->actual :type/Float)
                    :name         (data/format-name "latitude")
                    :display_name "Latitude"
-                   :fingerprint  {:global {:distinct-count 94}, :type {:type/Number {:min 10.06, :max 40.78, :avg 35.51, :q1 34.06, :q3 37.77}}}}
+                   :fingerprint  {:global {:distinct-count 94}, :type {:type/Number {:min 10.06, :max 40.78, :avg 35.51, :q1 34.0, :q3 38.0}}}}
      :name        {:special_type :type/Name
                    :base_type    (data/expected-base-type->actual :type/Text)
                    :name         (data/format-name "name")
@@ -244,7 +244,7 @@
                 :display_name "Venue ID"
                 :fingerprint  (if (data/fks-supported?)
                                 {:global {:distinct-count 100}}
-                                {:global {:distinct-count 100}, :type {:type/Number {:min 1.0, :max 100.0, :avg 51.97, :q1 27.7, :q3 76.13}}})}
+                                {:global {:distinct-count 100}, :type {:type/Number {:min 1.0, :max 100.0, :avg 51.97, :q1 28.0, :q3 76.0}}})}
      :user_id  {:extra_info   (if (data/fks-supported?) {:target_table_id (data/id :users)}
                                   {})
                 :target       (target-field (users-col :id))
@@ -256,7 +256,7 @@
                 :display_name "User ID"
                 :fingerprint  (if (data/fks-supported?)
                                 {:global {:distinct-count 15}}
-                                {:global {:distinct-count 15}, :type {:type/Number {:min 1.0, :max 15.0, :avg 7.93 :q1 4.47, :q3 11.25}}})})))
+                                {:global {:distinct-count 15}, :type {:type/Number {:min 1.0, :max 15.0, :avg 7.93 :q1 4.0, :q3 11.0}}})})))
 
 
 ;;; #### aggregate columns

--- a/test/metabase/query_processor_test/aggregation_test.clj
+++ b/test/metabase/query_processor_test/aggregation_test.clj
@@ -253,7 +253,8 @@
          (ql/aggregation (ql/cum-sum $id))
          (ql/breakout $price))
        booleanize-native-form
-       (format-rows-by [int int])))
+       (format-rows-by [int int])
+       tu/round-fingerprint-cols))
 
 
 ;;; ------------------------------------------------ CUMULATIVE COUNT ------------------------------------------------
@@ -319,4 +320,5 @@
          (ql/aggregation (ql/cum-count))
          (ql/breakout $price))
        booleanize-native-form
-       (format-rows-by [int int])))
+       (format-rows-by [int int])
+       tu/round-fingerprint-cols))

--- a/test/metabase/query_processor_test/breakout_test.clj
+++ b/test/metabase/query_processor_test/breakout_test.clj
@@ -35,7 +35,8 @@
          (ql/breakout $user_id)
          (ql/order-by (ql/asc $user_id)))
        booleanize-native-form
-       (format-rows-by [int int])))
+       (format-rows-by [int int])
+       tu/round-fingerprint-cols))
 
 ;;; BREAKOUT w/o AGGREGATION
 ;; This should act as a "distinct values" query and return ordered results
@@ -48,7 +49,8 @@
          (ql/breakout $user_id)
          (ql/limit 10))
        booleanize-native-form
-       (format-rows-by [int])))
+       (format-rows-by [int])
+       tu/round-fingerprint-cols))
 
 
 ;;; "BREAKOUT" - MULTIPLE COLUMNS W/ IMPLICT "ORDER_BY"
@@ -67,7 +69,8 @@
          (ql/breakout $user_id $venue_id)
          (ql/limit 10))
        booleanize-native-form
-       (format-rows-by [int int int])))
+       (format-rows-by [int int int])
+       tu/round-fingerprint-cols))
 
 ;;; "BREAKOUT" - MULTIPLE COLUMNS W/ EXPLICIT "ORDER_BY"
 ;; `breakout` should not implicitly order by any fields specified in `order_by`
@@ -86,7 +89,8 @@
          (ql/order-by (ql/desc $user_id))
          (ql/limit 10))
        booleanize-native-form
-       (format-rows-by [int int int])))
+       (format-rows-by [int int int])
+       tu/round-fingerprint-cols))
 
 (qp-expect-with-all-engines
   {:rows  [[2 8 "Artisan"]
@@ -116,7 +120,8 @@
            (ql/breakout $category_id)
            (ql/limit 5))
          booleanize-native-form
-         (format-rows-by [int int str]))))
+         (format-rows-by [int int str])
+         tu/round-fingerprint-cols)))
 
 (datasets/expect-with-engines (non-timeseries-engines-with-feature :foreign-keys)
   [["Wine Bar" "Thai" "Thai" "Thai" "Thai" "Steakhouse" "Steakhouse" "Steakhouse" "Steakhouse" "Southern"]

--- a/test/metabase/query_processor_test/order_by_test.clj
+++ b/test/metabase/query_processor_test/order_by_test.clj
@@ -4,7 +4,8 @@
             [metabase.query-processor-test :refer :all]
             [metabase.query-processor.middleware.expand :as ql]
             [metabase.test.data :as data]
-            [metabase.test.data.datasets :as datasets :refer [*engine*]]))
+            [metabase.test.data.datasets :as datasets :refer [*engine*]]
+            [metabase.test.util :as tu]))
 
 (expect-with-non-timeseries-dbs
   [[1 12 375]
@@ -44,7 +45,8 @@
          (ql/breakout $price)
          (ql/order-by (ql/asc (ql/aggregate-field 0))))
        booleanize-native-form
-       (format-rows-by [int int])))
+       (format-rows-by [int int])
+       tu/round-fingerprint-cols))
 
 
 ;;; order_by aggregate ["sum" field-id]
@@ -63,7 +65,8 @@
          (ql/breakout $price)
          (ql/order-by (ql/desc (ql/aggregate-field 0))))
        booleanize-native-form
-       (format-rows-by [int int])))
+       (format-rows-by [int int])
+       tu/round-fingerprint-cols))
 
 
 ;;; order_by aggregate ["distinct" field-id]
@@ -82,7 +85,8 @@
          (ql/breakout $price)
          (ql/order-by (ql/asc (ql/aggregate-field 0))))
        booleanize-native-form
-       (format-rows-by [int int])))
+       (format-rows-by [int int])
+       tu/round-fingerprint-cols))
 
 
 ;;; order_by aggregate ["avg" field-id]
@@ -101,7 +105,9 @@
          (ql/breakout $price)
          (ql/order-by (ql/asc (ql/aggregate-field 0))))
        booleanize-native-form
-       :data (format-rows-by [int int])))
+       :data
+       (format-rows-by [int int])
+       tu/round-fingerprint-cols))
 
 ;;; ### order_by aggregate ["stddev" field-id]
 ;; SQRT calculations are always NOT EXACT (normal behavior) so round everything to the nearest int.
@@ -121,4 +127,6 @@
          (ql/breakout $price)
          (ql/order-by (ql/desc (ql/aggregate-field 0))))
        booleanize-native-form
-       :data (format-rows-by [int (comp int math/round)])))
+       :data
+       (format-rows-by [int (comp int math/round)])
+       tu/round-fingerprint-cols))

--- a/test/metabase/query_processor_test/remapping_test.clj
+++ b/test/metabase/query_processor_test/remapping_test.clj
@@ -32,7 +32,8 @@
            (ql/order-by (ql/asc $name))
            (ql/limit 4))
          booleanize-native-form
-         (format-rows-by [str int str]))))
+         (format-rows-by [str int str])
+         tu/round-fingerprint-cols)))
 
 (defn- select-columns
   "Focuses the given resultset to columns that return true when passed

--- a/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
+++ b/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
@@ -17,8 +17,8 @@
    :type {:type/Number {:avg 2.0
                         :min 1.0
                         :max 3.0
-                        :q1 1.0
-                        :q3 3.0}}}
+                        :q1 1.25
+                        :q3 2.75}}}
   (transduce identity
              (fingerprinter (field/map->FieldInstance {:base_type :type/Number}))
              [1.0 2.0 3.0]))

--- a/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
+++ b/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
@@ -16,7 +16,9 @@
   {:global {:distinct-count 3}
    :type {:type/Number {:avg 2.0
                         :min 1.0
-                        :max 3.0}}}
+                        :max 3.0
+                        :q1 1.25
+                        :q3 2.75}}}
   (transduce identity
              (fingerprinter (field/map->FieldInstance {:base_type :type/Number}))
              [1.0 2.0 3.0]))

--- a/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
+++ b/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
@@ -17,8 +17,8 @@
    :type {:type/Number {:avg 2.0
                         :min 1.0
                         :max 3.0
-                        :q1 1.25
-                        :q3 2.75}}}
+                        :q1 1.0
+                        :q3 3.0}}}
   (transduce identity
              (fingerprinter (field/map->FieldInstance {:base_type :type/Number}))
              [1.0 2.0 3.0]))

--- a/test/metabase/sync/analyze/query_results_test.clj
+++ b/test/metabase/sync/analyze/query_results_test.clj
@@ -24,7 +24,7 @@
 
 (defn- name->fingerprints [field-or-metadata]
   (zipmap (map column->name-keyword field-or-metadata)
-          (map :fingerprint field-or-metadata)))
+          (map :fingerprint (tu/round-fingerprint-cols field-or-metadata))))
 
 (defn- name->special-type [field-or-metadata]
   (zipmap (map column->name-keyword field-or-metadata)

--- a/test/metabase/sync/analyze/query_results_test.clj
+++ b/test/metabase/sync/analyze/query_results_test.clj
@@ -72,7 +72,7 @@
 ;; Native queries don't know what the associated Fields are for the results, we need to compute the fingerprints, but
 ;; they should sill be the same except for some of the optimizations we do when we have all the information.
 (expect
-  (update mutil/venue-fingerprints :category_id assoc :type {:type/Number {:min 2.0, :max 74.0, :avg 29.98}})
+  (update mutil/venue-fingerprints :category_id assoc :type {:type/Number {:min 2.0, :max 74.0, :avg 29.98, :q1 6.9, :q3 49.24}})
   (tt/with-temp Card [card {:dataset_query   {:database (data/id)
                                               :type     :native
                                               :native   {:query "select * from venues"}}}]

--- a/test/metabase/sync/analyze/query_results_test.clj
+++ b/test/metabase/sync/analyze/query_results_test.clj
@@ -72,7 +72,7 @@
 ;; Native queries don't know what the associated Fields are for the results, we need to compute the fingerprints, but
 ;; they should sill be the same except for some of the optimizations we do when we have all the information.
 (expect
-  (update mutil/venue-fingerprints :category_id assoc :type {:type/Number {:min 2.0, :max 74.0, :avg 29.98, :q1 6.9, :q3 49.24}})
+  (update mutil/venue-fingerprints :category_id assoc :type {:type/Number {:min 2.0, :max 74.0, :avg 29.98, :q1 7.0, :q3 49.0}})
   (tt/with-temp Card [card {:dataset_query   {:database (data/id)
                                               :type     :native
                                               :native   {:query "select * from venues"}}}]

--- a/test/metabase/test/mock/util.clj
+++ b/test/metabase/test/mock/util.clj
@@ -48,12 +48,12 @@
                                       :percent-email 0.0, :average-length 15.63}}}
    :id          nil
    :price       {:global {:distinct-count 4},
-                 :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03, :q1 1.46, :q3 2.49}}}
+                 :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03, :q1 1.0, :q3 2.0}}}
    :latitude    {:global {:distinct-count 94},
-                 :type   {:type/Number {:min 10.06, :max 40.78, :avg 35.51, :q1 34.06, :q3 37.77}}}
+                 :type   {:type/Number {:min 10.06, :max 40.78, :avg 35.51, :q1 34.0, :q3 38.0}}}
    :category_id {:global {:distinct-count 28}}
    :longitude   {:global {:distinct-count 84},
-                 :type   {:type/Number {:min -165.37, :max -73.95, :avg -116.0 :q1 -122.41, :q3 -118.26}}}})
+                 :type   {:type/Number {:min -165.37, :max -73.95, :avg -116.0 :q1 -122.0, :q3 -118.0}}}})
 
 ;; This is just a fake implementation that just swoops in and returns somewhat-correct looking results for different
 ;; queries we know will get ran as part of sync

--- a/test/metabase/test/mock/util.clj
+++ b/test/metabase/test/mock/util.clj
@@ -48,12 +48,12 @@
                                       :percent-email 0.0, :average-length 15.63}}}
    :id          nil
    :price       {:global {:distinct-count 4},
-                 :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03}}}
+                 :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03, :q1 1.46, :q3 2.49}}}
    :latitude    {:global {:distinct-count 94},
-                 :type   {:type/Number {:min 10.06, :max 40.78, :avg 35.51}}}
+                 :type   {:type/Number {:min 10.06, :max 40.78, :avg 35.51, :q1 34.06, :q3 37.77}}}
    :category_id {:global {:distinct-count 28}}
    :longitude   {:global {:distinct-count 84},
-                 :type   {:type/Number {:min -165.37, :max -73.95, :avg -116.0}}}})
+                 :type   {:type/Number {:min -165.37, :max -73.95, :avg -116.0 :q1 -122.41, :q3 -118.26}}}})
 
 ;; This is just a fake implementation that just swoops in and returns somewhat-correct looking results for different
 ;; queries we know will get ran as part of sync

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -416,7 +416,7 @@
                              [:data :cols]
                              [:cols])]
        (round-fingerprint-cols maybe-data-cols query-results))
-     (map round-fingerprint)))
+     (map round-fingerprint query-results)))
   ([k query-results]
    (update-in query-results k #(map round-fingerprint %))))
 

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -409,11 +409,16 @@
       (update-in-if-present [:fingerprint :type :type/Number] round-fingerprint-fields 0 [:q1 :q3])
       (update-in-if-present [:fingerprint :type :type/Text] round-fingerprint-fields 2 [:percent-json :percent-url :percent-email :average-length])))
 
-(defn round-fingerprint-cols [query-results]
-  (let [maybe-data-cols (if (contains? query-results :data)
-                          [:data :cols]
-                          [:cols])]
-    (update-in query-results maybe-data-cols #(map round-fingerprint %))))
+(defn round-fingerprint-cols
+  ([query-results]
+   (if (map? query-results)
+     (let [maybe-data-cols (if (contains? query-results :data)
+                             [:data :cols]
+                             [:cols])]
+       (round-fingerprint-cols maybe-data-cols query-results))
+     (map round-fingerprint)))
+  ([k query-results]
+   (update-in query-results k #(map round-fingerprint %))))
 
 (defn round-all-decimals
   "Uses `walk/postwalk` to crawl `data`, looking for any double values, will round any it finds"

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -397,14 +397,14 @@
             (update-in-if-present fprint [field] (fn [num]
                                                    (if (integer? num)
                                                      num
-                                                     (u/round-to-decimals 3 num)))))
+                                                     (u/round-to-decimals 2 num)))))
           fprint-type-map fields))
 
 (defn round-fingerprint
-  "Rounds the numerical fields of a fingerprint to 4 decimal places"
+  "Rounds the numerical fields of a fingerprint to 2 decimal places"
   [field]
   (-> field
-      (update-in-if-present [:fingerprint :type :type/Number] round-fingerprint-fields [:min :max :avg])
+      (update-in-if-present [:fingerprint :type :type/Number] round-fingerprint-fields [:min :max :avg :q1 :q3])
       (update-in-if-present [:fingerprint :type :type/Text] round-fingerprint-fields [:percent-json :percent-url :percent-email :average-length])))
 
 (defn round-fingerprint-cols [query-results]


### PR DESCRIPTION
This changes the number fingerprinter to accumulate intermediary results in a histogram. It's ~4x faster than our current implementation for all input sizes. Memory consumption is within margin of error (theoretically is slightly bigger -- about 500B/column and it's pretty well behaved in terms of garbage as most of the work is done in Java-land using mutation and unboxed doubles). 
Aside from the speedup it gives us a lot of interesting statistics for "free". Already implemented are 1st and 3rd quartile (and therefore interquartile range) which enable us to use [Freedman-Diaconis rule to determine optimal bin width](https://en.wikipedia.org/wiki/Freedman%E2%80%93Diaconis_rule) and Tukey's fences (1.5*IQR heuristic) to find outliers. 

Downsides:
* min, max, and avg are no longer exact
* additional dependency on bigml/histogram 