### PR TITLE
Add ns declaration sorting linter :shirt:

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,18 @@ jobs:
           command: lein with-profile +ci docstring-checker
           no_output_timeout: 5m
 
+  be-linter-namespace-decls:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: /home/circleci/
+      - restore_cache:
+          <<: *restore-be-deps-cache
+      - run:
+          name: Run namespace decl checker
+          command: lein with-profile +ci check-namespace-decls
+          no_output_timeout: 5m
+
   be-linter-bikeshed:
     <<: *defaults
     steps:
@@ -599,6 +611,9 @@ workflows:
       - be-linter-docstring-checker:
           requires:
             - be-deps
+      - be-linter-namespace-decls:
+          requires:
+            - be-deps
       - be-linter-bikeshed:
           requires:
             - be-deps
@@ -676,6 +691,7 @@ workflows:
           requires:
             - be-linter-eastwood
             - be-linter-docstring-checker
+            - be-linter-namespace-decls
             - be-linter-bikeshed
             - be-linter-reflection-warnings
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 - [ ] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.
 ### Tests
 -  [ ] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
--  [ ] If there are changes to the backend codebase, run the backend tests with `lein test && lein eastwood && lein bikeshed && lein docstring-checker && ./bin/reflection-linter`
+-  [ ] If there are changes to the backend codebase, run the backend tests with `lein test && lein eastwood && lein bikeshed && lein docstring-checker && lein check-namespace-decls && ./bin/reflection-linter`
 
 -  [ ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
 (unless it's a tiny documentation change).

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -278,7 +278,7 @@ Some drivers require additional environment variables when testing since they ar
 
 ##### Run the linters:
 
-    lein eastwood && lein bikeshed && lein docstring-checker && ./bin/reflection-linter
+    lein eastwood && lein bikeshed && lein docstring-checker && lein check-namespace-decls && ./bin/reflection-linter
 
 #### Developing with Emacs
 

--- a/modules/drivers/sparksql/src/metabase/driver/FixedHiveConnection.clj
+++ b/modules/drivers/sparksql/src/metabase/driver/FixedHiveConnection.clj
@@ -1,11 +1,10 @@
 (ns metabase.driver.FixedHiveConnection
-  (:import [org.apache.hive.jdbc HiveConnection]
-           [java.sql ResultSet SQLException]
-           java.util.Properties)
   (:gen-class
    :extends org.apache.hive.jdbc.HiveConnection
    :init init
-   :constructors {[String java.util.Properties] [String java.util.Properties]}))
+   :constructors {[String java.util.Properties] [String java.util.Properties]})
+  (:import [java.sql ResultSet SQLException]
+           org.apache.hive.jdbc.HiveConnection))
 
 (defn -init
   "Initializes the connection"

--- a/modules/drivers/sparksql/src/metabase/driver/FixedHiveDriver.clj
+++ b/modules/drivers/sparksql/src/metabase/driver/FixedHiveDriver.clj
@@ -1,12 +1,12 @@
 (ns metabase.driver.FixedHiveDriver
-  (:import clojure.lang.Reflector
-           java.util.Properties
-           org.apache.hive.jdbc.HiveDriver)
   (:gen-class
    :extends org.apache.hive.jdbc.HiveDriver
    :init init
    :prefix "driver-"
-   :constructors {[] []}))
+   :constructors {[] []})
+  (:import clojure.lang.Reflector
+           java.util.Properties
+           org.apache.hive.jdbc.HiveDriver))
 
 (defn driver-init
   "Initializes the Hive driver, fixed to work with Metabase"

--- a/project.clj
+++ b/project.clj
@@ -18,6 +18,7 @@
    "ring"                              ["with-profile" "+ring" "ring"]
    "test"                              ["with-profile" "+expectations" "expectations"]
    "bikeshed"                          ["with-profile" "+bikeshed" "bikeshed" "--max-line-length" "205"]
+   "check-namespace-decls"             ["with-profile" "+check-namespace-decls" "check-namespace-decls"]
    "eastwood"                          ["with-profile" "+eastwood" "eastwood"]
    "check-reflection-warnings"         ["with-profile" "+reflection-warnings" "check"]
    "docstring-checker"                 ["with-profile" "+docstring-checker" "docstring-checker"]
@@ -116,11 +117,11 @@
 
   ;; TODO - WHAT DOES THIS DO?
   :manifest {"Liquibase-Package"
-             #=(eval
-                (str "liquibase.change,liquibase.changelog,liquibase.database,liquibase.parser,liquibase.precondition,"
-                     "liquibase.datatype,liquibase.serializer,liquibase.sqlgenerator,liquibase.executor,"
-                     "liquibase.snapshot,liquibase.logging,liquibase.diff,liquibase.structure,"
-                     "liquibase.structurecompare,liquibase.lockservice,liquibase.sdk,liquibase.ext"))}
+             #= (eval
+                 (str "liquibase.change,liquibase.changelog,liquibase.database,liquibase.parser,liquibase.precondition,"
+                      "liquibase.datatype,liquibase.serializer,liquibase.sqlgenerator,liquibase.executor,"
+                      "liquibase.snapshot,liquibase.logging,liquibase.diff,liquibase.structure,"
+                      "liquibase.structurecompare,liquibase.lockservice,liquibase.sdk,liquibase.ext"))}
 
   :target-path "target/%s"
 
@@ -150,6 +151,7 @@
      [jonase/eastwood "0.3.1"
       :exclusions [org.clojure/clojure]]                              ; Linting
      [lein-bikeshed "0.4.1"]                                          ; Linting
