### PR TITLE
Ignore leading `jdbc` prefix in JDBC connection uri

### DIFF
--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -46,12 +46,15 @@
                                   ;; if we don't have an absolute path then make sure we start from "user.dir"
                                   [(System/getProperty "user.dir") "/" db-file-name options]))))))
 
+(def ^:private jdbc-connection-regex
+  #"^(jdbc:)?([^:/@]+)://(?:([^:/@]+)(?::([^:@]+))?@)?([^:@]+)(?::(\d+))?/([^/?]+)(?:\?(.*))?$")
+
 (defn- parse-connection-string
   "Parse a DB connection URI like
   `postgres://cam@localhost.com:5432/cams_cool_db?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory` and
   return a broken-out map."
   [uri]
-  (when-let [[_ protocol user pass host port db query] (re-matches #"^([^:/@]+)://(?:([^:/@]+)(?::([^:@]+))?@)?([^:@]+)(?::(\d+))?/([^/?]+)(?:\?(.*))?$" uri)]
+  (when-let [[_ _ protocol user pass host port db query] (re-matches jdbc-connection-regex uri)]
     (merge {:type     (case (keyword protocol)
                         :postgres   :postgres
                         :postgresql :postgres

--- a/test/metabase/db_test.clj
+++ b/test/metabase/db_test.clj
@@ -18,3 +18,10 @@
    :ssl "true", :sslfactory "org.postgresql.ssl.NonValidatingFactory"}
   (#'mdb/parse-connection-string (str "postgres://tom:1234@localhost:5432/toms_cool_db"
                                       "?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory")))
+
+;; the leading "jdbc" found in driver JDBC docs should be ignored
+(expect
+  {:type :postgres, :user "tom", :password "1234", :host "localhost", :port "5432", :dbname "toms_cool_db",
+   :ssl "true", :sslfactory "org.postgresql.ssl.NonValidatingFactory"}
+  (#'mdb/parse-connection-string (str "jdbc:postgres://tom:1234@localhost:5432/toms_cool_db"
+                                      "?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory")))


### PR DESCRIPTION
Many vendor JDBC docs include a `jdbc` prefix like:
`jdbc:postgresql://localhost/test`. Previously if a connection URI
specified via MB_DB_CONNECTION_URI included the `jdbc` prefix, it
would fail to parse. Metabase would then fallback to using H2 rather
than the specified database. This commit changes the JDBC connection
string regex to ignore the `jdbc` prefix when present.

Fixes #8465
