### PR TITLE
CollectionBadge cleanup

### DIFF
--- a/frontend/src/metabase/questions/components/CollectionBadge.jsx
+++ b/frontend/src/metabase/questions/components/CollectionBadge.jsx
@@ -13,14 +13,19 @@ import cx from "classnames";
   entityType: "collections",
   entityId: (state, props) => props.collectionId || "root",
   wrapped: true,
+  loadingAndErrorWrapper: false,
+  properties: ["name"],
 })
 class CollectionBadge extends React.Component {
   render() {
-    const { analyticsContext, object } = this.props;
+    const { analyticsContext, object, className } = this.props;
+    if (!object) {
+      return null;
+    }
     return (
       <Link
         to={Urls.collection(object.id)}
-        className={cx("inline-block link")}
+        className={cx(className, "block link")}
         data-metabase-event={`${analyticsContext};Collection Badge Click`}
       >
         <Flex align="center">


### PR DESCRIPTION
If a collection hasn't been loaded we use the EntityObjectLoader to load it, but don't disable the automagic LoadingAndErrorWrapper:

![screenshot 2019-02-13 17 00 02](https://user-images.githubusercontent.com/18193/52755516-120cf000-2fb3-11e9-8a8e-3a2f282888ac.png)

We should disable LoadingAndErrorWrapper and also provide `properties: ["name"]` which will skip hitting the endpoint if the object was previously loaded for any reason (as long as `name` was loaded)