### PR TITLE
Piechart with no results on dashboard should display No Results instead of asking which columns need to be used

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
@@ -7,7 +7,7 @@ import { t } from "c-3po";
 import ChartTooltip from "../components/ChartTooltip.jsx";
 import ChartWithLegend from "../components/ChartWithLegend.jsx";
 
-import { ChartSettingsError } from "metabase/visualizations/lib/errors";
+import { ChartSettingsError, MinRowsError } from "metabase/visualizations/lib/errors";
 import { getFriendlyName } from "metabase/visualizations/lib/utils";
 import {
   metricSetting,
@@ -49,6 +49,11 @@ export default class PieChart extends Component {
   }
 
   static checkRenderable([{ data: { cols, rows } }], settings) {
+    // This prevents showing "Which columns do you want to use" when
+    // the piechart is displayed with no results in the dashboard
+    if (rows.length < 1) {
+      throw new MinRowsError(1, 0);
+    }
     if (!settings["pie.dimension"] || !settings["pie.metric"]) {
       throw new ChartSettingsError(t`Which columns do you want to use?`, {
         section: `Data`,


### PR DESCRIPTION
For SQL-based Pie Charts displayed on the dashboard, not having any results displays a "Which columns do you want to use?"

![proddash1](https://user-images.githubusercontent.com/395294/49659904-41333e00-fa13-11e8-9288-55575bff7f2c.PNG)

![proddash2](https://user-images.githubusercontent.com/395294/49659922-47291f00-fa13-11e8-89d7-0f0bb5ccc234.PNG)

With the fix, this is what it displays on no results. This is in line with behavior of the other visualizations.

![proddash3](https://user-images.githubusercontent.com/395294/49659952-61fb9380-fa13-11e8-8e44-7a5a9195130f.PNG)





-  [x] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [x] Sign the [Contributor License Agreement]