### PR TITLE
use fitViewport on DashboardApp to stretch display

### DIFF
--- a/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
@@ -4,6 +4,7 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import { push } from "react-router-redux";
 import title from "metabase/hoc/Title";
+import fitViewport from "metabase/hoc/FitViewPort";
 
 import Dashboard from "metabase/dashboard/components/Dashboard.jsx";
 
@@ -66,6 +67,7 @@ type DashboardAppState = {
 
 @connect(mapStateToProps, mapDispatchToProps)
 @title(({ dashboard }) => dashboard && dashboard.name)
+@fitViewport
 export default class DashboardApp extends Component {
   state: DashboardAppState = {
     addCardOnLoad: null,
@@ -80,7 +82,7 @@ export default class DashboardApp extends Component {
 
   render() {
     return (
-      <div>
+      <div className={this.props.fitClassNames}>
         <Dashboard addCardOnLoad={this.state.addCardOnLoad} {...this.props} />
         {/* For rendering modal urls */}
         {this.props.children}


### PR DESCRIPTION
Handles cases where the dashboard content itself isn't enough to stretch the background which is most noticeable in night mode. This probably started when we refactored the react root to not use a flex context, but since existing dashboards for most folks probably had a decent amount of content it wasn't widely noticed or reported. This change also coincidentally restores the dashboard empty state messaging which we should have noticed was missing when not in fullscreen. 😲

Fixes #9171 