### PR TITLE
set absolute max rows on JDBC connections; redshift code cleanup

### DIFF
--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -30,26 +30,27 @@
 ;;
 ;; See also: [Related Postgres JDBC driver issue on GitHub](https://github.com/pgjdbc/pgjdbc/issues/79)
 ;;           [How to access the equivalent of information_schema.constraint_column_usage in Redshift](https://forums.aws.amazon.com/thread.jspa?threadID=133514)
+(def ^:private fk-query
+  "SELECT source_column.attname AS \"fk-column-name\",
+          dest_table.relname    AS \"dest-table-name\",
+          dest_table_ns.nspname AS \"dest-table-schema\",
+          dest_column.attname   AS \"dest-column-name\"
+   FROM pg_constraint c
+          JOIN pg_namespace n             ON c.connamespace          = n.oid
+          JOIN pg_class source_table      ON c.conrelid              = source_table.oid
+          JOIN pg_attribute source_column ON c.conrelid              = source_column.attrelid
+          JOIN pg_class dest_table        ON c.confrelid             = dest_table.oid
+          JOIN pg_namespace dest_table_ns ON dest_table.relnamespace = dest_table_ns.oid
+          JOIN pg_attribute dest_column   ON c.confrelid             = dest_column.attrelid
+   WHERE c.contype                 = 'f'::char
+          AND source_table.relname = ?
+          AND n.nspname            = ?
+          AND source_column.attnum = ANY(c.conkey)
+          AND dest_column.attnum   = ANY(c.confkey)")
+
 (defmethod driver/describe-table-fks :redshift [_ database table]
   (set (for [fk (jdbc/query (sql-jdbc.conn/db->pooled-connection-spec database)
-                            ["SELECT source_column.attname AS \"fk-column-name\",
-                                     dest_table.relname    AS \"dest-table-name\",
-                                     dest_table_ns.nspname AS \"dest-table-schema\",
-                                     dest_column.attname   AS \"dest-column-name\"
-                              FROM pg_constraint c
-                                     JOIN pg_namespace n             ON c.connamespace          = n.oid
-                                     JOIN pg_class source_table      ON c.conrelid              = source_table.oid
-                                     JOIN pg_attribute source_column ON c.conrelid              = source_column.attrelid
-                                     JOIN pg_class dest_table        ON c.confrelid             = dest_table.oid
-                                     JOIN pg_namespace dest_table_ns ON dest_table.relnamespace = dest_table_ns.oid
-                                     JOIN pg_attribute dest_column   ON c.confrelid             = dest_column.attrelid
-                              WHERE c.contype                 = 'f'::char
-                                     AND source_table.relname = ?
-                                     AND n.nspname            = ?
-                                     AND source_column.attnum = ANY(c.conkey)
-                                     AND dest_column.attnum   = ANY(c.confkey)"
-                             (:name table)
-                             (:schema table)])]
+                            [fk-query (:name table) (:schema table)])]
          {:fk-column-name   (:fk-column-name fk)
           :dest-table       {:name   (:dest-table-name fk)
                              :schema (:dest-table-schema fk)}
@@ -93,11 +94,13 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defmethod sql-jdbc.conn/connection-details->spec :redshift [_ {:keys [host port db], :as opts}]
-  (merge {:classname "com.amazon.redshift.jdbc.Driver" ; must be in classpath
-          :subprotocol "redshift"
-          :subname (str "//" host ":" port "/" db "?OpenSourceSubProtocolOverride=false")
-          :ssl true}
-         (dissoc opts :host :port :db)))
+  (merge
+   {:classname                     "com.amazon.redshift.jdbc.Driver" ; must be in classpath
+    :subprotocol                   "redshift"
+    :subname                       (str "//" host ":" port "/" db)
+    :ssl                           true
+    :OpenSourceSubProtocolOverride false}
+   (dissoc opts :host :port :db)))
 
 ;; HACK ! When we test against Redshift we use a session-unique schema so we can run simultaneous tests
 ;; against a single remote host; when running tests tell the sync process to ignore all the other schemas

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -9,6 +9,7 @@
             [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
             [metabase.mbql.util :as mbql.u]
             [metabase.query-processor
+             [interface :as qp.i]
              [store :as qp.store]
              [util :as qputil]]
             [metabase.util
@@ -267,7 +268,7 @@
   [driver {settings :settings, query :native, :as outer-query}]
   (let [query (assoc query
                 :remark   (qputil/query->remark outer-query)
-                :max-rows (mbql.u/query->max-rows-limit outer-query))]
+                :max-rows (or (mbql.u/query->max-rows-limit outer-query) qp.i/absolute-max-results))]
     (do-with-try-catch
       (fn []
         (let [db-connection (sql-jdbc.conn/db->pooled-connection-spec (qp.store/database))]


### PR DESCRIPTION
`(.setMaxRows statement absolute-max-results)` if query has no other limit set -- usually it should have got one via default `:constraints` or the MBQL `:limit` clause. *Just in case* if did not, make sure the databases don't try to return tens of millions of rows.

Also a bit of code cleanup in the Redshift driver namespace.
