### PR TITLE
Make sure Max Cache Entry Size setting handles string inputs correctly

### DIFF
--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -108,7 +108,10 @@
   :type    :integer
   :default 1000
   :setter  (fn [new-value]
-             (when (> new-value global-max-caching-kb)
+             (when (and new-value
+                        (> (cond-> new-value
+                             (string? new-value) Integer/parseInt)
+                           global-max-caching-kb))
                (throw (IllegalArgumentException.
                        (str
                         (tru "Failed setting `query-caching-max-kb` to {0}." new-value)

--- a/test/metabase/public_settings_test.clj
+++ b/test/metabase/public_settings_test.clj
@@ -49,3 +49,10 @@
     (i18n/with-user-locale zz
       [(= zz (i18n/user-locale))
        (tru "Host")])))
+
+;; Make sure Max Cache Entry Size can be set via with a string value, which is what comes back from the API (#9143)
+(expect
+  "1000"
+  ;; use with temp value macro so original value gets reset after test run
+  (tu/with-temporary-setting-values [query-caching-max-kb nil]
+    (public-settings/query-caching-max-kb "1000")))


### PR DESCRIPTION
Fixes #9143