### PR TITLE
X-ray settings toggle 

### DIFF
--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -518,6 +518,7 @@ export const getActiveSection = createSelector(
 );
 
 export const getXraysEnabled = createSelector(getSettingValues, settings => {
-  console.log(settings);
-  return settings["enable-xrays"];
+  // apparently "null" is true for boolean settings so we need to check for
+  // false explicitly here rather than use the value of the setting
+  return settings["enable-xrays"] !== false;
 });

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -91,6 +91,11 @@ const SECTIONS = [
         display_name: t`Enable Nested Queries`,
         type: "boolean",
       },
+      {
+        key: "enable-xrays",
+        display_name: t`Enable X-ray features`,
+        type: "boolean",
+      },
     ],
   },
   {
@@ -511,3 +516,8 @@ export const getActiveSection = createSelector(
     }
   },
 );
+
+export const getXraysEnabled = createSelector(getSettingValues, settings => {
+  console.log(settings);
+  return settings["enable-xrays"];
+});

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -516,9 +516,3 @@ export const getActiveSection = createSelector(
     }
   },
 );
-
-export const getXraysEnabled = createSelector(getSettingValues, settings => {
-  // apparently "null" is true for boolean settings so we need to check for
-  // false explicitly here rather than use the value of the setting
-  return settings["enable-xrays"] !== false;
-});

--- a/frontend/src/metabase/components/BrowseApp.jsx
+++ b/frontend/src/metabase/components/BrowseApp.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Box, Flex } from "grid-styled";
 import { t } from "c-3po";
 import BrowserCrumbs from "metabase/components/BrowserCrumbs";
+import { connect } from "react-redux";
 
 import EntityItem from "metabase/components/EntityItem";
 import EntityListLoader from "metabase/entities/containers/EntityListLoader";
@@ -9,6 +10,7 @@ import EntityObjectLoader from "metabase/entities/containers/EntityObjectLoader"
 
 import { normal } from "metabase/lib/colors";
 import Question from "metabase-lib/lib/Question";
+import { getXraysEnabled } from "metabase/admin/settings/selectors";
 
 import Card from "metabase/components/Card";
 import { Grid, GridItem } from "metabase/components/Grid";
@@ -136,6 +138,9 @@ export class SchemaBrowser extends React.Component {
   }
 }
 
