### PR TITLE
Fingerprinting: make ints coercable to Date 

### DIFF
--- a/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+++ b/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
@@ -165,7 +165,8 @@
   String                 (->date [this] (-> this du/str->date-time t.coerce/to-date))
   java.util.Date         (->date [this] this)
   DateTime               (->date [this] (t.coerce/to-date this))
-  Long                   (->date [^Long this] (java.util.Date. this)))
+  Long                   (->date [^Long this] (java.util.Date. this))
+  Integer                (->date [^Integer this] (java.util.Date. this)))
 
 (deffingerprinter :type/DateTime
   ((map ->date)

--- a/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+++ b/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
@@ -53,15 +53,14 @@
    (.offer acc x)
    acc))
 
-(defmulti
-  ^{:doc "Return a fingerprinter transducer for a given field based on the field's type."
-    :arglists '([field])}
-  fingerprinter (fn [{:keys [base_type special_type unit] :as field}]
-                  [(cond
-                     (du/date-extract-units unit)  :type/Integer
-                     (field/unix-timestamp? field) :type/DateTime
-                     :else                         base_type)
-                   (or special_type :type/*)]))
+(defmulti fingerprinter
+  "Return a fingerprinter transducer for a given field based on the field's type."
+   (fn [{:keys [base_type special_type unit] :as field}]
+     [(cond
+        (du/date-extract-units unit)  :type/Integer
+        (field/unix-timestamp? field) :type/DateTime
+        :else                         base_type)
+      (or special_type :type/*)]))
 
 (def ^:private global-fingerprinter
   (redux/post-complete

--- a/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+++ b/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
@@ -166,7 +166,7 @@
   java.util.Date         (->date [this] this)
   DateTime               (->date [this] (t.coerce/to-date this))
   Long                   (->date [^Long this] (java.util.Date. this))
-  Integer                (->date [^Integer this] (java.util.Date. this)))
+  Integer                (->date [^Integer this] (java.util.Date. (long this))))
 
 (deffingerprinter :type/DateTime
   ((map ->date)


### PR DESCRIPTION
Fixes an omission in fingerprinting code where we coerced only longs to Date.