### PR TITLE
Add missing insights to driver test [ci drivers]

### DIFF
--- a/test/metabase/driver/druid_test.clj
+++ b/test/metabase/driver/druid_test.clj
@@ -100,7 +100,8 @@
                                    {:name "venue_price", :display_name "Venue Price"}
                                    {:name "venue_name",  :display_name "Venue Name"}
                                    {:name "count",       :display_name "Count", :base_type :type/Integer}])
-               :native_form {:query native-query-1}}}
+               :native_form {:query native-query-1}
+               :insights    nil}}
   (process-native-query native-query-1))
 
 

--- a/test/metabase/driver/mongo_test.clj
+++ b/test/metabase/driver/mongo_test.clj
@@ -79,7 +79,8 @@
                :columns     ["count"]
                :cols        [{:name "count", :display_name "Count", :base_type :type/Integer}]
                :native_form {:collection "venues"
-                             :query      native-query}}}
+                             :query      native-query}
+               :insights  nil}}
   (-> (qp/process-query {:native   {:query      native-query
                                     :collection "venues"}
                          :type     :native

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -135,7 +135,8 @@
   {:columns ["id" "dotted.name"]
    :rows    [[1 "toucan_cage"]
              [2 "four_loko"]
-             [3 "ouija_board"]]}
+             [3 "ouija_board"]]
+   :insights nil}
   (-> (data/dataset metabase.driver.postgres-test/dots-in-names
         (data/run-mbql-query objects.stuff))
       :data (dissoc :cols :native_form :results_metadata)))
@@ -153,8 +154,9 @@
     [["Cam" 1]]]])
 
 (expect-with-engine :postgres
-  {:columns ["name" "name_2"]
-   :rows    [["Cam" "Rasta"]]}
+  {:columns  ["name" "name_2"]
+   :rows     [["Cam" "Rasta"]]
+   :insights nil}
   (-> (data/dataset metabase.driver.postgres-test/duplicate-names
         (data/run-mbql-query people
           {:fields [$name $bird_id->birds.name]}))


### PR DESCRIPTION
This commit fixes CI failures due to unexpected (nil) insights being
present in the results.
