### PR TITLE
Insights: choose the right code-path for UNIX timestamps

### DIFF
--- a/src/metabase/sync/analyze/fingerprint/insights.clj
+++ b/src/metabase/sync/analyze/fingerprint/insights.clj
@@ -36,9 +36,11 @@
 (defn- timeseries-insight
   [{:keys [numbers datetimes]}]
   (redux/post-complete
-   (let [x-position (-> datetimes first :position)
+   (let [datetime   (first datetimes)
+         x-position (:position datetime)
          y-position (-> numbers first :position)
-         xfn        (if (-> datetimes first :base_type (isa? :type/DateTime))
+         xfn        (if (or (-> datetime :base_type (isa? :type/DateTime))
+                            (field/unix-timestamp? datetime))
                       #(some-> %
                                (nth x-position)
                                ;; at this point in the pipeline, dates are still stings


### PR DESCRIPTION
Fixes a bug where timestamps would have base_type BigInt, but were already cast to java.sql.Timestamp. Insights ignored that and treated them as numbers.