### PR TITLE
Increased support & tests for Query.constraints.max-results

### DIFF
--- a/bin/build-driver.sh
+++ b/bin/build-driver.sh
@@ -21,10 +21,20 @@ checksum_file="$driver_project_dir/target/checksum.txt"
 
 ######################################## CALCULATING CHECKSUMS ########################################
 
+md5_command=''
+if [ `command -v md5` ]; then
+    md5_command=md5
+elif [ `command -v md5sum` ]; then
+    md5_command=md5sum
+else
+    echo "Don't know what command to use to calculate md5sums."
+    exit -2
+fi
+
 # Calculate a checksum of all the driver source files. If we've already built the driver and the checksum is the same
 # there's no need to build the driver a second time
 calculate_checksum() {
-    find "$driver_project_dir" -name '*.clj' -or -name '*.yaml' | sort | cat | md5sum
+    find "$driver_project_dir" -name '*.clj' -or -name '*.yaml' | sort | cat | $md5_command
 }
 
 # Check whether the saved checksum for the driver sources from the last build is the same as the current one. If so,
@@ -127,7 +137,7 @@ build_driver_uberjar() {
 
     if [ ! -f "$target_jar" ]; then
         echo "Error: could not find $target_jar. Build failed."
-        exit -1
+        return -1
     fi
 }
 
@@ -150,25 +160,47 @@ save_checksum() {
     echo "$checksum" > "$checksum_file"
 }
 
+copy_target_to_dest() {
+    # ok, finally, copy finished JAR to the resources dir
+    echo "Copying $target_jar -> $dest_location"
+    cp "$target_jar" "$dest_location"
+}
+
 # Runs all the steps needed to build the driver.
 build_driver() {
-    delete_old_drivers
-    install_metabase_core
-    build_metabase_uberjar
-    build_parents
-    build_driver_uberjar
-    strip_and_compress
-    save_checksum
+    delete_old_drivers &&
+        install_metabase_core &&
+        build_metabase_uberjar &&
+        build_parents &&
+        build_driver_uberjar &&
+        strip_and_compress &&
+        save_checksum &&
+        copy_target_to_dest
 }
 
 ######################################## PUTTING IT ALL TOGETHER ########################################
 
