### PR TITLE
Code cleanup and i18n fixes

### DIFF
--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -42,8 +42,10 @@
   (let [source-card-id (query->source-card-id query)]
     (api/cancellable-json-response
      (fn []
-       (qp/process-query-and-save-with-max! query {:executed-by api/*current-user-id*, :context :ad-hoc,
-                                                   :card-id     source-card-id,        :nested? (boolean source-card-id)})))))
+       (qp/process-query-and-save-with-max!
+           query
+           {:executed-by api/*current-user-id*, :context :ad-hoc,
+            :card-id     source-card-id,        :nested? (boolean source-card-id)})))))
 
 
 ;;; ----------------------------------- Downloading Query Results in Other Formats -----------------------------------

--- a/src/metabase/api/field.clj
+++ b/src/metabase/api/field.clj
@@ -1,5 +1,9 @@
 (ns metabase.api.field
   (:require [compojure.core :refer [DELETE GET POST PUT]]
+            [metabase
+             [query-processor :as qp]
+             [related :as related]
+             [util :as u]]
             [metabase.api.common :as api]
             [metabase.db.metadata-queries :as metadata]
             [metabase.models
@@ -7,9 +11,6 @@
              [field :as field :refer [Field]]
              [field-values :as field-values :refer [FieldValues]]
              [table :refer [Table]]]
-            [metabase.query-processor :as qp]
-            [metabase.related :as related]
-            [metabase.util :as u]
             [metabase.util.schema :as su]
             [schema.core :as s]
             [toucan

--- a/src/metabase/driver/generic_sql/query_processor.clj
+++ b/src/metabase/driver/generic_sql/query_processor.clj
@@ -34,7 +34,7 @@
   "The outer query currently being processed."
   nil)
 
-(def ^:private ^:dynamic *nested-query-level*
+(def ^:dynamic *nested-query-level*
   "How many levels deep are we into nested queries? (0 = top level.) We keep track of this so we know what level to
   find referenced aggregations (otherwise something like [:aggregation 0] could be ambiguous in a nested query).
   Each nested query increments this counter by 1."

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -23,6 +23,8 @@
             [toucan.db :as db])
   (:import [java.io File IOException]))
 
+(alter-meta! #'stencil.core/render-file assoc :style/indent 1)
+
 ;; Dev only -- disable template caching
 (when config/is-dev?
   (stencil-loader/set-cache (cache/ttl-cache-factory {} :ttl 0)))
@@ -47,7 +49,7 @@
    :link         "https://www.metabase.com/feedback/inactive"})
 
 (defn- follow-up-context []
-  {:heading      (str (trs "We hope you've been enjoying Metabase."))
+  {:heading      (str (trs "We hope you''ve been enjoying Metabase."))
    :callToAction (str (trs "Would you mind taking a fast 6 question survey to tell us how it’s going?"))
    :link         "https://www.metabase.com/feedback/active"})
 
@@ -90,10 +92,9 @@
   {:pre [(map? new-user)]}
   (let [recipients (all-admin-recipients)]
     (email/send-message!
-      :subject      (format (if google-auth?
-                              "%s created a Metabase account"
-                              "%s accepted their Metabase invite")
-                            (:common_name new-user))
+      :subject      (str (if google-auth?
+                           (trs "{0} created a Metabase account"     (:common_name new-user))
+                           (trs "{0} accepted their Metabase invite" (:common_name new-user))))
       :recipients   recipients
       :message-type :html
       :message      (stencil/render-file "metabase/email/user_joined_notification"
@@ -121,7 +122,7 @@
                         :passwordResetUrl password-reset-url
                         :logoHeader       true})]
     (email/send-message!
-      :subject      "[Metabase] Password Reset Request"
+      :subject      (str (trs "[Metabase] Password Reset Request"))
       :recipients   [email]
       :message-type :html
       :message      message-body)))
@@ -160,7 +161,7 @@
                             (random-quote-context))
         message-body (stencil/render-file "metabase/email/notification" context)]
     (email/send-message!
-      :subject      "[Metabase] Notification"
+      :subject      (str (trs "[Metabase] Notification"))
       :recipients   [email]
       :message-type :html
       :message      message-body)))
@@ -169,9 +170,9 @@
   "Format and send an email to the system admin following up on the installation."
   [email msg-type]
   {:pre [(u/email? email) (contains? #{"abandon" "follow-up"} msg-type)]}
-  (let [subject      (if (= "abandon" msg-type)
-                       "[Metabase] Help make Metabase better."
-                       "[Metabase] Tell us how things are going.")
+  (let [subject      (str (if (= "abandon" msg-type)
+                            (trs "[Metabase] Help make Metabase better.")
+                            (trs "[Metabase] Tell us how things are going.")))
         context      (merge notification-context
                             (random-quote-context)
                             (if (= "abandon" msg-type)

--- a/src/metabase/mbql/schema.clj
+++ b/src/metabase/mbql/schema.clj
@@ -492,7 +492,7 @@
 
 ;;; ----------------------------------------------- MBQL [Inner] Query -----------------------------------------------
 
-(declare MBQLQuery)
+(declare Query MBQLQuery)
 
 (def ^:private SourceQuery
   "Schema for a valid value for a `:source-query` clause."
@@ -518,10 +518,10 @@
 
 (def JoinQueryInfo
   "Schema for information about about a JOIN (or equivalent) that should be performed using a recursive MBQL or native
-  query. "
-  {:join-alias su/NonBlankString
-   ;; TODO - put a proper schema in here once I figure out what it is. I think it's (s/recursive #'Query)?
-   :query      s/Any})
+  query."
+  ;; Similar to a `JoinTable` but instead of referencing a table, it references a query expression
+  (assoc JoinTableInfo
+    :query (s/recursive #'Query)))
 
 (def JoinInfo
   "Schema for information about a JOIN (or equivalent) that needs to be performed, either `JoinTableInfo` or

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -56,17 +56,17 @@
       :Segment (extract-ids :segment inner-query)})))
 
 
-;;; -------------------------------------------------- Revisions --------------------------------------------------
+;;; --------------------------------------------------- Revisions ----------------------------------------------------
 
 (defn serialize-instance
   "Serialize a `Card` for use in a `Revision`."
   ([instance]
    (serialize-instance nil nil instance))
   ([_ _ instance]
-   (dissoc instance :created_at :updated_at)))
+   (dissoc instance :created_at :updated_at :result_metadata)))
 
 
-;;; -------------------------------------------------- Lifecycle --------------------------------------------------
+;;; --------------------------------------------------- Lifecycle ----------------------------------------------------
 
 (defn populate-query-fields
   "Lift `database_id`, `table_id`, and `query_type` from query definition."

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -102,6 +102,7 @@
   (assert-not-admin-group permissions)
   (assert-valid-object permissions))
 
+
 ;;; ------------------------------------------------- Path Util Fns --------------------------------------------------
 
 (def ^:private MapOrID
@@ -569,8 +570,10 @@
   [current-revision old new]
   (when *current-user-id*
     (db/insert! PermissionsRevision
-      :id     (inc current-revision) ; manually specify ID here so if one was somehow inserted in the meantime in the fraction of a second
-      :before  old                   ; since we called `check-revision-numbers` the PK constraint will fail and the transaction will abort
+      ;; manually specify ID here so if one was somehow inserted in the meantime in the fraction of a second since we
+      ;; called `check-revision-numbers` the PK constraint will fail and the transaction will abort
+      :id     (inc current-revision)
+      :before  old
       :after   new
       :user_id *current-user-id*)))
 

--- a/src/metabase/models/revision/diff.clj
+++ b/src/metabase/models/revision/diff.clj
@@ -16,6 +16,9 @@
     [:updated_at _ _]
     nil
 
+    [:result_metadata _ _]
+    nil
+
     [:dataset_query _ _]
     "modified the query"
 

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -1,5 +1,5 @@
 (ns metabase.public-settings
-  (:require [clojure.string :as s]
+  (:require [clojure.string :as str]
             [metabase
              [config :as config]
              [types :as types]]
@@ -47,8 +47,8 @@
   (tru "The base URL of this Metabase instance, e.g. \"http://metabase.my-company.com\".")
   :setter (fn [new-value]
             (setting/set-string! :site-url (when new-value
-                                             (cond->> (s/replace new-value #"/$" "")
-                                               (not (s/starts-with? new-value "http")) (str "http://"))))))
+                                             (cond->> (str/replace new-value #"/$" "")
+                                               (not (str/starts-with? new-value "http")) (str "http://"))))))
 
 (defsetting site-locale
   (str  (tru "The default language for this Metabase instance.")

--- a/src/metabase/public_settings/metastore.clj
+++ b/src/metabase/public_settings/metastore.clj
@@ -118,7 +118,7 @@
     (try
       (when (seq new-value)
         (when (s/check ValidToken new-value)
-          (throw (ex-info (tru "Token format is invalid. Token should be 64 hexadecimal characters.")
+          (throw (ex-info (str (tru "Token format is invalid. Token should be 64 hexadecimal characters."))
                    {:status-code 400})))
         (valid-token->features new-value)
         (log/info (trs "Token is valid.")))

--- a/src/metabase/query_processor/middleware/add_query_throttle.clj
+++ b/src/metabase/query_processor/middleware/add_query_throttle.clj
@@ -18,7 +18,7 @@
 
 (defn- throw-503-unavailable
   []
-  (throw (ex-info (tru "Max concurrent query limit reached")
+  (throw (ex-info (str (tru "Max concurrent query limit reached"))
            {:type        ::concurrent-query-limit-reached
             :status-code 503})))
 

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -46,9 +46,12 @@
       (str/replace #"_" "-")
       keyword))
 
+;; TODO - rename this to `get-in-mbql-query-recursive` or something like that?
 (defn get-in-query
-  "Similar to `get-in` but will look in either `:query` or recursively in `[:query :source-query]`. Using
-  this function will avoid having to check if there's a nested query vs. top-level query."
+  "Similar to `get-in` but will look in either `:query` or recursively in `[:query :source-query]`. Using this function
+  will avoid having to check if there's a nested query vs. top-level query. Results in deeper levels of nesting are
+  preferred; i.e. if a key is present in both a `:source-query` and the top-level query, the value from the source
+  query will be returned."
   ([m ks]
    (get-in-query m ks nil))
   ([m ks not-found]

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -571,6 +571,11 @@
    (when-let [[_ java-major-version-str] (re-matches #"^(?:1\.)?(\d+).*$" java-version-str)]
      (>= (Integer/parseInt java-major-version-str) 9))))
 
+(defn hexadecimal-string?
+  "Returns truthy if `new-value` is a hexadecimal-string"
+  [new-value]
+  (and (string? new-value)
+       (re-matches #"[0-9a-f]{64}" new-value)))
 
 (defn snake-key
   "Convert a keyword or string `k` from `lisp-case` to `snake-case`."

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -18,9 +18,9 @@
            [java.text Normalizer Normalizer$Form]
            java.util.concurrent.TimeoutException))
 
-;; This is the very first log message that will get printed.  It's here because this is one of the very first
-;; namespaces that gets loaded, and the first that has access to the logger It shows up a solid 10-15 seconds before
-;; the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
+;; This is the very first log message that will get printed.
+;; It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
+;; It shows up a solid 10-15 seconds before the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
 (log/info (trs "Loading Metabase..."))
 
 ;; Set the default width for pprinting to 200 instead of 72. The default width is too narrow and wastes a lot of space

--- a/src/metabase/util/embed.clj
+++ b/src/metabase/util/embed.clj
@@ -7,12 +7,14 @@
             [cheshire.core :as json]
             [clojure.string :as str]
             [hiccup.core :refer [html]]
+            [metabase
+             [public-settings :as public-settings]
+             [util :as u]]
             [metabase.models.setting :as setting]
-            [metabase.public-settings :as public-settings]
-            [metabase.util.i18n :refer [tru]]
+            [metabase.util.i18n :refer [trs tru]]
             [ring.util.codec :as codec]))
 
-;;; ------------------------------------------------------------ PUBLIC LINKS UTIL FNS ------------------------------------------------------------
+;;; --------------------------------------------- PUBLIC LINKS UTIL FNS ----------------------------------------------
 
 (defn- oembed-url
   "Return an oEmbed URL for the RELATIVE-PATH.
@@ -51,7 +53,7 @@
                   :frameborder 0}]))
 
 
-;;; ------------------------------------------------------------ EMBEDDING UTIL FNS ------------------------------------------------------------
+;;; ----------------------------------------------- EMBEDDING UTIL FNS -----------------------------------------------
 
 (setting/defsetting ^:private embedding-secret-key
   (tru "Secret key used to sign JSON Web Tokens for requests to `/api/embed` endpoints.")
@@ -68,8 +70,9 @@
     (json/parse-string (codecs/bytes->str (codec/base64-decode header)) keyword)))
 
 (defn- check-valid-alg
-  "Check that the JWT `alg` isn't `none`. `none` is valid per the standard, but for obvious reasons we want to make sure our keys are signed.
-   Unfortunately, I don't think there's an easy way to do this with the JWT library we use, so manually parse the token and check the alg."
+  "Check that the JWT `alg` isn't `none`. `none` is valid per the standard, but for obvious reasons we want to make sure
+  our keys are signed. Unfortunately, I don't think there's an easy way to do this with the JWT library we use, so
+  manually parse the token and check the alg."
   [^String message]
   (let [{:keys [alg]} (jwt-header message)]
     (when-not alg
@@ -78,9 +81,9 @@
       (throw (Exception. (str (trs "JWT `alg` cannot be `none`.")))))))
 
 (defn unsign
-  "Parse a \"signed\" (base-64 encoded) JWT and return a Clojure representation.
-   Check that the signature is valid (i.e., check that it was signed with `embedding-secret-key`)
-   and it's otherwise a valid JWT (e.g., not expired), or throw an Exception."
+  "Parse a \"signed\" (base-64 encoded) JWT and return a Clojure representation. Check that the signature is
+  valid (i.e., check that it was signed with `embedding-secret-key`) and it's otherwise a valid JWT (e.g., not
+  expired), or throw an Exception."
   [^String message]
   (when (seq message)
     (try

--- a/test/metabase/automagic_dashboards/comparison_test.clj
+++ b/test/metabase/automagic_dashboards/comparison_test.clj
@@ -1,15 +1,16 @@
 (ns metabase.automagic-dashboards.comparison-test
   (:require [expectations :refer :all]
             [metabase.automagic-dashboards
-             [comparison :refer :all :as c]
+             [comparison :as c :refer :all]
              [core :refer [automagic-analysis]]]
             [metabase.models
              [card :refer [Card]]
              [query :as query]
              [segment :refer [Segment]]
-             [table :refer [Table] :as table]]
-            [metabase.test.data :as data]
-            [metabase.test.automagic-dashboards :refer :all]
+             [table :as table :refer [Table]]]
+            [metabase.test
+             [automagic-dashboards :refer :all]
+             [data :as data]]
             [toucan.util.test :as tt]))
 
 (def ^:private segment

--- a/test/metabase/cmd/load_from_h2_test.clj
+++ b/test/metabase/cmd/load_from_h2_test.clj
@@ -12,8 +12,7 @@
 
 (def ^:private models-to-exclude
   "Models that should *not* be migrated in `load-from-h2`."
-  #{"LegacyQueryExecution"
-    "Query"
+  #{"Query"
     "QueryCache"
     "QueryExecution"})
 

--- a/test/metabase/events/revision_test.clj
+++ b/test/metabase/events/revision_test.clj
@@ -45,8 +45,7 @@
    :cache_ttl              nil
    :query_type             :query
    :table_id               (data/id :categories)
-   :visualization_settings {}
-   :result_metadata        nil})
+   :visualization_settings {}})
 
 (defn- dashboard->revision-object [dashboard]
   {:description  nil

--- a/test/metabase/query_processor/util_test.clj
+++ b/test/metabase/query_processor/util_test.clj
@@ -108,17 +108,6 @@
                         :native      {:query "SELECT pg_sleep(15), 2 AS two"}})))
 
 
-(defrecord ^:private TestRecord1 [x])
-(defrecord ^:private TestRecord2 [x])
-
-(def ^:private test-tree
-  {:a {:aa (TestRecord1. 1)
-       :ab (TestRecord2. 1)}
-   :b (TestRecord1. 1)
-   :c (TestRecord2. 1)
-   :d [1 2 3 4]})
-
-
 (def ^:private test-inner-map
   {:test {:value 10}})
 

--- a/test/metabase/query_processor_test/failure_test.clj
+++ b/test/metabase/query_processor_test/failure_test.clj
@@ -2,8 +2,8 @@
   "Tests for how the query processor as a whole handles failures."
   (:require [expectations :refer [expect]]
             [metabase.query-processor :as qp]
-            [metabase.test.data :as data]
-            [metabase.query-processor.interface :as qp.i])
+            [metabase.query-processor.interface :as qp.i]
+            [metabase.test.data :as data])
   (:import metabase.driver.h2.H2Driver))
 
 (defn- bad-query []


### PR DESCRIPTION
Make sure we wrap `tru`/`trs` calls in `(str ...)` in a few places it was missing. Fix a few single quotes in i18n. Clean some namespace forms. Add some missing i18n tags. Remove some dead code from tests.