### PR TITLE
fix postgres connection string

### DIFF
--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -37,7 +37,7 @@
   {:user        "camsaul"
    :classname   "org.postgresql.Driver"
    :subprotocol "postgresql"
-   :subname     "//localhost:5432/bird_sightings?OpenSourceSubProtocolOverride=true"
+   :subname     "//localhost:5432/bird_sightings?sslmode=disable&OpenSourceSubProtocolOverride=true"
    :sslmode     "disable"}
   (sql/connection-details->spec pg-driver {:ssl    false
                                            :host   "localhost"
@@ -53,7 +53,7 @@
    :subprotocol "postgresql"
    :user        "camsaul"
    :sslfactory  "org.postgresql.ssl.NonValidatingFactory"
-   :subname     "//localhost:5432/bird_sightings?OpenSourceSubProtocolOverride=true"}
+   :subname     "//localhost:5432/bird_sightings?ssl=true&sslmode=require&OpenSourceSubProtocolOverride=true"}
   (sql/connection-details->spec pg-driver {:ssl    true
                                            :host   "localhost"
                                            :port   5432
@@ -285,7 +285,7 @@
 
 ;; make sure connection details w/ extra params work as expected
 (expect
-  "//localhost:5432/cool?OpenSourceSubProtocolOverride=true&prepareThreshold=0"
+  "//localhost:5432/cool?sslmode=disable&OpenSourceSubProtocolOverride=true&prepareThreshold=0"
   (:subname (sql/connection-details->spec pg-driver {:host               "localhost"
                                                      :port               "5432"
                                                      :dbname             "cool"


### PR DESCRIPTION
This is an update to pass query parameters to the postgres connection string during validates and execution. This addresses an issue when upgrading postgres and getting the an error when using a string like:
postgresql://host:port/database?user=toto@toto&password=xxxxxx&ssl=true&sslmode=require

###### Before submitting the PR, please make sure you do the following 
-  [x] If there are changes to the backend codebase, run the backend tests with `lein test && lein eastwood && lein bikeshed && lein docstring-checker && ./bin/reflection-linter`
-  [ ] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