+clean_local_repo() {
+    echo "Deleting existing installed metabase-core and driver dependencies..."
+    rm -rf ~/.m2/repository/metabase-core
+    rm -rf ~/.m2/repository/metabase/*-driver
+}
+
+retry_clean_build() {
+    echo "Building without cleaning failed. Retrying clean build..."
+    clean_local_repo
+    build_driver
+}
+
 mkdir -p resources/modules
 
-if [ ! "$(checksum_is_same)" ]; then
-    build_driver
+# run only a specific step with ./bin/build-driver.sh <driver> <step>
+if [ $# -eq 2 ]; then
+    $2
+# Build driver if checksum has changed
+elif [ ! "$(checksum_is_same)" ]; then
+    build_driver || retry_clean_build
+# Either way, always copy the target uberjar to the dest location
+else
+    copy_target_to_dest
 fi
-
-# ok, finally, copy finished JAR to the resources dir
-echo "Copying $target_jar -> $dest_location"
-cp "$target_jar" "$dest_location"

--- a/frontend/test/metabase-lib/Question.integ.spec.js
+++ b/frontend/test/metabase-lib/Question.integ.spec.js
@@ -74,7 +74,7 @@ describe("Question", () => {
 
       const results1 = await question.apiGetResults({ ignoreCache: true });
       expect(results1[0]).toBeDefined();
-      expect(results1[0].data.rows.length).toEqual(10000);
+      expect(results1[0].data.rows.length).toEqual(2000);
 
       question._parameterValues = { [templateTagId]: "5" };
       const results2 = await question.apiGetResults({ ignoreCache: true });

--- a/modules/drivers/sparksql/resources/metabase-plugin.yaml
+++ b/modules/drivers/sparksql/resources/metabase-plugin.yaml
@@ -6,6 +6,7 @@ driver:
   - name: hive-like
     lazy-load: true
     abstract: true
+    parent: sql-jdbc
   - name: sparksql
     display-name: Spark SQL
     lazy-load: true

--- a/src/metabase/mbql/schema.clj
+++ b/src/metabase/mbql/schema.clj
@@ -558,7 +558,11 @@
     (s/optional-key :filter)       Filter
     (s/optional-key :limit)        su/IntGreaterThanZero
     (s/optional-key :order-by)     (distinct-non-empty [OrderBy])
-    (s/optional-key :page)         {:page  su/IntGreaterThanOrEqualToZero
+    ;; page = page num, starting with 1. items = number of items per page.
+    ;; e.g.
+    ;; {:page 1, :items 10} = items 1-10
+    ;; {:page 2, :items 10} = items 11-20
+    (s/optional-key :page)         {:page  su/IntGreaterThanZero
                                     :items su/IntGreaterThanZero}
     ;; Various bits of middleware add additonal keys, such as `fields-is-implicit?`, to record bits of state or pass
     ;; info to other pieces of middleware. Everyone else can ignore them.
@@ -597,13 +601,21 @@
   "Additional constraints added to a query limiting the maximum number of rows that can be returned. Mostly useful
   because native queries don't support the MBQL `:limit` clause. For MBQL queries, if `:limit` is set, it will
   override these values."
-  {;; maximum number of results to allow for a query with aggregations
-   (s/optional-key :max-results)           su/IntGreaterThanOrEqualToZero
-   ;; maximum number of results to allow for a query with no aggregations
-   (s/optional-key :max-results-bare-rows) su/IntGreaterThanOrEqualToZero
-   ;; other Constraints might be used somewhere, but I don't know about them. Add them if you come across them for
-   ;; documentation purposes
-   s/Keyword                               s/Any})
+  (s/constrained
+   { ;; maximum number of results to allow for a query with aggregations. If `max-results-bare-rows` is unset, this
+    ;; applies to all queries
+    (s/optional-key :max-results)           su/IntGreaterThanOrEqualToZero
+    ;; maximum number of results to allow for a query with no aggregations.
+    ;; If set, this should be LOWER than `:max-results`
+    (s/optional-key :max-results-bare-rows) su/IntGreaterThanOrEqualToZero
+    ;; other Constraints might be used somewhere, but I don't know about them. Add them if you come across them for
+    ;; documentation purposes
+    s/Keyword                               s/Any}
+   (fn [{:keys [max-results max-results-bare-rows]}]
+     (if-not (core/and max-results max-results-bare-rows)
+       true
+       (core/>= max-results max-results-bare-rows)))
+   "max-results-bare-rows must be less or equal to than max-results"))
 
 (def ^:private MiddlewareOptions
   "Additional options that can be used to toggle middleware on or off."
@@ -644,6 +656,8 @@
           :question
           :xlsx-download))
 
+;; TODO - this schema is somewhat misleading because if you use a function like `qp/process-query-and-save-with-max!`
+;; some of these keys (e.g. `:context`) are in fact required
 (def Info
   "Schema for query `:info` dictionary, which is used for informational purposes to record information about how a query
   was executed in QueryExecution and other places. It is considered bad form for middleware to change its behavior
@@ -683,6 +697,7 @@
   `Card.dataset_query`."
   (s/constrained
    ;; TODO - move database/virtual-id into this namespace so we don't have to use the magic number here
+   ;; Something like `metabase.mbql.constants`
    {:database                         (s/cond-pre (s/eq -1337) su/IntGreaterThanZero)
     ;; Type of query. `:query` = MBQL; `:native` = native. TODO - consider normalizing `:query` to `:mbql`
     :type                             (s/enum :query :native)

--- a/src/metabase/mbql/util.clj
+++ b/src/metabase/mbql/util.clj
@@ -476,3 +476,34 @@
   [aggregation->name-fn :- (s/pred fn?), aggregations :- [mbql.s/Aggregation]]
   (-> (pre-alias-aggregations aggregation->name-fn aggregations)
       uniquify-named-aggregations))
+
+(defn query->max-rows-limit
+  "Calculate the absolute maximum number of results that should be returned by this query (MBQL or native), useful for
+  doing the equivalent of
+
+    java.sql.Statement statement = ...;
+    statement.setMaxRows(<max-rows-limit>).
+
+  to ensure the DB cursor or equivalent doesn't fetch more rows than will be consumed.
+
+  This is calculated as follows:
+
+  *  If query is `MBQL` and has a `:limit` or `:page` clause, returns appropriate number
+  *  If query has `:constraints` with `:max-results-bare-rows` or `:max-results`, returns the appropriate number
+     *  `:max-results-bare-rows` is returned if set and Query does not have any aggregations
+     *  `:max-results` is returned otherwise
+  *  If none of the above are set, returns `nil`. In this case, you should use something like the Metabase QP's
+     `max-rows-limit`"
+  [{{:keys [max-results max-results-bare-rows]}                      :constraints
+    {limit :limit, aggregations :aggregation, {:keys [items]} :page} :query
+    query-type                                                       :type}]
+  (let [safe-min          (fn [& args]
+                            (when-let [args (seq (filter some? args))]
+                              (reduce min args)))
+        mbql-limit        (when (= query-type :query)
+                            (safe-min items limit))
+        constraints-limit (or
+                           (when-not aggregations
+                             max-results-bare-rows)
+                           max-results)]
+    (safe-min mbql-limit constraints-limit)))

--- a/src/metabase/query_processor/middleware/limit.clj
+++ b/src/metabase/query_processor/middleware/limit.clj
@@ -1,19 +1,20 @@
 (ns metabase.query-processor.middleware.limit
   "Middleware that handles limiting the maximum number of rows returned by a query."
-  (:require (metabase.query-processor [interface :as i]
-                                      [util :as qputil])))
+  (:require [metabase.mbql.util :as mbql.u]
+            [metabase.query-processor
+             [interface :as i]
+             [util :as qputil]]))
 
 (defn limit
   "Add an implicit `limit` clause to MBQL queries without any aggregations, and limit the maximum number of rows that
   can be returned in post-processing."
   [qp]
-  (fn [{{:keys [max-results max-results-bare-rows]} :constraints, query-type :type, :as query}]
-    (let [query   (cond-> query
-                    (and (= query-type :query)
-                         (qputil/query-without-aggregations-or-limits? query))
-                    (assoc-in [:query :limit] (or max-results-bare-rows
-                                                  max-results
-                                                  i/absolute-max-results)))
-          results (qp query)]
-      (update results :rows (partial take (or max-results
-                                              i/absolute-max-results))))))
+  (fn [{query-type :type, :as query}]
+    (let [max-rows (or (mbql.u/query->max-rows-limit query)
+                       i/absolute-max-results)
+          query    (cond-> query
+                     (and (= query-type :query)
+                          (qputil/query-without-aggregations-or-limits? query))
+                     (assoc-in [:query :limit] max-rows))
+          results  (qp query)]
+      (update results :rows (partial take max-rows)))))

--- a/test/metabase/driver/sql_jdbc/execute_test.clj
+++ b/test/metabase/driver/sql_jdbc/execute_test.clj
@@ -1,0 +1,59 @@
+(ns metabase.driver.sql-jdbc.execute-test
+  (:require [clojure.java.jdbc :as jdbc]
+            [metabase.driver.sql-jdbc-test :as sql-jdbc-test]
+            [metabase.query-processor :as qp]
+            [metabase.test.data :as data]
+            [metabase.test.data.datasets :as datasets])
+  (:import java.sql.PreparedStatement))
+
+(defn- do-with-max-rows [f]
+  (let [orig-query jdbc/query
+        max-rows   (atom nil)]
+    (with-redefs [jdbc/query (fn [conn sql-params & [opts]]
+                               (when (sequential? sql-params)
+                                 (let [[statement] sql-params]
+                                   (when (instance? PreparedStatement statement)
+                                     (reset! max-rows (.getMaxRows ^PreparedStatement statement)))))
+                               (orig-query conn sql-params opts))]
+      (let [result (f)]
+        (or (when @max-rows
+              {:max-rows @max-rows})
+            result)))))
+
+(defmacro ^:private with-max-rows
+  "Runs query in `body`, and returns the max rows that was set for (via `PreparedStatement.setMaxRows()`) for that
+  query. This number is the number we've instructed JDBC to limit the results to."
+  [& body]
+  `(do-with-max-rows (fn [] ~@body)))
+
+;; We should be setting statement max rows based on appropriate limits when running queries (Snowflake runs tests with
+(datasets/expect-with-drivers @sql-jdbc-test/sql-jdbc-drivers
+  {:max-rows 10}
+  (with-max-rows
+    (qp/process-query
+      {:database (data/id)
+       :type     :query
+       :query    {:source-table (data/id :venues)
+                  :limit        10}})))
+
+(datasets/expect-with-drivers @sql-jdbc-test/sql-jdbc-drivers
+  {:max-rows 5}
+  (with-max-rows
+    (qp/process-query
+      {:database (data/id)
+       :type     :query
+       :query    {:source-table (data/id :venues)
+                  :limit        10}
+       :constraints {:max-results 5}})))
+
+
+(datasets/expect-with-drivers @sql-jdbc-test/sql-jdbc-drivers
+  {:max-rows 15}
+  (with-max-rows
+    (qp/process-query
+      {:database    (data/id)
+       :type        :native
+       :native      (qp/query->native {:database (data/id)
+                                       :type     :query
+                                       :query    {:source-table (data/id :venues)}})
+       :constraints {:max-results 15}})))

--- a/test/metabase/driver/sql_jdbc_test.clj
+++ b/test/metabase/driver/sql_jdbc_test.clj
@@ -19,7 +19,8 @@
 (def ^:private venues-table     (delay (Table (id :venues))))
 (def ^:private users-name-field (delay (Field (id :users :name))))
 
-(defonce sql-jdbc-drivers
+(defonce ^{:doc "Set of drivers descending from `:sql-jdbc`, for test purposes (i.e. `expect-with-drivers`)"}
+  sql-jdbc-drivers
   (delay
    (du/profile "resolve @metabase.driver.sql-jdbc-test/sql-jdbc-drivers"
      (set

--- a/test/metabase/query_processor_test/constraints_test.clj
+++ b/test/metabase/query_processor_test/constraints_test.clj
@@ -1,0 +1,70 @@
+(ns metabase.query-processor-test.constraints-test
+  "Test for MBQL `:constraints`"
+  (:require [metabase
+             [query-processor :as qp]
+             [query-processor-test :as qp.test]]
+            [metabase.test.data :as data]))
+
+(defn- mbql-query []
+  {:database (data/id)
+   :type     :query
+   :query    {:source-table (data/id :venues)
+              :fields       [[:field-id (data/id :venues :name)]]
+              :order-by     [[:asc [:field-id (data/id :venues :id)]]]}})
+
+(defn- native-query []
+  (qp/query->native (mbql-query)))
+
+;; Do `:max-results` constraints affect the number of rows returned by native queries?
+(qp.test/expect-with-non-timeseries-dbs
+  [["Red Medicine"]
+   ["Stout Burgers & Beers"]
+   ["The Apple Pan"]
+   ["Wurstküche"]
+   ["Brite Spot Family Restaurant"]]
+  (qp.test/rows
+    (qp/process-query
+      {:database    (data/id)
+       :type        :native
+       :native      (native-query)
+       :constraints {:max-results 5}})))
+
+;; does it also work when running via `process-query-and-save-with-max!`, the function that powers endpoints like
+;; `POST /api/dataset`?
+(qp.test/expect-with-non-timeseries-dbs
+  [["Red Medicine"]
+   ["Stout Burgers & Beers"]
+   ["The Apple Pan"]
+   ["Wurstküche"]
+   ["Brite Spot Family Restaurant"]]
+  (qp.test/rows
+    (qp/process-query-and-save-with-max!
+        {:database    (data/id)
+         :type        :native
+         :native      (native-query)
+         :constraints {:max-results 5}}
+        {:context :question})))
+
+;; constraints should override MBQL `:limit` if lower
+(qp.test/expect-with-non-timeseries-dbs
+  [["Red Medicine"]
+   ["Stout Burgers & Beers"]
+   ["The Apple Pan"]]
+  (qp.test/rows
+    (qp/process-query
+      (-> (mbql-query)
+          (assoc-in [:query :limit] 10)
+          (assoc :constraints {:max-results 3})))))
+
+;; However if `:limit` is lower than `:constraints` we should not return more than the `:limit`
+(qp.test/expect-with-non-timeseries-dbs
+  [["Red Medicine"]
+   ["Stout Burgers & Beers"]
+   ["The Apple Pan"]
+   ["Wurstküche"]
+   ["Brite Spot Family Restaurant"]]
+  (qp.test/rows
+    (qp/process-query
+      (-> (mbql-query)
+          (assoc-in [:query :limit] 5)
+          (assoc :constraints {:max-results 10})))))


### PR DESCRIPTION
At the request of @tlrobinson and @mazameli.

*  Support passing query `:constraints` `:max-results` to limit the number of results returned by a query in via the API. (Supports all query types)
*  Directly limit results returned by JDBC via [`Statement.setMaxRows`](https://docs.oracle.com/javase/8/docs/api/java/sql/Statement.html#setMaxRows-int-). 
*  Refactor logic used to determine effective query limit and move into `mbql` namespace.
*  Dozens of additional tests