### PR TITLE
update Dockerfile due to deprecated base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # STAGE 1: builder
 ###################
 
-FROM java:openjdk-8-jdk-alpine as builder
+FROM openjdk:8-alpine as builder
 
 WORKDIR /app/source
 
@@ -15,7 +15,7 @@ ENV LC_CTYPE en_US.UTF-8
 # nodejs:  frontend building
 # make:    backend building
 # gettext: translations
-RUN apk add --update bash nodejs git wget make gettext
+RUN apk add --update bash nodejs git wget make gettext nodejs-npm
 
 # yarn:    frontend dependencies
 RUN npm install -g yarn


### PR DESCRIPTION
Due to Issue [8444](https://github.com/metabase/metabase/issues/8444), the docker base image was deprecated and changed to ```openjdk:8-alpine```, ```nodejs-npm``` package is also added.