### PR TITLE
xray i18n fixes

### DIFF
--- a/resources/automagic_dashboards/comparison/Country.yaml
+++ b/resources/automagic_dashboards/comparison/Country.yaml
@@ -1,5 +1,5 @@
 title: A look at your [[this]]
-transient_title: Here's an overview of your [[this]]
+transient_title: Here''s an overview of your [[this]]
 description: How [[this]] is distributed and more.
 applies_to: GenericTable.Country
 metrics:

--- a/resources/automagic_dashboards/comparison/FK.yaml
+++ b/resources/automagic_dashboards/comparison/FK.yaml
@@ -1,5 +1,5 @@
 title: A look at your [[this]]
-transient_title: Here's an overview of your [[this]]
+transient_title: Here''s an overview of your [[this]]
 description: How [[this]] is distributed and more.
 applies_to: GenericTable.FK
 metrics:

--- a/resources/automagic_dashboards/comparison/GenericField.yaml
+++ b/resources/automagic_dashboards/comparison/GenericField.yaml
@@ -1,5 +1,5 @@
 title: A look at your [[this]]
-transient_title: Here's an overview of your [[this]]
+transient_title: Here''s an overview of your [[this]]
 description: How [[this]] is distributed and more.
 applies_to: GenericTable.*
 metrics:

--- a/resources/automagic_dashboards/comparison/State.yaml
+++ b/resources/automagic_dashboards/comparison/State.yaml
@@ -1,5 +1,5 @@
 title: A look at your [[this]]
-transient_title: Here's an overview of your [[this]]
+transient_title: Here''s an overview of your [[this]]
 description: How [[this]] is distributed and more.
 applies_to: GenericTable.State
 metrics:

--- a/resources/automagic_dashboards/field/Country.yaml
+++ b/resources/automagic_dashboards/field/Country.yaml
@@ -1,5 +1,5 @@
 title: A look at your [[this]]
-transient_title: Here's a closer look at your [[this]] field
+transient_title: Here''s a closer look at your [[this]] field
 description: The number of [[GenericTable]] per country, and how each country is represented in different categories.
 applies_to: GenericTable.Country
 metrics:

--- a/resources/automagic_dashboards/field/DateTime.yaml
+++ b/resources/automagic_dashboards/field/DateTime.yaml
@@ -1,5 +1,5 @@
 title: A look at your [[this]]
-transient_title: Here's a closer look at your [[this]]
+transient_title: Here''s a closer look at your [[this]]
 description: How [[GenericTable]] are distributed across this time field, and if it has any seasonal patterns.
 applies_to: GenericTable.DateTime
 metrics:

--- a/resources/automagic_dashboards/field/GenericField.yaml
+++ b/resources/automagic_dashboards/field/GenericField.yaml
@@ -1,5 +1,5 @@
 title: A look at your [[this]]
-transient_title: Here's an overview of your [[this]]
+transient_title: Here''s an overview of your [[this]]
 description: A look at [[GenericTable]] across your [[this]], and how it changes over time.
 applies_to: GenericTable.*
 metrics:

--- a/resources/automagic_dashboards/field/State.yaml
+++ b/resources/automagic_dashboards/field/State.yaml
@@ -1,5 +1,5 @@
 title: A look at your [[this]]
-transient_title: Here's an overview of your [[this]]
+transient_title: Here''s an overview of your [[this]]
 description: How many [[GenericTable]] there are per state, and how each state is represented across other categories.
 applies_to: GenericTable.State
 metrics:

--- a/resources/automagic_dashboards/metric/GenericMetric.yaml
+++ b/resources/automagic_dashboards/metric/GenericMetric.yaml
@@ -1,6 +1,6 @@
 title: A look at the [[this]]
-transient_title: Here's a quick look at the [[this]]
-description: How it's distributed across time and other categories.
+transient_title: Here''s a quick look at the [[this]]
+description: How it''s distributed across time and other categories.
 applies_to: GenericTable
 metrics:
 # Placeholder that will get overloaded by reference to the actual metric, so we can

--- a/resources/automagic_dashboards/question/GenericQuestion.yaml
+++ b/resources/automagic_dashboards/question/GenericQuestion.yaml
@@ -1,4 +1,4 @@
 title: "A closer look at your [[this]]"
-transient_title: "Here's a closer look at your [[this]]"
+transient_title: "Here''s a closer look at your [[this]]"
 description: A closer look at the metrics and dimensions used in this saved question.
 applies_to: GenericTable

--- a/resources/automagic_dashboards/table/GenericTable.yaml
+++ b/resources/automagic_dashboards/table/GenericTable.yaml
@@ -1,6 +1,6 @@
 title: "A look at your [[this]]"
