### PR TITLE
Fix header modal sizing

### DIFF
--- a/frontend/src/metabase/components/Header.jsx
+++ b/frontend/src/metabase/components/Header.jsx
@@ -30,7 +30,7 @@ export default class Header extends Component {
     this.updateHeaderHeight();
   }
 
-  componentWillUpdate() {
+  componentDidUpdate() {
     const modalIsOpen = !!this.props.headerModalMessage;
     if (modalIsOpen) {
       this.updateHeaderHeight();


### PR DESCRIPTION
Incorrect:

![screenshot 2019-02-13 17 01 32](https://user-images.githubusercontent.com/18193/52754911-06b8c500-2fb1-11e9-9219-3702ba84dd57.png)

Correct:

![screenshot 2019-02-13 16 58 37](https://user-images.githubusercontent.com/18193/52754940-16d0a480-2fb1-11e9-9317-e0dbf404eac3.png)

Unfortunately I don't think this is easily testable in Jest/Enzyme.