### PR TITLE
Dataset exports should check for nested queries

### DIFF
--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -120,8 +120,9 @@
   [export-format query]
   {query         su/JSONString
    export-format ExportFormat}
-  (let [query (json/parse-string query keyword)]
-    (api/read-check Database (:database query))
+  (let [{:keys [database] :as query} (json/parse-string query keyword)]
+    (when-not (= database database/virtual-id)
+      (api/read-check Database database))
     (as-format export-format
       (qp/process-query-and-save-execution! (-> query
                                                 (dissoc :constraints)

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -7,8 +7,13 @@
             [dk.ative.docjure.spreadsheet :as spreadsheet]
             [expectations :refer :all]
             [medley.core :as m]
-            [metabase.models.query-execution :refer [QueryExecution]]
-            [metabase.query-processor :as qp]
+            [metabase
+             [query-processor :as qp]
+             [util :as u]]
+            [metabase.models
+             [card :refer [Card]]
+             [database :as database]
+             [query-execution :refer [QueryExecution]]]
             [metabase.query-processor.middleware.expand :as ql]
             [metabase.test
              [data :refer :all]
@@ -17,7 +22,8 @@
              [dataset-definitions :as defs]
              [datasets :refer [expect-with-engine]]
              [users :refer :all]]
-            [toucan.db :as db]))
+            [toucan.db :as db]
+            [toucan.util.test :as tt]))
 
 (defn user-details [user]
   (tu/match-$ user
@@ -202,3 +208,16 @@
                 (json/generate-string (wrap-inner-query
                                         (query users))))]
     (take 5 (parse-and-sort-csv result))))
+
+;; Check that we can export the results of a nested query
+(expect
+  16
+  (tt/with-temp Card [card {:dataset_query {:database (id)
+                                            :type :native
+                                            :native {:query "SELECT * FROM USERS;"}}}]
+    (let [result ((user->client :rasta) :post 200 "dataset/csv"
+                  :query (json/generate-string
+                          {:database database/virtual-id
+                           :type :query
+                           :query {:source_table (str "card__" (u/get-id card))}}))]
+      (count (csv/read-csv result)))))


### PR DESCRIPTION
When POSTing to the `/dataset` endoint, there was code that if the
database was our fake database id (used for nested queries) but that
same check wasn't present for the dataset exports. This commit adds
that check and a test that validates it.

Fixes #8256
