### PR TITLE
Add query-perms/can-run-query? helper fn :closed_lock_with_key:

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -20,7 +20,6 @@
              [collection :as collection :refer [Collection]]
              [database :refer [Database]]
              [interface :as mi]
-             [permissions :as perms]
              [pulse :as pulse :refer [Pulse]]
              [query :as query]
              [table :refer [Table]]
@@ -208,6 +207,12 @@
       metadata
       (result-metadata-for-query query))))
 
+(defn check-data-permissions-for-query
+  "Check that we have *data* permissions to run the QUERY in question."
+  [query]
+  {:pre [(map? query)]}
+  (api/check-403 (query-perms/can-run-query? query)))
+
 (api/defendpoint POST "/"
   "Create a new `Card`."
   [:as {{:keys [collection_id collection_position dataset_query description display metadata_checksum name
@@ -221,8 +226,7 @@
    result_metadata        (s/maybe qr/ResultsMetadata)
    metadata_checksum      (s/maybe su/NonBlankString)}
   ;; check that we have permissions to run the query that we're trying to save
-  (api/check-403 (perms/set-has-full-permissions-for-set? @api/*current-user-permissions-set*
-                   (query-perms/perms-set dataset_query)))
+  (check-data-permissions-for-query dataset_query)
   ;; check that we have permissions for the collection we're trying to save this card to, if applicable
   (collection/check-write-perms-for-collection collection_id)
   ;; everything is g2g, now save the card
@@ -248,13 +252,6 @@
 
 
 ;;; ------------------------------------------------- Updating Cards -------------------------------------------------
-
-(defn check-data-permissions-for-query
-  "Check that we have *data* permissions to run the QUERY in question."
-  [query]
-  {:pre [(map? query)]}
-  (api/check-403 (perms/set-has-full-permissions-for-set? @api/*current-user-permissions-set*
-                   (query-perms/perms-set query))))
 
 (defn- check-allowed-to-modify-query
   "If the query is being modified, check that we have data permissions to run the query."

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -6,6 +6,7 @@
             [metabase
              [public-settings :as public-settings]
              [util :as u]]
+            [metabase.api.common :as api :refer [*current-user-id*]]
             [metabase.api.common :as api :refer [*current-user-id* *current-user-permissions-set*]]
             [metabase.mbql.util :as mbql.u]
             [metabase.models
@@ -112,8 +113,7 @@
     ;; Make sure the User saving the Card has the appropriate permissions to run its query. We don't want Users saving
     ;; Cards with queries they wouldn't be allowed to run!
     (when *current-user-id*
-      (when-not (perms/set-has-full-permissions-for-set? @*current-user-permissions-set*
-                  (query-perms/perms-set query :throw-exceptions))
+      (when-not (query-perms/can-run-query? query)
         (throw (Exception. (str (tru "You do not have permissions to run ad-hoc native queries against Database {0}."
                                      (:database query)))))))
     ;; make sure this Card doesn't have circular source query references

--- a/src/metabase/models/query/permissions.clj
+++ b/src/metabase/models/query/permissions.clj
@@ -123,3 +123,9 @@
     (= (keyword query-type) :query)  (mbql-permissions-path-set query throw-exceptions? already-preprocessed?)
     (= (keyword query-type) :native) #{(perms/adhoc-native-query-path database)}
     :else                            (throw (Exception. (str (tru "Invalid query type: {0}" query-type))))))
+
+(s/defn can-run-query?
+  "Return `true` if the current-user has sufficient permissions to run `query`."
+  [query]
+  (let [user-perms @api/*current-user-permissions-set*]
+    (perms/set-has-full-permissions-for-set? user-perms (perms-set query))))


### PR DESCRIPTION
Instead of repeating the rather verbose 

```clj
(perms/set-has-full-permissions-for-set? @api/*current-user-permissions-set*
  (query-perms/perms-set dataset_query))
```