### PR TITLE
Make row chart y-axis labels darker

### DIFF
--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
@@ -31,7 +31,8 @@
 }
 
 .LineAreaBarChart .dc-chart g.row text.outside {
-  fill: var(--color-text-light);
+  fill: var(--color-text-medium);
+  font-weight: 900;
 }
 .LineAreaBarChart .dc-chart g.row text.inside {
   fill: white;


### PR DESCRIPTION
A little two-liner to improve legibility of row chart y-axes.


**Before**

![screen shot 2018-10-23 at 3 38 36 pm](https://user-images.githubusercontent.com/2223916/47395125-38dca900-d6da-11e8-964c-b9693d0138d9.png)


**After**

![screen shot 2018-10-23 at 3 40 22 pm](https://user-images.githubusercontent.com/2223916/47395129-3bd79980-d6da-11e8-8820-b939940ee9c4.png)

**Comparison to bar chart x-axes:**

![screen shot 2018-10-23 at 3 40 47 pm](https://user-images.githubusercontent.com/2223916/47395138-442fd480-d6da-11e8-958b-6e618c1fbd7e.png)
