### PR TITLE
Swappable connection pooling backends [DO NOT MERGE]

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -71,6 +71,7 @@
    [com.mattbertolini/liquibase-slf4j "2.0.0"]                        ; Java Migrations lib logging. We don't actually use this AFAIK (?)
    [com.mchange/c3p0 "0.9.5.2"]                                       ; connection pooling library
    [com.taoensso/nippy "2.14.0"]                                      ; Fast serialization (i.e., GZIP) library for Clojure
+   [com.zaxxer/HikariCP "3.1.0"]                                      ; connection pool library
    [compojure "1.6.1" :exclusions [ring/ring-codec]]                  ; HTTP Routing library built on Ring
    [crypto-random "1.2.0"]                                            ; library for generating cryptographically secure random bytes and strings
    [dk.ative/docjure "1.13.0"]                                        ; Excel export

--- a/src/metabase/db/connection_pool.clj
+++ b/src/metabase/db/connection_pool.clj
@@ -5,63 +5,25 @@
   The aim here is to completely encapsulate the connection pool library we use -- that way we can swap it out if we
   want to at some point without having to touch any other files. (TODO - this is currently true of everything except
   for the options, which are c3p0-specific -- consider abstracting those as well?)"
-  (:require [metabase.util :as u])
-  (:import com.mchange.v2.c3p0.DataSources
-           [java.sql Driver DriverManager]
-           [java.util Map Properties]
-           javax.sql.DataSource))
+  (:require [metabase.db.connection-pool.interface :as i]
+            [metabase.util :as u]))
 
-;;; ------------------------------------------------ Proxy DataSource ------------------------------------------------
+(def ^:private current-backend
+  (atom :hikari))
 
-(defn- set-property! [^Properties properties, k v]
-  (if (some? k)
-    (.put properties (name k) v)
-    (.remove properties (name k))))
+(defn set-backend! [new-backend]
+  (reset! current-backend new-backend))
 
-(defn- proxy-data-source
-  "Normal c3p0 DataSource classes do not properly work with our JDBC proxy drivers for whatever reason. Use our own
-  instead, which works nicely."
-  (^DataSource [^String jdbc-url, ^Properties properties]
-   (proxy-data-source (DriverManager/getDriver jdbc-url) jdbc-url properties))
+(defn- load-backend [backend]
+  (require (symbol (format "metabase.db.connection-pool.%s" (name backend)))))
 
-  (^DataSource [^Driver driver, ^String jdbc-url, ^Properties properties]
-   (reify DataSource
-     (getConnection [_]
-       (.connect driver jdbc-url properties))
-     (getConnection [_ username password]
-       (doseq [[k v] {"user" username, "password" password}]
-         (set-property! properties k v))
-       (.connect driver jdbc-url properties)))))
+(defn the-backend []
+  (u/prog1 @current-backend
+    (when-not (get-method i/connection-pool-spec <>)
+      (load-backend <>))))
 
+(defn connection-pool-spec [jdbc-spec]
+  (i/connection-pool-spec (the-backend) jdbc-spec))
 
