### PR TITLE
Upgrade node version in packages.json and the Dockerfile [ci all]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # STAGE 1: builder
 ###################
 
-FROM java:openjdk-8-jdk-alpine as builder
+FROM openjdk:8-jdk-alpine as builder
 
 WORKDIR /app/source
 
@@ -15,7 +15,7 @@ ENV LC_CTYPE en_US.UTF-8
 # nodejs:  frontend building
 # make:    backend building
 # gettext: translations
-RUN apk add --update bash nodejs git wget make gettext
+RUN apk add --update bash nodejs nodejs-npm git wget make gettext
 
 # yarn:    frontend dependencies
 RUN npm install -g yarn

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "repository": "https://github.com/metabase/metabase",
   "license": "private",
   "engines": {
-    "node": ">=6.7.0",
-    "npm": "2.15.9"
+    "node": ">=8.11.4",
+    "npm": "8.11.4"
   },
   "dependencies": {
     "ace-builds": "^1.2.2",


### PR DESCRIPTION
Using version 220 of `jest-localstorage-mock` required that we upgrade
our version of NodeJS from our previous minimum of 6.11.3. To support
that, this commit switches from the deprecated
`java:openjdk-8-jdk-alpine` docker image to the newer
`openjdk:8-jdk-alpine` image. This image is running Alpine version 3.8 which
has NodeJS 8.11.4 in it's repository. This also bumps the minimum
version of node in the packages.json file.



