### PR TITLE
include complete exception info in messages captured by metabase.logger

### DIFF
--- a/src/metabase/logger.clj
+++ b/src/metabase/logger.clj
@@ -6,7 +6,8 @@
             [clj-time
              [coerce :as coerce]
              [core :as t]
-             [format :as time]])
+             [format :as time]]
+            [clojure.string :as str])
   (:import org.apache.log4j.spi.LoggingEvent))
 
 (def ^:private ^:const max-log-entries 2500)
@@ -22,16 +23,26 @@
 
 (defonce ^:private formatter (time/formatter "MMM dd HH:mm:ss" (t/default-time-zone)))
 
+(defn- event->log-string [^LoggingEvent event]
+  ;; for messages that include an Exception, include the string representation of it (i.e., its stacktrace)
+  ;; separated by newlines
+  (str/join
+   "\n"
+   (cons
+    (let [ts    (time/unparse formatter (coerce/from-long (.getTimeStamp event)))
+          level (.getLevel event)
+          fqns  (.getLoggerName event)
+          msg   (.getMessage event)]
+      (format "%s \033[1m%s %s\033[0m :: %s" ts level fqns msg))
+    (seq (.getThrowableStrRep event)))))
+
 (defn -append
   "Append a new EVENT to the `messages` atom.
-   [Overrides an `AppenderSkeleton` method](http://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/AppenderSkeleton.html#append(org.apache.log4j.spi.LoggingEvent))"
+   [Overrides an `AppenderSkeleton`
+  method](http://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/AppenderSkeleton.html#append(org.apache.log4j.spi.LoggingEvent))"
   [_, ^LoggingEvent event]
-  (let [ts    (time/unparse formatter (coerce/from-long (.getTimeStamp event)))
-        level (.getLevel event)
-        fqns  (.getLoggerName event)
-        msg   (.getMessage event)]
-    (swap! messages conj (format "%s \033[1m%s %s\033[0m :: %s" ts level fqns msg))
-    nil))
+  (swap! messages conj (event->log-string event))
+  nil)
 
 (defn -close
   "No-op if something tries to close this logging appender.


### PR DESCRIPTION
metabase.logger was not including the stuff the logger normally prints out about Exception, like classname, message, and stacktrace. That made things a bit less useful. Fix this 🔧 