### PR TITLE
Use histograms for fingerprinting numbers

### DIFF
--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -331,7 +331,7 @@
     :name         "count"
     :special_type "type/Quantity"
     :fingerprint  {:global {:distinct-count 1},
-                   :type   {:type/Number {:min 100.0, :max 100.0, :avg 100.0}}}}]
+                   :type   {:type/Number {:min 100.0, :max 100.0, :avg 100.0, :q1 100.0, :q3 100.0}}}}]
   (tu/with-non-admin-groups-no-root-collection-perms
     (let [metadata  [{:base_type    :type/Integer
                       :display_name "Count Chocula"
@@ -539,7 +539,7 @@
     :name         "count"
     :special_type "type/Quantity"
     :fingerprint  {:global {:distinct-count 1},
-                   :type   {:type/Number {:min 100.0, :max 100.0, :avg 100.0}}}}]
+                   :type   {:type/Number {:min 100.0, :max 100.0, :avg 100.0, :q1 100.0, :q3 100.0}}}}]
   (let [metadata [{:base_type    :type/Integer
                    :display_name "Count Chocula"
                    :name         "count_chocula"

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -7,13 +7,8 @@
             [dk.ative.docjure.spreadsheet :as spreadsheet]
             [expectations :refer :all]
             [medley.core :as m]
-            [metabase
-             [query-processor :as qp]
-             [util :as u]]
-            [metabase.models
-             [card :refer [Card]]
-             [database :as database]
-             [query-execution :refer [QueryExecution]]]
+            [metabase.models.query-execution :refer [QueryExecution]]
+            [metabase.query-processor :as qp]
             [metabase.query-processor.middleware.expand :as ql]
             [metabase.test
              [data :refer :all]
@@ -22,8 +17,7 @@
              [dataset-definitions :as defs]
              [datasets :refer [expect-with-engine]]
              [users :refer :all]]
-            [toucan.db :as db]
-            [toucan.util.test :as tt]))
+            [toucan.db :as db]))
 
 (defn user-details [user]
   (tu/match-$ user
@@ -208,16 +202,3 @@
                 (json/generate-string (wrap-inner-query
                                         (query users))))]
     (take 5 (parse-and-sort-csv result))))
-
-;; Check that we can export the results of a nested query
-(expect
-  16
-  (tt/with-temp Card [card {:dataset_query {:database (id)
-                                            :type :native
-                                            :native {:query "SELECT * FROM USERS;"}}}]
-    (let [result ((user->client :rasta) :post 200 "dataset/csv"
-                  :query (json/generate-string
-                          {:database database/virtual-id
-                           :type :query
-                           :query {:source_table (str "card__" (u/get-id card))}}))]
-      (count (csv/read-csv result)))))

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -491,7 +491,12 @@
     ;; run the Card which will populate its result_metadata column
     ((user->client :crowberto) :post 200 (format "card/%d/query" (u/get-id card)))
     ;; Now fetch the metadata for this "table"
