### PR TITLE
Query schema fixes; add query validation middleware [ci drivers]

### DIFF
--- a/frontend/test/__runner__/backend.js
+++ b/frontend/test/__runner__/backend.js
@@ -60,6 +60,7 @@ export const BackendResource = createSharedResource("BackendResource", {
         ],
         {
           env: {
+            MB_DB_TYPE: "h2",
             MB_DB_FILE: server.dbFile,
             MB_JETTY_PORT: server.port,
           },

--- a/frontend/test/reference/databases.integ.spec.js
+++ b/frontend/test/reference/databases.integ.spec.js
@@ -41,7 +41,6 @@ describe("The Reference Section", () => {
     display: "scalar",
     dataset_query: {
       database: 1,
-      table_id: 1,
       type: "query",
       query: { "source-table": 1, aggregation: ["count"] },
     },

--- a/frontend/test/reference/metrics.integ.spec.js
+++ b/frontend/test/reference/metrics.integ.spec.js
@@ -47,7 +47,6 @@ describe("The Reference Section", () => {
     display: "scalar",
     dataset_query: {
       database: 1,
-      table_id: 1,
       type: "query",
       query: { "source-table": 1, aggregation: [["metric", 1]] },
     },

--- a/frontend/test/reference/segments.integ.spec.js
+++ b/frontend/test/reference/segments.integ.spec.js
@@ -56,7 +56,6 @@ describe("The Reference Section", () => {
     display: "scalar",
     dataset_query: {
       database: 1,
-      table_id: 1,
       type: "query",
       query: {
         "source-table": 1,

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -499,11 +499,6 @@
     (check (not (:archived object))
       [404 {:message (tru "The object has been archived."), :error_code "archived"}])))
 
-(defn with-current-user-info
-  "Associates the login-attributes of the current users to `m`"
-  [m]
-  (assoc m :user @*current-user*))
-
 (s/defn column-will-change? :- s/Bool
   "Helper for PATCH-style operations to see if a column is set to change when `object-updates` (i.e., the input to the
   endpoint) is applied.

--- a/src/metabase/api/field.clj
+++ b/src/metabase/api/field.clj
@@ -264,19 +264,18 @@
   "Generate the MBQL query used to power FieldValues search in `search-values` below. The actual query generated differs
   slightly based on whether the two Fields are the same Field."
   [field search-field value limit]
-  (api/with-current-user-info
-    {:database (db-id field)
-     :type     :query
-     :query    {:source-table (table-id field)
-                :filter       [:starts-with [:field-id (u/get-id search-field)] value {:case-sensitive false}]
-                ;; if both fields are the same then make sure not to refer to it twice in the `:breakout` clause.
-                ;; Otherwise this will break certain drivers like BigQuery that don't support duplicate
-                ;; identifiers/aliases
-                :breakout     (if (= (u/get-id field) (u/get-id search-field))
-                                [[:field-id (u/get-id field)]]
-                                [[:field-id (u/get-id field)]
-                                 [:field-id (u/get-id search-field)]])
-                :limit        limit}}))
+  {:database (db-id field)
+   :type     :query
+   :query    {:source-table (table-id field)
+              :filter       [:starts-with [:field-id (u/get-id search-field)] value {:case-sensitive false}]
+              ;; if both fields are the same then make sure not to refer to it twice in the `:breakout` clause.
+              ;; Otherwise this will break certain drivers like BigQuery that don't support duplicate
+              ;; identifiers/aliases
+              :breakout     (if (= (u/get-id field) (u/get-id search-field))
+                              [[:field-id (u/get-id field)]]
+                              [[:field-id (u/get-id field)]
+                               [:field-id (u/get-id search-field)]])
+              :limit        limit}})
 
 (s/defn search-values
   "Search for values of `search-field` that start with `value` (up to `limit`, if specified), and return like
@@ -304,7 +303,8 @@
         [result result]))))
 
 (api/defendpoint GET "/:id/search/:search-id"
-  "Search for values of a Field that match values of another Field when breaking out by the "
+  "Search for values of a Field with `search-id` that start with `value`. See docstring for
+  `metabase.api.field/search-values` for a more detailed explanation."
   [id search-id value limit]
   {value su/NonBlankString
    limit (s/maybe su/IntStringGreaterThanZero)}

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -2,7 +2,8 @@
   (:require [clojure.string :as str]
             [compojure.core :refer [GET]]
             [honeysql.helpers :as h]
-            [metabase.api.common :refer [*current-user-id* *current-user-permissions-set* check-403 defendpoint define-routes]]
+            [metabase.api.common :refer [*current-user-id* *current-user-permissions-set* check-403 defendpoint
+                                         define-routes]]
             [metabase.models
              [card :refer [Card]]
              [card-favorite :refer [CardFavorite]]
@@ -45,7 +46,7 @@
   default-columns)
 
 (defn- ->column
-  "Returns the column name. If the column is aliased, i.e. [`:original_namd` `:aliased_name`], return the aliased
+  "Returns the column name. If the column is aliased, i.e. [`:original_name` `:aliased_name`], return the aliased
   column name"
   [column-or-aliased]
   (if (sequential? column-or-aliased)
@@ -95,7 +96,7 @@
   [query-map entity-type entity-columns]
   (let [col-name->column (u/key-by ->column entity-columns)
         cols-or-nils     (make-canonical-columns entity-type col-name->column)]
-    (apply h/merge-select query-map (concat cols-or-nils ))))
+    (apply h/merge-select query-map (concat cols-or-nils))))
 
 ;; TODO - not used anywhere except `merge-name-and-archived-search` anymore so we can roll it into that
 (s/defn ^:private merge-name-search

--- a/src/metabase/db/migrations.clj
+++ b/src/metabase/db/migrations.clj
@@ -26,17 +26,14 @@
              [permissions-group :as perm-group :refer [PermissionsGroup]]
              [permissions-group-membership :as perm-membership :refer [PermissionsGroupMembership]]
              [pulse :refer [Pulse]]
-             [query-execution :as query-execution :refer [QueryExecution]]
              [setting :as setting :refer [Setting]]
              [user :refer [User]]]
-            [metabase.query-processor.util :as qputil]
             [metabase.util
              [date :as du]
              [i18n :refer [trs]]]
             [toucan
              [db :as db]
-             [models :as models]]
-            [metabase.models.permissions-group :as group])
+             [models :as models]])
   (:import java.util.UUID))
 
 ;;; # Migration Helpers
