### PR TITLE
Variables in text cards [prototype]

### DIFF
--- a/frontend/src/metabase/dashboard/components/AddSeriesModal.jsx
+++ b/frontend/src/metabase/dashboard/components/AddSeriesModal.jsx
@@ -92,7 +92,7 @@ export default class AddSeriesModal extends Component {
     if (card.display === "text") {
       return { rows: [], cols: [], columns: [] };
     }
-    return getIn(this.props.dashcardData, [dashcard.id, card.id]).data;
+    return getIn(this.props.dashcardData, [dashcard.id, card.id, "data"]);
   }
 
   async onCardChange(card, e) {

--- a/frontend/src/metabase/dashboard/components/AddSeriesModal.jsx
+++ b/frontend/src/metabase/dashboard/components/AddSeriesModal.jsx
@@ -88,6 +88,13 @@ export default class AddSeriesModal extends Component {
     this.setState({ searchValue: e.target.value.toLowerCase() });
   }
 
+  getDashcardData(dashcard, card) {
+    if (card.display === "text") {
+      return { rows: [], cols: [], columns: [] };
+    }
+    return getIn(this.props.dashcardData, [dashcard.id, card.id]).data;
+  }
+
   async onCardChange(card, e) {
     const { dashcard, dashcardData } = this.props;
     let { CardVisualization } = getVisualizationRaw([{ card: dashcard.card }]);
@@ -100,18 +107,12 @@ export default class AddSeriesModal extends Component {
             clear: true,
           });
         }
-        let sourceDataset = getIn(this.props.dashcardData, [
-          dashcard.id,
-          dashcard.card.id,
-        ]);
-        let seriesDataset = getIn(this.props.dashcardData, [
-          dashcard.id,
-          card.id,
-        ]);
+        let sourceData = this.getDashcardData(dashcard, dashcard.card);
+        let seriesData = this.getDashcardData(dashcard, card);
         if (
           CardVisualization.seriesAreCompatible(
-            { card: dashcard.card, data: sourceDataset.data },
-            { card: card, data: seriesDataset.data },
+            { card: dashcard.card, data: sourceData },
+            { card: card, data: seriesData },
           )
         ) {
           this.setState({
@@ -241,7 +242,7 @@ export default class AddSeriesModal extends Component {
       .concat(this.state.series)
       .map(card => ({
         card: card,
-        data: getIn(dashcardData, [dashcard.id, card.id, "data"]),
+        data: this.getDashcardData(dashcard, card),
       }))
       .filter(s => !!s.data);
 

--- a/frontend/src/metabase/dashboard/dashboard.js
+++ b/frontend/src/metabase/dashboard/dashboard.js
@@ -380,11 +380,10 @@ export const fetchDashboardCardData = createThunkAction(
     if (dashboard) {
       for (const dashcard of dashboard.ordered_cards) {
         // we skip over virtual cards, i.e. dashcards that do not have backing cards in the backend
-        if (_.isObject(dashcard.visualization_settings.virtual_card)) {
-          continue;
+        if (!_.isObject(dashcard.visualization_settings.virtual_card)) {
+          dispatch(fetchCardData(dashcard.card, dashcard, options));
         }
-        const cards = [dashcard.card].concat(dashcard.series || []);
-        for (const card of cards) {
+        for (const card of (dashcard.series || [])) {
           dispatch(fetchCardData(card, dashcard, options));
         }
       }


### PR DESCRIPTION
Prototype implementation of #9080 

Currently instead of using question IDs as the variables you have to add an additional question (edit a dashboard then click the "+Edit" button, then use the index of the additional questions, starting at 0, e.x. `foo = {{1}}` for the first additional question.