+     [lein-check-namespace-decls "1.0.1"]                             ; lints namespace declarations
      [lein-environ "1.1.0"]                                           ; easy access to environment variables
      [lein-expectations "0.0.8"]                                      ; run unit tests with 'lein expectations'
      ;; TODO - should this be moved to the new RING profile?
@@ -245,6 +247,11 @@
      {:include [#"^metabase"]
       :exclude [#"test"
                 #"^metabase\.http-client$"]}}]
+
+   :check-namespace-decls
+   [:include-all-drivers
+    {:source-paths          ["test"]
+     :check-namespace-decls {:prefix-rewriting true}}]
 
    ;; build the uberjar with `lein uberjar`
    :uberjar

--- a/src/metabase/api/automagic_dashboards.clj
+++ b/src/metabase/api/automagic_dashboards.clj
@@ -1,11 +1,11 @@
 (ns metabase.api.automagic-dashboards
   (:require [buddy.core.codecs :as codecs]
             [cheshire.core :as json]
-            [compojure.core :refer [GET POST]]
+            [compojure.core :refer [GET]]
             [metabase.api.common :as api]
             [metabase.automagic-dashboards
              [comparison :refer [comparison-dashboard]]
-             [core :refer [candidate-tables automagic-analysis]]
+             [core :refer [automagic-analysis candidate-tables]]
              [rules :as rules]]
             [metabase.models
              [card :refer [Card]]

--- a/src/metabase/api/common/internal.clj
+++ b/src/metabase/api/common/internal.clj
@@ -4,8 +4,9 @@
   (:require [clojure.string :as str]
             [clojure.tools.logging :as log]
             [medley.core :as m]
-            [metabase.config :as config]
-            [metabase.util :as u]
+            [metabase
+             [config :as config]
+             [util :as u]]
             [metabase.util
              [i18n :as ui18n :refer [tru]]
              [schema :as su]]

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -2,13 +2,13 @@
   "/api/dashboard endpoints."
   (:require [clojure.tools.logging :as log]
             [compojure.core :refer [DELETE GET POST PUT]]
-            [metabase.automagic-dashboards.populate :as magic.populate]
             [metabase
              [events :as events]
              [query-processor :as qp]
              [related :as related]
              [util :as u]]
             [metabase.api.common :as api]
+            [metabase.automagic-dashboards.populate :as magic.populate]
             [metabase.models
              [card :refer [Card]]
              [collection :as collection]

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -3,7 +3,6 @@
   (:require [clojure.string :as str]
             [clojure.tools.logging :as log]
             [compojure.core :refer [DELETE GET POST PUT]]
-            [metabase.util.i18n :refer [tru]]
             [metabase
              [config :as config]
              [driver :as driver]
@@ -11,10 +10,10 @@
              [public-settings :as public-settings]
              [sample-data :as sample-data]
              [util :as u]]
-            [metabase.driver.util :as driver.u]
             [metabase.api
              [common :as api]
              [table :as table-api]]
+            [metabase.driver.util :as driver.u]
             [metabase.mbql.util :as mbql.u]
             [metabase.models
              [card :refer [Card]]
@@ -30,6 +29,7 @@
              [sync-metadata :as sync-metadata]]
             [metabase.util
              [cron :as cron-util]
+             [i18n :refer [tru]]
              [schema :as su]]
             [schema.core :as s]
             [toucan

--- a/src/metabase/api/ldap.clj
+++ b/src/metabase/api/ldap.clj
@@ -3,12 +3,12 @@
   (:require [clojure.set :as set]
             [clojure.tools.logging :as log]
             [compojure.core :refer [PUT]]
-            [metabase.api.common :refer :all]
+            [metabase.api.common :as api]
             [metabase.integrations.ldap :as ldap]
             [metabase.models.setting :as setting]
             [metabase.util.schema :as su]))
 
-(def ^:private ^:const mb-settings->ldap-details
+(def ^:private mb-settings->ldap-details
   {:ldap-enabled             :enabled
    :ldap-host                :host
    :ldap-port                :port
@@ -85,11 +85,11 @@
         #"(?s).*"
         {:message message}))))
 
-(defendpoint PUT "/settings"
+(api/defendpoint PUT "/settings"
   "Update LDAP related settings. You must be a superuser to do this."
   [:as {settings :body}]
   {settings su/Map}
-  (check-superuser)
+  (api/check-superuser)
   (let [ldap-settings (select-keys settings (keys mb-settings->ldap-details))
         ldap-details  (-> (set/rename-keys ldap-settings mb-settings->ldap-details)
                           (assoc :port
@@ -108,4 +108,4 @@
        :body   (humanize-error-messages results)})))
 
 
-(define-routes)
+(api/define-routes)

--- a/src/metabase/automagic_dashboards/filters.clj
+++ b/src/metabase/automagic_dashboards/filters.clj
@@ -1,12 +1,13 @@
 (ns metabase.automagic-dashboards.filters
-  (:require [metabase.models.field :as field :refer [Field]]
-            [metabase.mbql.normalize :as normalize]
+  (:require [metabase.mbql
+             [normalize :as normalize]
+             [util :as mbql.u]]
+            [metabase.models.field :as field :refer [Field]]
             [metabase.query-processor.util :as qp.util]
             [metabase.util :as u]
             [metabase.util.schema :as su]
             [schema.core :as s]
-            [toucan.db :as db]
-            [metabase.mbql.util :as mbql.u]))
+            [toucan.db :as db]))
 
 (def ^:private FieldReference
   [(s/one (s/constrained su/KeywordOrString

--- a/src/metabase/automagic_dashboards/rules.clj
+++ b/src/metabase/automagic_dashboards/rules.clj
@@ -7,7 +7,7 @@
             [metabase.query-processor.util :as qp.util]
             [metabase.util :as u]
             [metabase.util
-             [i18n :refer [trs tru LocalizedString]]
+             [i18n :refer [LocalizedString trs tru]]
              [schema :as su]]
             [schema
              [coerce :as sc]

--- a/src/metabase/cmd/reset_password.clj
+++ b/src/metabase/cmd/reset_password.clj
@@ -1,6 +1,6 @@
 (ns metabase.cmd.reset-password
   (:require [metabase.db :as mdb]
-            [metabase.models.user :refer [User] :as user]
+            [metabase.models.user :as user :refer [User]]
             [metabase.util.i18n :refer [trs]]
             [toucan.db :as db]))
 

--- a/src/metabase/email.clj
+++ b/src/metabase/email.clj
@@ -3,7 +3,7 @@
             [metabase.models.setting :as setting :refer [defsetting]]
             [metabase.util :as u]
             [metabase.util
-             [i18n :refer [tru trs]]
+             [i18n :refer [trs tru]]
              [schema :as su]]
             [postal
              [core :as postal]

--- a/src/metabase/integrations/slack.clj
+++ b/src/metabase/integrations/slack.clj
@@ -4,10 +4,11 @@
             [clojure.core.memoize :as memoize]
             [clojure.java.io :as io]
             [clojure.tools.logging :as log]
+            [metabase
+             [config :as config]
+             [util :as u]]
             [metabase.models.setting :as setting :refer [defsetting]]
-            [metabase.util :as u]
-            [metabase.util.i18n :refer [tru]]
-            [metabase.config :as config]))
+            [metabase.util.i18n :refer [tru]]))
 
 ;; Define a setting which captures our Slack api token
 (defsetting slack-token (tru "Slack API bearer token obtained from https://api.slack.com/web#authentication"))

--- a/src/metabase/middleware.clj
+++ b/src/metabase/middleware.clj
@@ -1,6 +1,6 @@
 (ns metabase.middleware
   "Metabase-specific middleware functions & configuration."
-  (:require [cheshire.generate :refer [add-encoder encode-nil encode-str]]
+  (:require [cheshire.generate :refer [add-encoder encode-str]]
             [clojure.java.jdbc :as jdbc]
             [clojure.string :as str]
             [clojure.tools.logging :as log]

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -7,8 +7,9 @@
              [public-settings :as public-settings]
              [util :as u]]
             [metabase.api.common :as api :refer [*current-user-id*]]
-            [metabase.api.common :as api :refer [*current-user-id* *current-user-permissions-set*]]
-            [metabase.mbql.util :as mbql.u]
+            [metabase.mbql
+             [normalize :as normalize]
+             [util :as mbql.u]]
             [metabase.models
              [dependency :as dependency]
              [field-values :as field-values]
@@ -22,8 +23,7 @@
             [metabase.util.i18n :as ui18n :refer [tru]]
             [toucan
              [db :as db]
-             [models :as models]]
-            [metabase.mbql.normalize :as normalize]))
+             [models :as models]]))
 
 (models/defmodel Card :report_card)
 

--- a/src/metabase/models/dimension.clj
+++ b/src/metabase/models/dimension.clj
@@ -2,8 +2,8 @@
   "Dimensions are used to define remappings for Fields handled automatically when those Fields are encountered by the
   Query Processor. For a more detailed explanation, refer to the documentation in
   `metabase.query-processor.middleware.add-dimension-projections`."
-  (:require [toucan.models :as models]
-            [metabase.util :as u]))
+  (:require [metabase.util :as u]
+            [toucan.models :as models]))
 
 (def dimension-types
   "Possible values for `Dimension.type`"

--- a/src/metabase/models/query_execution.clj
+++ b/src/metabase/models/query_execution.clj
@@ -1,9 +1,9 @@
 (ns metabase.models.query-execution
   "QueryExecution is a log of very time a query is executed, and other information such as the User who executed it, run
   time, context it was executed in, etc."
-  (:require [metabase.util :as u]
+  (:require [metabase.mbql.schema :as mbql.s]
+            [metabase.util :as u]
             [metabase.util.i18n :refer [tru]]
-            [metabase.mbql.schema :as mbql.s]
             [schema.core :as s]
             [toucan.models :as models]))
 

--- a/src/metabase/plugins/jdbc_proxy.clj
+++ b/src/metabase/plugins/jdbc_proxy.clj
@@ -2,8 +2,8 @@
   "JDBC proxy driver used for drivers added at runtime. DriverManager refuses to recognize drivers that weren't loaded
   by the system classloader, so we need to wrap our drivers loaded at runtime with a proxy class loaded at launch time."
   (:require [clojure.tools.logging :as log]
-            [metabase.util :as u]
             [metabase.plugins.classloader :as classloader]
+            [metabase.util :as u]
             [metabase.util.i18n :refer [trs]])
   (:import [java.sql Driver DriverManager]))
 

--- a/src/metabase/pulse/color.clj
+++ b/src/metabase/pulse/color.clj
@@ -5,8 +5,8 @@
             [metabase.util.i18n :refer [trs]]
             [schema.core :as s])
   (:import java.io.InputStream
-           [javax.script Invocable ScriptEngine ScriptEngineManager]
-           [jdk.nashorn.api.scripting JSObject ScriptObjectMirror]))
+           [javax.script Invocable ScriptEngineManager]
+           jdk.nashorn.api.scripting.JSObject))
 
 (defn- make-js-engine-with-script [^String script]
   (let [engine-mgr (ScriptEngineManager.)

--- a/src/metabase/query_processor/middleware/auto_bucket_datetimes.clj
+++ b/src/metabase/query_processor/middleware/auto_bucket_datetimes.clj
@@ -6,10 +6,10 @@
              [predicates :as mbql.preds]
              [schema :as mbql.s]
              [util :as mbql.u]]
+            [metabase.mbql.schema.helpers :as mbql.s.helpers]
             [metabase.models.field :refer [Field]]
             [metabase.util :as u]
             [metabase.util.schema :as su]
-            [metabase.mbql.schema.helpers :as mbql.s.helpers]
             [schema.core :as s]
             [toucan.db :as db]))
 

--- a/src/metabase/query_processor/middleware/fetch_source_query.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query.clj
@@ -2,13 +2,14 @@
   "Middleware responsible for 'hydrating' the source query for queries that use another query as their source."
   (:require [clojure.string :as str]
             [clojure.tools.logging :as log]
-            [metabase.mbql.schema :as mbql.s]
+            [metabase.mbql
+             [normalize :as normalize]
+             [schema :as mbql.s]]
             [metabase.query-processor.interface :as i]
             [metabase.util :as u]
             [metabase.util.i18n :refer [trs tru]]
             [schema.core :as s]
-            [toucan.db :as db]
-            [metabase.mbql.normalize :as normalize]))
+            [toucan.db :as db]))
 
 (defn- trim-query
   "Native queries can have trailing SQL comments. This works when executed directly, but when we use the query in a

--- a/src/metabase/query_processor/middleware/parameters/dates.clj
+++ b/src/metabase/query_processor/middleware/parameters/dates.clj
@@ -5,9 +5,9 @@
              [format :as tf]]
             [medley.core :as m]
             [metabase.mbql.schema :as mbql.s]
-            [schema.core :as s]
+            [metabase.models.params :as params]
             [metabase.util.schema :as su]
-            [metabase.models.params :as params])
+            [schema.core :as s])
   (:import [org.joda.time DateTime DateTimeConstants]))
 
 (s/defn date-type?

--- a/src/metabase/query_processor/middleware/parameters/sql.clj
+++ b/src/metabase/query_processor/middleware/parameters/sql.clj
@@ -7,10 +7,11 @@
             [honeysql.core :as hsql]
             [medley.core :as m]
             [metabase.driver :as driver]
-            [metabase.driver.util :as driver.u]
-            [metabase.driver.sql :as sql]
-            [metabase.models.field :as field :refer [Field]]
+            [metabase.driver
+             [sql :as sql]
+             [util :as driver.u]]
             [metabase.driver.sql.query-processor :as sql.qp]
+            [metabase.models.field :as field :refer [Field]]
             [metabase.query-processor.middleware.parameters.dates :as date-params]
             [metabase.util
              [date :as du]

--- a/src/metabase/query_processor/middleware/resolve_database.clj
+++ b/src/metabase/query_processor/middleware/resolve_database.clj
@@ -1,7 +1,7 @@
 (ns metabase.query-processor.middleware.resolve-database
-  (:require [metabase.util :as u]
+  (:require [metabase.models.database :as database :refer [Database]]
             [metabase.query-processor.store :as qp.store]
-            [metabase.models.database :as database :refer [Database]]
+            [metabase.util :as u]
             [metabase.util.i18n :refer [tru]]
             [toucan.db :as db]))
 

--- a/src/metabase/query_processor/store.clj
+++ b/src/metabase/query_processor/store.clj
@@ -16,9 +16,10 @@
              [database :refer [Database]]
              [field :refer [Field]]
              [table :refer [Table]]]
-            [metabase.util.i18n :refer [tru]]
             [metabase.util :as u]
-            [metabase.util.schema :as su]
+            [metabase.util
+             [i18n :refer [tru]]
+             [schema :as su]]
             [schema.core :as s]))
 
 ;;; ---------------------------------------------- Setting up the Store ----------------------------------------------

