### PR TITLE
Add TaskHistory for storage of sync metrics

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -4988,3 +4988,64 @@ databaseChangeLog:
         - dropColumn:
             tableName: metabase_field
             columnName: raw_column_id
+
+# Create the TaskHistory table, intended to provide debugging info on our background/quartz processes
+  - changeSet:
+      id: 94
+      author: senior
+      comment: 'Added 0.31.0'
+      changes:
+        - createTable:
+            tableName: task_history
+            remarks: 'Timing and metadata info about background/quartz processes'
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: task
+                  type: VARCHAR(254)
+                  remarks: 'Name of the task'
+                  constraints:
+                    nullable: false
+              # The sync tasks all have a db_id, but there are others that won't, such as the pulses
+              # task or task history cleanup. The way around this is to create a join table between
+              # TASK_HISTORY and METABASE_DATABASE, but that doesn't seem worth it right now.
+              - column:
+                  name: db_id
+                  type: integer
+              - column:
+                  name: started_at
+                  type: datetime
+                  constraints:
+                    nullable: false
+              - column:
+                  name: ended_at
+                  type: datetime
+                  constraints:
+                    nullable: false
+              - column:
+                  name: duration
+                  type: int
+                  constraints:
+                    nullable: false
+              - column:
+                  name: task_details
+                  remarks: 'JSON string with additional info on the task'
+                  type: text
+        - createIndex:
+            indexName: idx_task_history_end_time
+            tableName: task_history
+            columns:
+              - column:
+                  name: ended_at
+        - createIndex:
+            indexName: idx_task_history_db_id
+            tableName: task_history
+            columns:
+              - column:
+                  name: db_id

--- a/src/metabase/cmd/load_from_h2.clj
+++ b/src/metabase/cmd/load_from_h2.clj
@@ -52,6 +52,7 @@
              [session :refer [Session]]
              [setting :refer [Setting]]
              [table :refer [Table]]
+             [task-history :refer [TaskHistory]]
              [user :refer [User]]
              [view-log :refer [ViewLog]]]))
 
@@ -93,6 +94,7 @@
    CollectionRevision
    DashboardFavorite
    Dimension
+   TaskHistory
    ;; migrate the list of finished DataMigrations as the very last thing (all models to copy over should be listed
    ;; above this line)
    DataMigrations])

--- a/src/metabase/models/task_history.clj
+++ b/src/metabase/models/task_history.clj
@@ -1,0 +1,31 @@
+(ns metabase.models.task-history
+  (:require [metabase.models.interface :as i]
+            [metabase.util :as u]
+            [toucan
+             [db :as db]
+             [models :as models]]))
+
+(models/defmodel TaskHistory :task_history)
+
+(defn cleanup-task-history!
+  "Deletes older TaskHistory rows. Will order TaskHistory by `ended_at` and delete everything after
+  `num-rows-to-keep`. This is intended for a quick cleanup of old rows."
+  [num-rows-to-keep]
+  ;; Ideally this would be one query, but MySQL does not allow nested queries with a limit. The query below orders the
+  ;; tasks by the time they finished, newest first. Then finds the first row after skipping `num-rows-to-keep`. Using
+  ;; the date that task finished, it deletes everything after that. As we continue to add TaskHistory entries, this
+  ;; ensures we'll have a good amount of history for debugging/troubleshooting, but not grow too large and fill the
+  ;; disk.
+  (when-let  [clean-before-date (db/select-one-field :ended_at TaskHistory {:limit    1
+                                                                            :offset   num-rows-to-keep
+                                                                            :order-by [[:ended_at :desc]]})]
+    (db/simple-delete! TaskHistory :ended_at [:<= clean-before-date])))
+
+(u/strict-extend (class TaskHistory)
+  models/IModel
+  (merge models/IModelDefaults
+         {:types (constantly {:task_details :json})})
+  i/IObjectPermissions
+  (merge i/IObjectPermissionsDefaults
+         {:can-read?  i/superuser?
+          :can-write? i/superuser?}))

