### PR TITLE
Ensure queries to compute metadata include user information

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -187,7 +187,7 @@
    This is obviously a bit wasteful so hopefully we can avoid having to do this."
   [query]
   (binding [qpi/*disable-qp-logging* true]
-    (let [{:keys [status], :as results} (qp/process-query query)]
+    (let [{:keys [status], :as results} (qp/process-query-without-save! api/*current-user-id* query)]
       (if (= status :failed)
         (log/error (trs "Error running query to determine Card result metadata:")
                    (u/pprint-to-str 'red results))


### PR DESCRIPTION
When saving a question and the included metadata is incorrect or
different we will execute another query to compute that metadata. This
commit adds the `:info` map needed to include the user and query hash
information we use in the SQL remark.

Fixes #8825
