### PR TITLE
Add support for extra parsed params for MySQL app DBs

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -88,10 +88,12 @@
   "Append `default-connection-args-string` to the connection string in CONNECTION-DETAILS, and an additional option to
   explicitly disable SSL if appropriate. (Newer versions of MySQL will complain if you don't explicitly disable SSL.)"
   {:argslist '([connection-spec details])}
-  [{connection-string :subname, :as connection-spec} {ssl? :ssl}]
-  (assoc connection-spec
-    :subname (str connection-string "?" default-connection-args-string (when-not ssl?
-                                                                         "&useSSL=false"))))
+  [connection-spec {ssl? :ssl}]
+  (update connection-spec :subname
+          (fn [subname]
+            (let [join-char (if (str/includes? subname "?") "&" "?")]
+              (str subname join-char default-connection-args-string (when-not ssl?
+                                                                      "&useSSL=false"))))))
 
 (defn- connection-details->spec [details]
   (-> details


### PR DESCRIPTION
Similar to 5e18196 which allows extra parameters for PostgreSQL
application databases, this commit refactors that code to allow it for
MySQL as well.