-    (tu/round-all-decimals 2 ((user->client :crowberto) :get 200 (format "table/card__%d/query_metadata" (u/get-id card))))))
+    (->> card
+         u/get-id
+         (format "table/card__%d/query_metadata")
+         ((user->client :crowberto) :get 200)
+         (tu/round-fingerprint-cols [:fields])
+         (tu/round-all-decimals 2))))
 
 ;; Test date dimensions being included with a nested query
 (tt/expect-with-temp [Card [card {:name          "Users"
@@ -532,7 +537,12 @@
     ;; run the Card which will populate its result_metadata column
     ((user->client :crowberto) :post 200 (format "card/%d/query" (u/get-id card)))
     ;; Now fetch the metadata for this "table"
-    (tu/round-all-decimals 2 ((user->client :crowberto) :get 200 (format "table/card__%d/query_metadata" (u/get-id card))))))
+    (->> card
+         u/get-id
+         (format "table/card__%d/query_metadata")
+         ((user->client :crowberto) :get 200)
+         (tu/round-fingerprint-cols [:fields])
+         (tu/round-all-decimals 2))))
 
 
 ;; make sure GET /api/table/:id/fks just returns nothing for 'virtual' tables

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -1,10 +1,7 @@
 (ns metabase.driver.mysql-test
   (:require [clj-time.core :as t]
             [expectations :refer :all]
-            [honeysql.core :as hsql]
             [metabase
-             [query-processor :as qp]
-             [query-processor-test :as qpt]
              [sync :as sync]
              [util :as u]]
             [metabase.driver
@@ -18,7 +15,9 @@
             [metabase.test.data
              [datasets :refer [expect-with-engine]]
              [interface :refer [def-database-definition]]]
+            [metabase.test.util :as tu]
             [metabase.util.date :as du]
+            [honeysql.core :as hsql]
             [toucan.db :as db]
             [toucan.util.test :as tt])
   (:import metabase.driver.mysql.MySQLDriver))
@@ -130,49 +129,3 @@
   ["?" (du/->Timestamp #inst "2018-01-03")]
   (tu/with-temporary-setting-values [report-timezone "UTC"]
     (hsql/format (sqlqp/->honeysql (MySQLDriver.) (du/->Timestamp #inst "2018-01-03")))))
-
-;; Most of our tests either deal in UTC (offset 00:00) or America/Los_Angeles timezones (-07:00/-08:00). When dealing
-;; with dates, we will often truncate the timestamp to a date. When we only test with negative timezone offsets, in
-;; combination with this truncation, means we could have a bug and it's hidden by this negative-only offset. As an
-;; example, if we have a datetime like 2018-08-17 00:00:00-08:00, converting to UTC this becomes 2018-08-17
-;; 08:00:00+00:00, which when truncated is still 2018-08-17. That same scenario in Hong Kong is 2018-08-17
-;; 00:00:00+08:00, which then becomes 2018-08-16 16:00:00+00:00 when converted to UTC, which will truncate to
-;; 2018-08-16, instead of 2018-08-17
-;;
-;; This test ensures if our JVM timezone and reporting timezone are Asia/Hong_Kong, we get a correctly formatted date
-(expect-with-engine :mysql
-  ["2018-04-18T00:00:00.000+08:00"]
-  (tu/with-jvm-tz (t/time-zone-for-id "Asia/Hong_Kong")
-    (tu/with-temporary-setting-values [report-timezone "Asia/Hong_Kong"]
-      (qpt/first-row
-        (du/with-effective-timezone (Database (data/id))
-          (qp/process-query
-           {:database (data/id),
-            :type :native,
-            :settings {:report-timezone "UTC"}
-            :native     {:query "SELECT cast({{date}} as date)"
-                         :template_tags {:date {:name "date" :display_name "Date" :type "date" }}}
-            :parameters [{:type "date/single" :target ["variable" ["template-tag" "date"]] :value "2018-04-18"}]}))))))
-
-;; This tests a similar scenario, but one in which the JVM timezone is in Hong Kong, but the report timezone is in Los
-;; Angeles. The Joda Time date parsing functions for the most part default to UTC. Our tests all run with a UTC JVM
-;; timezone. This test catches a bug where we are incorrectly assuming a date is in UTC when the JVM timezone is
-;; different.
-;;
-;; The original bug can be found here: https://github.com/metabase/metabase/issues/8262. The MySQL driver code was
-;; parsing the date using JodateTime's date parser, which is in UTC. The MySQL driver code was assuming that date was
-;; in the system timezone rather than UTC which caused an incorrect conversion and with the trucation, let to it being
-;; off by a day
-(expect-with-engine :mysql
-  ["2018-04-18T00:00:00.000-07:00"]
-  (tu/with-jvm-tz (t/time-zone-for-id "Asia/Hong_Kong")
-    (tu/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
-      (qpt/first-row
-        (du/with-effective-timezone (Database (data/id))
-          (qp/process-query
-            {:database (data/id),
-             :type :native,
-             :settings {:report-timezone "UTC"}
-             :native     {:query "SELECT cast({{date}} as date)"
-                          :template_tags {:date {:name "date" :display_name "Date" :type "date" }}}
-             :parameters [{:type "date/single" :target ["variable" ["template-tag" "date"]] :value "2018-04-18"}]}))))))

--- a/test/metabase/pulse/render_test.clj
+++ b/test/metabase/pulse/render_test.clj
@@ -322,22 +322,6 @@
     {:row row-values
      :bar-width nil}))
 
-(def ^:private default-test-card
-  {:visualization_settings
-   {"table.column_formatting" [{:columns       ["a"]
-                                :type          :single
-                                :operator      ">"
-                                :value         5
-                                :color         "#ff0000"
-                                :highlight_row true}
-                               {:columns       ["c"]
-                                :type          "range"
-                                :min_type      "custom"
-                                :min_value     3
-                                :max_type      "custom"
-                                :max_value     9
-                                :colors        ["#00ff00" "#0000ff"]}]}})
-
 ;; Smoke test for background color selection. Background color decided by some shared javascript code. It's being
 ;; invoked and included in the cell color of the pulse table. This is somewhat fragile code as the only way to find
 ;; that style information is to crawl the clojure-ized HTML datastructure and pick apart the style string associated
@@ -348,108 +332,24 @@
    {"1" "",                     "2" "",                     "3" "rgba(0, 255, 0, 0.75)"
     "4" "",                     "5" "",                     "6" "rgba(0, 128, 128, 0.75)"
     "7" "rgba(255, 0, 0, 0.65)" "8" "rgba(255, 0, 0, 0.2)"  "9" "rgba(0, 0, 255, 0.75)"}
-  (let [query-results {:cols [{:name "a"} {:name "b"} {:name "c"}]
+  (let [viz-settings  {"table.column_formatting" [{:columns       ["a"]
+                                                   :type          :single
+                                                   :operator      ">"
+                                                   :value         5
+                                                   :color         "#ff0000"
+                                                   :highlight_row true}
+                                                  {:columns       ["c"]
+                                                   :type          "range"
+                                                   :min_type      "custom"
+                                                   :min_value     3
+                                                   :max_type      "custom"
+                                                   :max_value     9
+                                                   :colors        ["#00ff00" "#0000ff"]}]}
+        query-results {:cols [{:name "a"} {:name "b"} {:name "c"}]
                        :rows [[1 2 3]
                               [4 5 6]
                               [7 8 9]]}]
-    (-> (color/make-color-selector query-results (:visualization_settings default-test-card))
+    (-> (color/make-color-selector query-results viz-settings)
         (#'render/render-table ["a" "b" "c"] (query-results->header+rows query-results))
         find-table-body
         cell-value->background-color)))
-
-;; Test rendering a bar graph
-;;
-;; These test render the bar graph to ensure no exceptions are thrown, then look at the flattened HTML data structures
-;; to see if the column names for the columns we're graphing are present in the result
-
-(defn- flatten-html-data
-  "Takes the tree-based Clojure HTML data structure and flattens it to a seq"
-  [html-data]
-  (tree-seq coll? seq html-data))
-
-(defn- render-bar-graph [results]
-  ;; `doall` here as the flatten won't force lazy-seqs
-  (doall (flatten-html-data (#'render/render:bar pacific-tz default-test-card results))))
-
-(def ^:private default-columns
-  [{:name         "Price",
-    :display_name "Price",
-    :base_type    :type/BigInteger
-    :special_type nil}
-   {:name         "NumPurchased",
-    :display_name "NumPurchased",
-    :base_type    :type/BigInteger
-    :special_type nil}])
-
-;; Render a bar graph with non-nil values for the x and y axis
-(expect
-  [true true]
-  (let [result (render-bar-graph {:cols default-columns
-                                  :rows [[10.0 1] [5.0 10] [2.50 20] [1.25 30]]})]
-    [(some #(= "Price" %) result)
-     (some #(= "NumPurchased" %) result)]))
-
-;; Check to make sure we allow nil values for the y-axis
-(expect
-  [true true]
-  (let [result (render-bar-graph {:cols default-columns
-                                  :rows [[10.0 1] [5.0 10] [2.50 20] [1.25 nil]]})]
-    [(some #(= "Price" %) result)
-     (some #(= "NumPurchased" %) result)]))
-
-;; Check to make sure we allow nil values for the y-axis
-(expect
-  [true true]
-  (let [result (render-bar-graph {:cols default-columns
-                                  :rows [[10.0 1] [5.0 10] [2.50 20] [nil 30]]})]
-    [(some #(= "Price" %) result)
-     (some #(= "NumPurchased" %) result)]))
-
-;; Check to make sure we allow nil values for both x and y on different rows
-(expect
-  [true true]
-  (let [result (render-bar-graph {:cols default-columns
-                                  :rows [[10.0 1] [5.0 10] [nil 20] [1.25 nil]]})]
-    [(some #(= "Price" %) result)
-     (some #(= "NumPurchased" %) result)]))
-
-;; Test rendering a sparkline
-;;
-;; Sparklines are a binary image either in-line or as an attachment, so there's not much introspection that we can do
-;; with the result. The tests below just check that we can render a sparkline (without eceptions) and that the
-;; attachment is included
-
-(defn- render-sparkline [results]
-  (-> (#'render/render:sparkline :attachment pacific-tz default-test-card results)
-      :attachments
-      count))
-
-;; Test that we can render a sparkline with all valid values
-(expect
-  1
-  (render-sparkline {:cols default-columns
-                     :rows [[10.0 1] [5.0 10] [2.50 20] [1.25 30]]}))
-
-;; Tex that we can have a nil value in the middle
-(expect
-  1
-  (render-sparkline {:cols default-columns
-                     :rows [[10.0 1] [11.0 2] [5.0 nil] [2.50 20] [1.25 30]]}))
-
-;; Test that we can have a nil value for the y-axis at the end of the results
-(expect
-  1
-  (render-sparkline {:cols default-columns
-                     :rows [[10.0 1] [11.0 2] [2.50 20] [1.25 nil]]}))
-
-;; Test that we can have a nil value for the x-axis at the end of the results
-(expect
-  1
-  (render-sparkline {:cols default-columns
-                     :rows [[10.0 1] [11.0 2] [nil 20] [1.25 30]]}))
-
-;; Test that we can have a nil value for both x and y axis for different rows
-(expect
-  1
-  (render-sparkline {:cols default-columns
-                     :rows [[10.0 1] [11.0 2] [nil 20] [1.25 nil]]}))

--- a/test/metabase/query_processor/expand_resolve_test.clj
+++ b/test/metabase/query_processor/expand_resolve_test.clj
@@ -98,7 +98,7 @@
                                                    :table-name         "VENUES"
                                                    :values             price-field-values
                                                    :fingerprint        {:global {:distinct-count 4}
-                                                                        :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03}}}})
+                                                                        :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03, :q1 1.46, :q3 2.49}}}})
                               :value       {:value 1
                                             :field (merge field-defaults
                                                           {:field-id           true
@@ -112,17 +112,18 @@
                                                            :table-name         "VENUES"
                                                            :values             price-field-values
                                                            :fingerprint        {:global {:distinct-count 4}
-                                                                                :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03}}}})}}
+                                                                                :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03, :q1 1.46, :q3 2.49}}}})}}
 
 
                :join-tables nil}
     :fk-field-ids #{}
     :table-ids    #{(id :venues)}}]
   (let [expanded-form (ql/expand (wrap-inner-query (query venues
-                                                     (ql/filter (ql/and (ql/> $price 1))))))]
-    (tu/boolean-ids-and-timestamps
-     (mapv obj->map [expanded-form
-                     (resolve' expanded-form)]))))
+                                                          (ql/filter (ql/and (ql/> $price 1))))))]
+    (tu/round-all-decimals 2
+     (tu/boolean-ids-and-timestamps
+      (mapv obj->map [expanded-form
+                      (resolve' expanded-form)])))))
 
 (def category-field-values
   {:values                (defs/field-values defs/test-data-map "categories" "name")
@@ -309,7 +310,7 @@
                                                              :table-name         "VENUES__via__VENUE_ID"
                                                              :values             price-field-values
                                                              :fingerprint        {:global {:distinct-count 4}
-                                                                                  :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03}}}})}]
+                                                                                  :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03, :q1 1.46, :q3 2.49}}}})}]
                    :breakout     [{:field (merge field-defaults
                                                  {:database-type      "DATE"
                                                   :base-type          :type/Date
@@ -337,9 +338,10 @@
   (let [expanded-form (ql/expand (wrap-inner-query (query checkins
                                                           (ql/aggregation (ql/sum $venue_id->venues.price))
                                                           (ql/breakout (ql/datetime-field $checkins.date :day-of-week)))))]
-    (tu/boolean-ids-and-timestamps
-     (mapv obj->map [expanded-form
-                     (resolve' expanded-form)]))))
+    (tu/round-all-decimals 2
+     (tu/boolean-ids-and-timestamps
+      (mapv obj->map [expanded-form
+                      (resolve' expanded-form)])))))
 
 ;; check that a schema invalidation error produces a reasonably-sized exception, < 50 lines.
 ;; previously the entire schema was being dumped which resulted in a ~5200 line exception (#5978)

--- a/test/metabase/query_processor/middleware/annotate_and_sort_test.clj
+++ b/test/metabase/query_processor/middleware/annotate_and_sort_test.clj
@@ -11,9 +11,3 @@
                                                                            [3 nil]
                                                                            [4   5]
                                                                            [6   7]]})))
-
-;; make sure that `infer-column-types` defaults `base_type` to `type/*` if there are no non-nil
-;; values when we peek.
-(expect
-  [{:name "a", :display_name "A", :base_type :type/*}]
-  (:cols (#'annotate-and-sort/infer-column-types {:columns [:a], :rows [[nil]]})))

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -128,7 +128,7 @@
                            :type   {:type/Text {:percent-json   0.0
                                                 :percent-url    0.0
                                                 :percent-email  0.0
-                                                :average-length 8.333}}}})))
+                                                :average-length 8.33}}}})))
 
 ;; #### users
 (defn users-col
@@ -152,7 +152,7 @@
                                  :type   {:type/Text {:percent-json   0.0
                                                       :percent-url    0.0
                                                       :percent-email  0.0
-                                                      :average-length 13.267}}}}
+                                                      :average-length 13.27}}}}
      :last_login {:special_type nil
                   :base_type    (data/expected-base-type->actual :type/DateTime)
                   :name         (data/format-name "last_login")
@@ -193,22 +193,22 @@
                    :display_name "Category ID"
                    :fingerprint  (if (data/fks-supported?)
                                    {:global {:distinct-count 28}}
-                                   {:global {:distinct-count 28}, :type {:type/Number {:min 2.0, :max 74.0, :avg 29.98}}})}
+                                   {:global {:distinct-count 28}, :type {:type/Number {:min 2.0, :max 74.0, :avg 29.98, :q1 7.0, :q3 49.0}}})}
      :price       {:special_type :type/Category
                    :base_type    (data/expected-base-type->actual :type/Integer)
                    :name         (data/format-name "price")
                    :display_name "Price"
-                   :fingerprint  {:global {:distinct-count 4}, :type {:type/Number {:min 1.0, :max 4.0, :avg 2.03}}}}
+                   :fingerprint  {:global {:distinct-count 4}, :type {:type/Number {:min 1.0, :max 4.0, :avg 2.03, :q1 1.0, :q3 2.0 }}}}
      :longitude   {:special_type :type/Longitude
                    :base_type    (data/expected-base-type->actual :type/Float)
                    :name         (data/format-name "longitude")
-                   :fingerprint  {:global {:distinct-count 84}, :type {:type/Number {:min -165.374, :max -73.953, :avg -115.998}}}
+                   :fingerprint  {:global {:distinct-count 84}, :type {:type/Number {:min -165.37, :max -73.95, :avg -116.0 :q1 -122.0, :q3 -118.0}}}
                    :display_name "Longitude"}
      :latitude    {:special_type :type/Latitude
                    :base_type    (data/expected-base-type->actual :type/Float)
                    :name         (data/format-name "latitude")
                    :display_name "Latitude"
-                   :fingerprint  {:global {:distinct-count 94}, :type {:type/Number {:min 10.065, :max 40.779, :avg 35.506}}}}
+                   :fingerprint  {:global {:distinct-count 94}, :type {:type/Number {:min 10.06, :max 40.78, :avg 35.51, :q1 34.0, :q3 38.0}}}}
      :name        {:special_type :type/Name
                    :base_type    (data/expected-base-type->actual :type/Text)
                    :name         (data/format-name "name")
@@ -244,7 +244,7 @@
                 :display_name "Venue ID"
                 :fingerprint  (if (data/fks-supported?)
                                 {:global {:distinct-count 100}}
-                                {:global {:distinct-count 100}, :type {:type/Number {:min 1.0, :max 100.0, :avg 51.965}}})}
+                                {:global {:distinct-count 100}, :type {:type/Number {:min 1.0, :max 100.0, :avg 51.97, :q1 28.0, :q3 76.0}}})}
      :user_id  {:extra_info   (if (data/fks-supported?) {:target_table_id (data/id :users)}
                                   {})
                 :target       (target-field (users-col :id))
@@ -256,7 +256,7 @@
                 :display_name "User ID"
                 :fingerprint  (if (data/fks-supported?)
                                 {:global {:distinct-count 15}}
-                                {:global {:distinct-count 15}, :type {:type/Number {:min 1.0, :max 15.0, :avg 7.929}}})})))
+                                {:global {:distinct-count 15}, :type {:type/Number {:min 1.0, :max 15.0, :avg 7.93 :q1 4.0, :q3 11.0}}})})))
 
 
 ;;; #### aggregate columns

--- a/test/metabase/query_processor_test/aggregation_test.clj
+++ b/test/metabase/query_processor_test/aggregation_test.clj
@@ -253,7 +253,8 @@
          (ql/aggregation (ql/cum-sum $id))
          (ql/breakout $price))
        booleanize-native-form
-       (format-rows-by [int int])))
+       (format-rows-by [int int])
+       tu/round-fingerprint-cols))
 
 
 ;;; ------------------------------------------------ CUMULATIVE COUNT ------------------------------------------------
@@ -319,4 +320,5 @@
          (ql/aggregation (ql/cum-count))
          (ql/breakout $price))
        booleanize-native-form
-       (format-rows-by [int int])))
+       (format-rows-by [int int])
+       tu/round-fingerprint-cols))

--- a/test/metabase/query_processor_test/breakout_test.clj
+++ b/test/metabase/query_processor_test/breakout_test.clj
@@ -35,7 +35,8 @@
          (ql/breakout $user_id)
          (ql/order-by (ql/asc $user_id)))
        booleanize-native-form
-       (format-rows-by [int int])))
+       (format-rows-by [int int])
+       tu/round-fingerprint-cols))
 
 ;;; BREAKOUT w/o AGGREGATION
 ;; This should act as a "distinct values" query and return ordered results
@@ -48,7 +49,8 @@
          (ql/breakout $user_id)
          (ql/limit 10))
        booleanize-native-form
-       (format-rows-by [int])))
+       (format-rows-by [int])
+       tu/round-fingerprint-cols))
 
 
 ;;; "BREAKOUT" - MULTIPLE COLUMNS W/ IMPLICT "ORDER_BY"
@@ -67,7 +69,8 @@
          (ql/breakout $user_id $venue_id)
          (ql/limit 10))
        booleanize-native-form
-       (format-rows-by [int int int])))
+       (format-rows-by [int int int])
+       tu/round-fingerprint-cols))
 
 ;;; "BREAKOUT" - MULTIPLE COLUMNS W/ EXPLICIT "ORDER_BY"
 ;; `breakout` should not implicitly order by any fields specified in `order_by`
@@ -86,7 +89,8 @@
          (ql/order-by (ql/desc $user_id))
          (ql/limit 10))
        booleanize-native-form
-       (format-rows-by [int int int])))
+       (format-rows-by [int int int])
+       tu/round-fingerprint-cols))
 
 (qp-expect-with-all-engines
   {:rows  [[2 8 "Artisan"]
@@ -116,7 +120,8 @@
            (ql/breakout $category_id)
            (ql/limit 5))
          booleanize-native-form
-         (format-rows-by [int int str]))))
+         (format-rows-by [int int str])
+         tu/round-fingerprint-cols)))
 
 (datasets/expect-with-engines (non-timeseries-engines-with-feature :foreign-keys)
   [["Wine Bar" "Thai" "Thai" "Thai" "Thai" "Steakhouse" "Steakhouse" "Steakhouse" "Steakhouse" "Southern"]

--- a/test/metabase/query_processor_test/order_by_test.clj
+++ b/test/metabase/query_processor_test/order_by_test.clj
@@ -4,7 +4,8 @@
             [metabase.query-processor-test :refer :all]
             [metabase.query-processor.middleware.expand :as ql]
             [metabase.test.data :as data]
-            [metabase.test.data.datasets :as datasets :refer [*engine*]]))
+            [metabase.test.data.datasets :as datasets :refer [*engine*]]
+            [metabase.test.util :as tu]))
 
 (expect-with-non-timeseries-dbs
   [[1 12 375]
@@ -44,7 +45,8 @@
          (ql/breakout $price)
          (ql/order-by (ql/asc (ql/aggregate-field 0))))
        booleanize-native-form
-       (format-rows-by [int int])))
+       (format-rows-by [int int])
+       tu/round-fingerprint-cols))
 
 
 ;;; order_by aggregate ["sum" field-id]
@@ -63,7 +65,8 @@
          (ql/breakout $price)
          (ql/order-by (ql/desc (ql/aggregate-field 0))))
        booleanize-native-form
-       (format-rows-by [int int])))
+       (format-rows-by [int int])
+       tu/round-fingerprint-cols))
 
 
 ;;; order_by aggregate ["distinct" field-id]
@@ -82,7 +85,8 @@
          (ql/breakout $price)
          (ql/order-by (ql/asc (ql/aggregate-field 0))))
        booleanize-native-form
-       (format-rows-by [int int])))
+       (format-rows-by [int int])
+       tu/round-fingerprint-cols))
 
 
 ;;; order_by aggregate ["avg" field-id]
@@ -101,7 +105,9 @@
          (ql/breakout $price)
          (ql/order-by (ql/asc (ql/aggregate-field 0))))
        booleanize-native-form
-       :data (format-rows-by [int int])))
+       :data
+       (format-rows-by [int int])
+       tu/round-fingerprint-cols))
 
 ;;; ### order_by aggregate ["stddev" field-id]
 ;; SQRT calculations are always NOT EXACT (normal behavior) so round everything to the nearest int.
@@ -121,4 +127,6 @@
          (ql/breakout $price)
          (ql/order-by (ql/desc (ql/aggregate-field 0))))
        booleanize-native-form
-       :data (format-rows-by [int (comp int math/round)])))
+       :data
+       (format-rows-by [int (comp int math/round)])
+       tu/round-fingerprint-cols))

--- a/test/metabase/query_processor_test/remapping_test.clj
+++ b/test/metabase/query_processor_test/remapping_test.clj
@@ -32,7 +32,8 @@
            (ql/order-by (ql/asc $name))
            (ql/limit 4))
          booleanize-native-form
-         (format-rows-by [str int str]))))
+         (format-rows-by [str int str])
+         tu/round-fingerprint-cols)))
 
 (defn- select-columns
   "Focuses the given resultset to columns that return true when passed

--- a/test/metabase/related_test.clj
+++ b/test/metabase/related_test.clj
@@ -1,17 +1,13 @@
 (ns metabase.related-test
-  (:require [clojure.java.jdbc :as jdbc]
-            [expectations :refer :all]
-            [metabase
-             [related :as r :refer :all]
-             [sync :as sync]]
+  (:require [expectations :refer :all]
             [metabase.models
              [card :refer [Card]]
              [collection :refer [Collection]]
              [metric :refer [Metric]]
              [segment :refer [Segment]]]
+            [metabase.related :as r :refer :all]
             [metabase.test.data :as data]
-            [metabase.test.data.one-off-dbs :as one-off-dbs]
-            [toucan.util.test :as tt][metabase.test.data.users :as users]
+            [metabase.test.data.users :as users]
             [toucan.util.test :as tt]))
 
 (expect
@@ -132,28 +128,6 @@
    :tables      [(data/id :users)]}
   (->> ((users/user->client :crowberto) :get 200 (format "table/%s/related" (data/id :venues)))
        result-mask))
-
-
-;; We should ignore non-active entities
-
-(defn- exec! [& statements]
-  (doseq [statement statements]
-    (jdbc/execute! one-off-dbs/*conn* [statement])))
-
-(expect
-  [1 0]
-  (one-off-dbs/with-blank-db
-    (exec! "CREATE TABLE blueberries_consumed (num SMALLINT NOT NULL, weight FLOAT)")
-    (one-off-dbs/insert-rows-and-sync! (range 50))
-    (let [count-related-fields (fn []
-                                 (->> ((users/user->client :crowberto) :get 200
-                                       (format "field/%s/related" (data/id :blueberries_consumed :num)))
-                                      :fields
-                                      count))
-          before               (count-related-fields)]
-      (exec! "ALTER TABLE blueberries_consumed DROP COLUMN weight")
-      (sync/sync-database! (data/db))
-      [before (count-related-fields)])))
 
 
 ;; Test transitive similarity:

--- a/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
+++ b/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
@@ -13,18 +13,12 @@
              [#inst "2013" #inst "2018" #inst "2015"]))
 
 (expect
-  {:global {:distinct-count 1}
-   :type {:type/DateTime {:earliest nil
-                          :latest   nil}}}
-  (transduce identity
-             (fingerprinter (field/map->FieldInstance {:base_type :type/DateTime}))
-             (repeat 10 nil)))
-
-(expect
   {:global {:distinct-count 3}
    :type {:type/Number {:avg 2.0
                         :min 1.0
-                        :max 3.0}}}
+                        :max 3.0
+                        :q1 1.25
+                        :q3 2.75}}}
   (transduce identity
              (fingerprinter (field/map->FieldInstance {:base_type :type/Number}))
              [1.0 2.0 3.0]))

--- a/test/metabase/sync/analyze/query_results_test.clj
+++ b/test/metabase/sync/analyze/query_results_test.clj
@@ -24,7 +24,7 @@
 
 (defn- name->fingerprints [field-or-metadata]
   (zipmap (map column->name-keyword field-or-metadata)
-          (map :fingerprint field-or-metadata)))
+          (map :fingerprint (tu/round-fingerprint-cols field-or-metadata))))
 
 (defn- name->special-type [field-or-metadata]
   (zipmap (map column->name-keyword field-or-metadata)
@@ -72,7 +72,7 @@
 ;; Native queries don't know what the associated Fields are for the results, we need to compute the fingerprints, but
 ;; they should sill be the same except for some of the optimizations we do when we have all the information.
 (expect
-  (update mutil/venue-fingerprints :category_id assoc :type {:type/Number {:min 2.0, :max 74.0, :avg 29.98}})
+  (update mutil/venue-fingerprints :category_id assoc :type {:type/Number {:min 2.0, :max 74.0, :avg 29.98, :q1 7.0, :q3 49.0}})
   (tt/with-temp Card [card {:dataset_query   {:database (data/id)
                                               :type     :native
                                               :native   {:query "select * from venues"}}}]

--- a/test/metabase/test/mock/util.clj
+++ b/test/metabase/test/mock/util.clj
@@ -48,12 +48,12 @@
                                       :percent-email 0.0, :average-length 15.63}}}
    :id          nil
    :price       {:global {:distinct-count 4},
-                 :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03}}}
+                 :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03, :q1 1.0, :q3 2.0}}}
    :latitude    {:global {:distinct-count 94},
-                 :type   {:type/Number {:min 10.06, :max 40.78, :avg 35.51}}}
+                 :type   {:type/Number {:min 10.06, :max 40.78, :avg 35.51, :q1 34.0, :q3 38.0}}}
    :category_id {:global {:distinct-count 28}}
    :longitude   {:global {:distinct-count 84},
-                 :type   {:type/Number {:min -165.37, :max -73.95, :avg -116.0}}}})
+                 :type   {:type/Number {:min -165.37, :max -73.95, :avg -116.0 :q1 -122.0, :q3 -118.0}}}})
 
 ;; This is just a fake implementation that just swoops in and returns somewhat-correct looking results for different
 ;; queries we know will get ran as part of sync

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -392,26 +392,33 @@
     m
     (apply update-in m ks f args)))
 
-(defn- round-fingerprint-fields [fprint-type-map fields]
+(defn- round-fingerprint-fields [fprint-type-map decimal-places fields]
   (reduce (fn [fprint field]
             (update-in-if-present fprint [field] (fn [num]
                                                    (if (integer? num)
                                                      num
-                                                     (u/round-to-decimals 3 num)))))
+                                                     (u/round-to-decimals decimal-places num)))))
           fprint-type-map fields))
 
 (defn round-fingerprint
-  "Rounds the numerical fields of a fingerprint to 4 decimal places"
+  "Rounds the numerical fields of a fingerprint to 2 decimal places"
   [field]
   (-> field
-      (update-in-if-present [:fingerprint :type :type/Number] round-fingerprint-fields [:min :max :avg])
-      (update-in-if-present [:fingerprint :type :type/Text] round-fingerprint-fields [:percent-json :percent-url :percent-email :average-length])))
+      (update-in-if-present [:fingerprint :type :type/Number] round-fingerprint-fields 2 [:min :max :avg])
+      ;; quartal estimation is order dependent and the ordering is not stable across different DB engines, hence more aggressive trimming
+      (update-in-if-present [:fingerprint :type :type/Number] round-fingerprint-fields 0 [:q1 :q3])
+      (update-in-if-present [:fingerprint :type :type/Text] round-fingerprint-fields 2 [:percent-json :percent-url :percent-email :average-length])))
 
-(defn round-fingerprint-cols [query-results]
-  (let [maybe-data-cols (if (contains? query-results :data)
-                          [:data :cols]
-                          [:cols])]
-    (update-in query-results maybe-data-cols #(map round-fingerprint %))))
+(defn round-fingerprint-cols
+  ([query-results]
+   (if (map? query-results)
+     (let [maybe-data-cols (if (contains? query-results :data)
+                             [:data :cols]
+                             [:cols])]
+       (round-fingerprint-cols maybe-data-cols query-results))
+     (map round-fingerprint query-results)))
+  ([k query-results]
+   (update-in query-results k #(map round-fingerprint %))))
 
 (defn round-all-decimals
   "Uses `walk/postwalk` to crawl `data`, looking for any double values, will round any it finds"


### PR DESCRIPTION
This changes the number fingerprinter to accumulate intermediary results in a histogram. It's ~4x faster than our current implementation for all input sizes. Memory consumption is within margin of error (theoretically is slightly bigger -- about 500B/column and it's pretty well behaved in terms of garbage as most of the work is done in Java-land using mutation and unboxed doubles). 
Aside from the speedup it gives us a lot of interesting statistics for "free". Already implemented are 1st and 3rd quartile (and therefore interquartile range) which enable us to use [Freedman-Diaconis rule to determine optimal bin width](https://en.wikipedia.org/wiki/Freedman%E2%80%93Diaconis_rule) and Tukey's fences (1.5*IQR heuristic) to find outliers. 

Downsides:
* min, max, and avg are no longer exact
* additional dependency on bigml/histogram 