### PR TITLE
Query results metadata: we don't need to check for empty names any more

### DIFF
--- a/src/metabase/sync/analyze/query_results.clj
+++ b/src/metabase/sync/analyze/query_results.clj
@@ -72,8 +72,8 @@
                 (redux/juxt
                  (apply f/col-wise (for [metadata result-metadata]
                                      (if-not (:fingerprint metadata)
-                                       (f/constant-fingerprinter (:fingerprint metadata))
-                                       (f/fingerprinter metadata))))
+                                       (f/fingerprinter metadata)
+                                       (f/constant-fingerprinter (:fingerprint metadata)))))
                  (insights/insights result-metadata))
                 (fn [[fingerprints insights]]
                   {:metadata (map (fn [fingerprint metadata]


### PR DESCRIPTION
.