### PR TITLE
add scroll to outer container for database / schema selector

### DIFF
--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -714,7 +714,7 @@ export const DatabaseSchemaPicker = ({
   }
 
   return (
-    <div>
+    <div className="scroll-y">
       <AccordianList
         id="DatabaseSchemaPicker"
         key="databaseSchemaPicker"


### PR DESCRIPTION
This is an initial attempt to resolve some of the issues with #8370. One thing I'm running into however is if you've got DBs with schemas mixed in with those that don't and one of those "accordion" sections is open you do get a bit of a funky double scroll bar effect as you try and get to the bottom of the list.