### PR TITLE
Don't log info messages or async load Liquibase during compilation

### DIFF
--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -215,7 +215,8 @@
 (def ^{:arglists '([])} ^DatabaseFactory database-factory
   "Return an instance of the Liquibase `DatabaseFactory`. This is done on a background thread at launch because
   otherwise it adds 2 seconds to startup time."
-  (partial deref (future (DatabaseFactory/getInstance))))
+  (when-not *compile-files*
+    (partial deref (future (DatabaseFactory/getInstance)))))
 
 (defn- conn->liquibase
   "Get a `Liquibase` object from JDBC CONN."

--- a/src/metabase/integrations/slack.clj
+++ b/src/metabase/integrations/slack.clj
@@ -62,7 +62,6 @@
         (channels-list :exclude_archived false)))
 
 (defn- files-channel* []
-  (println "(maybe-get-files-channel):" (maybe-get-files-channel)) ; NOCOMMIT
   (or (maybe-get-files-channel)
       (do (log/error (u/format-color 'red channel-missing-msg))
           (throw (ex-info channel-missing-msg {:status-code 400})))))

--- a/src/metabase/task/task_history_cleanup.clj
+++ b/src/metabase/task/task_history_cleanup.clj
@@ -11,9 +11,9 @@
             [puppetlabs.i18n.core :refer [trs]]
             [toucan.db :as db]))
 
-(def ^:private ^:const job-name    "task-history-cleanup")
-(def ^:private ^:const job-key     (format "metabase.task.%s.job" job-name))
-(def ^:private ^:const trigger-key (format "metabase.task.%s.trigger" job-name))
+(def ^:private job-name    "task-history-cleanup")
+(def ^:private job-key     (format "metabase.task.%s.job" job-name))
+(def ^:private trigger-key (format "metabase.task.%s.trigger" job-name))
 
 (defonce ^:private job     (atom nil))
 (defonce ^:private trigger (atom nil))

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -21,15 +21,17 @@
 ;; This is the very first log message that will get printed.
 ;; It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
 ;; It shows up a solid 10-15 seconds before the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
-(log/info (trs "Loading Metabase..."))
+(when-not *compile-files*
+  (log/info (trs "Loading Metabase...")))
 
 ;; Log the maximum memory available to the JVM at launch time as well since it is very handy for debugging things
-(log/info (trs "Maximum memory available to JVM: {0}"
-               (loop [mem (.maxMemory (Runtime/getRuntime)), [suffix & more] ["B" "KB" "MB" "GB"]]
-                 (if (and (seq more)
-                          (>= mem 1024))
-                   (recur (/ mem 1024.0) more)
-                   (format "%.1f %s" mem suffix)))))
+(when-not *compile-files*
+  (log/info (trs "Maximum memory available to JVM: {0}"
+                 (loop [mem (.maxMemory (Runtime/getRuntime)), [suffix & more] ["B" "KB" "MB" "GB"]]
+                   (if (and (seq more)
+                            (>= mem 1024))
+                     (recur (/ mem 1024.0) more)
+                     (format "%.1f %s" mem suffix))))))
 
 ;; Set the default width for pprinting to 200 instead of 72. The default width is too narrow and wastes a lot of space
 ;; for pprinting huge things like expanded queries

--- a/src/metabase/util/encryption.clj
+++ b/src/metabase/util/encryption.clj
@@ -31,14 +31,15 @@
       (secret-key->hash secret-key))))
 
 ;; log a nice message letting people know whether DB details encryption is enabled
-(log/info
- (if default-secret-key
-   (trs "Saved credentials encryption is ENABLED for this Metabase instance.")
-   (trs "Saved credentials encryption is DISABLED for this Metabase instance."))
- (u/emoji (if default-secret-key "🔐" "🔓"))
- "\n"
- (trs "For more information, see")
- "https://www.metabase.com/docs/latest/operations-guide/start.html#encrypting-your-database-connection-details-at-rest")
+(when-not *compile-files*
+  (log/info
+   (if default-secret-key
+     (trs "Saved credentials encryption is ENABLED for this Metabase instance.")
+     (trs "Saved credentials encryption is DISABLED for this Metabase instance."))
+   (u/emoji (if default-secret-key "🔐" "🔓"))
+   "\n"
+   (trs "For more information, see")
+   "https://www.metabase.com/docs/latest/operations-guide/start.html#encrypting-your-database-connection-details-at-rest"))
 
 (defn encrypt
   "Encrypt string `s` as hex bytes using a `secret-key` (a 64-byte byte array), by default the hashed value of


### PR DESCRIPTION
There are a few things that are only need to happen during runtime like loading Liquibase (done asychronously to speed up launch) or logging the "Starting Metabase" message. Check if we're compiling the uberjar and skip these if logging messages if we are.

Also: don't try to run sync tasks for Databases that no longer exist (previously caused a warning but didn't affect anything)