### PR TITLE
Fixes

### DIFF
--- a/lein-plugins/include-drivers/project.clj
+++ b/lein-plugins/include-drivers/project.clj
@@ -1,4 +1,4 @@
-(defproject metabase/lein-include-drivers "1.0.4"
+(defproject metabase/lein-include-drivers "1.0.5"
   :min-lein-version "2.5.0"
   :eval-in-leiningen true
   :deploy-repositories [["clojars" {:sign-releases false}]])

--- a/lein-plugins/include-drivers/src/leiningen/include_drivers.clj
+++ b/lein-plugins/include-drivers/src/leiningen/include_drivers.clj
@@ -1,7 +1,7 @@
 (ns leiningen.include-drivers
   (:require [clojure.string :as str]
             [leiningen.core.project :as p])
-  (import java.io.File))
+  (:import java.io.File))
 
 (defn- file-exists? [^String filename]
   (.exists (File. filename)))

--- a/project.clj
+++ b/project.clj
@@ -154,10 +154,7 @@
      [lein-bikeshed "0.4.1"]                                          ; Linting
      [lein-check-namespace-decls "1.0.1"]                             ; lints namespace declarations
      [lein-environ "1.1.0"]                                           ; easy access to environment variables
-     [lein-expectations "0.0.8"]                                      ; run unit tests with 'lein expectations'
-     ;; TODO - should this be moved to the new RING profile?
-     [lein-ring "0.12.5"                                              ; start the HTTP server with 'lein ring server'
-      :exclusions [org.clojure/clojure]]]
+     [lein-expectations "0.0.8"]]                                     ; run unit tests with 'lein expectations'
 
     :env      {:mb-run-mode "dev"}
     :jvm-opts ["-Dlogfile.path=target/log"]
@@ -183,7 +180,9 @@
    [:exclude-tests {}]
 
    :ring
-   [:exclude-tests {}]
+   [:exclude-tests
+    {:dependencies
+     [[lein-ring "0.12.5" :exclusions [org.clojure/clojure]]]}]       ; start the HTTP server with 'lein ring server'
 
    :with-include-drivers-middleware
    {:plugins

--- a/project.clj
+++ b/project.clj
@@ -112,7 +112,7 @@
    [org.eclipse.jetty/jetty-server "9.4.14.v20181114"]                ; We require JDK 8 which allows us to run Jetty 9.4, ring-jetty-adapter runs on 1.7 which forces an older version
    [ring/ring-json "0.4.0"]                                           ; Ring middleware for reading/writing JSON automatically
    [stencil "0.5.0"]                                                  ; Mustache templates for Clojure
-   [toucan "1.11.0-SNAPSHOT" :exclusions [org.clojure/java.jdbc honeysql]]]    ; Model layer, hydration, and DB utilities
+   [toucan "1.11.0" :exclusions [org.clojure/java.jdbc honeysql]]]    ; Model layer, hydration, and DB utilities
 
   :main ^:skip-aot metabase.core
 
@@ -156,7 +156,7 @@
      [lein-environ "1.1.0"]                                           ; easy access to environment variables
      [lein-expectations "0.0.8"]                                      ; run unit tests with 'lein expectations'
      ;; TODO - should this be moved to the new RING profile?
-     [lein-ring "0.12.3"                                              ; start the HTTP server with 'lein ring server'
+     [lein-ring "0.12.5"                                              ; start the HTTP server with 'lein ring server'
       :exclusions [org.clojure/clojure]]]
 
     :env      {:mb-run-mode "dev"}
@@ -187,7 +187,7 @@
 
    :with-include-drivers-middleware
    {:plugins
-    [[metabase/lein-include-drivers "1.0.4"]]
+    [[metabase/lein-include-drivers "1.0.5"]]
 
     :middleware
     [leiningen.include-drivers/middleware]}

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -89,25 +89,34 @@
   (or (:type @connection-string-details)
       (config/config-kw :mb-db-type)))
 
