### PR TITLE
Change accent5 to a redder orange

### DIFF
--- a/frontend/src/metabase/css/core/colors.css
+++ b/frontend/src/metabase/css/core/colors.css
@@ -7,7 +7,7 @@
   --color-accent2: #a989c5;
   --color-accent3: #ef8c8c;
   --color-accent4: #f9d45c;
-  --color-accent5: #f1b556;
+  --color-accent5: #F2A86F;
   --color-accent6: #a6e7f3;
   --color-accent7: #7172ad;
   --color-white: #ffffff;

--- a/frontend/src/metabase/css/core/colors.css
+++ b/frontend/src/metabase/css/core/colors.css
@@ -7,7 +7,7 @@
   --color-accent2: #a989c5;
   --color-accent3: #ef8c8c;
   --color-accent4: #f9d45c;
-  --color-accent5: #F2A86F;
+  --color-accent5: #f2a86f;
   --color-accent6: #a6e7f3;
   --color-accent7: #7172ad;
   --color-white: #ffffff;

--- a/frontend/src/metabase/lib/colors.js
+++ b/frontend/src/metabase/lib/colors.js
@@ -19,7 +19,7 @@ const colors = {
   accent2: "#A989C5",
   accent3: "#EF8C8C",
   accent4: "#F9D45C",
-  accent5: "#F1B556",
+  accent5: "#F2A86F",
   accent6: "#A6E7F3",
   accent7: "#7172AD",
   white: "#FFFFFF",


### PR DESCRIPTION
This is a small tweak to `accent5` to make it more red and less yellow so that it has better contrast vs. our yellow.

**Examples**

**Before**
![screen shot 2018-10-08 at 2 47 58 pm](https://user-images.githubusercontent.com/2223916/46635541-b5cc2800-cb09-11e8-95be-a4a0734bdc36.png)

**After**
![new-pie-color](https://user-images.githubusercontent.com/2223916/46635554-b9f84580-cb09-11e8-8f8e-20178d3fa5b5.png)

**Before**
![screen shot 2018-10-08 at 2 49 04 pm](https://user-images.githubusercontent.com/2223916/46635574-c8466180-cb09-11e8-8cc9-0660ad91cdde.png)

**After**
![screen shot 2018-10-08 at 2 47 27 pm](https://user-images.githubusercontent.com/2223916/46635579-cc727f00-cb09-11e8-8238-4a3ea2b38f32.png)

**Before**
![screen shot 2018-10-08 at 2 49 10 pm](https://user-images.githubusercontent.com/2223916/46635612-eb711100-cb09-11e8-90ca-b384fcded5fb.png)

**After**
![screen shot 2018-10-08 at 2 47 35 pm](https://user-images.githubusercontent.com/2223916/46635626-f461e280-cb09-11e8-9306-1135b18d3630.png)

**Before**
![screen shot 2018-10-08 at 2 50 57 pm](https://user-images.githubusercontent.com/2223916/46635707-2e32e900-cb0a-11e8-8162-4081f2b37448.png)

**After**
![screen shot 2018-10-08 at 2 50 51 pm](https://user-images.githubusercontent.com/2223916/46635715-31c67000-cb0a-11e8-8c2d-128812a72ff5.png)

**Before**
![screen shot 2018-10-08 at 3 01 10 pm](https://user-images.githubusercontent.com/2223916/46635970-0f812200-cb0b-11e8-9a04-a4e39db31c47.png)

**After**
![screen shot 2018-10-08 at 2 54 38 pm](https://user-images.githubusercontent.com/2223916/46635744-460a6d00-cb0a-11e8-9b65-c59df40d4bf1.png)
