### PR TITLE
Athena driver

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -7,7 +7,8 @@ set -e
 
 # Translate various Heroku environment variables to Metabase equivalents
 
-if [ "$PORT" ]; then
+# if MB_JETTY_PORT is already set, don't override it
+if [ -z $MB_JETTY_PORT ] && [ "$PORT" ]; then
     export MB_JETTY_PORT="$PORT"
 fi
 

--- a/project.clj
+++ b/project.clj
@@ -101,9 +101,11 @@
                  [ring/ring-json "0.4.0"]                             ; Ring middleware for reading/writing JSON automatically
                  [stencil "0.5.0"]                                    ; Mustache templates for Clojure
                  [toucan "1.1.9"                                      ; Model layer, hydration, and DB utilities
-                  :exclusions [honeysql]]]
+                  :exclusions [honeysql]]
+                  [br.com.quintoandar.amazonaws/athena-jdbc "42-2.0.5"]]
   :repositories [["bintray" "https://dl.bintray.com/crate/crate"]     ; Repo for Crate JDBC driver
-                 ["redshift" "https://s3.amazonaws.com/redshift-driver-downloads"]]
+                 ["redshift" "https://s3.amazonaws.com/redshift-driver-downloads"]
+                 ["athena" "https://s3.amazonaws.com/athena-drivers-download"]]
   :plugins [[lein-environ "1.1.0"]                                    ; easy access to environment variables
             [lein-ring "0.12.3"                                       ; start the HTTP server with 'lein ring server'
              :exclusions [org.clojure/clojure]]]                      ; TODO - should this be a dev dependency ?

