### PR TITLE
Adjust to latest AWS experience

### DIFF
--- a/docs/operations-guide/running-metabase-on-elastic-beanstalk.md
+++ b/docs/operations-guide/running-metabase-on-elastic-beanstalk.md
@@ -231,7 +231,7 @@ This will create a new certificate inside your AWS environment which can be reus
 * Click on the blue button **Create Record Set** (a new panel will open up on the right side of the page)
 	* Enter in a **Name**: for your application.  this should be the exact url you plan to access Metabase with.  (e.g. metabase.mycompany.com)
 	* Under the dropdown for **Type**: select *A - IPv4 Address* (sometimes you can also choose CNAME - Canonical name but this may cause more trouble)
-	* In the box labeled **Alias**: choose your elastic bean environment in the drop-down or directly input the full path to your Elastic Beanstalk environment (e.g. mycompany-metabase.elasticbeanstalk.com)
+	* In the box labeled **Alias**: choose your elastic beanstalk environment in the drop-down or directly input the full path to your Elastic Beanstalk environment (e.g. mycompany-metabase.elasticbeanstalk.com)
 	* Leave all other settings in their default values and click the **Create** button at the bottom of the page
 	* NOTE: after the record is created you must wait for your change to propagate on the internet which can take 5-10 minutes, sometimes longer (but usually not more than 30 minutes).
 


### PR DESCRIPTION
In my experience (installed metabase on AWS the November, 16th) :
 * changing the DB type to mysql will result in an error very difficult to diagnose so clearly state that only pgsql is supported (see http://discourse.metabase.com/t/setup-on-aws-beanstalk-with-mysql/4848)
 * routing traffic to port 443 of the EC2 instances does not work for me (and from the NGINX config inside eb.zip, I would say this is normal even if I am not an expert on this area). Also, the final protection against invalid hostname access did not work for me (but I did not change that section because I may have done something wrong)
 * you can use an existing SSL certificate, no need to upload a new one (also, but not done in this change, you should now use the AWS certificate manager instead of AWS CLI I think)
 * using CNAME in Route53 does not work

Finally, I think that sometimes AWS change the load balancer from Classic to Application and in this case some parts do not work but I am unsure about this



###### Before submitting the PR, please make sure you do the following 
-  [ ] If there are changes to the backend codebase, run the backend tests with `lein test && lein eastwood && lein bikeshed && lein docstring-checker && ./bin/reflection-linter`
-  [ ] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
