### PR TITLE
Undefined cols, rows, length of data

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings.js
+++ b/frontend/src/metabase/visualizations/lib/settings.js
@@ -129,7 +129,7 @@ function getComputedSetting(
   const settings = { ...storedSettings, ...computedSettings };
 
   try {
-    if (settingDef.getValue) {
+    if (settingDef.getValue && object[0] !== undefined && object[0]['data'] !== undefined) {
       return (computedSettings[settingId] = settingDef.getValue(
         object,
         settings,
@@ -137,13 +137,13 @@ function getComputedSetting(
       ));
     }
 
-    if (storedSettings[settingId] !== undefined) {
+    if (storedSettings[settingId] !== undefined && object[0] !== undefined && object[0]['data'] !== undefined) {
       if (!settingDef.isValid || settingDef.isValid(object, settings, extra)) {
         return (computedSettings[settingId] = storedSettings[settingId]);
       }
     }
 
-    if (settingDef.getDefault) {
+    if (settingDef.getDefault && object[0] !== undefined && object[0]['data'] !== undefined) {
       const defaultValue = settingDef.getDefault(object, settings, extra);
 
       return (computedSettings[settingId] = defaultValue);


### PR DESCRIPTION
With this commit: [fix(settings): add checking on object and data that undefined. It would be traversed from table formatting](https://github.com/metabase/metabase/commit/269c35e8eddd36cf30453892fbf3f4a609903fe2)
I am safe handling undefined object that passed from result to table default formatter/setting. I looked in 0.31 there's much more formatting for table. Therefore I put this safe handler, I experienced some error when fetching data to table

###### Before submitting the PR, please make sure you do the following 
-  [ ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