--- a/src/metabase/setup.clj
+++ b/src/metabase/setup.clj
@@ -1,5 +1,5 @@
 (ns metabase.setup
-  (:require [metabase.models.setting :refer [Setting defsetting]]
+  (:require [metabase.models.setting :refer [defsetting Setting]]
             [toucan.db :as db]))
 
 (defsetting ^:private setup-token

--- a/src/metabase/sync/field_values.clj
+++ b/src/metabase/sync/field_values.clj
@@ -3,7 +3,7 @@
   (:require [clojure.tools.logging :as log]
             [metabase.models
              [field :refer [Field]]
-             [field-values :refer [FieldValues] :as field-values]]
+             [field-values :as field-values :refer [FieldValues]]]
             [metabase.sync
              [interface :as i]
              [util :as sync-util]]

--- a/src/metabase/task/DynamicClassLoadHelper.clj
+++ b/src/metabase/task/DynamicClassLoadHelper.clj
@@ -1,11 +1,11 @@
 (ns metabase.task.DynamicClassLoadHelper
   "This is needed to get the JDBC backend for Quartz working, or something like that. See
   http://clojurequartz.info/articles/durable_quartz_stores.html for details."
-  (:require [clojure.string :as str])
   (:gen-class
    :extends clojure.lang.DynamicClassLoader
    :exposes-methods {loadClass superLoadClass}
-   :implements [org.quartz.spi.ClassLoadHelper]))
+   :implements [org.quartz.spi.ClassLoadHelper])
+  (:require [clojure.string :as str]))
 
 ;; docstrings are copies of the ones for the corresponding methods of the ClassLoadHelper interface
 

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -12,7 +12,7 @@
             [colorize.core :as colorize]
             [medley.core :as m]
             [metabase.config :as config]
