### PR TITLE
Select component style tweaks

### DIFF
--- a/frontend/src/metabase/components/ColumnarSelector.css
+++ b/frontend/src/metabase/components/ColumnarSelector.css
@@ -55,10 +55,8 @@
 }
 
 .ColumnarSelector-row--selected {
-  color: inherit !important;
+  color: var(--color-brand);
   background: white;
-  border-top: var(--border-size) var(--border-style) var(--color-border);
-  border-bottom: var(--border-size) var(--border-style) var(--color-border);
 }
 
 .ColumnarSelector-row--disabled {

--- a/frontend/src/metabase/components/Select.jsx
+++ b/frontend/src/metabase/components/Select.jsx
@@ -57,7 +57,7 @@ class BrowserSelect extends Component {
   };
   static defaultProps = {
     className: "",
-    width: 320,
+    width: 300,
     height: 320,
     rowHeight: 40,
     multiple: false,


### PR DESCRIPTION
A couple small tweaks to the `Select` component to make things feel nicer.

- Matches the width to the trigger width
- Fixes the `selected` style

<img width="378" alt="screen shot 2018-10-18 at 11 34 23 am" src="https://user-images.githubusercontent.com/5248953/47176238-f4ac6b80-d2c9-11e8-951c-8358bfa432a5.png">
