### PR TITLE
Add unique constraints: Table db_id/schema/name, Field table_id/parent_id/name

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -5141,6 +5141,19 @@ databaseChangeLog:
 # reason or another those would-be constraints are already violated. This is to fix issue where sometimes the same Field
 # or Table is synced more than once (see #669, #8950, #9048)
 #
+# Note that the SQL standard says unique constraints should not apply to columns with NULL values. Consider the following:
+#
+# INSERT INTO metabase_table (db_id, schema, name) VALUES (1, 'PUBLIC', 'my_table');
+# INSERT INTO metabase_table (db_id, schema, name) VALUES (1, 'PUBLIC', 'my_table'); -- fails: violates UNIQUE constraint
+#
+# INSERT INTO metabase_table (db_id, schema, name) VALUES (1, NULL, 'my_table');
+# INSERT INTO metabase_table (db_id, schema, name) VALUES (1, NULL, 'my_table'); -- succeeds: because schema is NULL constraint does not apply
+#
+# Thus these constraints won't work if the data warehouse DB in question doesn't use schemas (e.g. MySQL or MongoDB). It
+# will work for other data warehouse types.
+#
+# Luckily Postgres (but not H2 or MySQL) supports constraints that only apply to columns matching conditions, so we can
+# add additional constraints to properly handle those cases.
   - changeSet:
       id: 98
       author: camsaul
@@ -5166,6 +5179,10 @@ databaseChangeLog:
             tableName: metabase_table
             columnNames: db_id, schema, name
             constraintName: idx_uniq_table_db_id_schema_name
+        # For Postgres, add additional constraint to apply if schema is NULL
+        - sql:
+            dbms: postgresql
+            sql: CREATE UNIQUE INDEX idx_uniq_table_db_id_schema_name_2col ON "metabase_table" ("db_id", "name") WHERE "schema" IS NULL
 
   - changeSet:
       id: 99
@@ -5192,3 +5209,7 @@ databaseChangeLog:
             tableName: metabase_field
             columnNames: table_id, parent_id, name
             constraintName: idx_uniq_field_table_id_parent_id_name
+        # For Postgres, add additional constraint to apply if schema is NULL
+        - sql:
+            dbms: postgresql
+            sql: CREATE UNIQUE INDEX idx_uniq_field_table_id_parent_id_name_2col ON "metabase_field" ("table_id", "name") WHERE "parent_id" IS NULL

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -5135,3 +5135,40 @@ databaseChangeLog:
             tableName: query_cache
             columnName: results
             newDataType: longblob
+
+#
+# Add unique constraints for (Field name + table_id + parent_id) and for (Table name + schema + db_id) unless for one
+# reason or another those would-be constraints are already violated. This is to fix issue where sometimes the same Field
+# or Table is synced more than once (see #669, #8950, #9048)
+#
+  - changeSet:
+      id: 98
+      author: camsaul
+      comment: 'Added 0.32.0'
+      preConditions:
+        - onFail: MARK_RAN
+        - onUpdateSQL: IGNORE
+        - sqlCheck:
+            expectedResult: 0
+            sql: SELECT count(*) FROM (SELECT count(*) FROM METABASE_TABLE GROUP BY DB_ID, SCHEMA, NAME HAVING count(*) > 1) t1
+      changes:
+        - addUniqueConstraint:
+            tableName: metabase_table
+            columnNames: db_id, schema, name
+            constraintName: idx_uniq_table_db_id_schema_name
+
+  - changeSet:
+      id: 99
+      author: camsaul
+      comment: 'Added 0.32.0'
+      preConditions:
+        - onFail: MARK_RAN
+        - onUpdateSQL: IGNORE
+        - sqlCheck:
+            expectedResult: 0
+            sql: SELECT count(*) FROM (SELECT count(*) FROM METABASE_FIELD GROUP BY TABLE_ID, PARENT_ID, NAME HAVING count(*) > 1) t1
+      changes:
+        - addUniqueConstraint:
+            tableName: metabase_field
+            columnNames: table_id, parent_id, name
+            constraintName: idx_uniq_field_table_id_parent_id_name

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -5148,9 +5148,19 @@ databaseChangeLog:
       preConditions:
         - onFail: MARK_RAN
         - onUpdateSQL: IGNORE
-        - sqlCheck:
-            expectedResult: 0
-            sql: SELECT count(*) FROM (SELECT count(*) FROM METABASE_TABLE GROUP BY DB_ID, SCHEMA, NAME HAVING count(*) > 1) t1
+        - or:
+            - and:
+                - dbms:
+                    type: mysql,mariadb
+                - sqlCheck:
+                    expectedResult: 0
+                    sql: SELECT count(*) FROM (SELECT count(*) FROM `metabase_table` GROUP BY `db_id`, `schema`, `name` HAVING count(*) > 1) t1
+            - and:
+                - dbms:
+                    type: h2,postgresql
+                - sqlCheck:
+                    expectedResult: 0
+                    sql: SELECT count(*) FROM (SELECT count(*) FROM METABASE_TABLE GROUP BY DB_ID, SCHEMA, NAME HAVING count(*) > 1) t1
       changes:
         - addUniqueConstraint:
             tableName: metabase_table