-transient_title: "Here's a quick look at your [[this]]"
-description: An overview of your [[this]] and how it's distributed across time, place, and categories.
+transient_title: "Here''s a quick look at your [[this]]"
+description: An overview of your [[this]] and how it''s distributed across time, place, and categories.
 metrics:
   - Count: ["count"]
   - CountDistinctFKs: [distinct, [dimension, FK]]
@@ -378,7 +378,7 @@ cards:
       metrics: Count
       score: 60
       group: ByTime
-      x_label: Created At by day of the week
+      x_label: "[[CreateTimestamp]] by day of the week"
   - DayOfWeekCreateDate:
       title: Weekdays when [[this.short-name]] were added
       visualization: bar
@@ -388,7 +388,7 @@ cards:
       metrics: Count
       score: 60
       group: ByTime
-      x_label: Created At by day of the week
+      x_label: "[[CreateDate]] by day of the week"
   - HourOfDayCreateDate:
       title: Hours when [[this.short-name]] were added
       visualization: bar
@@ -398,7 +398,7 @@ cards:
       metrics: Count
       score: 50
       group: ByTime
-      x_label: Created At by hour of the day
+      x_label: "[[CreateTimestamp]] by hour of the day"
   - HourOfDayCreateDate:
       title: Hours when [[this.short-name]] were added
       visualization: bar
@@ -408,7 +408,7 @@ cards:
       metrics: Count
       score: 50
       group: ByTime
-      x_label: Created At by hour of the day
+      x_label: "[[CreateTime]] by hour of the day"
   - DayOfMonthCreateDate:
       title: Days when [[this.short-name]] were added
       visualization: bar
@@ -418,7 +418,7 @@ cards:
       metrics: Count
       score: 40
       group: ByTime
-      x_label: Created At by day of the month
+      x_label: "[[CreateTimestamp]] by day of the month"
   - DayOfMonthCreateDate:
       title: Days when [[this.short-name]] were added
       visualization: bar
@@ -428,7 +428,7 @@ cards:
       metrics: Count
       score: 40
       group: ByTime
-      x_label: Created At by day of the month
+      x_label: "[[CreateDate]] by day of the month"
   - MonthOfYearCreateDate:
       title: Months when [[this.short-name]] were added
       visualization: bar
@@ -438,7 +438,7 @@ cards:
       metrics: Count
       score: 40
       group: ByTime
-      x_label: Created At by month of the year
+      x_label: "[[CreateTimestamp]] by month of the year"
   - MonthOfYearCreateDate:
       title: Months when [[this.short-name]] were added
       visualization: bar
@@ -448,7 +448,7 @@ cards:
       metrics: Count
       score: 40
       group: ByTime
-      x_label: Created At by month of the year
+      x_label: "[[CreateDate]] by month of the year"
   - QuerterOfYearCreateDate:
       title: Quarters when [[this.short-name]] were added
       visualization: bar
@@ -458,7 +458,7 @@ cards:
       metrics: Count
       score: 40
       group: ByTime
-      x_label: Created At by quarter of the year
+      x_label: "[[CreateTimestamp]] by quarter of the year"
   - QuerterOfYearCreateDate:
       title: Quarters when [[this.short-name]] were added
       visualization: bar
@@ -468,7 +468,7 @@ cards:
       metrics: Count
       score: 40
       group: ByTime
-      x_label: Created At by quarter of the year
+      x_label: "[[CreateDate]] by quarter of the year"
   - DayOfWeekJoinDate:
       title: Weekdays when [[this.short-name]] joined
       visualization: bar

--- a/resources/automagic_dashboards/table/GenericTable/Correlations.yaml
+++ b/resources/automagic_dashboards/table/GenericTable/Correlations.yaml
@@ -1,6 +1,6 @@
 title: "[[this]] comparisons and correlations"
 transient_title: "How some of the numbers in [[this]] relate to each other"
-description: If you're into correlations, this is the x-ray for you.
+description: If you''re into correlations, this is the x-ray for you.
 applies_to: GenericTable
 
 dimensions:

--- a/resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
+++ b/resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
@@ -1,5 +1,5 @@
 title: Overview of your [[this]] data from Google Analytics
-transient_title: Here's an overview of your [[this]] data from Google Analytics
+transient_title: Here''s an overview of your [[this]] data from Google Analytics
 description: Some interesting metrics about your GA stats to get you started.
 metrics:
   - Sessions:

--- a/resources/automagic_dashboards/table/TransactionTable.yaml
+++ b/resources/automagic_dashboards/table/TransactionTable.yaml
@@ -1,5 +1,5 @@
 title: A look at your [[this]]
