### PR TITLE
Floats should never be categories

### DIFF
--- a/src/metabase/sync/analyze/classifiers/category.clj
+++ b/src/metabase/sync/analyze/classifiers/category.clj
@@ -23,8 +23,9 @@
 
 (defn- cannot-be-category-or-list?
   [{:keys [base_type special_type]}]
-  (or (isa? base_type    :type/DateTime)
-      (isa? base_type    :type/Collection)
+  (or (isa? base_type :type/DateTime)
+      (isa? base_type :type/Collection)
+      (isa? base_type :type/Float)
       ;; Don't let IDs become list Fields (they already can't become categories, because they already have a special
       ;; type). It just doesn't make sense to cache a sequence of numbers since they aren't inherently meaningful
       (isa? special_type :type/PK)


### PR DESCRIPTION
Float being classified as a category is almost always a false positive caused by sparse data.