--- a/src/metabase/task/task_history_cleanup.clj
+++ b/src/metabase/task/task_history_cleanup.clj
@@ -1,0 +1,58 @@
+(ns metabase.task.task-history-cleanup
+  (:require [clj-time.core :as time]
+            [clojure.tools.logging :as log]
+            [clojurewerkz.quartzite
+             [jobs :as jobs]
+             [triggers :as triggers]]
+            [clojurewerkz.quartzite.schedule.cron :as cron]
+            [metabase.models.task-history :as thist :refer [TaskHistory]]
+            [metabase.task :as task]
+            [metabase.util.date :as du]
+            [puppetlabs.i18n.core :refer [trs]]
+            [toucan.db :as db]))
+
+(def ^:private ^:const job-name    "task-history-cleanup")
+(def ^:private ^:const job-key     (format "metabase.task.%s.job" job-name))
+(def ^:private ^:const trigger-key (format "metabase.task.%s.trigger" job-name))
+
+(defonce ^:private job     (atom nil))
+(defonce ^:private trigger (atom nil))
+
+(def ^:private history-rows-to-keep
+  "Maximum number of TaskHistory rows. This is not a `const` so that we can redef it in tests"
+  100000)
+
+(defn- task-history-cleanup!
+  []
+  (log/debug "Cleaning up task history")
+  (let [before-cleanup (time/now)
+        result         (thist/cleanup-task-history! history-rows-to-keep)
+        after-cleanup  (time/now)]
+    (db/insert! TaskHistory {:task       job-name
+                             :started_at (du/->Timestamp before-cleanup)
+                             :ended_at   (du/->Timestamp after-cleanup)
+                             :duration   (du/calculate-duration before-cleanup after-cleanup)})
+    (log/debug (trs "Task history cleanup successful, rows were {0}deleted"
+                    (when-not result (str (trs "not")
+                                          " "))))))
+
+(jobs/defjob TaskHistoryCleanup
+  [_]
+  (task-history-cleanup!))
+
+(defn task-init
+  "Job initialization"
+  []
+  ;; build our job
+  (reset! job (jobs/build
+               (jobs/of-type TaskHistoryCleanup)
+               (jobs/with-identity (jobs/key job-key))))
+  ;; build our trigger
+  (reset! trigger (triggers/build
+                   (triggers/with-identity (triggers/key trigger-key))
+                   (triggers/start-now)
+                   (triggers/with-schedule
+                     ;; run every day at midnight
+                     (cron/cron-schedule "0 0 * * * ? *"))))
+  ;; submit ourselves to the scheduler
+  (task/schedule-task! @job @trigger))

--- a/src/metabase/util/date.clj
+++ b/src/metabase/util/date.clj
@@ -7,7 +7,9 @@
             [clojure.math.numeric-tower :as math]
             [clojure.tools.logging :as log]
             [metabase.util :as u]
-            [puppetlabs.i18n.core :refer [trs]])
+            [metabase.util.schema :as su]
+            [puppetlabs.i18n.core :refer [trs]]
+            [schema.core :as s])
   (:import clojure.lang.Keyword
            [java.sql Time Timestamp]
            [java.util Calendar Date TimeZone]
@@ -456,3 +458,9 @@
    (some-> (str->date-time-with-formatters ordered-time-parsers date-str tz)
            coerce/to-long
            Time.)))
+
+(s/defn calculate-duration :- su/NonNegativeInt
+  "Given two datetimes, caculate the time between them, return the result in millis"
+  [begin-time :- (s/protocol coerce/ICoerce)
+   end-time :- (s/protocol coerce/ICoerce)]
+  (- (coerce/to-long end-time) (coerce/to-long begin-time)))

--- a/src/metabase/util/schema.clj
+++ b/src/metabase/util/schema.clj
@@ -118,6 +118,12 @@
       (s/constrained s/Int (partial < 0) (tru "Integer greater than zero"))
     (tru "value must be an integer greater than zero.")))
 
