### PR TITLE
Fix color for night mode borders

### DIFF
--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -76,7 +76,7 @@
 
 .Dashboard.Dashboard--night .DashCard .Card {
   background-color: var(--color-bg-black);
-  border: 1px solid var(--color-accent2);
+  border: 1px solid var(--color-text-medium);
 }
 
 .Dashboard.Dashboard--night .enable-dots-onhover .dc-tooltip circle.dot:hover,


### PR DESCRIPTION
In the aftermath of the events of the colorpocalypse some color knowledge was lost. During this period of darkness a certain purple character started preaching that some shades of dark grey were actually purple and much chaos ensued. 

tl;dr; the color sync script thought the old night color was closest to purple so it switched it out.

Chaos:
<img width="1772" alt="screen shot 2018-09-25 at 2 29 03 pm" src="https://user-images.githubusercontent.com/5248953/46045190-d63fbf80-c0d1-11e8-920a-490e67163ad3.png">
Some level of decency:
<img width="1772" alt="screen shot 2018-09-25 at 2 40 46 pm" src="https://user-images.githubusercontent.com/5248953/46045213-e6f03580-c0d1-11e8-8d62-5f7af51938a5.png">