-            [metabase.util.i18n :refer [tru trs]]
+            [metabase.util.i18n :refer [trs tru]]
             [ring.util.codec :as codec])
   (:import [java.net InetAddress InetSocketAddress Socket]
            [java.text Normalizer Normalizer$Form]

--- a/src/metabase/util/cron.clj
+++ b/src/metabase/util/cron.clj
@@ -3,8 +3,8 @@
    See http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/crontrigger.html#format for details on cron
    format."
   (:require [clojure.string :as str]
-            [schema.core :as s]
-            [metabase.util.schema :as su])
+            [metabase.util.schema :as su]
+            [schema.core :as s])
   (:import org.quartz.CronExpression))
 
 (def CronScheduleString

--- a/src/metabase/util/schema.clj
+++ b/src/metabase/util/schema.clj
@@ -4,11 +4,13 @@
             [clojure.string :as str]
             [medley.core :as m]
             [metabase.util :as u]
-            [metabase.util.password :as password]
-            [metabase.util.i18n :refer [tru]]
-            [schema.core :as s]
-            [schema.macros :as s.macros]
-            [schema.utils :as s.utils]))
+            [metabase.util
+             [i18n :refer [tru]]
+             [password :as password]]
+            [schema
+             [core :as s]
+             [macros :as s.macros]
+             [utils :as s.utils]]))
 
 ;; always validate all schemas in s/defn function declarations. See
 ;; https://github.com/plumatic/schema#schemas-in-practice for details.

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -1,6 +1,10 @@
 (ns metabase.api.database-test
   "Tests for /api/database endpoints."
-  (:require [expectations :refer :all]
+  (:require [clojure.string :as str]
+            [expectations :refer :all]
+            [metabase
+             [driver :as driver]
+             [util :as u]]
             [metabase.api.database :as database-api]
             [metabase.driver.util :as driver.u]
             [metabase.models
@@ -20,15 +24,11 @@
              [data :as data]
              [util :as tu :refer [match-$]]]
             [metabase.test.data
-             [datasets :as datasets]
              [env :as tx.env]
              [users :refer :all]]
             [metabase.test.util.log :as tu.log]
-            [metabase.util :as u]
             [toucan.db :as db]
-            [toucan.util.test :as tt]
-            [metabase.driver :as driver]
-            [clojure.string :as str]))
+            [toucan.util.test :as tt]))
 
 ;; HELPER FNS
 

