### PR TITLE
Switch from caching estimates to actuals

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -144,7 +144,7 @@
   :profiles {:dev {:dependencies [[clj-http-fake "1.0.3"]             ; Library to mock clj-http responses
                                   [expectations "2.2.0-beta2"]        ; unit tests
                                   [ring/ring-mock "0.3.0"]]           ; Library to create mock Ring requests for unit tests
-                   :plugins [[docstring-checker "1.0.2"]              ; Check that all public vars have docstrings. Run with 'lein docstring-checker'
+                   :plugins [[docstring-checker "1.0.3"]              ; Check that all public vars have docstrings. Run with 'lein docstring-checker'
                              [jonase/eastwood "0.3.1"
                               :exclusions [org.clojure/clojure]]      ; Linting
                              [lein-bikeshed "0.4.1"]                  ; Linting

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -5079,3 +5079,18 @@ databaseChangeLog:
               name: settings
               type: text
               remarks: 'Serialized JSON FE-specific settings like formatting, etc. Scope of what is stored here may increase in future.'
+#
+# Change MySQL/Maria's blob type to LONGBLOB to more closely match what H2 and PostgreSQL support for size limits
+#
+  - changeSet:
+      id: 97
+      author: senior
+      comment: 'Added 0.32.0'
+      preconditions:
+        - onFail: MARK_RAN
+        - dbms: mysql, mariadb
+      changes:
+        - modifyDataType:
+            tableName: query_cache
+            columnName: results
+            newDataType: longblob

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -109,7 +109,9 @@
 (defn compress
   "Compress OBJ, returning a byte array."
   [obj]
-  (nippy/freeze obj {:compressor nippy/snappy-compressor}))
+  (if (bytes? obj)
+    obj
+    (nippy/freeze obj {:compressor nippy/snappy-compressor})))
 
 (defn decompress
   "Decompress COMPRESSED-BYTES."

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -92,13 +92,27 @@
   :type    :boolean
   :default false)
 
+(def ^:private ^:const global-max-caching-kb
+  "Although depending on the database, we can support much larger cached values (1GB for PG, 2GB for H2 and 4GB for
+  MySQL) we are not curretly setup to deal with data of that size. The datatypes we are using will hold this data in
+  memory and will not truly be streaming. This is a global max in order to prevent our users from setting the caching
+  value so high it becomes a performance issue. The value below represents 200MB"
+  (* 200 1024))
+
 (defsetting query-caching-max-kb
   (tru "The maximum size of the cache, per saved question, in kilobytes:")
   ;; (This size is a measurement of the length of *uncompressed* serialized result *rows*. The actual size of
   ;; the results as stored will vary somewhat, since this measurement doesn't include metadata returned with the
   ;; results, and doesn't consider whether the results are compressed, as the `:db` backend does.)
   :type    :integer
-  :default 1000)
+  :default 1000
+  :setter  (fn [new-value]
+             (when (> new-value global-max-caching-kb)
+               (throw (IllegalArgumentException.
+                       (str
+                        (tru "Failed setting `query-caching-max-kb` to {0}." new-value)
+                        (tru "Values greater than {1} are not allowed." global-max-caching-kb)))))
+             (setting/set-integer! :query-caching-max-kb new-value)))
 
 (defsetting query-caching-max-ttl
   (tru "The absolute maximum time to keep any cached query results, in seconds.")

--- a/src/metabase/query_processor/middleware/cache_backend/db.clj
+++ b/src/metabase/query_processor/middleware/cache_backend/db.clj
@@ -1,13 +1,15 @@
 (ns metabase.query-processor.middleware.cache-backend.db
   (:require [clojure.tools.logging :as log]
-            [metabase.models
-             [interface :as models]
-             [query-cache :refer [QueryCache]]]
-            [metabase.public-settings :as public-settings]
+            [metabase
+             [public-settings :as public-settings]
+             [util :as u]]
+            [metabase.models.query-cache :refer [QueryCache]]
             [metabase.query-processor.middleware.cache-backend.interface :as i]
-            [metabase.util :as u]
             [metabase.util.date :as du]
-            [toucan.db :as db]))
+            [taoensso.nippy :as nippy]
+            [toucan.db :as db])
+  (:import [java.io BufferedOutputStream ByteArrayOutputStream DataOutputStream]
+           java.util.zip.GZIPOutputStream))
 
 (defn- cached-results
   "Return cached results for QUERY-HASH if they exist and are newer than MAX-AGE-SECONDS."
@@ -25,10 +27,52 @@
     :updated_at [:<= (du/->Timestamp (- (System/currentTimeMillis)
                                         (* 1000 (public-settings/query-caching-max-ttl))))]))
 
