### PR TITLE
Remove :columns from QP results; test cleanup 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -347,7 +347,7 @@ jobs:
       - restore_cache:
           <<: *restore-be-deps-cache
       - run:
-          name: Wait for SparkSQL to be ready
+          name: Wait for Presto to be ready
           command: >
             /home/circleci/metabase/metabase/.circleci/skip-driver-tests.sh sparksql ||
             while ! nc -z localhost 8080; do sleep 0.1; done

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -183,8 +183,8 @@
 ;; middleware namespace for more details
 
 (s/defn ^:private result-metadata-for-query :- qr/ResultsMetadata
-  "Fetch the results metadata for a QUERY by running the query and seeing what the QP gives us in return.
-   This is obviously a bit wasteful so hopefully we can avoid having to do this."
+  "Fetch the results metadata for a `query` by running the query and seeing what the QP gives us in return. This is
+  obviously a bit wasteful so hopefully we can avoid having to do this."
   [query]
   (binding [qpi/*disable-qp-logging* true]
     (let [{:keys [status], :as results} (qp/process-query query)]

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -96,12 +96,12 @@
 (defn as-format
   "Return a response containing the RESULTS of a query in the specified format."
   {:style/indent 1, :arglists '([export-format results])}
-  [export-format {{:keys [columns rows cols]} :data, :keys [status], :as response}]
+  [export-format {{:keys [rows cols]} :data, :keys [status], :as response}]
   (api/let-404 [export-conf (ex/export-formats export-format)]
     (if (= status :completed)
       ;; successful query, send file
       {:status  200
-       :body    ((:export-fn export-conf) columns (maybe-modify-date-values cols rows))
+       :body    ((:export-fn export-conf) (map :name cols) (maybe-modify-date-values cols rows))
        :headers {"Content-Type"        (str (:content-type export-conf) "; charset=utf-8")
                  "Content-Disposition" (str "attachment; filename=\"query_result_" (du/date->iso-8601) "." (:ext export-conf) "\"")}}
       ;; failed query, send error message

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -65,14 +65,14 @@
   (card-with-uuid uuid))
 
 (defn run-query-for-card-with-id
-  "Run the query belonging to Card with CARD-ID with PARAMETERS and other query options (e.g. `:constraints`)."
+  "Run the query belonging to Card with `card-id` with `parameters` and other query options (e.g. `:constraints`)."
   {:style/indent 2}
   [card-id parameters & options]
   (u/prog1 (-> ;; run this query with full superuser perms
             (binding [api/*current-user-permissions-set*     (atom #{"/"})
                       qp/*allow-queries-with-no-executor-id* true]
               (apply card-api/run-query-for-card card-id, :parameters parameters, :context :public-question, options))
-            (u/select-nested-keys [[:data :columns :cols :rows :rows_truncated] [:json_query :parameters] :error :status]))
+            (u/select-nested-keys [[:data :cols :rows :rows_truncated] [:json_query :parameters] :error :status]))
     ;; if the query failed instead of returning anything about the query just return a generic error message
     (when (= (:status <>) :failed)
       (throw (ex-info "An error occurred while running the query." {:status-code 400})))))

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -180,7 +180,7 @@
           :settings {:report-timezone \"US/Pacific\"
                      :other-setting   \"and its value\"}}
 
-  Results should look like:
+  Results returned by the driver should look like:
 
          {:columns [\"id\", \"name\"]
           :rows    [[1 \"Lucky Bird\"]
@@ -191,18 +191,28 @@
      features are:
 
   *  `:foreign-keys` - Does this database support foreign key relationships?
+
   *  `:nested-fields` - Does this database support nested fields (e.g. Mongo)?
+
   *  `:set-timezone` - Does this driver support setting a timezone for the query?
+
   *  `:basic-aggregations` - Does the driver support *basic* aggregations like `:count` and `:sum`? (Currently,
       everything besides standard deviation is considered \"basic\"; only GA doesn't support this).
+
   *  `:standard-deviation-aggregations` - Does this driver support standard deviation aggregations?
+
   *  `:expressions` - Does this driver support expressions (e.g. adding the values of 2 columns together)?
+
   *  `:native-parameters` - Does the driver support parameter substitution on native queries?
+
   *  `:expression-aggregations` - Does the driver support using expressions inside aggregations? e.g. something like
       \"sum(x) + count(y)\" or \"avg(x + y)\"
+
   *  `:nested-queries` - Does the driver support using a query as the `:source-query` of another MBQL query? Examples
       are CTEs or subselects in SQL queries.
+
   *  `:binning` - Does the driver support binning as specified by the `binning-strategy` clause?
+
   *  `:no-case-sensitivity-string-filter-options` - An anti-feature: does this driver not let you specify whether or not
       our string search filter clauses (`:contains`, `:starts-with`, and `:ends-with`, collectively the equivalent of
       SQL `LIKE` are case-senstive or not? This informs whether we should present you with the 'Case Sensitive' checkbox

--- a/src/metabase/driver/googleanalytics/query_processor.clj
+++ b/src/metabase/driver/googleanalytics/query_processor.clj
@@ -9,7 +9,8 @@
              [date :as du]
              [i18n :as ui18n :refer [tru]]
              [schema :as su]]
-            [schema.core :as s])
+            [schema.core :as s]
+            [metabase.util :as u])
   (:import [com.google.api.services.analytics.model GaData GaData$ColumnHeaders]))
 
 (def ^:private ^:const earliest-date "2005-01-01")
@@ -332,8 +333,7 @@
         ^GaData response (do-query query)
         columns          (map header->column (.getColumnHeaders response))
         getters          (map header->getter-fn (.getColumnHeaders response))]
-    {:columns  (map :name columns)
-     :cols     columns
+    {:columns  (map (comp u/keyword->qualified-name :name) columns)
      :rows     (for [row (.getRows response)]
                  (for [[data getter] (map vector row getters)]
                    (getter data)))

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -789,7 +789,9 @@
                  (class e)
                  (.getMessage e)
                  "\n"
-                 (u/pprint-to-str (u/filtered-stacktrace e)))
+                 (u/pprint-to-str (u/filtered-stacktrace e))
+                 "\n"
+                 (u/pprint-to-str 'red (ex-data e)))
       (render:error card data))))
 
 (s/defn ^:private render-pulse-card :- RenderedPulseCard

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -103,10 +103,10 @@
       ;; TODO - should we log the fully preprocessed query here?
       check-features/check-features
       wrap-value-literals/wrap-value-literals
+      dev/check-results-format
       annotate/add-column-info
       perms/check-query-permissions
       resolve-joined-tables/resolve-joined-tables
-      dev/check-results-format
       limit/limit
       cumulative-ags/handle-cumulative-aggregations
       results-metadata/record-and-return-metadata!
@@ -223,6 +223,9 @@
 ;; `process-query-and-save-execution!` is the function used by various things like API endpoints and pulses;
 ;; `process-query` is more of an internal function
 
+;; TODO - shouldn't (or couldn't) all this stuff below be implemented as middleware? We could disable it by default
+;; and turn it on/off with a `:middleware` option. It's just cluttering up this namespace right now IMO
+
 (defn- save-query-execution!
   "Save a `QueryExecution` and update the average execution time for the corresponding `Query`."
   [query-execution]
@@ -244,9 +247,7 @@
       (assoc :status    :failed
              :error     error-message
              :row_count 0
-             :data      {:rows    []
-                         :cols    []
-                         :columns []})))
+             :data      {:rows [], :cols []})))
 
 (defn- save-and-return-successful-query!
   "Save QueryExecution state and construct a completed (successful) query response"

--- a/src/metabase/query_processor/interface.clj
+++ b/src/metabase/query_processor/interface.clj
@@ -8,6 +8,8 @@
    https://support.office.com/en-nz/article/Excel-specifications-and-limits-1672b34d-7043-467e-8e27-269d656771c3"
   1048576)
 
+;; TODO - I think we could do this more generally by just changing the log level for the QP namespaces to error or
+;; warn with the help of a macro like `metabase.test.util/suppress-output`
 (def ^:dynamic ^Boolean *disable-qp-logging*
   "Should we disable logging for the QP? (e.g., during sync we probably want to turn it off to keep logs less
   cluttered)."

--- a/src/metabase/query_processor/middleware/add_dimension_projections.clj
+++ b/src/metabase/query_processor/middleware/add_dimension_projections.clj
@@ -212,8 +212,6 @@
         ;; Get the entires we're going to add to `:cols` for each of the remapped values we add
         internal-only-cols (map :new-column internal-only-dims)]
     (-> results
-        ;; add the names of each newly added column to the end of `:columns`
-        (update :columns concat (map :to internal-only-dims))
         ;; add remapping info `:remapped_from` and `:remapped_to` to each existing `:col`
         (update :cols add-remapping-info remapping-dimensions internal-only-cols)
         ;; now add the entries for each newly added column to the end of `:cols`

--- a/src/metabase/query_processor/middleware/dev.clj
+++ b/src/metabase/query_processor/middleware/dev.clj
@@ -1,6 +1,6 @@
 (ns metabase.query-processor.middleware.dev
-  "Middleware that's only active in dev and test scenarios. These middleware functions do additional checks
-   of query processor behavior that are undesirable in normal production use."
+  "Middleware that's only active in dev and test scenarios. These middleware functions do additional checks of query
+  processor behavior that are undesirable in normal production use."
   (:require [metabase.config :as config]
             [schema.core :as s]))
 
@@ -9,21 +9,22 @@
 
 (def QPResultsFormat
   "Schema for the expected format of results returned by a query processor."
-  {:columns               [(s/cond-pre s/Keyword s/Str)]
+  {;; driver QPs must return this. The `annotate` middleware uses this to generate the `:cols` map, and will discard
+   ;; this key when it's finished because it's not used anywhere else thereafter.
+   :columns               [s/Str]
    ;; This is optional because QPs don't neccesarily have to add it themselves; annotate will take care of that
    (s/optional-key :cols) [{s/Keyword s/Any}]
    :rows                  s/Any
    s/Keyword              s/Any})
 
 (def ^{:arglists '([results])} validate-results
-  "Validate that the RESULTS of executing a query match the `QPResultsFormat` schema.
-   Throws an `Exception` if they are not; returns RESULTS as-is if they are."
+  "Validate that the RESULTS of executing a query match the `QPResultsFormat` schema. Throws an `Exception` if they are
+  not; returns RESULTS as-is if they are."
   (s/validator QPResultsFormat))
 
 (def ^{:arglists '([qp])} check-results-format
-  "Make sure the results of a QP execution are in the expected format.
-   This takes place *after* the 'annotation' stage of post-processing.
-   This check is skipped in prod to avoid wasting CPU cycles."
+  "Make sure the results of a QP execution are in the expected format. This takes place *after* the 'annotation' stage
+  of post-processing. This check is skipped in prod to avoid wasting CPU cycles."
   (if config/is-prod?
     identity
     (fn [qp]

--- a/src/metabase/sync/analyze/query_results.clj
+++ b/src/metabase/sync/analyze/query_results.clj
@@ -21,7 +21,7 @@
                  "Valid field datetime unit keyword or string"))
 
 (def ^:private ResultColumnMetadata
-  "Result metadata for a single column"
+  "Schema for result metadata for a single column, found in a QP response under `data.results_metadata.columns`."
   {:name                          su/NonBlankString
    :display_name                  su/NonBlankString
    (s/optional-key :description)  (s/maybe su/NonBlankString)
@@ -41,8 +41,9 @@
   special type with a nil special type"
   [result-metadata col]
   (update result-metadata :special_type (fn [original-value]
-                                          ;; If we already know the special type, becouse it is stored, don't classify again,
-                                          ;; but try to refine special type set upstream for aggregation cols (which come back as :type/Number).
+                                          ;; If we already know the special type, becouse it is stored, don't classify
+                                          ;; again, but try to refine special type set upstream for aggregation cols
+                                          ;; (which come back as :type/Number).
                                           (case original-value
                                             (nil :type/Number) (classify-name/infer-special-type col)
                                             original-value))))
@@ -54,7 +55,8 @@
   [column]
   (merge
    (u/select-non-nil-keys column [:name :display_name :description :base_type :special_type :unit :fingerprint])
-   ;; since years are actually returned as text they can't be used for breakout purposes so don't advertise them as DateTime columns
+   ;; since years are actually returned as text they can't be used for breakout purposes so don't advertise them as
+   ;; DateTime columns
    (when (= (:unit column) :year)
      {:base_type :type/Text
       :unit      nil})))

--- a/src/metabase/util/export.clj
+++ b/src/metabase/util/export.clj
@@ -24,8 +24,8 @@
   (cons (map :display_name (get-in results [:result :data :cols]))
         (get-in results [:result :data :rows])))
 
-(defn- export-to-xlsx [columns rows]
-  (let [wb  (spreadsheet/create-workbook "Query result" (cons (mapv name columns) rows))
+(defn- export-to-xlsx [column-names rows]
+  (let [wb  (spreadsheet/create-workbook "Query result" (cons (mapv name column-names) rows))
         ;; note: byte array streams don't need to be closed
         out (ByteArrayOutputStream.)]
     (spreadsheet/save-workbook! out wb)
@@ -39,20 +39,20 @@
          (spreadsheet/create-workbook "Query result" )
          (spreadsheet/save-workbook! file-path))))
 
-(defn- export-to-csv [columns rows]
+(defn- export-to-csv [column-names rows]
   (with-out-str
     ;; turn keywords into strings, otherwise we get colons in our output
-    (csv/write-csv *out* (into [(mapv name columns)] rows))))
+    (csv/write-csv *out* (into [(mapv name column-names)] rows))))
 
 (defn export-to-csv-writer
-  "Write a CSV to `FILE` with the header a and rows found in `RESULTS`"
+  "Write a CSV to `file` with the header a and rows found in `results`."
   [^File file results]
   (with-open [fw (java.io.FileWriter. file)]
     (csv/write-csv fw (results->cells results))))
 
-(defn- export-to-json [columns rows]
+(defn- export-to-json [column-names rows]
   (for [row rows]
-    (zipmap columns row)))
+    (zipmap column-names row)))
 
 (def export-formats
   "Map of export types to their relevant metadata"

--- a/test/metabase/api/automagic_dashboards_test.clj
+++ b/test/metabase/api/automagic_dashboards_test.clj
@@ -130,21 +130,23 @@
 
 ;;; ------------------- Comparisons -------------------
 
-(def ^:private segment {:table_id (data/id :venues)
-                        :definition {:filter [:> [:field-id (data/id :venues :price)] 10]}})
+(def ^:private segment
+  (delay
+   {:table_id   (data/id :venues)
+    :definition {:filter [:> [:field-id (data/id :venues :price)] 10]}}))
 
 (expect
-  (tt/with-temp* [Segment [{segment-id :id} segment]]
+  (tt/with-temp* [Segment [{segment-id :id} @segment]]
     (api-call "table/%s/compare/segment/%s"
               [(data/id :venues) segment-id])))
 
 (expect
-  (tt/with-temp* [Segment [{segment-id :id} segment]]
+  (tt/with-temp* [Segment [{segment-id :id} @segment]]
     (api-call "table/%s/rule/example/indepth/compare/segment/%s"
               [(data/id :venues) segment-id])))
 
 (expect
-  (tt/with-temp* [Segment [{segment-id :id} segment]]
+  (tt/with-temp* [Segment [{segment-id :id} @segment]]
     (api-call "adhoc/%s/cell/%s/compare/segment/%s"
               [(->> {:query {:filter [:> [:field-id (data/id :venues :price)] 10]
                              :source-table (data/id :venues)}

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -207,7 +207,7 @@
                            :series                 []}]})
   ;; fetch a dashboard WITH a dashboard card on it
   (tt/with-temp* [Dashboard     [{dashboard-id :id} {:name "Test Dashboard"}]
-                  Card          [{card-id :id}      {:name "Dashboard Test Card"}]
+                  Card          [{card-id :id}      {:name "Dashboard Test Card", :dataset_query {}}]
                   DashboardCard [_                  {:dashboard_id dashboard-id, :card_id card-id}]]
     (with-dashboards-in-readable-collection [dashboard-id]
       (card-api-test/with-cards-in-readable-collection [card-id]
@@ -603,8 +603,8 @@
        :row   4}]
    3 #{0}}
   (tt/with-temp* [Dashboard [{dashboard-id :id}]
-                  Card      [{card-id :id}]
-                  Card      [{series-id-1 :id} {:name "Series Card"}]]
+                  Card      [{card-id :id}     {:dataset_query {}}]
+                  Card      [{series-id-1 :id} {:name "Series Card", :dataset_query {}}]]
     (with-dashboards-in-writeable-collection [dashboard-id]
       (card-api-test/with-cards-in-readable-collection [card-id series-id-1]
         (let [dashboard-card ((user->client :rasta) :post 200 (format "dashboard/%d/cards" dashboard-id)
@@ -690,10 +690,10 @@
        :updated_at             true}]}
   ;; fetch a dashboard WITH a dashboard card on it
   (tt/with-temp* [Dashboard     [{dashboard-id :id}]
-                  Card          [{card-id :id}]
+                  Card          [{card-id :id}       {:dataset_query {}}]
                   DashboardCard [{dashcard-id-1 :id} {:dashboard_id dashboard-id, :card_id card-id}]
                   DashboardCard [{dashcard-id-2 :id} {:dashboard_id dashboard-id, :card_id card-id}]
-                  Card          [{series-id-1 :id}   {:name "Series Card"}]]
+                  Card          [{series-id-1 :id}   {:name "Series Card", :dataset_query {}}]]
     (with-dashboards-in-writeable-collection [dashboard-id]
       (array-map
        1 [(remove-ids-and-booleanize-timestamps (retrieve-dashboard-card dashcard-id-1))

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -24,9 +24,7 @@
             [metabase.test.data
              [datasets :as datasets]
              [users :refer :all]]
-            [toucan
-             [db :as db]
-             [hydrate :as hydrate]]
+            [toucan.db :as db]
             [toucan.util.test :as tt]))
 
 ;; HELPER FNS
@@ -645,14 +643,16 @@
 
 (expect
   {:valid false, :message "Error!"}
-  (with-redefs [database-api/test-database-connection test-database-connection]
-    (#'database-api/test-connection-details "h2" {:db "ABC"})))
+  (tu/suppress-output
+    (with-redefs [database-api/test-database-connection test-database-connection]
+      (#'database-api/test-connection-details "h2" {:db "ABC"}))))
 
 (expect
   {:valid false}
-  (with-redefs [database-api/test-database-connection test-database-connection]
-    ((user->client :crowberto) :post 200 "database/validate"
-     {:details {:engine :h2, :details {:db "ABC"}}})))
+  (tu/suppress-output
+    (with-redefs [database-api/test-database-connection test-database-connection]
+      ((user->client :crowberto) :post 200 "database/validate"
+       {:details {:engine :h2, :details {:db "ABC"}}}))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -66,13 +66,12 @@
 
 (defn successful-query-results
   ([]
-   {:data       {:columns ["count"]
-                 :cols    [{:base_type    "type/Integer"
-                            :special_type "type/Number"
-                            :name         "count"
-                            :display_name "count"
-                            :source       "aggregation"}]
-                 :rows    [[100]]}
+   {:data       {:cols [{:base_type    "type/Integer"
+                         :special_type "type/Number"
+                         :name         "count"
+                         :display_name "count"
+                         :source       "aggregation"}]
+                 :rows [[100]]}
     :json_query {:parameters nil}
     :status     "completed"})
   ([results-format]
@@ -196,11 +195,12 @@
 ;; query info)
 (expect-for-response-formats [response-format]
   "An error occurred while running the query."
-  (with-embedding-enabled-and-new-secret-key
-    (with-temp-card [card {:enable_embedding true, :dataset_query {:database (data/id)
-                                                                   :type     :native
-                                                                   :native   {:query "SELECT * FROM XYZ"}}}]
-      (http/client :get 400 (card-query-url card response-format)))))
+  (tu/suppress-output
+   (with-embedding-enabled-and-new-secret-key
+     (with-temp-card [card {:enable_embedding true, :dataset_query {:database (data/id)
+                                                                    :type     :native
+                                                                    :native   {:query "SELECT * FROM XYZ"}}}]
+       (http/client :get 400 (card-query-url card response-format))))))
 
 ;; check that the endpoint doesn't work if embedding isn't enabled
 (expect-for-response-formats [response-format]
@@ -395,12 +395,13 @@
 ;; query info)
 (expect
   "An error occurred while running the query."
-  (with-embedding-enabled-and-new-secret-key
-    (with-temp-dashcard [dashcard {:dash {:enable_embedding true}
-                                   :card {:dataset_query {:database (data/id)
-                                                          :type     :native,
-                                                          :native   {:query "SELECT * FROM XYZ"}}}}]
-      (http/client :get 400 (dashcard-url dashcard)))))
+  (tu/suppress-output
+    (with-embedding-enabled-and-new-secret-key
+      (with-temp-dashcard [dashcard {:dash {:enable_embedding true}
+                                     :card {:dataset_query {:database (data/id)
+                                                            :type     :native,
+                                                            :native   {:query "SELECT * FROM XYZ"}}}}]
+        (http/client :get 400 (dashcard-url dashcard))))))
 
 ;; check that the endpoint doesn't work if embedding isn't enabled
 (expect

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -641,7 +641,7 @@
 (defn- dimension-options-for-field [response field-name]
   (->> response
        :fields
-       (m/find-first #(.equalsIgnoreCase field-name (:name %)))
+       (m/find-first #(.equalsIgnoreCase ^String field-name, ^String (:name %)))
        :dimension_options))
 
 (defn- extract-dimension-options
@@ -691,7 +691,7 @@
 
 (qpt/expect-with-non-timeseries-dbs-except #{:oracle :mongo :redshift :sparksql}
   []
-  (data/with-db (data/get-or-create-database! defs/test-data-with-time)
+  (data/dataset test-data-with-time
     (let [response ((user->client :rasta) :get 200 (format "table/%d/query_metadata" (data/id :users)))]
       (dimension-options-for-field response "last_login_time"))))
 

--- a/test/metabase/automagic_dashboards/comparison_test.clj
+++ b/test/metabase/automagic_dashboards/comparison_test.clj
@@ -12,8 +12,10 @@
             [metabase.test.automagic-dashboards :refer :all]
             [toucan.util.test :as tt]))
 
-(def ^:private segment {:table_id (data/id :venues)
-                        :definition {:filter [:> [:field-id (data/id :venues :price)] 10]}})
+(def ^:private segment
+  (delay
+   {:table_id   (data/id :venues)
+    :definition {:filter [:> [:field-id (data/id :venues :price)] 10]}}))
 
 (defn- test-comparison
   [left right]
@@ -25,14 +27,14 @@
       pos?))
 
 (expect
-  (tt/with-temp* [Segment [{segment-id :id} segment]]
+  (tt/with-temp* [Segment [{segment-id :id} @segment]]
     (with-rasta
       (with-dashboard-cleanup
         (and (test-comparison (Table (data/id :venues)) (Segment segment-id))
              (test-comparison (Segment segment-id) (Table (data/id :venues))))))))
 
 (expect
-  (tt/with-temp* [Segment [{segment1-id :id} segment]
+  (tt/with-temp* [Segment [{segment1-id :id} @segment]
                   Segment [{segment2-id :id} {:table_id (data/id :venues)
                                               :definition {:filter [:< [:field-id (data/id :venues :price)] 4]}}]]
     (with-rasta

--- a/test/metabase/driver/bigquery_test.clj
+++ b/test/metabase/driver/bigquery_test.clj
@@ -50,10 +50,9 @@
 ;; make sure that BigQuery native queries maintain the column ordering specified in the SQL -- post-processing
 ;; ordering shouldn't apply (Issue #2821)
 (expect-with-engine :bigquery
-  {:columns ["venue_id" "user_id" "checkins_id"],
-   :cols    [{:name "venue_id",    :display_name "Venue ID",    :base_type :type/Integer}
-             {:name "user_id",     :display_name  "User ID",    :base_type :type/Integer}
-             {:name "checkins_id", :display_name "Checkins ID", :base_type :type/Integer}]}
+  {:cols [{:name "venue_id", :display_name "Venue ID", :base_type :type/Integer}
+          {:name "user_id", :display_name "User ID", :base_type :type/Integer}
+          {:name "checkins_id", :display_name "Checkins ID", :base_type :type/Integer}]}
 
   (select-keys (:data (qp/process-query
                         {:native   {:query (str "SELECT `test_data.checkins`.`venue_id` AS `venue_id`, "
@@ -63,18 +62,19 @@
                                                 "LIMIT 2")}
                          :type     :native
                          :database (data/id)}))
-               [:cols :columns]))
+               [:cols]))
 
 ;; make sure that the bigquery driver can handle named columns with characters that aren't allowed in BQ itself
 (expect-with-engine :bigquery
-  {:rows    [[113]]
-   :columns ["User_ID_Plus_Venue_ID"]}
+  {:rows      [[113]]
+   :col-names ["User_ID_Plus_Venue_ID"]}
   (qptest/rows+column-names
     (qp/process-query {:database (data/id)
                        :type     "query"
                        :query    {:source-table (data/id :checkins)
-                                  :aggregation  [["named" ["max" ["+" ["field-id" (data/id :checkins :user_id)]
-                                                                      ["field-id" (data/id :checkins :venue_id)]]]
+                                  :aggregation  [["named" ["max" ["+"
+                                                                  ["field-id" (data/id :checkins :user_id)]
+                                                                  ["field-id" (data/id :checkins :venue_id)]]]
                                                   "User ID Plus Venue ID"]]}})))
 
 ;; can we generate unique names?
@@ -134,7 +134,7 @@
      [:min [:field-id (data/id :venues :id)]]])))
 
 (expect-with-engine :bigquery
-  {:rows [[7929 7929]], :columns ["sum" "sum_2"]}
+  {:rows [[7929 7929]], :col-names ["sum" "sum_2"]}
   (qptest/rows+column-names
     (qp/process-query {:database (data/id)
                        :type     "query"
@@ -143,7 +143,7 @@
                                                 [:sum [:field-id (data/id :checkins :user_id)]]]}})))
 
 (expect-with-engine :bigquery
-  {:rows [[7929 7929 7929]], :columns ["sum" "sum_2" "sum_3"]}
+  {:rows [[7929 7929 7929]], :col-names ["sum" "sum_2" "sum_3"]}
   (qptest/rows+column-names
     (qp/process-query {:database (data/id)
                        :type     "query"

--- a/test/metabase/driver/druid_test.clj
+++ b/test/metabase/driver/druid_test.clj
@@ -93,8 +93,7 @@
 (expect-with-engine :druid
   {:row_count 2
    :status    :completed
-   :data      {:columns     ["timestamp" "id" "user_name" "venue_price" "venue_name" "count"]
-               :rows        [["2013-01-03T08:00:00.000Z" "931" "Simcha Yan" "1" "Kinaree Thai Bistro"       1]
+   :data      {:rows        [["2013-01-03T08:00:00.000Z" "931" "Simcha Yan" "1" "Kinaree Thai Bistro"       1]
                              ["2013-01-10T08:00:00.000Z" "285" "Kfir Caj"   "2" "Ruen Pair Thai Restaurant" 1]]
                :cols        (mapv #(merge col-defaults %)
                                   [{:name "timestamp",   :display_name "Timestamp"}
@@ -277,12 +276,12 @@
 
 ;; check that we can name an expression aggregation w/ aggregation at top-level
 (expect-with-engine :druid
-  {:rows    [["1"  442.0]
-             ["2" 1845.0]
-             ["3"  460.0]
-             ["4"  245.0]]
-   :columns ["venue_price"
-             "New Price"]}
+  {:rows      [["1"  442.0]
+               ["2" 1845.0]
+               ["3"  460.0]
+               ["4"  245.0]]
+   :col-names ["venue_price"
+               "New Price"]}
   (rows+column-names
     (druid-query
       {:aggregation [[:named [:sum [:+ $venue_price 1]] "New Price"]]
@@ -290,11 +289,11 @@
 
 ;; check that we can name an expression aggregation w/ expression at top-level
 (expect-with-engine :druid
-  {:rows    [["1"  180.0]
-             ["2" 1189.0]
-             ["3"  304.0]
-             ["4"  155.0]]
-   :columns ["venue_price" "Sum-41"]}
+  {:rows      [["1"  180.0]
+               ["2" 1189.0]
+               ["3"  304.0]
+               ["4"  155.0]]
+   :col-names ["venue_price" "Sum-41"]}
   (rows+column-names
     (druid-query
       {:aggregation [[:named [:- [:sum $venue_price] 41] "Sum-41"]]
@@ -317,21 +316,22 @@
 
 (expect
   #"com.jcraft.jsch.JSchException:"
-  (try
-    (let [engine :druid
-          details    {:ssl            false
-                      :password       "changeme"
-                      :tunnel-host    "localhost"
-                      :tunnel-pass    "BOGUS-BOGUS"
-                      :port           5432
-                      :dbname         "test"
-                      :host           "http://localhost"
-                      :tunnel-enabled true
-                      :tunnel-port    22
-                      :tunnel-user    "bogus"}]
-      (driver/can-connect-with-details? engine details :rethrow-exceptions))
-       (catch Exception e
-         (.getMessage e))))
+  (tu/suppress-output
+    (try
+      (let [engine  :druid
+            details {:ssl            false
+                     :password       "changeme"
+                     :tunnel-host    "localhost"
+                     :tunnel-pass    "BOGUS-BOGUS"
+                     :port           5432
+                     :dbname         "test"
+                     :host           "http://localhost"
+                     :tunnel-enabled true
+                     :tunnel-port    22
+                     :tunnel-user    "bogus"}]
+        (driver/can-connect-with-details? engine details :rethrow-exceptions))
+      (catch Exception e
+        (.getMessage e)))))
 
 ;; Query cancellation test, needs careful coordination between the query thread, cancellation thread to ensure
 ;; everything works correctly together

--- a/test/metabase/driver/generic_sql/connection_test.clj
+++ b/test/metabase/driver/generic_sql/connection_test.clj
@@ -1,7 +1,9 @@
 (ns metabase.driver.generic-sql.connection-test
   (:require [expectations :refer :all]
             [metabase.driver :as driver]
-            [metabase.test.data :refer :all]))
+            [metabase.test.data :refer :all]
+            [metabase.test.data.datasets :as datasets]
+            [metabase.test.util :as tu]))
 
 ;; ## TESTS FOR CAN-CONNECT?
 
@@ -10,17 +12,22 @@
   true
   (driver/can-connect-with-details? :h2 (:details (db))))
 
+;; Ehe following tests only run for Postgres. Maybe we should rewrite them so they work with H2.
+
 ;; Lie and say Test DB is Postgres. CAN-CONNECT? should fail
-(expect
+(datasets/expect-with-engine :postgres
   false
-  (driver/can-connect-with-details? :postgres (:details (db))))
+  (tu/suppress-output
+    (driver/can-connect-with-details? :postgres (:details (db)))))
 
 ;; Random made-up DBs should fail
-(expect
+(datasets/expect-with-engine :postgres
   false
-  (driver/can-connect-with-details? :postgres {:host "localhost", :port 5432, :dbname "ABCDEFGHIJKLMNOP", :user "rasta"}))
+  (tu/suppress-output
+    (driver/can-connect-with-details? :postgres {:host "localhost", :port 5432, :dbname "ABCDEFGHIJKLMNOP", :user "rasta"})))
 
 ;; Things that you can connect to, but are not DBs, should fail
-(expect
+(datasets/expect-with-engine :postgres
   false
-  (driver/can-connect-with-details? :postgres {:host "google.com", :port 80}))
+  (tu/suppress-output
+    (driver/can-connect-with-details? :postgres {:host "google.com", :port 80})))

--- a/test/metabase/driver/generic_sql/native_test.clj
+++ b/test/metabase/driver/generic_sql/native_test.clj
@@ -3,7 +3,9 @@
   (:require [expectations :refer :all]
             [medley.core :as m]
             [metabase.query-processor :as qp]
-            [metabase.test.data :as data]))
+            [metabase.test
+             [data :as data]
+             [util :as tu]]))
 
 ;; Just check that a basic query works
 (expect
@@ -11,7 +13,6 @@
    :row_count 2
    :data      {:rows        [[100]
                              [99]]
-               :columns     ["ID"]
                :cols        [{:name "ID", :display_name "ID", :base_type :type/Integer}]
                :native_form {:query "SELECT ID FROM VENUES ORDER BY ID DESC LIMIT 2", :params []}}}
   (-> (qp/process-query {:native   {:query "SELECT ID FROM VENUES ORDER BY ID DESC LIMIT 2"}
@@ -26,7 +27,6 @@
    :row_count 2
    :data      {:rows        [[100 "Mohawk Bend" 46]
                              [99 "Golden Road Brewing" 10]]
-               :columns     ["ID" "NAME" "CATEGORY_ID"]
                :cols        [{:name "ID",          :display_name "ID",          :base_type :type/Integer}
                              {:name "NAME",        :display_name "Name",        :base_type :type/Text}
                              {:name "CATEGORY_ID", :display_name "Category ID", :base_type :type/Integer}]
@@ -38,11 +38,13 @@
       (m/dissoc-in [:data :insights])))
 
 ;; Check that we get proper error responses for malformed SQL
-(expect {:status :failed
-         :class  java.lang.Exception
-         :error  "Column \"ZID\" not found"}
-  (dissoc (qp/process-query {:native   {:query "SELECT ZID FROM CHECKINS LIMIT 2"} ; make sure people know it's to be expected
-                             :type     :native
-                             :database (data/id)})
-          :stacktrace
-          :query))
+(expect
+  {:status :failed
+   :class  java.lang.Exception
+   :error  "Column \"ZID\" not found"}
+  (tu/suppress-output
+    (dissoc (qp/process-query {:native   {:query "SELECT ZID FROM CHECKINS LIMIT 2"} ; make sure people know it's to be expected
+                               :type     :native
+                               :database (data/id)})
+            :stacktrace
+            :query)))

--- a/test/metabase/driver/generic_sql_test.clj
+++ b/test/metabase/driver/generic_sql_test.clj
@@ -5,10 +5,11 @@
             [metabase.models
              [field :refer [Field]]
              [table :as table :refer [Table]]]
-            [metabase.test.data :refer :all]
+            [metabase.test
+             [data :as data :refer :all]
+             [util :as tu]]
             [metabase.test.data.datasets :as datasets]
-            [toucan.db :as db]
-            [metabase.test.data :as data])
+            [toucan.db :as db])
   (:import metabase.driver.h2.H2Driver))
 
 (def ^:private users-table      (delay (Table :name "USERS")))
@@ -97,19 +98,20 @@
 ;;; Make sure invalid ssh credentials are detected if a direct connection is possible
 (expect
   #"com.jcraft.jsch.JSchException:"
-  (try (let [engine :postgres
-             details {:ssl false,
-                      :password "changeme",
-                      :tunnel-host "localhost", ;; this test works if sshd is running or not
-                      :tunnel-pass "BOGUS-BOGUS-BOGUS",
-                      :port 5432,
-                      :dbname "test",
-                      :host "localhost",
-                      :tunnel-enabled true,
-                      :tunnel-port 22,
-                      :engine :postgres,
-                      :user "postgres",
-                      :tunnel-user "example"}]
-         (driver/can-connect-with-details? engine details :rethrow-exceptions))
-       (catch Exception e
-         (.getMessage e))))
+  (tu/suppress-output
+    (try (let [engine  :postgres
+               details {:ssl            false
+                        :password       "changeme"
+                        :tunnel-host    "localhost" ; this test works if sshd is running or not
+                        :tunnel-pass    "BOGUS-BOGUS-BOGUS"
+                        :port           5432
+                        :dbname         "test"
+                        :host           "localhost"
+                        :tunnel-enabled true
+                        :tunnel-port    22
+                        :engine         :postgres
+                        :user           "postgres"
+                        :tunnel-user    "example"}]
+           (driver/can-connect-with-details? engine details :rethrow-exceptions))
+         (catch Exception e
+           (.getMessage e)))))

--- a/test/metabase/driver/googleanalytics_test.clj
+++ b/test/metabase/driver/googleanalytics_test.clj
@@ -216,8 +216,7 @@
 (expect
   {:row_count 1
    :status    :completed
-   :data      {:columns     [:ga:eventLabel :ga:totalEvents]
-               :rows        [["Toucan Sighting" 1000]]
+   :data      {:rows        [["Toucan Sighting" 1000]]
                :native_form expected-ga-query
                :cols        [{:description     "This is ga:eventLabel"
                               :special_type    nil
@@ -240,7 +239,7 @@
                                                                             :base_type    :type/Text})]
     (do-with-some-fields
      (fn [objects]
-       (let [results {:columns [:ga:eventLabel :ga:totalEvents]
+       (let [results {:columns ["ga:eventLabel" "ga:totalEvents"]
                       :rows    [["Toucan Sighting" 1000]]}
              qp      (#'metabase.query-processor/qp-pipeline (constantly results))
              query   (query-with-some-fields objects)]

--- a/test/metabase/driver/mongo/util_test.clj
+++ b/test/metabase/driver/mongo/util_test.clj
@@ -1,7 +1,8 @@
 (ns metabase.driver.mongo.util-test
   (:require [expectations :refer [expect]]
             [metabase.driver :as driver]
-            [metabase.driver.mongo.util :as mongo-util])
+            [metabase.driver.mongo.util :as mongo-util]
+            [metabase.test.util :as tu])
   (:import com.mongodb.ReadPreference))
 
 ;; test that people can specify additional connection options like `?readPreference=nearest`
@@ -29,18 +30,19 @@
 
 (expect
   #"We couldn't connect to the ssh tunnel host"
-  (try
-    (let [engine  :mongo
-          details {:ssl            false
-                   :password       "changeme"
-                   :tunnel-host    "localhost"
-                   :tunnel-pass    "BOGUS-BOGUS"
-                   :port           5432
-                   :dbname         "test"
-                   :host           "localhost"
-                   :tunnel-enabled true
-                   :tunnel-port    22
-                   :tunnel-user    "bogus"}]
-      (driver/can-connect-with-details? engine details :rethrow-exceptions))
-       (catch Exception e
-         (.getMessage e))))
+  (tu/suppress-output
+    (try
+      (let [engine  :mongo
+            details {:ssl            false
+                     :password       "changeme"
+                     :tunnel-host    "localhost"
+                     :tunnel-pass    "BOGUS-BOGUS"
+                     :port           5432
+                     :dbname         "test"
+                     :host           "localhost"
+                     :tunnel-enabled true
+                     :tunnel-port    22
+                     :tunnel-user    "bogus"}]
+        (driver/can-connect-with-details? engine details :rethrow-exceptions))
+      (catch Exception e
+        (.getMessage e)))))

--- a/test/metabase/driver/mongo_test.clj
+++ b/test/metabase/driver/mongo_test.clj
@@ -76,7 +76,6 @@
   {:status    :completed
    :row_count 1
    :data      {:rows        [[1]]
-               :columns     ["count"]
                :cols        [{:name "count", :display_name "Count", :base_type :type/Integer}]
                :native_form {:collection "venues"
                              :query      native-query}}}

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -70,7 +70,7 @@
   #{{:name "number-of-cans", :base_type :type/Boolean, :special_type :type/Category}
     {:name "id",             :base_type :type/Integer, :special_type :type/PK}
     {:name "thing",          :base_type :type/Text,    :special_type :type/Category}}
-  (data/with-temp-db [db tiny-int-ones]
+  (data/with-current-db [db tiny-int-ones]
     (db->fields db)))
 
 ;; if someone says specifies `tinyInt1isBit=false`, it should come back as a number instead
@@ -78,7 +78,7 @@
   #{{:name "number-of-cans", :base_type :type/Integer, :special_type :type/Quantity}
     {:name "id",             :base_type :type/Integer, :special_type :type/PK}
     {:name "thing",          :base_type :type/Text,    :special_type :type/Category}}
-  (data/with-temp-db [db tiny-int-ones]
+  (data/with-current-db [db tiny-int-ones]
     (tt/with-temp Database [db {:engine "mysql"
                                 :details (assoc (:details db)
                                            :additional-options "tinyInt1isBit=false")}]

--- a/test/metabase/driver/oracle_test.clj
+++ b/test/metabase/driver/oracle_test.clj
@@ -56,20 +56,21 @@
 
 (expect
   com.jcraft.jsch.JSchException
-  (let [engine :oracle
-        details {:ssl false,
-                 :password "changeme",
-                 :tunnel-host "localhost",
-                 :tunnel-pass "BOGUS-BOGUS-BOGUS",
-                 :port 12345,
-                 :service-name "test",
-                 :sid "asdf",
-                 :host "localhost",
-                 :tunnel-enabled true,
-                 :tunnel-port 22,
-                 :user "postgres",
-                 :tunnel-user "example"}]
-    (#'oracle/can-connect? details)))
+  (tu/suppress-output
+    (let [engine  :oracle
+          details {:ssl            false
+                   :password       "changeme"
+                   :tunnel-host    "localhost"
+                   :tunnel-pass    "BOGUS-BOGUS-BOGUS"
+                   :port           12345
+                   :service-name   "test"
+                   :sid            "asdf"
+                   :host           "localhost"
+                   :tunnel-enabled true
+                   :tunnel-port    22
+                   :user           "postgres"
+                   :tunnel-user    "example"}]
+      (#'oracle/can-connect? details))))
 
 (expect-with-engine :oracle
   "UTC"

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -6,7 +6,7 @@
             [metabase
              [driver :as driver]
              [query-processor :as qp]
-             [query-processor-test :refer [rows]]
+             [query-processor-test :refer [rows rows+column-names]]
              [sync :as sync]
              [util :as u]]
             [metabase.driver
@@ -62,7 +62,7 @@
 ;; Verify that we identify JSON columns and mark metadata properly during sync
 (expect-with-engine :postgres
   :type/SerializedJSON
-  (data/with-temp-db
+  (data/with-current-db
     [_
      (i/create-database-definition "Postgres with a JSON Field"
        ["venues"
@@ -131,13 +131,13 @@
       ["ouija_board"]]]])
 
 (expect-with-engine :postgres
-  {:columns ["id" "dotted.name"]
-   :rows    [[1 "toucan_cage"]
-             [2 "four_loko"]
-             [3 "ouija_board"]]}
+  {:col-names ["id" "dotted.name"]
+   :rows      [[1 "toucan_cage"]
+               [2 "four_loko"]
+               [3 "ouija_board"]]}
   (-> (data/dataset metabase.driver.postgres-test/dots-in-names
         (data/run-mbql-query objects.stuff))
-      :data (dissoc :cols :native_form :results_metadata :insights)))
+      rows+column-names))
 
 
 ;; Make sure that duplicate column names (e.g. caused by using a FK) still return both columns
@@ -152,12 +152,12 @@
     [["Cam" 1]]]])
 
 (expect-with-engine :postgres
-  {:columns ["name" "name_2"]
-   :rows    [["Cam" "Rasta"]]}
+  {:col-names ["name" "name_2"]
+   :rows      [["Cam" "Rasta"]]}
   (-> (data/dataset metabase.driver.postgres-test/duplicate-names
         (data/run-mbql-query people
           {:fields [$name $bird_id->birds.name]}))
-      :data (dissoc :cols :native_form :results_metadata :insights)))
+      rows+column-names))
 
 
 ;;; Check support for `inet` columns

--- a/test/metabase/driver/presto_test.clj
+++ b/test/metabase/driver/presto_test.clj
@@ -135,20 +135,21 @@
 
 (expect
   #"com.jcraft.jsch.JSchException:"
-  (try
-    (let [engine  :presto
-          details {:ssl            false,
-                   :password       "changeme",
-                   :tunnel-host    "localhost",
-                   :tunnel-pass    "BOGUS-BOGUS",
-                   :catalog        "BOGUS"
-                   :host           "localhost",
-                   :tunnel-enabled true,
-                   :tunnel-port    22,
-                   :tunnel-user    "bogus"}]
-      (driver/can-connect-with-details? engine details :rethrow-exceptions))
-    (catch Exception e
-      (.getMessage e))))
+  (tu/suppress-output
+    (try
+      (let [engine  :presto
+            details {:ssl            false
+                     :password       "changeme"
+                     :tunnel-host    "localhost"
+                     :tunnel-pass    "BOGUS-BOGUS"
+                     :catalog        "BOGUS"
+                     :host           "localhost"
+                     :tunnel-enabled true
+                     :tunnel-port    22
+                     :tunnel-user    "bogus"}]
+        (driver/can-connect-with-details? engine details :rethrow-exceptions))
+      (catch Exception e
+        (.getMessage e)))))
 
 (datasets/expect-with-engine :presto
   "UTC"

--- a/test/metabase/events/activity_feed_test.clj
+++ b/test/metabase/events/activity_feed_test.clj
@@ -31,8 +31,8 @@
   {:topic       :card-create
    :user_id     (user->id :rasta)
    :model       "card"
-   :database_id nil
-   :table_id    nil
+   :database_id (data/id)
+   :table_id    (data/id :venues)
    :details     {:name "My Cool Card", :description nil}}
   (tt/with-temp Card [card {:name "My Cool Card"}]
     (with-temp-activities
@@ -69,8 +69,8 @@
   {:topic       :card-update
    :user_id     (user->id :rasta)
    :model       "card"
-   :database_id nil
-   :table_id    nil
+   :database_id (data/id)
+   :table_id    (data/id :venues)
    :details     {:name "My Cool Card", :description nil}}
   (tt/with-temp Card [card {:name "My Cool Card"}]
     (with-temp-activities
@@ -85,8 +85,8 @@
   {:topic       :card-delete
    :user_id     (user->id :rasta)
    :model       "card"
-   :database_id nil
-   :table_id    nil
+   :database_id (data/id)
+   :table_id    (data/id :venues)
    :details     {:name "My Cool Card", :description nil}}
   (tt/with-temp Card [card {:name "My Cool Card"}]
     (with-temp-activities

--- a/test/metabase/models/query/permissions_test.clj
+++ b/test/metabase/models/query/permissions_test.clj
@@ -14,7 +14,8 @@
             [metabase.test.data :as data]
             [metabase.test.data.users :as users]
             [metabase.util :as u]
-            [toucan.util.test :as tt]))
+            [toucan.util.test :as tt]
+            [metabase.test.util :as tu]))
 
 ;;; ---------------------------------------------- Permissions Checking ----------------------------------------------
 
@@ -233,5 +234,6 @@
 ;; invalid/legacy queries should return perms for something that doesn't exist so no one gets to see it
 (expect
   #{"/db/0/"}
-  (query-perms/perms-set (data/mbql-query venues
-                           {:filter [:WOW 100 200]})))
+  (tu/suppress-output
+    (query-perms/perms-set (data/mbql-query venues
+                             {:filter [:WOW 100 200]}))))

--- a/test/metabase/pulse_test.clj
+++ b/test/metabase/pulse_test.clj
@@ -49,7 +49,7 @@
 
 (defn- pulse-test-fixture
   [f]
-  (data/with-db (data/get-or-create-database! defs/test-data)
+  (data/with-copy-of-test-db
     (tu/with-temporary-setting-values [site-url "https://metabase.com/testmb"]
       (f))))
 

--- a/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
+++ b/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
@@ -116,18 +116,17 @@
    :display_name    "Foo"})
 
 (expect
-  {:rows    [[1 "Red Medicine"                  4 3 "Foo"]
-             [2 "Stout Burgers & Beers"        11 2 "Bar"]
-             [3 "The Apple Pan"                11 2 "Bar"]
-             [4 "Wurstküche"                   29 2 "Baz"]
-             [5 "Brite Spot Family Restaurant" 20 2 "Qux"]]
-   :columns ["ID" "NAME" "CATEGORY_ID" "PRICE" "Foo"]
-   :cols    [example-result-cols-id
-             example-result-cols-name
-             (assoc example-result-cols-category-id
-               :remapped_to "Foo")
-             example-result-cols-price
-             example-result-cols-foo]}
+  {:rows [[1 "Red Medicine"                  4 3 "Foo"]
+          [2 "Stout Burgers & Beers"        11 2 "Bar"]
+          [3 "The Apple Pan"                11 2 "Bar"]
+          [4 "Wurstküche"                   29 2 "Baz"]
+          [5 "Brite Spot Family Restaurant" 20 2 "Qux"]]
+   :cols [example-result-cols-id
+          example-result-cols-name
+          (assoc example-result-cols-category-id
+            :remapped_to "Foo")
+          example-result-cols-price
+          example-result-cols-foo]}
   ;; swap out `hydrate` with one that will add some fake dimensions and values for CATEGORY_ID.
   (with-redefs [hydrate/hydrate (fn [fields & _]
                                   (for [{field-name :name, :as field} fields]
@@ -138,16 +137,15 @@
                                                           :values                [4 11 29 20]}))))]
     (#'add-dim-projections/remap-results
      nil
-     {:rows    [[1 "Red Medicine"                  4 3]
-                [2 "Stout Burgers & Beers"        11 2]
-                [3 "The Apple Pan"                11 2]
-                [4 "Wurstküche"                   29 2]
-                [5 "Brite Spot Family Restaurant" 20 2]]
-      :columns ["ID" "NAME" "CATEGORY_ID" "PRICE"]
-      :cols    [example-result-cols-id
-                example-result-cols-name
-                example-result-cols-category-id
-                example-result-cols-price]})))
+     {:rows [[1 "Red Medicine"                  4 3]
+             [2 "Stout Burgers & Beers"        11 2]
+             [3 "The Apple Pan"                11 2]
+             [4 "Wurstküche"                   29 2]
+             [5 "Brite Spot Family Restaurant" 20 2]]
+      :cols [example-result-cols-id
+             example-result-cols-name
+             example-result-cols-category-id
+             example-result-cols-price]})))
 
 ;; test that external remappings get the appropriate `:remapped_from`/`:remapped_to` info
 (def ^:private example-result-cols-category
@@ -165,22 +163,20 @@
     :base_type       :type/Text}))
 
 (expect
-  {:rows    []
-   :columns ["ID" "NAME" "CATEGORY_ID" "PRICE" "CATEGORY"]
-   :cols    [example-result-cols-id
-             example-result-cols-name
-             (assoc example-result-cols-category-id
-               :remapped_to "CATEGORY")
-             example-result-cols-price
-             (assoc example-result-cols-category
-               :remapped_from "CATEGORY_ID"
-               :display_name  "My Venue Category")]}
+  {:rows []
+   :cols [example-result-cols-id
+          example-result-cols-name
+          (assoc example-result-cols-category-id
+            :remapped_to "CATEGORY")
+          example-result-cols-price
+          (assoc example-result-cols-category
+            :remapped_from "CATEGORY_ID"
+            :display_name  "My Venue Category")]}
   (#'add-dim-projections/remap-results
    [{:name "My Venue Category", :field_id 11, :human_readable_field_id 27}]
-   {:rows    []
-    :columns ["ID" "NAME" "CATEGORY_ID" "PRICE" "CATEGORY"]
-    :cols    [example-result-cols-id
-              example-result-cols-name
-              example-result-cols-category-id
-              example-result-cols-price
-              example-result-cols-category]}))
+   {:rows []
+    :cols [example-result-cols-id
+           example-result-cols-name
+           example-result-cols-category-id
+           example-result-cols-price
+           example-result-cols-category]}))

--- a/test/metabase/query_processor/middleware/format_rows_test.clj
+++ b/test/metabase/query_processor/middleware/format_rows_test.clj
@@ -23,7 +23,7 @@
      [3 "Kaneonuskatew Eiran" "2014-11-06T00:00:00.000Z" "16:15:00.000Z"]
      [4 "Simcha Yan" "2014-01-01T00:00:00.000Z" "08:30:00.000Z"]
      [5 "Quentin Sören" "2014-10-03T00:00:00.000Z" "17:30:00.000Z"]])
-  (->> (data/with-db (data/get-or-create-database! defs/test-data-with-time)
+  (->> (data/dataset test-data-with-time
          (data/run-mbql-query users
            {:order-by [[:asc $id]]
             :limit    5}))
@@ -52,7 +52,7 @@
      [4 "Simcha Yan" "2014-01-01T00:00:00.000Z" "08:30:00.000Z"]
      [5 "Quentin Sören" "2014-10-03T00:00:00.000Z" "17:30:00.000Z"]])
   (tu/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
-    (->> (data/with-db (data/get-or-create-database! defs/test-data-with-time)
+    (->> (data/dataset test-data-with-time
            (data/run-mbql-query users
              {:order-by [[:asc $id]]
               :limit    5}))

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -80,14 +80,6 @@
      ~query-form))
 
 
-(defn ->columns
-  "Generate the vector that should go in the `columns` part of a QP result; done by calling `format-name` against each
-  column name."
-  [& names]
-  (mapv (partial data/format-name)
-        names))
-
-
 ;; Predefinied Column Fns: These are meant for inclusion in the expected output of the QP tests, to save us from
 ;; writing the same results several times
 
@@ -159,11 +151,6 @@
                                                           :latest   "2014-12-05T15:15:00.000Z"}}}})))
 
 ;; #### venues
-(defn venues-columns
-  "Names of all columns for the `venues` table."
-  []
-  (->columns "id" "name" "category_id" "latitude" "longitude" "price"))
-
 (defn venues-col
   "Return column information for the `venues` column named by keyword COL."
   [col]
@@ -337,8 +324,8 @@
   "Return the result rows and column names from query RESULTS, or throw an Exception if they're missing."
   {:style/indent 0}
   [results]
-  {:rows    (rows results)
-   :columns (get-in results [:data :columns])})
+  {:rows      (rows results)
+   :col-names (map :name (get-in results [:data :cols]))})
 
 (defn first-row
   "Return the first row in the RESULTS of a query, or throw an Exception if they're missing."

--- a/test/metabase/query_processor_test/aggregation_test.clj
+++ b/test/metabase/query_processor_test/aggregation_test.clj
@@ -15,7 +15,6 @@
 
 (qp-expect-with-all-engines
   {:rows        [[100]]
-   :columns     ["count"]
    :cols        [(aggregate-col :count)]
    :native_form true}
   (->> (data/run-mbql-query venues
@@ -27,7 +26,6 @@
 ;;; ----------------------------------------------- "SUM" AGGREGATION ------------------------------------------------
 (qp-expect-with-all-engines
   {:rows        [[203]]
-   :columns     ["sum"]
    :cols        [(aggregate-col :sum (venues-col :price))]
    :native_form true}
   (->> (data/run-mbql-query venues
@@ -39,7 +37,6 @@
 ;;; ----------------------------------------------- "AVG" AGGREGATION ------------------------------------------------
 (qp-expect-with-all-engines
   {:rows        [[35.5059]]
-   :columns     ["avg"]
    :cols        [(aggregate-col :avg (venues-col :latitude))]
    :native_form true}
   (->> (data/run-mbql-query venues
@@ -51,7 +48,6 @@
 ;;; ------------------------------------------ "DISTINCT COUNT" AGGREGATION ------------------------------------------
 (qp-expect-with-all-engines
   {:rows        [[15]]
-   :columns     ["count"]
    :cols        [(aggregate-col :count (Field (data/id :checkins :user_id)))]
    :native_form true}
   (->> (data/run-mbql-query checkins
@@ -73,7 +69,6 @@
                  [ 8 "25°"                          11 34.1015 -118.342 2]
                  [ 9 "Krua Siri"                    71 34.1018 -118.301 1]
                  [10 "Fred 62"                      20 34.1046 -118.292 2]]
-   :columns     (venues-columns)
    :cols        (venues-cols)
    :native_form true}
     (-> (data/run-mbql-query venues
@@ -87,8 +82,7 @@
 ;;; ----------------------------------------------- STDDEV AGGREGATION -----------------------------------------------
 
 (qp-expect-with-engines (non-timeseries-engines-with-feature :standard-deviation-aggregations)
-  {:columns     ["stddev"]
-   :cols        [(aggregate-col :stddev (venues-col :latitude))]
+  {:cols        [(aggregate-col :stddev (venues-col :latitude))]
    :rows        [[3.4]]
    :native_form true}
   (-> (data/run-mbql-query venues
@@ -175,7 +169,6 @@
 ;;; cum_sum w/o breakout should be treated the same as sum
 (qp-expect-with-all-engines
   {:rows        [[120]]
-   :columns     ["sum"]
    :cols        [(aggregate-col :sum (users-col :id))]
    :native_form true}
   (->> (data/run-mbql-query users
@@ -201,8 +194,6 @@
                  [13  91]
                  [14 105]
                  [15 120]]
-   :columns     [(data/format-name "id")
-                 "sum"]
    :cols        [(breakout-col (users-col :id))
                  (aggregate-col :sum (users-col :id))]
    :native_form true}
@@ -230,8 +221,6 @@
                  ["Simcha Yan"          101]
                  ["Spiros Teofil"       112]
                  ["Szymon Theutrich"    120]]
-   :columns     [(data/format-name "name")
-                 "sum"]
    :cols        [(breakout-col (users-col :name))
                  (aggregate-col :sum (users-col :id))]
    :native_form true}
@@ -245,9 +234,7 @@
 
 ;;; Cumulative sum w/ a different breakout field that requires grouping
 (qp-expect-with-all-engines
-  {:columns     [(data/format-name "price")
-                 "sum"]
-   :cols        [(breakout-col (venues-col :price))
+  {:cols        [(breakout-col (venues-col :price))
                  (aggregate-col :sum (venues-col :id))]
    :rows        [[1 1211]
                  [2 4066]
@@ -271,7 +258,6 @@
 ;;; cum_count w/o breakout should be treated the same as count
 (qp-expect-with-all-engines
   {:rows        [[15]]
-   :columns     ["count"]
    :cols        [(cumulative-count-col users-col :id)]
    :native_form true}
   (->> (data/run-mbql-query users
@@ -296,8 +282,6 @@
                  ["Simcha Yan"          13]
                  ["Spiros Teofil"       14]
                  ["Szymon Theutrich"    15]]
-   :columns     [(data/format-name "name")
-                 "count"]
    :cols        [(breakout-col (users-col :name))
                  (cumulative-count-col users-col :id)]
    :native_form true}
@@ -311,9 +295,7 @@
 
 ;; Cumulative count w/ a different breakout field that requires grouping
 (qp-expect-with-all-engines
-  {:columns     [(data/format-name "price")
-                 "count"]
-   :cols        [(breakout-col (venues-col :price))
+  {:cols        [(breakout-col (venues-col :price))
                  (cumulative-count-col venues-col :id)]
    :rows        [[1 22]
                  [2 81]

--- a/test/metabase/query_processor_test/breakout_test.clj
+++ b/test/metabase/query_processor_test/breakout_test.clj
@@ -23,8 +23,6 @@
 ;;; single column
 (qp-expect-with-all-engines
   {:rows        [[1 31] [2 70] [3 75] [4 77] [5 69] [6 70] [7 76] [8 81] [9 68] [10 78] [11 74] [12 59] [13 76] [14 62] [15 34]]
-   :columns     [(data/format-name "user_id")
-                 "count"]
    :cols        [(breakout-col (checkins-col :user_id))
                  (aggregate-col :count)]
    :native_form true}
@@ -39,7 +37,6 @@
 ;; This should act as a "distinct values" query and return ordered results
 (qp-expect-with-all-engines
   {:cols        [(breakout-col (checkins-col :user_id))]
-   :columns     [(data/format-name "user_id")]
    :rows        [[1] [2] [3] [4] [5] [6] [7] [8] [9] [10]]
    :native_form true}
   (->> (data/run-mbql-query checkins
@@ -53,9 +50,6 @@
 ;; Fields should be implicitly ordered :ASC for all the fields in `breakout` that are not specified in `order-by`
 (qp-expect-with-all-engines
   {:rows        [[1 1 1] [1 5 1] [1 7 1] [1 10 1] [1 13 1] [1 16 1] [1 26 1] [1 31 1] [1 35 1] [1 36 1]]
-   :columns     [(data/format-name "user_id")
-                 (data/format-name "venue_id")
-                 "count"]
    :cols        [(breakout-col (checkins-col :user_id))
                  (breakout-col (checkins-col :venue_id))
                  (aggregate-col :count)]
@@ -71,9 +65,6 @@
 ;; `breakout` should not implicitly order by any fields specified in `order-by`
 (qp-expect-with-all-engines
   {:rows        [[15 2 1] [15 3 1] [15 7 1] [15 14 1] [15 16 1] [15 18 1] [15 22 1] [15 23 2] [15 24 1] [15 27 1]]
-   :columns     [(data/format-name "user_id")
-                 (data/format-name "venue_id")
-                 "count"]
    :cols        [(breakout-col (checkins-col :user_id))
                  (breakout-col (checkins-col :venue_id))
                  (aggregate-col :count)]
@@ -92,9 +83,6 @@
                  [4 2 "BBQ"]
                  [5 7 "Bakery"]
                  [6 2 "Bar"]]
-   :columns     [(data/format-name "category_id")
-                 "count"
-                 "Foo"]
    :cols        [(assoc (breakout-col (venues-col :category_id))
                    :remapped_to "Foo")
                  (aggregate-col :count)

--- a/test/metabase/query_processor_test/expression_aggregations_test.clj
+++ b/test/metabase/query_processor_test/expression_aggregations_test.clj
@@ -167,12 +167,12 @@
 
 ;; check that we can name an expression aggregation w/ aggregation at top-level
 (datasets/expect-with-engines (non-timeseries-engines-with-feature :expression-aggregations)
-  {:rows    [[1  44]
-             [2 177]
-             [3  52]
-             [4  30]]
-   :columns [(data/format-name "price")
-             (driver/format-custom-field-name *driver* "New Price")]} ; Redshift annoyingly always lowercases column aliases
+  {:rows      [[1  44]
+               [2 177]
+               [3  52]
+               [4  30]]
+   :col-names [(data/format-name "price")
+               (driver/format-custom-field-name *driver* "New Price")]} ; Redshift annoyingly always lowercases column aliases
     (format-rows-by [int int]
       (rows+column-names (data/run-mbql-query venues
                            {:aggregation [[:named [:sum [:+ $price 1]] "New Price"]]
@@ -180,12 +180,12 @@
 
 ;; check that we can name an expression aggregation w/ expression at top-level
 (datasets/expect-with-engines (non-timeseries-engines-with-feature :expression-aggregations)
-  {:rows    [[1 -19]
-             [2  77]
-             [3  -2]
-             [4 -17]]
-   :columns [(data/format-name "price")
-             (driver/format-custom-field-name *driver* "Sum-41")]}
+  {:rows      [[1 -19]
+               [2  77]
+               [3  -2]
+               [4 -17]]
+   :col-names [(data/format-name "price")
+               (driver/format-custom-field-name *driver* "Sum-41")]}
   (format-rows-by [int int]
     (rows+column-names (data/run-mbql-query venues
                          {:aggregation [[:named [:- [:sum $price] 41] "Sum-41"]]
@@ -206,26 +206,26 @@
 
 ;; check that we can handle METRICS (ick) inside a NAMED clause
 (datasets/expect-with-engines (non-timeseries-engines-with-feature :expression-aggregations)
-  {:rows    [[2 118]
-             [3  39]
-             [4  24]]
-   :columns [(data/format-name "price")
-             (driver/format-custom-field-name *driver* "My Cool Metric")]}
+  {:rows      [[2 118]
+               [3  39]
+               [4  24]]
+   :col-names [(data/format-name "price")
+               (driver/format-custom-field-name *driver* "My Cool Metric")]}
   (tt/with-temp Metric [metric {:table_id   (data/id :venues)
                                 :definition {:aggregation [:sum [:field-id (data/id :venues :price)]]
                                              :filter      [:> [:field-id (data/id :venues :price)] 1]}}]
     (format-rows-by [int int]
       (rows+column-names (data/run-mbql-query venues
-                           {:aggregation  [[:named [:metric (u/get-id metric)] "My Cool Metric"]]
-                            :breakout     [[:field-id $price]]})))))
+                           {:aggregation [[:named [:metric (u/get-id metric)] "My Cool Metric"]]
+                            :breakout    [[:field-id $price]]})))))
 
 ;; check that METRICS (ick) with a nested aggregation still work inside a NAMED clause
 (datasets/expect-with-engines (non-timeseries-engines-with-feature :expression-aggregations)
-  {:rows    [[2 118]
-             [3  39]
-             [4  24]]
-   :columns [(data/format-name "price")
-             (driver/format-custom-field-name *driver* "My Cool Metric")]}
+  {:rows      [[2 118]
+               [3  39]
+               [4  24]]
+   :col-names [(data/format-name "price")
+               (driver/format-custom-field-name *driver* "My Cool Metric")]}
   (tt/with-temp Metric [metric {:table_id   (data/id :venues)
                                 :definition {:aggregation [[:sum [:field-id (data/id :venues :price)]]]
                                              :filter      [:> [:field-id (data/id :venues :price)] 1]}}]

--- a/test/metabase/query_processor_test/field_visibility_test.clj
+++ b/test/metabase/query_processor_test/field_visibility_test.clj
@@ -37,8 +37,7 @@
 
 ;;; Make sure :sensitive information fields are never returned by the QP
 (qp-expect-with-all-engines
-  {:columns     (->columns "id" "name" "last_login")
-   :cols        [(users-col :id)
+  {:cols        [(users-col :id)
                  (users-col :name)
                  (users-col :last_login)]
    :rows        [[ 1 "Plato Yeshua"]

--- a/test/metabase/query_processor_test/fields_test.clj
+++ b/test/metabase/query_processor_test/fields_test.clj
@@ -16,7 +16,6 @@
                  ["25°"                           8]
                  ["Krua Siri"                     9]
                  ["Fred 62"                      10]]
-   :columns     (->columns "name" "id")
    :cols        [(venues-col :name)
                  (venues-col :id)]
    :native_form true}

--- a/test/metabase/query_processor_test/filter_test.clj
+++ b/test/metabase/query_processor_test/filter_test.clj
@@ -89,7 +89,6 @@
 ;;; FILTER -- "BETWEEN" with dates
 (qp-expect-with-all-engines
   {:rows        [[29]]
-   :columns     ["count"]
    :cols        [(aggregate-col :count)]
    :native_form true}
   (->> (data/run-mbql-query checkins

--- a/test/metabase/query_processor_test/nested_field_test.clj
+++ b/test/metabase/query_processor_test/nested_field_test.clj
@@ -79,40 +79,40 @@
 ;;; Nested Field in BREAKOUT
 ;; Let's see how many tips we have by source.service
 (datasets/expect-with-engines (non-timeseries-engines-with-feature :nested-fields)
-  {:rows        [["facebook"   107]
-                 ["flare"      105]
-                 ["foursquare" 100]
-                 ["twitter"     98]
-                 ["yelp"        90]]
-   :columns     ["source.service" "count"]
-   :native_form true}
+  {:rows      [["facebook"   107]
+               ["flare"      105]
+               ["foursquare" 100]
+               ["twitter"     98]
+               ["yelp"        90]]
+   :col-names ["source.service" "count"]}
   (->> (data/dataset geographical-tips
          (data/run-mbql-query tips
            {:aggregation [[:count]]
             :breakout    [$tips.source.service]}))
        booleanize-native-form
-       :data (#(dissoc % :cols)) (format-rows-by [str int])))
+       rows+column-names
+       (format-rows-by [str int])))
 
 ;;; Nested Field in FIELDS
 ;; Return the first 10 tips with just tip.venue.name
 (datasets/expect-with-engines (non-timeseries-engines-with-feature :nested-fields)
-  {:columns ["venue.name"]
-   :rows    [["Lucky's Gluten-Free Café"]
-             ["Joe's Homestyle Eatery"]
-             ["Lower Pac Heights Cage-Free Coffee House"]
-             ["Oakland European Liquor Store"]
-             ["Tenderloin Gormet Restaurant"]
-             ["Marina Modern Sushi"]
-             ["Sunset Homestyle Grill"]
-             ["Kyle's Low-Carb Grill"]
-             ["Mission Homestyle Churros"]
-             ["Sameer's Pizza Liquor Store"]]}
-  (select-keys (:data (data/dataset geographical-tips
-                        (data/run-mbql-query tips
-                          {:fields   [$tips.venue.name]
-                           :order-by [[:asc $id]]
-                           :limit    10})))
-               [:columns :rows]))
+  {:col-names ["venue.name"]
+   :rows      [["Lucky's Gluten-Free Café"]
+               ["Joe's Homestyle Eatery"]
+               ["Lower Pac Heights Cage-Free Coffee House"]
+               ["Oakland European Liquor Store"]
+               ["Tenderloin Gormet Restaurant"]
+               ["Marina Modern Sushi"]
+               ["Sunset Homestyle Grill"]
+               ["Kyle's Low-Carb Grill"]
+               ["Mission Homestyle Churros"]
+               ["Sameer's Pizza Liquor Store"]]}
+  (rows+column-names
+    (data/dataset geographical-tips
+      (data/run-mbql-query tips
+        {:fields   [$tips.venue.name]
+         :order-by [[:asc $id]]
+         :limit    10}))))
 
 
 ;;; Nested Field w/ ordering by aggregation

--- a/test/metabase/query_processor_test/order_by_test.clj
+++ b/test/metabase/query_processor_test/order_by_test.clj
@@ -30,9 +30,7 @@
 
 ;;; order-by aggregate ["count"]
 (qp-expect-with-all-engines
-  {:columns     [(data/format-name "price")
-                 "count"]
-   :rows        [[4  6]
+  {:rows        [[4  6]
                  [3 13]
                  [1 22]
                  [2 59]]
@@ -49,9 +47,7 @@
 
 ;;; order-by aggregate ["sum" field-id]
 (qp-expect-with-all-engines
-  {:columns     [(data/format-name "price")
-                 "sum"]
-   :rows        [[2 2855]
+  {:rows        [[2 2855]
                  [1 1211]
                  [3  615]
                  [4  369]]
@@ -68,9 +64,7 @@
 
 ;;; order-by aggregate ["distinct" field-id]
 (qp-expect-with-all-engines
-  {:columns     [(data/format-name "price")
-                 "count"]
-   :rows        [[4  6]
+  {:rows        [[4  6]
                  [3 13]
                  [1 22]
                  [2 59]]
@@ -87,9 +81,7 @@
 
 ;;; order-by aggregate ["avg" field-id]
 (expect-with-non-timeseries-dbs
-  {:columns     [(data/format-name "price")
-                 "avg"]
-   :rows        [[3 22]
+  {:rows        [[3 22]
                  [2 28]
                  [1 32]
                  [4 53]]
@@ -108,9 +100,7 @@
 ;; SQRT calculations are always NOT EXACT (normal behavior) so round everything to the nearest int.
 ;; Databases might use different versions of SQRT implementations
 (datasets/expect-with-engines (non-timeseries-engines-with-feature :standard-deviation-aggregations)
-  {:columns     [(data/format-name "price")
-                 "stddev"]
-   :rows        [[3 (if (contains? #{:mysql :crate} *engine*) 25 26)]
+  {:rows        [[3 (if (contains? #{:mysql :crate} *engine*) 25 26)]
                  [1 24]
                  [2 21]
                  [4 (if (contains? #{:mysql :crate} *engine*) 14 15)]]

--- a/test/metabase/query_processor_test/time_field_test.clj
+++ b/test/metabase/query_processor_test/time_field_test.clj
@@ -9,7 +9,7 @@
 
 (defmacro ^:private time-query [additional-clauses]
   `(qpt/rows
-     (data/with-db (data/get-or-create-database! defs/test-data-with-time)
+     (data/dataset ~'test-data-with-time
        (data/run-mbql-query users
          ~(merge
            {:fields   `[~'$id ~'$name ~'$last_login_time]

--- a/test/metabase/query_processor_test/timezones_test.clj
+++ b/test/metabase/query_processor_test/timezones_test.clj
@@ -16,12 +16,7 @@
 (def ^:private mysql-driver (MySQLDriver.))
 
 (defn- call-with-timezones-db [f]
-  ;; Does the database exist?
-  (when-not (i/metabase-instance defs/test-data-with-timezones *engine*)
-    ;; The database doesn't exist, so we need to create it
-    (data/get-or-create-database! defs/test-data-with-timezones))
-  ;; The database can now be used in tests
-  (data/with-db (data/get-or-create-database! defs/test-data-with-timezones)
+  (data/dataset test-data-with-timezones
     (f)))
 
 (defmacro ^:private with-tz-db
@@ -114,14 +109,14 @@
   (with-tz-db
     (tu/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
       (process-query'
-       {:database (data/id)
-        :type :native
+       {:database   (data/id)
+        :type       :native
         :native     {:query         (format "select %s, %s, %s from %s where {{just_a_date}}"
                                             (field-identifier :users :id)
                                             (field-identifier :users :name)
                                             (field-identifier :users :last_login)
                                             (users-table-identifier))
-                     :template-tags {:just_a_date {:name "just_a_date", :display_name "Just A Date", :type "dimension",
+                     :template-tags {:just_a_date {:name      "just_a_date", :display_name "Just A Date", :type "dimension",
                                                    :dimension ["field-id" (data/id :users :last_login)]}}}
         :parameters [{:type "date/single", :target ["dimension" ["template-tag" "just_a_date"]], :value "2014-08-02"}]}))))
 

--- a/test/metabase/sync/sync_metadata/comments_test.clj
+++ b/test/metabase/sync/sync_metadata/comments_test.clj
@@ -31,7 +31,7 @@
   #{{:name (data/format-name "id"), :description nil}
     {:name (data/format-name "with_comment"), :description "comment"}
     {:name (data/format-name "no_comment"), :description nil}}
-  (data/with-temp-db [db basic-field-comments]
+  (data/with-current-db [db basic-field-comments]
      (db->fields db)))
 
 ;; test changing the description in metabase db so we can check it is not overwritten by comment in source db when resyncing
@@ -43,7 +43,7 @@
 (ds/expect-with-engines #{:h2 :postgres}
   #{{:name (data/format-name "id"), :description nil}
     {:name (data/format-name "updated_desc"), :description "updated description"}}
-  (data/with-temp-db [db update-desc]
+  (data/with-current-db [db update-desc]
     ;; change the description in metabase while the source table comment remains the same
     (db/update-where! Field {:id (data/id "update_desc" "updated_desc")}, :description "updated description")
     ;; now sync the DB again, this should NOT overwrite the manually updated description
@@ -59,7 +59,7 @@
 (ds/expect-with-engines #{:h2 :postgres}
   #{{:name (data/format-name "id"), :description nil}
     {:name (data/format-name "comment_after_sync"), :description "added comment"}}
-  (data/with-temp-db [db comment-after-sync]
+  (data/with-current-db [db comment-after-sync]
     ;; modify the source DB to add the comment and resync
     (i/create-db! ds/*driver* (assoc-in comment-after-sync [:table-definitions 0 :field-definitions 0 :field-comment] "added comment") true)
     (sync/sync-table! (Table (data/id "comment_after_sync")))
@@ -81,13 +81,13 @@
 ;; test basic comments on table
 (ds/expect-with-engines #{:h2 :postgres}
   #{{:name (data/format-name "table_with_comment"), :description "table comment"}}
-  (data/with-temp-db [db (basic-table "table_with_comment" "table comment")]
+  (data/with-current-db [db (basic-table "table_with_comment" "table comment")]
     (db->tables db)))
 
 ;; test changing the description in metabase on table to check it is not overwritten by comment in source db when resyncing
 (ds/expect-with-engines #{:h2 :postgres}
   #{{:name (data/format-name "table_with_updated_desc"), :description "updated table description"}}
-  (data/with-temp-db [db (basic-table "table_with_updated_desc" "table comment")]
+  (data/with-current-db [db (basic-table "table_with_updated_desc" "table comment")]
      ;; change the description in metabase while the source table comment remains the same
      (db/update-where! Table {:id (data/id "table_with_updated_desc")}, :description "updated table description")
      ;; now sync the DB again, this should NOT overwrite the manually updated description
@@ -97,7 +97,7 @@
 ;; test adding a comment to the source table that was initially empty, so we can check that the resync picks it up
 (ds/expect-with-engines #{:h2 :postgres}
   #{{:name (data/format-name "table_with_comment_after_sync"), :description "added comment"}}
-  (data/with-temp-db [db (basic-table "table_with_comment_after_sync" nil)]
+  (data/with-current-db [db (basic-table "table_with_comment_after_sync" nil)]
      ;; modify the source DB to add the comment and resync
      (i/create-db! ds/*driver* (basic-table "table_with_comment_after_sync" "added comment") true)
      (metabase.sync.sync-metadata.tables/sync-tables! db)

--- a/test/metabase/task/send_pulses_test.clj
+++ b/test/metabase/task/send_pulses_test.clj
@@ -35,7 +35,7 @@
                              :body    {"My Question Name" true}})
    :exceptions []}
   (et/with-fake-inbox
-    (data/with-db (data/get-or-create-database! defs/test-data)
+    (data/with-copy-of-test-db
       (let [exceptions (atom [])
             on-error   (fn [_ exception]
                          (swap! exceptions conj exception))]
@@ -65,7 +65,7 @@
                   PulseChannelRecipient [_               {:user_id          (users/user->id :rasta)
                                                           :pulse_channel_id pc-id}]]
     (et/with-fake-inbox
-      (data/with-db (data/get-or-create-database! defs/test-data)
+      (data/with-copy-of-test-db
         (let [exceptions (atom [])
               on-error   (fn [_ exception]
                            (swap! exceptions conj exception))]

--- a/test/metabase/task/sync_databases_test.clj
+++ b/test/metabase/task/sync_databases_test.clj
@@ -125,15 +125,17 @@
 ;; Check that you can't UPDATE a DB's schedule to something invalid
 (expect
   Exception
-  (tt/with-temp Database [database {:engine :postgres}]
-    (db/update! Database (u/get-id database)
-      :metadata_sync_schedule "2 CANS PER DAY")))
+  (tu/suppress-output
+    (tt/with-temp Database [database {:engine :postgres}]
+      (db/update! Database (u/get-id database)
+        :metadata_sync_schedule "2 CANS PER DAY"))))
 
 (expect
   Exception
-  (tt/with-temp Database [database {:engine :postgres}]
-    (db/update! Database (u/get-id database)
-      :cache_field_values_schedule "2 CANS PER DAY")))
+  (tu/suppress-output
+    (tt/with-temp Database [database {:engine :postgres}]
+      (db/update! Database (u/get-id database)
+        :cache_field_values_schedule "2 CANS PER DAY"))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/test/metabase/test/data/dataset_definitions.clj
+++ b/test/metabase/test/data/dataset_definitions.clj
@@ -1,5 +1,5 @@
 (ns metabase.test.data.dataset-definitions
-  "Definitions of various datasets for use in tests with `with-temp-db`."
+  "Definitions of various datasets for use in tests with `with-current-db` and related functions."
   (:require [clojure.tools.reader.edn :as edn]
             [metabase.test.data.interface :as di]
             [metabase.util.date :as du])

--- a/test/metabase/timeseries_query_processor_test.clj
+++ b/test/metabase/timeseries_query_processor_test.clj
@@ -8,63 +8,62 @@
             [metabase.timeseries-query-processor-test.util :refer :all]))
 
 (defn data [results]
-  (when-let [data (or (:data results)
-                      (println (u/pprint-to-str results)))] ; DEBUG
-    (-> data
-        (select-keys [:columns :rows])
-        (update :rows vec))))
+  (when-let [{:keys [cols rows]} (or (:data results)
+                                     (println (u/pprint-to-str 'red results)))]
+    {:rows      (vec rows)
+     :col-names (mapv :name cols)}))
 
 ;;; # Tests
 
 ;;; "bare rows" query, limit
 (expect-with-timeseries-dbs
-  {:columns ["id"
-             "count"
-             "user_last_login"
-             "user_name"
-             "venue_category_name"
-             "venue_latitude"
-             "venue_longitude"
-             "venue_name"
-             "venue_price"
-             "timestamp"]
-   :rows [["931", 1, "2014-01-01T08:30:00.000Z", "Simcha Yan", "Thai", "34.094",  "-118.344", "Kinaree Thai Bistro",       "1", "2013-01-03T08:00:00.000Z"]
-          ["285", 1, "2014-07-03T01:30:00.000Z", "Kfir Caj",   "Thai", "34.1021", "-118.306", "Ruen Pair Thai Restaurant", "2", "2013-01-10T08:00:00.000Z"]]}
+  {:col-names ["id"
+               "count"
+               "user_last_login"
+               "user_name"
+               "venue_category_name"
+               "venue_latitude"
+               "venue_longitude"
+               "venue_name"
+               "venue_price"
+               "timestamp"]
+   :rows      [["931", 1, "2014-01-01T08:30:00.000Z", "Simcha Yan", "Thai", "34.094",  "-118.344", "Kinaree Thai Bistro",       "1", "2013-01-03T08:00:00.000Z"]
+               ["285", 1, "2014-07-03T01:30:00.000Z", "Kfir Caj",   "Thai", "34.1021", "-118.306", "Ruen Pair Thai Restaurant", "2", "2013-01-10T08:00:00.000Z"]]}
   (data (data/run-mbql-query checkins
           {:limit 2})))
 
 ;;; "bare rows" query, limit, order-by timestamp desc
 (expect-with-timeseries-dbs
-  {:columns ["id"
-             "count"
-             "user_last_login"
-             "user_name"
-             "venue_category_name"
-             "venue_latitude"
-             "venue_longitude"
-             "venue_name"
-             "venue_price"
-             "timestamp"]
-   :rows    [["693", 1, "2014-07-03T19:30:00.000Z", "Frans Hevel", "Mexican", "34.0489", "-118.238", "Señor Fish",       "2", "2015-12-29T08:00:00.000Z"]
-             ["570", 1, "2014-07-03T01:30:00.000Z", "Kfir Caj",    "Chinese", "37.7949", "-122.406", "Empress of China", "3", "2015-12-26T08:00:00.000Z"]]}
+  {:col-names ["id"
+               "count"
+               "user_last_login"
+               "user_name"
+               "venue_category_name"
+               "venue_latitude"
+               "venue_longitude"
+               "venue_name"
+               "venue_price"
+               "timestamp"]
+   :rows      [["693", 1, "2014-07-03T19:30:00.000Z", "Frans Hevel", "Mexican", "34.0489", "-118.238", "Señor Fish",       "2", "2015-12-29T08:00:00.000Z"]
+               ["570", 1, "2014-07-03T01:30:00.000Z", "Kfir Caj",    "Chinese", "37.7949", "-122.406", "Empress of China", "3", "2015-12-26T08:00:00.000Z"]]}
   (data (data/run-mbql-query checkins
           {:order-by [[:desc $timestamp]]
            :limit    2})))
 
 ;;; "bare rows" query, limit, order-by timestamp asc
 (expect-with-timeseries-dbs
-  {:columns ["id"
-             "count"
-             "user_last_login"
-             "user_name"
-             "venue_category_name"
-             "venue_latitude"
-             "venue_longitude"
-             "venue_name"
-             "venue_price"
-             "timestamp"]
-   :rows    [["931", 1, "2014-01-01T08:30:00.000Z", "Simcha Yan", "Thai", "34.094",  "-118.344", "Kinaree Thai Bistro",       "1", "2013-01-03T08:00:00.000Z"]
-             ["285", 1, "2014-07-03T01:30:00.000Z", "Kfir Caj",   "Thai", "34.1021", "-118.306", "Ruen Pair Thai Restaurant", "2", "2013-01-10T08:00:00.000Z"]]}
+  {:col-names ["id"
+               "count"
+               "user_last_login"
+               "user_name"
+               "venue_category_name"
+               "venue_latitude"
+               "venue_longitude"
+               "venue_name"
+               "venue_price"
+               "timestamp"]
+   :rows      [["931", 1, "2014-01-01T08:30:00.000Z", "Simcha Yan", "Thai", "34.094",  "-118.344", "Kinaree Thai Bistro",       "1", "2013-01-03T08:00:00.000Z"]
+               ["285", 1, "2014-07-03T01:30:00.000Z", "Kfir Caj",   "Thai", "34.1021", "-118.306", "Ruen Pair Thai Restaurant", "2", "2013-01-10T08:00:00.000Z"]]}
   (data (data/run-mbql-query checkins
           {:order-by [[:asc $timestamp]]
            :limit    2})))
@@ -73,18 +72,18 @@
 
 ;;; fields clause
 (expect-with-timeseries-dbs
-  {:columns ["venue_name" "venue_category_name" "timestamp"],
-   :rows    [["Kinaree Thai Bistro"       "Thai" "2013-01-03T08:00:00.000Z"]
-             ["Ruen Pair Thai Restaurant" "Thai" "2013-01-10T08:00:00.000Z"]]}
+  {:col-names ["venue_name" "venue_category_name" "timestamp"],
+   :rows      [["Kinaree Thai Bistro"       "Thai" "2013-01-03T08:00:00.000Z"]
+               ["Ruen Pair Thai Restaurant" "Thai" "2013-01-10T08:00:00.000Z"]]}
   (data (data/run-mbql-query checkins
           {:fields [$venue_name $venue_category_name $timestamp]
            :limit  2})))
 
 ;;; fields clause, order by timestamp asc
 (expect-with-timeseries-dbs
-  {:columns ["venue_name" "venue_category_name" "timestamp"],
-   :rows    [["Kinaree Thai Bistro"       "Thai" "2013-01-03T08:00:00.000Z"]
-             ["Ruen Pair Thai Restaurant" "Thai" "2013-01-10T08:00:00.000Z"]]}
+  {:col-names ["venue_name" "venue_category_name" "timestamp"],
+   :rows      [["Kinaree Thai Bistro"       "Thai" "2013-01-03T08:00:00.000Z"]
+               ["Ruen Pair Thai Restaurant" "Thai" "2013-01-10T08:00:00.000Z"]]}
   (data (data/run-mbql-query checkins
           {:fields   [$venue_name $venue_category_name $timestamp]
            :order-by [[:asc $timestamp]]
@@ -92,9 +91,9 @@
 
 ;;; fields clause, order by timestamp desc
 (expect-with-timeseries-dbs
-  {:columns ["venue_name" "venue_category_name" "timestamp"],
-   :rows    [["Señor Fish"       "Mexican" "2015-12-29T08:00:00.000Z"]
-             ["Empress of China" "Chinese" "2015-12-26T08:00:00.000Z"]]}
+  {:col-names ["venue_name" "venue_category_name" "timestamp"],
+   :rows      [["Señor Fish"       "Mexican" "2015-12-29T08:00:00.000Z"]
+               ["Empress of China" "Chinese" "2015-12-26T08:00:00.000Z"]]}
   (data (data/run-mbql-query checkins
           {:fields   [$venue_name $venue_category_name $timestamp]
            :order-by [[:desc $timestamp]]
@@ -118,22 +117,22 @@
 
 ;;; avg
 (expect-with-timeseries-dbs
-  {:columns ["avg"]
-   :rows    [[1.992]]}
+  {:col-names ["avg"]
+   :rows      [[1.992]]}
   (data (data/run-mbql-query checkins
           {:aggregation [[:avg $venue_price]]})))
 
 ;;; sum
 (expect-with-timeseries-dbs
-  {:columns ["sum"]
-   :rows    [[1992.0]]}
+  {:col-names ["sum"]
+   :rows      [[1992.0]]}
   (data (data/run-mbql-query checkins
           {:aggregation [[:sum $venue_price]]})))
 
 ;;; avg
 (expect-with-timeseries-dbs
-  {:columns ["avg"]
-   :rows    [[1.992]]}
+  {:col-names ["avg"]
+   :rows      [[1.992]]}
   (->> (data/run-mbql-query checkins
          {:aggregation [[:avg $venue_price]]})
        (format-rows-by [(partial u/round-to-decimals 3)])
@@ -148,55 +147,55 @@
 
 ;;; 1 breakout (distinct values)
 (expect-with-timeseries-dbs
-  {:columns ["user_name"]
-   :rows    [["Broen Olujimi"]
-             ["Conchúr Tihomir"]
-             ["Dwight Gresham"]
-             ["Felipinho Asklepios"]
-             ["Frans Hevel"]
-             ["Kaneonuskatew Eiran"]
-             ["Kfir Caj"]
-             ["Nils Gotam"]
-             ["Plato Yeshua"]
-             ["Quentin Sören"]
-             ["Rüstem Hebel"]
-             ["Shad Ferdynand"]
-             ["Simcha Yan"]
-             ["Spiros Teofil"]
-             ["Szymon Theutrich"]]}
+  {:col-names ["user_name"]
+   :rows      [["Broen Olujimi"]
+               ["Conchúr Tihomir"]
+               ["Dwight Gresham"]
+               ["Felipinho Asklepios"]
+               ["Frans Hevel"]
+               ["Kaneonuskatew Eiran"]
+               ["Kfir Caj"]
+               ["Nils Gotam"]
+               ["Plato Yeshua"]
+               ["Quentin Sören"]
+               ["Rüstem Hebel"]
+               ["Shad Ferdynand"]
+               ["Simcha Yan"]
+               ["Spiros Teofil"]
+               ["Szymon Theutrich"]]}
   (data (data/run-mbql-query checkins
           {:breakout [$user_name]})))
 
 ;;; 2 breakouts
 (expect-with-timeseries-dbs
-  {:columns ["user_name" "venue_category_name"]
-   :rows    [["Broen Olujimi" "American"]
-             ["Broen Olujimi" "Artisan"]
-             ["Broen Olujimi" "BBQ"]
-             ["Broen Olujimi" "Bakery"]
-             ["Broen Olujimi" "Bar"]
-             ["Broen Olujimi" "Burger"]
-             ["Broen Olujimi" "Café"]
-             ["Broen Olujimi" "Caribbean"]
-             ["Broen Olujimi" "Deli"]
-             ["Broen Olujimi" "Dim Sum"]]}
+  {:col-names ["user_name" "venue_category_name"]
+   :rows      [["Broen Olujimi" "American"]
+               ["Broen Olujimi" "Artisan"]
+               ["Broen Olujimi" "BBQ"]
+               ["Broen Olujimi" "Bakery"]
+               ["Broen Olujimi" "Bar"]
+               ["Broen Olujimi" "Burger"]
+               ["Broen Olujimi" "Café"]
+               ["Broen Olujimi" "Caribbean"]
+               ["Broen Olujimi" "Deli"]
+               ["Broen Olujimi" "Dim Sum"]]}
   (data (data/run-mbql-query checkins
           {:breakout [$user_name $venue_category_name]
            :limit    10})))
 
 ;;; 1 breakout w/ explicit order by
 (expect-with-timeseries-dbs
-  {:columns ["user_name"]
-   :rows    [["Szymon Theutrich"]
-             ["Spiros Teofil"]
-             ["Simcha Yan"]
-             ["Shad Ferdynand"]
-             ["Rüstem Hebel"]
-             ["Quentin Sören"]
-             ["Plato Yeshua"]
-             ["Nils Gotam"]
-             ["Kfir Caj"]
-             ["Kaneonuskatew Eiran"]]}
+  {:col-names ["user_name"]
+   :rows      [["Szymon Theutrich"]
+               ["Spiros Teofil"]
+               ["Simcha Yan"]
+               ["Shad Ferdynand"]
+               ["Rüstem Hebel"]
+               ["Quentin Sören"]
+               ["Plato Yeshua"]
+               ["Nils Gotam"]
+               ["Kfir Caj"]
+               ["Kaneonuskatew Eiran"]]}
   (data (data/run-mbql-query checkins
           {:breakout [$user_name]
            :order-by [[:desc $user_name]]
@@ -204,17 +203,17 @@
 
 ;;; 2 breakouts w/ explicit order by
 (expect-with-timeseries-dbs
-  {:columns ["user_name" "venue_category_name"]
-   :rows    [["Broen Olujimi"       "American"]
-             ["Conchúr Tihomir"     "American"]
-             ["Dwight Gresham"      "American"]
-             ["Felipinho Asklepios" "American"]
-             ["Frans Hevel"         "American"]
-             ["Kaneonuskatew Eiran" "American"]
-             ["Kfir Caj"            "American"]
-             ["Nils Gotam"          "American"]
-             ["Plato Yeshua"        "American"]
-             ["Quentin Sören"       "American"]]}
+  {:col-names ["user_name" "venue_category_name"]
+   :rows      [["Broen Olujimi"       "American"]
+               ["Conchúr Tihomir"     "American"]
+               ["Dwight Gresham"      "American"]
+               ["Felipinho Asklepios" "American"]
+               ["Frans Hevel"         "American"]
+               ["Kaneonuskatew Eiran" "American"]
+               ["Kfir Caj"            "American"]
+               ["Nils Gotam"          "American"]
+               ["Plato Yeshua"        "American"]
+               ["Quentin Sören"       "American"]]}
   (data (data/run-mbql-query checkins
           {:breakout [$user_name $venue_category_name]
            :order-by [[:asc $venue_category_name]]
@@ -222,39 +221,39 @@
 
 ;;; count w/ 1 breakout
 (expect-with-timeseries-dbs
-  {:columns ["user_name" "count"]
-   :rows    [["Broen Olujimi"       62]
-             ["Conchúr Tihomir"     76]
-             ["Dwight Gresham"      76]
-             ["Felipinho Asklepios" 70]
-             ["Frans Hevel"         78]
-             ["Kaneonuskatew Eiran" 75]
-             ["Kfir Caj"            59]
-             ["Nils Gotam"          68]
-             ["Plato Yeshua"        31]
-             ["Quentin Sören"       69]
-             ["Rüstem Hebel"        34]
-             ["Shad Ferdynand"      70]
-             ["Simcha Yan"          77]
-             ["Spiros Teofil"       74]
-             ["Szymon Theutrich"    81]]}
+  {:col-names ["user_name" "count"]
+   :rows      [["Broen Olujimi"       62]
+               ["Conchúr Tihomir"     76]
+               ["Dwight Gresham"      76]
+               ["Felipinho Asklepios" 70]
+               ["Frans Hevel"         78]
+               ["Kaneonuskatew Eiran" 75]
+               ["Kfir Caj"            59]
+               ["Nils Gotam"          68]
+               ["Plato Yeshua"        31]
+               ["Quentin Sören"       69]
+               ["Rüstem Hebel"        34]
+               ["Shad Ferdynand"      70]
+               ["Simcha Yan"          77]
+               ["Spiros Teofil"       74]
+               ["Szymon Theutrich"    81]]}
   (data (data/run-mbql-query checkins
           {:aggregation [[:count]]
            :breakout    [$user_name]})))
 
 ;;; count w/ 2 breakouts
 (expect-with-timeseries-dbs
-  {:columns ["user_name" "venue_category_name" "count"]
-   :rows    [["Broen Olujimi" "American"  8]
-             ["Broen Olujimi" "Artisan"   1]
-             ["Broen Olujimi" "BBQ"       7]
-             ["Broen Olujimi" "Bakery"    2]
-             ["Broen Olujimi" "Bar"       5]
-             ["Broen Olujimi" "Burger"    2]
-             ["Broen Olujimi" "Café"      1]
-             ["Broen Olujimi" "Caribbean" 1]
-             ["Broen Olujimi" "Deli"      2]
-             ["Broen Olujimi" "Dim Sum"   2]]}
+  {:col-names ["user_name" "venue_category_name" "count"]
+   :rows      [["Broen Olujimi" "American"  8]
+               ["Broen Olujimi" "Artisan"   1]
+               ["Broen Olujimi" "BBQ"       7]
+               ["Broen Olujimi" "Bakery"    2]
+               ["Broen Olujimi" "Bar"       5]
+               ["Broen Olujimi" "Burger"    2]
+               ["Broen Olujimi" "Café"      1]
+               ["Broen Olujimi" "Caribbean" 1]
+               ["Broen Olujimi" "Deli"      2]
+               ["Broen Olujimi" "Dim Sum"   2]]}
   (data (data/run-mbql-query checkins
           {:aggregation [[:count]]
            :breakout    [$user_name $venue_category_name]
@@ -294,12 +293,12 @@
 
 ;;; filter =
 (expect-with-timeseries-dbs
-  {:columns ["user_name" "venue_name" "venue_category_name" "timestamp"]
-   :rows    [["Plato Yeshua" "Fred 62"        "Diner"    "2013-03-12T07:00:00.000Z"]
-             ["Plato Yeshua" "Dimples"        "Karaoke"  "2013-04-11T07:00:00.000Z"]
-             ["Plato Yeshua" "Baby Blues BBQ" "BBQ"      "2013-06-03T07:00:00.000Z"]
-             ["Plato Yeshua" "The Daily Pint" "Bar"      "2013-07-25T07:00:00.000Z"]
-             ["Plato Yeshua" "Marlowe"        "American" "2013-09-10T07:00:00.000Z"]]}
+  {:col-names ["user_name" "venue_name" "venue_category_name" "timestamp"]
+   :rows      [["Plato Yeshua" "Fred 62"        "Diner"    "2013-03-12T07:00:00.000Z"]
+               ["Plato Yeshua" "Dimples"        "Karaoke"  "2013-04-11T07:00:00.000Z"]
+               ["Plato Yeshua" "Baby Blues BBQ" "BBQ"      "2013-06-03T07:00:00.000Z"]
+               ["Plato Yeshua" "The Daily Pint" "Bar"      "2013-07-25T07:00:00.000Z"]
+               ["Plato Yeshua" "Marlowe"        "American" "2013-09-10T07:00:00.000Z"]]}
   (data (data/run-mbql-query checkins
           {:fields [$user_name $venue_name $venue_category_name $timestamp]
            :filter [:= $user_name "Plato Yeshua"]
@@ -315,8 +314,8 @@
 
 ;;; filter AND
 (expect-with-timeseries-dbs
-  {:columns ["user_name" "venue_name" "timestamp"]
-   :rows    [["Plato Yeshua" "The Daily Pint" "2013-07-25T07:00:00.000Z"]]}
+  {:col-names ["user_name" "venue_name" "timestamp"]
+   :rows      [["Plato Yeshua" "The Daily Pint" "2013-07-25T07:00:00.000Z"]]}
   (data (data/run-mbql-query checkins
           {:fields [$user_name $venue_name $timestamp]
            :filter [:and
@@ -343,8 +342,8 @@
 
 ;;; filter INSIDE
 (expect-with-timeseries-dbs
-  {:columns ["venue_name"]
-   :rows    [["Red Medicine"]]}
+  {:col-names ["venue_name"]
+   :rows      [["Red Medicine"]]}
   (data (data/run-mbql-query checkins
           {:breakout [$venue_name]
            :filter   [:inside $venue_latitude $venue_longitude 10.0649 -165.379 10.0641 -165.371]})))
@@ -367,111 +366,111 @@
 
 ;;; filter STARTS_WITH
 (expect-with-timeseries-dbs
-  {:columns ["venue_category_name"]
-   :rows    [["Mediterannian"] ["Mexican"]]}
+  {:col-names ["venue_category_name"]
+   :rows      [["Mediterannian"] ["Mexican"]]}
   (data (data/run-mbql-query checkins
           {:breakout [$venue_category_name]
            :filter   [:starts-with $venue_category_name "Me"]})))
 
 (expect-with-timeseries-dbs
-  {:columns ["venue_category_name"]
-   :rows    []}
+  {:col-names ["venue_category_name"]
+   :rows      []}
   (data (data/run-mbql-query checkins
           {:breakout [$venue_category_name]
            :filter   [:starts-with $venue_category_name "ME"]})))
 
 (expect-with-timeseries-dbs
-  {:columns ["venue_category_name"]
-   :rows    [["Mediterannian"] ["Mexican"]]}
+  {:col-names ["venue_category_name"]
+   :rows      [["Mediterannian"] ["Mexican"]]}
   (data (data/run-mbql-query checkins
           {:breakout [$venue_category_name]
            :filter   [:starts-with $venue_category_name "ME" {:case-sensitive false}]})))
 
 ;;; filter ENDS_WITH
 (expect-with-timeseries-dbs
-  {:columns ["venue_category_name"]
-   :rows    [["American"]
-             ["Artisan"]
-             ["Asian"]
-             ["Caribbean"]
-             ["German"]
-             ["Korean"]
-             ["Mediterannian"]
-             ["Mexican"]]}
+  {:col-names ["venue_category_name"]
+   :rows      [["American"]
+               ["Artisan"]
+               ["Asian"]
+               ["Caribbean"]
+               ["German"]
+               ["Korean"]
+               ["Mediterannian"]
+               ["Mexican"]]}
   (data (data/run-mbql-query checkins
           {:breakout [$venue_category_name]
            :filter   [:ends-with $venue_category_name "an"]})))
 
 (expect-with-timeseries-dbs
-  {:columns ["venue_category_name"]
-   :rows    []}
+  {:col-names ["venue_category_name"]
+   :rows      []}
   (data (data/run-mbql-query checkins
           {:breakout [$venue_category_name]
            :filter   [:ends-with $venue_category_name "AN"]})))
 
 (expect-with-timeseries-dbs
-  {:columns ["venue_category_name"]
-   :rows    [["American"]
-             ["Artisan"]
-             ["Asian"]
-             ["Caribbean"]
-             ["German"]
-             ["Korean"]
-             ["Mediterannian"]
-             ["Mexican"]]}
+  {:col-names ["venue_category_name"]
+   :rows      [["American"]
+               ["Artisan"]
+               ["Asian"]
+               ["Caribbean"]
+               ["German"]
+               ["Korean"]
+               ["Mediterannian"]
+               ["Mexican"]]}
   (data (data/run-mbql-query checkins
           {:breakout [$venue_category_name]
            :filter   [:ends-with $venue_category_name "AN" {:case-sensitive false}]})))
 
 ;;; filter CONTAINS
 (expect-with-timeseries-dbs
-  {:columns ["venue_category_name"]
-   :rows    [["American"]
-             ["Bakery"]
-             ["Brewery"]
-             ["Burger"]
-             ["Diner"]
-             ["German"]
-             ["Mediterannian"]
-             ["Southern"]]}
+  {:col-names ["venue_category_name"]
+   :rows      [["American"]
+               ["Bakery"]
+               ["Brewery"]
+               ["Burger"]
+               ["Diner"]
+               ["German"]
+               ["Mediterannian"]
+               ["Southern"]]}
   (data (data/run-mbql-query checkins
           {:breakout [$venue_category_name]
            :filter   [:contains $venue_category_name "er"]})))
 
 (expect-with-timeseries-dbs
-  {:columns ["venue_category_name"]
-   :rows    []}
+  {:col-names ["venue_category_name"]
+   :rows      []}
   (data (data/run-mbql-query checkins
           {:breakout [$venue_category_name]
            :filter   [:contains $venue_category_name "eR"]})))
 
 (expect-with-timeseries-dbs
-  {:columns ["venue_category_name"]
-   :rows    [["American"]
-             ["Bakery"]
-             ["Brewery"]
-             ["Burger"]
-             ["Diner"]
-             ["German"]
-             ["Mediterannian"]
-             ["Southern"]]}
+  {:col-names ["venue_category_name"]
+   :rows      [["American"]
+               ["Bakery"]
+               ["Brewery"]
+               ["Burger"]
+               ["Diner"]
+               ["German"]
+               ["Mediterannian"]
+               ["Southern"]]}
   (data (data/run-mbql-query checkins
           {:breakout [$venue_category_name]
            :filter   [:contains $venue_category_name "eR" {:case-sensitive false}]})))
 
 ;;; order by aggregate field (?)
 (expect-with-timeseries-dbs
-  {:columns ["user_name" "venue_category_name" "count"]
-   :rows    [["Szymon Theutrich"    "Bar"      13]
-             ["Dwight Gresham"      "Mexican"  12]
-             ["Felipinho Asklepios" "Bar"      10]
-             ["Felipinho Asklepios" "Japanese" 10]
-             ["Kaneonuskatew Eiran" "Bar"      10]
-             ["Shad Ferdynand"      "Mexican"  10]
-             ["Spiros Teofil"       "American" 10]
-             ["Spiros Teofil"       "Bar"      10]
-             ["Dwight Gresham"      "Bar"       9]
-             ["Frans Hevel"         "Japanese"  9]]}
+  {:col-names ["user_name" "venue_category_name" "count"]
+   :rows      [["Szymon Theutrich"    "Bar"      13]
+               ["Dwight Gresham"      "Mexican"  12]
+               ["Felipinho Asklepios" "Bar"      10]
+               ["Felipinho Asklepios" "Japanese" 10]
+               ["Kaneonuskatew Eiran" "Bar"      10]
+               ["Shad Ferdynand"      "Mexican"  10]
+               ["Spiros Teofil"       "American" 10]
+               ["Spiros Teofil"       "Bar"      10]
+               ["Dwight Gresham"      "Bar"       9]
+               ["Frans Hevel"         "Japanese"  9]]}
   (data (data/run-mbql-query checkins
           {:aggregation [[:count]]
            :breakout    [$user_name $venue_category_name]
@@ -480,12 +479,12 @@
 
 ;;; date bucketing - default (day)
 (expect-with-timeseries-dbs
-  {:columns ["timestamp" "count"]
-   :rows    [["2013-01-03+00:00" 1]
-             ["2013-01-10+00:00" 1]
-             ["2013-01-19+00:00" 1]
-             ["2013-01-22+00:00" 1]
-             ["2013-01-23+00:00" 1]]}
+  {:col-names ["timestamp" "count"]
+   :rows      [["2013-01-03+00:00" 1]
+               ["2013-01-10+00:00" 1]
+               ["2013-01-19+00:00" 1]
+               ["2013-01-22+00:00" 1]
+               ["2013-01-23+00:00" 1]]}
   (data (data/run-mbql-query checkins
           {:aggregation [[:count]]
            :breakout    [$timestamp]
@@ -493,12 +492,12 @@
 
 ;;; date bucketing - minute
 (expect-with-timeseries-dbs
-  {:columns ["timestamp" "count"]
-   :rows    [["2013-01-03T08:00:00+00:00" 1]
-             ["2013-01-10T08:00:00+00:00" 1]
-             ["2013-01-19T08:00:00+00:00" 1]
-             ["2013-01-22T08:00:00+00:00" 1]
-             ["2013-01-23T08:00:00+00:00" 1]]}
+  {:col-names ["timestamp" "count"]
+   :rows      [["2013-01-03T08:00:00+00:00" 1]
+               ["2013-01-10T08:00:00+00:00" 1]
+               ["2013-01-19T08:00:00+00:00" 1]
+               ["2013-01-22T08:00:00+00:00" 1]
+               ["2013-01-23T08:00:00+00:00" 1]]}
   (data (data/run-mbql-query checkins
           {:aggregation [[:count]]
            :breakout    [[:datetime-field $timestamp :minute]]
@@ -506,8 +505,8 @@
 
 ;;; date bucketing - minute-of-hour
 (expect-with-timeseries-dbs
-  {:columns ["timestamp" "count"]
-   :rows    [[0 1000]]}
+  {:col-names ["timestamp" "count"]
+   :rows      [[0 1000]]}
   (data (data/run-mbql-query checkins
           {:aggregation [[:count]]
            :breakout    [[:datetime-field $timestamp :minute-of-hour]]
@@ -515,12 +514,12 @@
 
 ;;; date bucketing - hour
 (expect-with-timeseries-dbs
-  {:columns ["timestamp" "count"]
-   :rows    [["2013-01-03T08:00:00+00:00" 1]
-             ["2013-01-10T08:00:00+00:00" 1]
-             ["2013-01-19T08:00:00+00:00" 1]
-             ["2013-01-22T08:00:00+00:00" 1]
-             ["2013-01-23T08:00:00+00:00" 1]]}
+  {:col-names ["timestamp" "count"]
+   :rows      [["2013-01-03T08:00:00+00:00" 1]
+               ["2013-01-10T08:00:00+00:00" 1]
+               ["2013-01-19T08:00:00+00:00" 1]
+               ["2013-01-22T08:00:00+00:00" 1]
+               ["2013-01-23T08:00:00+00:00" 1]]}
   (data (data/run-mbql-query checkins
           {:aggregation [[:count]]
            :breakout    [[:datetime-field $timestamp :hour]]
@@ -528,9 +527,9 @@
 
 ;;; date bucketing - hour-of-day
 (expect-with-timeseries-dbs
-  {:columns ["timestamp" "count"]
-   :rows    [[7 719]
-             [8 281]]}
+  {:col-names ["timestamp" "count"]
+   :rows      [[7 719]
+               [8 281]]}
   (data (data/run-mbql-query checkins
           {:aggregation [[:count]]
            :breakout    [[:datetime-field $timestamp :hour-of-day]]
@@ -538,12 +537,12 @@
 
 ;;; date bucketing - week
 (expect-with-timeseries-dbs
-  {:columns ["timestamp" "count"]
-   :rows    [["2012-12-30" 1]
-             ["2013-01-06" 1]
-             ["2013-01-13" 1]
-             ["2013-01-20" 4]
-             ["2013-01-27" 1]]}
+  {:col-names ["timestamp" "count"]
+   :rows      [["2012-12-30" 1]
+               ["2013-01-06" 1]
+               ["2013-01-13" 1]
+               ["2013-01-20" 4]
+               ["2013-01-27" 1]]}
   (data (data/run-mbql-query checkins
           {:aggregation [[:count]]
            :breakout    [[:datetime-field $timestamp :week]]
@@ -551,12 +550,12 @@
 
 ;;; date bucketing - day
 (expect-with-timeseries-dbs
-  {:columns ["timestamp" "count"]
-   :rows    [["2013-01-03+00:00" 1]
-             ["2013-01-10+00:00" 1]
-             ["2013-01-19+00:00" 1]
-             ["2013-01-22+00:00" 1]
-             ["2013-01-23+00:00" 1]]}
+  {:col-names ["timestamp" "count"]
+   :rows      [["2013-01-03+00:00" 1]
+               ["2013-01-10+00:00" 1]
+               ["2013-01-19+00:00" 1]
+               ["2013-01-22+00:00" 1]
+               ["2013-01-23+00:00" 1]]}
   (data (data/run-mbql-query checkins
           {:aggregation [[:count]]
            :breakout    [[:datetime-field $timestamp :day]]
@@ -564,12 +563,12 @@
 
 ;;; date bucketing - day-of-week
 (expect-with-timeseries-dbs
-  {:columns ["timestamp" "count"]
-   :rows    [[1 135]
-             [2 143]
-             [3 153]
-             [4 136]
-             [5 139]]}
+  {:col-names ["timestamp" "count"]
+   :rows      [[1 135]
+               [2 143]
+               [3 153]
+               [4 136]
+               [5 139]]}
   (data (data/run-mbql-query checkins
           {:aggregation [[:count]]
            :breakout    [[:datetime-field $timestamp :day-of-week]]
@@ -577,12 +576,12 @@
 
 ;;; date bucketing - day-of-month
 (expect-with-timeseries-dbs
-  {:columns ["timestamp" "count"]
-   :rows    [[1 36]
-             [2 36]
-             [3 42]
-             [4 35]
-             [5 43]]}
+  {:col-names ["timestamp" "count"]
+   :rows      [[1 36]
+               [2 36]
+               [3 42]
+               [4 35]
+               [5 43]]}
   (data (data/run-mbql-query checkins
           {:aggregation [[:count]]
            :breakout    [[:datetime-field $timestamp :day-of-month]]
@@ -590,12 +589,12 @@
 
 ;;; date bucketing - day-of-year
 (expect-with-timeseries-dbs
-  {:columns ["timestamp" "count"]
-   :rows    [[3 2]
-             [4 6]
-             [5 1]
-             [6 1]
-             [7 2]]}
+  {:col-names ["timestamp" "count"]
+   :rows      [[3 2]
+               [4 6]
+               [5 1]
+               [6 1]
+               [7 2]]}
   (data (data/run-mbql-query checkins
           {:aggregation [[:count]]
            :breakout    [[:datetime-field $timestamp :day-of-year]]
@@ -603,12 +602,12 @@
 
 ;;; date bucketing - week-of-year
 (expect-with-timeseries-dbs
-  {:columns ["timestamp" "count"]
-   :rows    [[1 10]
-             [2  7]
-             [3  8]
-             [4 10]
-             [5  4]]}
+  {:col-names ["timestamp" "count"]
+   :rows      [[1 10]
+               [2  7]
+               [3  8]
+               [4 10]
+               [5  4]]}
   (data (data/run-mbql-query checkins
           {:aggregation [[:count]]
            :breakout    [[:datetime-field $timestamp :week-of-year]]
@@ -616,12 +615,12 @@
 
 ;;; date bucketing - month
 (expect-with-timeseries-dbs
-  {:columns ["timestamp" "count"]
-   :rows    [["2013-01-01"  8]
-             ["2013-02-01" 11]
-             ["2013-03-01" 21]
-             ["2013-04-01" 26]
-             ["2013-05-01" 23]]}
+  {:col-names ["timestamp" "count"]
+   :rows      [["2013-01-01"  8]
+               ["2013-02-01" 11]
+               ["2013-03-01" 21]
+               ["2013-04-01" 26]
+               ["2013-05-01" 23]]}
   (data (data/run-mbql-query checkins
           {:aggregation [[:count]]
            :breakout    [[:datetime-field $timestamp :month]]
@@ -631,12 +630,12 @@
 ;; timeseries query rather than a topN query. The dates below are formatted incorrectly due to
 ;; https://github.com/metabase/metabase/issues/5969.
 (expect-with-timeseries-dbs
-  {:columns ["timestamp" "count"]
-   :rows    [["2013-01-01" 8]
-             ["2013-02-01" 11]
-             ["2013-03-01" 21]
-             ["2013-04-01" 26]
-             ["2013-05-01" 23]]}
+  {:col-names ["timestamp" "count"]
+   :rows      [["2013-01-01" 8]
+               ["2013-02-01" 11]
+               ["2013-03-01" 21]
+               ["2013-04-01" 26]
+               ["2013-05-01" 23]]}
   (-> (data/run-mbql-query checkins
         {:aggregation [[:count]]
          :breakout    [[:datetime-field $timestamp :month]]})
@@ -645,12 +644,12 @@
 
 ;;; date bucketing - month-of-year
 (expect-with-timeseries-dbs
-  {:columns ["timestamp" "count"]
-   :rows    [[1  38]
-             [2  70]
-             [3  92]
-             [4  89]
-             [5 111]]}
+  {:col-names ["timestamp" "count"]
+   :rows      [[1  38]
+               [2  70]
+               [3  92]
+               [4  89]
+               [5 111]]}
   (data (data/run-mbql-query checkins
           {:aggregation [[:count]]
            :breakout    [[:datetime-field $timestamp :month-of-year]]
@@ -658,12 +657,12 @@
 
 ;;; date bucketing - quarter
 (expect-with-timeseries-dbs
-  {:columns ["timestamp" "count"]
-   :rows    [["2013-01-01" 40]
-             ["2013-04-01" 75]
-             ["2013-07-01" 55]
-             ["2013-10-01" 65]
-             ["2014-01-01" 107]]}
+  {:col-names ["timestamp" "count"]
+   :rows      [["2013-01-01" 40]
+               ["2013-04-01" 75]
+               ["2013-07-01" 55]
+               ["2013-10-01" 65]
+               ["2014-01-01" 107]]}
   (data (data/run-mbql-query checkins
           {:aggregation [[:count]]
            :breakout    [[:datetime-field $timestamp :quarter]]
@@ -671,11 +670,11 @@
 
 ;;; date bucketing - quarter-of-year
 (expect-with-timeseries-dbs
-  {:columns ["timestamp" "count"]
-   :rows    [[1 200]
-             [2 284]
-             [3 278]
-             [4 238]]}
+  {:col-names ["timestamp" "count"]
+   :rows      [[1 200]
+               [2 284]
+               [3 278]
+               [4 238]]}
   (data (data/run-mbql-query checkins
           {:aggregation [[:count]]
            :breakout    [[:datetime-field $timestamp :quarter-of-year]]
@@ -683,10 +682,10 @@
 
 ;;; date bucketing - year
 (expect-with-timeseries-dbs
-  {:columns ["timestamp" "count"]
-   :rows    [[2013 235]
-             [2014 498]
-             [2015 267]]}
+  {:col-names ["timestamp" "count"]
+   :rows      [[2013 235]
+               [2014 498]
+               [2015 267]]}
   (data (data/run-mbql-query checkins
           {:aggregation [[:count]]
            :breakout    [[:datetime-field $timestamp :year]]
@@ -851,7 +850,7 @@
 
 ;;; MIN & MAX
 
-;; tests for dimension columns
+;; tests for dimension col-names
 (expect-with-timeseries-dbs
   [4.0]
   (first-row
@@ -864,7 +863,7 @@
     (data/run-mbql-query checkins
       {:aggregation [[:min $venue_price]]})))
 
-;; tests for metric columns
+;; tests for metric col-names
 (expect-with-timeseries-dbs
   [1.0]
   (first-row
@@ -878,7 +877,7 @@
       {:aggregation [[:min $count]]})))
 
 (expect-with-timeseries-dbs
-  ;; some sort of weird quirk w/ druid where all columns in breakout get converted to strings
+  ;; some sort of weird quirk w/ druid where all col-names in breakout get converted to strings
   [["1" 34.0071] ["2" 33.7701] ["3" 10.0646] ["4" 33.983]]
   (rows (data/run-mbql-query checkins
           {:aggregation [[:min $venue_latitude]]

--- a/test/metabase/timeseries_query_processor_test/util.clj
+++ b/test/metabase/timeseries_query_processor_test/util.clj
@@ -21,12 +21,12 @@
   []
   (doseq [engine event-based-dbs]
     (datasets/with-engine-when-testing engine
-      (data/do-with-temp-db @flattened-db-def (constantly nil)))))
+      (data/do-with-current-db @flattened-db-def (constantly nil)))))
 
 (defn do-with-flattened-dbdef
   "Execute F with a flattened version of the test data DB as the current DB def."
   [f]
-  (data/do-with-temp-db @flattened-db-def (u/drop-first-arg f)))
+  (data/do-with-current-db @flattened-db-def (u/drop-first-arg f)))
 
 (defmacro with-flattened-dbdef
   "Execute BODY using the flattened test data DB definition."


### PR DESCRIPTION
✅ Remove `:columns` from QP results since they're not used in FE anymore.
✅ New `tu/suppress-output` macro to, predictably, supress the output of its body. Use this throughout tests to remove noise (such as stacktraces that are printed for tests that are supposed to cause Exceptions)
✅ New `data/with-copy-of-test-db`, `data/with-copy-of-db`, and `data/with-copy-of-test-db` macros to make a temporary copy of a test DB. Recursively copies Tables & Fields so the data doesn't need to be reloaded into a new DB and re-synced.
✅ Fix some broken tests that weren't actually running correctly
✅ Other small cleanup