--- a/src/metabase/driver/athena.clj
+++ b/src/metabase/driver/athena.clj
@@ -50,7 +50,7 @@
     :seconds      (hsql/call :from_unixtime expr)
     :milliseconds (recur (hx// expr 1000.0) :seconds)))
 
-(defn mbql->native
+(defn- mbql->native
   "Transpile MBQL query into a native SQL statement."
   [driver {inner-query :query, database :database, :as outer-query}]
   (binding [sqlqp/*query* outer-query]

--- a/src/metabase/driver/athena.clj
+++ b/src/metabase/driver/athena.clj
@@ -1,0 +1,79 @@
+(ns metabase.driver.athena
+  "Athena driver."
+  (:require [metabase.driver :as driver]
+            [metabase.util :as u]
+            [metabase.driver.generic-sql :as sql]
+            [honeysql
+             [core :as hsql]]
+            [metabase.util
+             [honeysql-extensions :as hx]]))
+
+(defrecord AthenaDriver []
+  clojure.lang.Named
+  (getName [_] "Athena"))
+
+(defn- connection-details->spec
+  [{:keys [region, s3_staging_dir, user, password]
+    :as   opts}]
+  {:classname "com.simba.athena.jdbc.Driver"
+   :subprotocol "awsathena"
+   :subname (str "//athena." region ".amazonaws.com:443")
+   :user        user
+   :password    password
+   :s3_staging_dir s3_staging_dir})
+
+(defn- unix-timestamp->timestamp [expr seconds-or-milliseconds]
+  (case seconds-or-milliseconds
+    :seconds      (hsql/call :from_unixtime expr)
+    :milliseconds (recur (hx// expr 1000.0) :seconds)))
+
+(defn- date [unit expr]
+  (case unit
+    :default         expr
+    :minute          (hsql/call :date_trunc (hx/literal :minute) expr)
+    :minute-of-hour  (hsql/call :minute expr)
+    :hour            (hsql/call :date_trunc (hx/literal :hour) expr)
+    :hour-of-day     (hsql/call :hour expr)
+    :day             (hsql/call :date_trunc (hx/literal :day) expr)
+    ;; Presto is ISO compliant, so we need to offset Monday = 1 to Sunday = 1
+    :day-of-week     (hx/+ (hx/mod (hsql/call :day_of_week expr) 7) 1)
+    :day-of-month    (hsql/call :day expr)
+    :day-of-year     (hsql/call :day_of_year expr)
+    ;; Similar to DoW, sicne Presto is ISO compliant the week starts on Monday, we need to shift that to Sunday
+    :week            (hsql/call :date_add (hx/literal :day) -1 (hsql/call :date_trunc (hx/literal :week) (hsql/call :date_add (hx/literal :day) 1 expr)))
+    ;; Offset by one day forward to "fake" a Sunday starting week
+    :week-of-year    (hsql/call :week (hsql/call :date_add (hx/literal :day) 1 expr))
+    :month           (hsql/call :date_trunc (hx/literal :month) expr)
+    :month-of-year   (hsql/call :month expr)
+    :quarter         (hsql/call :date_trunc (hx/literal :quarter) expr)
+    :quarter-of-year (hsql/call :quarter expr)
+    :year            (hsql/call :year expr)))
+
+(u/strict-extend AthenaDriver
+  driver/IDriver
+  (merge (sql/IDriverSQLDefaultsMixin)
+         {:details-fields (constantly [{:name         "region"
+                                        :display-name "Region"
+                                        :placeholder  "us-east-1"
+                                        :required     true}
+                                       {:name         "s3_staging_dir"
+                                        :display-name "Staging dir"
+                                        :placeholder  "See 'Query result location' in Athena settings"}
+                                       {:name         "user"
+                                        :display-name "AWS access key"
+                                        :placeholder  "AWS_ACCESS_KEY_ID"
+                                        :required     true}
+                                       {:name         "password"
+                                        :display-name "AWS secret key"
+                                        :type         :password
+                                        :placeholder  "AWS_SECRET_ACCESS_KEY"
+                                        :required     true}])})
+  sql/ISQLDriver
+  (merge (sql/ISQLDriverDefaultsMixin)
+        {:connection-details->spec   (u/drop-first-arg connection-details->spec)
+          :column->base-type         (constantly nil)
+          :string-length-fn          (constantly nil)
+          :date                      (u/drop-first-arg date)
+          :unix-timestamp->timestamp (u/drop-first-arg unix-timestamp->timestamp)}))
+
+(driver/register-driver! :athena (AthenaDriver.))

--- a/src/metabase/driver/athena.clj
+++ b/src/metabase/driver/athena.clj
@@ -109,6 +109,7 @@
           :column->base-type         (u/drop-first-arg column->base-type)
           :string-length-fn          (u/drop-first-arg string-length-fn)
           :date                      (u/drop-first-arg date)
+          :table-types               (constantly ["EXTERNAL_TABLE", "TABLE", "VIEW", "FOREIGN TABLE", "MATERIALIZED VIEW"])
           :unix-timestamp->timestamp (u/drop-first-arg unix-timestamp->timestamp)}))
 
 (driver/register-driver! :athena (AthenaDriver.))

--- a/src/metabase/driver/generic_sql.clj
+++ b/src/metabase/driver/generic_sql.clj
@@ -323,7 +323,7 @@
    Fetch *all* Tables, then filter out ones whose schema is in `excluded-schemas` Clojure-side."
   [driver, ^DatabaseMetaData metadata]
   (set (for [table (filter #(not (contains? (excluded-schemas driver) (:table_schem %)))
-                           (get-tables metadata nil))]
+                           (get-tables metadata nil (table-types driver)))]
          {:name   (:table_name table)
           :schema (:table_schem table)})))
 

--- a/test/metabase/driver/athena_test.clj
+++ b/test/metabase/driver/athena_test.clj
@@ -1,0 +1,23 @@
+(ns metabase.driver.athena-test
+  (:require [expectations :refer [expect]]
+            [metabase.driver
+             [generic-sql :as sql]])
+  (:import metabase.driver.athena.AthenaDriver))
+
+
+;; make sure connection details work as expected
+(expect
+  (str "//athena.us-east-1.amazonaws.com:443")
+  (:subname (sql/connection-details->spec (AthenaDriver.) {:region "us-east-1"})))
+
+(expect
+  (str "user")
+  (:user (sql/connection-details->spec (AthenaDriver.) {:user "user"})))
+
+(expect
+  (str "pwd")
+  (:password (sql/connection-details->spec (AthenaDriver.) {:password "pwd"})))
+
+(expect
+  (str "s3://my-bucket/athena-results")
+  (:s3_staging_dir (sql/connection-details->spec (AthenaDriver.) {:s3_staging_dir "s3://my-bucket/athena-results"})))

--- a/test/metabase/driver/generic_sql_test.clj
+++ b/test/metabase/driver/generic_sql_test.clj
@@ -18,7 +18,7 @@
 (def ^:private generic-sql-engines
   (delay (set (for [engine datasets/all-valid-engines
                     :let   [driver (driver/engine->driver engine)]
-                    :when  (not (contains? #{:bigquery :presto :sparksql} engine))       ; bigquery, presto and sparksql don't use the generic sql implementations of things like `field-avg-length`
+                    :when  (not (contains? #{:bigquery :presto :sparksql :athena} engine))       ; bigquery, presto, sparksql and athena don't use the generic sql implementations of things like `field-avg-length`
                     :when  (extends? ISQLDriver (class driver))]
                 (do (require (symbol (str "metabase.test.data." (name engine))) :reload) ; otherwise it gets all snippy if you try to do `lein test metabase.driver.generic-sql-test`
                     engine)))))


### PR DESCRIPTION
###### Before submitting the PR, please make sure you do the following 
-  [x] If there are changes to the backend codebase, run the backend tests with `lein test && lein eastwood && lein bikeshed && lein docstring-checker && ./bin/reflection-linter`
-  [x] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).


Implementing Athena driver. Tried to use as much of generic_sql as possible, but had to make some changes:
1. Athena doesn't support prepared statements, so the driver implements it own `mbql->native` method.
2. Athena has a table type called `EXTERNAL_TABLE`. Just extended `ISQLDriverDefaultsMixin` so each driver could implement its own table types

Ps.: The Athena JDBC driver is hosted at QuintoAndar's bucket for now, it would be nice to move it from there at some point. 

Based much on the work on #8577 .

Hopes this PR helps to resolve #3960 