### PR TITLE
Use default value for apple-mobile-web-app-status-bar-style

### DIFF
--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -5,7 +5,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, minimal-ui" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
-        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+        <meta name="apple-mobile-web-app-status-bar-style" content="default" />
 
         {{{embed_code}}}
 


### PR DESCRIPTION
The `black-translucent` setting doesn't make sense when on the dashboard as the page background is white and so iOS is showing the text as white.

![image](https://user-images.githubusercontent.com/246103/50666382-83b54f80-0fac-11e9-86d6-c7ee6425ba66.png)
