### PR TITLE
Update pl.po

### DIFF
--- a/locales/pl.po
+++ b/locales/pl.po
@@ -133,7 +133,7 @@ msgstr "Jeśli jesteś pewny, proszę wpisać"
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:53
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:70
 msgid "DELETE"
-msgstr "Usuń"
+msgstr "Delete"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:71
 msgid "in this box:"
@@ -183,7 +183,7 @@ msgstr "Przerwij"
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:123
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Delete"
-msgstr "Uusń"
+msgstr "Delete"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:128
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:76


### PR DESCRIPTION
Unnecessary translation.
It cannot by translated. When deleting database it’s necessary to input “delete” in original spelling. Word it’s not case sensitive.

![2018-11-18 13_51_15-bazy danych admin metabase](https://user-images.githubusercontent.com/39137187/48673342-9086fc80-eb40-11e8-8d7b-1d7e1a47826c.png)