+(defn- throw-if-max-exceeded [max-num-bytes bytes-in-flight]
+  (when (< max-num-bytes bytes-in-flight)
+    (throw (ex-info "Exceeded the max number of bytes" {:type ::max-bytes}))))
 
-(defn- results-below-max-threshold? [compressed-result-bytes]
-  (let [max-bytes (* (public-settings/query-caching-max-kb) 1024)]
-    (> max-bytes (alength compressed-result-bytes))))
+(defn- limited-byte-output-stream
+  "Returns a `FilterOutputStream` that will throw an exception if more than `max-num-bytes` are written to
+  `output-stream`"
+  [max-num-bytes output-stream]
+  (let [bytes-so-far (atom 0)]
+    (proxy [java.io.FilterOutputStream] [output-stream]
+      (write
+        ([byte-or-byte-array]
+         (let [^java.io.OutputStream this this]
+           (if-let [^bytes byte-arr (and (bytes? byte-or-byte-array)
+                                         byte-or-byte-array)]
+             (do
+               (swap! bytes-so-far + (alength byte-arr))
+               (throw-if-max-exceeded max-num-bytes @bytes-so-far)
+               (proxy-super write byte-arr))
+
+             (let [^byte b byte-or-byte-array]
+               (swap! bytes-so-far inc)
+               (throw-if-max-exceeded max-num-bytes @bytes-so-far)
+               (proxy-super write b)))))
+        ([byte-arr offset length]
+         (let [^java.io.OutputStream this this]
+           (swap! bytes-so-far + length)
+           (throw-if-max-exceeded max-num-bytes @bytes-so-far)
+           (proxy-super write byte-arr offset length)))))))
+
+(defn- compress-until-max
+  "Compresses `results` and returns a byte array. If more than `max-bytes` is written, `::exceeded-max-bytes` is
+  returned."
+  [max-bytes results]
+  (try
+    (let [bos  (ByteArrayOutputStream.)
+          lbos (limited-byte-output-stream max-bytes bos)]
+      (with-open [buff-out (BufferedOutputStream. lbos)
+                  gz-out   (GZIPOutputStream. buff-out)
+                  data-out (DataOutputStream. gz-out)]
+        (nippy/freeze-to-out! data-out results))
+      (.toByteArray bos))
+    (catch clojure.lang.ExceptionInfo e
+      (if (= ::max-bytes (:type (ex-data e)))
+        ::exceeded-max-bytes
+        (throw e)))))
 
 (defn- save-results!
   "Save the RESULTS of query with QUERY-HASH, updating an existing QueryCache entry
@@ -36,8 +80,9 @@
   [query-hash results]
   ;; Explicitly compressing the results here rather than having Toucan compress it automatically. This allows us to
   ;; get the size of the compressed output to decide whether or not to store it.
-  (let [compressed-results (models/compress results)]
-    (if (results-below-max-threshold? compressed-results)
+  (let [max-bytes          (* (public-settings/query-caching-max-kb) 1024)
+        compressed-results (compress-until-max max-bytes results)]
+    (if-not (= ::exceeded-max-bytes compressed-results)
       (do
         (purge-old-cache-entries!)
         (or (db/update-where! QueryCache {:query_hash query-hash}

--- a/test/metabase/query_processor/middleware/cache_backend/db_test.clj
+++ b/test/metabase/query_processor/middleware/cache_backend/db_test.clj
@@ -6,11 +6,11 @@
 (defn- in-kb [x]
   (* 1024 x))
 
+;; We should successfully compress data smaller than the max and return the byte array
 (expect
-  (tu/with-temporary-setting-values [query-caching-max-kb 128]
-    (#'cache-db/results-below-max-threshold? (byte-array (in-kb 100)))))
+  (bytes? (#'cache-db/compress-until-max (in-kb 10) (range 1 10))))
 
+;; If the data is more than the max allowed, return `:exceeded-max-bytes`
 (expect
-  false
-  (tu/with-temporary-setting-values [query-caching-max-kb 1]
-    (#'cache-db/results-below-max-threshold? (byte-array (in-kb 2)))))
+  ::cache-db/exceeded-max-bytes
+  (#'cache-db/compress-until-max 10 (repeat 10000 (range 1 10))))

--- a/test/metabase/query_processor/middleware/cache_backend/db_test.clj
+++ b/test/metabase/query_processor/middleware/cache_backend/db_test.clj
@@ -1,0 +1,16 @@
+(ns metabase.query-processor.middleware.cache-backend.db-test
+  (:require [expectations :refer :all]
+            [metabase.query-processor.middleware.cache-backend.db :as cache-db]
+            [metabase.test.util :as tu]))
+
+(defn- in-kb [x]
+  (* 1024 x))
+
+(expect
+  (tu/with-temporary-setting-values [query-caching-max-kb 128]
+    (#'cache-db/results-below-max-threshold? (byte-array (in-kb 100)))))
+
+(expect
+  false
+  (tu/with-temporary-setting-values [query-caching-max-kb 1]
+    (#'cache-db/results-below-max-threshold? (byte-array (in-kb 2)))))

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -54,31 +54,6 @@
   (tu/with-temporary-setting-values [enable-query-caching true]
     (#'cache/is-cacheable? {:cache-ttl nil})))
 
-
-;;; ------------------------------------- results-are-below-max-byte-threshold? --------------------------------------
-
-(expect
-  (tu/with-temporary-setting-values [query-caching-max-kb 128]
-    (#'cache/results-are-below-max-byte-threshold? {:data {:rows [[1 "ABCDEF"]
-                                                                  [3 "GHIJKL"]]}})))
-
-(expect
-  false
-  (tu/with-temporary-setting-values [query-caching-max-kb 1]
-    (#'cache/results-are-below-max-byte-threshold? {:data {:rows (repeat 500 [1 "ABCDEF"])}})))
-
-;; check that `#'cache/results-are-below-max-byte-threshold?` is lazy and fails fast if the query is over the
-;; threshold rather than serializing the entire thing
-(expect
-  false
-  (let [lazy-seq-realized? (atom false)]
-    (tu/with-temporary-setting-values [query-caching-max-kb 1]
-      (#'cache/results-are-below-max-byte-threshold? {:data {:rows (lazy-cat (repeat 500 [1 "ABCDEF"])
-                                                                             (do (reset! lazy-seq-realized? true)
-                                                                                 [2 "GHIJKL"]))}})
-      @lazy-seq-realized?)))
-
-
 ;;; ------------------------------------------ End-to-end middleware tests -------------------------------------------
 
 ;; if there's nothing in the cache, cached results should *not* be returned


### PR DESCRIPTION
This PR does two things. The first is it switches MySQL from BLOB to LONGBLOB. BLOB (what we previously used) will only support 16KB sizes, which is pretty small and caused #7479. `LONGBLOB` can store up to 4GB which allows us to support a baseline size across the three DBs that we support, MySQL (4GB), H2 (2GB) and PostgreSQL (1GB). Although we don't want to store data that size (more discussion on that in the diff) 16KB is too small.

The second thing that it does is switch from using an unrelated estimate of the stringified size of the resultset to determine whether or not the nippy compressed/serialized resultset would be too big. With this PR it checks the actual compressed size. The first commit makes a minimal change to just look at the compressed byte array and determine if it's too big (could cause memory issues) and the second commit switches to a stream that counts the bytes as it goes by. It will stop the compression/serialization process if it exceeds the max amount.

More discussion around limits and some trade-offs in the diffs.