### PR TITLE
Never strip plugin manifest when removing plugin duplicate classes

### DIFF
--- a/lein-commands/strip-and-compress/metabase/strip_and_compress_module.clj
+++ b/lein-commands/strip-and-compress/metabase/strip_and_compress_module.clj
@@ -5,13 +5,19 @@
            [java.util.zip ZipEntry ZipFile ZipOutputStream]
            org.apache.commons.io.IOUtils))
 
+(def ^:private files-to-always-include
+  "Files to always include regardless of whether they are present in blacklist JAR."
+  #{"metabase-plugin.yaml"})
+
 (defn- files-blacklist
   "Get a set of all files in the Metabase uberjar."
   [^String blacklist-jar]
   (with-open [zip-file (ZipFile. blacklist-jar)]
     (set
-     (for [^ZipEntry zip-entry (enumeration-seq (.entries zip-file))]
-       (str zip-entry)))))
+     (for [^ZipEntry zip-entry (enumeration-seq (.entries zip-file))
+           :let                [filename (str zip-entry)]
+           :when               (not (files-to-always-include filename))]
+       filename))))
 
 (defn -main
   "Remove any classes from a module JAR that are also found in the Metabase uberjar. Compress the module JAR using the

--- a/project.clj
+++ b/project.clj
@@ -257,6 +257,9 @@
     :source-paths ["lein-commands/sample-dataset"]
     :main         ^:skip-aot metabase.sample-dataset.generate}
 
+   ;; lein strip-and-compress my-plugin.jar [path/to/metabase.jar]
+   ;; strips classes from my-plugin.jar that already exist in other JAR and recompresses with higher compression ratio.
+   ;; Second arg (other JAR) is optional; defaults to target/uberjar/metabase.jar
    :strip-and-compress
    {:source-paths ["src"
                    "lein-commands/strip-and-compress"]

--- a/src/metabase/plugins/initialize.clj
+++ b/src/metabase/plugins/initialize.clj
@@ -1,4 +1,10 @@
 (ns metabase.plugins.initialize
+  "Logic related to initializing plugins, i.e. running the `init` steps listed in the plugin manifest. This is done when
+  Metabase launches as soon as all dependencies for that plugin are met; for plugins with unmet dependencies, it is
+  retried after other plugins are loaded (e.g. for things like BigQuery which depend on the shared Google driver.)
+
+  Note that this is not the same thing as initializing *drivers* -- drivers are initialized lazily when first needed;
+  this step on the other hand runs at launch time and sets up that lazy load logic."
   (:require [clojure.tools.logging :as log]
             [metabase.plugins
              [dependencies :as deps]


### PR DESCRIPTION
To prevent Metabase plugins from containing duplicate classes we strip out any files present in the Metabase uberjar or in parent plugin JARs when building.

This logic was accidentally stripping out the Metabase plugin manifest from the BigQuery and Google Analytics drivers because their parent driver (Google shared dependencies) contained its own plugin manifest, causing them to load incorrectly when restarting Metabase.

Fixed by adding `metabase-plugin.yaml` to whitelist of files to always include in plugin JARs