@@ -205,40 +202,6 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                           Migrating QueryExecutions                                            |
 ;;; +----------------------------------------------------------------------------------------------------------------+
-
-;; We're copying over data from the legacy `query_queryexecution` table to the new `query_execution` table; see #4522
-;; and #4531 for details
-
-;; model definition for the old table to facilitate the data copying process
-(models/defmodel ^:private ^:deprecated LegacyQueryExecution :query_queryexecution)
-
-(u/strict-extend (class LegacyQueryExecution)
-  models/IModel
-  (merge models/IModelDefaults
-         {:default-fields (constantly [:executor_id :result_rows :started_at :json_query :error :running_time])
-          :types          (constantly {:json_query :json, :error :clob})}))
-
-(defn- LegacyQueryExecution->QueryExecution
-  "Convert a LegacyQueryExecution to a format suitable for insertion as a new-format QueryExecution."
-  [{query :json_query, :as query-execution}]
-  (-> (assoc query-execution
-        :hash   (qputil/query-hash query)
-        :native (not (qputil/mbql-query? query)))
-      ;; since error is nullable now remove the old blank error message strings
-      (update :error (fn [error-message]
-                       (when-not (str/blank? error-message)
-                         error-message)))
-      (dissoc :json_query)))
-
-;; Migrate entries from the old query execution table to the new one. This might take a few minutes
-(defmigration ^{:author "camsaul", :added "0.23.0"} migrate-query-executions
-  ;; migrate the most recent 100,000 entries. Make sure the DB doesn't get snippy by trying to insert too many records
-  ;; at once. Divide the INSERT statements into chunks of 1,000
-  (binding [query-execution/*validate-context* false]
-    (doseq [chunk (partition-all 1000 (db/select LegacyQueryExecution {:limit 100000, :order-by [[:id :desc]]}))]
-      (db/insert-many! QueryExecution
-        (for [query-execution chunk]
-          (LegacyQueryExecution->QueryExecution query-execution))))))
 
 ;; drop the legacy QueryExecution table now that we don't need it anymore
 (defmigration ^{:author "camsaul", :added "0.23.0"} drop-old-query-execution-table

--- a/src/metabase/driver/bigquery.clj
+++ b/src/metabase/driver/bigquery.clj
@@ -1,6 +1,5 @@
 (ns metabase.driver.bigquery
-  (:require [cheshire.core :as json]
-            [clj-time
+  (:require [clj-time
              [coerce :as tcoerce]
              [core :as time]
              [format :as tformat]]
@@ -33,7 +32,8 @@
   (:import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
            com.google.api.client.http.HttpRequestInitializer
            [com.google.api.services.bigquery Bigquery Bigquery$Builder BigqueryScopes]
-           [com.google.api.services.bigquery.model QueryRequest QueryResponse Table TableCell TableFieldSchema TableList TableList$Tables TableReference TableRow TableSchema]
+           [com.google.api.services.bigquery.model QueryRequest QueryResponse Table TableCell TableFieldSchema TableList
+            TableList$Tables TableReference TableRow TableSchema]
            honeysql.format.ToSql
            java.sql.Time
            [java.util Collections Date]
@@ -445,16 +445,11 @@
 
 (defn- field->identifier
   "Generate appropriate identifier for a Field for SQL parameters. (NOTE: THIS IS ONLY USED FOR SQL PARAMETERS!)"
-  ;; TODO - Making a DB call for each field to fetch its dataset is inefficient and makes me cry, but this method is
+  ;; TODO - Making 2 DB calls for each field to fetch its dataset is inefficient and makes me cry, but this method is
   ;; currently only used for SQL params so it's not a huge deal at this point
   [{table-id :table_id, :as field}]
-  ;; manually write the query here to save us from having to do 2 seperate queries...
-  (let [[{:keys [details table-name]}] (db/query {:select    [[:database.details :details] [:table.name :table-name]]
-                                                  :from      [[:metabase_table :table]]
-                                                  :left-join [[:metabase_database :database]
-                                                              [:= :database.id :table.db_id]]
-                                                  :where     [:= :table.id (u/get-id table-id)]})
-        details (json/parse-string (u/jdbc-clob->str details) keyword)]
+  (let [{table-name :name, database-id :db_id} (db/select-one ['Table :name :db_id], :id (u/get-id table-id))
+        details                                (db/select-one-field :details 'Database, :id (u/get-id database-id))]
     (map->BigQueryIdentifier {:dataset-name (:dataset-id details), :table-name table-name, :field-name (:name field)})))
 
 (defn- field->breakout-identifier [driver field]

--- a/src/metabase/mbql/normalize.clj
+++ b/src/metabase/mbql/normalize.clj
@@ -209,7 +209,8 @@
                 :expressions  normalize-expressions-tokens
                 :order-by     normalize-order-by-tokens
                 :source-query normalize-source-query}
-   :parameters {::sequence normalize-query-parameter}})
+   :parameters {::sequence normalize-query-parameter}
+   :context    #(some-> % mbql.u/normalize-token)})
 
 (defn normalize-tokens
   "Recursively normalize tokens in `x`.

--- a/src/metabase/mbql/schema/helpers.clj
+++ b/src/metabase/mbql/schema/helpers.clj
@@ -55,14 +55,20 @@
 
 ;;; ----------------------------------------------------- one-of -----------------------------------------------------
 
-;; TODO - consider using impl in `mbql.u` instead
-(defn is-clause?
-  "True if `x` is a given MBQL clause.
+;; TODO - this is a copy of the one in the `metabase.mbql.util` namespace. We need to reorganize things a bit so we
+;; can use the same fn and avoid circular refs
+(defn ^:deprecated is-clause?
+  "If `x` an MBQL clause, and an instance of clauses defined by keyword(s) `k-or-ks`?
 
-     (is-clause? :field-id [:field-id 10]) ;-> true"
-  [clause-name x]
-  (and (sequential? x)
-       (= (first x) clause-name)))
+    (is-clause? :count [:count 10])        ; -> true
+    (is-clause? #{:+ :- :* :/} [:+ 10 20]) ; -> true"
+  [k-or-ks x]
+  (and
+   (sequential? x)
+   (keyword? (first x))
+   (if (coll? k-or-ks)
+     ((set k-or-ks) (first x))
+     (= k-or-ks (first x)))))
 
 (defn one-of*
   "Interal impl of `one-of` macro."

--- a/src/metabase/mbql/util.clj
+++ b/src/metabase/mbql/util.clj
@@ -88,6 +88,9 @@
 ;;; |                                       Functions for manipulating queries                                       |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
+;; TODO - I think we actually should move this stuff into a `mbql.helpers` namespace so we can use the util functions
+;; above in the `schema.helpers` namespace instead of duplicating them
+
 (s/defn simplify-compound-filter :- mbql.s/Filter
   "Simplify compound `:and`, `:or`, and `:not` compound filters, combining or eliminating them where possible. This
   also fixes theoretically disallowed compound filters like `:and` with only a single subclause."

--- a/src/metabase/models/query_execution.clj
+++ b/src/metabase/models/query_execution.clj
@@ -1,37 +1,20 @@
 (ns metabase.models.query-execution
+  "QueryExecution is a log of very time a query is executed, and other information such as the User who executed it, run
+  time, context it was executed in, etc."
   (:require [metabase.util :as u]
             [metabase.util.i18n :refer [tru]]
+            [metabase.mbql.schema :as mbql.s]
             [schema.core :as s]
             [toucan.models :as models]))
 
 (models/defmodel QueryExecution :query_execution)
 
-(def ^:dynamic ^Boolean *validate-context*
-  "Whether we should validate the values of `context` for QueryExecutions when INSERTing them.
-   (In normal usage, this should always be `true`, but this switch is provided so we can migrating
-   legacy QueryExecution entries, which have no `context` information)."
-  true)
-
-(def Context
-  "Schema for valid values of QueryExecution `:context`."
-  (s/enum :ad-hoc
-          :csv-download
-          :dashboard
-          :embedded-dashboard
-          :embedded-question
-          :json-download
-          :map-tiles
-          :metabot
-          :public-dashboard
-          :public-question
-          :pulse
-          :question
-          :xlsx-download))
+(def ^:private ^{:arglists '([context])} validate-context
+  (s/validator mbql.s/Context))
 
 (defn- pre-insert [{context :context, :as query-execution}]
   (u/prog1 query-execution
-    (when *validate-context*
-      (s/validate Context context))))
+    (validate-context context)))
 
 (defn- post-select [{:keys [result_rows] :as query-execution}]
   ;; sadly we have 2 ways to reference the row count :(

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -122,6 +122,7 @@
     results))
 
 (defn- run-query-with-cache [qp {cache-ttl :cache_ttl, :as query}]
+  ;; TODO - Query should already have a `info.hash`, shouldn't it?
   (let [query-hash (qputil/query-hash query)]
     (or (cached-results query-hash cache-ttl)
         (run-query-and-save-results-if-successful! query-hash qp query))))

--- a/src/metabase/query_processor/middleware/results_metadata.clj
+++ b/src/metabase/query_processor/middleware/results_metadata.clj
@@ -8,7 +8,9 @@
             [metabase.query-processor.interface :as i]
             [metabase.sync.analyze.query-results :as qr]
             [metabase.util :as u]
-            [metabase.util.encryption :as encryption]
+            [metabase.util
+             [encryption :as encryption]
+             [i18n :refer [tru]]]
             [ring.util.codec :as codec]
             [toucan.db :as db]))
 
@@ -65,6 +67,7 @@
           ;; if for some reason we weren't able to record results metadata for this query then just proceed as normal
           ;; rather than failing the entire query
           (catch Throwable e
-            (log/error "Error recording results metadata for query:" (.getMessage e) "\n"
+            (log/error (tru "Error recording results metadata for query:")
+                       (.getMessage e) "\n"
                        (u/pprint-to-str (u/filtered-stacktrace e)))
             results))))))

--- a/src/metabase/query_processor/middleware/validate.clj
+++ b/src/metabase/query_processor/middleware/validate.clj
@@ -1,0 +1,8 @@
+(ns metabase.query-processor.middleware.validate
+  "Middleware for checking that a normalized query is valid."
+  (:require [metabase.mbql.schema :as mbql.s]))
+
+(defn validate-query
+  "Middleware that validates a query immediately after normalization."
+  [qp]
+  (comp qp mbql.s/validate-query))

--- a/test/metabase/driver/bigquery_test.clj
+++ b/test/metabase/driver/bigquery_test.clj
@@ -177,9 +177,9 @@
 
 (defn- native-timestamp-query [db-or-db-id timestamp-str timezone-str]
   (-> (qp/process-query
-        {:native   {:query (format "select datetime(TIMESTAMP \"%s\", \"%s\")" timestamp-str timezone-str)
-                    :type  :native}
-         :database (u/get-id db-or-db-id)})
+        {:database (u/get-id db-or-db-id)
+         :type     :native
+         :native   {:query (format "select datetime(TIMESTAMP \"%s\", \"%s\")" timestamp-str timezone-str)}})
       :data
       :rows
       ffirst))

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -147,10 +147,10 @@
       (qpt/first-row
         (du/with-effective-timezone (Database (data/id))
           (qp/process-query
-           {:database (data/id),
-            :type :native,
-            :settings {:report-timezone "UTC"}
-            :native     {:query "SELECT cast({{date}} as date)"
+           {:database   (data/id)
+            :type       :native
+            :settings   {:report-timezone "UTC"}
+            :native     {:query         "SELECT cast({{date}} as date)"
                          :template-tags {:date {:name "date" :display_name "Date" :type "date" }}}
             :parameters [{:type "date/single" :target ["variable" ["template-tag" "date"]] :value "2018-04-18"}]}))))))
 

--- a/test/metabase/mbql/normalize_test.clj
+++ b/test/metabase/mbql/normalize_test.clj
@@ -274,6 +274,16 @@
     :type     :query
     :query    {"source_query" {"source_table" 1, "aggregation" "rows"}}}))
 
+;; Does the QueryExecution context get normalized?
+(expect
+  {:context :json-download}
+  (#'normalize/normalize-tokens {:context "json-download"}))
+
+;; if `:context` is `nil` it's not our problem
+(expect
+  {:context nil}
+  (#'normalize/normalize-tokens {:context nil}))
+
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                  CANONICALIZE                                                  |
@@ -588,6 +598,12 @@
    {:database 4
     :type     :query
     :query    {:source-query {:source-table 1, :aggregation :rows}}}))
+
+;; make sure canonicalization can handle aggregations with expressions where the Field normally goes
+(expect
+  {:query {:aggregation [[:sum [:* [:field-id 4] [:field-id 1]]]]}}
+  (#'normalize/canonicalize
+   {:query {:aggregation [[:sum [:* [:field-id 4] [:field-id 1]]]]}}))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/test/metabase/query_processor/middleware/results_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/results_metadata_test.clj
@@ -10,6 +10,7 @@
              [permissions :as perms]
              [permissions-group :as group]]
             [metabase.query-processor.middleware.results-metadata :as results-metadata]
+            [metabase.query-processor.util :as qputil]
             [metabase.test
              [data :as data]
              [util :as tu]]
@@ -54,7 +55,7 @@
   (tt/with-temp Card [card]
     (qp/process-query (assoc (native-query "SELECT ID, NAME, PRICE, CATEGORY_ID, LATITUDE, LONGITUDE FROM VENUES")
                         :info {:card-id    (u/get-id card)
-                               :query-hash (byte-array 0)}))
+                               :query-hash (qputil/query-hash {})}))
     (round-all-decimals' (card-metadata card))))
 
 ;; check that using a Card as your source doesn't overwrite the results metadata...
@@ -120,7 +121,7 @@
     :name         "count"
     :special_type "type/Quantity"
     :fingerprint  {:global {:distinct-count 3},
-                   :type {:type/Number {:min 235.0, :max 498.0, :avg 333.33}}}}]
+                   :type   {:type/Number {:min 235.0, :max 498.0, :avg 333.33}}}}]
   (tt/with-temp Card [card]
     (qp/process-query {:database (data/id)
                        :type     :query
@@ -128,5 +129,5 @@
                                   :aggregation  [[:count]]
                                   :breakout     [[:datetime-field [:field-id (data/id :checkins :date)] :year]]}
                        :info     {:card-id    (u/get-id card)
-                                  :query-hash (byte-array 0)}})
+                                  :query-hash (qputil/query-hash {})}})
     (round-all-decimals' (card-metadata card))))

--- a/test/metabase/query_processor_test/aggregation_test.clj
+++ b/test/metabase/query_processor_test/aggregation_test.clj
@@ -133,7 +133,7 @@
   (format-rows-by [int (partial u/round-to-decimals 4)]
     (rows (data/run-mbql-query venues
             {:aggregation [[:max $latitude]]
-             :breakout    $price}))))
+             :breakout    [$price]}))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -236,7 +236,7 @@
    :native_form true}
   (->> (data/run-mbql-query users
          {:aggregation [[:cum-sum $id]]
-          :breakout    $name})
+          :breakout    [$name]})
        booleanize-native-form
        (format-rows-by [str int])
        tu/round-fingerprint-cols))
@@ -255,7 +255,7 @@
    :native_form true}
   (->> (data/run-mbql-query venues
          {:aggregation [[:cum-sum $id]]
-          :breakout    $price})
+          :breakout    [$price]})
        booleanize-native-form
        (format-rows-by [int int])))
 
@@ -302,7 +302,7 @@
    :native_form true}
   (->> (data/run-mbql-query users
          {:aggregation [[:cum-count $id]]
-          :breakout    $name})
+          :breakout    [$name]})
        booleanize-native-form
        (format-rows-by [str int])
        tu/round-fingerprint-cols))
@@ -321,6 +321,6 @@
    :native_form true}
   (->> (data/run-mbql-query venues
          {:aggregation [[:cum-count $id]]
-          :breakout    $price})
+          :breakout    [$price]})
        booleanize-native-form
        (format-rows-by [int int])))

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -362,7 +362,7 @@
     {:database (data/id)
      :type     :query
      :query    {:source-query {:source-table (data/id :venues)}
-                :breakout     [:field-id [:field-literal "category_id" :type/Integer]]
+                :breakout     [[:field-id [:field-literal "category_id" :type/Integer]]]
                 :limit        10}}))
 
 ;; Make sure we can filter by string fields

--- a/test/metabase/sync/analyze/query_results_test.clj
+++ b/test/metabase/sync/analyze/query_results_test.clj
@@ -53,9 +53,9 @@
 ;; Getting the result metadata for a card backed by an MBQL query should use the fingerprints from the related fields
 (expect
   mutil/venue-fingerprints
-  (tt/with-temp Card [card {:dataset_query   {:database (data/id)
-                                              :type     :query
-                                              :query    {:source-table (data/id :venues)}}}]
+  (tt/with-temp Card [card {:dataset_query {:database (data/id)
+                                            :type     :query
+                                            :query    {:source-table (data/id :venues)}}}]
     (tu/throw-if-called fprint/with-global-fingerprinter ; check for a "proper" fingerprinter, fallthrough for PKs is fune.
       (name->fingerprints
        (query->result-metadata (query-for-card card))))))
@@ -63,18 +63,18 @@
 ;; Getting the result metadata for a card backed by an MBQL query should just infer the types of all the fields
 (expect
   venue-name->special-types
-  (tt/with-temp Card [card {:dataset_query   {:database (data/id)
-                                              :type     :query
-                                              :query    {:source-table (data/id :venues)}}}]
+  (tt/with-temp Card [card {:dataset_query {:database (data/id)
+                                            :type     :query
+                                            :query    {:source-table (data/id :venues)}}}]
     (name->special-type (query->result-metadata (query-for-card card)))))
 
 ;; Native queries don't know what the associated Fields are for the results, we need to compute the fingerprints, but
 ;; they should sill be the same except for some of the optimizations we do when we have all the information.
 (expect
   (update mutil/venue-fingerprints :category_id assoc :type {:type/Number {:min 2.0, :max 74.0, :avg 29.98}})
-  (tt/with-temp Card [card {:dataset_query   {:database (data/id)
-                                              :type     :native
-                                              :native   {:query "select * from venues"}}}]
+  (tt/with-temp Card [card {:dataset_query {:database (data/id)
+                                            :type     :native
+                                            :native   {:query "select * from venues"}}}]
     (name->fingerprints
      (query->result-metadata (query-for-card card)))))
 
@@ -83,27 +83,27 @@
 ;; only
 (expect
   (assoc venue-name->special-types :category_id nil, :price nil)
-  (tt/with-temp Card [card {:dataset_query   {:database (data/id)
-                                              :type     :native
-                                              :native   {:query "select * from venues"}}}]
+  (tt/with-temp Card [card {:dataset_query {:database (data/id)
+                                            :type     :native
+                                            :native   {:query "select * from venues"}}}]
     (name->special-type
      (query->result-metadata (query-for-card card)))))
 
 ;; Limiting to just 1 column on an MBQL query should still get the result metadata from the Field
 (expect
   (select-keys mutil/venue-fingerprints [:longitude])
-  (tt/with-temp Card [card {:dataset_query   {:database (data/id)
-                                              :type     :query
-                                              :query    {:source-table (data/id :venues)}}}]
+  (tt/with-temp Card [card {:dataset_query {:database (data/id)
+                                            :type     :query
+                                            :query    {:source-table (data/id :venues)}}}]
     (tu/throw-if-called fprint/fingerprinter
       (name->fingerprints
-       (query->result-metadata (assoc-in (query-for-card card) [:query :fields] [:field-id (data/id :venues :longitude)]))))))
+       (query->result-metadata (assoc-in (query-for-card card) [:query :fields] [[:field-id (data/id :venues :longitude)]]))))))
 
 ;; Similar query as above, just native so that we need to calculate the fingerprint
 (expect
   (select-keys mutil/venue-fingerprints [:longitude])
-  (tt/with-temp Card [card {:dataset_query   {:database (data/id)
-                                              :type     :native
-                                              :native   {:query "select longitude from venues"}}}]
+  (tt/with-temp Card [card {:dataset_query {:database (data/id)
+                                            :type     :native
+                                            :native   {:query "select longitude from venues"}}}]
     (name->fingerprints
      (query->result-metadata (query-for-card card)))))


### PR DESCRIPTION
Follow-on to #8506.

Finish up the new query validation schema and add middleware to validate queries with it so we can still be sure queries are valid once the `expand` middleware is removed. Fix a few tests that were running invalid queries 

### Upcoming PRs:

- [ ] Add `:parameters` and `:template-tags` to the schema
- [ ] remove `expand` middleware & `qp.interface` record types; rework middleware and drivers to operate on non-expanded queries