### PR TITLE
Fix SQLServer datetime grouping for locales with yyyy-dd-MM dates

### DIFF
--- a/src/metabase/util/honeysql_extensions.clj
+++ b/src/metabase/util/honeysql_extensions.clj
@@ -141,6 +141,7 @@
 (def ^{:arglists '([& exprs])} floor   "SQL `floor` function."  (partial hsql/call :floor))
 (def ^{:arglists '([& exprs])} hour    "SQL `hour` function."   (partial hsql/call :hour))
 (def ^{:arglists '([& exprs])} minute  "SQL `minute` function." (partial hsql/call :minute))
+(def ^{:arglists '([& exprs])} day     "SQL `day` function."    (partial hsql/call :day))
 (def ^{:arglists '([& exprs])} week    "SQL `week` function."   (partial hsql/call :week))
 (def ^{:arglists '([& exprs])} month   "SQL `month` function."  (partial hsql/call :month))
 (def ^{:arglists '([& exprs])} quarter "SQL `quarter` function."(partial hsql/call :quarter))


### PR DESCRIPTION
Don't try to format datetimes as `yyyy-MM-dd` strings and cast them back to datetimes to extract the month in SQL Server, because with non-US-English locales it will assume the strings are of the format `yyyy-dd-MM` and interpret the day as the month.

Fixed by switching 

```sql
cast(format(x, 'yyyy-MM-dd') AS datetime)
```
to 

```sql
datefromparts(year(x), month(x), 1)
```

instead.

Includes test. Fixes #9057