### PR TITLE
Whitelist cyrillic characters for slugs

### DIFF
--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -734,7 +734,7 @@ export function stripId(name: string) {
 }
 
 export function slugify(name: string) {
-  return name && name.toLowerCase().replace(/[^a-z0-9_]/g, "_");
+  return name && name.toLowerCase().replace(/[^a-z\u0400-\u04ff0-9_]/g, "_");
 }
 
 export function assignUserColors(


### PR DESCRIPTION
Minor change to allow cyrillic characters for slug names.

Prior to this change, e.g. the query filter called "Мой тэг" would get slugified to "_______", which has at least 2 issues:
- The name in the URL is not descriptive enough
- Filters, titled in cyrillic characters and of same length (let's call them tag1 & tag2) are slugified to the same string (`tag.length` consecutive "_"s). Adding a filter `tag1=value1`, implicitly forces another filter `tag2=value1`. Which returns wrong results for the user.