--- a/test/metabase/api/geojson_test.clj
+++ b/test/metabase/api/geojson_test.clj
@@ -3,9 +3,9 @@
             [metabase.api.geojson :as geojson-api]
             [metabase.test.data.users :refer [user->client]]
             [metabase.test.util :as tu]
+            [metabase.test.util.log :as tu.log]
             [metabase.util :as u]
-            [schema.core :as s]
-            [metabase.test.util.log :as tu.log]))
+            [schema.core :as s]))
 
 (def ^:private ^String test-geojson-url
   "URL of a GeoJSON file used for test purposes."

--- a/test/metabase/api/pulse_test.clj
+++ b/test/metabase/api/pulse_test.clj
@@ -7,6 +7,7 @@
              [middleware :as middleware]
              [util :as u]]
             [metabase.api.card-test :as card-api-test]
+            [metabase.integrations.slack :as slack]
             [metabase.models
              [card :refer [Card]]
              [collection :refer [Collection]]
@@ -927,8 +928,8 @@
 (expect
   [{:name "channel", :type "select", :displayName "Post to", :options ["#foo" "@bar"], :required true}]
   (tu/with-temporary-setting-values [slack-token "something"]
-    (with-redefs [metabase.integrations.slack/channels-list (constantly [{:name "foo"}])
-                  metabase.integrations.slack/users-list (constantly [{:name "bar"}])]
+    (with-redefs [slack/channels-list (constantly [{:name "foo"}])
+                  slack/users-list    (constantly [{:name "bar"}])]
       (-> ((user->client :rasta) :get 200 "pulse/form_input")
           (get-in [:channels :slack :fields])))))
 

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -6,12 +6,13 @@
              [http-client :as http]
              [middleware :as middleware]
              [util :as u]]
-            [metabase.models.user :refer [User]]
+            [metabase.models
+             [collection-test :as collection-test]
+             [user :refer [User]]]
             [metabase.test
              [data :refer :all]
              [util :as tu :refer [random-name]]]
             [metabase.test.data.users :as test-users]
-            [metabase.models.collection-test :as collection-test]
             [toucan.db :as db]
             [toucan.util.test :as tt]))
 

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -3,9 +3,7 @@
              [core :as t]
              [format :as t.format]]
             [expectations :refer :all]
-            [metabase.api
-             [card :as card.api]
-             [common :as api]]
+            [metabase.api.card :as card.api]
             [metabase.automagic-dashboards
              [core :as magic :refer :all]
              [rules :as rules]]
@@ -26,8 +24,7 @@
             [metabase.util.date :as date]
             [puppetlabs.i18n.core :as i18n :refer [tru]]
             [toucan.db :as db]
-            [toucan.util.test :as tt]
-            [metabase.util :as u]))
+            [toucan.util.test :as tt]))
 
 ;;; ------------------- `->reference` -------------------
 

