### PR TITLE
Make sure SQLServer tests run in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,6 +265,8 @@ jobs:
           <<: *restore-be-deps-cache
       - run:
           name: Run backend unit tests (SQL Server)
+          environment:
+            ENGINES: h2,sqlserver
           command: >
             /home/circleci/metabase/metabase/.circleci/skip-driver-tests.sh sqlserver ||
             lein with-profile +ci test


### PR DESCRIPTION
We seemed to be missing correct env var settings to run SQLServer tests in the new CircleCI 2.0 config file. Luckily all the tests are still passing so we caught this in time