### PR TITLE
Fullscreen dash header fixes

### DIFF
--- a/frontend/src/metabase/components/Header.jsx
+++ b/frontend/src/metabase/components/Header.jsx
@@ -159,7 +159,7 @@ export default class Header extends Component {
           <div className="Entity py3">
             <span className="inline-block mb1">{titleAndDescription}</span>
             {attribution}
-            {!this.props.isEditingInfo && (
+            {this.props.showBadge && (
               <CollectionBadge
                 collectionId={item.collection_id}
                 analyticsContext={this.props.analyticsContext}

--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -51,6 +51,10 @@
   background-color: var(--color-bg-black);
 }
 
+.Dashboard.Dashboard--night .DashboardHeader {
+  color: var(--color-text-white);
+}
+
 .Dashboard.Dashboard--night .Card {
   color: var(--color-text-white);
 }

--- a/frontend/src/metabase/dashboard/components/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader.jsx
@@ -297,16 +297,18 @@ export default class DashboardHeader extends Component {
       );
     }
 
-    buttons.push(
-      <Tooltip tooltip={t`Move dashboard`}>
-        <Link
-          to={location.pathname + "/move"}
-          data-metabase-event={"Dashboard;Move"}
-        >
-          <Icon className="text-brand-hover" name="move" size={18} />
-        </Link>
-      </Tooltip>,
-    );
+    if (!isFullscreen) {
+      buttons.push(
+        <Tooltip tooltip={t`Move dashboard`}>
+          <Link
+            to={location.pathname + "/move"}
+            data-metabase-event={"Dashboard;Move"}
+          >
+            <Icon className="text-brand-hover" name="move" size={18} />
+          </Link>
+        </Tooltip>,
+      );
+    }
 
     if (!isFullscreen && !isEditing && canEdit) {
       buttons.push(

--- a/frontend/src/metabase/dashboard/components/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader.jsx
@@ -347,6 +347,7 @@ export default class DashboardHeader extends Component {
         analyticsContext="Dashboard"
         item={dashboard}
         isEditing={this.props.isEditing}
+        showBadge={!this.props.isEditing && !this.props.isFullscreen}
         isEditingInfo={this.props.isEditing}
         headerButtons={this.getHeaderButtons()}
         editingTitle={t`You are editing a dashboard`}


### PR DESCRIPTION
Some small fixes to dash headers in fullscreen mode
- [x] Hide the collection badge when in fullscreen (seems like an un-necessary distraction in that context)
- [x] Hide the move action
- [x] Fix the night mode dash title color