--- a/test/metabase/automagic_dashboards/filters_test.clj
+++ b/test/metabase/automagic_dashboards/filters_test.clj
@@ -1,6 +1,6 @@
 (ns metabase.automagic-dashboards.filters-test
   (:require [expectations :refer :all]
-            [metabase.automagic-dashboards.filters :refer :all :as filters]))
+            [metabase.automagic-dashboards.filters :as filters :refer :all]))
 
 ;; Replace range with the more specific `:=`.
 (expect

--- a/test/metabase/automagic_dashboards/populate_test.clj
+++ b/test/metabase/automagic_dashboards/populate_test.clj
@@ -1,3 +1,0 @@
-(ns metabase.automagic-dashboards.populate-test
-  (:require [expectations :refer :all]
-            [metabase.automagic-dashboards.populate :as populate]))

--- a/test/metabase/automagic_dashboards/rules_test.clj
+++ b/test/metabase/automagic_dashboards/rules_test.clj
@@ -1,6 +1,6 @@
 (ns metabase.automagic-dashboards.rules-test
   (:require [expectations :refer :all]
-            [metabase.automagic-dashboards.rules :refer :all :as rules]))
+            [metabase.automagic-dashboards.rules :as rules :refer :all]))
 
 (expect nil   (#'rules/ensure-seq nil))
 (expect [nil] (#'rules/ensure-seq [nil]))

--- a/test/metabase/email/messages_test.clj
+++ b/test/metabase/email/messages_test.clj
@@ -1,8 +1,7 @@
 (ns metabase.email.messages-test
   (:require [expectations :refer :all]
             [metabase.email-test :refer [inbox with-fake-inbox]]
-            [metabase.email.messages :as msgs :refer [send-new-user-email! send-password-reset-email!]]
-            [metabase.test.util :as tu])
+            [metabase.email.messages :as msgs :refer [send-new-user-email! send-password-reset-email!]])
   (:import java.io.IOException))
 
 ;; new user email

--- a/test/metabase/middleware_test.clj
+++ b/test/metabase/middleware_test.clj
@@ -1,22 +1,13 @@
 (ns metabase.middleware-test
   (:require [cheshire.core :as json]
-            [clojure.java.io :as io]
-            [clojure.tools.logging :as log]
-            [compojure.core :refer [GET]]
             [expectations :refer :all]
-            [metabase
-             [config :as config]
-             [middleware :as middleware :refer :all :as mid]
-             [routes :as routes]
-             [util :as u]]
             [metabase.api.common :refer [*current-user* *current-user-id*]]
+            [metabase.middleware :as mid :refer :all]
             [metabase.models.session :refer [Session]]
             [metabase.test.data.users :refer :all]
             [metabase.util.date :as du]
             [ring.mock.request :as mock]
-            [ring.util.response :as resp]
-            [toucan.db :as db]
-            [clojure.string :as string]))
+            [toucan.db :as db]))
 
 ;;  ===========================  TEST wrap-session-id middleware  ===========================
 

--- a/test/metabase/models/dependency_test.clj
+++ b/test/metabase/models/dependency_test.clj
@@ -2,7 +2,6 @@
   (:require [expectations :refer :all]
             [metabase.models.dependency :refer :all]
             [metabase.test.data :refer :all]
-            [metabase.util :as u]
             [metabase.util.date :as du]
             [toucan
              [db :as db]

--- a/test/metabase/models/humanization_test.clj
+++ b/test/metabase/models/humanization_test.clj
@@ -1,7 +1,6 @@
 (ns metabase.models.humanization-test
   (:require [expectations :refer :all]
             [metabase.models
-             [field :refer [Field]]
              [humanization :as humanization :refer :all]
              [table :refer [Table]]]
             [metabase.test.util :as tu]

--- a/test/metabase/models/metric_test.clj
+++ b/test/metabase/models/metric_test.clj
@@ -5,7 +5,7 @@
              [metric :as metric :refer :all]
              [table :refer [Table]]]
             [metabase.test.data :refer :all]
-            [metabase.test.data.users :refer [user->id fetch-user]]
+            [metabase.test.data.users :refer [fetch-user user->id]]
             [metabase.util :as u]
             [toucan.util.test :as tt]))
 

--- a/test/metabase/models/revision_test.clj
+++ b/test/metabase/models/revision_test.clj
@@ -2,7 +2,7 @@
   (:require [expectations :refer :all]
             [metabase.models
              [card :refer [Card]]
-             [revision :refer :all :as revision]]
+             [revision :as revision :refer :all]]
             [metabase.test.data.users :refer :all]
             [metabase.util :as u]
             [toucan.models :as models]

--- a/test/metabase/models/session_test.clj
+++ b/test/metabase/models/session_test.clj
@@ -4,7 +4,6 @@
              [session :refer :all]
              [user :refer [User]]]
             [metabase.test.util :as tu]
-            [metabase.util :as u]
             [metabase.util.date :as du]
             [toucan.db :as db]
             [toucan.util.test :as tt]))

--- a/test/metabase/models/task_history_test.clj
+++ b/test/metabase/models/task_history_test.clj
@@ -1,7 +1,5 @@
 (ns metabase.models.task-history-test
-  (:require [clj-time
-             [coerce :as tcoerce]
-             [core :as time]]
+  (:require [clj-time.core :as time]
             [expectations :refer :all]
             [metabase.models.task-history :refer :all]
             [metabase.test.util :as tu]

--- a/test/metabase/public_settings_test.clj
+++ b/test/metabase/public_settings_test.clj
@@ -2,7 +2,7 @@
   (:require [expectations :refer :all]
             [metabase.public-settings :as public-settings]
             [metabase.test.util :as tu]
-            [puppetlabs.i18n.core :as i18n :refer [tru trs]]))
+            [puppetlabs.i18n.core :as i18n :refer [tru]]))
 
  ;; double-check that setting the `site-url` setting will automatically strip off trailing slashes
 (expect

--- a/test/metabase/query_processor/middleware/add_query_throttle_test.clj
+++ b/test/metabase/query_processor/middleware/add_query_throttle_test.clj
@@ -4,9 +4,7 @@
             [metabase.query-processor.middleware
              [add-query-throttle :as throttle :refer :all]
              [catch-exceptions :as catch-exceptions]]
-            [metabase.test
-             [data :as data]
-             [util :as tu]]
+            [metabase.test.util :as tu]
             [metabase.util :as u])
   (:import java.util.concurrent.Semaphore))
 

