### PR TITLE
Show pinning message to admins

### DIFF
--- a/frontend/src/metabase/containers/Overworld.jsx
+++ b/frontend/src/metabase/containers/Overworld.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import _ from "underscore";
 import { Box, Flex } from "grid-styled";
 import { connect } from "react-redux";
-import { t } from "c-3po";
+import { t, jt } from "c-3po";
 
 import CollectionItemsLoader from "metabase/containers/CollectionItemsLoader";
 import CandidateListLoader from "metabase/containers/CandidateListLoader";
@@ -98,17 +98,22 @@ class Overworld extends React.Component {
                     }
                     return (
                       <Box mx={PAGE_PADDING} mt={[1, 3]}>
-                        <SectionHeading>
-                          {t`Try these x-rays based on your data.`}
-                        </SectionHeading>
-                        <Box>
-                          <ExplorePane
-                            candidates={candidates}
-                            withMetabot={false}
-                            title=""
-                            gridColumns={[1, 1 / 3]}
-                            asCards={true}
-                          />
+                        {user.is_superuser && <AdminPinMessage />}
+                        <Box mt={[1, 3]}>
+                          <Flex align="center">
+                            <SectionHeading>
+                              {t`Try these x-rays based on your data.`}
+                            </SectionHeading>
+                          </Flex>
+                          <Box>
+                            <ExplorePane
+                              candidates={candidates}
+                              withMetabot={false}
+                              title=""
+                              gridColumns={[1, 1 / 3]}
+                              asCards={true}
+                            />
+                          </Box>
                         </Box>
                       </Box>
                     );
@@ -264,6 +269,64 @@ class Overworld extends React.Component {
             );
           }}
         </DatabaseListLoader>
