### PR TITLE
Added support for Decimal128 MongoDB type #8646

### DIFF
--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -222,7 +222,8 @@
              [clojure.lang.IPersistentMap    :type/Dictionary]
              [clojure.lang.IPersistentVector :type/Array]
              [org.postgresql.util.PGobject   :type/*]
-             [nil                            :type/*]]) ; all-NULL columns in DBs like Mongo w/o explicit types
+             [nil                            :type/*] ; all-NULL columns in DBs like Mongo w/o explicit types
+             [org.bson.types.Decimal128      :type/Decimal]]) ; Decimal128 support added, sum, avg math exp are now working on frontend for Decimal128 data type ( Mongo )
       (log/warn (trs "Don''t know how to map class ''{0}'' to a Field base_type, falling back to :type/*." klass))
       :type/*))
 


### PR DESCRIPTION
sum, avg math exp are now working on frontend for Decimal128 data type ( Mongo )



###### Before submitting the PR, please make sure you do the following
- [ ] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.
### Tests
-  [ ] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [ ] If there are changes to the backend codebase, run the backend tests with `lein test && lein eastwood && lein bikeshed && lein docstring-checker && ./bin/reflection-linter`

-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
