### PR TITLE
docs: Now Java 8 is required

### DIFF
--- a/docs/operations-guide/running-the-metabase-jar-file.md
+++ b/docs/operations-guide/running-the-metabase-jar-file.md
@@ -19,7 +19,7 @@ You should see output such as:
     Java(TM) SE Runtime Environment (build 1.8.0_31-b13)
     Java HotSpot(TM) 64-Bit Server VM (build 25.31-b07, mixed mode)
 
-If you did not see the output above and instead saw either an error or your Java version is less than 1.7, then you need to install the Java Runtime.
+If you did not see the output above and instead saw either an error or your Java version is less than 1.8, then you need to install the Java Runtime.
 
 [OpenJDK Downloads](http://openjdk.java.net/install/)
 [Oracle's Java Downloads](http://www.oracle.com/technetwork/java/javase/downloads/index.html)


### PR DESCRIPTION

Also https://metabase.com/start/jar.html still mention Java 7:

> Metabase requires that you have Java **7** or higher available on your system. We have run Metabase with both the OpenJDK and Oracle JDK, so feel free to use either.

