### PR TITLE
Remove unnecessary Dashboard CSS 

### DIFF
--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -1,8 +1,3 @@
-.Dashboard {
-  background-color: var(--color-bg-light);
-  min-height: 100vh;
-}
-
 .DashboardHeader {
   background-color: white;
   border-bottom: var(--border-size) var(--border-style) var(--color-border);


### PR DESCRIPTION
Addresses #7903 

I believe this height declaration was [originally added](https://github.com/metabase/metabase/commit/ac4c6da3ab680e95398ed2566877d2682a123123#diff-dd6ee8ddd7f0d9f7dcc2f143f6e6758fR6) to get the background of dashboards to fill the viewport if there wasn't enough dash content to stretch the `.Dashboard` container, but since we moved to managing colors like that using `withBackground` that's no longer needed. Should fix the issues people have run into with `iframe-resizer` as noted in the original issue.