### PR TITLE
Fix currency formatting of negative numbers when currency_in_header = true

### DIFF
--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -124,7 +124,8 @@ const getDayFormat = options =>
 const RANGE_SEPARATOR = ` – `;
 
 // for extracting number portion from a formatted currency string
-const NUMBER_REGEX = /[\+\-]?[0-9\., ]+/;
+// NOTE: match minus/plus and number separately to handle interposed currency symbol -$1.23
+const NUMBER_REGEX = /([\+\-])?[^0-9]*([0-9\., ]+)/;
 
 const DEFAULT_NUMBER_SEPARATORS = ".,";
 
@@ -190,7 +191,7 @@ export function formatNumber(number: number, options: FormattingOptions = {}) {
       ) {
         const match = formatted.match(NUMBER_REGEX);
         if (match) {
-          formatted = match[0].trim();
+          formatted = (match[1] || "").trim() + (match[2] || "").trim();
         }
       }
 

--- a/frontend/test/lib/formatting.unit.spec.js
+++ b/frontend/test/lib/formatting.unit.spec.js
@@ -52,6 +52,44 @@ describe("formatting", () => {
       expect(formatNumber(1.111)).toEqual("1.11");
       expect(formatNumber(111.111)).toEqual("111.11");
     });
+
+    describe("number_style = currency", () => {
+      it("should handle positive currency", () => {
+        expect(
+          formatNumber(1.23, { number_style: "currency", currency: "USD" }),
+        ).toBe("$1.23");
+      });
+
+      it("should handle negative currency", () => {
+        expect(
+          formatNumber(-1.23, { number_style: "currency", currency: "USD" }),
+        ).toBe("-$1.23");
+      });
+
+      describe("with currency_in_header = true and type = cell", () => {
+        it("should handle positive currency", () => {
+          expect(
+            formatNumber(1.23, {
+              number_style: "currency",
+              currency: "USD",
+              currency_in_header: true,
+              type: "cell",
+            }),
+          ).toBe("1.23");
+        });
+
+        it("should handle negative currency", () => {
+          expect(
+            formatNumber(-1.23, {
+              number_style: "currency",
+              currency: "USD",
+              currency_in_header: true,
+              type: "cell",
+            }),
+          ).toBe("-1.23");
+        });
+      });
+    });
   });
 
   describe("formatValue", () => {


### PR DESCRIPTION
Resolves #8968

We should probably include this in 0.31.2 as well.