-(def db-connection-details
+(def ^:private db-connection-details
   "Connection details that can be used when pretending the Metabase DB is itself a `Database` (e.g., to use the Generic
   SQL driver functions on the Metabase DB itself)."
-  (delay (or @connection-string-details
-             (case (db-type)
-               :h2       {:type     :h2                               ; TODO - we probably don't need to specifc `:type` here since we can just call (db-type)
-                          :db       @db-file}
-               :mysql    {:type     :mysql
-                          :host     (config/config-str :mb-db-host)
-                          :port     (config/config-int :mb-db-port)
-                          :dbname   (config/config-str :mb-db-dbname)
-                          :user     (config/config-str :mb-db-user)
-                          :password (config/config-str :mb-db-pass)}
-               :postgres {:type     :postgres
-                          :host     (config/config-str :mb-db-host)
-                          :port     (config/config-int :mb-db-port)
-                          :dbname   (config/config-str :mb-db-dbname)
-                          :user     (config/config-str :mb-db-user)
-                          :password (config/config-str :mb-db-pass)}))))
+  (delay
+   (when (= (db-type) :h2)
+     (log/warn
+      (u/format-color 'red
+          (str
+           (trs "WARNING: Using Metabase with an H2 application database is not recomended for production deployments.")
+           (trs "For production deployments, we highly recommend using Postgres, MySQL, or MariaDB instead.")
+           (trs "If you decide to continue to use H2, please be sure to back up the database file regularly.")
+           (trs "See https://metabase.com/docs/latest/operations-guide/start.html#migrating-from-using-the-h2-database-to-mysql-or-postgres for more information.")))))
+   (or @connection-string-details
+       (case (db-type)
+         :h2       {:type     :h2 ; TODO - we probably don't need to specifc `:type` here since we can just call (db-type)
+                    :db       @db-file}
+         :mysql    {:type     :mysql
+                    :host     (config/config-str :mb-db-host)
+                    :port     (config/config-int :mb-db-port)
+                    :dbname   (config/config-str :mb-db-dbname)
+                    :user     (config/config-str :mb-db-user)
+                    :password (config/config-str :mb-db-pass)}
+         :postgres {:type     :postgres
+                    :host     (config/config-str :mb-db-host)
+                    :port     (config/config-int :mb-db-port)
+                    :dbname   (config/config-str :mb-db-dbname)
+                    :user     (config/config-str :mb-db-user)
+                    :password (config/config-str :mb-db-pass)}))))
 
 (defn jdbc-details
   "Takes our own MB details map and formats them properly for connection details for JDBC."

--- a/src/metabase/plugins.clj
+++ b/src/metabase/plugins.clj
@@ -10,14 +10,11 @@
             [metabase.util :as u]
             [metabase.util.i18n :refer [trs]]
             [yaml.core :as yaml])
-  (:import java.io.File
-           [java.nio.file Files Path]))
+  (:import [java.nio.file Files Path]))
 
 (defn- plugins-dir-filename ^String []
   (or (env/env :mb-plugins-dir)
-      (str (System/getProperty "user.dir")
-           File/separator
-           "plugins")))
+      (.getAbsolutePath (io/file "plugins"))))
 
 ;; logic for determining plugins dir -- see below
 (defonce ^:private plugins-dir*

--- a/test/metabase/sync/analyze/fingerprint/insights_test.clj
+++ b/test/metabase/sync/analyze/fingerprint/insights_test.clj
@@ -1,6 +1,6 @@
 (ns metabase.sync.analyze.fingerprint.insights-test
   (:require [expectations :refer :all]
-            [metabase.sync.analyze.fingerprint.insights :refer :all :as i]))
+            [metabase.sync.analyze.fingerprint.insights :as i :refer :all]))
 
 (def ^:private cols [{:base_type :type/DateTime} {:base_type :type/Number}])
 


### PR DESCRIPTION
*  Fix running `lein ring` or `lein nrepl` with Clojure 1.10/Leiningen 2.9.0
*  As discussed in #6510, set H2 to always defrag on-disk database on shutdown, which can reduce the size of the database file by GIGABYTES. If file gets too large (due to never being defragmented) it can take so long to open the file Metabase will timeout assume the DB connection doesn't work
*  Log a warning message when using H2 that we recommend using Postgres or MySQL instead for production deployments