### PR TITLE
Add support of Duration field type #8875

### DIFF
--- a/frontend/src/metabase/lib/core.js
+++ b/frontend/src/metabase/lib/core.js
@@ -201,6 +201,11 @@ export const field_special_types = [
     section: t`Common`,
   },
   {
+    id: TYPE.Duration,
+    name: t`Duration`,
+    section: t`Common`,
+  },
+  {
     id: TYPE.Description,
     name: t`Description`,
     section: t`Common`,

--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -3,6 +3,9 @@
 import d3 from "d3";
 import inflection from "inflection";
 import moment from "moment";
+import momentDurationFormatSetup from "moment-duration-format";
+momentDurationFormatSetup(moment);
+
 import Humanize from "humanize-plus";
 import React from "react";
 import { ngettext, msgid } from "c-3po";
@@ -470,6 +473,10 @@ export function formatTime(value: Value) {
   }
 }
 
+export function formatDuration(value: Value) {
+  return moment.duration(parseInt(value), "seconds").format("h:mm:ss");
+}
+
 // https://github.com/angular/angular.js/blob/v1.6.3/src/ng/directive/input.js#L27
 const EMAIL_WHITELIST_REGEX = /^(?=.{1,254}$)(?=.{1,64}@)[-!#$%&'*+/0-9=?A-Z^_`a-z{|}~]+(\.[-!#$%&'*+/0-9=?A-Z^_`a-z{|}~]+)*@[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$/;
 
@@ -613,6 +620,8 @@ export function formatValueRaw(value: Value, options: FormattingOptions = {}) {
     return formatEmail(value, options);
   } else if (column && isa(column.base_type, TYPE.Time)) {
     return formatTime(value);
+  } else if (column && isa(column.special_type, TYPE.Duration)) {
+    return formatDuration(value);
   } else if (column && column.unit != null) {
     return formatDateTimeWithUnit(value, column.unit, options);
   } else if (

--- a/frontend/test/lib/formatting.unit.spec.js
+++ b/frontend/test/lib/formatting.unit.spec.js
@@ -1,6 +1,11 @@
 import { isElementOfType } from "react-dom/test-utils";
 
-import { formatNumber, formatValue, formatUrl } from "metabase/lib/formatting";
+import {
+  formatNumber,
+  formatValue,
+  formatUrl,
+  formatDuration,
+} from "metabase/lib/formatting";
 import ExternalLink from "metabase/components/ExternalLink.jsx";
 import { TYPE } from "metabase/lib/types";
 
@@ -190,6 +195,15 @@ describe("formatting", () => {
           rich: true,
         }),
       ).toEqual("data:text/plain;charset=utf-8,hello%20world");
+    });
+  });
+
+  describe("formatDuration", () => {
+    it("should format seconds to h:mm:ss format", () => {
+      expect(formatDuration(12345)).toEqual("3:25:45");
+    });
+    it("should format correctly if column is a string", () => {
+      expect(formatDuration("123")).toEqual("2:03");
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "leaflet.heat": "^0.2.0",
     "lodash.memoize": "^4.1.2",
     "moment": "2.19.3",
+    "moment-duration-format": "^2.2.2",
     "mustache": "^2.3.2",
     "node-libs-browser": "^2.0.0",
     "normalizr": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8314,6 +8314,11 @@ module-deps-sortable@4.0.6:
     through2 "^2.0.0"
     xtend "^4.0.0"
 
+moment-duration-format@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/moment-duration-format/-/moment-duration-format-2.2.2.tgz#b957612de26016c9ad9eb6087c054573e5127779"
+  integrity sha1-uVdhLeJgFsmtnrYIfAVFc+USd3k=
+
 moment@2.19.3:
   version "2.19.3"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.3.tgz#bdb99d270d6d7fda78cc0fbace855e27fe7da69f"


### PR DESCRIPTION
It seems that it was already supported on the backend, so just added
support to the frontend. It only supports a single format now (h:mm:ss)
but it’s not very hard to add a dialog for allowing to choose format in
the future.

<img width="395" alt="screen shot 2019-01-06 at 4 06 01 pm" src="https://user-images.githubusercontent.com/805/50743466-1b918400-11cd-11e9-9515-90cada3680a8.png">

This is my first PR so please let me know if I'm missing anything obvious.

###### Before submitting the PR, please make sure you do the following
- [x] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.
### Tests
-  [x] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [x] If there are changes to the backend codebase, run the backend tests with `lein test && lein eastwood && lein bikeshed && lein docstring-checker && ./bin/reflection-linter`

-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
