### PR TITLE
Bump Monger to 3.5.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -61,7 +61,7 @@
                  [com.mattbertolini/liquibase-slf4j "2.0.0"]          ; Java Migrations lib
                  [com.mchange/c3p0 "0.9.5.2"]                         ; connection pooling library
                  [com.microsoft.sqlserver/mssql-jdbc "6.4.0.jre8"]    ; SQLServer JDBC driver
-                 [com.novemberain/monger "3.1.0"]                     ; MongoDB Driver
+                 [com.novemberain/monger "3.5.0"]                     ; MongoDB Driver
                  [com.taoensso/nippy "2.13.0"]                        ; Fast serialization (i.e., GZIP) library for Clojure
                  [compojure "1.5.2"]                                  ; HTTP Routing library built on Ring
                  [crypto-random "1.2.0"]                              ; library for generating cryptographically secure random bytes and strings


### PR DESCRIPTION
This updates Monger to [3.5.0](https://github.com/michaelklishin/monger/blob/master/ChangeLog.md). References #9030, #6678.

 - [x] Submit CLA form