-transient_title: "It looks like your [[this]] has transactions, so here's a look at them"
+transient_title: It looks like your [[this]] has transactions, so here''s a look at them
 description: Some metrics we found about your transactions.
 metrics:
 - AvgDiscount:

--- a/resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
+++ b/resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
@@ -1,5 +1,5 @@
 title: "[[this]] per country"
-transient_title: Here's a closer look at your [[this]] per country
+transient_title: Here''s a closer look at your [[this]] per country
 description: A deeper look at how different countries are performing for you.
 applies_to: TransactionTable
 metrics:

--- a/resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
+++ b/resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
@@ -1,5 +1,5 @@
 title: "[[this]] per product"
-transient_title: Here's a closer look at your [[this]] by products
+transient_title: Here''s a closer look at your [[this]] by products
 description: How your different products are performing.
 applies_to: TransactionTable
 metrics:

--- a/resources/automagic_dashboards/table/TransactionTable/BySource.yaml
+++ b/resources/automagic_dashboards/table/TransactionTable/BySource.yaml
@@ -1,5 +1,5 @@
 title: "[[this]] per source"
-transient_title: Here's a closer look at your [[this]] per source
+transient_title: Here''s a closer look at your [[this]] per source
 description: Where most of your traffic is coming from.
 applies_to: TransactionTable
 metrics:

--- a/resources/automagic_dashboards/table/TransactionTable/ByState.yaml
+++ b/resources/automagic_dashboards/table/TransactionTable/ByState.yaml
@@ -1,5 +1,5 @@
 title: "[[this]] per state"
-transient_title: Here's a closer look at your [[this]] per state
+transient_title: Here''s a closer look at your [[this]] per state
 description: Which US states are bringing you the most business.
 applies_to: TransactionTable
 metrics:
@@ -75,7 +75,7 @@ groups:
 - Transactions:
     title: Transactions per state
 - Users:
-    title: Where you've acquired your users
+    title: Where you''ve acquired your users
 dashboard_filters:
   - Timestamp
   - Source

--- a/resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
+++ b/resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
@@ -1,5 +1,5 @@
 title: "[[this]] over time"
-transient_title: Here's a closer look at your [[this]] over time
+transient_title: Here''s a closer look at your [[this]] over time
 description: Whether or not there are any patterns to when they happen.
 applies_to: TransactionTable
 metrics:

--- a/resources/automagic_dashboards/table/UserTable.yaml
+++ b/resources/automagic_dashboards/table/UserTable.yaml
@@ -1,5 +1,5 @@
 title: A look at your [[this]]
-transient_title: "Here's an overview of the people in your [[this]]"
+transient_title: "Here''s an overview of the people in your [[this]]"
 description: An exploration of your users to get you started.
 metrics:
 - Count:

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -565,18 +565,19 @@
 (defn capitalize-first
   "Capitalize only the first letter in a given string."
   [s]
-  (str (str/upper-case (subs s 0 1)) (subs s 1)))
+  (let [s (str s)]
+    (str (str/upper-case (subs s 0 1)) (subs s 1))))
 
 (defn- instantiate-metadata
   [x context bindings]
   (-> (walk/postwalk
        (fn [form]
          (if (ui18n/localized-string? form)
-           (let [form     (str form)
-                 new-form (fill-templates :string context bindings form)]
-             (if (not= new-form form)
-               (capitalize-first new-form)
-               new-form))
+           (let [s     (str form)
+                 new-s (fill-templates :string context bindings s)]
+             (if (not= new-s s)
+               (capitalize-first new-s)
+               s))
            form))
        x)
       (u/update-when :visualization #(instantate-visualization % bindings (:metrics context)))))

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -565,15 +565,15 @@
 (defn capitalize-first
   "Capitalize only the first letter in a given string."
   [s]
-  (let [s (str s)]
-    (str (str/upper-case (subs s 0 1)) (subs s 1))))
+  (str (str/upper-case (subs s 0 1)) (subs s 1)))
 
 (defn- instantiate-metadata
   [x context bindings]
   (-> (walk/postwalk
        (fn [form]
-         (if (string? form)
-           (let [new-form (fill-templates :string context bindings form)]
+         (if (ui18n/localized-string? form)
+           (let [form     (str form)
+                 new-form (fill-templates :string context bindings form)]
              (if (not= new-form form)
                (capitalize-first new-form)
                new-form))


### PR DESCRIPTION
Fixes 2 i18n xray bugs:
1) one code path filled templates before instantiating localized string to concrete language resulting in no matches found
2) we did not escape single quotes in xray heursitics

Note: 2) sadly means a bunch of translations need to be redone (unless we manually relpace "heres" -> "here's" in .POs, but that feels icky).