### PR TITLE
Increase ROW_ALPHA to make conditional formatted rows stand out more.

### DIFF
--- a/frontend/src/metabase/visualizations/lib/table_format.js
+++ b/frontend/src/metabase/visualizations/lib/table_format.js
@@ -6,7 +6,7 @@
 import { alpha, getColorScale, roundColor } from "metabase/lib/colors";
 
 const CELL_ALPHA = 0.65;
-const ROW_ALPHA = 0.2;
+const ROW_ALPHA = 0.3;
 const GRADIENT_ALPHA = 0.75;
 
 import type { Column } from "metabase/meta/types/Dataset";


### PR DESCRIPTION
When using the "highlight entire row" feature of conditional formatting, I can barely tell the difference between yellow and green (even red [not shown] is difficult):
![metabase-colors](https://user-images.githubusercontent.com/1714/47034392-1a037300-d12c-11e8-81b3-7817e215ca4b.png)

Changing alpha values from 0.2 to 0.3 is sufficient for them to start standing out (for me, at least), which would be my recommended fix:
![metabase-colors-2](https://user-images.githubusercontent.com/1714/47034417-2a1b5280-d12c-11e8-93ae-bb0b92f86b81.png)

I realise this could be screen dependent, but this is true on both my laptop Dell XPS QHD screen, and my benq 24'.
