### PR TITLE
fix translate error

### DIFF
--- a/locales/zh.po
+++ b/locales/zh.po
@@ -7780,7 +7780,7 @@ msgstr "系统时区是“{0}”"
 #. startup database.  validates connection & runs any necessary migrations
 #: src/metabase/core.clj
 msgid "Setting up and migrating Metabase DB. Please sit tight, this may take a minute..."
-msgstr "Metabse数据库设置、迁移中。坐稳了，这个可能要花一年时间……"
+msgstr "Metabse数据库设置、迁移中。坐稳了，这个可能要花一点时间……"
 
 #: src/metabase/core.clj
 msgid "Looks like this is a new installation ... preparing setup wizard"


### PR DESCRIPTION
"一年时间" means one year, it's terrible, here "take a minute" should be translated to "一点时间".



###### Before submitting the PR, please make sure you do the following 
-  [ ] If there are changes to the backend codebase, run the backend tests with `lein test && lein eastwood && lein bikeshed && lein docstring-checker && ./bin/reflection-linter`
-  [ ] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [ ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
