### PR TITLE
default to case insensitive select search for friendlier UX

### DIFF
--- a/frontend/src/metabase/components/Select.jsx
+++ b/frontend/src/metabase/components/Select.jsx
@@ -61,6 +61,7 @@ class BrowserSelect extends Component {
     height: 320,
     rowHeight: 40,
     multiple: false,
+    searchCaseInsensitive: true,
     searchFuzzy: true,
   };
 


### PR DESCRIPTION
Search case insensitively in `Select`s what for to make things easier on people.
<img width="1738" alt="screen shot 2018-10-15 at 5 34 14 pm" src="https://user-images.githubusercontent.com/5248953/46985750-d0ba1180-d0a0-11e8-9a37-ec615c534d21.png">