-;;; ------------------------------------------- Creating Connection Pools --------------------------------------------
-
-(defn- map->properties ^Properties [m]
-  (u/prog1 (Properties.)
-           (doseq [[k v] m]
-             (.setProperty <> (name k) (str v)))))
-
-(defn- spec->properties ^Properties [spec]
-  (map->properties (dissoc spec :classname :subprotocol :subname)))
-
-(defn- unpooled-data-source ^DataSource [{:keys [subname subprotocol], :as spec}]
-  {:pre [(string? subname) (string? subprotocol)]}
-  (proxy-data-source (format "jdbc:%s:%s" subprotocol subname) (spec->properties spec)))
-
-(defn- pooled-data-source ^DataSource
-  ([spec]
-   (DataSources/pooledDataSource (unpooled-data-source spec)))
-  ([spec, ^Map pool-properties]
-   (DataSources/pooledDataSource (unpooled-data-source spec), pool-properties)))
-
-(def ^{:arglists '([spec] [spec pool-properties-map])} connection-pool-spec
-  "Create a new connection pool for a JDBC `spec` and return a spec for it. Optionally pass a map of connection pool
-  properties -- see https://www.mchange.com/projects/c3p0/#configuration_properties for a description of valid options
-  and their default values."
-  (comp (fn [x] {:datasource x}) pooled-data-source))
-
-
-(defn destroy-connection-pool!
-  "Immediately release all resources held by a connection pool."
-  [^DataSource pooled-data-source]
-  (DataSources/destroy pooled-data-source))
+(defn destroy-connection-pool! [pool-spec]
+  (i/destroy-connection-pool! (the-backend) pool-spec))

--- a/src/metabase/db/connection_pool/c3p0.clj
+++ b/src/metabase/db/connection_pool/c3p0.clj
@@ -1,0 +1,57 @@
+(ns metabase.db.connection-pool.c3p0
+  "c3p0 implementation of Metabase connection pools for application DB and JDBC-based drivers."
+  (:require [metabase.db.connection-pool.interface :as i]
+            [metabase.util :as u])
+  (:import com.mchange.v2.c3p0.DataSources
+           [java.sql Driver DriverManager]
+           [java.util Map Properties]
+           javax.sql.DataSource))
+
+(defn- set-property! [^Properties properties, k v]
+  (if (some? k)
+    (.put properties (name k) v)
+    (.remove properties (name k))))
+
+(defn- map->properties ^Properties [m]
+  (u/prog1 (Properties.)
+           (doseq [[k v] m]
+             (.setProperty <> (name k) (str v)))))
+
+(defn- spec->properties ^Properties [spec]
+  (map->properties (dissoc spec :classname :subprotocol :subname)))
+
+(defn- proxy-data-source
+  "Normal c3p0 DataSource classes do not properly work with our JDBC proxy drivers for whatever reason. Use our own
+  instead, which works nicely."
+  (^DataSource [{:keys [subname subprotocol], :as spec}]
+   {:pre [(string? subname) (string? subprotocol)]}
+   (proxy-data-source (format "jdbc:%s:%s" subprotocol subname) (spec->properties spec)))
+
+  (^DataSource [^String jdbc-url, ^Properties properties]
+   (proxy-data-source (DriverManager/getDriver jdbc-url) jdbc-url properties))
+
+  (^DataSource [^Driver driver, ^String jdbc-url, ^Properties properties]
+   (reify DataSource
+     (getConnection [_]
+       (.connect driver jdbc-url properties))
+     (getConnection [_ username password]
+       (doseq [[k v] {"user" username, "password" password}]
+         (set-property! properties k v))
+       (.connect driver jdbc-url properties)))))
+
+(defn- pooled-data-source ^DataSource
+  ([spec]
+   (DataSources/pooledDataSource (proxy-data-source spec)))
+  ([spec, ^Map pool-properties]
+   (DataSources/pooledDataSource (proxy-data-source spec), pool-properties)))
+
+;; See https://www.mchange.com/projects/c3p0/#configuration_properties for a description of valid options and their
+;; default values.
+(defmethod i/connection-pool-spec :c3p0
+  [_ & args]
+  {:datasource (apply pooled-data-source args)})
+
+
+(defmethod i/destroy-connection-pool! :c3p0
+  [_, {:keys [^DataSource datasource]}]
+  (DataSources/destroy datasource))

--- a/src/metabase/db/connection_pool/hikari.clj
+++ b/src/metabase/db/connection_pool/hikari.clj
@@ -1,0 +1,21 @@
+(ns metabase.db.connection-pool.hikari
+  "HikariCP implementation of Metabase connection pools for application DB and JDBC-based drivers."
+  (:require [metabase.db.connection-pool.interface :as i])
+  (:import [com.zaxxer.hikari HikariConfig HikariDataSource]))
+
+(defn- hikari-ds [{:keys [subname subprotocol], :as spec} & [pool-options]]
+  (let [config (doto (HikariConfig.)
+                 (.setJdbcUrl (format "jdbc:%s:%s" subprotocol subname)))]
+    (doseq [[k v] (dissoc spec :classname :subprotocol :subname :type)
+            :when v]
+      (.addDataSourceProperty config (name k) v))
+    (HikariDataSource. config)))
+
+(defmethod i/connection-pool-spec :hikari
+  [_ jdbc-spec & [pool-options]]
+  {:datasource (hikari-ds jdbc-spec pool-options)})
+
+
+(defmethod i/destroy-connection-pool! :hikari
+  [_, {:keys [^HikariDataSource datasource]}]
+  (.close datasource))

--- a/src/metabase/db/connection_pool/interface.clj
+++ b/src/metabase/db/connection_pool/interface.clj
@@ -1,0 +1,21 @@
+(ns metabase.db.connection-pool.interface)
+
+(defn- dispatch-on-backend [backend & _] backend)
+
+#_(def connection-pool-spec nil) ; NOCOMMIT
+
+(defmulti connection-pool-spec
+  "Create a new connection pool for a JDBC `spec` and return a spec for it. Optionally pass a map of connection pool
+  properties."
+  {:arglists '([backend jdbc-spec] [backend jdbc-spec pool-properties])}
+  dispatch-on-backend)
+
+#_(def destroy-connection-pool! nil) ; NOCOMMIT
+
+(defmulti destroy-connection-pool!
+  "Immediately release all resources held by a connection pool.
+
+  (This is the internal implementation of `metabase.db.connection-pool/destroy-connection-pool!`; unless you are
+  providing a new connection pooling backend,"
+  {:arglists '([backend pool-spec])}
+  dispatch-on-backend)

--- a/src/metabase/db/connection_pool/noop.clj
+++ b/src/metabase/db/connection_pool/noop.clj
@@ -1,0 +1,11 @@
+(ns metabase.db.connection-pool.noop
+  (:require [clojure.java.jdbc :as jdbc]
+            [metabase.db.connection-pool.interface :as i])
+  (:import java.sql.Connection))
+
+(defmethod i/connection-pool-spec :noop
+  [_ jdbc-spec & _]
+  {:connection (jdbc/get-connection jdbc-spec)})
+
+(defmethod i/destroy-connection-pool! :noop [_ {:keys [^Connection connection]}]
+  (.close connection))

--- a/src/metabase/db/connection_pool/test.clj
+++ b/src/metabase/db/connection_pool/test.clj
@@ -1,0 +1,87 @@
+(ns metabase.db.connection-pool.test
+  (:require [metabase.db.connection-pool :as connection-pool]
+            [clojure.java.jdbc :as jdbc]
+            [metabase.util.date :as du]))
+
+
+
+
+;;; ------------------------------------------------ Proxy DataSource ------------------------------------------------
+
+
+
+
+;; NOCOMMIT
+
+(def %jdbc-spec%
+  {:classname   "org.postgresql.Driver",
+   :subprotocol "postgresql",
+   :subname
+   "//localhost:5432/metabase?type=%3Apostgres&OpenSourceSubProtocolOverride=true",
+   :type        :postgres,
+   :dbname      "test-data",
+   :user        "cam",
+   :password    nil})
+
+(defn- num-connections []
+  (jdbc/with-db-connection [conn %jdbc-spec%]
+    (-> (jdbc/query conn "SELECT sum(numbackends) AS connections FROM pg_stat_database;") first :connections)))
+
+(defn- test-with-backend [backend n]
+  (connection-pool/set-backend! backend)
+  (let [spec (connection-pool/connection-pool-spec %jdbc-spec%)]
+    (try
+      (dorun
+       (pmap (fn [_]
+               (jdbc/query spec "SELECT 1 AS one;"))
+             (range n)))
+      (finally (connection-pool/destroy-connection-pool! spec)))))
+
+(defn- test-it [n]
+  (let [c3p0   (partial test-with-backend :c3p0 n)
+        hikari (partial test-with-backend :hikari n)
+        noop   (partial test-with-backend :noop n)]
+    (du/profile (c3p0))
+    (du/profile (hikari))
+    #_(du/profile (noop))))
+
+(defn- median [coll]
+  (nth (sort coll)
+       (int (/ (count coll) 2))))
+
+(defn- percentile [percent coll]
+  (nth (sort coll)
+       (int (* (count coll) percent))))
+
+(defn- format-nano [ns]
+  (int (/ ns 1000.0)))
+
+(defn- test-with-backend-2 [backend n]
+  (connection-pool/set-backend! backend)
+  (let [spec  (connection-pool/connection-pool-spec %jdbc-spec%)
+        times (atom [])]
+    (try
+      (dotimes [_ 1000]
+        (jdbc/query spec "SELECT 1 AS one;"))
+      (dorun
+       (pmap
+        (fn [_]
+          (let [start-time (System/nanoTime)]
+            (jdbc/query spec "SELECT 1 AS one;")
+            (swap! times conj (- (System/nanoTime) start-time))))
+        (range n)))
+      (println backend
+               "min:" (format-nano (reduce min @times))
+               "median time:" (format-nano (median @times))
+               "95th " (format-nano (percentile 0.95 @times))
+               "99th" (format-nano (percentile 0.99 @times))
+               "max:" (format-nano (reduce max @times)))
+      (finally (connection-pool/destroy-connection-pool! spec)))))
+
+(defn- test-it-2 [n]
+  (let [c3p0   (partial test-with-backend-2 :c3p0 n)
+        hikari (partial test-with-backend-2 :hikari n)
+        noop   (partial test-with-backend-2 :noop n)]
+    (hikari)
+    (c3p0)
+    (noop)))

--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -64,7 +64,7 @@
     ;; remove the cached reference to the pool so we don't try to use it anymore
     (swap! database-id->connection-pool dissoc (u/get-id database))
     ;; now actively shut down the pool so that any open connections are closed
-    (connection-pool/destroy-connection-pool! (:datasource pool))
+    (connection-pool/destroy-connection-pool! pool)
     (when-let [ssh-tunnel (:ssh-tunnel pool)]
       (.disconnect ^com.jcraft.jsch.Session ssh-tunnel))))
 


### PR DESCRIPTION
Experimental code used for benchmarking as part of my investigation for #3052

I'm not sure we really need to make the connection pooling library a configuration option, I think we can decide whether HikariCP is going to be an improvement or not and switch to it and take out c3p0 entirely if we do.

However letting them be swappable makes it easier to test things for comparison purposes. Pushing this as a PR so I can work on some other things and come back to this later and do a few more tests before coming to a conclusion