### PR TITLE
Escape single quotes in BigQuery strings

### DIFF
--- a/modules/drivers/bigquery/src/metabase/driver/bigquery.clj
+++ b/modules/drivers/bigquery/src/metabase/driver/bigquery.clj
@@ -372,8 +372,7 @@
 ;; parameters (`?` symbols)
 (defmethod sql.qp/->honeysql [:bigquery String]
   [_ s]
-  ;; TODO - what happens if `s` contains single-quotes? Shouldn't we be escaping them somehow?
-  (hx/literal s))
+  (hx/literal (str/replace s "'" "\\'")))
 
 (defmethod sql.qp/->honeysql [:bigquery Boolean]
   [_ bool]


### PR DESCRIPTION
Fixes #8708 

Queries against BigQuery constructed by the Query Builder currently fail if a string value contains a single quote. This pull request fixes this issue by escaping single quotes in strings.

### Notes
- `lein bikeshed` throws some `java.io.FileNotFoundExceptions`, but they don't seem to be related to this change
- All other test pass
- Not tests have been added for this fix. Happy to contribute some, but I need to figure out how Clojure unit tests work first...
- Contributor agreement has been signed already
