### PR TITLE
Only add lazy-loaded modules to classpath when needed :sleeping:

### DIFF
--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -102,7 +102,8 @@
 ;; HACK ! When we test against Redshift we use a session-unique schema so we can run simultaneous tests
 ;; against a single remote host; when running tests tell the sync process to ignore all the other schemas
 (def ^:private excluded-schemas
-  (when config/is-test?
+  (if-not config/is-test?
+    (constantly nil)
     (memoize
      (fn []
        (require 'metabase.test.data.redshift)

--- a/src/metabase/plugins/classloader.clj
+++ b/src/metabase/plugins/classloader.clj
@@ -119,11 +119,14 @@
    (some #(when (instance? DynamicClassLoader %) %)
          (classloader-hierarchy (.getContextClassLoader (Thread/currentThread))))))
 
+(defonce ^:private already-added (atom #{}))
 
 (defn add-url-to-classpath!
   "Add a URL (presumably for a local JAR) to the classpath."
   [^URL url]
-  ;; `add-classpath-url` will return non-truthy if it couldn't add the URL, e.g. because the classloader wasn't one
-  ;; that allowed it
-  (assert (dynapath/add-classpath-url (the-top-level-classloader) url))
-  (log/info (u/format-color 'blue (trs "Added URL {0} to classpath" url))))
+  (when-not (@already-added url)
+    (swap! already-added conj url)
+    ;; `add-classpath-url` will return non-truthy if it couldn't add the URL, e.g. because the classloader wasn't one
+    ;; that allowed it
+    (assert (dynapath/add-classpath-url (the-top-level-classloader) url))
+    (log/info (u/format-color 'blue (trs "Added URL {0} to classpath" url)))))

--- a/src/metabase/plugins/init_steps.clj
+++ b/src/metabase/plugins/init_steps.clj
@@ -5,8 +5,9 @@
 
   The entire list of possible init steps is below, as impls for the `do-init-step!` multimethod."
   (:require [clojure.tools.logging :as log]
-            [metabase.plugins.classloader :as classloader]
-            [metabase.plugins.jdbc-proxy :as jdbc-proxy]
+            [metabase.plugins
+             [classloader :as classloader]
+             [jdbc-proxy :as jdbc-proxy]]
             [metabase.util :as u]
             [metabase.util.i18n :refer [trs]]))
 
@@ -26,7 +27,6 @@
     (require (symbol nmspace))))
 
 (defmethod do-init-step! :register-jdbc-driver [{class-name :class}]
-  (log/debug (u/format-color 'blue (trs "Registering JDBC proxy driver wrapping {0}..." class-name)))
   (jdbc-proxy/create-and-register-proxy-driver! class-name))
 
 (defn do-init-steps!

--- a/src/metabase/plugins/initialize.clj
+++ b/src/metabase/plugins/initialize.clj
@@ -9,7 +9,8 @@
 
 (defonce ^:private initialized-plugin-names (atom #{}))
 
-(defn- init! [{init-steps :init, {plugin-name :name} :info, driver-or-drivers :driver, :as info}]
+(defn- init!
+  [{:keys [add-to-classpath!], init-steps :init, {plugin-name :name} :info, driver-or-drivers :driver, :as info}]
   {:pre [(string? plugin-name)]}
   (when (deps/all-dependencies-satisfied? @initialized-plugin-names info)
     ;; for each driver, if it's lazy load, register a lazy-loaded placeholder driver
@@ -19,6 +20,7 @@
           (lazy-loaded-driver/register-lazy-loaded-driver! (assoc info :driver driver))))
       ;; if *any* of the drivers is not lazy-load, initialize it now
       (when (some false? (map :lazy-load drivers))
+        (add-to-classpath!)
         (init-steps/do-init-steps! init-steps)))
     ;; record this plugin as initialized and find any plugins ready to be initialized because depended on this one !
     ;;

--- a/src/metabase/plugins/initialize.clj
+++ b/src/metabase/plugins/initialize.clj
@@ -20,7 +20,8 @@
           (lazy-loaded-driver/register-lazy-loaded-driver! (assoc info :driver driver))))
       ;; if *any* of the drivers is not lazy-load, initialize it now
       (when (some false? (map :lazy-load drivers))
-        (add-to-classpath!)
+        (when add-to-classpath!
+          (add-to-classpath!))
         (init-steps/do-init-steps! init-steps)))
     ;; record this plugin as initialized and find any plugins ready to be initialized because depended on this one !
     ;;

--- a/src/metabase/plugins/lazy_loaded_driver.clj
+++ b/src/metabase/plugins/lazy_loaded_driver.clj
@@ -47,7 +47,8 @@
 (defn- make-initialize! [driver add-to-classpath! init-steps]
   (fn [_]
     ;; First things first: add the driver to the classpath!
-    (add-to-classpath!)
+    (when add-to-classpath!
+      (add-to-classpath!))
     ;; remove *this* implementation of `initialize!`, because as you will see below, we want to give
     ;; lazy-load drivers the option to implement `initialize!` and do other things, which means we need to
     ;; manually call it. When we do so we don't want to get stuck in an infinite loop of calls back to this


### PR DESCRIPTION
Pulling this out of PR #9137 because the two sets of changes have nothing to do with each other.

Made some tweaks to delay adding driver plugin JARs to the classpath until the driver is actually loaded for the first time. Shouldn't make a huge difference because we're not initializing classes in the JARs until the drivers are loaded for the first time, but you can never be too sure about these things. So this could further shrink memory usage as there will be absolutely zero possibility classes from those plugins can get loaded before we want them to.

What will make a difference however is our classloader won't have to dig around through plugins that don't need to be activated yet looking for classes it's trying to load, so that should save a little time and memory. Don't think it's going to be a huge difference but we will see