### PR TITLE
Warn on Postgres conn str w/ ssl=true but not sslmode=require :warning:

### DIFF
--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -55,18 +55,28 @@
   return a broken-out map."
   [uri]
   (when-let [[_ _ protocol user pass host port db query] (re-matches jdbc-connection-regex uri)]
-    (merge {:type     (case (keyword protocol)
-                        :postgres   :postgres
-                        :postgresql :postgres
-                        :mysql      :mysql)
-            :user     user
-            :password pass
-            :host     host
-            :port     port
-            :dbname   db}
-           (some-> query
-                   codec/form-decode
-                   walk/keywordize-keys))))
+    (u/prog1 (merge {:type     (case (keyword protocol)
+                                 :postgres   :postgres
+                                 :postgresql :postgres
+                                 :mysql      :mysql)
+                     :user     user
+                     :password pass
+                     :host     host
+                     :port     port
+                     :dbname   db}
+                    (some-> query
+                            codec/form-decode
+                            walk/keywordize-keys))
+      ;; If someone is using Postgres and specifies `ssl=true` they might need to specify `sslmode=require`. Let's let
+      ;; them know about that to make their lives a little easier. See https://github.com/metabase/metabase/issues/8908
+      ;; for more details.
+      (when (and (= (:type <>) :postgres)
+                 (= (:ssl <>) "true")
+                 (not (:sslmode <>)))
+        (log/warn (trs "Warning: Postgres connection string with `ssl=true` detected.")
+                  (trs "You may need to add `?sslmode=require` to your application DB connection string.")
+                  (trs "If Metabase fails to launch, please add it and try again.")
+                  (trs "See https://github.com/metabase/metabase/issues/8908 for more details."))))))
 
 (def ^:private connection-string-details
   (delay (when-let [uri (config/config-str :mb-db-connection-uri)]

--- a/test/metabase/db_test.clj
+++ b/test/metabase/db_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.db-test
   (:require [expectations :refer [expect]]
-            [metabase.db :as mdb]))
+            [metabase.db :as mdb]
+            [metabase.test.util.log :as tu.log]))
 
 ;; parse minimal connection string
 (expect
@@ -16,12 +17,14 @@
 (expect
   {:type :postgres, :user "tom", :password "1234", :host "localhost", :port "5432", :dbname "toms_cool_db",
    :ssl "true", :sslfactory "org.postgresql.ssl.NonValidatingFactory"}
-  (#'mdb/parse-connection-string (str "postgres://tom:1234@localhost:5432/toms_cool_db"
-                                      "?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory")))
+  (tu.log/suppress-output
+    (#'mdb/parse-connection-string (str "postgres://tom:1234@localhost:5432/toms_cool_db"
+                                        "?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory"))))
 
 ;; the leading "jdbc" found in driver JDBC docs should be ignored
 (expect
   {:type :postgres, :user "tom", :password "1234", :host "localhost", :port "5432", :dbname "toms_cool_db",
    :ssl "true", :sslfactory "org.postgresql.ssl.NonValidatingFactory"}
-  (#'mdb/parse-connection-string (str "jdbc:postgres://tom:1234@localhost:5432/toms_cool_db"
-                                      "?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory")))
+  (tu.log/suppress-output
+    (#'mdb/parse-connection-string (str "jdbc:postgres://tom:1234@localhost:5432/toms_cool_db"
+                                        "?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory"))))


### PR DESCRIPTION
Sometimes you need to add `?sslmode=require` to your Postgres connection string if you use `?ssl=true`. Not sure why. Print a message so people who aren't doing this know to do so

Resolves #8908 