### PR TITLE
Fix Snowflake sql.tx/field-base-type->sql-type impl [ci snowflake]

### DIFF
--- a/modules/drivers/snowflake/project.clj
+++ b/modules/drivers/snowflake/project.clj
@@ -2,7 +2,7 @@
   :min-lein-version "2.5.0"
 
   :dependencies
-  [[net.snowflake/snowflake-jdbc "3.6.20"]]
+  [[net.snowflake/snowflake-jdbc "3.6.21"]]
 
   :profiles
   {:provided

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -15,16 +15,15 @@
 
 (sql-jdbc.tx/add-test-extensions! :snowflake)
 
-(defmethod sql.tx/field-base-type->sql-type :snowflake [_ field]
-  ({:type/BigInteger "BIGINT"
-     :type/Boolean    "BOOLEAN"
-     :type/Date       "DATE"
-     :type/DateTime   "TIMESTAMPLTZ"
-     :type/Decimal    "DECIMAL"
-     :type/Float      "FLOAT"
-     :type/Integer    "INTEGER"
-     :type/Text       "TEXT"
-     :type/Time       "TIME"} field))
+(defmethod sql.tx/field-base-type->sql-type [:snowflake :type/BigInteger] [_ _] "BIGINT")
+(defmethod sql.tx/field-base-type->sql-type [:snowflake :type/Boolean]    [_ _] "BOOLEAN")
+(defmethod sql.tx/field-base-type->sql-type [:snowflake :type/Date]       [_ _] "DATE")
+(defmethod sql.tx/field-base-type->sql-type [:snowflake :type/DateTime]   [_ _] "TIMESTAMPLTZ")
+(defmethod sql.tx/field-base-type->sql-type [:snowflake :type/Decimal]    [_ _] "DECIMAL")
+(defmethod sql.tx/field-base-type->sql-type [:snowflake :type/Float]      [_ _] "FLOAT")
+(defmethod sql.tx/field-base-type->sql-type [:snowflake :type/Integer]    [_ _] "INTEGER")
+(defmethod sql.tx/field-base-type->sql-type [:snowflake :type/Text]       [_ _] "TEXT")
+(defmethod sql.tx/field-base-type->sql-type [:snowflake :type/Time]       [_ _] "TIME")
 
 (defmethod tx/dbdef->connection-details :snowflake [_ context {:keys [database-name]}]
   (merge

--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -28,8 +28,8 @@
 ;;; |                                           Creating Connection Pools                                            |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(def ^:private database-id->connection-pool
-  "A map of our currently open connection pools, keyed by Database `:id`."
+(defonce ^:private ^{:doc "A map of our currently open connection pools, keyed by Database `:id`."}
+  database-id->connection-pool
   (atom {}))
 
 (def ^:private data-warehouse-connection-pool-properties


### PR DESCRIPTION
Forgot to update snowflake's implementation of `sql.tx/field-base-type->sql-type` for the new driver architecture. Wasn't affecting anything because it's only used when creating test DBs and the Snowflake test extensions are set up not to recreate test databases that have already been created