### PR TITLE
Fix QP include-current behavior for previous/next time intervals

### DIFF
--- a/src/metabase/query_processor/middleware/desugar.clj
+++ b/src/metabase/query_processor/middleware/desugar.clj
@@ -25,6 +25,12 @@
     [:time-interval field :last    unit options] (recur [:time-interval field -1 unit options])
     [:time-interval field :next    unit options] (recur [:time-interval field  1 unit options])
 
+    [:time-interval field (n :guard #{-1}) unit (_ :guard :include-current)]
+    [:between [:datetime-field field unit] [:relative-datetime n unit] [:relative-datetime 0 unit]]
+
+    [:time-interval field (n :guard #{1}) unit (_ :guard :include-current)]
+    [:between [:datetime-field field unit] [:relative-datetime 0 unit] [:relative-datetime n unit]]
+
     [:time-interval field (n :guard #{-1 0 1}) unit _]
     [:= [:datetime-field field unit] [:relative-datetime n unit]]
 

--- a/test/metabase/query_processor/middleware/desugar_test.clj
+++ b/test/metabase/query_processor/middleware/desugar_test.clj
@@ -43,6 +43,65 @@
     :query    {:source-table 1
                :filter       [:time-interval [:field-id 1] 2 :month {:include-current true}]}}))
 
+
+;; `time-interval` with value = 1 or = -1 should generate an `=` clause
+(expect
+  {:database 1
+   :type     :query
+   :query    {:source-table 1
+              :filter       [:=
+                             [:datetime-field [:field-id 1] :month]
+                             [:relative-datetime 1 :month]]}}
+  (desugar
+   {:database 1
+    :type     :query
+    :query    {:source-table 1
+               :filter       [:time-interval [:field-id 1] 1 :month]}}))
+
+(expect
+  {:database 1
+   :type     :query
+   :query    {:source-table 1
+              :filter       [:=
+                             [:datetime-field [:field-id 1] :week]
+                             [:relative-datetime -1 :week]]}}
+  (desugar
+   {:database 1
+    :type     :query
+    :query    {:source-table 1
+               :filter       [:time-interval [:field-id 1] -1 :week]}}))
+
+
+;; test the `include-current` option -- interval with value = 1 or = -1 should generate a `between` clause
+(expect
+  {:database 1
+   :type     :query
+   :query    {:source-table 1
+              :filter       [:between
+                             [:datetime-field [:field-id 1] :month]
+                             [:relative-datetime 0 :month]
+                             [:relative-datetime 1 :month]]}}
+  (desugar
+   {:database 1
+    :type     :query
+    :query    {:source-table 1
+               :filter       [:time-interval [:field-id 1] 1 :month {:include-current true}]}}))
+
+(expect
+  {:database 1
+   :type     :query
+   :query    {:source-table 1
+              :filter       [:between
+                             [:datetime-field [:field-id 1] :day]
+                             [:relative-datetime -1 :day]
+                             [:relative-datetime 0 :day]]}}
+  (desugar
+   {:database 1
+    :type     :query
+    :query    {:source-table 1
+               :filter       [:time-interval [:field-id 1] -1 :day {:include-current true}]}}))
+
+
 ;; test using keywords like `:current`
 (expect
   {:database 1


### PR DESCRIPTION
PR #8274 squashed so we can rebase it against `release-0.31.1` and run CI against it

Fixes #8073