### PR TITLE
Make sure with-test-user macro causes *is-superuser?* to be bound correctly

### DIFF
--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -166,7 +166,10 @@
 (defn do-with-test-user
   "Call `f` with various `metabase.api.common` dynamic vars bound to the test User named by `user-kwd`."
   [user-kwd f]
-  ((middleware/bind-current-user (fn [_] (f))) {:metabase-user-id (user->id user-kwd)}))
+  ((middleware/bind-current-user (fn [_] (f)))
+   (let [user-id (user->id user-kwd)]
+     {:metabase-user-id user-id
+      :is-superuser?    (db/select-one-field :is_superuser User :id user-id)})))
 
 (defmacro with-test-user
   "Call `body` with various `metabase.api.common` dynamic vars like `*current-user*` bound to the test User named by


### PR DESCRIPTION
Noticed this why writing some tests today. Our test util macro `with-test-user` binds things like `*current-user*` and `*current-user-permissions-set*` using the same function the API middleware uses so you can run things under the context of a certain current user and test the results. However, it wasn't passing the admin status of that user, meaning `*is-superuser?*` wasn't bound correctly.