+@connect(state => ({
+  xraysEnabled: getXraysEnabled(state),
+}))
 export class TableBrowser extends React.Component {
   render() {
     const { dbId, schemaName } = this.props.params;
@@ -185,19 +190,21 @@ export class TableBrowser extends React.Component {
                             </Link>
                             <Box ml="auto" mr={1} className="hover-child">
                               <Flex align="center">
-                                <Tooltip tooltip={t`X-ray this table`}>
-                                  <Link
-                                    to={`auto/dashboard/table/${table.id}`}
-                                    data-metabase-event={`${ANALYTICS_CONTEXT};Table Item;X-ray Click`}
-                                  >
-                                    <Icon
-                                      name="bolt"
-                                      mx={1}
-                                      color={normal.yellow}
-                                      size={20}
-                                    />
-                                  </Link>
-                                </Tooltip>
+                                {this.props.xraysEnabled && (
+                                  <Tooltip tooltip={t`X-ray this table`}>
+                                    <Link
+                                      to={`auto/dashboard/table/${table.id}`}
+                                      data-metabase-event={`${ANALYTICS_CONTEXT};Table Item;X-ray Click`}
+                                    >
+                                      <Icon
+                                        name="bolt"
+                                        mx={1}
+                                        color={normal.yellow}
+                                        size={20}
+                                      />
+                                    </Link>
+                                  </Tooltip>
+                                )}
                                 <Tooltip tooltip={t`Learn about this table`}>
                                   <Link
                                     to={`reference/databases/${dbId}/tables/${

--- a/frontend/src/metabase/components/BrowseApp.jsx
+++ b/frontend/src/metabase/components/BrowseApp.jsx
@@ -10,7 +10,7 @@ import EntityObjectLoader from "metabase/entities/containers/EntityObjectLoader"
 
 import { normal } from "metabase/lib/colors";
 import Question from "metabase-lib/lib/Question";
-import { getXraysEnabled } from "metabase/admin/settings/selectors";
+import { getXraysEnabled } from "metabase/selectors/settings";
 
 import Card from "metabase/components/Card";
 import { Grid, GridItem } from "metabase/components/Grid";

--- a/frontend/src/metabase/containers/Overworld.jsx
+++ b/frontend/src/metabase/containers/Overworld.jsx
@@ -34,7 +34,7 @@ import { entityListLoader } from "metabase/entities/containers/EntityListLoader"
 const PAGE_PADDING = [1, 2, 4];
 
 import { createSelector } from "reselect";
-import { getXraysEnabled } from "metabase/admin/settings/selectors";
+import { getXraysEnabled } from "metabase/selectors/settings";
 
 // use reselect select to avoid re-render if list doesn't change
 const getParitionedCollections = createSelector(

--- a/frontend/src/metabase/containers/Overworld.jsx
+++ b/frontend/src/metabase/containers/Overworld.jsx
@@ -34,6 +34,7 @@ import { entityListLoader } from "metabase/entities/containers/EntityListLoader"
 const PAGE_PADDING = [1, 2, 4];
 
 import { createSelector } from "reselect";
+import { getXraysEnabled } from "metabase/admin/settings/selectors";
 
 // use reselect select to avoid re-render if list doesn't change
 const getParitionedCollections = createSelector(
@@ -68,10 +69,11 @@ const getParitionedCollections = createSelector(
   // split out collections, pinned, and unpinned since bulk actions only apply to unpinned
   ...getParitionedCollections(state, props),
   user: getUser(state, props),
+  xraysEnabled: getXraysEnabled(state),
 }))
 class Overworld extends React.Component {
   render() {
-    const { user } = this.props;
+    const { user, xraysEnabled } = this.props;
     return (
       <Box>
         <Flex px={PAGE_PADDING} pt={3} pb={1} align="center">
@@ -88,7 +90,7 @@ class Overworld extends React.Component {
               d => d.model === "dashboard" && d.collection_position != null,
             );
 
-            if (!pinnedDashboards.length > 0) {
+            if (xraysEnabled && !pinnedDashboards.length > 0) {
               return (
                 <CandidateListLoader>
                   {({ candidates, sampleCandidates, isSample }) => {

--- a/frontend/src/metabase/containers/Overworld.jsx
+++ b/frontend/src/metabase/containers/Overworld.jsx
@@ -124,7 +124,7 @@ class Overworld extends React.Component {
               );
             }
 
-            if (items.length === 0) {
+            if (pinnedDashboards.length === 0) {
               return null;
             }
 

--- a/frontend/src/metabase/qb/components/actions/XRayCard.jsx
+++ b/frontend/src/metabase/qb/components/actions/XRayCard.jsx
@@ -5,11 +5,13 @@ import type {
   ClickActionProps,
 } from "metabase/meta/types/Visualization";
 
+import MetabaseSettings from "metabase/lib/settings";
+
 import { t } from "c-3po";
 import { utf8_to_b64url } from "metabase/lib/card";
 
-export default ({ question, settings }: ClickActionProps): ClickAction[] => {
-  if (!settings["enable-xrays"]) {
+export default ({ question }: ClickActionProps): ClickAction[] => {
+  if (!MetabaseSettings.get("enable_xrays")) {
     return [];
   }
   return [

--- a/frontend/src/metabase/qb/components/actions/XRayCard.jsx
+++ b/frontend/src/metabase/qb/components/actions/XRayCard.jsx
@@ -8,7 +8,10 @@ import type {
 import { t } from "c-3po";
 import { utf8_to_b64url } from "metabase/lib/card";
 
-export default ({ question }: ClickActionProps): ClickAction[] => {
+export default ({ question, settings }: ClickActionProps): ClickAction[] => {
+  if (!settings["enable-xrays"]) {
+    return [];
+  }
   return [
     {
       name: "xray-card",

--- a/frontend/src/metabase/qb/components/drill/AutomaticDashboardDrill.jsx
+++ b/frontend/src/metabase/qb/components/drill/AutomaticDashboardDrill.jsx
@@ -7,6 +7,8 @@ import type {
   ClickActionProps,
 } from "metabase/meta/types/Visualization";
 
+import MetabaseSettings from "metabase/lib/settings";
+
 export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
   const query = question.query();
   if (!(query instanceof StructuredQuery)) {
@@ -15,7 +17,11 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
 
   // questions with a breakout
   const dimensions = (clicked && clicked.dimensions) || [];
-  if (!clicked || dimensions.length === 0) {
+  if (
+    !clicked ||
+    dimensions.length === 0 ||
+    !MetabaseSettings.get("enable_xrays")
+  ) {
     return [];
   }
 

--- a/frontend/src/metabase/qb/components/drill/CompareToRestDrill.js
+++ b/frontend/src/metabase/qb/components/drill/CompareToRestDrill.js
@@ -7,6 +7,8 @@ import type {
   ClickActionProps,
 } from "metabase/meta/types/Visualization";
 
+import MetabaseSettings from "metabase/lib/settings";
+
 export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
   const query = question.query();
   if (!(query instanceof StructuredQuery)) {
@@ -15,7 +17,12 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
 
   // questions with a breakout
   const dimensions = (clicked && clicked.dimensions) || [];
-  if (!clicked || dimensions.length === 0) {
+  if (
+    !clicked ||
+    dimensions.length === 0 ||
+    // xrays must be enabled for this to work
+    !MetabaseSettings.get("enable_xrays")
+  ) {
     return [];
   }
 

--- a/frontend/src/metabase/reference/databases/FieldSidebar.jsx
+++ b/frontend/src/metabase/reference/databases/FieldSidebar.jsx
@@ -1,15 +1,26 @@
 /* eslint "react/prop-types": "warn" */
 import React from "react";
 import PropTypes from "prop-types";
-import S from "metabase/components/Sidebar.css";
 import { t } from "c-3po";
-import Breadcrumbs from "metabase/components/Breadcrumbs.jsx";
-import SidebarItem from "metabase/components/SidebarItem.jsx";
-
+import { connect } from "react-redux";
 import cx from "classnames";
 import pure from "recompose/pure";
 
-const FieldSidebar = ({ database, table, field, style, className }) => (
+import { getXraysEnabled } from "metabase/selectors/settings";
+
+import Breadcrumbs from "metabase/components/Breadcrumbs";
+import SidebarItem from "metabase/components/SidebarItem";
+
+import S from "metabase/components/Sidebar.css";
+
+const FieldSidebar = ({
+  database,
+  table,
+  field,
+  style,
+  className,
+  xraysEnabled,
+}) => (
   <div className={cx(S.sidebar, className)} style={style}>
     <ul>
       <div className={S.breadcrumbs}>
@@ -38,14 +49,14 @@ const FieldSidebar = ({ database, table, field, style, className }) => (
         name={t`Details`}
       />
 
-      {
+      {xraysEnabled && (
         <SidebarItem
           key={`/auto/dashboard/field/${field.id}`}
           href={`/auto/dashboard/field/${field.id}`}
           icon="bolt"
           name={t`X-ray this field`}
         />
-      }
+      )}
     </ul>
   </div>
 );
@@ -56,6 +67,9 @@ FieldSidebar.propTypes = {
   field: PropTypes.object,
   className: PropTypes.string,
   style: PropTypes.object,
+  xraysEnabled: PropTypes.bool,
 };
 
-export default pure(FieldSidebar);
+export default connect(state => ({
+  xraysEnabled: getXraysEnabled(state),
+}))(pure(FieldSidebar));

--- a/frontend/src/metabase/reference/databases/FieldSidebar.jsx
+++ b/frontend/src/metabase/reference/databases/FieldSidebar.jsx
@@ -2,25 +2,17 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { t } from "c-3po";
-import { connect } from "react-redux";
 import cx from "classnames";
 import pure from "recompose/pure";
 
-import { getXraysEnabled } from "metabase/selectors/settings";
+import MetabaseSettings from "metabase/lib/settings";
 
 import Breadcrumbs from "metabase/components/Breadcrumbs";
 import SidebarItem from "metabase/components/SidebarItem";
 
 import S from "metabase/components/Sidebar.css";
 
-const FieldSidebar = ({
-  database,
-  table,
-  field,
-  style,
-  className,
-  xraysEnabled,
-}) => (
+const FieldSidebar = ({ database, table, field, style, className }) => (
   <div className={cx(S.sidebar, className)} style={style}>
     <ul>
       <div className={S.breadcrumbs}>
@@ -49,7 +41,7 @@ const FieldSidebar = ({
         name={t`Details`}
       />
 
-      {xraysEnabled && (
+      {MetabaseSettings.get("enable_xrays") && (
         <SidebarItem
           key={`/auto/dashboard/field/${field.id}`}
           href={`/auto/dashboard/field/${field.id}`}
@@ -67,9 +59,6 @@ FieldSidebar.propTypes = {
   field: PropTypes.object,
   className: PropTypes.string,
   style: PropTypes.object,
-  xraysEnabled: PropTypes.bool,
 };
 
-export default connect(state => ({
-  xraysEnabled: getXraysEnabled(state),
-}))(pure(FieldSidebar));
+export default pure(FieldSidebar);

--- a/frontend/src/metabase/reference/databases/TableSidebar.jsx
+++ b/frontend/src/metabase/reference/databases/TableSidebar.jsx
@@ -1,15 +1,19 @@
 /* eslint "react/prop-types": "warn" */
 import React from "react";
 import PropTypes from "prop-types";
-import S from "metabase/components/Sidebar.css";
 import { t } from "c-3po";
-import Breadcrumbs from "metabase/components/Breadcrumbs.jsx";
-import SidebarItem from "metabase/components/SidebarItem.jsx";
-
+import { connect } from "react-redux";
 import cx from "classnames";
 import pure from "recompose/pure";
 
-const TableSidebar = ({ database, table, style, className }) => (
+import { getXraysEnabled } from "metabase/admin/settings/selectors";
+
+import S from "metabase/components/Sidebar.css";
+
+import Breadcrumbs from "metabase/components/Breadcrumbs.jsx";
+import SidebarItem from "metabase/components/SidebarItem.jsx";
+
+const TableSidebar = ({ database, table, style, className, xraysEnabled }) => (
   <div className={cx(S.sidebar, className)} style={style}>
     <div className={S.breadcrumbs}>
       <Breadcrumbs
@@ -44,12 +48,14 @@ const TableSidebar = ({ database, table, style, className }) => (
         icon="all"
         name={t`Questions about this table`}
       />
-      <SidebarItem
-        key={`/auto/dashboard/table/${table.id}`}
-        href={`/auto/dashboard/table/${table.id}`}
-        icon="bolt"
-        name={t`X-ray this table`}
-      />
+      {xraysEnabled && (
+        <SidebarItem
+          key={`/auto/dashboard/table/${table.id}`}
+          href={`/auto/dashboard/table/${table.id}`}
+          icon="bolt"
+          name={t`X-ray this table`}
+        />
+      )}
     </ol>
   </div>
 );
@@ -59,6 +65,9 @@ TableSidebar.propTypes = {
   table: PropTypes.object,
   className: PropTypes.string,
   style: PropTypes.object,
+  xraysEnabled: PropTypes.bool,
 };
 
-export default pure(TableSidebar);
+export default connect(state => ({ xraysEnabled: getXraysEnabled(state) }))(
+  pure(TableSidebar),
+);

--- a/frontend/src/metabase/reference/databases/TableSidebar.jsx
+++ b/frontend/src/metabase/reference/databases/TableSidebar.jsx
@@ -2,18 +2,17 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { t } from "c-3po";
-import { connect } from "react-redux";
 import cx from "classnames";
 import pure from "recompose/pure";
 
-import { getXraysEnabled } from "metabase/selectors/settings";
+import MetabaseSettings from "metabase/lib/settings";
+
+import Breadcrumbs from "metabase/components/Breadcrumbs";
+import SidebarItem from "metabase/components/SidebarItem";
 
 import S from "metabase/components/Sidebar.css";
 
-import Breadcrumbs from "metabase/components/Breadcrumbs.jsx";
-import SidebarItem from "metabase/components/SidebarItem.jsx";
-
-const TableSidebar = ({ database, table, style, className, xraysEnabled }) => (
+const TableSidebar = ({ database, table, style, className }) => (
   <div className={cx(S.sidebar, className)} style={style}>
     <div className={S.breadcrumbs}>
       <Breadcrumbs
@@ -48,7 +47,7 @@ const TableSidebar = ({ database, table, style, className, xraysEnabled }) => (
         icon="all"
         name={t`Questions about this table`}
       />
-      {xraysEnabled && (
+      {MetabaseSettings.get("enable_xrays") && (
         <SidebarItem
           key={`/auto/dashboard/table/${table.id}`}
           href={`/auto/dashboard/table/${table.id}`}
@@ -65,9 +64,6 @@ TableSidebar.propTypes = {
   table: PropTypes.object,
   className: PropTypes.string,
   style: PropTypes.object,
-  xraysEnabled: PropTypes.bool,
 };
 
-export default connect(state => ({ xraysEnabled: getXraysEnabled(state) }))(
-  pure(TableSidebar),
-);
+export default pure(TableSidebar);

--- a/frontend/src/metabase/reference/databases/TableSidebar.jsx
+++ b/frontend/src/metabase/reference/databases/TableSidebar.jsx
@@ -6,7 +6,7 @@ import { connect } from "react-redux";
 import cx from "classnames";
 import pure from "recompose/pure";
 
-import { getXraysEnabled } from "metabase/admin/settings/selectors";
+import { getXraysEnabled } from "metabase/selectors/settings";
 
 import S from "metabase/components/Sidebar.css";
 

--- a/frontend/src/metabase/reference/metrics/MetricSidebar.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricSidebar.jsx
@@ -1,15 +1,19 @@
 /* eslint "react/prop-types": "warn" */
 import React from "react";
 import PropTypes from "prop-types";
-import S from "metabase/components/Sidebar.css";
 import { t } from "c-3po";
-import Breadcrumbs from "metabase/components/Breadcrumbs.jsx";
-import SidebarItem from "metabase/components/SidebarItem.jsx";
-
 import cx from "classnames";
 import pure from "recompose/pure";
+import { connect } from "react-redux";
 
-const MetricSidebar = ({ metric, user, style, className }) => (
+import { getXraysEnabled } from "metabase/selectors/settings";
+
+import Breadcrumbs from "metabase/components/Breadcrumbs";
+import SidebarItem from "metabase/components/SidebarItem";
+
+import S from "metabase/components/Sidebar.css";
+
+const MetricSidebar = ({ metric, user, style, className, xraysEnabled }) => (
   <div className={cx(S.sidebar, className)} style={style}>
     <ul>
       <div className={S.breadcrumbs}>
@@ -32,12 +36,14 @@ const MetricSidebar = ({ metric, user, style, className }) => (
         icon="all"
         name={t`Questions about ${metric.name}`}
       />
-      <SidebarItem
-        key={`/auto/dashboard/metric/${metric.id}`}
-        href={`/auto/dashboard/metric/${metric.id}`}
-        icon="bolt"
-        name={t`X-ray this metric`}
-      />
+      {xraysEnabled && (
+        <SidebarItem
+          key={`/auto/dashboard/metric/${metric.id}`}
+          href={`/auto/dashboard/metric/${metric.id}`}
+          icon="bolt"
+          name={t`X-ray this metric`}
+        />
+      )}
       {user &&
         user.is_superuser && (
           <SidebarItem
@@ -56,6 +62,9 @@ MetricSidebar.propTypes = {
   user: PropTypes.object,
   className: PropTypes.string,
   style: PropTypes.object,
+  xraysEnabled: PropTypes.bool,
 };
 
-export default pure(MetricSidebar);
+export default connect(state => ({
+  xraysEnabled: getXraysEnabled(state),
+}))(pure(MetricSidebar));

--- a/frontend/src/metabase/reference/metrics/MetricSidebar.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricSidebar.jsx
@@ -4,16 +4,15 @@ import PropTypes from "prop-types";
 import { t } from "c-3po";
 import cx from "classnames";
 import pure from "recompose/pure";
-import { connect } from "react-redux";
 
-import { getXraysEnabled } from "metabase/selectors/settings";
+import MetabaseSettings from "metabase/lib/settings";
 
 import Breadcrumbs from "metabase/components/Breadcrumbs";
 import SidebarItem from "metabase/components/SidebarItem";
 
 import S from "metabase/components/Sidebar.css";
 
-const MetricSidebar = ({ metric, user, style, className, xraysEnabled }) => (
+const MetricSidebar = ({ metric, user, style, className }) => (
   <div className={cx(S.sidebar, className)} style={style}>
     <ul>
       <div className={S.breadcrumbs}>
@@ -36,7 +35,7 @@ const MetricSidebar = ({ metric, user, style, className, xraysEnabled }) => (
         icon="all"
         name={t`Questions about ${metric.name}`}
       />
-      {xraysEnabled && (
+      {MetabaseSettings.get("enable_xrays") && (
         <SidebarItem
           key={`/auto/dashboard/metric/${metric.id}`}
           href={`/auto/dashboard/metric/${metric.id}`}
@@ -62,9 +61,6 @@ MetricSidebar.propTypes = {
   user: PropTypes.object,
   className: PropTypes.string,
   style: PropTypes.object,
-  xraysEnabled: PropTypes.bool,
 };
 
-export default connect(state => ({
-  xraysEnabled: getXraysEnabled(state),
-}))(pure(MetricSidebar));
+export default pure(MetricSidebar);

--- a/frontend/src/metabase/reference/segments/SegmentSidebar.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentSidebar.jsx
@@ -1,15 +1,19 @@
 /* eslint "react/prop-types": "warn" */
 import React from "react";
 import PropTypes from "prop-types";
-import S from "metabase/components/Sidebar.css";
 import { t } from "c-3po";
-import Breadcrumbs from "metabase/components/Breadcrumbs.jsx";
-import SidebarItem from "metabase/components/SidebarItem.jsx";
-
 import cx from "classnames";
 import pure from "recompose/pure";
+import { connect } from "react-redux";
 
-const SegmentSidebar = ({ segment, user, style, className }) => (
+import { getXraysEnabled } from "metabase/selectors/settings";
+
+import Breadcrumbs from "metabase/components/Breadcrumbs";
+import SidebarItem from "metabase/components/SidebarItem";
+
+import S from "metabase/components/Sidebar.css";
+
+const SegmentSidebar = ({ segment, user, style, className, xraysEnabled }) => (
   <div className={cx(S.sidebar, className)} style={style}>
     <ul>
       <div className={S.breadcrumbs}>
@@ -38,13 +42,14 @@ const SegmentSidebar = ({ segment, user, style, className }) => (
         icon="all"
         name={t`Questions about this segment`}
       />
-      <SidebarItem
-        key={`/auto/dashboard/segment/${segment.id}`}
-        href={`/auto/dashboard/segment/${segment.id}`}
-        icon="bolt"
-        name={t`X-ray this segment`}
-      />
-
+      {xraysEnabled && (
+        <SidebarItem
+          key={`/auto/dashboard/segment/${segment.id}`}
+          href={`/auto/dashboard/segment/${segment.id}`}
+          icon="bolt"
+          name={t`X-ray this segment`}
+        />
+      )}
       {user &&
         user.is_superuser && (
           <SidebarItem
@@ -63,6 +68,9 @@ SegmentSidebar.propTypes = {
   user: PropTypes.object,
   className: PropTypes.string,
   style: PropTypes.object,
+  xraysEnabled: PropTypes.bool,
 };
 
-export default pure(SegmentSidebar);
+export default connect(state => ({
+  xraysEnabled: getXraysEnabled(state),
+}))(pure(SegmentSidebar));

--- a/frontend/src/metabase/reference/segments/SegmentSidebar.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentSidebar.jsx
@@ -4,16 +4,15 @@ import PropTypes from "prop-types";
 import { t } from "c-3po";
 import cx from "classnames";
 import pure from "recompose/pure";
-import { connect } from "react-redux";
 
-import { getXraysEnabled } from "metabase/selectors/settings";
+import MetabaseSettings from "metabase/lib/settings";
 
 import Breadcrumbs from "metabase/components/Breadcrumbs";
 import SidebarItem from "metabase/components/SidebarItem";
 
 import S from "metabase/components/Sidebar.css";
 
-const SegmentSidebar = ({ segment, user, style, className, xraysEnabled }) => (
+const SegmentSidebar = ({ segment, user, style, className }) => (
   <div className={cx(S.sidebar, className)} style={style}>
     <ul>
       <div className={S.breadcrumbs}>
@@ -42,7 +41,7 @@ const SegmentSidebar = ({ segment, user, style, className, xraysEnabled }) => (
         icon="all"
         name={t`Questions about this segment`}
       />
-      {xraysEnabled && (
+      {MetabaseSettings.get("enable_xrays") && (
         <SidebarItem
           key={`/auto/dashboard/segment/${segment.id}`}
           href={`/auto/dashboard/segment/${segment.id}`}
@@ -68,9 +67,6 @@ SegmentSidebar.propTypes = {
   user: PropTypes.object,
   className: PropTypes.string,
   style: PropTypes.object,
-  xraysEnabled: PropTypes.bool,
 };
 
-export default connect(state => ({
-  xraysEnabled: getXraysEnabled(state),
-}))(pure(SegmentSidebar));
+export default pure(SegmentSidebar);

--- a/frontend/src/metabase/selectors/settings.js
+++ b/frontend/src/metabase/selectors/settings.js
@@ -3,6 +3,8 @@ export const getIsPublicSharingEnabled = state =>
   state.settings.values["public_sharing"];
 export const getIsApplicationEmbeddingEnabled = state =>
   state.settings.values["embedding"];
+// Whether or not xrays are enabled on the instance
+export const getXraysEnabled = state => state.settings.values["enable_xrays"];
 
 // NOTE: these are admin-only settings
 export const getSiteUrl = state => state.settings.values["site-url"];

--- a/frontend/test/metabase-bootstrap.js
+++ b/frontend/test/metabase-bootstrap.js
@@ -3,6 +3,7 @@ import "number-to-locale-string";
 import "metabase/css/index.css";
 
 window.MetabaseBootstrap = {
+  enable_xrays: true,
   timezones: [
     "GMT",
     "UTC",

--- a/frontend/test/metabase-lib/Mode.unit.spec.js
+++ b/frontend/test/metabase-lib/Mode.unit.spec.js
@@ -84,13 +84,18 @@ describe("Mode", () => {
 
     describe("for a question with an aggregation and a time breakout", () => {
       it("has pivot as mode actions 1 and 2", () => {
-        expect(timeBreakoutQuestionMode.actions().length).toBe(4);
         expect(timeBreakoutQuestionMode.actions()[0].name).toBe(
           "pivot-by-category",
         );
         expect(timeBreakoutQuestionMode.actions()[1].name).toBe(
           "pivot-by-location",
         );
+      });
+
+      describe("with xrays enabled", () => {
+        it("has the correct number of items", () => {
+          expect(timeBreakoutQuestionMode.actions().length).toBe(4);
+        });
       });
     });
   });

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -131,6 +131,11 @@
   :type    :json
   :default {})
 
+(defsetting enable-xrays
+  (tru "Allow users to explore data using Xrays")
+  :type    :boolean
+  :default true)
+
 (defn remove-public-uuid-if-public-sharing-is-disabled
   "If public sharing is *disabled* and OBJECT has a `:public_uuid`, remove it so people don't try to use it (since it
    won't work). Intended for use as part of a `post-select` implementation for Cards and Dashboards."

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -132,7 +132,7 @@
   :default {})
 
 (defsetting enable-xrays
-  (tru "Allow users to explore data using Xrays")
+  (tru "Allow users to explore data using X-rays")
   :type    :boolean
   :default true)
 

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -169,6 +169,7 @@
    :embedding             (enable-embedding)
    :enable_query_caching  (enable-query-caching)
    :enable_nested_queries (enable-nested-queries)
+   :enable_xrays          (enable-xrays)
    :engines               ((resolve 'metabase.driver/available-drivers))
    :ga_code               "UA-60817802-1"
    :google_auth_client_id (setting/get :google-auth-client-id)


### PR DESCRIPTION
Adds in a setting in the `General` settings in the admin section to disable x-rays for an instance. Does so by hiding UI triggers that direct users to routes that use x-ray resources. This setting defaults to "enabled" and the primary motivation here is to help out Metabase users who are dealing with data sources where allowing users to run x-rays on them incurs performance or monetary costs by giving them the ability to effectively disable the feature.

TODOs

- [x] Hide x-rays in click actions