### PR TITLE
Ensure we handle no git Metadata for BQ startup

### DIFF
--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -61,7 +61,10 @@
 (defn- version-info-from-shell-script []
   (try
     (let [[tag hash branch date] (-> (shell/sh "./bin/version") :out s/trim (s/split #" "))]
-      {:tag tag, :hash hash, :branch branch, :date date})
+      {:tag    (or tag "?")
+       :hash   (or hash "?")
+       :branch (or branch "?")
+       :date   (or date "?")})
     ;; if ./bin/version fails (e.g., if we are developing on Windows) just return something so the whole thing doesn't barf
     (catch Throwable _
       {:tag "?", :hash "?", :branch "?", :date "?"})))

--- a/src/metabase/driver/google.clj
+++ b/src/metabase/driver/google.clj
@@ -46,11 +46,18 @@
   (u/auto-retry 2
     (execute-no-auto-retry request)))
 
+(defn- create-application-name
+  "Creates the application name string, separated out from the `def` below so it's testable with different values"
+  [{:keys [tag ^String hash branch]}]
+  (let [encoded-hash (some-> hash (.getBytes "UTF-8") codec/base64-encode)]
+    (format "Metabase/%s (GPN:Metabse; %s %s)"
+            (or tag "?")
+            (or encoded-hash "?")
+            (or branch "?"))))
+
 (def ^:const ^String application-name
   "The application name we should use for Google drivers. Requested by Google themselves -- see #2627"
-  (let [{:keys [tag ^String hash branch]} config/mb-version-info
-        encoded-hash                      (-> hash (.getBytes "UTF-8") codec/base64-encode)]
-    (format "Metabase/%s (GPN:Metabse; %s %s)" tag encoded-hash branch)))
+  (create-application-name config/mb-version-info))
 
 
 (defn- fetch-access-and-refresh-tokens* [scopes, ^String client-id, ^String client-secret, ^String auth-code]

--- a/test/metabase/driver/google_test.clj
+++ b/test/metabase/driver/google_test.clj
@@ -1,0 +1,26 @@
+(ns metabase.driver.google-test
+  (:require [expectations :refer :all]
+            [metabase.config :as config]
+            [metabase.driver.google :as google]))
+
+;; Typical scenario, all config information included
+(expect
+  "Metabase/v0.30.0-snapshot (GPN:Metabse; NWNjNWY0Mw== master)"
+  (#'google/create-application-name  {:tag "v0.30.0-snapshot", :hash "5cc5f43", :branch "master", :date "2018-08-21"}))
+
+;; It's possible to have two hashes come back from our script. Sending a string with a newline in it for the
+;; application name will cause Google connections to fail
+(expect
+  "Metabase/v0.30.0-snapshot (GPN:Metabse; NWNjNWY0MwphYmNkZWYx master)"
+  (#'google/create-application-name {:tag "v0.30.0-snapshot", :hash "5cc5f43\nabcdef1", :branch "master", :date "2018-08-21"}))
+
+;; It's possible to have all ? values if there was some failure in reading version information, or if non was available
+(expect
+  "Metabase/? (GPN:Metabse; Pw== ?)"
+  (#'google/create-application-name {:tag "?", :hash "?", :branch "?", :date "?"}))
+
+;; This shouldn't be possible now that config/mb-version-info always returns a value, but testing an empty map just in
+;; case
+(expect
+  "Metabase/? (GPN:Metabse; ? ?)"
+  (#'google/create-application-name {}))


### PR DESCRIPTION
When connecting to a Google service, we identify ourselves with a
string that includes version, hash and branch information. If a user
downloads a Metabase tarball from Github, it won't have that Git
metadata and we will throw a NullPointerException on startup.

This commit just ensures we always have a value for that string, even
when there is no git metadata available.

Fixes #8368