### PR TITLE
SQL/native editor syntax highlight styling

### DIFF
--- a/frontend/src/metabase/css/core/colors.css
+++ b/frontend/src/metabase/css/core/colors.css
@@ -29,11 +29,11 @@
   --color-border: #d7dbde;
 
   /* saturated colors for sql editor */
-  --color-saturated-brand: #2D86D4;
-  --color-saturated-green: #70A63A;
-  --color-saturated-purple: #885AB1;
-  --color-saturated-red: #ED6E6E;
-  --color-saturated-yellow: #F9CF48;
+  --color-saturated-brand: #2d86d4;
+  --color-saturated-green: #70a63a;
+  --color-saturated-purple: #885ab1;
+  --color-saturated-red: #ed6e6e;
+  --color-saturated-yellow: #f9cf48;
 
   /* night mode colors */
   --night-mode-color: color(var(--color-text-white) alpha(-14%));

--- a/frontend/src/metabase/css/core/colors.css
+++ b/frontend/src/metabase/css/core/colors.css
@@ -28,6 +28,13 @@
   --color-shadow: rgba(0, 0, 0, 0.08);
   --color-border: #d7dbde;
 
+  /* saturated colors for sql editor */
+  --color-saturated-brand: #2D86D4;
+  --color-saturated-green: #70A63A;
+  --color-saturated-purple: #885AB1;
+  --color-saturated-red: #ED6E6E;
+  --color-saturated-yellow: #F9CF48;
+
   /* night mode colors */
   --night-mode-color: color(var(--color-text-white) alpha(-14%));
   --night-mode-card: #42484e;

--- a/frontend/src/metabase/css/core/colors.css
+++ b/frontend/src/metabase/css/core/colors.css
@@ -28,8 +28,8 @@
   --color-shadow: rgba(0, 0, 0, 0.08);
   --color-border: #d7dbde;
 
-  /* saturated colors for sql editor */
-  --color-saturated-brand: #2d86d4;
+  /* Saturated colors for the SQL editor. Shouldn't be used elsewhere since they're not white-labelable. */
+  --color-saturated-blue: #2d86d4;
   --color-saturated-green: #70a63a;
   --color-saturated-purple: #885ab1;
   --color-saturated-red: #ed6e6e;

--- a/frontend/src/metabase/lib/colors.js
+++ b/frontend/src/metabase/lib/colors.js
@@ -39,7 +39,8 @@ const colors = {
   "bg-white": "#FFFFFF",
   shadow: "rgba(0,0,0,0.08)",
   border: "#D7DBDE",
-  "saturated-brand": "#2D86D4",
+  /* Saturated colors for the SQL editor. Shouldn't be used elsewhere since they're not white-labelable. */
+  "saturated-blue": "#2D86D4",
   "saturated-green": "#70A63A",
   "saturated-purple": "#885AB1",
   "saturated-red": "#ED6E6E",

--- a/frontend/src/metabase/lib/colors.js
+++ b/frontend/src/metabase/lib/colors.js
@@ -39,6 +39,11 @@ const colors = {
   "bg-white": "#FFFFFF",
   shadow: "rgba(0,0,0,0.08)",
   border: "#D7DBDE",
+  "saturated-brand": "#2D86D4",
+  "saturated-green": "#70A63A",
+  "saturated-purple": "#885AB1",
+  "saturated-red": "#ED6E6E",
+  "saturated-yellow": "#F9CF48",
 };
 /* eslint-enable no-color-literals */
 export default colors;

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.css
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.css
@@ -1,5 +1,21 @@
 .NativeQueryEditor .ace_editor {
   height: 100%;
+  background-color: var(--color-bg-light);
+  color: var(--color-text-dark);
+}
+.NativeQueryEditor .ace_editor .ace_keyword {
+  color: var(--color-saturated-purple);
+}
+.NativeQueryEditor .ace_editor .ace_function {
+  color: var(--color-saturated-brand);
+}
+.NativeQueryEditor .ace_editor .ace_constant,
+.NativeQueryEditor .ace_editor .ace_type {
+  color: var(--color-saturated-red);
+}
+.NativeQueryEditor .ace_editor .ace_string,
+.NativeQueryEditor .ace_editor .ace_variable {
+  color: var(--color-saturated-green);
 }
 
 .NativeQueryEditor .react-resizable {
@@ -22,7 +38,7 @@
   padding-top: 2px;
   font-size: 10px;
   font-weight: 700;
-  color: var(--color-text-medium);
+  color: var(--color-text-light);
   padding-left: 0;
   padding-right: 0;
   display: block;

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.css
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.css
@@ -8,7 +8,7 @@
 }
 .NativeQueryEditor .ace_editor .ace_function,
 .NativeQueryEditor .ace_editor .ace_variable {
-  color: var(--color-saturated-brand);
+  color: var(--color-saturated-blue);
 }
 .NativeQueryEditor .ace_editor .ace_constant,
 .NativeQueryEditor .ace_editor .ace_type {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.css
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.css
@@ -6,15 +6,15 @@
 .NativeQueryEditor .ace_editor .ace_keyword {
   color: var(--color-saturated-purple);
 }
-.NativeQueryEditor .ace_editor .ace_function {
+.NativeQueryEditor .ace_editor .ace_function,
+.NativeQueryEditor .ace_editor .ace_variable {
   color: var(--color-saturated-brand);
 }
 .NativeQueryEditor .ace_editor .ace_constant,
 .NativeQueryEditor .ace_editor .ace_type {
   color: var(--color-saturated-red);
 }
-.NativeQueryEditor .ace_editor .ace_string,
-.NativeQueryEditor .ace_editor .ace_variable {
+.NativeQueryEditor .ace_editor .ace_string {
   color: var(--color-saturated-green);
 }
 


### PR DESCRIPTION
Changes the colors of our SQL editor's syntax highlighting to match the Metabase color palette.

TO-DO:
- [x] Check this with a few more DB types (highlighting is different per DB driver…)
- [x] Nicer highlighting for Druid and GA

**New hotness:**

![screen shot 2019-01-21 at 5 03 23 pm](https://user-images.githubusercontent.com/2223916/51506020-e8d7b600-1d9e-11e9-9eaa-980ee6cfff8b.png)

**JSON-based queries:**

![screen shot 2019-01-22 at 1 33 01 pm](https://user-images.githubusercontent.com/2223916/51567209-7ffa4780-1e4b-11e9-8aca-562da99c1234.png)

**Sad old state of affairs:**

![screen shot 2019-01-21 at 5 03 56 pm](https://user-images.githubusercontent.com/2223916/51506028-f68d3b80-1d9e-11e9-8cb1-455749f057f5.png)