+      </Box>
+    );
+  }
+}
+
+class AdminPinMessage extends React.Component {
+  state = {
+    showMessage: false,
+  };
+
+  static storageKey = "mb-admin-homepage-pin-propaganda-hidden";
+
+  componentWillMount = async () => {
+    const isHidden = await window.localStorage.getItem(this.storageKey);
+    this.setState({
+      showMessage: !isHidden,
+    });
+  };
+  dismissPinMessage = async () => {
+    await window.localStorage.setItem(this.storageKey, true);
+    this.setState({
+      showMessage: false,
+    });
+  };
+  render() {
+    const { showMessage } = this.state;
+
+    if (!showMessage) {
+      return null;
+    }
+
+    const link = (
+      <Link className="link" to={Urls.collection()}>{t`Our analytics`}</Link>
+    );
+
+    return (
+      <Box>
+        <SectionHeading>{t`Start here`}</SectionHeading>
+
+        <Flex
+          bg={colors["bg-medium"]}
+          p={2}
+          align="center"
+          style={{ borderRadius: 6 }}
+          className="hover-parent hover--visibility"
+        >
+          <Icon name="dashboard" color={colors["brand"]} size={32} mr={1} />
+          <Box ml={1}>
+            <h3>{t`Your most important dashboards go here`}</h3>
+            <p className="m0 text-medium text-bold">{jt`Pin dashboards in ${link} to have them appear in the space`}</p>
+          </Box>
+          <Icon
+            className="hover-child text-brand-hover cursor-pointer bg-medium"
+            name="close"
+            ml="auto"
+            onClick={() => this.dismissPinMessage()}
+          />
+        </Flex>
       </Box>
     );
   }

--- a/frontend/src/metabase/containers/Overworld.jsx
+++ b/frontend/src/metabase/containers/Overworld.jsx
@@ -317,8 +317,8 @@ class AdminPinMessage extends React.Component {
         >
           <Icon name="dashboard" color={colors["brand"]} size={32} mr={1} />
           <Box ml={1}>
-            <h3>{t`Your most important dashboards go here`}</h3>
-            <p className="m0 text-medium text-bold">{jt`Pin dashboards in ${link} to have them appear in the space`}</p>
+            <h3>{t`Your team's most important dashboards go here`}</h3>
+            <p className="m0 text-medium text-bold">{jt`Pin dashboards in ${link} to have them appear in this space for everyone`}</p>
           </Box>
           <Icon
             className="hover-child text-brand-hover cursor-pointer bg-medium"

--- a/frontend/src/metabase/containers/Overworld.jsx
+++ b/frontend/src/metabase/containers/Overworld.jsx
@@ -274,24 +274,16 @@ class Overworld extends React.Component {
   }
 }
 
+const PIN_MESSAGE_STORAGE_KEY = "mb-admin-homepage-pin-propaganda-hidden";
+
 class AdminPinMessage extends React.Component {
   state = {
-    showMessage: false,
+    showMessage: !window.localStorage.getItem(PIN_MESSAGE_STORAGE_KEY),
   };
 
-  static storageKey = "mb-admin-homepage-pin-propaganda-hidden";
-
-  componentWillMount = async () => {
-    const isHidden = await window.localStorage.getItem(this.storageKey);
-    this.setState({
-      showMessage: !isHidden,
-    });
-  };
-  dismissPinMessage = async () => {
-    await window.localStorage.setItem(this.storageKey, true);
-    this.setState({
-      showMessage: false,
-    });
+  dismissPinMessage = () => {
+    window.localStorage.setItem(PIN_MESSAGE_STORAGE_KEY, "true");
+    this.setState({ showMessage: false });
   };
   render() {
     const { showMessage } = this.state;

--- a/frontend/src/metabase/containers/Overworld.jsx
+++ b/frontend/src/metabase/containers/Overworld.jsx
@@ -274,9 +274,10 @@ class Overworld extends React.Component {
   }
 }
 
-const PIN_MESSAGE_STORAGE_KEY = "mb-admin-homepage-pin-propaganda-hidden";
+export const PIN_MESSAGE_STORAGE_KEY =
+  "mb-admin-homepage-pin-propaganda-hidden";
 
-class AdminPinMessage extends React.Component {
+export class AdminPinMessage extends React.Component {
   state = {
     showMessage: !window.localStorage.getItem(PIN_MESSAGE_STORAGE_KEY),
   };

--- a/frontend/test/containers/Overworld.unit.spec.js
+++ b/frontend/test/containers/Overworld.unit.spec.js
@@ -1,0 +1,38 @@
+import React from "react";
+import Icon from "metabase/components/Icon";
+
+import {
+  AdminPinMessage,
+  PIN_MESSAGE_STORAGE_KEY,
+} from "metabase/containers/Overworld";
+import { shallow } from "enzyme";
+
+describe("AdminPinMessage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  it("should show the admin pin message if the admin hasn't dismissed it", () => {
+    const wrapper = shallow(<AdminPinMessage />);
+
+    expect(wrapper.find(Icon).length).toBe(2);
+  });
+
+  it("should not show the message if the admin has dismissed it", () => {
+    localStorage.setItem(PIN_MESSAGE_STORAGE_KEY, "true");
+    const wrapper = shallow(<AdminPinMessage />);
+    expect(wrapper.getNode(0)).toBe(null);
+  });
+
+  it("should set the proper local storage key if the dismiss icon is clicked", () => {
+    const wrapper = shallow(<AdminPinMessage />);
+    const dismiss = wrapper.find(Icon).at(1);
+
+    dismiss.simulate("click");
+
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      PIN_MESSAGE_STORAGE_KEY,
+      "true",
+    );
+    expect(wrapper.getNode(0)).toBe(null);
+  });
+});

--- a/frontend/test/jest-setup.js
+++ b/frontend/test/jest-setup.js
@@ -1,4 +1,5 @@
 import "raf/polyfill";
+import "jest-localstorage-mock";
 
 // NOTE: this is needed because sometimes asynchronous code tries to access
 // window.location or similar jsdom properties after the tests have ended and

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "jasmine-reporters": "^2.2.0",
     "jasmine-spec-reporter": "^3.0.0",
     "jest": "^19.0.2",
+    "jest-localstorage-mock": "^2.2.0",
     "jscodeshift": "0.5.0",
     "jsonwebtoken": "^7.2.1",
     "karma": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5832,6 +5832,10 @@ jest-jasmine2@^19.0.2:
     jest-message-util "^19.0.0"
     jest-snapshot "^19.0.2"
 
+jest-localstorage-mock@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/jest-localstorage-mock/-/jest-localstorage-mock-2.2.0.tgz#ce9a9de01dfdde2ad8aa08adf73acc7e5cc394cf"
+
 jest-matcher-utils@^19.0.0:
   version "19.0.0"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-19.0.0.tgz#5ecd9b63565d2b001f61fbf7ec4c7f537964564d"


### PR DESCRIPTION
Adds a small dismissible message to the homepage for admins that lets people know how they can add dashboards from the 'Our analytics' collection to the homepage by pinning.

@tlrobinson Let me know what you think of the use of local storage for storing the dismissed state.

Supersedes the implementation in #8314 