### PR TITLE
Could the admin nav bar use a little color?

### DIFF
--- a/frontend/src/metabase/css/admin.css
+++ b/frontend/src/metabase/css/admin.css
@@ -7,7 +7,7 @@
 }
 
 .AdminNav {
-  background: var(--color-accent2);
+  background: var(--color-admin-navbar);
   color: var(--color-text-white);
   font-size: 0.85rem;
 }

--- a/frontend/src/metabase/css/admin.css
+++ b/frontend/src/metabase/css/admin.css
@@ -7,7 +7,7 @@
 }
 
 .AdminNav {
-  background: var(--color-bg-dark);
+  background: var(--color-accent2);
   color: var(--color-text-white);
   font-size: 0.85rem;
 }

--- a/frontend/src/metabase/css/core/colors.css
+++ b/frontend/src/metabase/css/core/colors.css
@@ -10,6 +10,7 @@
   --color-accent5: #f2a86f;
   --color-accent6: #98d9d9;
   --color-accent7: #7172ad;
+  --color-admin-navbar: #7172ad;
   --color-white: #ffffff;
   --color-black: #2e353b;
   --color-success: #84bb4c;

--- a/frontend/src/metabase/lib/colors.js
+++ b/frontend/src/metabase/lib/colors.js
@@ -22,6 +22,7 @@ const colors = {
   accent5: "#F2A86F",
   accent6: "#98D9D9",
   accent7: "#7172AD",
+  "admin-navbar": "#7172AD",
   white: "#FFFFFF",
   black: "#2E353B",
   success: "#84BB4C",


### PR DESCRIPTION
Kyle and I were talking last week about how the admin panel feels somewhat unnecessarily dreary. I tried a few of our colors just for kicks real quick, and `accent2`, our purple, felt kind of interesting because it still helps you immediately tell that you're in the admin area, and it doesn't miscommunicate anything about good/bad status conditions like green/red might.

![screen shot 2018-10-29 at 5 30 32 pm](https://user-images.githubusercontent.com/2223916/47688139-2adacc80-dba1-11e8-8e16-e2423064c206.png)

Using our brand blue felt confusing to me:

![screen shot 2018-10-29 at 5 31 56 pm](https://user-images.githubusercontent.com/2223916/47688189-5cec2e80-dba1-11e8-8589-47d0a8ae44ab.png)
