### PR TITLE
Make smart scalars smart about previous value

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
@@ -87,7 +87,10 @@ export default class Smart extends React.Component {
       return null;
     }
 
-    const change = formatNumber(insight["last-change"] * 100);
+    const lastChange = insight["last-change"];
+    const previousValue = insight["previous-value"];
+
+    const change = formatNumber(lastChange * 100);
     const isNegative = (change && Math.sign(change) < 0) || false;
 
     let color = isNegative ? colors["error"] : colors["success"];
@@ -160,25 +163,31 @@ export default class Smart extends React.Component {
           />
         )}
         <Box className="SmartWrapper">
-          <Flex align="center" mt={1} flexWrap="wrap">
-            <Flex align="center" color={color}>
-              <Icon name={isNegative ? "arrowDown" : "arrowUp"} />
-              {changeDisplay}
+          {!lastChange || !previousValue ? (
+            <Box
+              color={colors["text-medium"]}
+            >{jt`Nothing to compare for the previous ${granularity}.`}</Box>
+          ) : (
+            <Flex align="center" mt={1} flexWrap="wrap">
+              <Flex align="center" color={color}>
+                <Icon name={isNegative ? "arrowDown" : "arrowUp"} />
+                {changeDisplay}
+              </Flex>
+              <h4
+                id="SmartScalar-PreviousValue"
+                className="flex align-center hide lg-show"
+                style={{
+                  color: colors["text-medium"],
+                }}
+              >
+                {!isFullscreen &&
+                  jt`${separator} was ${formatValue(
+                    previousValue,
+                    settings.column(column),
+                  )} ${granularityDisplay}`}
+              </h4>
             </Flex>
-            <h4
-              id="SmartScalar-PreviousValue"
-              className="flex align-center hide lg-show"
-              style={{
-                color: colors["text-medium"],
-              }}
-            >
-              {!isFullscreen &&
-                jt`${separator} was ${formatValue(
-                  insight["previous-value"],
-                  settings.column(column),
-                )} ${granularityDisplay}`}
-            </h4>
-          </Flex>
+          )}
         </Box>
       </ScalarWrapper>
     );

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
@@ -165,6 +165,7 @@ export default class Smart extends React.Component {
         <Box className="SmartWrapper">
           {!lastChange || !previousValue ? (
             <Box
+              className="text-centered"
               color={colors["text-medium"]}
             >{jt`Nothing to compare for the previous ${granularity}.`}</Box>
           ) : (

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
@@ -165,7 +165,7 @@ export default class Smart extends React.Component {
         <Box className="SmartWrapper">
           {!lastChange || !previousValue ? (
             <Box
-              className="text-centered"
+              className="text-centered text-bold mt1"
               color={colors["text-medium"]}
             >{jt`Nothing to compare for the previous ${granularity}.`}</Box>
           ) : (

--- a/src/metabase/sync/analyze/fingerprint/insights.clj
+++ b/src/metabase/sync/analyze/fingerprint/insights.clj
@@ -135,19 +135,26 @@
   "We downsize UNIX timestamps to lessen the chance of overflows and numerical instabilities."
   #(/ % (* 1000 60 60 24)))
 
-(defn- about-equidistant?
-  [xs]
-  (->> xs
-       (partition 2 1)
-       (map (fn [[a b]]
-              (if (and a b (not= a b))
-                (- b a)
-                Double/POSITIVE_INFINITY)))
-       (partition 2 1)
-       (map (fn [[d1 d2]]
-              (- 1 (/ (min d1 d2)
-                      (max d1 d2)))))
-       (every? (partial > 0.1))))
+(defn- about=
+  [a b]
+  (< 0.9 (/ a b) 1.1))
+
+(def ^:private unit->duration
+  {:minute  (/ 1 24 60)
+   :hour    (/ 24)
+   :day     1
+   :week    7
+   :month   30.5
+   :quarter (* 30.4 3)
+   :year    365.1})
+
+(defn- valid-period?
+  [from to unit]
+  (when (and from to)
+    (let [delta (- to from)]
+      (if unit
+        (about= delta (unit->duration unit))
+        (some (partial about= delta) (vals unit->duration))))))
 
 (defn- timeseries-insight
   [{:keys [numbers datetimes]}]
@@ -165,25 +172,26 @@
                      ;; at this stage in the pipeline the value is still an int, so we can use it
                      ;; directly.
                      (comp (stats/somef ms->day) #(nth % x-position)))]
-    (apply redux/juxt (for [number-col numbers]
-                        (redux/post-complete
-                         (let [y-position (:position number-col)
-                               yfn        #(nth % y-position)]
-                           (redux/juxt ((map yfn) (last-n 2))
-                                       ((map xfn) (last-n 3))
-                                       (stats/simple-linear-regression xfn yfn)
-                                       (best-fit xfn yfn)))
-                         (fn [[[previous current] last-3-timestamps [offset slope] best-fit]]
-                           (let [equidistant? (about-equidistant? last-3-timestamps)]
-                             {:last-value     current
-                              :previous-value (when equidistant?
-                                                previous)
-                              :last-change    (when equidistant?
-                                                (change current previous))
-                              :slope          slope
-                              :offset         offset
-                              :best-fit       best-fit
-                              :col            (:name number-col)})))))))
+    (apply redux/juxt
+           (for [number-col numbers]
+             (redux/post-complete
+              (let [y-position (:position number-col)
+                    yfn        #(nth % y-position)]
+                (redux/juxt ((map yfn) (last-n 2))
+                            ((map xfn) (last-n 2))
+                            (stats/simple-linear-regression xfn yfn)
+                            (best-fit xfn yfn)))
+              (fn [[[y-previous y-current] [x-previous x-current] [offset slope] best-fit]]
+                (let [show-change? (valid-period? x-previous x-current (:unit datetime))]
+                  {:last-value     y-current
+                   :previous-value (when show-change?
+                                     y-previous)
+                   :last-change    (when show-change?
+                                     (change y-current y-previous))
+                   :slope          slope
+                   :offset         offset
+                   :best-fit       best-fit
+                   :col            (:name number-col)})))))))
 
 (defn- datetime-truncated-to-year?
   "This is hackish as hell, but we change datetimes with year granularity to strings upstream and

--- a/test/metabase/sync/analyze/fingerprint/insights_test.clj
+++ b/test/metabase/sync/analyze/fingerprint/insights_test.clj
@@ -38,9 +38,9 @@
 (defn- valid-period?
   ([from to] (valid-period? from to nil))
   ([from to period]
-   (#'i/valid-period? (some-> from (.getTime) (#'i/ms->day))
-                      (some-> to (.getTime) (#'i/ms->day))
-                      period)))
+   (boolean (#'i/valid-period? (some-> from (.getTime) (#'i/ms->day))
+                               (some-> to (.getTime) (#'i/ms->day))
+                               period))))
 
 (expect
   true
@@ -50,7 +50,7 @@
   (valid-period? #inst "2015-02" #inst "2015-03"))
 (expect
   false
-  (valid-period? #inst "2015-01" #inst "2015-04"))
+  (valid-period? #inst "2015-01" #inst "2015-03"))
 (expect
   false
   (valid-period? #inst "2015-01" nil))

--- a/test/metabase/sync/analyze/fingerprint/insights_test.clj
+++ b/test/metabase/sync/analyze/fingerprint/insights_test.clj
@@ -34,29 +34,44 @@
       first
       :last-value))
 
+
+(defn- valid-period?
+  ([from to] (valid-period? from to nil))
+  ([from to period]
+   (#'i/valid-period? (some-> from (.getTime) (#'i/ms->day))
+                      (some-> to (.getTime) (#'i/ms->day))
+                      period)))
+
 (expect
   true
-  (#'i/about-equidistant? [1 2 3]))
+  (valid-period? #inst "2015-01" #inst "2015-02"))
+(expect
+  true
+  (valid-period? #inst "2015-02" #inst "2015-03"))
 (expect
   false
-  (#'i/about-equidistant? [1 2 3 46 7 3]))
+  (valid-period? #inst "2015-01" #inst "2015-04"))
 (expect
   false
-  (#'i/about-equidistant? [1 2 nil 3]))
+  (valid-period? #inst "2015-01" nil))
+(expect
+  true
+  (valid-period? #inst "2015-01-01" #inst "2015-01-02"))
+(expect
+  true
+  (valid-period? #inst "2015-01-01" #inst "2015-01-08"))
+(expect
+  true
+  (valid-period? #inst "2015-01-01" #inst "2015-04-03"))
+(expect
+  true
+  (valid-period? #inst "2015" #inst "2016"))
 (expect
   false
-  (#'i/about-equidistant? [1 2 2 3]))
+  (valid-period? #inst "2015-01-01" #inst "2015-01-09"))
 (expect
   true
-  (#'i/about-equidistant? [1 2]))
+  (valid-period? #inst "2015-01-01" #inst "2015-04-03" :quarter))
 (expect
-  true
-  (#'i/about-equidistant? [1]))
-(expect
-  true
-  (#'i/about-equidistant? []))
-(expect
-  true
-  ;; We want enough leeway that things such as different number of days in a month do not register
-  (#'i/about-equidistant? (for [dt [#inst "2015-01" #inst "2015-02" #inst "2015-03"]]
-                            (#'i/ms->day (.getTime dt)))))
+  false
+  (valid-period? #inst "2015-01-01" #inst "2015-04-03" :month))

--- a/test/metabase/sync/analyze/fingerprint/insights_test.clj
+++ b/test/metabase/sync/analyze/fingerprint/insights_test.clj
@@ -1,6 +1,6 @@
 (ns metabase.sync.analyze.fingerprint.insights-test
   (:require [expectations :refer :all]
-            [metabase.sync.analyze.fingerprint.insights :refer :all]))
+            [metabase.sync.analyze.fingerprint.insights :refer :all :as i]))
 
 (def ^:private cols [{:base_type :type/DateTime} {:base_type :type/Number}])
 
@@ -33,3 +33,30 @@
   (-> (transduce identity (insights cols) [[nil nil]])
       first
       :last-value))
+
+(expect
+  true
+  (#'i/about-equidistant? [1 2 3]))
+(expect
+  false
+  (#'i/about-equidistant? [1 2 3 46 7 3]))
+(expect
+  false
+  (#'i/about-equidistant? [1 2 nil 3]))
+(expect
+  false
+  (#'i/about-equidistant? [1 2 2 3]))
+(expect
+  true
+  (#'i/about-equidistant? [1 2]))
+(expect
+  true
+  (#'i/about-equidistant? [1]))
+(expect
+  true
+  (#'i/about-equidistant? []))
+(expect
+  true
+  ;; We want enough leeway that things such as different number of days in a month do not register
+  (#'i/about-equidistant? (for [dt [#inst "2015-01" #inst "2015-02" #inst "2015-03"]]
+                            (#'i/ms->day (.getTime dt)))))


### PR DESCRIPTION
Adds check if what we're comparing seems like 2 consecutive values, and if not, returns nil, rather than  :previous-value and :last-change

We check if values are consecutive, by storing the last two x values (time offsets) and checking if the difference between them is about (+/- 10%) the same as one of the expected time intervals (day, month, week, ...). 

Not sure about the fudge factor. 10% is the minimum so that January (31 days) vs February (28) goes through, but I could see going for a higher value to be more lenient of lazy SQL such as:
```
select count(*), min(my_date) from my_table group by year(my_date), month(my_date)
``` 

Needs frontend loving (mostly how to present this, the implementation is trivial).