### PR TITLE
Fixes #8562 by escaping '{login}' in zh.po as in the original string

### DIFF
--- a/locales/zh.po
+++ b/locales/zh.po
@@ -8006,7 +8006,7 @@ msgstr "用户搜索基础.（将采用递归检索）"
 
 #: src/metabase/integrations/ldap.clj
 msgid "User lookup filter, the placeholder '{login}' will be replaced by the user supplied login."
-msgstr "用户查找过滤器，占位符“{Login}”将被用户提供的登录替换"
+msgstr "用户查找过滤器，占位符'{login}'将被用户提供的登录替换"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Attribute to use for the user's email. (usually ''mail'', ''email'' or ''userPrincipalName'')"


### PR DESCRIPTION
Steps to reproduce the bug this PR fixes:

    wget http://downloads.metabase.com/v0.30.3/metabase.jar
    java -Duser.language=zh -jar metabase.jar

=> 💣 

###### Before submitting the PR, please make sure you do the following 
-  [ ] If there are changes to the backend codebase, run the backend tests with `lein test && lein eastwood && lein bikeshed && lein docstring-checker && ./bin/reflection-linter`
-  [ ] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [ ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
