### PR TITLE
Fix equals not working for tables with conditional formatting (#8478)

### DIFF
--- a/frontend/src/metabase/visualizations/lib/table_format.js
+++ b/frontend/src/metabase/visualizations/lib/table_format.js
@@ -135,9 +135,9 @@ function compileFormatter(
       case ">":
         return v => (v > value ? color : null);
       case "=":
-        return v => (v === value ? color : null);
+        return v => (v == value ? color : null);
       case "!=":
-        return v => (v !== value ? color : null);
+        return v => (v != value ? color : null);
     }
   } else if (format.type === "range") {
     const columnMin = name =>


### PR DESCRIPTION
Fixes #8478. Should get in to a 0.30.x patch since colors was released in 0.30 and are not working.

Since <, <=, >=, and > perform type coercion implicitly I think == and != should be used to be consistent. It may have to be revisited when handling other types (like coloring cells based on string values).

-  [x] If there are changes to the backend codebase, run the backend tests with `lein test && lein eastwood && lein bikeshed && lein docstring-checker && ./bin/reflection-linter`
-  [x] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [x] Sign the [Contributor License Agreement]
