### PR TITLE
Cache Slack files-channel to avoid rate limiting :floppy_disk:

### DIFF
--- a/src/metabase/integrations/slack.clj
+++ b/src/metabase/integrations/slack.clj
@@ -1,17 +1,19 @@
 (ns metabase.integrations.slack
   (:require [cheshire.core :as json]
             [clj-http.client :as http]
+            [clojure.core.memoize :as memoize]
             [clojure.java.io :as io]
             [clojure.tools.logging :as log]
             [metabase.models.setting :as setting :refer [defsetting]]
+            [metabase.util :as u]
             [metabase.util.i18n :refer [tru]]
-            [metabase.util :as u]))
+            [metabase.config :as config]))
 
 ;; Define a setting which captures our Slack api token
 (defsetting slack-token (tru "Slack API bearer token obtained from https://api.slack.com/web#authentication"))
 
-(def ^:private ^:const ^String slack-api-base-url "https://slack.com/api")
-(def ^:private ^:const ^String files-channel-name "metabase_files")
+(def ^:private ^String slack-api-base-url "https://slack.com/api")
+(def ^:private ^String files-channel-name "metabase_files")
 
 (defn slack-configured?
   "Is Slack integration configured?"
@@ -59,13 +61,28 @@
                         channel))
         (channels-list :exclude_archived false)))
 
-(defn files-channel
-  "Calls Slack api `channels.info` to check whether a channel named #metabase_files exists. If it doesn't,
-   throws an error that advices an admin to create it."
-  []
+(defn- files-channel* []
+  (println "(maybe-get-files-channel):" (maybe-get-files-channel)) ; NOCOMMIT
   (or (maybe-get-files-channel)
       (do (log/error (u/format-color 'red channel-missing-msg))
           (throw (ex-info channel-missing-msg {:status-code 400})))))
+
+(def ^{:arglists '([])} files-channel
+  "Calls Slack api `channels.info` to check whether a channel named #metabase_files exists. If it doesn't, throws an
+  error that advices an admin to create it."
+  ;; If the channel has successfully been created we can cache the information about it from the API response. We need
+  ;; this information every time we send out a pulse, but making a call to the `channels.list` endpoint everytime we
+  ;; send a Pulse can result in us seeing 429 (rate limiting) status codes -- see
+  ;; https://github.com/metabase/metabase/issues/8967
+  ;;
+  ;; Of course, if `files-channel*` *fails* (because the channel is not created), this won't get cached; this is what
+  ;; we want -- to remind people to create it
+  (if config/is-test?
+    ;; don't cache the channel when running tests, because we don't actually hit the Slack API, and we don't want one
+    ;; test causing their "fake" channel to get cached and mess up other tests
+    files-channel*
+    (let [six-hours-ms (* 6 60 60 1000)]
+      (memoize/ttl files-channel* :ttl/threshold six-hours-ms))))
 
 
 (defn upload-file!


### PR DESCRIPTION
I think the main reason something like #8967 was happening is that we were running out of memory in Heroku so it would retry sending the Slack pulse a few times, repeatedly hitting the Slack API. The OOM should now be fixed.

Either way we don't need to fetch the entire list of Slack channels every time we send a pulse. We do still need to know information about the `metabase_files` channel, so fetch the info once and cache it for six hours. Reduces number of Slack API calls needed to send a Pulse by 50%

Fixed #8967