### PR TITLE
Restore `build-for-test` script

### DIFF
--- a/bin/build-for-test
+++ b/bin/build-for-test
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -eu
+
+VERSION_PROPERTY_NAME="src_hash"
+
+source-hash() {
+  # hash all the files that might change a backend-only uberjar build (for integration tests)
+  (
+    find src project.clj resources/sample-dataset.db.mv.db -type f -print0 | xargs -0 shasum ;
+    find resources -type f \( -iname \*.clj -o -iname \*.edn -o -iname \*.yaml -o -iname \*.properties \) -not -name "version.properties" -print0 | xargs -0 shasum ;
+  ) | shasum | awk '{ print $1 }'
+}
+
+uberjar-hash() {
+  # java -jar target/uberjar/metabase.jar version | grep -oE 'source_hash [a-f0-9]+' | awk '{ print $2 }'
+  # pulling the version.properties directly from the jar is much faster
+  unzip -c target/uberjar/metabase.jar version.properties | grep "$VERSION_PROPERTY_NAME" | cut -f2 -d=
+}
+
+check-uberjar-hash() {
+  expected_hash=$(source-hash)
+  actual_hash=$(uberjar-hash)
+  if [ "$expected_hash" == "$actual_hash" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+build-uberjar-for-test() {
+  ./bin/build version
+  echo "$VERSION_PROPERTY_NAME=$(source-hash)" >> resources/version.properties
+  ./bin/build uberjar
+}
+
+if [ ! -f "target/uberjar/metabase.jar" ] || ! check-uberjar-hash; then
+  echo "Building uberjar for testing"
+  build-uberjar-for-test
+else
+  echo "Uberjar already up to date for testing"
+fi


### PR DESCRIPTION
Needed for `yarn test-integrated` but was removed in CircleCI 2.0 port