### PR TITLE
Add plugins dir to Dockerfiles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,13 @@
 .babel_cache/*
+.git/*
 docs/*
 OSX/*
 target/*
 
 **node_modules
 **metabase.jar
+
+*.db
 
 .dockerignore
 Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,10 @@ RUN mkdir -p bin target/uberjar
 COPY --from=builder /app/source/target/uberjar/metabase.jar /app/target/uberjar/
 COPY --from=builder /app/source/bin/start /app/bin/
 
+# create the plugins directory, with writable permissions
+RUN mkdir -p /plugins
+RUN chmod a+rwx /plugins
+
 # expose our default runtime port
 EXPOSE 3000
 

--- a/bin/docker/Dockerfile
+++ b/bin/docker/Dockerfile
@@ -18,6 +18,10 @@ COPY ./metabase.jar /app/
 # add our run script to the image
 COPY ./run_metabase.sh /app/
 
+# create the plugins directory, with writable permissions
+RUN mkdir -p /plugins
+RUN chmod a+rwx /plugins
+
 # expose our default runtime port
 EXPOSE 3000
 


### PR DESCRIPTION
Docker images stopped working after modular plugins refactor due to missing /plugins directory.