### PR TITLE
Fix dashboard remove modal button spacing

### DIFF
--- a/frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx
+++ b/frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx
@@ -2,13 +2,12 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { t } from "c-3po";
 import MetabaseAnalytics from "metabase/lib/analytics";
-import ModalContent from "metabase/components/ModalContent.jsx";
+
+import Button from "metabase/components/Button";
+import ModalContent from "metabase/components/ModalContent";
 
 export default class RemoveFromDashboardModal extends Component {
-  constructor(props, context) {
-    super(props, context);
-    this.state = { deleteCard: false };
-  }
+  state = { deleteCard: false };
 
   static propTypes = {
     dashcard: PropTypes.object.isRequired,
@@ -32,21 +31,14 @@ export default class RemoveFromDashboardModal extends Component {
   }
 
   render() {
+    const { onClose } = this.props;
     return (
-      <ModalContent
-        title={t`Remove this question?`}
-        onClose={() => this.props.onClose()}
-      >
-        <div className="Form-actions flex-align-right">
-          <button className="Button Button" onClick={this.props.onClose}>
-            {t`Cancel`}
-          </button>
-          <button
-            className="Button Button--danger ml2"
-            onClick={() => this.onRemove()}
-          >
+      <ModalContent title={t`Remove this question?`} onClose={() => onClose()}>
+        <div className="flex-align-right">
+          <Button onClick={onClose}>{t`Cancel`}</Button>
+          <Button danger ml={2} onClick={() => this.onRemove()}>
             {t`Remove`}
-          </button>
+          </Button>
         </div>
       </ModalContent>
     );


### PR DESCRIPTION
Noticed this while working on smart scalars. I think this one got missed when we added built in padding to all modals so it was adding extra space to actions on its own so this gets it in line with other modals. Also cleans this up a bit to use the proper `Button` component, etc.

Before:
<img width="756" alt="screen shot 2018-09-25 at 2 17 27 pm" src="https://user-images.githubusercontent.com/5248953/46044106-b78bf980-c0ce-11e8-8325-f978dc48adc9.png">

After:
<img width="764" alt="screen shot 2018-09-25 at 2 22 01 pm" src="https://user-images.githubusercontent.com/5248953/46044107-b78bf980-c0ce-11e8-8c3f-dfe76b8d865d.png">

