### PR TITLE
Remove SQL comments before parsing as a template

### DIFF
--- a/src/metabase/query_processor/middleware/parameters/sql.clj
+++ b/src/metabase/query_processor/middleware/parameters/sql.clj
@@ -538,6 +538,9 @@
   {:query  s/Str
    :params [s/Any]})
 
+(defn- strip-sql-comments [sql]
+  (str/join "\n" (str/split sql #"--.*\r?\n")))
+
 (s/defn ^:private parse-optional :- ParseTemplateResponse
   "Attempts to parse SQL parameter string `s`. Parses any optional clauses or parameters found, returns a query map."
   [s :- s/Str, param-key->value :- ParamValues]
@@ -553,6 +556,7 @@
 (s/defn ^:private parse-template :- ParseTemplateResponse
   [sql :- s/Str, param-key->value :- ParamValues]
   (-> sql
+      strip-sql-comments
       (parse-optional param-key->value)
       (update :query str/trim)))
 


### PR DESCRIPTION
This commit "pre-parses" the SQL template, removing any comments
it encounters before parsing the string as a SQL template. After the
comments are removed the template is parses as before.

Fixes #7742
