### PR TITLE
Java 11 support :arrow_up: [ci drivers]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,21 @@ jobs:
       - restore_cache:
           <<: *restore-be-deps-cache
       - run:
-          name: Run backend unit tests
+          name: Run backend unit tests with Java 8
+          command: lein with-profile +ci test
+          no_output_timeout: 5m
+
+  be-tests-java-11:
+    <<: *defaults
+    docker:
+      - image: circleci/clojure:openjdk-11-lein-2.8.1
+    steps:
+      - attach_workspace:
+          at: /home/circleci/
+      - restore_cache:
+          <<: *restore-be-deps-cache
+      - run:
+          name: Run backend unit tests with Java 11
           command: lein with-profile +ci test
           no_output_timeout: 5m
 
@@ -574,6 +588,9 @@ workflows:
           requires:
             - checkout
       - be-tests:
+          requires:
+            - be-deps
+      - be-tests-java-11:
           requires:
             - be-deps
       - be-linter-eastwood:

--- a/bin/docker/run_metabase.sh
+++ b/bin/docker/run_metabase.sh
@@ -114,7 +114,6 @@ JAVA_OPTS="${JAVA_OPTS} -XX:+IgnoreUnrecognizedVMOptions"
 JAVA_OPTS="${JAVA_OPTS} -Dfile.encoding=UTF-8"
 JAVA_OPTS="${JAVA_OPTS} -Dlogfile.path=target/log"
 JAVA_OPTS="${JAVA_OPTS} -server"
-JAVA_OPTS="${JAVA_OPTS} --add-modules=java.xml.bind"                # needed for Java 9 (Oracle VM only) because java.xml.bind is no longer on SE classpath by default since it's EE
 
 if [ ! -z "$JAVA_TIMEZONE" ]; then
     JAVA_OPTS="${JAVA_OPTS} -Duser.timezone=${JAVA_TIMEZONE}"

