### PR TITLE
Quieter tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,15 +401,22 @@ jobs:
       - restore_cache:
           <<: *restore-fe-deps-cache
       - run:
-          name: Run yarn
-          command: SAUCE_CONNECT_DOWNLOAD_ON_INSTALL=true yarn
+          name: Run yarn if yarn.lock checksum has changed
+          command: >
+            if [ ! -f yarn.lock.checksum ] || [ "$(md5sum yarn.lock)" != "$(cat yarn.lock.checksum)" ];
+              then SAUCE_CONNECT_DOWNLOAD_ON_INSTALL=true yarn;
+            fi
           no_output_timeout: 5m
+      - run:
+          name: Save yarn checksum
+          command: md5sum yarn.lock > yarn.lock.checksum
       - save_cache:
           key: fe-deps-{{ checksum "yarn.lock" }}
           paths:
             - /home/circleci/.yarn
             - /home/circleci/.yarn-cache
             - /home/circleci/metabase/metabase/node_modules
+            - /home/circleci/yarn.lock.checksum
 
   fe-linter-eslint:
     <<: *defaults
@@ -484,7 +491,9 @@ jobs:
       - run:
           name: Build uberjar if needed
           command: >
-            if [ ! -f './target/uberjar/metabase.jar' ]; then ./bin/build version uberjar; fi
+            if [ ! -f './target/uberjar/metabase.jar' ];
+              then ./bin/build version uberjar;
+            fi
           no_output_timeout: 5m
       - save_cache:
           key: uberjar-{{ checksum "./backend-checksums.txt" }}

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -16,7 +16,7 @@ Delete an Alert. (DEPRECATED -- don't delete a Alert anymore -- archive it inste
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/alert/`
@@ -34,7 +34,7 @@ Fetch all questions for the given question (`Card`) id
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `POST /api/alert/`
@@ -53,7 +53,7 @@ Create a new Alert.
 
 *  **`alert_above_goal`** value may be nil, or if non-nil, value must be a boolean.
 
-*  **`new-alert-request-body`** 
+*  **`new-alert-request-body`**
 
 
 ## `PUT /api/alert/:id`
@@ -62,7 +62,7 @@ Update a `Alert` with ID.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 *  **`alert_condition`** value may be nil, or if non-nil, value must be one of: `goal`, `rows`.
 
@@ -76,7 +76,7 @@ Update a `Alert` with ID.
 
 *  **`archived`** value may be nil, or if non-nil, value must be a boolean.
 
-*  **`alert-updates`** 
+*  **`alert-updates`**
 
 
 ## `PUT /api/alert/:id/unsubscribe`
@@ -85,7 +85,7 @@ Unsubscribes a user from the given alert
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/automagic-dashboards/:entity/:entity-id-or-query`
@@ -96,7 +96,7 @@ Return an automagic dashboard for entity `entity` with id `ìd`.
 
 *  **`entity`** Invalid entity type
 
-*  **`entity-id-or-query`** 
+*  **`entity-id-or-query`**
 
 *  **`show`** invalid show value
 
@@ -111,7 +111,7 @@ Return an automagic dashboard analyzing cell in  automagic dashboard for entity 
 
 *  **`entity`** Invalid entity type
 
-*  **`entity-id-or-query`** 
+*  **`entity-id-or-query`**
 
 *  **`cell-query`** value couldn't be parsed as base64 encoded JSON
 
@@ -128,7 +128,7 @@ Return an automagic comparison dashboard for cell in automagic dashboard for ent
 
 *  **`entity`** Invalid entity type
 
-*  **`entity-id-or-query`** 
+*  **`entity-id-or-query`**
 
 *  **`cell-query`** value couldn't be parsed as base64 encoded JSON
 
@@ -136,7 +136,7 @@ Return an automagic comparison dashboard for cell in automagic dashboard for ent
 
 *  **`comparison-entity`** Invalid comparison entity type. Can only be one of "table", "segment", or "adhoc"
 
-*  **`comparison-entity-id-or-query`** 
+*  **`comparison-entity-id-or-query`**
 
 
 ## `GET /api/automagic-dashboards/:entity/:entity-id-or-query/cell/:cell-query/rule/:prefix/:rule`
@@ -148,7 +148,7 @@ Return an automagic dashboard analyzing cell in question  with id `id` defined b
 
 *  **`entity`** Invalid entity type
 
-*  **`entity-id-or-query`** 
+*  **`entity-id-or-query`**
 
 *  **`cell-query`** value couldn't be parsed as base64 encoded JSON
 
@@ -169,7 +169,7 @@ Return an automagic comparison dashboard for cell in automagic dashboard for ent
 
 *  **`entity`** Invalid entity type
 
-*  **`entity-id-or-query`** 
+*  **`entity-id-or-query`**
 
 *  **`cell-query`** value couldn't be parsed as base64 encoded JSON
 
@@ -181,7 +181,7 @@ Return an automagic comparison dashboard for cell in automagic dashboard for ent
 
 *  **`comparison-entity`** Invalid comparison entity type. Can only be one of "table", "segment", or "adhoc"
 
-*  **`comparison-entity-id-or-query`** 
+*  **`comparison-entity-id-or-query`**
 
 
 ## `GET /api/automagic-dashboards/:entity/:entity-id-or-query/compare/:comparison-entity/:comparison-entity-id-or-query`
@@ -193,13 +193,13 @@ Return an automagic comparison dashboard for entity `entity` with id `ìd` compa
 
 *  **`entity`** Invalid entity type
 
-*  **`entity-id-or-query`** 
+*  **`entity-id-or-query`**
 
 *  **`show`** invalid show value
 
 *  **`comparison-entity`** Invalid comparison entity type. Can only be one of "table", "segment", or "adhoc"
 
-*  **`comparison-entity-id-or-query`** 
+*  **`comparison-entity-id-or-query`**
 
 
 ## `GET /api/automagic-dashboards/:entity/:entity-id-or-query/rule/:prefix/:rule`
@@ -210,7 +210,7 @@ Return an automagic dashboard for entity `entity` with id `ìd` using rule `rule
 
 *  **`entity`** Invalid entity type
 
-*  **`entity-id-or-query`** 
+*  **`entity-id-or-query`**
 
 *  **`prefix`** invalid value for prefix
 
@@ -228,7 +228,7 @@ Return an automagic comparison dashboard for entity `entity` with id `ìd` using
 
 *  **`entity`** Invalid entity type
 
-*  **`entity-id-or-query`** 
+*  **`entity-id-or-query`**
 
 *  **`prefix`** invalid value for prefix
 
@@ -238,7 +238,7 @@ Return an automagic comparison dashboard for entity `entity` with id `ìd` using
 
 *  **`comparison-entity`** Invalid comparison entity type. Can only be one of "table", "segment", or "adhoc"
 
-*  **`comparison-entity-id-or-query`** 
+*  **`comparison-entity-id-or-query`**
 
 
 ## `GET /api/automagic-dashboards/database/:id/candidates`
@@ -247,7 +247,7 @@ Return a list of candidates for automagic dashboards orderd by interestingness.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `DELETE /api/card/:card-id/favorite`
@@ -256,7 +256,7 @@ Unfavorite a Card.
 
 ##### PARAMS:
 
-*  **`card-id`** 
+*  **`card-id`**
 
 
 ## `DELETE /api/card/:card-id/public_link`
@@ -267,7 +267,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`card-id`** 
+*  **`card-id`**
 
 
 ## `DELETE /api/card/:id`
@@ -276,7 +276,7 @@ Delete a Card. (DEPRECATED -- don't delete a Card anymore -- archive it instead.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/card/`
@@ -298,7 +298,7 @@ Get `Card` with ID.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/card/:id/related`
@@ -307,7 +307,7 @@ Return related entities.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/card/embeddable`
@@ -345,7 +345,7 @@ Create a new `Card`.
 
 *  **`name`** value must be a non-blank string.
 
-*  **`dataset_query`** 
+*  **`dataset_query`**
 
 *  **`display`** value must be a non-blank string.
 
@@ -356,7 +356,7 @@ Favorite a Card.
 
 ##### PARAMS:
 
-*  **`card-id`** 
+*  **`card-id`**
 
 
 ## `POST /api/card/:card-id/public_link`
@@ -369,7 +369,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`card-id`** 
+*  **`card-id`**
 
 
 ## `POST /api/card/:card-id/query`
@@ -378,9 +378,9 @@ Run the query associated with a Card.
 
 ##### PARAMS:
 
-*  **`card-id`** 
+*  **`card-id`**
 
-*  **`parameters`** 
+*  **`parameters`**
 
 *  **`ignore_cache`** value may be nil, or if non-nil, value must be a boolean.
 
@@ -392,7 +392,7 @@ Run the query associated with a Card, and return its results as a file in the sp
 
 ##### PARAMS:
 
-*  **`card-id`** 
+*  **`card-id`**
 
 *  **`export-format`** value must be one of: `csv`, `json`, `xlsx`.
 
@@ -417,7 +417,7 @@ Return related entities for an ad-hoc query.
 
 ##### PARAMS:
 
-*  **`query`** 
+*  **`query`**
 
 
 ## `PUT /api/card/:id`
@@ -442,7 +442,7 @@ Update a `Card`.
 
 *  **`collection_id`** value may be nil, or if non-nil, value must be an integer greater than zero.
 
-*  **`card-updates`** 
+*  **`card-updates`**
 
 *  **`name`** value may be nil, or if non-nil, value must be a non-blank string.
 
@@ -450,7 +450,7 @@ Update a `Card`.
 
 *  **`dataset_query`** value may be nil, or if non-nil, value must be a map.
 
-*  **`id`** 
+*  **`id`**
 
 *  **`display`** value may be nil, or if non-nil, value must be a non-blank string.
 
@@ -474,7 +474,7 @@ Fetch a specific Collection with standard details added
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/collection/:id/items`
@@ -486,7 +486,7 @@ Fetch a specific Collection's items with the following options:
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 *  **`model`** value may be nil, or if non-nil, value must be one of: `card`, `collection`, `dashboard`, `pulse`.
 
@@ -546,7 +546,7 @@ Modify an existing Collection, including archiving or unarchiving it, or moving 
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 *  **`name`** value may be nil, or if non-nil, value must be a non-blank string.
 
@@ -558,7 +558,7 @@ Modify an existing Collection, including archiving or unarchiving it, or moving 
 
 *  **`parent_id`** value may be nil, or if non-nil, value must be an integer greater than zero.
 
-*  **`collection-updates`** 
+*  **`collection-updates`**
 
 
 ## `PUT /api/collection/graph`
@@ -580,7 +580,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`dashboard-id`** 
+*  **`dashboard-id`**
 
 
 ## `DELETE /api/dashboard/:id`
@@ -589,7 +589,7 @@ Delete a `Dashboard`.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `DELETE /api/dashboard/:id/cards`
@@ -598,7 +598,7 @@ Remove a `DashboardCard` from a `Dashboard`.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 *  **`dashcardId`** value must be a valid integer greater than zero.
 
@@ -609,7 +609,7 @@ Unfavorite a Dashboard.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/dashboard/`
@@ -631,7 +631,7 @@ Get `Dashboard` with ID.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/dashboard/:id/related`
@@ -640,7 +640,7 @@ Return related entities.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/dashboard/:id/revisions`
@@ -649,7 +649,7 @@ Fetch `Revisions` for `Dashboard` with ID.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/dashboard/embeddable`
@@ -684,7 +684,7 @@ Create a new `Dashboard`.
 
 *  **`collection_position`** value may be nil, or if non-nil, value must be an integer greater than zero.
 
-*  **`dashboard`** 
+*  **`dashboard`**
 
 
 ## `POST /api/dashboard/:dashboard-id/public_link`
@@ -697,7 +697,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`dashboard-id`** 
+*  **`dashboard-id`**
 
 
 ## `POST /api/dashboard/:id/cards`
@@ -706,15 +706,15 @@ Add a `Card` to a `Dashboard`.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 *  **`cardId`** value may be nil, or if non-nil, value must be an integer greater than zero.
 
 *  **`parameter_mappings`** value must be an array. Each value must be a map.
 
-*  **`series`** 
+*  **`series`**
 
-*  **`dashboard-card`** 
+*  **`dashboard-card`**
 
 
 ## `POST /api/dashboard/:id/favorite`
@@ -723,7 +723,7 @@ Favorite a Dashboard.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `POST /api/dashboard/:id/revert`
@@ -732,7 +732,7 @@ Revert a `Dashboard` to a prior `Revision`.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 *  **`revision_id`** value must be an integer greater than zero.
 
@@ -743,7 +743,7 @@ Save a denormalized description of dashboard.
 
 ##### PARAMS:
 
-*  **`dashboard`** 
+*  **`dashboard`**
 
 
 ## `POST /api/dashboard/save/collection/:parent-collection-id`
@@ -752,9 +752,9 @@ Save a denormalized description of dashboard into collection with ID `:parent-co
 
 ##### PARAMS:
 
-*  **`parent-collection-id`** 
+*  **`parent-collection-id`**
 
-*  **`dashboard`** 
+*  **`dashboard`**
 
 
 ## `PUT /api/dashboard/:id`
@@ -783,7 +783,7 @@ Update a `Dashboard`.
 
 *  **`collection_id`** value may be nil, or if non-nil, value must be an integer greater than zero.
 
-*  **`dash-updates`** 
+*  **`dash-updates`**
 
 *  **`name`** value may be nil, or if non-nil, value must be a non-blank string.
 
@@ -791,7 +791,7 @@ Update a `Dashboard`.
 
 *  **`embedding_params`** value may be nil, or if non-nil, value must be a valid embedding params map.
 
-*  **`id`** 
+*  **`id`**
 
 *  **`position`** value may be nil, or if non-nil, value must be an integer greater than zero.
 
@@ -810,9 +810,9 @@ Update `Cards` on a `Dashboard`. Request body should have the form:
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
-*  **`cards`** 
+*  **`cards`**
 
 
 ## `DELETE /api/database/:id`
@@ -821,7 +821,7 @@ Delete a `Database`.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/database/`
@@ -843,7 +843,7 @@ Get `Database` with ID.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/database/:id/autocomplete_suggestions`
@@ -857,7 +857,7 @@ Return a list of autocomplete suggestions for a given PREFIX.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 *  **`prefix`** value must be a non-blank string.
 
@@ -868,7 +868,7 @@ Get a list of all `Fields` in `Database`.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/database/:id/idfields`
@@ -877,7 +877,7 @@ Get a list of all primary key `Fields` for `Database`.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/database/:id/metadata`
@@ -887,7 +887,7 @@ Get metadata about a `Database`, including all of its `Tables` and `Fields`.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/database/:id/schema/:schema`
@@ -896,9 +896,9 @@ Returns a list of tables for the given database `id` and `schema`
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
-*  **`schema`** 
+*  **`schema`**
 
 
 ## `GET /api/database/:id/schemas`
@@ -907,7 +907,7 @@ Returns a list of all the schemas found for the database `id`
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/database/:virtual-db/metadata`
@@ -945,7 +945,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `POST /api/database/:id/rescan_values`
@@ -956,7 +956,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `POST /api/database/:id/sync`
@@ -965,7 +965,7 @@ Update the metadata for this `Database`. This happens asynchronously.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `POST /api/database/:id/sync_schema`
@@ -976,7 +976,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `POST /api/database/sample_dataset`
@@ -1019,13 +1019,13 @@ You must be a superuser to do this.
 
 *  **`caveats`** value may be nil, or if non-nil, value must be a string.
 
-*  **`is_full_sync`** 
+*  **`is_full_sync`**
 
 *  **`details`** value may be nil, or if non-nil, value must be a map.
 
-*  **`id`** 
+*  **`id`**
 
-*  **`is_on_demand`** 
+*  **`is_on_demand`**
 
 
 ## `POST /api/dataset/`
@@ -1036,7 +1036,7 @@ Execute a query and retrieve the results in the usual format.
 
 *  **`database`** value must be an integer.
 
-*  **`query`** 
+*  **`query`**
 
 
 ## `POST /api/dataset/:export-format`
@@ -1056,9 +1056,9 @@ Get historical query execution duration.
 
 ##### PARAMS:
 
-*  **`database`** 
+*  **`database`**
 
-*  **`query`** 
+*  **`query`**
 
 
 ## `DELETE /api/email/`
@@ -1096,7 +1096,7 @@ Fetch a Card via a JSON Web Token signed with the `embedding-secret-key`.
 
 ##### PARAMS:
 
-*  **`token`** 
+*  **`token`**
 
 
 ## `GET /api/embed/card/:token/field/:field-id/remapping/:remapped-id`
@@ -1106,11 +1106,11 @@ Fetch remapped Field values. This is the same as `GET /api/field/:id/remapping/:
 
 ##### PARAMS:
 
-*  **`token`** 
+*  **`token`**
 
-*  **`field-id`** 
+*  **`field-id`**
 
-*  **`remapped-id`** 
+*  **`remapped-id`**
 
 *  **`value`** value must be a non-blank string.
 
@@ -1121,11 +1121,11 @@ Search for values of a Field that is referenced by an embedded Card.
 
 ##### PARAMS:
 
-*  **`token`** 
+*  **`token`**
 
-*  **`field-id`** 
+*  **`field-id`**
 
-*  **`search-field-id`** 
+*  **`search-field-id`**
 
 *  **`value`** value must be a non-blank string.
 
@@ -1138,9 +1138,9 @@ Fetch FieldValues for a Field that is referenced by an embedded Card.
 
 ##### PARAMS:
 
-*  **`token`** 
+*  **`token`**
 
-*  **`field-id`** 
+*  **`field-id`**
 
 
 ## `GET /api/embed/card/:token/query`
@@ -1154,11 +1154,11 @@ Fetch the results of running a Card using a JSON Web Token signed with the `embe
 
 ##### PARAMS:
 
-*  **`token`** 
+*  **`token`**
 
-*  **`&`** 
+*  **`&`**
 
-*  **`query-params`** 
+*  **`query-params`**
 
 
 ## `GET /api/embed/card/:token/query/:export-format`
@@ -1167,13 +1167,13 @@ Like `GET /api/embed/card/query`, but returns the results as a file in the speci
 
 ##### PARAMS:
 
-*  **`token`** 
+*  **`token`**
 
 *  **`export-format`** value must be one of: `csv`, `json`, `xlsx`.
 
-*  **`&`** 
+*  **`&`**
 
-*  **`query-params`** 
+*  **`query-params`**
 
 
 ## `GET /api/embed/dashboard/:token`
@@ -1186,7 +1186,7 @@ Fetch a Dashboard via a JSON Web Token signed with the `embedding-secret-key`.
 
 ##### PARAMS:
 
-*  **`token`** 
+*  **`token`**
 
 
 ## `GET /api/embed/dashboard/:token/dashcard/:dashcard-id/card/:card-id`
@@ -1195,15 +1195,15 @@ Fetch the results of running a Card belonging to a Dashboard using a JSON Web To
 
 ##### PARAMS:
 
-*  **`token`** 
+*  **`token`**
 
-*  **`dashcard-id`** 
+*  **`dashcard-id`**
 
-*  **`card-id`** 
+*  **`card-id`**
 
-*  **`&`** 
+*  **`&`**
 
-*  **`query-params`** 
+*  **`query-params`**
 
 
 ## `GET /api/embed/dashboard/:token/dashcard/:dashcard-id/card/:card-id/:export-format`
@@ -1213,17 +1213,17 @@ Fetch the results of running a Card belonging to a Dashboard using a JSON Web To
 
 ##### PARAMS:
 
-*  **`token`** 
+*  **`token`**
 
 *  **`export-format`** value must be one of: `csv`, `json`, `xlsx`.
 
-*  **`dashcard-id`** 
+*  **`dashcard-id`**
 
-*  **`card-id`** 
+*  **`card-id`**
 
-*  **`&`** 
+*  **`&`**
 
-*  **`query-params`** 
+*  **`query-params`**
 
 
 ## `GET /api/embed/dashboard/:token/field/:field-id/remapping/:remapped-id`
@@ -1233,11 +1233,11 @@ Fetch remapped Field values. This is the same as `GET /api/field/:id/remapping/:
 
 ##### PARAMS:
 
-*  **`token`** 
+*  **`token`**
 
-*  **`field-id`** 
+*  **`field-id`**
 
-*  **`remapped-id`** 
+*  **`remapped-id`**
 
 *  **`value`** value must be a non-blank string.
 
@@ -1248,11 +1248,11 @@ Search for values of a Field that is referenced by a Card in an embedded Dashboa
 
 ##### PARAMS:
 
-*  **`token`** 
+*  **`token`**
 
-*  **`field-id`** 
+*  **`field-id`**
 
-*  **`search-field-id`** 
+*  **`search-field-id`**
 
 *  **`value`** value must be a non-blank string.
 
@@ -1265,9 +1265,9 @@ Fetch FieldValues for a Field that is used as a param in an embedded Dashboard.
 
 ##### PARAMS:
 
-*  **`token`** 
+*  **`token`**
 
-*  **`field-id`** 
+*  **`field-id`**
 
 
 ## `DELETE /api/field/:id/dimension`
@@ -1276,7 +1276,7 @@ Remove the dimension associated to field at ID
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/field/:id`
@@ -1285,7 +1285,7 @@ Get `Field` with ID.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/field/:id/related`
@@ -1294,7 +1294,7 @@ Return related entities.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/field/:id/remapping/:remapped-id`
@@ -1303,22 +1303,22 @@ Fetch remapped Field values.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
-*  **`remapped-id`** 
+*  **`remapped-id`**
 
-*  **`value`** 
+*  **`value`**
 
 
 ## `GET /api/field/:id/search/:search-id`
 
-Search for values of a Field that match values of another Field when breaking out by the 
+Search for values of a Field that match values of another Field when breaking out by the
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
-*  **`search-id`** 
+*  **`search-id`**
 
 *  **`value`** value must be a non-blank string.
 
@@ -1331,7 +1331,7 @@ Get the count and distinct count of `Field` with ID.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/field/:id/values`
@@ -1341,7 +1341,7 @@ If a Field's value of `has_field_values` is `list`, return a list of all the dis
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/field/field-literal%2C:field-name%2Ctype%2F:field-type/values`
@@ -1351,7 +1351,7 @@ Implementation of the field values endpoint for fields in the Saved Questions 'v
 
 ##### PARAMS:
 
-*  **`_`** 
+*  **`_`**
 
 
 ## `POST /api/field/:id/dimension`
@@ -1360,7 +1360,7 @@ Sets the dimension for the given field at ID
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 *  **`type`** value must be one of: `external`, `internal`.
 
@@ -1378,7 +1378,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `POST /api/field/:id/rescan_values`
@@ -1390,7 +1390,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `POST /api/field/:id/values`
@@ -1400,7 +1400,7 @@ Update the fields values and human-readable values for a `Field` whose special t
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 *  **`value-pairs`** value must be an array. Each value must be an array.
 
@@ -1427,7 +1427,7 @@ Update `Field` with ID.
 
 *  **`fk_target_field_id`** value may be nil, or if non-nil, value must be an integer greater than zero.
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/geojson/:key`
@@ -1459,7 +1459,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 *  **`revision_message`** value must be a non-blank string.
 
@@ -1470,7 +1470,7 @@ Fetch *all* `Metrics`.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/metric/:id`
@@ -1481,7 +1481,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/metric/:id/related`
@@ -1490,7 +1490,7 @@ Return related entities.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/metric/:id/revisions`
@@ -1501,7 +1501,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `POST /api/metric/`
@@ -1514,7 +1514,7 @@ You must be a superuser to do this.
 
 *  **`name`** value must be a non-blank string.
 
-*  **`description`** 
+*  **`description`**
 
 *  **`table_id`** value must be an integer greater than zero.
 
@@ -1529,7 +1529,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 *  **`revision_id`** value must be an integer greater than zero.
 
@@ -1542,7 +1542,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 *  **`definition`** value must be a map.
 
@@ -1560,7 +1560,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 *  **`important_field_ids`** value must be an array. Each value must be an integer greater than zero.
 
@@ -1572,11 +1572,11 @@ Notification about a potential schema change to one of our `Databases`.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
-*  **`table_id`** 
+*  **`table_id`**
 
-*  **`table_name`** 
+*  **`table_name`**
 
 
 ## `DELETE /api/permissions/group/:group-id`
@@ -1587,7 +1587,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`group-id`** 
+*  **`group-id`**
 
 
 ## `DELETE /api/permissions/membership/:id`
@@ -1598,7 +1598,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/permissions/graph`
@@ -1623,7 +1623,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/permissions/membership`
@@ -1664,7 +1664,7 @@ You must be a superuser to do this.
 ## `PUT /api/permissions/graph`
 
 Do a batch update of Permissions by passing in a modified graph. This should return the same graph, in the same
-  format, that you got from `GET /api/permissions/graph`, with any changes made in the wherever neccesary. This
+  format, that you got from `GET /api/permissions/graph`, with any changes made in the wherever necessary. This
   modified graph must correspond to the `PermissionsGraph` schema. If successful, this endpoint returns the updated
   permissions graph; use this as a base for any further modifications.
 
@@ -1687,7 +1687,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`group-id`** 
+*  **`group-id`**
 
 *  **`name`** value must be a non-blank string.
 
@@ -1698,7 +1698,7 @@ Fetch a Card you're considering embedding by passing a JWT TOKEN.
 
 ##### PARAMS:
 
-*  **`token`** 
+*  **`token`**
 
 
 ## `GET /api/preview-embed/card/:token/query`
@@ -1707,20 +1707,20 @@ Fetch the query results for a Card you're considering embedding by passing a JWT
 
 ##### PARAMS:
 
-*  **`token`** 
+*  **`token`**
 
-*  **`&`** 
+*  **`&`**
 
-*  **`query-params`** 
+*  **`query-params`**
 
 
 ## `GET /api/preview-embed/dashboard/:token`
 
-Fetch a Dashboard you're considering embedding by passing a JWT TOKEN. 
+Fetch a Dashboard you're considering embedding by passing a JWT TOKEN.
 
 ##### PARAMS:
 
-*  **`token`** 
+*  **`token`**
 
 
 ## `GET /api/preview-embed/dashboard/:token/dashcard/:dashcard-id/card/:card-id`
@@ -1729,15 +1729,15 @@ Fetch the results of running a Card belonging to a Dashboard you're considering 
 
 ##### PARAMS:
 
-*  **`token`** 
+*  **`token`**
 
-*  **`dashcard-id`** 
+*  **`dashcard-id`**
 
-*  **`card-id`** 
+*  **`card-id`**
 
-*  **`&`** 
+*  **`&`**
 
-*  **`query-params`** 
+*  **`query-params`**
 
 
 ## `GET /api/public/card/:uuid`
@@ -1747,7 +1747,7 @@ Fetch a publicly-accessible Card an return query results as well as `:card` info
 
 ##### PARAMS:
 
-*  **`uuid`** 
+*  **`uuid`**
 
 
 ## `GET /api/public/card/:uuid/field/:field-id/remapping/:remapped-id`
@@ -1757,11 +1757,11 @@ Fetch remapped Field values. This is the same as `GET /api/field/:id/remapping/:
 
 ##### PARAMS:
 
-*  **`uuid`** 
+*  **`uuid`**
 
-*  **`field-id`** 
+*  **`field-id`**
 
-*  **`remapped-id`** 
+*  **`remapped-id`**
 
 *  **`value`** value must be a non-blank string.
 
@@ -1772,11 +1772,11 @@ Search for values of a Field that is referenced by a public Card.
 
 ##### PARAMS:
 
-*  **`uuid`** 
+*  **`uuid`**
 
-*  **`field-id`** 
+*  **`field-id`**
 
-*  **`search-field-id`** 
+*  **`search-field-id`**
 
 *  **`value`** value must be a non-blank string.
 
@@ -1789,9 +1789,9 @@ Fetch FieldValues for a Field that is referenced by a public Card.
 
 ##### PARAMS:
 
-*  **`uuid`** 
+*  **`uuid`**
 
-*  **`field-id`** 
+*  **`field-id`**
 
 
 ## `GET /api/public/card/:uuid/query`
@@ -1801,7 +1801,7 @@ Fetch a publicly-accessible Card an return query results as well as `:card` info
 
 ##### PARAMS:
 
-*  **`uuid`** 
+*  **`uuid`**
 
 *  **`parameters`** value may be nil, or if non-nil, value must be a valid JSON string.
 
@@ -1813,7 +1813,7 @@ Fetch a publicly-accessible Card and return query results in the specified forma
 
 ##### PARAMS:
 
-*  **`uuid`** 
+*  **`uuid`**
 
 *  **`export-format`** value must be one of: `csv`, `json`, `xlsx`.
 
@@ -1826,7 +1826,7 @@ Fetch a publicly-accessible Dashboard. Does not require auth credentials. Public
 
 ##### PARAMS:
 
-*  **`uuid`** 
+*  **`uuid`**
 
 
 ## `GET /api/public/dashboard/:uuid/card/:card-id`
@@ -1836,9 +1836,9 @@ Fetch the results for a Card in a publicly-accessible Dashboard. Does not requir
 
 ##### PARAMS:
 
-*  **`uuid`** 
+*  **`uuid`**
 
-*  **`card-id`** 
+*  **`card-id`**
 
 *  **`parameters`** value may be nil, or if non-nil, value must be a valid JSON string.
 
@@ -1850,11 +1850,11 @@ Fetch remapped Field values. This is the same as `GET /api/field/:id/remapping/:
 
 ##### PARAMS:
 
-*  **`uuid`** 
+*  **`uuid`**
 
-*  **`field-id`** 
+*  **`field-id`**
 
-*  **`remapped-id`** 
+*  **`remapped-id`**
 
 *  **`value`** value must be a non-blank string.
 
@@ -1865,11 +1865,11 @@ Search for values of a Field that is referenced by a Card in a public Dashboard.
 
 ##### PARAMS:
 
-*  **`uuid`** 
+*  **`uuid`**
 
-*  **`field-id`** 
+*  **`field-id`**
 
-*  **`search-field-id`** 
+*  **`search-field-id`**
 
 *  **`value`** value must be a non-blank string.
 
@@ -1882,9 +1882,9 @@ Fetch FieldValues for a Field that is referenced by a Card in a public Dashboard
 
 ##### PARAMS:
 
-*  **`uuid`** 
+*  **`uuid`**
 
-*  **`field-id`** 
+*  **`field-id`**
 
 
 ## `GET /api/public/oembed`
@@ -1908,7 +1908,7 @@ Delete a Pulse. (DEPRECATED -- don't delete a Pulse anymore -- archive it instea
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/pulse/`
@@ -1926,7 +1926,7 @@ Fetch `Pulse` with ID.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/pulse/form_input`
@@ -1940,7 +1940,7 @@ Get HTML rendering of a Card with `id`.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/pulse/preview_card_info/:id`
@@ -1949,7 +1949,7 @@ Get JSON object containing HTML rendering of a Card with `id` and other informat
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/pulse/preview_card_png/:id`
@@ -1958,7 +1958,7 @@ Get PNG rendering of a Card with `id`.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `POST /api/pulse/`
@@ -2005,7 +2005,7 @@ Update a Pulse with `id`.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 *  **`name`** value may be nil, or if non-nil, value must be a non-blank string.
 
@@ -2019,7 +2019,7 @@ Update a Pulse with `id`.
 
 *  **`archived`** value may be nil, or if non-nil, value must be a boolean.
 
-*  **`pulse-updates`** 
+*  **`pulse-updates`**
 
 
 ## `GET /api/revision/`
@@ -2065,7 +2065,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 *  **`revision_message`** value must be a non-blank string.
 
@@ -2083,7 +2083,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/segment/:id/related`
@@ -2092,7 +2092,7 @@ Return related entities.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/segment/:id/revisions`
@@ -2103,7 +2103,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `POST /api/segment/`
@@ -2116,7 +2116,7 @@ You must be a superuser to do this.
 
 *  **`name`** value must be a non-blank string.
 
-*  **`description`** 
+*  **`description`**
 
 *  **`table_id`** value must be an integer greater than zero.
 
@@ -2131,7 +2131,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 *  **`revision_id`** value must be an integer greater than zero.
 
@@ -2144,7 +2144,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 *  **`name`** value must be a non-blank string.
 
@@ -2186,7 +2186,7 @@ Login.
 
 *  **`password`** value must be a non-blank string.
 
-*  **`remote-address`** 
+*  **`remote-address`**
 
 
 ## `POST /api/session/forgot_password`
@@ -2195,11 +2195,11 @@ Send a reset email when user has forgotten their password.
 
 ##### PARAMS:
 
-*  **`server-name`** 
+*  **`server-name`**
 
 *  **`email`** value must be a valid email address.
 
-*  **`remote-address`** 
+*  **`remote-address`**
 
 
 ## `POST /api/session/google_auth`
@@ -2210,7 +2210,7 @@ Login with Google Auth.
 
 *  **`token`** value must be a non-blank string.
 
-*  **`remote-address`** 
+*  **`remote-address`**
 
 
 ## `POST /api/session/reset_password`
@@ -2250,7 +2250,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`settings`** 
+*  **`settings`**
 
 
 ## `PUT /api/setting/:key`
@@ -2264,7 +2264,7 @@ You must be a superuser to do this.
 
 *  **`key`** value must be a non-blank string.
 
-*  **`value`** 
+*  **`value`**
 
 
 ## `GET /api/setup/admin_checklist`
@@ -2281,7 +2281,7 @@ Special endpoint for creating the first user during setup.
 
 ##### PARAMS:
 
-*  **`engine`** 
+*  **`engine`**
 
 *  **`schedules`** value may be nil, or if non-nil, value must be a valid map of schedule maps for a DB.
 
@@ -2293,17 +2293,17 @@ Special endpoint for creating the first user during setup.
 
 *  **`password`** Insufficient password strength
 
-*  **`name`** 
+*  **`name`**
 
-*  **`is_full_sync`** 
+*  **`is_full_sync`**
 
 *  **`site_name`** value must be a non-blank string.
 
 *  **`token`** Token does not match the setup token.
 
-*  **`details`** 
+*  **`details`**
 
-*  **`is_on_demand`** 
+*  **`is_on_demand`**
 
 *  **`last_name`** value must be a non-blank string.
 
@@ -2316,7 +2316,7 @@ Validate that we can connect to a database given a set of details.
 
 *  **`engine`** value must be a valid database engine.
 
-*  **`details`** 
+*  **`details`**
 
 *  **`token`** Token does not match the setup token.
 
@@ -2333,7 +2333,7 @@ You must be a superuser to do this.
 
 *  **`metabot-enabled`** value must be a boolean.
 
-*  **`slack-settings`** 
+*  **`slack-settings`**
 
 
 ## `GET /api/table/`
@@ -2347,7 +2347,7 @@ Get `Table` with ID.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/table/:id/fks`
@@ -2356,7 +2356,7 @@ Get all foreign keys whose destination is a `Field` that belongs to this `Table`
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/table/:id/query_metadata`
@@ -2369,7 +2369,7 @@ Get metadata about a `Table` useful for running queries.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 *  **`include_sensitive_fields`** value may be nil, or if non-nil, value must be a valid boolean string ('true' or 'false').
 
@@ -2380,7 +2380,7 @@ Return related entities.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/table/card__:id/fks`
@@ -2395,7 +2395,7 @@ Return metadata for the 'virtual' table for a Card.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `POST /api/table/:id/discard_values`
@@ -2407,7 +2407,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `POST /api/table/:id/rescan_values`
@@ -2419,7 +2419,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `PUT /api/table/:id`
@@ -2428,7 +2428,7 @@ Update `Table` with ID.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 *  **`display_name`** value may be nil, or if non-nil, value must be a non-blank string.
 
@@ -2479,7 +2479,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/user/`
@@ -2499,7 +2499,7 @@ Fetch a `User`. You must be fetching yourself *or* be a superuser.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/user/current`
@@ -2521,7 +2521,7 @@ You must be a superuser to do this.
 
 *  **`email`** value must be a valid email address.
 
-*  **`password`** 
+*  **`password`**
 
 *  **`login_attributes`** value may be nil, or if non-nil, value must be a map with each value either a string or number.
 
@@ -2534,7 +2534,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `PUT /api/user/:id`
@@ -2543,7 +2543,7 @@ Update an existing, active `User`.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 *  **`email`** value may be nil, or if non-nil, value must be a valid email address.
 
@@ -2551,7 +2551,7 @@ Update an existing, active `User`.
 
 *  **`last_name`** value may be nil, or if non-nil, value must be a non-blank string.
 
-*  **`is_superuser`** 
+*  **`is_superuser`**
 
 *  **`login_attributes`** value may be nil, or if non-nil, value must be a map with each value either a string or number.
 
@@ -2562,11 +2562,11 @@ Update a user's password.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 *  **`password`** Insufficient password strength
 
-*  **`old_password`** 
+*  **`old_password`**
 
 
 ## `PUT /api/user/:id/qbnewb`
@@ -2575,7 +2575,7 @@ Indicate that a user has been informed about the vast intricacies of 'the' Query
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `PUT /api/user/:id/reactivate`
@@ -2586,7 +2586,7 @@ You must be a superuser to do this.
 
 ##### PARAMS:
 
-*  **`id`** 
+*  **`id`**
 
 
 ## `GET /api/util/logs`

--- a/src/metabase/api/permissions.clj
+++ b/src/metabase/api/permissions.clj
@@ -67,7 +67,7 @@
 
 (api/defendpoint PUT "/graph"
   "Do a batch update of Permissions by passing in a modified graph. This should return the same graph, in the same
-  format, that you got from `GET /api/permissions/graph`, with any changes made in the wherever neccesary. This
+  format, that you got from `GET /api/permissions/graph`, with any changes made in the wherever necessary. This
   modified graph must correspond to the `PermissionsGraph` schema. If successful, this endpoint returns the updated
   permissions graph; use this as a base for any further modifications.
 

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -65,7 +65,7 @@
       (catch com.unboundid.util.LDAPSDKException e
         (log/error
          (u/format-color 'red
-             (trs "Problem connecting to LDAP server, will fallback to local authentication {0}" (.getMessage e))))))))
+             (trs "Problem connecting to LDAP server, will fallback to local authentication: {0}" (.getMessage e))))))))
 
 (defn- email-login
   "Find a matching `User` if one exists and return a new Session for them, or `nil` if they couldn't be authenticated."

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -129,7 +129,7 @@
 
   MySQL gets snippy if we try to run the entire DB migration as one single string; it seems to only like it if we run
   one statement at a time; Liquibase puts each DDL statement on its own line automatically so just split by lines and
-  filter out blank / comment lines. Even though this is not neccesary for H2 or Postgres go ahead and do it anyway
+  filter out blank / comment lines. Even though this is not necessary for H2 or Postgres go ahead and do it anyway
   because it keeps the code simple and doesn't make a significant performance difference."
   [^Liquibase liquibase]
   (for [line  (s/split-lines (migrations-sql liquibase))

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -114,6 +114,7 @@
                   (trs "Switching Field to use a search widget instead."))
         (db/update! 'Field (u/get-id field) :has_field_values nil)
         (db/delete! FieldValues :field_id (u/get-id field)))
+
       ;; if the FieldValues object already exists then update values in it
       (and field-values values)
       (do
@@ -122,6 +123,7 @@
           :values                values
           :human_readable_values (fixup-human-readable-values field-values values))
         ::fv-updated)
+
       ;; if FieldValues object doesn't exist create one
       values
       (do
@@ -131,6 +133,7 @@
           :values                values
           :human_readable_values human-readable-values)
         ::fv-created)
+
       ;; otherwise this Field isn't eligible, so delete any FieldValues that might exist
       :else
       (do

--- a/src/metabase/models/params.clj
+++ b/src/metabase/models/params.clj
@@ -143,7 +143,7 @@
 
 (defn- param-field-ids->fields
   "Get the Fields (as a map of Field ID -> Field) that shoudl be returned for hydrated `:param_fields` for a Card or
-  Dashboard. These only contain the minimal amount of information neccesary needed to power public or embedded
+  Dashboard. These only contain the minimal amount of information necessary needed to power public or embedded
   parameter widgets."
   [field-ids]
   (when (seq field-ids)

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -581,7 +581,7 @@
                      (u/pprint-to-str 'blue new))))
 
 (s/defn update-graph!
-  "Update the permissions graph, making any changes neccesary to make it match NEW-GRAPH.
+  "Update the permissions graph, making any changes necessary to make it match NEW-GRAPH.
    This should take in a graph that is exactly the same as the one obtained by `graph` with any changes made as
    needed. The graph is revisioned, so if it has been updated by a third party since you fetched it this function will
    fail and return a 409 (Conflict) exception. If nothing needs to be done, this function returns `nil`; otherwise it

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -180,7 +180,6 @@
                 ;; query failed instead of giving people a failure response and trying to get results from that. So do
                 ;; everyone a favor and throw an Exception
                 (let [results (m/dissoc-in results [:query :results-promise])]
-                  (log/error (tru "Error preprocessing query") "\n" (u/pprint-to-str 'red results))
                   (throw (ex-info (str (tru "Error preprocessing query")) results)))))))]
     (recieve-native-query (qp-pipeline deliver-native-query))))
 

--- a/src/metabase/task/sync_databases.clj
+++ b/src/metabase/task/sync_databases.clj
@@ -64,7 +64,7 @@
    :job-class          UpdateFieldValues})
 
 
-;; These getter functions are not strictly neccesary but are provided primarily so we can get some extra validation by
+;; These getter functions are not strictly necessary but are provided primarily so we can get some extra validation by
 ;; using them
 
 (s/defn ^:private job-key :- JobKey

--- a/test/metabase/api/automagic_dashboards_test.clj
+++ b/test/metabase/api/automagic_dashboards_test.clj
@@ -130,21 +130,23 @@
 
 ;;; ------------------- Comparisons -------------------
 
-(def ^:private segment {:table_id (data/id :venues)
-                        :definition {:filter [:> [:field-id (data/id :venues :price)] 10]}})
+(def ^:private segment
+  (delay
+   {:table_id   (data/id :venues)
+    :definition {:filter [:> [:field-id (data/id :venues :price)] 10]}}))
 
 (expect
-  (tt/with-temp* [Segment [{segment-id :id} segment]]
+  (tt/with-temp* [Segment [{segment-id :id} @segment]]
     (api-call "table/%s/compare/segment/%s"
               [(data/id :venues) segment-id])))
 
 (expect
-  (tt/with-temp* [Segment [{segment-id :id} segment]]
+  (tt/with-temp* [Segment [{segment-id :id} @segment]]
     (api-call "table/%s/rule/example/indepth/compare/segment/%s"
               [(data/id :venues) segment-id])))
 
 (expect
-  (tt/with-temp* [Segment [{segment-id :id} segment]]
+  (tt/with-temp* [Segment [{segment-id :id} @segment]]
     (api-call "adhoc/%s/cell/%s/compare/segment/%s"
               [(->> {:query {:filter [:> [:field-id (data/id :venues :price)] 10]
                              :source-table (data/id :venues)}

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -24,9 +24,8 @@
             [metabase.test.data
              [datasets :as datasets]
              [users :refer :all]]
-            [toucan
-             [db :as db]
-             [hydrate :as hydrate]]
+            [metabase.test.util.log :as tu.log]
+            [toucan.db :as db]
             [toucan.util.test :as tt]))
 
 ;; HELPER FNS
@@ -50,12 +49,12 @@
       (finally
         (db/delete! Database :id (:id db))))))
 
-(defmacro ^:private expect-with-temp-db-created-via-api {:style/indent 1} [[binding & [options]] expected actual]
+(defmacro ^:private expect-with-temp-db-created-via-api {:style/indent 1} [[db-binding & [options]] expected actual]
   ;; use `gensym` instead of auto gensym here so we can be sure it's a unique symbol every time. Otherwise since
   ;; expectations hashes its body to generate function names it will treat every usage this as the same test and only
   ;; a single one will end up being ran
   (let [result (gensym "result-")]
-    `(let [~result (delay (do-with-temp-db-created-via-api ~options (fn [~binding]
+    `(let [~result (delay (do-with-temp-db-created-via-api ~options (fn [~db-binding]
                                                                       [~expected
                                                                        ~actual])))]
        (expect
@@ -181,62 +180,40 @@
                 :fields_hash     $}))
       (update :entity_type (comp (partial str "entity/") name))))
 
-
-;; TODO - this is a test code smell, each test should clean up after itself and this step shouldn't be neccessary. One
-;; day we should be able to remove this! If you're writing a NEW test that needs this, fix your brain and your test!
-;; To reïterate, this is BAD BAD BAD BAD BAD BAD! It will break tests if you use it! Don't use it!
-(defn- ^:deprecated delete-randomly-created-databases!
-  "Delete all the randomly created Databases we've made so far. Optionally specify one or more IDs to SKIP."
-  [& {:keys [skip]}]
-  (let [ids-to-skip (into (set skip)
-                          (for [engine datasets/all-valid-engines
-                                :let   [id (datasets/when-testing-engine engine
-                                             (:id (data/get-or-create-test-data-db! (driver/engine->driver engine))))]
-                                :when  id]
-                            id))]
-    (when-let [dbs (seq (db/select [Database :name :engine :id] :id [:not-in ids-to-skip]))]
-      (println (u/format-color 'red (str "\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
-                                         "WARNING: deleting randomly created databases:\n%s"
-                                         "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n\n")
-                 (u/pprint-to-str (for [db dbs]
-                                    (dissoc db :features))))))
-    (db/delete! Database :id [:not-in ids-to-skip])))
-
-
 ;; ## GET /api/database
 ;; Test that we can get all the DBs (ordered by name)
 ;; Database details *should not* come back for Rasta since she's not a superuser
-(expect-with-temp-db-created-via-api [{db-id :id}]
-  (set (filter identity (conj (for [engine datasets/all-valid-engines]
-                                (datasets/when-testing-engine engine
-                                  (merge default-db-details
-                                         (match-$ (data/get-or-create-test-data-db! (driver/engine->driver engine))
-                                           {:created_at         $
-                                            :engine             (name $engine)
-                                            :id                 $
-                                            :updated_at         $
-                                            :timezone           $
-                                            :name               "test-data"
-                                            :native_permissions "write"
-                                            :features           (map name (driver/features (driver/engine->driver engine)))}))))
-                              (merge default-db-details
-                                     (match-$ (Database db-id)
-                                       {:created_at         $
-                                        :engine             "postgres"
-                                        :id                 $
-                                        :updated_at         $
-                                        :name               $
-                                        :timezone           $
-                                        :native_permissions "write"
-                                        :features           (map name (driver/features (driver/engine->driver :postgres)))})))))
-  (do
-    (delete-randomly-created-databases! :skip [db-id])
-    (set ((user->client :rasta) :get 200 "database"))))
+(expect-with-temp-db-created-via-api [{db-id :id, db-name :name}]
+  (set (filter some? (conj (for [engine datasets/all-valid-engines]
+                             (datasets/when-testing-engine engine
+                               (merge default-db-details
+                                      (match-$ (data/get-or-create-test-data-db! (driver/engine->driver engine))
+                                        {:created_at         $
+                                         :engine             (name $engine)
+                                         :id                 $
+                                         :updated_at         $
+                                         :timezone           $
+                                         :name               "test-data"
+                                         :native_permissions "write"
+                                         :features           (map name (driver/features (driver/engine->driver engine)))}))))
+                           (merge default-db-details
+                                  (match-$ (Database db-id)
+                                    {:created_at         $
+                                     :engine             "postgres"
+                                     :id                 $
+                                     :updated_at         $
+                                     :name               $
+                                     :timezone           $
+                                     :native_permissions "write"
+                                     :features           (map name (driver/features (driver/engine->driver :postgres)))})))))
+  (->> ((user->client :rasta) :get 200 "database")
+       (filter #(#{"test-data" db-name} (:name %)))
+       set))
 
 
 
 ;; GET /api/databases (include tables)
-(expect-with-temp-db-created-via-api [{db-id :id}]
+(expect-with-temp-db-created-via-api [{db-id :id, db-name :name}]
   (set (cons (merge default-db-details
                     (match-$ (Database db-id)
                       {:created_at         $
@@ -263,9 +240,9 @@
                                               :tables             (sort-by :name (for [table (db/select Table, :db_id (:id database))]
                                                                                    (table-details table)))
                                               :features           (map name (driver/features (driver/engine->driver engine)))}))))))))
-  (do
-    (delete-randomly-created-databases! :skip [db-id])
-    (set ((user->client :rasta) :get 200 "database" :include_tables true))))
+  (->> ((user->client :rasta) :get 200 "database" :include_tables true)
+       (filter #(#{"test-data" db-name} (:name %)))
+       set))
 
 (def ^:private default-field-details
   {:description        nil
@@ -646,13 +623,15 @@
 (expect
   {:valid false, :message "Error!"}
   (with-redefs [database-api/test-database-connection test-database-connection]
-    (#'database-api/test-connection-details "h2" {:db "ABC"})))
+    (tu.log/suppress-output
+      (#'database-api/test-connection-details "h2" {:db "ABC"}))))
 
 (expect
   {:valid false}
   (with-redefs [database-api/test-database-connection test-database-connection]
-    ((user->client :crowberto) :post 200 "database/validate"
-     {:details {:engine :h2, :details {:db "ABC"}}})))
+    (tu.log/suppress-output
+      ((user->client :crowberto) :post 200 "database/validate"
+       {:details {:engine :h2, :details {:db "ABC"}}}))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -21,6 +21,7 @@
              [dataset-definitions :as defs]
              [datasets :refer [expect-with-engine]]
              [users :refer :all]]
+            [metabase.test.util.log :as tu.log]
             [toucan.db :as db]
             [toucan.util.test :as tt]))
 
@@ -126,9 +127,10 @@
   (let [check-error-message (fn [output]
                               (update output :error (fn [error-message]
                                                       (boolean (re-find #"Syntax error in SQL statement" error-message)))))
-        result              ((user->client :rasta) :post 200 "dataset" {:database (id)
-                                                                        :type     "native"
-                                                                        :native   {:query "foobar"}})]
+        result              (tu.log/suppress-output
+                              ((user->client :rasta) :post 200 "dataset" {:database (id)
+                                                                          :type     "native"
+                                                                          :native   {:query "foobar"}}))]
     [(check-error-message (format-response result))
      (check-error-message (format-response (most-recent-query-execution)))]))
 

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -22,6 +22,7 @@
             [metabase.test
              [data :as data]
              [util :as tu]]
+            [metabase.test.util.log :as tu.log]
             [toucan.db :as db]
             [toucan.util.test :as tt])
   (:import java.io.ByteArrayInputStream))
@@ -196,11 +197,12 @@
 ;; query info)
 (expect-for-response-formats [response-format]
   "An error occurred while running the query."
-  (with-embedding-enabled-and-new-secret-key
-    (with-temp-card [card {:enable_embedding true, :dataset_query {:database (data/id)
-                                                                   :type     :native
-                                                                   :native   {:query "SELECT * FROM XYZ"}}}]
-      (http/client :get 400 (card-query-url card response-format)))))
+  (tu.log/suppress-output
+    (with-embedding-enabled-and-new-secret-key
+      (with-temp-card [card {:enable_embedding true, :dataset_query {:database (data/id)
+                                                                     :type     :native
+                                                                     :native   {:query "SELECT * FROM XYZ"}}}]
+        (http/client :get 400 (card-query-url card response-format))))))
 
 ;; check that the endpoint doesn't work if embedding isn't enabled
 (expect-for-response-formats [response-format]
@@ -395,12 +397,13 @@
 ;; query info)
 (expect
   "An error occurred while running the query."
-  (with-embedding-enabled-and-new-secret-key
-    (with-temp-dashcard [dashcard {:dash {:enable_embedding true}
-                                   :card {:dataset_query {:database (data/id)
-                                                          :type     :native,
-                                                          :native   {:query "SELECT * FROM XYZ"}}}}]
-      (http/client :get 400 (dashcard-url dashcard)))))
+  (tu.log/suppress-output
+    (with-embedding-enabled-and-new-secret-key
+      (with-temp-dashcard [dashcard {:dash {:enable_embedding true}
+                                     :card {:dataset_query {:database (data/id)
+                                                            :type     :native,
+                                                            :native   {:query "SELECT * FROM XYZ"}}}}]
+        (http/client :get 400 (dashcard-url dashcard))))))
 
 ;; check that the endpoint doesn't work if embedding isn't enabled
 (expect

--- a/test/metabase/api/pulse_test.clj
+++ b/test/metabase/api/pulse_test.clj
@@ -23,9 +23,7 @@
             [metabase.test
              [data :as data]
              [util :as tu]]
-            [metabase.test.data
-             [dataset-definitions :as defs]
-             [users :refer :all]]
+            [metabase.test.data.users :refer :all]
             [metabase.test.mock.util :refer [pulse-channel-defaults]]
             [toucan.db :as db]
             [toucan.util.test :as tt]))
@@ -754,8 +752,10 @@
 ;; Check that a rando (e.g. someone without collection write access) isn't allowed to delete a pulse
 (expect
   "You don't have permissions to do that."
-  (tt/with-temp* [Database  [db]
-                  Table     [table {:db_id (u/get-id db)}]
+  (tt/with-temp* [Database  [db    (select-keys (data/db) [:engine :details])]
+                  Table     [table (-> (Table (data/id :venues))
+                                       (dissoc :id)
+                                       (assoc :db_id (u/get-id db)))]
                   Card      [card  {:dataset_query {:database (u/get-id db)
                                                     :type     "query"
                                                     :query    {:source-table (u/get-id table)
@@ -779,7 +779,7 @@
   [(assoc (pulse-details pulse-1) :can_write false, :collection_id true)
    (assoc (pulse-details pulse-2) :can_write false, :collection_id true)]
   (with-pulses-in-readable-collection [pulse-1 pulse-2]
-    ;; delete anything else in DB just to be sure; this step may not be neccesary any more
+    ;; delete anything else in DB just to be sure; this step may not be necessary any more
     (db/delete! Pulse :id [:not-in #{(u/get-id pulse-1)
                                      (u/get-id pulse-2)}])
     (for [pulse ((user->client :rasta) :get 200 "pulse")]
@@ -791,7 +791,7 @@
   [(assoc (pulse-details pulse-1) :can_write true)
    (assoc (pulse-details pulse-2) :can_write true)]
   (do
-    ;; delete anything else in DB just to be sure; this step may not be neccesary any more
+    ;; delete anything else in DB just to be sure; this step may not be necessary any more
     (db/delete! Pulse :id [:not-in #{(u/get-id pulse-1)
                                      (u/get-id pulse-2)}])
     ((user->client :crowberto) :get 200 "pulse")))
@@ -855,13 +855,11 @@
   (tu/with-non-admin-groups-no-root-collection-perms
     (tu/with-model-cleanup [Pulse]
       (et/with-fake-inbox
-        (data/with-db (data/get-or-create-database! defs/sad-toucan-incidents)
+        (data/dataset sad-toucan-incidents
           (tt/with-temp* [Collection [collection]
-                          Database   [db]
-                          Table      [table {:db_id (u/get-id db)}]
-                          Card       [card  {:dataset_query {:database (u/get-id db)
+                          Card       [card  {:dataset_query {:database (data/id)
                                                              :type     "query"
-                                                             :query    {:source-table (u/get-id table),
+                                                             :query    {:source-table (data/id :incidents)
                                                                         :aggregation  [[:count]]}}}]]
             (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
             (card-api-test/with-cards-in-readable-collection [card]
@@ -886,8 +884,10 @@
 ;; This test follows a flow that the user/UI would follow by first creating a pulse, then making a small change to
 ;; that pulse and testing it. The primary purpose of this test is to ensure tha the pulse/test endpoint accepts data
 ;; of the same format that the pulse GET returns
-(tt/expect-with-temp [Card [card-1]
-                      Card [card-2]]
+(tt/expect-with-temp [Card [card-1 {:dataset_query
+                                    {:database (data/id), :type :query, :query {:source-table (data/id :venues)}}}]
+                      Card [card-2 {:dataset_query
+                                    {:database (data/id), :type :query, :query {:source-table (data/id :venues)}}}]]
   {:response {:ok true}
    :emails   (et/email-to :rasta {:subject "Pulse: A Pulse"
                                   :body    {"A Pulse" true}})}
@@ -917,6 +917,7 @@
             ;; Don't update the pulse, but test the pulse with the updated recipients
             {:response ((user->client :rasta) :post 200 "pulse/test" (assoc result :channels [email-channel]))
              :emails   (et/regex-email-bodies #"A Pulse")}))))))
+
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                         GET /api/pulse/form_input                                              |

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -18,7 +18,6 @@
              [permissions :as perms]
              [permissions-group :as perms-group]
              [table :as table :refer [Table]]]
-            [metabase.query-processor.util :as qputil]
             [metabase.test
              [data :as data]
              [util :as tu :refer [match-$]]]
@@ -691,7 +690,7 @@
 
 (qpt/expect-with-non-timeseries-dbs-except #{:oracle :mongo :redshift :sparksql}
   []
-  (data/with-db (data/get-or-create-database! defs/test-data-with-time)
+  (data/dataset test-data-with-time
     (let [response ((user->client :rasta) :get 200 (format "table/%d/query_metadata" (data/id :users)))]
       (dimension-options-for-field response "last_login_time"))))
 

--- a/test/metabase/automagic_dashboards/comparison_test.clj
+++ b/test/metabase/automagic_dashboards/comparison_test.clj
@@ -12,8 +12,10 @@
             [metabase.test.automagic-dashboards :refer :all]
             [toucan.util.test :as tt]))
 
-(def ^:private segment {:table_id (data/id :venues)
-                        :definition {:filter [:> [:field-id (data/id :venues :price)] 10]}})
+(def ^:private segment
+  (delay
+   {:table_id   (data/id :venues)
+    :definition {:filter [:> [:field-id (data/id :venues :price)] 10]}}))
 
 (defn- test-comparison
   [left right]
@@ -25,14 +27,14 @@
       pos?))
 
 (expect
-  (tt/with-temp* [Segment [{segment-id :id} segment]]
+  (tt/with-temp* [Segment [{segment-id :id} @segment]]
     (with-rasta
       (with-dashboard-cleanup
         (and (test-comparison (Table (data/id :venues)) (Segment segment-id))
              (test-comparison (Segment segment-id) (Table (data/id :venues))))))))
 
 (expect
-  (tt/with-temp* [Segment [{segment1-id :id} segment]
+  (tt/with-temp* [Segment [{segment1-id :id} @segment]
                   Segment [{segment2-id :id} {:table_id (data/id :venues)
                                               :definition {:filter [:< [:field-id (data/id :venues :price)] 4]}}]]
     (with-rasta
@@ -42,7 +44,7 @@
 (expect
   (with-rasta
     (with-dashboard-cleanup
-      (let [q (query/adhoc-query {:query {:filter (-> segment :definition :filter)
+      (let [q (query/adhoc-query {:query {:filter (-> @segment :definition :filter)
                                           :source-table (data/id :venues)}
                                   :type :query
                                   :database (data/id)})]
@@ -50,7 +52,7 @@
 
 (expect
   (tt/with-temp* [Card [{card-id :id} {:table_id      (data/id :venues)
-                                       :dataset_query {:query {:filter (-> segment :definition :filter)
+                                       :dataset_query {:query {:filter (-> @segment :definition :filter)
                                                                :source-table (data/id :venues)}
                                                        :type :query
                                                        :database (data/id)}}]]

--- a/test/metabase/driver/druid_test.clj
+++ b/test/metabase/driver/druid_test.clj
@@ -17,6 +17,7 @@
              [data :as data]
              [util :as tu]]
             [metabase.test.data.datasets :as datasets :refer [expect-with-engine]]
+            [metabase.test.util.log :as tu.log]
             [metabase.timeseries-query-processor-test.util :as tqpt]
             [toucan.util.test :as tt]))
 
@@ -329,7 +330,8 @@
                       :tunnel-enabled true
                       :tunnel-port    22
                       :tunnel-user    "bogus"}]
-      (driver/can-connect-with-details? engine details :rethrow-exceptions))
+      (tu.log/suppress-output
+        (driver/can-connect-with-details? engine details :rethrow-exceptions)))
        (catch Exception e
          (.getMessage e))))
 

--- a/test/metabase/driver/generic_sql/connection_test.clj
+++ b/test/metabase/driver/generic_sql/connection_test.clj
@@ -1,7 +1,9 @@
 (ns metabase.driver.generic-sql.connection-test
   (:require [expectations :refer :all]
             [metabase.driver :as driver]
-            [metabase.test.data :refer :all]))
+            [metabase.test.data :refer :all]
+            [metabase.test.util.log :as tu.log]
+            [metabase.util :as u]))
 
 ;; ## TESTS FOR CAN-CONNECT?
 
@@ -13,14 +15,17 @@
 ;; Lie and say Test DB is Postgres. CAN-CONNECT? should fail
 (expect
   false
-  (driver/can-connect-with-details? :postgres (:details (db))))
+  (tu.log/suppress-output
+    (driver/can-connect-with-details? :postgres (:details (db)))))
 
 ;; Random made-up DBs should fail
 (expect
   false
-  (driver/can-connect-with-details? :postgres {:host "localhost", :port 5432, :dbname "ABCDEFGHIJKLMNOP", :user "rasta"}))
+  (tu.log/suppress-output
+    (driver/can-connect-with-details? :postgres {:host "localhost", :port 5432, :dbname "ABCDEFGHIJKLMNOP", :user "rasta"})))
 
 ;; Things that you can connect to, but are not DBs, should fail
 (expect
   false
-  (driver/can-connect-with-details? :postgres {:host "google.com", :port 80}))
+  (tu.log/suppress-output
+    (driver/can-connect-with-details? :postgres {:host "google.com", :port 80})))

--- a/test/metabase/driver/generic_sql/native_test.clj
+++ b/test/metabase/driver/generic_sql/native_test.clj
@@ -3,7 +3,8 @@
   (:require [expectations :refer :all]
             [medley.core :as m]
             [metabase.query-processor :as qp]
-            [metabase.test.data :as data]))
+            [metabase.test.data :as data]
+            [metabase.test.util.log :as tu.log]))
 
 ;; Just check that a basic query works
 (expect
@@ -38,11 +39,13 @@
       (m/dissoc-in [:data :insights])))
 
 ;; Check that we get proper error responses for malformed SQL
-(expect {:status :failed
-         :class  java.lang.Exception
-         :error  "Column \"ZID\" not found"}
-  (dissoc (qp/process-query {:native   {:query "SELECT ZID FROM CHECKINS LIMIT 2"} ; make sure people know it's to be expected
-                             :type     :native
-                             :database (data/id)})
+(expect
+  {:status :failed
+   :class  java.lang.Exception
+   :error  "Column \"ZID\" not found"}
+  (dissoc (tu.log/suppress-output
+            (qp/process-query {:native   {:query "SELECT ZID FROM CHECKINS LIMIT 2"}
+                               :type     :native
+                               :database (data/id)}))
           :stacktrace
           :query))

--- a/test/metabase/driver/generic_sql_test.clj
+++ b/test/metabase/driver/generic_sql_test.clj
@@ -5,10 +5,10 @@
             [metabase.models
              [field :refer [Field]]
              [table :as table :refer [Table]]]
-            [metabase.test.data :refer :all]
+            [metabase.test.data :as data :refer :all]
             [metabase.test.data.datasets :as datasets]
-            [toucan.db :as db]
-            [metabase.test.data :as data])
+            [metabase.test.util.log :as tu.log]
+            [toucan.db :as db])
   (:import metabase.driver.h2.H2Driver))
 
 (def ^:private users-table      (delay (Table :name "USERS")))
@@ -97,19 +97,20 @@
 ;;; Make sure invalid ssh credentials are detected if a direct connection is possible
 (expect
   #"com.jcraft.jsch.JSchException:"
-  (try (let [engine :postgres
-             details {:ssl false,
-                      :password "changeme",
-                      :tunnel-host "localhost", ;; this test works if sshd is running or not
-                      :tunnel-pass "BOGUS-BOGUS-BOGUS",
-                      :port 5432,
-                      :dbname "test",
-                      :host "localhost",
-                      :tunnel-enabled true,
-                      :tunnel-port 22,
-                      :engine :postgres,
-                      :user "postgres",
-                      :tunnel-user "example"}]
-         (driver/can-connect-with-details? engine details :rethrow-exceptions))
+  (try (let [engine  :postgres
+             details {:ssl            false
+                      :password       "changeme"
+                      :tunnel-host    "localhost" ; this test works if sshd is running or not
+                      :tunnel-pass    "BOGUS-BOGUS-BOGUS"
+                      :port           5432
+                      :dbname         "test"
+                      :host           "localhost"
+                      :tunnel-enabled true
+                      :tunnel-port    22
+                      :engine         :postgres
+                      :user           "postgres"
+                      :tunnel-user    "example"}]
+         (tu.log/suppress-output
+           (driver/can-connect-with-details? engine details :rethrow-exceptions)))
        (catch Exception e
          (.getMessage e))))

--- a/test/metabase/driver/mongo/util_test.clj
+++ b/test/metabase/driver/mongo/util_test.clj
@@ -1,7 +1,8 @@
 (ns metabase.driver.mongo.util-test
   (:require [expectations :refer [expect]]
             [metabase.driver :as driver]
-            [metabase.driver.mongo.util :as mongo-util])
+            [metabase.driver.mongo.util :as mongo-util]
+            [metabase.test.util.log :as tu.log])
   (:import com.mongodb.ReadPreference))
 
 ;; test that people can specify additional connection options like `?readPreference=nearest`
@@ -41,6 +42,7 @@
                    :tunnel-enabled true
                    :tunnel-port    22
                    :tunnel-user    "bogus"}]
-      (driver/can-connect-with-details? engine details :rethrow-exceptions))
+      (tu.log/suppress-output
+        (driver/can-connect-with-details? engine details :rethrow-exceptions)))
        (catch Exception e
          (.getMessage e))))

--- a/test/metabase/driver/oracle_test.clj
+++ b/test/metabase/driver/oracle_test.clj
@@ -5,14 +5,9 @@
             [metabase.driver
              [generic-sql :as sql]
              [oracle :as oracle]]
-            [metabase.models
-             [database :refer [Database]]
-             [setting :as setting]]
-            [metabase.test.data :as data]
-            [metabase.test.data
-             [dataset-definitions :as defs]
-             [datasets :refer [expect-with-engine]]]
-            [metabase.test.util :as tu])
+            [metabase.test.data.datasets :refer [expect-with-engine]]
+            [metabase.test.util :as tu]
+            [metabase.test.util.log :as tu.log])
   (:import metabase.driver.oracle.OracleDriver))
 
 ;; make sure we can connect with an SID
@@ -56,20 +51,21 @@
 
 (expect
   com.jcraft.jsch.JSchException
-  (let [engine :oracle
-        details {:ssl false,
-                 :password "changeme",
-                 :tunnel-host "localhost",
-                 :tunnel-pass "BOGUS-BOGUS-BOGUS",
-                 :port 12345,
-                 :service-name "test",
-                 :sid "asdf",
-                 :host "localhost",
-                 :tunnel-enabled true,
-                 :tunnel-port 22,
-                 :user "postgres",
-                 :tunnel-user "example"}]
-    (#'oracle/can-connect? details)))
+  (let [engine  :oracle
+        details {:ssl            false
+                 :password       "changeme"
+                 :tunnel-host    "localhost"
+                 :tunnel-pass    "BOGUS-BOGUS-BOGUS"
+                 :port           12345
+                 :service-name   "test"
+                 :sid            "asdf"
+                 :host           "localhost"
+                 :tunnel-enabled true
+                 :tunnel-port    22
+                 :user           "postgres"
+                 :tunnel-user    "example"}]
+    (tu.log/suppress-output
+      (#'oracle/can-connect? details))))
 
 (expect-with-engine :oracle
   "UTC"

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -6,7 +6,7 @@
             [metabase
              [driver :as driver]
              [query-processor :as qp]
-             [query-processor-test :refer [rows]]
+             [query-processor-test :refer [rows rows+column-names]]
              [sync :as sync]
              [util :as u]]
             [metabase.driver
@@ -137,7 +137,7 @@
              [3 "ouija_board"]]}
   (-> (data/dataset metabase.driver.postgres-test/dots-in-names
         (data/run-mbql-query objects.stuff))
-      :data (dissoc :cols :native_form :results_metadata :insights)))
+      rows+column-names))
 
 
 ;; Make sure that duplicate column names (e.g. caused by using a FK) still return both columns
@@ -157,15 +157,15 @@
   (-> (data/dataset metabase.driver.postgres-test/duplicate-names
         (data/run-mbql-query people
           {:fields [$name $bird_id->birds.name]}))
-      :data (dissoc :cols :native_form :results_metadata :insights)))
+      rows+column-names))
 
 
 ;;; Check support for `inet` columns
 (i/def-database-definition ^:private ip-addresses
   [["addresses"
-     [{:field-name "ip", :base-type {:native "inet"}}]
-     [[(hsql/raw "'192.168.1.1'::inet")]
-      [(hsql/raw "'10.4.4.15'::inet")]]]])
+    [{:field-name "ip", :base-type {:native "inet"}}]
+    [[(hsql/raw "'192.168.1.1'::inet")]
+     [(hsql/raw "'10.4.4.15'::inet")]]]])
 
 ;; Filtering by inet columns should add the appropriate SQL cast, e.g. `cast('192.168.1.1' AS inet)` (otherwise this
 ;; wouldn't work)

--- a/test/metabase/driver/presto_test.clj
+++ b/test/metabase/driver/presto_test.clj
@@ -10,6 +10,7 @@
              [data :as data]
              [util :as tu]]
             [metabase.test.data.datasets :as datasets]
+            [metabase.test.util.log :as tu.log]
             [toucan.db :as db])
   (:import metabase.driver.presto.PrestoDriver))
 
@@ -137,16 +138,17 @@
   #"com.jcraft.jsch.JSchException:"
   (try
     (let [engine  :presto
-          details {:ssl            false,
-                   :password       "changeme",
-                   :tunnel-host    "localhost",
-                   :tunnel-pass    "BOGUS-BOGUS",
+          details {:ssl            false
+                   :password       "changeme"
+                   :tunnel-host    "localhost"
+                   :tunnel-pass    "BOGUS-BOGUS"
                    :catalog        "BOGUS"
-                   :host           "localhost",
-                   :tunnel-enabled true,
-                   :tunnel-port    22,
+                   :host           "localhost"
+                   :tunnel-enabled true
+                   :tunnel-port    22
                    :tunnel-user    "bogus"}]
-      (driver/can-connect-with-details? engine details :rethrow-exceptions))
+      (tu.log/suppress-output
+        (driver/can-connect-with-details? engine details :rethrow-exceptions)))
     (catch Exception e
       (.getMessage e))))
 

--- a/test/metabase/models/query/permissions_test.clj
+++ b/test/metabase/models/query/permissions_test.clj
@@ -14,7 +14,8 @@
             [metabase.test.data :as data]
             [metabase.test.data.users :as users]
             [metabase.util :as u]
-            [toucan.util.test :as tt]))
+            [toucan.util.test :as tt]
+            [metabase.test.util.log :as tu.log]))
 
 ;;; ---------------------------------------------- Permissions Checking ----------------------------------------------
 
@@ -233,5 +234,6 @@
 ;; invalid/legacy queries should return perms for something that doesn't exist so no one gets to see it
 (expect
   #{"/db/0/"}
-  (query-perms/perms-set (data/mbql-query venues
-                           {:filter [:WOW 100 200]})))
+  (tu.log/suppress-output
+    (query-perms/perms-set (data/mbql-query venues
+                             {:filter [:WOW 100 200]}))))

--- a/test/metabase/task/sync_databases_test.clj
+++ b/test/metabase/task/sync_databases_test.clj
@@ -7,6 +7,7 @@
             [metabase.models.database :refer [Database]]
             [metabase.task.sync-databases :as sync-db]
             [metabase.test.util :as tu]
+            [metabase.test.util.log :as tu.log]
             [metabase.util :as u]
             [metabase.util.date :as du]
             [toucan.db :as db]
@@ -126,14 +127,16 @@
 (expect
   Exception
   (tt/with-temp Database [database {:engine :postgres}]
-    (db/update! Database (u/get-id database)
-      :metadata_sync_schedule "2 CANS PER DAY")))
+    (tu.log/suppress-output
+      (db/update! Database (u/get-id database)
+        :metadata_sync_schedule "2 CANS PER DAY"))))
 
 (expect
   Exception
   (tt/with-temp Database [database {:engine :postgres}]
-    (db/update! Database (u/get-id database)
-      :cache_field_values_schedule "2 CANS PER DAY")))
+    (tu.log/suppress-output
+      (db/update! Database (u/get-id database)
+        :cache_field_values_schedule "2 CANS PER DAY"))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -20,6 +20,7 @@
              [dataset-definitions :as defs]
              [datasets :refer [*driver*]]
              [interface :as i]]
+            [metabase.test.util.log :as tu.log]
             [toucan.db :as db])
   (:import [metabase.test.data.interface DatabaseDefinition TableDefinition]))
 
@@ -286,7 +287,10 @@
                           (or (i/metabase-instance database-definition engine)
                               (create-database! database-definition engine driver)))]
      (try
-       (get-or-create!)
+       ;; it's ok to ignore output here because it's usually the IllegalArgException, and if it fails again we don't
+       ;; suppress it
+       (tu.log/suppress-output
+         (get-or-create!))
        ;; occasionally we'll see an error like
        ;;   java.lang.IllegalArgumentException: No implementation of method: :database->connection-details
        ;;   of protocol: IDriverTestExtensions found for class: metabase.driver.h2.H2Driver

--- a/test/metabase/test/data/datasets.clj
+++ b/test/metabase/test/data/datasets.clj
@@ -6,9 +6,10 @@
             [colorize.core :as color]
             [environ.core :refer [env]]
             [expectations :refer [expect]]
-            (metabase [config :as config]
-                      [driver :as driver]
-                      [plugins :as plugins])
+            [metabase
+             [config :as config]
+             [driver :as driver]
+             [plugins :as plugins]]
             [metabase.test.data.interface :as i]))
 
 ;; When running tests, we need to make sure plugins (i.e., the Oracle JDBC driver) are loaded because otherwise the
@@ -75,6 +76,7 @@
   [engine]
   (try (i/engine (driver/engine->driver engine))
        (catch IllegalArgumentException _
+         (println "Reloading test extensions: (require " (engine->test-extensions-ns-symbol engine) ":reload)")
          (require (engine->test-extensions-ns-symbol engine) :reload)))
   (driver/engine->driver engine))
 

--- a/test/metabase/test/util/log.clj
+++ b/test/metabase/test/util/log.clj
@@ -1,0 +1,44 @@
+(ns metabase.test.util.log
+  "Utils for controlling the logging that goes on when running tests."
+  (:require [clojure.tools.logging :as log]
+            [metabase.util :as u])
+  (:import [org.apache.log4j Level Logger LogManager]
+           [org.apache.commons.io.output NullOutputStream NullWriter]
+           java.io.PrintStream))
+
+(defn do-with-suppressed-output
+  "Impl for `suppress-output` macro; don't use this directly."
+  [f]
+  ;; yes, swapping out *out*/*err*, swapping out System.out/System.err, and setting all the log levels to OFF is
+  ;; really necessary to suppress everyting (!)
+  (let [orig-out         (System/out)
+        orig-err         (System/err)
+        null-stream      (PrintStream. (NullOutputStream.))
+        null-writer      (NullWriter.)
+        loggers          (cons
+                          (Logger/getRootLogger)
+                          (enumeration-seq (LogManager/getCurrentLoggers)))
+        logger+old-level (vec (for [^Logger logger loggers]
+                                [logger (.getLevel logger)]))]
+    (try
+      (System/setOut null-stream)
+      (System/setErr null-stream)
+      (doseq [^Logger logger loggers]
+        (.setLevel logger Level/OFF))
+      (binding [*out* null-writer
+                *err* null-writer]
+        (f))
+      (finally
+        (System/setOut orig-out)
+        (System/setErr orig-err)
+        (.close null-stream)            ; not 100% sure this is necessary
+        (.close null-writer)
+        (doseq [[^Logger logger, ^Level old-level] logger+old-level]
+          (.setLevel logger old-level))))))
+
+(defmacro suppress-output
+  "Execute `body` with all logging/`*out*`/`*err*` messages suppressed. Useful for avoiding cluttering up test output
+  for tests with stacktraces and error messages from tests that are supposed to fail."
+  {:style/indent 0}
+  [& body]
+  `(do-with-suppressed-output (fn [] ~@body)))


### PR DESCRIPTION
We had a few tests that weren't working right, dumping a bunch of stacktraces in the test output. Fix those tests. Also add a new macro, `suppress-output`, to suppress stacktraces and error messages for tests that are suppose to throw Exceptions, which made it hard to notice when things actually went wrong (like the aforementioned bad tests)