### PR TITLE
Fix MetaBot

### DIFF
--- a/src/metabase/integrations/slack.clj
+++ b/src/metabase/integrations/slack.clj
@@ -8,7 +8,10 @@
              [config :as config]
              [util :as u]]
             [metabase.models.setting :as setting :refer [defsetting]]
-            [metabase.util.i18n :refer [tru]]))
+            [metabase.util
+             [i18n :refer [tru]]
+             [schema :as su]]
+            [schema.core :as s]))
 
 ;; Define a setting which captures our Slack api token
 (defsetting slack-token (tru "Slack API bearer token obtained from https://api.slack.com/web#authentication"))
@@ -39,8 +42,15 @@
                                                                                :conn-timeout   1000
                                                                                :socket-timeout 1000}))))
 
-(def ^{:arglists '([endpoint & {:as params}]), :style/indent 1} GET  "Make a GET request to the Slack API."  (partial do-slack-request http/get  :query-params))
-(def ^{:arglists '([endpoint & {:as params}]), :style/indent 1} POST "Make a POST request to the Slack API." (partial do-slack-request http/post :form-params))
+(def ^{:arglists '([endpoint & {:as params}]), :style/indent 1}
+  GET
+  "Make a GET request to the Slack API."
+  (partial do-slack-request http/get  :query-params))
+
+(def ^{:arglists '([endpoint & {:as params}]), :style/indent 1}
+  POST
+  "Make a POST request to the Slack API."
+  (partial do-slack-request http/post :form-params))
 
 (def ^{:arglists '([& {:as args}])} channels-list
   "Calls Slack api `channels.list` function and returns the list of available channels."
@@ -50,7 +60,7 @@
   "Calls Slack api `users.list` function and returns the list of available users."
   (comp :members (partial GET :users.list)))
 
-(def ^:private ^:const ^String channel-missing-msg
+(def ^:private ^String channel-missing-msg
   (str "Slack channel named `metabase_files` is missing! Please create the channel in order to complete "
        "the Slack integration. The channel is used for storing graphs that are included in pulses and "
        "MetaBot answers."))
@@ -84,18 +94,16 @@
     (let [six-hours-ms (* 6 60 60 1000)]
       (memoize/ttl files-channel* :ttl/threshold six-hours-ms))))
 
+(def ^:private NonEmptyByteArray
+  (s/constrained
+   (Class/forName "[B")
+   #(pos? (count %))
+   "Non-empty byte array"))
 
-(defn upload-file!
+(s/defn upload-file!
   "Calls Slack api `files.upload` function and returns the body of the uploaded file."
-  [file filename channel-ids-str]
-  {:pre [file
-         (instance? (Class/forName "[B") file)
-         (not (zero? (count file)))
-         (string? filename)
-         (seq filename)
-         (string? channel-ids-str)
-         (seq channel-ids-str)
-         (seq (slack-token))]}
+  [file :- NonEmptyByteArray, filename :- su/NonBlankString, channel-ids-str :- su/NonBlankString]
+  {:pre [(seq (slack-token))]}
   (let [response (http/post (str slack-api-base-url "/files.upload") {:multipart [{:name "token",    :content (slack-token)}
                                                                                   {:name "file",     :content file}
                                                                                   {:name "filename", :content filename}
@@ -106,11 +114,10 @@
         (log/debug "Uploaded image" <>))
       (log/warn "Error uploading file to Slack:" (u/pprint-to-str response)))))
 
-(defn post-chat-message!
-  "Calls Slack api `chat.postMessage` function and posts a message to a given channel.
-   ATTACHMENTS should be serialized JSON."
-  [channel-id text-or-nil & [attachments]]
-  {:pre [(string? channel-id)]}
+(s/defn post-chat-message!
+  "Calls Slack api `chat.postMessage` function and posts a message to a given channel. `attachments` should be
+  serialized JSON."
+  [channel-id :- su/NonBlankString, text-or-nil :- (s/maybe s/Str) & [attachments]]
   ;; TODO: it would be nice to have an emoji or icon image to use here
   (POST :chat.postMessage
     :channel     channel-id

--- a/src/metabase/metabot/slack.clj
+++ b/src/metabase/metabot/slack.clj
@@ -12,7 +12,7 @@
   (binding [*channel-id* channel-id]
     (f)))
 
-(defn with-channel-id
+(defmacro with-channel-id
   "Execute `body` with `channel-id` as the current Slack channel; all messages will be posted to that channel. (This is
   bound to the channel that recieved the MetaBot command we're currently handling by the
   `metabase.metabot.events/handle-slack-event` event handler.)"
@@ -20,18 +20,23 @@
   [channel-id & body]
   `(do-with-channel-id ~channel-id (fn [] ~@body)))
 
-(def ^{:arglists '([text-or-nil] [text-or-nil attachments])} post-chat-message!
+(defn post-chat-message!
   "Post a MetaBot response Slack message. Goes to channel where the MetaBot command we're replying to was posted."
-  (partial slack/post-chat-message! *channel-id*))
+  {:arglists '([text-or-nil] [text-or-nil attachments])}
+  [& args]
+  {:pre [(some? *channel-id*)]}
+  (apply slack/post-chat-message! *channel-id* args))
 
 (defn format-exception
   "Format a `Throwable` the way we'd like for posting it on Slack."
   [^Throwable e]
   (str (tru "Uh oh! :cry:\n> {0}" (.getMessage e))))
 
+;; TODO - this stuff should be implemented with an agent or something. Or with core.async
 (defn do-async
   "Impl for `async` macro."
   [f]
+  ;; don't fret -- futures preserve the calling thread's dynamic bindings, so `*channel-id*` will still be bound
   (future
     (try
       (f)

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -230,27 +230,78 @@
 ;; breadcrumbing in the frontend.
 
 (def VisibleCollections
-  "Includes the possible values for visible collections, either `:all` or a set of ids"
-  (s/cond-pre (s/eq :all) #{su/IntGreaterThanZero}))
+  "Includes the possible values for visible collections, either `:all` or a set of ids, possibly including `\"root\"` to
+  represent the root collection."
+  (s/cond-pre (s/eq :all) #{(s/cond-pre (s/eq "root") su/IntGreaterThanZero)}))
 
 (s/defn permissions-set->visible-collection-ids :- VisibleCollections
   "Given a `permissions-set` (presumably those of the current user), return a set of IDs of Collections that the
   permissions set allows you to view. For those with *root* permissions (e.g., an admin), this function will return
-  `:all`, signifying that you are allowed to view all Collections.
+  `:all`, signifying that you are allowed to view all Collections. For *Root Collection* permissions, the response
+  will include \"root\".
 
-    (permissions-set->visible-collection-ids #{\"/collection/10/\"}) ; -> #{10}
-    (permissions-set->visible-collection-ids #{\"/\"})               ; -> :all"
+    (permissions-set->visible-collection-ids #{\"/collection/10/\"})   ; -> #{10}
+    (permissions-set->visible-collection-ids #{\"/\"})                 ; -> :all
+    (permissions-set->visible-collection-ids #{\"/collection/root/\"}) ; -> #{\"root\"}
+
+  You probably don't want to consume the results of this function directly -- most of the time, the reason you are
+  calling this function in the first place is because you want add a `FILTER` clause to an application DB query (e.g.
+  to only fetch Cards that belong to Collections visible to the current User). Use
+  `visible-collection-ids->honeysql-filter-clause` to generate a filter clause that handles all possible outputs of
+  this function correctly.
+
+  !!! IMPORTANT NOTE !!!
+
+  Because the result may include `nil` for the Root Collection, or may be `:all`, MAKE SURE YOU HANDLE THOSE
+  SITUATIONS CORRECTLY before using these IDs to make a DB call. Better yet, use
+  `collection-ids->honeysql-filter-clause` to generate appropriate HoneySQL."
   [permissions-set :- #{perms/UserPath}]
   (if (contains? permissions-set "/")
     :all
-    (set (for [path  permissions-set
-               :let  [[_ id-str] (re-matches #"/collection/(\d+)/(read/)?" path)]
-               :when id-str]
-           (Integer/parseInt id-str)))))
+    (set
+     (for [path  permissions-set
+           :let  [[_ id-str] (re-matches #"/collection/((?:\d+)|root)/(read/)?" path)]
+           :when id-str]
+       (cond-> id-str
+         (not= id-str "root") Integer/parseInt)))))
+
+
+(s/defn visible-collection-ids->honeysql-filter-clause
+  "Generate an appropriate HoneySQL `:where` clause to filter something by visible Collection IDs, such as the ones
+  returned by `permissions-set->visible-collection-ids`. Correctly handles all possible values returned by that
+  function, including `:all` and `nil` Collection IDs (for the Root Collection).
+
+  Guaranteed to always generate a valid HoneySQL form, so this can be used directly in a query without further checks.
+
+    (db/select Card
+      {:where (collection/visible-collection-ids->honeysql-filter-clause
+               (collection/permissions-set->visible-collection-ids
+                @*current-user-permissions-set*))})"
+  ([collection-ids :- VisibleCollections]
+   (visible-collection-ids->honeysql-filter-clause :collection_id collection-ids))
+
+  ([collection-id-field :- s/Keyword, collection-ids :- VisibleCollections]
+   (if (= collection-ids :all)
+     true
+     (let [{non-root-ids false, root-id true} (group-by (partial = "root") collection-ids)
+           non-root-clause                    (when (seq non-root-ids)
+                                                [:in collection-id-field non-root-ids])
+           root-clause                        (when (seq root-id)
+                                                [:= collection-id-field nil])]
+       (cond
+         (and root-clause non-root-clause)
+         [:or root-clause non-root-clause]
+
+         (or root-clause non-root-clause)
+         (or root-clause non-root-clause)
+
+         :else
+         false)))))
+
 
 (s/defn effective-location-path :- (s/maybe LocationPath)
   "Given a `location-path` and a set of Collection IDs one is allowed to view (obtained from
-  `permissions-set->visibile-collection-ids` above), calculate the 'effective' location path (excluding IDs of
+  `permissions-set->visible-collection-ids` above), calculate the 'effective' location path (excluding IDs of
   Collections for which we do not have read perms) we should show to the User.
 
   When called with a single argument, `collection`, this is used as a hydration function to hydrate
@@ -262,7 +313,7 @@
      (effective-location-path (:location collection)
                               (permissions-set->visible-collection-ids @*current-user-permissions-set*))))
 
-  ([real-location-path :- LocationPath, allowed-collection-ids :- (s/cond-pre (s/eq :all) #{su/IntGreaterThanZero})]
+  ([real-location-path :- LocationPath, allowed-collection-ids :- VisibleCollections]
    (if (= allowed-collection-ids :all)
      real-location-path
      (apply location-path (for [id    (location-path->ids real-location-path)

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -11,6 +11,7 @@
              [interface :as i]
              [permissions :as perms]
              [permissions-group :as perm-group]]
+            [metabase.util.i18n :refer [trs]]
             [toucan
              [db :as db]
              [models :as models]]))
@@ -41,37 +42,33 @@
 
 
 (defn- schedule-tasks!
-  "(Re)schedule sync operation tasks for DATABASE. (Existing scheduled tasks will be deleted first.)"
+  "(Re)schedule sync operation tasks for `database`. (Existing scheduled tasks will be deleted first.)"
   [database]
   (try
     ;; this is done this way to avoid circular dependencies
     (require 'metabase.task.sync-databases)
     ((resolve 'metabase.task.sync-databases/schedule-tasks-for-db!) database)
     (catch Throwable e
-      (log/error "Error scheduling tasks for DB:" (.getMessage e) "\n"
-                 (u/pprint-to-str (u/filtered-stacktrace e))))))
+      (log/error e (trs "Error scheduling tasks for DB")))))
 
 (defn- unschedule-tasks!
-  "Unschedule any currently pending sync operation tasks for DATABASE."
+  "Unschedule any currently pending sync operation tasks for `database`."
   [database]
   (try
     (require 'metabase.task.sync-databases)
     ((resolve 'metabase.task.sync-databases/unschedule-tasks-for-db!) database)
     (catch Throwable e
-      (log/error "Error unscheduling tasks for DB:" (.getMessage e) "\n"
-                 (u/pprint-to-str (u/filtered-stacktrace e))))))
+      (log/error e (trs "Error unscheduling tasks for DB.")))))
 
-(defn- post-insert [{database-id :id, :as database}]
+(defn- post-insert [database]
   (u/prog1 database
-    ;; add this database to the all users and metabot permissions groups
-    (doseq [{group-id :id} [(perm-group/all-users)
-                            (perm-group/metabot)]]
-      (perms/grant-full-db-permissions! group-id database-id))
-    ;; schedule the Database sync tasks
+    ;; add this database to the All Users permissions groups
+    (perms/grant-full-db-permissions! (perm-group/all-users) database)
+    ;; schedule the Database sync & analyze tasks
     (schedule-tasks! database)))
 
 (defn- post-select [{driver :engine, :as database}]
-  ;; TODO - this is only really needed for API responses
+  ;; TODO - this is only really needed for API responses. This should be a `hydrate` thing instead!
   (cond-> database
     (driver/initialized? driver) (assoc :features (driver.u/features driver))))
 
@@ -83,25 +80,32 @@
   (driver/notify-database-updated driver database))
 
 ;; TODO - this logic would make more sense in post-update if such a method existed
-(defn- pre-update [{new-metadata-schedule :metadata_sync_schedule, new-fieldvalues-schedule :cache_field_values_schedule, :as database}]
+(defn- pre-update
+  [{new-metadata-schedule :metadata_sync_schedule, new-fieldvalues-schedule :cache_field_values_schedule, :as database}]
   (u/prog1 database
     ;; if the sync operation schedules have changed, we need to reschedule this DB
     (when (or new-metadata-schedule new-fieldvalues-schedule)
       (let [{old-metadata-schedule    :metadata_sync_schedule
-             old-fieldvalues-schedule :cache_field_values_schedule} (db/select-one [Database :metadata_sync_schedule :cache_field_values_schedule]
+             old-fieldvalues-schedule :cache_field_values_schedule} (db/select-one [Database
+                                                                                    :metadata_sync_schedule
+                                                                                    :cache_field_values_schedule]
                                                                       :id (u/get-id database))
             ;; if one of the schedules wasn't passed continue using the old one
             new-metadata-schedule    (or new-metadata-schedule old-metadata-schedule)
             new-fieldvalues-schedule (or new-fieldvalues-schedule old-fieldvalues-schedule)]
-        (when (or (not= new-metadata-schedule old-metadata-schedule)
-                  (not= new-fieldvalues-schedule old-fieldvalues-schedule))
-          (log/info "DB's schedules have changed!\n"
-                    (format "Sync metadata was: '%s', is now: '%s'\n" old-metadata-schedule new-metadata-schedule)
-                    (format "Cache FieldValues was: '%s', is now: '%s'\n" old-fieldvalues-schedule new-fieldvalues-schedule))
+        (when-not (= [new-metadata-schedule new-fieldvalues-schedule]
+                     [old-metadata-schedule old-fieldvalues-schedule])
+          (log/info
+           (trs "{0} Database ''{1}'' sync/analyze schedules have changed!" (:engine database) (:name database))
+           "\n"
+           (trs "Sync metadata was: ''{0}'' is now: ''{1}''" old-metadata-schedule new-metadata-schedule)
+           "\n"
+           (trs "Cache FieldValues was: ''{0}'', is now: ''{1}''" old-fieldvalues-schedule new-fieldvalues-schedule))
           ;; reschedule the database. Make sure we're passing back the old schedule if one of the two wasn't supplied
-          (schedule-tasks! (assoc database
-                             :metadata_sync_schedule      new-metadata-schedule
-                             :cache_field_values_schedule new-fieldvalues-schedule)))))))
+          (schedule-tasks!
+           (assoc database
+             :metadata_sync_schedule      new-metadata-schedule
+             :cache_field_values_schedule new-fieldvalues-schedule)))))))
 
 
 (defn- perms-objects-set [database _]

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -65,12 +65,12 @@
   [card-results]
   (let [{channel-id :id} (slack/files-channel)]
     (for [{{card-id :id, card-name :name, :as card} :card, result :result} card-results]
-      {:title      card-name
+      {:title                  card-name
        :attachment-bytes-thunk (fn [] (render/render-pulse-card-to-png (defaulted-timezone card) card result))
-       :title_link (urls/card-url card-id)
-       :attachment-name "image.png"
-       :channel-id channel-id
-       :fallback   card-name})))
+       :title_link             (urls/card-url card-id)
+       :attachment-name        "image.png"
+       :channel-id             channel-id
+       :fallback               card-name})))
 
 (defn create-and-upload-slack-attachments!
   "Create an attachment in Slack for a given Card by rendering its result into an image and uploading it."
@@ -160,8 +160,8 @@
 (defmethod create-notification [:pulse :slack]
   [pulse results {{channel-id :channel} :details :as channel}]
   (log/debug (u/format-color 'cyan "Sending Pulse (%d: %s) via Slack" (:id pulse) (:name pulse)))
-  {:channel-id channel-id
-   :message (str "Pulse: " (:name pulse))
+  {:channel-id  channel-id
+   :message     (str "Pulse: " (:name pulse))
    :attachments (create-slack-attachment-data results)})
 
 (defmethod create-notification [:alert :email]

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -148,7 +148,7 @@
 
 (s/defn ^:private fields-to-fingerprint :- (s/maybe [i/FieldInstance])
   "Return a sequences of Fields belonging to TABLE for which we should generate (and save) fingerprints.
-   This should include NEW fields that are active and visibile."
+   This should include NEW fields that are active and visible."
   [table :- i/TableInstance]
   (seq (db/select Field
          (honeysql-for-fields-that-need-fingerprint-updating table))))

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -317,7 +317,7 @@
        (concat
         frames-after-last-mb
         ;; add a little arrow to the frame so it stands out more
-        (cons (str "--> " last-mb-frame)
+        (cons (some->> last-mb-frame (str "--> "))
               frames-before-last-mb))))})
 
 (defn deref-with-timeout

--- a/test/metabase/metabot/command_test.clj
+++ b/test/metabase/metabot/command_test.clj
@@ -1,7 +1,18 @@
 (ns metabase.metabot.command-test
   (:require [expectations :refer [expect]]
-            [metabase.metabot.command :as metabot.cmd]
-            [metabase.models.card :refer [Card]]
+            [metabase.metabot
+             [command :as metabot.cmd]
+             [test-util :as metabot.test.u]]
+            [metabase.models
+             [card :refer [Card]]
+             [collection :refer [Collection]]
+             [permissions :as perms]
+             [permissions-group :as group]]
+            [metabase.test
+             [data :as data]
+             [util :as tu]]
+            [metabase.util :as u]
+            [metabase.util.i18n :refer [tru]]
             [toucan.util.test :as tt]))
 
 ;; Check that `metabot/list` returns a string with card information and passes the permissions checks
@@ -17,3 +28,94 @@
   (tt/with-temp* [Card [_]
                   Card [_ {:archived true}]]
     (metabot.cmd/command "list")))
+
+(defn- command [& args]
+  (tu/with-temporary-setting-values [site-url "https://metabase.mysite.com"]
+    (metabot.test.u/with-slack-messages
+      (try
+        (apply metabot.cmd/command args)
+        (catch Throwable e
+          (list 'Exception. (.getMessage e)))))))
+
+;; ok, now let's look at the actual response in its entirety
+(tt/expect-with-temp [Card [{:keys [name id]}]
+                      Card [_ {:archived true}]]
+  {:response (format "Here's your 1 most recent cards:\n%d.  <https://metabase.mysite.com/question/%d|\"%s\">"
+                     id id name)
+   :messages []}
+  (command "list"))
+
+(defn- venues-count-query []
+  {:database (data/id)
+   :type     :query
+   :query    {:source-table (data/id :venues)
+              :aggregation  [[:count]]}})
+
+;; Check that when we call the `show` command it passes something resembling what we'd like to the correct `pulse/`
+;; functions
+(expect
+  {:response "Ok, just a second..."
+   :messages `[(~'post-chat-message!
+                nil
+                (~'create-and-upload-slack-attachments!
+                 (~'create-slack-attachment-data
+                  (~{:card   metabase.models.card.CardInstance
+                     :result clojure.lang.PersistentHashMap}))))]}
+  (tt/with-temp Card [{card-id :id} {:dataset_query (venues-count-query)}]
+    (command "show" card-id)))
+
+;; Show also work when you try to show Card by name
+(expect
+  {:response "Ok, just a second..."
+   :messages `[(~'post-chat-message!
+                nil
+                (~'create-and-upload-slack-attachments!
+                 (~'create-slack-attachment-data
+                  (~{:card   metabase.models.card.CardInstance
+                     :result clojure.lang.PersistentHashMap}))))]}
+  (tt/with-temp Card [_ {:dataset_query (venues-count-query), :name "Cam's Cool MetaBot Card"}]
+    (command "show" "Cam's Cool M")))
+
+;; If you try to show more than one Card by name, it should ask you to be more specific
+(tt/expect-with-temp [Card [{card-1-id :id} {:dataset_query (venues-count-query), :name "Cam's Cool MetaBot Card 1"}]
+                      Card [{card-2-id :id} {:dataset_query (venues-count-query), :name "Cam's Cool MetaBot Card 2"}]]
+  {:response
+   (list
+    'Exception.
+    (str "Could you be a little more specific, or use the ID? I found these cards with names that matched:"
+         "\n"
+         (format "%d.  <https://metabase.mysite.com/question/%d|\"Cam's Cool MetaBot Card 1\">" card-1-id card-1-id)
+         "\n"
+         (format "%d.  <https://metabase.mysite.com/question/%d|\"Cam's Cool MetaBot Card 2\">" card-2-id card-2-id)))
+
+   :messages []}
+  (command "show" "Cam's Cool M"))
+
+;; If you try to show an archived Card it shouldn't work
+(expect
+  {:response '(Exception. "Card Cam's Cool MetaBot Card not found.")
+   :messages []}
+  (tt/with-temp Card [_ {:dataset_query (venues-count-query), :name "Cam's Cool MetaBot Card", :archived true}]
+    (command "show" "Cam's Cool MetaBot Card")))
+
+;; If you try to show a Card with a name that doesn't exist, you should get a Not Found message.
+(expect
+  {:response '(Exception. "Card Cam's Card that doesn't exist at all not found.")
+   :messages []}
+  (command "show" "Cam's Card that doesn't exist at all"))
+
+;; If you try to show a Card with an ID that doesn't exist, you should get a Not Found message.
+(expect
+  {:response (list 'Exception. (str (tru "Card {0} not found." Integer/MAX_VALUE)))
+   :messages []}
+  (command "show" Integer/MAX_VALUE))
+
+;; If you try to show a Card that's in a collection that the MetaBot doesn't have permissions for, it should throw an
+;; Exception
+(expect
+  {:response '(Exception. "You don't have permissions to do that.")
+   :messages []}
+  (tt/with-temp* [Collection [collection]
+                  Card       [{card-id :id} {:collection_id (u/get-id collection), :dataset_query (venues-count-query)}]]
+    (perms/revoke-collection-permissions! (group/metabot) collection)
+    (command "show" card-id)))

--- a/test/metabase/metabot/events_test.clj
+++ b/test/metabase/metabot/events_test.clj
@@ -1,0 +1,110 @@
+(ns metabase.metabot.events-test
+  (:require [cheshire.core :as json]
+            [expectations :refer [expect]]
+            [metabase.metabot
+             [command :as metabot.cmd]
+             [events :as metabot.events]
+             [slack :as metabot.slack]
+             [test-util :as metabot.test.u]]))
+
+;; check that things get parsed correctly
+(expect
+  '(show 100)
+  (#'metabot.events/str->tokens "show 100"))
+
+(expect
+  '(show "Birdwatching Hot Spots")
+  (#'metabot.events/str->tokens "show \"Birdwatching Hot Spots\""))
+
+(expect
+  '(SHOW :wow)
+  (#'metabot.events/str->tokens "SHOW :wow"))
+
+(defn- handle-slack-event [event]
+  (metabot.test.u/with-slack-messages
+    (metabot.events/handle-slack-event
+     1000000
+     (json/generate-string
+      (merge {:type "message", :ts "1001"} event)))))
+
+;; MetaBot shouldn't handle events that aren't of type "message"
+(expect
+  []
+  (handle-slack-event {:text "metabot list", :type "not_a_message"}))
+
+;; MetaBot shouldn't handle "message" events if the subtype is something like "bot_message"
+(expect
+  []
+  (handle-slack-event {:text "metabot list", :subtype "bot_message"}))
+
+;; MetaBot shouldn't handlle events if they were posted after the MetaBot start time
+(expect
+  []
+  (handle-slack-event {:text "metabot list", :ts "999"}))
+
+;; MetaBot shouldn't handle events that don't start with metabot
+(expect
+  []
+  (handle-slack-event {:text "metabase list"}))
+
+;; Make sure the message CHANNEL gets bound correctly!
+(expect
+  '[(post-chat-message! "#she-watch-channel-zero")]
+  (with-redefs [metabot.cmd/command (fn [& _] @#'metabot.slack/*channel-id*)]
+    (handle-slack-event {:text "metabot list", :channel "#she-watch-channel-zero"})))
+
+;; (but we should allow misspellings like `metaboat` or `meatbot` :scream_cat:
+(expect
+  '[(post-chat-message! "OK")]
+  (with-redefs [metabot.cmd/command (constantly "OK")]
+    (handle-slack-event {:text "meatbot list"})))
+
+(expect
+  '[(post-chat-message! "OK")]
+  (with-redefs [metabot.cmd/command (constantly "OK")]
+    (handle-slack-event {:text "metaboat list"})))
+
+;; If the command function returns a string, we should post that directly as a chat message
+(expect
+  '[(post-chat-message! "(command list)")]
+  (with-redefs [metabot.cmd/command (fn [& args] (str (cons 'command args)))]
+    (handle-slack-event {:text "metabot list"})))
+
+;; command strings should get parsed correctly as if they were EDN
+(expect
+  [(list
+    'post-chat-message!
+    (str "(command \"class clojure.lang.Symbol symbol\""
+         " \"class java.lang.Double 1.0\""
+         " \"class java.lang.Long 2\""
+         " \"class clojure.lang.Keyword :keyword\""
+         " \"class java.lang.String String\")"))]
+  (with-redefs [metabot.cmd/command (fn [& args]
+                                      (str (cons 'command (for [arg args]
+                                                            (str (class arg) " " arg)))))]
+    (handle-slack-event {:text "metabot symbol 1.0 2 :keyword \"String\""})))
+
+;; if the command function returns something other than a string, we should post that as a code block
+(expect
+  '[(post-chat-message! "```\n(command list)\n```")]
+  (with-redefs [metabot.cmd/command (fn [& args]
+                                      (cons 'command args))]
+    (metabot.test.u/with-slack-messages
+      (#'metabot.events/handle-slack-message {:text "metabot list"}))))
+
+;; if the command function sends stuff async, that should get posted
+(expect
+  '[(post-chat-message! "HERE ARE YOUR RESULTZ" "[attachment]")
+    (post-chat-message! "Just a second...")]
+  (with-redefs [metabot.cmd/command (fn [& args]
+                                      (metabot.slack/async
+                                        (metabot.slack/post-chat-message! "HERE ARE YOUR RESULTZ" "[attachment]"))
+                                      "Just a second...")]
+    (handle-slack-event {:text "metabot list"})))
+
+;; if the command function throws an Exception, we should post an 'Uh-oh' message
+(expect
+  '[(post-chat-message! "Uh oh! :cry:\n> Sorry, maybe next time!")]
+  (with-redefs [metabot.cmd/command (fn [& args]
+                                      (throw (Exception. "Sorry, maybe next time!")))]
+    (handle-slack-event {:text "metabot list"})))

--- a/test/metabase/metabot/test_util.clj
+++ b/test/metabase/metabot/test_util.clj
@@ -1,0 +1,43 @@
+(ns metabase.metabot.test-util
+  (:require [medley.core :as m]
+            [metabase.metabot.slack :as metabot.slack]
+            [metabase.pulse :as pulse]))
+
+(defn do-with-slack-messages [f]
+  (let [messages (atom [])]
+    (with-redefs [metabot.slack/post-chat-message!
+                  (fn [& args]
+                    (swap! messages conj (cons 'post-chat-message! args))
+                    nil)
+
+                  pulse/create-and-upload-slack-attachments!
+                  (fn [& args]
+                    (cons 'create-and-upload-slack-attachments! args))
+
+                  pulse/create-slack-attachment-data
+                  (fn [card-results]
+                    (list 'create-slack-attachment-data
+                          (for [result card-results]
+                            (m/map-vals class result))))
+
+                  ;; this is bascially the same as the real implementation but doesn't do things in a future, and
+                  ;; doesn't log errors
+                  metabot.slack/do-async
+                  (fn [f]
+                    (try
+                      (f)
+                      nil
+                      (catch Throwable e
+                        (metabot.slack/post-chat-message!
+                         (#'metabot.slack/format-exception e)))))]
+
+      (if-let [response (f)]
+        {:response response, :messages @messages}
+        @messages))))
+
+(defmacro with-slack-messages
+  "Execute body with the functions that post to Slack mocked, returning a sequence of all fncalls to relevant functions
+  like `post-chat-message!`. Use this to write tests for the MetaBot without actually having to worry about setting up
+  Slack!"
+  [& body]
+  `(do-with-slack-messages (fn [] ~@body)))

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -487,6 +487,19 @@
      "/db/2/native/"
      "/collection/9/read/"}))
 
+;; for the Root Collection we should return `"root"`
+(expect
+  #{8 9 "root"}
+  (collection/permissions-set->visible-collection-ids
+   #{"/collection/8/"
+     "/collection/9/read/"
+     "/collection/root/"}))
+
+(expect
+  #{"root"}
+  (collection/permissions-set->visible-collection-ids
+   #{"/collection/root/read/"}))
+
 ;; Can we calculate `effective-location-path`?
 (expect "/10/20/"    (collection/effective-location-path "/10/20/30/" #{10 20}))
 (expect "/10/30/"    (collection/effective-location-path "/10/20/30/" #{10 30}))

--- a/test/metabase/models/permissions_group_test.clj
+++ b/test/metabase/models/permissions_group_test.clj
@@ -7,6 +7,7 @@
              [permissions-group-membership :refer [PermissionsGroupMembership]]
              [user :refer [User]]]
             [metabase.test.data.users :as test-users]
+            [metabase.util :as u]
             [metabase.util.honeysql-extensions :as hx]
             [toucan.db :as db]
             [toucan.util.test :as tt])
@@ -98,9 +99,17 @@
   (tt/with-temp Database [{database-id :id}]
     (group-has-full-access? (:id (perm-group/admin)) (perms/object-path database-id))))
 
+;; (Except for the MetaBot, which doesn't get data permissions)
 (expect
+  false
   (tt/with-temp Database [{database-id :id}]
     (group-has-full-access? (:id (perm-group/metabot)) (perms/object-path database-id))))
+
+;; Attempting to create a data permissions entry for the MetaBot should throw an Exception
+(expect
+  Exception
+  (tt/with-temp Database [{database-id :id}]
+    (db/insert! Permissions :group_id (u/get-id (perm-group/metabot)), :object (perms/object-path database-id))))
 
 
 ;;; -------------- flipping the is_superuser bit should add/remove user from Admin group as appropriate --------------

--- a/test/metabase/models/permissions_test.clj
+++ b/test/metabase/models/permissions_test.clj
@@ -4,7 +4,7 @@
              [collection :as collection :refer [Collection]]
              [collection-test :as collection-test]
              [database :refer [Database]]
-             [permissions :as perms]
+             [permissions :as perms :refer [Permissions]]
              [permissions-group :as group :refer [PermissionsGroup]]
              [table :refer [Table]]]
             [metabase.test.data :as data]
@@ -580,6 +580,15 @@
     ;; now fetch the perms that have been granted
     (get-in (perms/graph) [:groups (u/get-id group) (u/get-id database) :schemas])))
 
+;; The data permissions graph should never return permissions for the MetaBot, because the MetaBot can only have
+;; collection permissions
+(expect
+  false
+  ;; need to swap out the perms check function because otherwise we couldn't even insert the object we want to insert
+  (with-redefs [perms/assert-valid-metabot-permissions (constantly nil)]
+    (tt/with-temp* [Database    [db]
+                    Permissions [perms {:group_id (u/get-id (group/metabot)), :object (perms/object-path db)}]]
+      (contains? (:groups (perms/graph)) (u/get-id (group/metabot))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
- Over 2 dozen new MetaBot tests. Which takes us from maybe 2 MetaBot tests to 30
- Fixes for several MetaBot bugs
- Remove MetaBot from data permissions graph and disallow giving MetaBot data permissions because it doesn't make sense. MetaBot can only show Cards and Cards exclusively use Collection permissions