### PR TITLE
Simplify SparkSQL driver; fix nested query support

### DIFF
--- a/test/metabase/driver/bigquery_test.clj
+++ b/test/metabase/driver/bigquery_test.clj
@@ -151,10 +151,11 @@
 ;; alias, e.g. something like `categories__via__category_id`, which is considerably different from what other SQL
 ;; databases do. (#4218)
 (expect-with-engine :bigquery
-  (str "SELECT `test_data.categories__via__category_id`.`name` AS `name`,"
-       " count(*) AS `count` FROM `test_data.venues` "
-       "LEFT JOIN `test_data.categories` `test_data.categories__via__category_id`"
-       " ON `test_data.venues`.`category_id` = `test_data.categories__via__category_id`.`id` "
+  (str "SELECT `categories__via__category_id`.`name` AS `name`,"
+       " count(*) AS `count` "
+       "FROM `test_data.venues` "
+       "LEFT JOIN `test_data.categories` `categories__via__category_id`"
+       " ON `test_data.venues`.`category_id` = `categories__via__category_id`.`id` "
        "GROUP BY `name` "
        "ORDER BY `name` ASC")
   ;; normally for test purposes BigQuery doesn't support foreign keys so override the function that checks that and

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -646,3 +646,22 @@
                       Collection [dest-card-collection]]
         (perms/grant-collection-read-permissions! (group/all-users) source-card-collection)
         (save-card-via-API-with-native-source-query! 403 db source-card-collection dest-card-collection)))))
+
+;; make sure that if we refer to a Field that is actually inside the source query, the QP is smart enough to figure
+;; out what you were referring to and behave appropriately
+(datasets/expect-with-engines (non-timeseries-engines-with-feature :nested-queries)
+  [[10]]
+  (format-rows-by [int]
+    (rows
+      (qp/process-query
+        {:database (data/id)
+         :type     :query
+         :query    {:source-query {:source-table (data/id :venues)
+                                   :fields       [(data/id :venues :id)
+                                                  (data/id :venues :name)
+                                                  (data/id :venues :category_id)
+                                                  (data/id :venues :latitude)
+                                                  (data/id :venues :longitude)
+                                                  (data/id :venues :price)]}
+                    :aggregation  [[:count]]
+                    :filter       [:= [:field-id (data/id :venues :category_id)] 50]}}))))


### PR DESCRIPTION
Stumbled across a weird edge case where certain nested MBQL queries would be compiled to SQL that incorrectly qualified top-level identifiers with the source table of the source query instead of the alias we gave to the source query. Example:

#### WHAT WAS BEING GENERATED (BAD)

```sql
SELECT *
FROM (SELECT * FROM "my_db"."my_table") "source"
ORDER BY "my_db"."my_table"."my_field"
```

#### WHAT SHOULD BE GENERATED (GOOD)

```sql
SELECT *
FROM (SELECT * FROM "my_db"."my_table") "source"
ORDER BY "source"."my_field"
```

Generating these sorts of MBQL queries is not possible on the frontend AFAIK but were generated automatically when applying GTAPs. Fix was simple; I was able to delete a lot of custom code in the SparkSQL driver and instead rely on the "generic" SQL implementation which handled this case correctly.

Added test for all drivers & fixed