--- a/frontend/test/__runner__/backend.js
+++ b/frontend/test/__runner__/backend.js
@@ -53,7 +53,6 @@ export const BackendResource = createSharedResource("BackendResource", {
           "-Xmx2g", // Hard limit of 2GB size for the heap since Circle is dumb and the JVM tends to go over the limit otherwise
           "-Xverify:none", // Skip bytecode verification for the JAR so it launches faster
           "-Djava.awt.headless=true", // when running on macOS prevent little Java icon from popping up in Dock
-          "--add-modules=java.xml.bind", // Tell Java 9 we want to use java.xml stuff
           "-Duser.timezone=US/Pacific",
           "-jar",
           "target/uberjar/metabase.jar",

--- a/modules/drivers/bigquery/project.clj
+++ b/modules/drivers/bigquery/project.clj
@@ -4,10 +4,6 @@
   :dependencies
   [[com.google.apis/google-api-services-bigquery "v2-rev20181202-1.27.0"]]
 
-  :jvm-opts
-  ["-XX:+IgnoreUnrecognizedVMOptions"
-   "--add-modules=java.xml.bind"]
-
   :profiles
   {:provided
    {:dependencies

--- a/modules/drivers/druid/project.clj
+++ b/modules/drivers/druid/project.clj
@@ -1,10 +1,6 @@
 (defproject metabase/druid-driver "1.0.0-SNAPSHOT"
   :min-lein-version "2.5.0"
 
-  :jvm-opts
-  ["-XX:+IgnoreUnrecognizedVMOptions"
-   "--add-modules=java.xml.bind"]
-
   :profiles
   {:provided
    {:dependencies [[metabase-core "1.0.0-SNAPSHOT"]]}

--- a/modules/drivers/google/project.clj
+++ b/modules/drivers/google/project.clj
@@ -7,10 +7,6 @@
   :dependencies
   [[com.google.api-client/google-api-client "1.27.0"]]
 
-  :jvm-opts
-  ["-XX:+IgnoreUnrecognizedVMOptions"
-   "--add-modules=java.xml.bind"]
-
   :profiles
   {:provided
    {:dependencies

--- a/modules/drivers/googleanalytics/project.clj
+++ b/modules/drivers/googleanalytics/project.clj
@@ -4,10 +4,6 @@
   :dependencies
   [[com.google.apis/google-api-services-analytics "v3-rev20180622-1.27.0"]]
 
-  :jvm-opts
-  ["-XX:+IgnoreUnrecognizedVMOptions"
-   "--add-modules=java.xml.bind"]
-
   :profiles
   {:provided
    {:dependencies

--- a/modules/drivers/mongo/project.clj
+++ b/modules/drivers/mongo/project.clj
@@ -4,10 +4,6 @@
   :dependencies
   [[com.novemberain/monger "3.5.0"]]
 
-  :jvm-opts
-  ["-XX:+IgnoreUnrecognizedVMOptions"
-   "--add-modules=java.xml.bind"]
-
   :profiles
   {:provided
    {:dependencies [[metabase-core "1.0.0-SNAPSHOT"]]}

--- a/modules/drivers/oracle/project.clj
+++ b/modules/drivers/oracle/project.clj
@@ -1,10 +1,6 @@
 (defproject metabase/oracle-driver "1.0.0"
   :min-lein-version "2.5.0"
 
-  :jvm-opts
-  ["-XX:+IgnoreUnrecognizedVMOptions"
-   "--add-modules=java.xml.bind"]
-
   :profiles
   {:provided
    {:dependencies [[metabase-core "1.0.0-SNAPSHOT"]]}

--- a/modules/drivers/presto/project.clj
+++ b/modules/drivers/presto/project.clj
@@ -1,10 +1,6 @@
 (defproject metabase/presto-driver "1.0.0-SNAPSHOT"
   :min-lein-version "2.5.0"
 
-  :jvm-opts
-  ["-XX:+IgnoreUnrecognizedVMOptions"
-   "--add-modules=java.xml.bind"]
-
   :profiles
   {:provided
    {:dependencies [[metabase-core "1.0.0-SNAPSHOT"]]}

--- a/modules/drivers/redshift/project.clj
+++ b/modules/drivers/redshift/project.clj
@@ -8,10 +8,6 @@
   :dependencies
   [[com.amazon.redshift/redshift-jdbc42-no-awssdk "1.2.18.1036"]]
 
-  :jvm-opts
-  ["-XX:+IgnoreUnrecognizedVMOptions"
-   "--add-modules=java.xml.bind"]
-
   :profiles
   {:provided
    {:dependencies [[metabase-core "1.0.0-SNAPSHOT"]]}

--- a/modules/drivers/snowflake/project.clj
+++ b/modules/drivers/snowflake/project.clj
@@ -4,10 +4,6 @@
   :dependencies
   [[net.snowflake/snowflake-jdbc "3.6.20"]]
 
-  :jvm-opts
-  ["-XX:+IgnoreUnrecognizedVMOptions"
-   "--add-modules=java.xml.bind"]
-
   :profiles
   {:provided
    {:dependencies [[metabase-core "1.0.0-SNAPSHOT"]]}

--- a/modules/drivers/sparksql/project.clj
+++ b/modules/drivers/sparksql/project.clj
@@ -34,10 +34,6 @@
   :aot [metabase.driver.FixedHiveConnection
         metabase.driver.FixedHiveDriver]
 
-  :jvm-opts
-  ["-XX:+IgnoreUnrecognizedVMOptions"
-   "--add-modules=java.xml.bind"]
-
   :profiles
   {:provided
    {:dependencies

--- a/modules/drivers/sqlite/project.clj
+++ b/modules/drivers/sqlite/project.clj
@@ -4,10 +4,6 @@
   :dependencies
   [[org.xerial/sqlite-jdbc "3.25.2"]]
 
-  :jvm-opts
-  ["-XX:+IgnoreUnrecognizedVMOptions"
-   "--add-modules=java.xml.bind"]
-
   :profiles
   {:provided
    {:dependencies [[metabase-core "1.0.0-SNAPSHOT"]]}

--- a/modules/drivers/sqlserver/project.clj
+++ b/modules/drivers/sqlserver/project.clj
@@ -4,10 +4,6 @@
   :dependencies
   [[com.microsoft.sqlserver/mssql-jdbc "7.0.0.jre8"]]
 
-  :jvm-opts
-  ["-XX:+IgnoreUnrecognizedVMOptions"
-   "--add-modules=java.xml.bind"]
-
   :profiles
   {:provided
    {:dependencies [[metabase-core "1.0.0-SNAPSHOT"]]}

--- a/modules/drivers/vertica/project.clj
+++ b/modules/drivers/vertica/project.clj
@@ -1,10 +1,6 @@
 (defproject metabase/vertica-driver "1.0.0-SNAPSHOT"
   :min-lein-version "2.5.0"
 
-  :jvm-opts
-  ["-XX:+IgnoreUnrecognizedVMOptions"
-   "--add-modules=java.xml.bind"]
-
   :profiles
   {:provided
    {:dependencies [[metabase-core "1.0.0-SNAPSHOT"]]}

--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
    [org.clojure/math.numeric-tower "0.0.4"]                           ; math functions like `ceil`
    [org.clojure/tools.logging "0.4.1"]                                ; logging framework
    [org.clojure/tools.namespace "0.2.11"]
-   [amalloy/ring-buffer "1.2.1"
+   [amalloy/ring-buffer "1.2.2"
     :exclusions [org.clojure/clojure
                  org.clojure/clojurescript]]                          ; fixed length queue implementation, used in log buffering
    [amalloy/ring-gzip-middleware "0.1.3"]                             ; Ring middleware to GZIP responses if client can handle it
@@ -77,6 +77,7 @@
    [honeysql "0.9.2" :exclusions [org.clojure/clojurescript]]         ; Transform Clojure data structures to SQL
    [io.forward/yaml "1.0.6"                                           ; Clojure wrapper for YAML library SnakeYAML (which we already use for liquidbase)
     :exclusions [org.clojure/clojure
+                 org.flatland/ordered
                  org.yaml/snakeyaml]]
    [kixi/stats "0.4.1" :exclusions [org.clojure/data.avl]]            ; Various statistic measures implemented as transducers
    [log4j/log4j "1.2.17"                                              ; logging framework. TODO - consider upgrading to Log4j 2 -- see https://logging.apache.org/log4j/log4j-2.6.1/manual/migration.html
@@ -86,10 +87,12 @@
                  com.sun.jmx/jmxri]]
    [medley "0.8.4"]                                                   ; lightweight lib of useful functions
    [metabase/throttle "1.0.1"]                                        ; Tools for throttling access to API endpoints and other code pathways
-   [mysql/mysql-connector-java "5.1.45"]                              ; !!! Don't upgrade to 6.0+ yet -- that's Java 8 only !!!
+   [mysql/mysql-connector-java "5.1.45"]                              ; MySQL JDBC driver
+   [javax.xml.bind/jaxb-api "2.3.0"]                                  ; add the `javax.xml.bind` classes which we're still using but were removed in Java 11
    [jdistlib "0.5.1" :exclusions [com.github.wendykierp/JTransforms]] ; Distribution statistic tests
    [net.sf.cssbox/cssbox "4.12" :exclusions [org.slf4j/slf4j-api]]    ; HTML / CSS rendering
    [org.clojars.pntblnk/clj-ldap "0.0.12"]                            ; LDAP client
+   [org.flatland/ordered "1.5.7"]                                     ; ordered maps & sets
    [org.liquibase/liquibase-core "3.6.2"                              ; migration management (Java lib)
     :exclusions [ch.qos.logback/logback-classic]]
    [org.postgresql/postgresql "42.2.2"]                               ; Postgres driver
@@ -101,7 +104,7 @@
    [redux "0.1.4"]                                                    ; Utility functions for building and composing transducers
    [ring/ring-core "1.6.3"]
    [ring/ring-jetty-adapter "1.6.3"]                                  ; Ring adapter using Jetty webserver (used to run a Ring server for unit tests)
-   [org.eclipse.jetty/jetty-server "9.4.11.v20180605"]                ; We require JDK 8 which allows us to run Jetty 9.4, ring-jetty-adapter runs on 1.7 which forces an older version
+   [org.eclipse.jetty/jetty-server "9.4.14.v20181114"]                ; We require JDK 8 which allows us to run Jetty 9.4, ring-jetty-adapter runs on 1.7 which forces an older version
    [ring/ring-json "0.4.0"]                                           ; Ring middleware for reading/writing JSON automatically
    [stencil "0.5.0"]                                                  ; Mustache templates for Clojure
    [expectations "2.2.0-beta2"]
@@ -122,7 +125,6 @@
   :jvm-opts
   ["-XX:+IgnoreUnrecognizedVMOptions"                                 ; ignore things not recognized for our Java version instead of refusing to start
    "-Xverify:none"                                                    ; disable bytecode verification when running in dev so it starts slightly faster
-   "--add-modules=java.xml.bind"                                      ; tell Java 9 (Oracle VM only) to add java.xml.bind to classpath. No longer on it by default. See https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j
    "-Djava.awt.headless=true"]                                        ; prevent Java icon from randomly popping up in dock when running `lein ring server`
 
   :javac-options ["-target" "1.8", "-source" "1.8"]


### PR DESCRIPTION
Java 11 is out now and we needed to bump a few dependencies to support it. Also `javax.xml.bind` is no longer shipped as part of the JRE so we needed to add it as a dependency. One cool benefit of that however is we no longer need to pass include the `--add-modules=java.xml.bind` argument to `java` when running Metabase on Java 9 or 10.

😎 