+(def NonNegativeInt
+  "Schema representing an integer 0 or greater"
+  (with-api-error-message
+      (s/constrained s/Int (partial <= 0) (tru "Integer greater than or equal to zero"))
+    (tru "value must be an integer zero or greater.")))
+
 (def PositiveNum
   "Schema representing a numeric value greater than zero. This allows floating point numbers and integers."
   (with-api-error-message

--- a/test/metabase/models/task_history_test.clj
+++ b/test/metabase/models/task_history_test.clj
@@ -1,0 +1,74 @@
+(ns metabase.models.task-history-test
+  (:require [clj-time
+             [coerce :as tcoerce]
+             [core :as time]]
+            [expectations :refer :all]
+            [metabase.models.task-history :refer :all]
+            [metabase.test.util :as tu]
+            [metabase.util :as u]
+            [metabase.util.date :as du]
+            [toucan.db :as db]
+            [toucan.util.test :as tt]))
+
+(defn add-second
+  "Adds one second to `t`"
+  [t]
+  (time/plus t (time/seconds 1)))
+
+(defn add-10-millis
+  "Adds 10 milliseconds to `t`"
+  [t]
+  (time/plus t (time/millis 10)))
+
+(defn make-10-millis-task
+  "Creates a map suitable for a `with-temp*` call for `TaskHistory`. Uses the `started_at` param sets the `ended_at`
+  to 10 milliseconds later"
+  [started-at]
+  (let [ended-at (add-10-millis started-at)]
+    {:started_at (du/->Timestamp started-at)
+     :ended_at   (du/->Timestamp ended-at)
+     :duration   (du/calculate-duration started-at ended-at)}))
+
+;; Basic cleanup test where older rows are deleted and newer rows kept
+(let [task-4 (tu/random-name)
+      task-5 (tu/random-name)]
+  (expect
+    #{task-4 task-5}
+    (let [t1-start (time/now)
+          t2-start (add-second t1-start)
+          t3-start (add-second t2-start)
+          t4-start (add-second t3-start)
+          t5-start (add-second t4-start)]
+      (tt/with-temp* [TaskHistory [t1 (make-10-millis-task t1-start)]
+                      TaskHistory [t2 (make-10-millis-task t2-start)]
+                      TaskHistory [t3 (make-10-millis-task t3-start)]
+                      TaskHistory [t4 (assoc (make-10-millis-task t4-start)
+                                        :task task-4)]
+                      TaskHistory [t5 (assoc (make-10-millis-task t5-start)
+                                        :task task-5)]]
+        ;; When the sync process runs, it creates several TaskHistory rows. We just want to work with the temp ones
+        ;; created, so delete any stale ones from previous tests
+        (db/delete! TaskHistory :id [:not-in (map u/get-id [t1 t2 t3 t4 t5])])
+        ;; Delete all but 2 task history rows
+        (cleanup-task-history! 2)
+        (set (map :task (TaskHistory)))))))
+
+;; Basic cleanup test where no work needs to be done and nothing is deleted
+(let [task-1 (tu/random-name)
+      task-2 (tu/random-name)]
+  (expect
+    [#{task-1 task-2}
+     #{task-1 task-2}]
+    (let [t1-start (time/now)
+          t2-start (add-second t1-start)]
+      (tt/with-temp* [TaskHistory [t1 (assoc (make-10-millis-task t1-start)
+                                        :task task-1)]
+                      TaskHistory [t2 (assoc (make-10-millis-task t2-start)
+                                        :task task-2)]]
+        ;; Cleanup any stale TalkHistory entries that are not the two being tested
+        (db/delete! TaskHistory :id [:not-in (map u/get-id [t1 t2])])
+        ;; We're keeping 100 rows, but there are only 2 present, so there should be no affect on running this
+        [(set (map :task (TaskHistory)))
+         (do
+           (cleanup-task-history! 100)
+           (set (map :task (TaskHistory))))]))))

--- a/test/metabase/sync/sync_metadata/sync_database_type_test.clj
+++ b/test/metabase/sync/sync_metadata/sync_database_type_test.clj
@@ -16,13 +16,14 @@
 
 ;; make sure that if a driver reports back a different database-type the Field gets updated accordingly
 (expect
-  [{:total-fields 16 :updated-fields 6}
-   #{{:name "NAME",        :database_type "VARCHAR"}
-     {:name "LATITUDE",    :database_type "DOUBLE"}
-     {:name "LONGITUDE",   :database_type "DOUBLE"}
-     {:name "ID",          :database_type "BIGINT"}
-     {:name "PRICE",       :database_type "INTEGER"}
-     {:name "CATEGORY_ID", :database_type "INTEGER"}}]
+  (concat
+   (repeat 2 {:total-fields 16 :updated-fields 6})
+   [#{{:name "NAME",        :database_type "VARCHAR"}
+      {:name "LATITUDE",    :database_type "DOUBLE"}
+      {:name "LONGITUDE",   :database_type "DOUBLE"}
+      {:name "ID",          :database_type "BIGINT"}
+      {:name "PRICE",       :database_type "INTEGER"}
+      {:name "CATEGORY_ID", :database_type "INTEGER"}}])
   ;; create a copy of the sample dataset :D
   (tt/with-temp Database [db (select-keys (data/db) [:details :engine])]
     (sync/sync-database! db)
@@ -32,33 +33,37 @@
       (db/update-where! Field {:table_id (u/get-id venues-table)}, :database_type "?")
       (db/update! Table (u/get-id venues-table) :fields_hash "something new")
       ;; now sync the DB again
-      (let [after-update-step-info (sut/sync-database! "sync-fields" db)]
-        [(sut/only-step-keys after-update-step-info)
+      (let [{:keys [step-info task-history]} (sut/sync-database! "sync-fields" db)]
+        [(sut/only-step-keys step-info)
+         (:task_details task-history)
          ;; The database_type of these Fields should get set to the correct types. Let's see...
          (set (map (partial into {})
                    (db/select [Field :name :database_type] :table_id (u/get-id venues-table))))]))))
 
 ;; make sure that if a driver reports back a different base-type the Field gets updated accordingly
 (expect
-  [{:updated-fields 16, :total-fields 16}
-   {:updated-fields 6, :total-fields 16}
-   #{{:name "NAME",        :base_type :type/Text}
-     {:name "LATITUDE",    :base_type :type/Float}
-     {:name "PRICE",       :base_type :type/Integer}
-     {:name "ID",          :base_type :type/BigInteger}
-     {:name "LONGITUDE",   :base_type :type/Float}
-     {:name "CATEGORY_ID", :base_type :type/Integer}}]
+  (concat
+   (repeat 2 {:updated-fields 16, :total-fields 16})
+   (repeat 2 {:updated-fields 6, :total-fields 16})
+   [#{{:name "NAME",        :base_type :type/Text}
+      {:name "LATITUDE",    :base_type :type/Float}
+      {:name "PRICE",       :base_type :type/Integer}
+      {:name "ID",          :base_type :type/BigInteger}
+      {:name "LONGITUDE",   :base_type :type/Float}
+      {:name "CATEGORY_ID", :base_type :type/Integer}}])
   ;; create a copy of the sample dataset :D
   (tt/with-temp Database [db (select-keys (data/db) [:details :engine])]
-    (let [new-db-step-info (sut/sync-database! "sync-fields" db)
+    (let [{new-step-info :step-info, new-task-history :task-history} (sut/sync-database! "sync-fields" db)
           venues-table     (Table :db_id (u/get-id db), :display_name "Venues")]
       (db/update! Table (u/get-id venues-table) :fields_hash "something new")
       ;; ok, now give all the Fields `:type/*` as their `base_type`
       (db/update-where! Field {:table_id (u/get-id venues-table)}, :base_type "type/*")
       ;; now sync the DB again
-      (let [after-update-step-info (sut/sync-database! "sync-fields" db)]
-        [(sut/only-step-keys new-db-step-info)
-         (sut/only-step-keys after-update-step-info)
+      (let [{after-step-info :step-info, after-task-history :task-history} (sut/sync-database! "sync-fields" db)]
+        [(sut/only-step-keys new-step-info)
+         (:task_details new-task-history)
+         (sut/only-step-keys after-step-info)
+         (:task_details after-task-history)
          ;; The database_type of these Fields should get set to the correct types. Let's see...
          (set (map (partial into {})
                    (db/select [Field :name :base_type] :table_id (u/get-id venues-table))))]))))

--- a/test/metabase/sync/util_test.clj
+++ b/test/metabase/sync/util_test.clj
@@ -1,14 +1,16 @@
 (ns metabase.sync.util-test
   "Tests for the utility functions shared by all parts of sync, such as the duplicate ops guard."
-  (:require [clj-time.coerce :as tcoerce]
-            [expectations :refer :all]
+  (:require [expectations :refer :all]
             [metabase
              [driver :as driver]
              [sync :as sync]]
-            [metabase.sync
-             [interface :as i]
-             [util :refer :all]]
-            [metabase.models.database :refer [Database] :as mdb]
+            [metabase.models
+             [database :as mdb :refer [Database]]
+             [task-history :refer [TaskHistory]]]
+            [metabase.sync.util :refer :all]
+            [metabase.test.util :as tu]
+            [metabase.util.date :as du]
+            [toucan.db :as db]
             [toucan.util.test :as tt]))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -58,56 +60,80 @@
      ;; Check the number of syncs that took place. Should be 2 (just the first)
      @calls-to-describe-database)))
 
-(defn call-with-operation-info
-  "Call `f` with `log-sync-summary` redef'd to intercept the step metadata before the information is logged. This is
-  useful to validate that the metadata is correct as the message might not be logged at all (depending on the logging
-  level)."
+(defn- call-with-operation-info
+  "Call `f` with `log-sync-summary` and `store-sync-summary!` redef'd. For `log-sync-summary`, it intercepts the step
+  metadata before the information is logged. For `store-sync-summary!` it will return the IDs for the newly created
+  TaskHistory rows. This is useful to validate that the metadata and history is correct as the message might not be
+  logged at all (depending on the logging level) or not stored."
   [f]
   (let [step-info-atom (atom [])
-        orig-fn (var-get #'metabase.sync.util/log-sync-summary)]
+        created-task-history-ids (atom [])
+        orig-log-fn (var-get #'metabase.sync.util/log-sync-summary)
+        orig-store-fn (var-get #'metabase.sync.util/store-sync-summary!)]
     (with-redefs [metabase.sync.util/log-sync-summary (fn [operation database {:keys [steps] :as operation-metadata}]
                                                         (swap! step-info-atom conj operation-metadata)
-                                                        (orig-fn operation database operation-metadata))]
+                                                        (orig-log-fn operation database operation-metadata))
+                  metabase.sync.util/store-sync-summary! (fn [operation database operation-metadata]
+                                                           (let [result (orig-store-fn operation database operation-metadata)]
+                                                             (swap! created-task-history-ids concat result)
+                                                             result))]
       (f))
-    @step-info-atom))
+    {:operation-results @step-info-atom
+     :task-history-ids @created-task-history-ids}))
 
 (defn sync-database!
-  "Calls `sync-database!` and returns the the metadata for `step` as the result. This function is useful for
-  validating that each steps metadata correctly reflects the changes that were made via a test scenario."
+  "Calls `sync-database!` and returns the the metadata for `step` as the result along with the `TaskHistory` for that
+  `step`. This function is useful for validating that each step's metadata correctly reflects the changes that were
+  made via a test scenario."
   [step db]
-  (let [operation-results (call-with-operation-info #(sync/sync-database! db))]
-    (-> (into {} (mapcat :steps operation-results))
-        (get step))))
+  (let [{:keys [operation-results task-history-ids]} (call-with-operation-info #(sync/sync-database! db))]
+    {:step-info    (-> (into {} (mapcat :steps operation-results))
+                       (get step))
+     :task-history (when (seq task-history-ids)
+                     (db/select-one TaskHistory :id [:in task-history-ids]
+                                    :task [:= step]))}))
 
 (defn only-step-keys
   "This function removes the generic keys for the step metadata, returning only the step specific keypairs to make
   validating the results for the given step easier."
   [step-info]
-  (dissoc step-info :start-time :end-time :duration :log-summary-fn))
-
-(defn- date-string? [s]
-  (-> s tcoerce/from-string boolean))
+  (dissoc step-info :start-time :end-time :log-summary-fn))
 
 (defn- validate-times [m]
-  (and (-> m :start-time date-string?)
-       (-> m :end-time date-string?)
-       (-> m :duration string?)))
+  (and (-> m :start-time du/is-temporal?)
+       (-> m :end-time du/is-temporal?)))
 
-(expect
-  [
-   ;; There should only be 1 operation info returned
-   true
-   ;; Validate that start/end/duration of the entire sync operation is included
-   true
-   ;; Each step should have a valid start/end/duration value
-   [true true]
-   ;; Each step name is included with the results, the order is preseverd
-   ["step1" "step2"]]
-  (let [sync-steps [(create-sync-step "step1" (fn [_] (Thread/sleep 10)))
-                    (create-sync-step "step2" (fn [_] (Thread/sleep 10)))]
-        mock-db    (mdb/map->DatabaseInstance {:name "test", :id  1, :engine :h2})
-        [results & none]    (call-with-operation-info #(run-sync-operation "sync" mock-db sync-steps))]
-    [(empty? none)
-     (validate-times results)
-     (map (comp validate-times second) (:steps results))
-     (map first (:steps results))]))
+(def ^:private default-task-history
+  {:id true, :db_id true, :started_at true, :ended_at true})
+
+(defn- fetch-task-history-row [task-name]
+  (let [task-history (db/select-one TaskHistory :task task-name)]
+    (assert (integer? (:duration task-history)))
+    (tu/boolean-ids-and-timestamps (dissoc task-history :duration))))
+
+(let [process-name (tu/random-name)
+      step-1-name  (tu/random-name)
+      step-2-name  (tu/random-name)]
+  (expect
+    {:valid-operation-metadata? true
+     :valid-step-metadata?      [true true]
+     :step-names                [step-1-name step-2-name]
+     :operation-history         (merge default-task-history
+                                       {:task process-name, :task_details nil})
+     :step-1-history            (merge default-task-history
+                                       {:task step-1-name, :task_details {:foo "bar"}})
+     :step-2-history            (merge default-task-history
+                                       {:task step-2-name, :task_details nil})}
+    (let [sync-steps [(create-sync-step step-1-name (fn [_] (Thread/sleep 10) {:foo "bar"}))
+                      (create-sync-step step-2-name (fn [_] (Thread/sleep 10)))]
+          mock-db    (mdb/map->DatabaseInstance {:name "test", :id 1, :engine :h2})
+          [results]  (:operation-results
+                      (call-with-operation-info #(run-sync-operation process-name mock-db sync-steps)))]
+
+      {:valid-operation-metadata? (validate-times results)
+       :valid-step-metadata?      (map (comp validate-times second) (:steps results))
+       :step-names                (map first (:steps results))
+       ;; Check that the TaskHistory was stored for the operation and each of the steps
+       :operation-history         (fetch-task-history-row process-name)
+       :step-1-history            (fetch-task-history-row step-1-name)
+       :step-2-history            (fetch-task-history-row step-2-name)})))

--- a/test/metabase/task/task_history_cleanup_test.clj
+++ b/test/metabase/task/task_history_cleanup_test.clj
@@ -1,0 +1,51 @@
+(ns metabase.task.task-history-cleanup-test
+  (:require [clj-time.core :as time]
+            [expectations :refer :all]
+            [metabase.models
+             [task-history :refer [TaskHistory]]
+             [task-history-test :as tht]]
+            [metabase.task.task-history-cleanup :as cleanup-task]
+            [metabase.test.util :as tu]
+            [metabase.util :as u]
+            [toucan.db :as db]
+            [toucan.util.test :as tt]))
+
+;; Basic run of the cleanup task when it needs to remove rows. Should also add a TaskHistory row once complete
+(let [task-2 (tu/random-name)
+      task-3 (tu/random-name)]
+  (expect
+    #{task-2 task-3 (var-get #'cleanup-task/job-name)}
+    (let [t1-start (time/now)
+          t2-start (tht/add-second t1-start)
+          t3-start (tht/add-second t2-start)]
+      (tt/with-temp* [TaskHistory [t1 (tht/make-10-millis-task t1-start)]
+                      TaskHistory [t2 (assoc (tht/make-10-millis-task t2-start)
+                                        :task task-2)]
+                      TaskHistory [t3 (assoc (tht/make-10-millis-task t3-start)
+                                        :task task-3)]]
+        (with-redefs [cleanup-task/history-rows-to-keep 2]
+          (db/delete! TaskHistory :id [:not-in (map u/get-id [t1 t2 t3])])
+          ;; Delete all but 2 task history rows
+          (#'cleanup-task/task-history-cleanup!)
+          (set (map :task (TaskHistory))))))))
+
+;; When the task runs and nothing is removed, it should still insert a new TaskHistory row
+(let [task-1 (tu/random-name)
+      task-2 (tu/random-name)
+      task-3 (tu/random-name)]
+  (expect
+    #{task-1 task-2 task-3 (var-get #'cleanup-task/job-name)}
+    (let [t1-start (time/now)
+          t2-start (tht/add-second t1-start)
+          t3-start (tht/add-second t2-start)]
+      (tt/with-temp* [TaskHistory [t1 (assoc (tht/make-10-millis-task t1-start)
+                                        :task task-1)]
+                      TaskHistory [t2 (assoc (tht/make-10-millis-task t2-start)
+                                        :task task-2)]
+                      TaskHistory [t3 (assoc (tht/make-10-millis-task t3-start)
+                                        :task task-3)]]
+        (with-redefs [cleanup-task/history-rows-to-keep 10]
+          (db/delete! TaskHistory :id [:not-in (map u/get-id [t1 t2 t3])])
+          ;; Delete all but 2 task history rows
+          (#'cleanup-task/task-history-cleanup!)
+          (set (map :task (TaskHistory))))))))

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -1,7 +1,9 @@
 (ns metabase.test.util
   "Helper functions and macros for writing unit tests."
   (:require [cheshire.core :as json]
-            [clj-time.core :as time]
+            [clj-time
+             [coerce :as tcoerce]
+             [core :as time]]
             [clojure.tools.logging :as log]
             [clojure.walk :as walk]
             [clojurewerkz.quartzite.scheduler :as qs]
@@ -29,6 +31,7 @@
              [segment :refer [Segment]]
              [setting :as setting]
              [table :refer [Table]]
+             [task-history :refer [TaskHistory]]
              [user :refer [User]]]
             [metabase.query-processor.middleware.expand :as ql]
             [metabase.query-processor.util :as qputil]
@@ -36,6 +39,7 @@
             [metabase.test.data
              [dataset-definitions :as defs]
              [datasets :refer [*driver*]]]
+            [metabase.util.date :as du]
             [toucan.db :as db]
             [toucan.util.test :as test])
   (:import com.mchange.v2.c3p0.PooledDataSource
@@ -110,9 +114,10 @@
   ([data]
    (boolean-ids-and-timestamps
     (every-pred (some-fn keyword? string?)
-                (some-fn #{:id :created_at :updated_at :last_analyzed :created-at :updated-at :field-value-id :field-id
+                (some-fn #{:id :last_analyzed :created-at :updated-at :field-value-id :field-id
                            :fields_hash :date_joined :date-joined :last_login}
-                         #(.endsWith (name %) "_id")))
+                         #(.endsWith (name %) "_id")
+                         #(.endsWith (name %) "_at")))
     data))
   ([pred data]
    (walk/prewalk (fn [maybe-map]
@@ -225,6 +230,17 @@
   {:with-temp-defaults (fn [_] {:db_id  (data/id)
                                 :active true
                                 :name   (random-name)})})
+
+(u/strict-extend (class TaskHistory)
+  test/WithTempDefaults
+  {:with-temp-defaults (fn [_]
+                         (let [started (time/now)
+                               ended   (time/plus started (time/millis 10))]
+                           {:db_id      (data/id)
+                            :task       (random-name)
+                            :started_at (du/->Timestamp started)
+                            :ended_at   (du/->Timestamp ended)
+                            :duration   (du/calculate-duration started ended)}))})
 
 (u/strict-extend (class User)
   test/WithTempDefaults


### PR DESCRIPTION
This adds a new table for storing sync metrics and a quartz task for
cleaning up old entries in the table.

For now this only stores sync metrics, but it seems useful to also
store information about when pulses are sent and other background
tasks that would be useful to have additional information on when
users have issues.

Fixes #7611

