### PR TITLE
Change query result hashing to convert integers to doubles first

### DIFF
--- a/src/metabase/query_processor/middleware/results_metadata.clj
+++ b/src/metabase/query_processor/middleware/results_metadata.clj
@@ -5,6 +5,7 @@
   (:require [buddy.core.hash :as hash]
             [cheshire.core :as json]
             [clojure.tools.logging :as log]
+            [clojure.walk :as walk]
             [metabase.driver :as driver]
             [metabase.query-processor.interface :as qp.i]
             [metabase.sync.analyze.query-results :as qr]
@@ -22,6 +23,15 @@
     (db/update! 'Card card-id
       :result_metadata metadata)))
 
+(defn- serialize-metadata-for-hashing
+  [metadata]
+  (->> metadata
+       (walk/postwalk (fn [node]
+                        (if (integer? node)
+                          (double node)
+                          node)))
+       json/generate-string))
+
 (defn- metadata-checksum
   "Simple, checksum of the column results METADATA.
    Results metadata is returned as part of all query results, with the hope that the frontend will pass it back to
@@ -37,7 +47,11 @@
    becomes impossible to alter the metadata and produce a correct checksum at any rate."
   [metadata]
   (when metadata
-    (encryption/maybe-encrypt (codec/base64-encode (hash/md5 (json/generate-string metadata))))))
+    (-> metadata
+        serialize-metadata-for-hashing
+        hash/md5
+        codec/base64-encode
+        encryption/maybe-encrypt)))
 
 (defn valid-checksum?
   "Is the CHECKSUM the right one for this column METADATA?"


### PR DESCRIPTION
When the FE returns the query result metadata, any integer values will
be converted to a floating point number. Those doubles hash different
than the original integers which causes the hashes not to match and
the query to be reran when saving the question. This commit just
converts the integer to a double before computing the hash.

Fixes #8824