--- a/test/metabase/query_processor/middleware/cache_backend/db_test.clj
+++ b/test/metabase/query_processor/middleware/cache_backend/db_test.clj
@@ -1,7 +1,6 @@
 (ns metabase.query-processor.middleware.cache-backend.db-test
   (:require [expectations :refer :all]
-            [metabase.query-processor.middleware.cache-backend.db :as cache-db]
-            [metabase.test.util :as tu]))
+            [metabase.query-processor.middleware.cache-backend.db :as cache-db]))
 
 (defn- in-kb [x]
   (* 1024 x))

--- a/test/metabase/query_processor/middleware/desugar_test.clj
+++ b/test/metabase/query_processor/middleware/desugar_test.clj
@@ -1,6 +1,6 @@
 (ns metabase.query-processor.middleware.desugar-test
-  (:require [metabase.query-processor.middleware.desugar :as desugar]
-            [expectations :refer [expect]]))
+  (:require [expectations :refer [expect]]
+            [metabase.query-processor.middleware.desugar :as desugar]))
 
 (def ^:private ^{:arglists '([query])} desugar
   (desugar/desugar identity))

--- a/test/metabase/query_processor/middleware/parameters/date_test.clj
+++ b/test/metabase/query_processor/middleware/parameters/date_test.clj
@@ -1,7 +1,7 @@
 (ns metabase.query-processor.middleware.parameters.date-test
   "Tests for datetime parameters."
-  (:require [expectations :refer :all]
-            [clj-time.core :as t]
+  (:require [clj-time.core :as t]
+            [expectations :refer :all]
             [metabase.query-processor.middleware.parameters.dates :refer :all]))
 
 ;; we hard code "now" to a specific point in time so that we can control the test output

--- a/test/metabase/query_processor/middleware/parameters/mbql_test.clj
+++ b/test/metabase/query_processor/middleware/parameters/mbql_test.clj
@@ -8,10 +8,7 @@
              [util :as u]]
             [metabase.mbql.normalize :as normalize]
             [metabase.query-processor.middleware.parameters.mbql :as mbql-params]
-            [metabase.test
-             [data :as data]
-             [util :as tu]]
-            [metabase.driver :as driver]
+            [metabase.test.data :as data]
             [metabase.test.data.datasets :as datasets]
             [metabase.util.date :as du]))
 

--- a/test/metabase/query_processor/middleware/permissions_test.clj
+++ b/test/metabase/query_processor/middleware/permissions_test.clj
@@ -1,13 +1,11 @@
 (ns metabase.query-processor.middleware.permissions-test
   "Tests for the middleware that checks whether the current user has permissions to run a given query."
   (:require [expectations :refer :all]
-            [metabase.api.common :as api]
             [metabase.models
              [database :refer [Database]]
              [permissions :as perms]
              [permissions-group :as perms-group]
-             [table :refer [Table]]
-             [user :as user]]
+             [table :refer [Table]]]
             [metabase.query-processor.middleware.permissions :refer [check-query-permissions]]
             [metabase.test.data.users :as users]
             [metabase.util :as u]

--- a/test/metabase/query_processor/middleware/resolve_joined_tables_test.clj
+++ b/test/metabase/query_processor/middleware/resolve_joined_tables_test.clj
@@ -2,8 +2,7 @@
   (:require [expectations :refer :all]
             [metabase.query-processor.middleware.resolve-joined-tables :as resolve-joined-tables]
             [metabase.query-processor.test-util :as qp.test-util]
-            [metabase.test.data :as data]
-            [metabase.query-processor.store :as qp.store]))
+            [metabase.test.data :as data]))
 
 (defn- resolve-joined-tables [query]
   (qp.test-util/with-everything-store

--- a/test/metabase/query_processor_test/aggregation_test.clj
+++ b/test/metabase/query_processor_test/aggregation_test.clj
@@ -8,8 +8,7 @@
             [metabase.test
              [data :as data]
              [util :as tu]]
-            [metabase.test.data.datasets :as datasets]
-            [toucan.util.test :as tt]))
+            [metabase.test.data.datasets :as datasets]))
 
 ;;; ---------------------------------------------- "COUNT" AGGREGATION -----------------------------------------------
 

--- a/test/metabase/query_processor_test/filter_test.clj
+++ b/test/metabase/query_processor_test/filter_test.clj
@@ -3,9 +3,7 @@
   (:require [metabase
              [driver :as driver]
              [query-processor-test :refer :all]]
-            [metabase.test
-             [data :as data]
-             [util :as tu]]
+            [metabase.test.data :as data]
             [metabase.test.data.datasets :as datasets]))
 
 ;;; FILTER -- "AND", ">", ">="

--- a/test/metabase/related_test.clj
+++ b/test/metabase/related_test.clj
@@ -10,8 +10,9 @@
              [metric :refer [Metric]]
              [segment :refer [Segment]]]
             [metabase.test.data :as data]
-            [metabase.test.data.one-off-dbs :as one-off-dbs]
-            [toucan.util.test :as tt][metabase.test.data.users :as users]
+            [metabase.test.data
+             [one-off-dbs :as one-off-dbs]
+             [users :as users]]
             [toucan.util.test :as tt]))
 
 (expect

--- a/test/metabase/sync/analyze/classifiers/name_test.clj
+++ b/test/metabase/sync/analyze/classifiers/name_test.clj
@@ -4,8 +4,6 @@
              [field :refer [Field]]
              [table :as table :refer [Table]]]
             [metabase.sync.analyze.classifiers.name :refer :all]
