### PR TITLE
Fix dashboard create modal form enter dismissal issue

### DIFF
--- a/frontend/src/metabase/components/form/StandardForm.jsx
+++ b/frontend/src/metabase/components/form/StandardForm.jsx
@@ -52,7 +52,11 @@ const StandardForm = ({
     <div className={cx("flex", { "Form-offset": !newForm })}>
       <div className="ml-auto flex align-center">
         {onClose && (
-          <Button className="mr1" onClick={onClose}>{t`Cancel`}</Button>
+          <Button
+            type="button"
+            className="mr1"
+            onClick={onClose}
+          >{t`Cancel`}</Button>
         )}
         <Button
           type="submit"


### PR DESCRIPTION
Fixes #8430 

It looks like because we weren't explicitly specifying the button type on the cancel button inside the `<form>` element, it was getting treated as a submit (which I guess is just what `<button>` elements inside of `<form>` elements do unless you specify otherwise). Setting the type to `button` properly submits the form and redirects to the new dashboard.