@@ -5164,9 +5174,19 @@ databaseChangeLog:
       preConditions:
         - onFail: MARK_RAN
         - onUpdateSQL: IGNORE
-        - sqlCheck:
-            expectedResult: 0
-            sql: SELECT count(*) FROM (SELECT count(*) FROM METABASE_FIELD GROUP BY TABLE_ID, PARENT_ID, NAME HAVING count(*) > 1) t1
+        - or:
+            - and:
+                - dbms:
+                    type: mysql,mariadb
+                - sqlCheck:
+                    expectedResult: 0
+                    sql: SELECT count(*) FROM (SELECT count(*) FROM `metabase_field` GROUP BY `table_id`, `parent_id`, `name` HAVING count(*) > 1) t1
+            - and:
+                - dbms:
+                    type: h2,postgresql
+                - sqlCheck:
+                    expectedResult: 0
+                    sql: SELECT count(*) FROM (SELECT count(*) FROM METABASE_FIELD GROUP BY TABLE_ID, PARENT_ID, NAME HAVING count(*) > 1) t1
       changes:
         - addUniqueConstraint:
             tableName: metabase_field

--- a/test/metabase/query_processor_test/aggregation_test.clj
+++ b/test/metabase/query_processor_test/aggregation_test.clj
@@ -332,11 +332,9 @@
 (expect
   (assoc (aggregate-col :sum (Field (data/id :venues :price)))
     :settings {:is_priceless false})
-  (tt/with-temp Field [copy-of-venues-price (-> (Field (data/id :venues :price))
-                                                (dissoc :id)
-                                                (assoc :settings {:is_priceless false}))]
+  (tu/with-temp-vals-in-db Field (data/id :venues :price) {:settings {:is_priceless false}}
     (let [results (data/run-mbql-query venues
-                    {:aggregation [[:sum [:field-id (u/get-id copy-of-venues-price)]]]})]
+                    {:aggregation [[:sum [:field-id $price]]]})]
       (or (-> results :data :cols first)
           results))))
 

--- a/test/metabase/sync/analyze/table_row_count_test.clj
+++ b/test/metabase/sync/analyze/table_row_count_test.clj
@@ -1,22 +1,19 @@
 (ns metabase.sync.analyze.table-row-count-test
   "Tests for the sync logic that updates a Table's row count."
-  (:require [metabase
-             [query-processor-test :as qp-test]
-             [util :as u]]
-            [metabase.models.table :refer [Table]]
+  (:require [metabase.models.table :refer [Table]]
+            [metabase.query-processor-test :as qp-test]
             [metabase.sync.analyze.table-row-count :as table-row-count]
-            [metabase.test.data :as data]
+            [metabase.test
+             [data :as data]
+             [util :as tu]]
             [metabase.test.data.datasets :as datasets]
-            [toucan.db :as db]
-            [toucan.util.test :as tt]))
+            [toucan.db :as db]))
 
 ;; test that syncing table row counts works
 ;; TODO - write a Druid version of this test. Works slightly differently since Druid doesn't have a 'venues' table
 ;; TODO - not sure why this doesn't work on Oracle. Seems to be an issue with the test rather than with the Oracle driver
 (datasets/expect-with-drivers (disj qp-test/non-timeseries-drivers :oracle)
   100
-  (tt/with-temp Table [venues-copy (let [venues-table (Table (data/id :venues))]
-                                     (assoc (select-keys venues-table [:schema :name :db_id])
-                                       :rows 0))]
-    (table-row-count/update-row-count! venues-copy)
-    (db/select-one-field :rows Table :id (u/get-id venues-copy))))
+  (tu/with-temp-vals-in-db Table (data/id :venues) {:rows 0}
+      (table-row-count/update-row-count! (Table (data/id :venues)))
+      (db/select-one-field :rows Table :id (data/id :venues))))


### PR DESCRIPTION
Add unique constraints for Field name + table_id + parent_id and for Table name + schema + db_id unless for one reason or another those would-be constraints are already violated. This is to fix issues where sometimes duplicate entries for the same Field or Table are saved by the sync process. 

Duplicate entires theoretically shouldn't happen, because the sync code guards against the sort of race conditions that could cause them, but it seems that nonetheless it's happened to people once or twice -- perhaps as the result of bugs in earlier versions of the sync code, or some existing bug we haven't yet fixed. Either way, I think it's best to be safe rather than sorry and add these constraints to make things a little more robust.

Implements #669.

Fixes #8950 and #9048 (in the sense that it will prevent similar "bad" syncs from happening again in the future)