### PR TITLE
Fix bug with MySQL date tz conversion for native queries

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -124,11 +124,8 @@
   (when timezone-id
     (time/unparse (.withZone timezone-offset-formatter (t/time-zone-for-id timezone-id)) date-time)))
 
-(defn- ^String system-timezone->offset-str
-  "Get the system/JVM timezone offset specified at `date-time`. The time is needed here as offsets can change for a
-  given timezone based on the time of year (i.e. daylight savings time)."
-  [date-time]
-  (timezone-id->offset-str (.getID (TimeZone/getDefault)) date-time))
+(def ^:private ^TimeZone utc   (TimeZone/getTimeZone "UTC"))
+(def ^:private utc-hsql-offset (hx/literal "+00:00"))
 
 (s/defn ^:private create-hsql-for-date
   "Returns an HoneySQL structure representing the date for MySQL. If there's a report timezone, we need to ensure the
@@ -138,14 +135,14 @@
   [date-obj :- java.util.Date
    date-literal-or-string :- (s/either s/Str Literal)]
   (let [date-as-dt                 (tcoerce/from-date date-obj)
-        report-timezone-offset-str (timezone-id->offset-str (driver/report-timezone) date-as-dt)
-        system-timezone-offset-str (system-timezone->offset-str date-as-dt)]
+        report-timezone-offset-str (timezone-id->offset-str (driver/report-timezone) date-as-dt)]
     (if (and report-timezone-offset-str
-             (not= report-timezone-offset-str system-timezone-offset-str))
+             (not (.hasSameRules utc (TimeZone/getTimeZone (driver/report-timezone)))))
       ;; if we have a report timezone we want to generate SQL like convert_tz('2004-01-01T12:00:00','-8:00','-2:00')
-      ;; to convert our timestamp from system timezone -> report timezone.
+      ;; to convert our timestamp from the UTC timezone -> report timezone. Note `date-object-literal` is assumed to be
+      ;; in UTC as `du/format-date` is being used which defaults to UTC.
       ;; See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_convert-tz
-      ;; (We're using raw offsets for the JVM timezone instead of the timezone ID because we can't be 100% sure that
+      ;; (We're using raw offsets for the JVM/report timezone instead of the timezone ID because we can't be 100% sure that
       ;; MySQL will accept either of our timezone IDs as valid.)
       ;;
       ;; Note there's a small chance that report timezone will never be set on the MySQL connection, if attempting to
@@ -157,7 +154,7 @@
       ;; was the previous behavior.
       (hsql/call :convert_tz
         date-literal-or-string
-        (hx/literal system-timezone-offset-str)
+        utc-hsql-offset
         (hx/literal report-timezone-offset-str))
       ;; otherwise if we don't have a report timezone we can continue to pass the object as-is, e.g. as a prepared
       ;; statement param
@@ -178,7 +175,7 @@
                             hx/->date
                             (hsql/format :quoting (sql/quote-style (MySQLDriver.)))
                             first)
-                        [(du/format-date :date-hour-minute-second-ms date)])))
+                        [date-str])))
 
 (defmethod sqlqp/->honeysql [MySQLDriver Time]
   [_ time-value]

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -1,7 +1,10 @@
 (ns metabase.driver.mysql-test
   (:require [clj-time.core :as t]
             [expectations :refer :all]
+            [honeysql.core :as hsql]
             [metabase
+             [query-processor :as qp]
+             [query-processor-test :as qpt]
              [sync :as sync]
              [util :as u]]
             [metabase.driver
@@ -15,9 +18,7 @@
             [metabase.test.data
              [datasets :refer [expect-with-engine]]
              [interface :refer [def-database-definition]]]
-            [metabase.test.util :as tu]
             [metabase.util.date :as du]
-            [honeysql.core :as hsql]
             [toucan.db :as db]
             [toucan.util.test :as tt])
   (:import metabase.driver.mysql.MySQLDriver))
@@ -129,3 +130,49 @@
   ["?" (du/->Timestamp #inst "2018-01-03")]
   (tu/with-temporary-setting-values [report-timezone "UTC"]
     (hsql/format (sqlqp/->honeysql (MySQLDriver.) (du/->Timestamp #inst "2018-01-03")))))
+
+;; Most of our tests either deal in UTC (offset 00:00) or America/Los_Angeles timezones (-07:00/-08:00). When dealing
+;; with dates, we will often truncate the timestamp to a date. When we only test with negative timezone offsets, in
+;; combination with this truncation, means we could have a bug and it's hidden by this negative-only offset. As an
+;; example, if we have a datetime like 2018-08-17 00:00:00-08:00, converting to UTC this becomes 2018-08-17
+;; 08:00:00+00:00, which when truncated is still 2018-08-17. That same scenario in Hong Kong is 2018-08-17
+;; 00:00:00+08:00, which then becomes 2018-08-16 16:00:00+00:00 when converted to UTC, which will truncate to
+;; 2018-08-16, instead of 2018-08-17
+;;
+;; This test ensures if our JVM timezone and reporting timezone are Asia/Hong_Kong, we get a correctly formatted date
+(expect-with-engine :mysql
+  ["2018-04-18T00:00:00.000+08:00"]
+  (tu/with-jvm-tz (t/time-zone-for-id "Asia/Hong_Kong")
+    (tu/with-temporary-setting-values [report-timezone "Asia/Hong_Kong"]
+      (qpt/first-row
+        (du/with-effective-timezone (Database (data/id))
+          (qp/process-query
+           {:database (data/id),
+            :type :native,
+            :settings {:report-timezone "UTC"}
+            :native     {:query "SELECT cast({{date}} as date)"
+                         :template_tags {:date {:name "date" :display_name "Date" :type "date" }}}
+            :parameters [{:type "date/single" :target ["variable" ["template-tag" "date"]] :value "2018-04-18"}]}))))))
+
+;; This tests a similar scenario, but one in which the JVM timezone is in Hong Kong, but the report timezone is in Los
+;; Angeles. The Joda Time date parsing functions for the most part default to UTC. Our tests all run with a UTC JVM
+;; timezone. This test catches a bug where we are incorrectly assuming a date is in UTC when the JVM timezone is
+;; different.
+;;
+;; The original bug can be found here: https://github.com/metabase/metabase/issues/8262. The MySQL driver code was
+;; parsing the date using JodateTime's date parser, which is in UTC. The MySQL driver code was assuming that date was
+;; in the system timezone rather than UTC which caused an incorrect conversion and with the trucation, let to it being
+;; off by a day
+(expect-with-engine :mysql
+  ["2018-04-18T00:00:00.000-07:00"]
+  (tu/with-jvm-tz (t/time-zone-for-id "Asia/Hong_Kong")
+    (tu/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
+      (qpt/first-row
+        (du/with-effective-timezone (Database (data/id))
+          (qp/process-query
+            {:database (data/id),
+             :type :native,
+             :settings {:report-timezone "UTC"}
+             :native     {:query "SELECT cast({{date}} as date)"
+                          :template_tags {:date {:name "date" :display_name "Date" :type "date" }}}
+             :parameters [{:type "date/single" :target ["variable" ["template-tag" "date"]] :value "2018-04-18"}]}))))))


### PR DESCRIPTION
The issue was around our usage of `du/format-date` with a built-in
date format (`:date-hour-minute-second-ms`). Those Joda Time date
formatters don't default to the system timezone, which the code
assumed. Instead it defaults to UTC. We have code in the MySQL driver
that works around a MySQL driver bug by converting the date to a
string and then using the MySQL `convert_tz()` function. That code was
converting the date from the system timezone to the report timezone,
rather than UTC, which is what the Joda Time date formatter was
returning.

Fixes #8262