### PR TITLE
SQL Server use getdate() instead of getutcdate()

### DIFF
--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -134,7 +134,7 @@
             (hx/format "yyyy-01-01" expr)))
 
 (defmethod driver/date-interval :sqlserver [_ unit amount]
-  (date-add unit amount :%getutcdate))
+  (date-add unit amount :%getdate))
 
 (defmethod sql.qp/unix-timestamp->timestamp [:sqlserver :seconds] [_ _ expr]
   ;; The second argument to DATEADD() gets casted to a 32-bit integer. BIGINT is 64 bites, so we tend to run into


### PR DESCRIPTION
This implements #8326.

Let's see what breaks.