### PR TITLE
Added support for Decimal128 MongoDB type #8646. Sum, avg math exp ar…

### DIFF
--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -447,7 +447,8 @@
              [clojure.lang.IPersistentVector :type/Array]
              [org.bson.types.ObjectId        :type/MongoBSONID]
              [org.postgresql.util.PGobject   :type/*]
-             [nil                            :type/*]]) ; all-NULL columns in DBs like Mongo w/o explicit types
+             [nil                            :type/*] ; all-NULL columns in DBs like Mongo w/o explicit types
+             [org.bson.types.Decimal128      :type/Decimal]]) ; Decimal128 support added, sum, avg math exp are now working on frontend for Decimal128 data type ( Mongo )
       (log/warn (trs "Don''t know how to map class ''{0}'' to a Field base_type, falling back to :type/*." klass))
       :type/*))
 


### PR DESCRIPTION
…e now working on frontend for Decimal128



###### Before submitting the PR, please make sure you do the following
- [ ] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.
### Tests
-  [ ] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [ ] If there are changes to the backend codebase, run the backend tests with `lein test && lein eastwood && lein bikeshed && lein docstring-checker && lein check-namespace-decls && ./bin/reflection-linter`

-  [ ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
