### PR TITLE
Add 'hide_parameters' hash option for dashboards and embedded dashboards/questions

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard.jsx
@@ -98,6 +98,7 @@ type Props = {
   refreshElapsed: number,
   isFullscreen: boolean,
   isNightMode: boolean,
+  hideParameters: ?string,
 
   onRefreshPeriodChange: (?number) => void,
   onNightModeChange: boolean => void,
@@ -226,6 +227,7 @@ export default class Dashboard extends Component {
       location,
       isFullscreen,
       isNightMode,
+      hideParameters,
     } = this.props;
     let { error } = this.state;
     isNightMode = isNightMode && isFullscreen;
@@ -238,6 +240,7 @@ export default class Dashboard extends Component {
           isEditing={isEditing}
           isFullscreen={isFullscreen}
           isNightMode={isNightMode}
+          hideParameters={hideParameters}
           parameters={parameters.map(p => ({
             ...p,
             value: parameterValues[p.id],

--- a/frontend/src/metabase/dashboard/hoc/DashboardControls.jsx
+++ b/frontend/src/metabase/dashboard/hoc/DashboardControls.jsx
@@ -26,6 +26,7 @@ type State = {
   isNightMode: boolean,
   refreshPeriod: ?number,
   refreshElapsed: ?number,
+  hideParameters: ?string,
 };
 
 const TICK_PERIOD = 0.25; // seconds
@@ -47,6 +48,8 @@ export default (ComposedComponent: ReactClass<any>) =>
 
         refreshPeriod: null,
         refreshElapsed: null,
+
+        hideParameters: null,
       };
 
       _interval: ?number;
@@ -88,6 +91,7 @@ export default (ComposedComponent: ReactClass<any>) =>
         );
         this.setNightMode(options.theme === "night" || options.night); // DEPRECATED: options.night
         this.setFullscreen(options.fullscreen);
+        this.setHideParameters(options.hide_parameters);
       };
 
       updateDashboardParams = () => {
@@ -162,6 +166,10 @@ export default (ComposedComponent: ReactClass<any>) =>
           }
           this.setState({ isFullscreen });
         }
+      };
+
+      setHideParameters = parameters => {
+        this.setState({ hideParameters: parameters });
       };
 
       _tickRefreshClock = async () => {

--- a/frontend/src/metabase/parameters/components/Parameters.jsx
+++ b/frontend/src/metabase/parameters/components/Parameters.jsx
@@ -25,6 +25,7 @@ type Props = {
 
   isFullscreen?: boolean,
   isNightMode?: boolean,
+  hideParameters?: ?string, // comma separated list of slugs
   isEditing?: boolean,
   isQB?: boolean,
   vertical?: boolean,
@@ -122,6 +123,7 @@ export default class Parameters extends Component {
       isEditing,
       isFullscreen,
       isNightMode,
+      hideParameters,
       isQB,
       setParameterName,
       setParameterValue,
@@ -131,6 +133,8 @@ export default class Parameters extends Component {
       vertical,
       commitImmediately,
     } = this.props;
+
+    const hiddenParameters = new Set((hideParameters || "").split(","));
 
     const parameters = this._parametersWithValues();
 
@@ -156,40 +160,42 @@ export default class Parameters extends Component {
         distance={9}
         onSortEnd={this.handleSortEnd}
       >
-        {parameters.map((parameter, index) => (
-          <ParameterWidget
-            key={parameter.id}
-            index={index}
-            className={cx("relative hover-parent hover--visibility", {
-              mb2: vertical,
-            })}
-            isEditing={isEditing}
-            isFullscreen={isFullscreen}
-            isNightMode={isNightMode}
-            parameter={parameter}
-            parameters={parameters}
-            editingParameter={editingParameter}
-            setEditingParameter={setEditingParameter}
-            setName={
-              setParameterName && (name => setParameterName(parameter.id, name))
-            }
-            setValue={
-              setParameterValue &&
-              (value => setParameterValue(parameter.id, value))
-            }
-            setDefaultValue={
-              setParameterDefaultValue &&
-              (value => setParameterDefaultValue(parameter.id, value))
-            }
-            remove={removeParameter && (() => removeParameter(parameter.id))}
-            commitImmediately={commitImmediately}
-          >
-            {/* show drag handle if editing and setParameterIndex provided */}
-            {isEditing && setParameterIndex ? (
-              <SortableParameterHandle />
-            ) : null}
-          </ParameterWidget>
-        ))}
+        {parameters
+          .filter(p => !hiddenParameters.has(p.slug))
+          .map((parameter, index) => (
+            <ParameterWidget
+              key={parameter.id}
+              className={cx("relative hover-parent hover--visibility", {
+                mb2: vertical,
+              })}
+              isEditing={isEditing}
+              isFullscreen={isFullscreen}
+              isNightMode={isNightMode}
+              parameter={parameter}
+              parameters={parameters}
+              editingParameter={editingParameter}
+              setEditingParameter={setEditingParameter}
+              setName={
+                setParameterName &&
+                (name => setParameterName(parameter.id, name))
+              }
+              setValue={
+                setParameterValue &&
+                (value => setParameterValue(parameter.id, value))
+              }
+              setDefaultValue={
+                setParameterDefaultValue &&
+                (value => setParameterDefaultValue(parameter.id, value))
+              }
+              remove={removeParameter && (() => removeParameter(parameter.id))}
+              commitImmediately={commitImmediately}
+            >
+              {/* show drag handle if editing and setParameterIndex provided */}
+              {isEditing && setParameterIndex ? (
+                <SortableParameterHandle />
+              ) : null}
+            </ParameterWidget>
+          ))}
       </ParameterWidgetList>
     );
   }

--- a/frontend/src/metabase/public/components/EmbedFrame.jsx
+++ b/frontend/src/metabase/public/components/EmbedFrame.jsx
@@ -94,7 +94,7 @@ export default class EmbedFrame extends Component {
 
     const footer = true;
 
-    const { bordered, titled, theme } = {
+    const { bordered, titled, theme, hide_parameters } = {
       ...DEFAULT_OPTIONS,
       ...parseHashOptions(location.hash),
     };
@@ -127,6 +127,7 @@ export default class EmbedFrame extends Component {
                     query={location.query}
                     setParameterValue={setParameterValue}
                     syncQueryString
+                    hideParameters={hide_parameters}
                     isQB
                   />
                 </div>


### PR DESCRIPTION
Append `#hide_parameters=slug` to dashboard URLs to hide specific parameter widgets in the UI.

e.x. this will set the `id` parameter to "1" and hide it in the UI:

```
/dashboard/42?id=1#hide_parameters=id
```

Multiple parameters can be specified by comma separating them, `#hide_parameters=slug1,slug2`:

```
/dashboard/42?id=1#hide_parameters=id,name
```

This is purely a UI control, of course. The user can manipulate the URL or make an API call directly to change the filter value.