### PR TITLE
Fix binning - serialize clojure Ratios as doubles (#9228)

### DIFF
--- a/src/metabase/util/honeysql_extensions.clj
+++ b/src/metabase/util/honeysql_extensions.clj
@@ -64,6 +64,12 @@
   java.lang.Number
   (to-sql [x] (str x)))
 
+;; Ratios are represented as the division of two numbers which may cause order-of-operation issues when dealing with
+;; queries. The easiest way around this is to convert them to their decimal representations.
+(extend-protocol honeysql.format/ToSql
+  clojure.lang.Ratio
+  (to-sql [x] (hformat/to-sql (double x))))
+
 ;; HoneySQL automatically assumes that dots within keywords are used to separate schema / table / field / etc. To
 ;; handle weird situations where people actually put dots *within* a single identifier we'll replace those dots with
 ;; lozenges, let HoneySQL do its thing, then switch them back at the last second


### PR DESCRIPTION
Fixes #9228

Clojure Ratio objects were being converted to "a/b" in SQL. This causes issues with order-of-operation sensitive queries such as x / a / b and is manifested by breaking binning when "nice ratios" are used.

@cgopalan and I couldn't figure out how to always wrap Ratio objects in parenthesis so instead we opted to convert them to doubles.