### PR TITLE
Remove runtime resolution of fn that is no longer needed

### DIFF
--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -1,13 +1,13 @@
 (ns metabase.driver.util
   "Utility functions for common operations on drivers."
-  (:require [clojure.tools.logging :as log]
+  (:require [clojure.string :as str]
+            [clojure.tools.logging :as log]
             [metabase
              [config :as config]
              [driver :as driver]
              [util :as u]]
             [metabase.util.i18n :refer [trs]]
-            [toucan.db :as db]
-            [clojure.string :as str]))
+            [toucan.db :as db]))
 
 (def ^:private can-connect-timeout-ms
   "Consider `can-connect?`/`can-connect-with-details?` to have failed after this many milliseconds.

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -3,6 +3,7 @@
             [metabase
              [config :as config]
              [types :as types]]
+            [metabase.driver.util :as driver.u]
             [metabase.models
              [common :as common]
              [setting :as setting :refer [defsetting]]]
@@ -185,9 +186,7 @@
    :enable_query_caching  (enable-query-caching)
    :enable_nested_queries (enable-nested-queries)
    :enable_xrays          (enable-xrays)
-   :engines               (do
-                            (require 'metabase.driver.util)
-                            ((resolve 'metabase.driver.util/available-drivers-info)))
+   :engines               (driver.u/available-drivers-info)
    :ga_code               "UA-60817802-1"
    :google_auth_client_id (setting/get :google-auth-client-id)
    :has_sample_dataset    (db/exists? 'Database, :is_sample true)


### PR DESCRIPTION
The driver reorganization moved some utility functions into a separate utility namespace, fixing a bunch of circular dependencies. Since there's none here anymore we don't need to resolve a function at runtime