### PR TITLE
Fix public/embed downloads when mounted at non-root context

### DIFF
--- a/frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx
@@ -156,7 +156,7 @@ const DashboardEmbedQueryButton = ({
 }) => (
   <DownloadButton
     method="GET"
-    url={`/api/embed/dashboard/${token}/dashcard/${dashcardId}/card/${
+    url={`api/embed/dashboard/${token}/dashcard/${dashcardId}/card/${
       card.id
     }/${type}`}
     extensions={[type]}

--- a/src/metabase/routes.clj
+++ b/src/metabase/routes.clj
@@ -80,14 +80,14 @@
 (defroutes ^:private public-routes
   (GET ["/question/:uuid.:export-format", :uuid u/uuid-regex, :export-format dataset-api/export-format-regex]
        [uuid export-format]
-       (redirect-including-query-string (format "/api/public/card/%s/query/%s" uuid export-format)))
+       (redirect-including-query-string (format "%s/api/public/card/%s/query/%s" (public-settings/site-url) uuid export-format)))
   (GET "*" [] public))
 
 ;; /embed routes. /embed/question/:token.:export-format redirects to /api/public/card/:token/query/:export-format
 (defroutes ^:private embed-routes
   (GET ["/question/:token.:export-format", :export-format dataset-api/export-format-regex]
        [token export-format]
-       (redirect-including-query-string (format "/api/embed/card/%s/query/%s" token export-format)))
+       (redirect-including-query-string (format "%s/api/embed/card/%s/query/%s" (public-settings/site-url) token export-format)))
   (GET "*" [] embed))
 
 ;; Redirect naughty users who try to visit a page other than setup if setup is not yet complete


### PR DESCRIPTION
Resolves issue mentioned in #4740 where download links didn't work when app was mounted at a non-root context like `/metabase`