-            [metabase.test.data :as data]
-            [metabase.util :as u]
             [toucan.util.test :as tt]))
 
 ;; Postfix + pluralization

--- a/test/metabase/sync/field_values_test.clj
+++ b/test/metabase/sync/field_values_test.clj
@@ -1,14 +1,12 @@
 (ns metabase.sync.field-values-test
   "Tests around the way Metabase syncs FieldValues, and sets the values of `field.has_field_values`."
   (:require [expectations :refer :all]
-            [metabase
-             [sync :as sync]
-             [util :as u]]
             [metabase.models
              [database :refer [Database]]
              [field :refer [Field]]
              [field-values :as field-values :refer [FieldValues]]
              [table :refer [Table]]]
+            [metabase.sync :as sync]
             [metabase.sync.util-test :as sut]
             [metabase.test.data :as data]
             [metabase.test.data.one-off-dbs :as one-off-dbs]

--- a/test/metabase/sync/sync_metadata/fields_test.clj
+++ b/test/metabase/sync/sync_metadata/fields_test.clj
@@ -18,8 +18,7 @@
             [metabase.test.data.one-off-dbs :as one-off-dbs]
             [toucan
              [db :as db]
-             [hydrate :refer [hydrate]]]
-            [toucan.util.test :as tt]))
+             [hydrate :refer [hydrate]]]))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                         Dropping & Undropping Columns                                          |

--- a/test/metabase/sync/sync_metadata/sync_database_type_test.clj
+++ b/test/metabase/sync/sync_metadata/sync_database_type_test.clj
@@ -10,7 +10,6 @@
              [table :refer [Table]]]
             [metabase.sync.util-test :as sut]
             [metabase.test.data :as data]
-            metabase.test.util ; to make sure defaults for with-temp are registered
             [toucan.db :as db]
             [toucan.util.test :as tt]))
 

--- a/test/metabase/sync_database/analyze_test.clj
+++ b/test/metabase/sync_database/analyze_test.clj
@@ -1,24 +1,20 @@
 (ns metabase.sync-database.analyze-test
-  ;; TODO - this namespace follows the old pattern of sync namespaces. Tests should be moved to appropriate new homes
-  ;; at some point
+  "TODO - this namespace follows the old pattern of sync namespaces. Tests should be moved to appropriate new homes at
+  some point"
   (:require [clojure.string :as str]
             [expectations :refer :all]
-            [metabase
-             [driver :as driver]
-             [util :as u]]
             [metabase.db.metadata-queries :as metadata-queries]
             [metabase.models
              [database :refer [Database]]
-             [field :refer [Field] :as field]
+             [field :as field :refer [Field]]
              [field-values :as field-values]
              [table :as table :refer [Table]]]
             [metabase.sync.analyze :as analyze]
-            [metabase.sync.analyze.fingerprint.fingerprinters :as fingerprinters]
             [metabase.sync.analyze.classifiers.text-fingerprint :as classify-text-fingerprint]
-            [metabase.test
-             [data :as data]
-             [util :as tu]]
+            [metabase.sync.analyze.fingerprint.fingerprinters :as fingerprinters]
+            [metabase.test.data :as data]
             [metabase.test.data.users :refer :all]
+            [metabase.util :as u]
             [toucan.db :as db]
             [toucan.util.test :as tt]))
 

--- a/test/metabase/test/data/sql/ddl.clj
+++ b/test/metabase/test/data/sql/ddl.clj
@@ -2,8 +2,7 @@
   (:require [metabase.driver :as driver]
             [metabase.test.data
              [interface :as tx]
-             [sql :as sql.tx]]
-            [metabase.util :as u]))
+             [sql :as sql.tx]]))
 
 (defmulti drop-db-ddl-statements
   "Return a sequence of DDL statements for dropping a DB using the multimethods in the SQL test extensons namespace, if

--- a/test/metabase/test/util/log.clj
+++ b/test/metabase/test/util/log.clj
@@ -1,10 +1,8 @@
 (ns metabase.test.util.log
   "Utils for controlling the logging that goes on when running tests."
-  (:require [clojure.tools.logging :as log]
-            [metabase.util :as u])
-  (:import [org.apache.log4j Level Logger LogManager]
+  (:import java.io.PrintStream
            [org.apache.commons.io.output NullOutputStream NullWriter]
-           java.io.PrintStream))
+           [org.apache.log4j Level Logger LogManager]))
 
 (defn do-with-suppressed-output
   "Impl for `suppress-output` macro; don't use this directly."

--- a/test/metabase/test_setup.clj
+++ b/test/metabase/test_setup.clj
@@ -2,7 +2,8 @@
   "Functions that run before + after unit tests (setup DB, start web server, load test data)."
   (:require [clojure
              [data :as data]
-             [set :as set]]
+             [set :as set]
+             [string :as str]]
             [clojure.java.io :as io]
             [clojure.tools.logging :as log]
             [expectations :refer :all]
@@ -16,8 +17,7 @@
             [metabase.models.setting :as setting]
             [metabase.plugins.initialize :as plugins.init]
             [metabase.test.data.env :as tx.env]
-            [yaml.core :as yaml]
-            [clojure.string :as str]))
+            [yaml.core :as yaml]))
 
 ;;; ---------------------------------------- Expectations Framework Settings -----------------------------------------
 


### PR DESCRIPTION
Wrote a linter this weekend to check that `ns` declarations are sorted and don't contain references to unused namespaces.

Ran it on our codebase and found a few dozen namespaces that needed a good sort. Fixed them all with with `M-x cljr-clean-ns` 