### PR TITLE
Add profiles for lein run and lein ring server that exclude test sources

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,6 +14,8 @@
    "generate-automagic-dashboards-pot" ["with-profile" "+generate-automagic-dashboards-pot" "run"]
    "install"                           ["with-profile" "+install" "install"]
    "install-for-building-drivers"      ["with-profile" "install-for-building-drivers" "install"]
+   "run"                               ["with-profile" "+run" "run"]
+   "ring"                              ["with-profile" "+ring" "ring"]
    "test"                              ["with-profile" "+expectations" "expectations"]
    "bikeshed"                          ["with-profile" "+bikeshed" "bikeshed" "--max-line-length" "205"]
    "eastwood"                          ["with-profile" "+eastwood" "eastwood"]
@@ -150,6 +152,7 @@
      [lein-bikeshed "0.4.1"]                                          ; Linting
      [lein-environ "1.1.0"]                                           ; easy access to environment variables
      [lein-expectations "0.0.8"]                                      ; run unit tests with 'lein expectations'
+     ;; TODO - should this be moved to the new RING profile?
      [lein-ring "0.12.3"                                              ; start the HTTP server with 'lein ring server'
       :exclusions [org.clojure/clojure]]]
 
@@ -170,6 +173,15 @@
    {:auto-clean true
     :aot        :all}
 
+   :exclude-tests
+   {:test-paths ^:replace []}
+
+   :run
+   [:exclude-tests {}]
+
+   :ring
+   [:exclude-tests {}]
+
    :with-include-drivers-middleware
    {:plugins
     [[metabase/lein-include-drivers "1.0.4"]]
@@ -181,7 +193,7 @@
    [:with-include-drivers-middleware
     {:injections
      [(require 'metabase.test-setup                                   ; for test setup stuff
-               'metabase.test.util)]                                  ; for the toucan.util.tes t default values for temp models
+               'metabase.test.util)]                                  ; for the toucan.util.test default values for temp models
 
      :resource-paths
      ["test_resources"]


### PR DESCRIPTION
Similar to what was going on in #9002 but I just made `ring` and `run` Leiningen aliases for themselves that add profiles of the same name which both inherit from a profile to exclude test paths. That means you don't need to remember to run a special command as with #9002. It just works transparently, 🆒 

### Sounds good, but what does that do?

Before this PR, `lein ring server` and `lein run` would for some reason include the test source code as part of the code it loaded and ran. After this PR, when you run with `lein ring server` or `lein run` the test sources don't exist as far as they're concerned. This speeds up launch quite a bit (half the source files = half the compilation) and with `lein ring server` you won't trigger a recompile if you `touch` or otherwise make changes to a test file. This is good because the test files in no way whatsoever affect what's being served anyway. 

TL;DR

Dramatic time-saver for core development team. Dramatic minor increase to productivity.