### PR TITLE
Do not require username for MongoDB connections

### DIFF
--- a/src/metabase/driver/mongo.clj
+++ b/src/metabase/driver/mongo.clj
@@ -178,7 +178,7 @@
                                                             (assoc driver/default-port-details :default 27017)
                                                             (assoc driver/default-dbname-details
                                                               :placeholder  (tru "carrierPigeonDeliveries"))
-                                                            driver/default-user-details
+                                                            (assoc driver/default-user-details :required false)
                                                             (assoc driver/default-password-details :name "pass")
                                                             {:name         "authdb"
                                                              :display-name (tru "Authentication Database")


### PR DESCRIPTION
Removes the requirement to specify a username to connect to a Mongo database. Helpful for connecting to Mongo databases that do not have authentication enabled.
 
Fixes #8325.