### PR TITLE
restructure visualization settings markup to fix label wrapping

### DIFF
--- a/frontend/src/metabase/query_builder/components/VisualizationSettings.jsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationSettings.jsx
@@ -37,21 +37,15 @@ export default class VisualizationSettings extends React.Component {
     ]);
 
     let triggerElement = (
-      <span className="px2 py1 text-bold cursor-pointer text-default flex align-center">
+      <div className="p1 text-bold cursor-pointer text-default flex align-center">
         <Icon className="mr1" name={CardVisualization.iconName} size={12} />
         {CardVisualization.uiName}
         <Icon className="ml1" name="chevrondown" size={8} />
-      </span>
+      </div>
     );
 
     return (
       <div className="relative">
-        <span
-          className="GuiBuilder-section-label pl0 Query-label"
-          style={{ marginLeft: 4 }}
-        >
-          {t`Visualization`}
-        </span>
         <PopoverWithTrigger
           id="VisualizationPopover"
           ref="displayPopover"
@@ -102,15 +96,18 @@ export default class VisualizationSettings extends React.Component {
     if (this.props.result && this.props.result.error === undefined) {
       const { chartSettings } = this.props.uiControls;
       return (
-        <div className="VisualizationSettings flex align-center">
-          {this.renderChartTypePicker()}
-          <span
-            className="text-brand-hover"
-            data-metabase-event="Query Builder;Chart Settings"
-            onClick={this.open}
-          >
-            <Icon name="gear" />
-          </span>
+        <div className="VisualizationSettings">
+          <div className="pl0 Query-label">{t`Visualization`}</div>
+          <div className="flex align-center">
+            {this.renderChartTypePicker()}
+            <span
+              className="text-brand-hover cursor-pointer"
+              data-metabase-event="Query Builder;Chart Settings"
+              onClick={this.open}
+            >
+              <Icon name="gear" />
+            </span>
+          </div>
           <Modal wide tall isOpen={chartSettings} onClose={this.close}>
             <ChartSettings
               question={this.props.question}


### PR DESCRIPTION
Fixes #8530 

The structure of this was a little odd and rather than treat these elements as two separate rows it was grouping the label and trigger and then the gear as separate columns, which was causing the label to wrap rather than just expand naturally especially when the string length changes as it is want to do when translated.

<img width="531" alt="screen shot 2018-10-29 at 4 03 04 pm" src="https://user-images.githubusercontent.com/5248953/47685572-23f98d00-db94-11e8-94e8-0060013b6724.png">
