### PR TITLE
xrays: Ensure adhoc query normalization

### DIFF
--- a/src/metabase/automagic_dashboards/filters.clj
+++ b/src/metabase/automagic_dashboards/filters.clj
@@ -203,12 +203,12 @@
   Assumes both filter clauses can be flattened by recursively merging `:and` claueses
   (ie. no `:and`s inside `:or` or `:not`)."
   [filter-clause refinement]
-  (let [in-refinement?  (into #{}
-                              (map collect-field-references)
-                              (flatten-filter-clause refinement))
+  (let [in-refinement?   (into #{}
+                               (map collect-field-references)
+                               (flatten-filter-clause refinement))
         existing-filters (->> filter-clause
-                             flatten-filter-clause
-                             (remove (comp in-refinement? collect-field-references)))]
+                              flatten-filter-clause
+                              (remove (comp in-refinement? collect-field-references)))]
     (if (seq existing-filters)
       ;; since the filters are programatically generated they won't have passed thru normalization, so make sure we
       ;; normalize them before passing them to `combine-filter-clauses`, which validates its input

--- a/src/metabase/models/query.clj
+++ b/src/metabase/models/query.clj
@@ -1,6 +1,7 @@
 (ns metabase.models.query
   "Functions related to the 'Query' model, which records stuff such as average query execution time."
   (:require [metabase.db :as mdb]
+            [metabase.mbql.normalize :as normalize]
             [metabase.util.honeysql-extensions :as hx]
             [toucan
              [db :as db]
@@ -77,6 +78,8 @@
 (defn adhoc-query
   "Wrap query map into a Query object (mostly to fascilitate type dispatch)."
   [query]
-  (->> {:dataset_query query}
+  (->> query
+       normalize/normalize
+       (hash-map :dataset_query)
        (merge (query->database-and-table-ids query))
        map->QueryInstance))


### PR DESCRIPTION
Changes to query expansion/normalization introduced a regression in x-rays where ad-hoc queries didn't get normalized beforehand which broke some functions that now expect a fully normalized query.