### PR TITLE
Add a C3P0 exclusion to Quartzite [ci drivers]

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,8 @@
                                commons-io
                                slingshot]]
                  [clj-time "0.13.0"]                                  ; library for dealing with date/time
-                 [clojurewerkz/quartzite "2.0.0"]                     ; scheduling library
+                 [clojurewerkz/quartzite "2.0.0"                      ; scheduling library
+                  :exclusions [c3p0]]
                  [colorize "0.1.1" :exclusions [org.clojure/clojure]] ; string output with ANSI color codes (for logging)
                  [com.amazon.redshift/redshift-jdbc42-no-awssdk       ; Redshift JDBC driver without embedded Amazon SDK
                   "1.2.12.1017"]


### PR DESCRIPTION
Just found out that Quartzite pulls in Quartz, which pulls in C3P0, but under a different groupId than the one we specify. This causes the dependency resolution to include both. On my system, that results in using a very old (2007) version of C3P0, not the one we specify in our project.clj.

This PR adds an exclusion to fix that.