### PR TITLE
Dropped tables should appear in a schema's data browse page

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -569,7 +569,7 @@
   [id schema]
   (api/read-check Database id)
   (api/check-403 (can-read-schema? id schema))
-  (->> (db/select Table :db_id id, :schema schema, {:order-by [[:name :asc]]})
+  (->> (db/select Table :db_id id, :schema schema, :active true, {:order-by [[:name :asc]]})
        (filter mi/can-read?)
        seq
        api/check-404))

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -766,3 +766,11 @@
     (perms/revoke-permissions! (perms-group/all-users) database-id)
     (perms/grant-permissions!  (perms-group/all-users) database-id "public" table-with-perms)
     (map :name ((user->client :rasta) :get 200 (format "database/%s/schema/%s" database-id "public")))))
+
+;; GET /api/database/:id/schema/:schema should exclude inactive Tables
+(expect
+  ["table"]
+  (tt/with-temp* [Database [{database-id :id}]
+                  Table    [_ {:db_id database-id, :schema "public", :name "table"}]
+                  Table    [_ {:db_id database-id, :schema "public", :name "inactive-table", :active false}]]
+    (map :name ((user->client :rasta) :get 200 (format "database/%s/schema/%s" database-id "public")))))


### PR DESCRIPTION
When the database had only a single schema, the dropped tables were
being hidden correctly. When multiple schemas were present, viewing
those tables their the schema route caused the inactive tables to
appear in the result.

Fixes #8822 fixes #8363

