### PR TITLE
Ensure connections are closed when a db is deleted [ci drivers]

### DIFF
--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -127,7 +127,7 @@
   (result-set-read-column [x _ _] (PersistentVector/adopt x)))
 
 
-(def ^:dynamic ^:private database-id->connection-pool
+(def ^:private database-id->connection-pool
   "A map of our currently open connection pools, keyed by Database `:id`."
   (atom {}))
 

--- a/test/metabase/driver/bigquery_test.clj
+++ b/test/metabase/driver/bigquery_test.clj
@@ -175,9 +175,9 @@
 
 (defn- native-timestamp-query [db-or-db-id timestamp-str timezone-str]
   (-> (qp/process-query
-        {:native   {:query (format "select datetime(TIMESTAMP \"%s\", \"%s\")" timestamp-str timezone-str)
-                    :type  :native}
-         :database (u/get-id db-or-db-id)})
+       {:native   {:query (format "select datetime(TIMESTAMP \"%s\", \"%s\")" timestamp-str timezone-str)}
+        :type     :native
+        :database (u/get-id db-or-db-id)})
       :data
       :rows
       ffirst))

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -141,6 +141,12 @@
         (throw (Exception. (format "No Table '%s' found for Database %d.\nFound: %s" table-name db-id
                                    (u/pprint-to-str (db/select-id->field :name Table, :db_id db-id, :active true))))))))
 
+(defn table-name
+  "Return the correct (database specific) table name for `table-name`. For most databases `table-name` is just
+  returned. For others (like Oracle), the real name is prefixed by the dataset and might be different"
+  [db-id table-name]
+  (db/select-one-field :name Table :id (get-table-id-or-explode db-id table-name)))
+
 (defn- get-field-id-or-explode [table-id field-name & {:keys [parent-id]}]
   (let [field-name (format-name field-name)]
     (or (db/select-one-id Field, :active true, :table_id table-id, :name field-name, :parent_id parent-id)

--- a/test/metabase/test/data/sparksql.clj
+++ b/test/metabase/test/data/sparksql.clj
@@ -35,6 +35,14 @@
 (defn- qualified-name-components [& args]
   (map dashes->underscores args))
 
+(defn- qualify+quote-name
+  ([db-name]
+   (dashes->underscores db-name))
+  ([_ table-name]
+   (dashes->underscores table-name))
+  ([_ _ field-name]
+   (dashes->underscores field-name)))
+
 (defn- database->connection-details [context {:keys [database-name]}]
   (merge {:host     "localhost"
           :port     10000
@@ -108,6 +116,7 @@
           :drop-db-if-exists-sql     drop-db-if-exists-sql
           :load-data!                load-data!
           :pk-sql-type               (constantly "INT")
+          :qualify+quote-name        (u/drop-first-arg qualify+quote-name)
           :qualified-name-components (u/drop-first-arg qualified-name-components)
           :quote-name                (u/drop-first-arg quote-name)})
   i/IDriverTestExtensions


### PR DESCRIPTION
This can cause issues, especially in test code that creates and
destroys many databases throughout the test suite. The connections are
left open and eventually the database runs out of connections, causing
the test run to fail.

This commit also makes a few other minor test related changes such as
adding a `table-name` similar to our `id` function that returns the
correct table name for the given database.
