### PR TITLE
Serialization docs

### DIFF
--- a/docs/enterprise-guide/authenticating-with-jwt.md
+++ b/docs/enterprise-guide/authenticating-with-jwt.md
@@ -26,5 +26,5 @@ These are additional settings you can fill in to pass user attributes to Metabas
 
 ---
 
-## That's it!
-Still need help? Feel free to reach out to us at the support email address you were provided.
+## Next: Copying contents of one Metabase instance to another
+Learn how to use [serialization](serialization.md) to create and load data dumps of the contents of a Metabase instance.

--- a/docs/enterprise-guide/serialization.md
+++ b/docs/enterprise-guide/serialization.md
@@ -1,0 +1,45 @@
+## Copying contents of one Metabase instance to another
+
+Metabase's serialization feature allows you to create a snapshot (called a dump) of the contents of a Metabase instance that can then be loaded into another instance.
+
+This lets you do things like create a set of dashboards in one Metabase instance and then easily copy those dashboards to a number of other Metabase instances that you've set up for your customers. You could also use this feature to enable a staging-to-production workflow for important dashboards or reports by dumping from a staging instance of Metabase and then loading that dump into your production instance(s).
+
+### What gets dumped and loaded
+Currently a dump file consists of the following Metabase artifacts:
+* Collections
+* Dashboards
+* Saved questions
+* Pulses
+* Segments and Metrics defined in the Data Model
+* Archived collections, dashboards, saved questions, or pulses
+
+It also contains a number of system settings:
+* Admin Panel settings, except for permissions
+* Database connection settings
+* Data Model settings
+
+The dump file does _not_ contain:
+* Permission settings
+* User accounts or settings
+* Alerts on saved questions
+
+### Before creating or loading a dump
+If your instance is currently running, you will need to stop it first before creating or loading a dump, unless your Metabase application database supports concurrent reads. The default application database type, H2, does not support concurrent reads.
+
+### Creating a data dump
+To create a dump of a Metabase instance, use the following command in your terminal:
+
+`java -jar metabase.jar dump [dump_name] --user [example@example.com]`
+
+The optional `--user` flag is used to specify a default administrator account for cases when this dump file is loaded into a blank Metabase instance. This user will also be marked as the creator of all artifacts that are copied over to the instance. If this flag isn't specified, it's assumed that the instance into which you're loading already has an admin user.
+
+### Loading a dump file
+To load a dump file into another instance of Metabase, use the following command, where `[my_dump]` is the path to the dump file you want to load:
+
+`java -jar metabase.jar load [my_dump] --mode [skip/update] --on-error [continue/abort]`
+
+The `--mode` flag lets you specify what to do when encountering a duplicate dashboard, question, etc. It can either `skip` that item and do nothing to it, or `update` it with the version being loaded. The default is `skip`.
+
+The `--on-error` flag allows you to specify whether the load process should keep going or stop when there's an error. The default is `continue`.
+
+Both of these flags are optional.

--- a/docs/enterprise-guide/serialization.md
+++ b/docs/enterprise-guide/serialization.md
@@ -43,3 +43,8 @@ The `--mode` flag lets you specify what to do when encountering a duplicate dash
 The `--on-error` flag allows you to specify whether the load process should keep going or stop when there's an error. The default is `continue`.
 
 Both of these flags are optional.
+
+---
+
+## That's it!
+Still need help? Feel free to reach out to us at the support email address you were provided.

--- a/docs/enterprise-guide/serialization.md
+++ b/docs/enterprise-guide/serialization.md
@@ -1,11 +1,11 @@
 ## Copying contents of one Metabase instance to another
 
-Metabase's serialization feature allows you to create a snapshot (called a dump) of the contents of a Metabase instance that can then be loaded into another instance.
+Metabase's serialization feature allows you to create a snapshot, called a dump, of the contents of a Metabase instance that can then be loaded into another instance.
 
 This lets you do things like create a set of dashboards in one Metabase instance and then easily copy those dashboards to a number of other Metabase instances that you've set up for your customers. You could also use this feature to enable a staging-to-production workflow for important dashboards or reports by dumping from a staging instance of Metabase and then loading that dump into your production instance(s).
 
 ### What gets dumped and loaded
-Currently a dump file consists of the following Metabase artifacts:
+**Currently a dump consists of the following Metabase artifacts:**
 * Collections
 * Dashboards
 * Saved questions
@@ -13,28 +13,28 @@ Currently a dump file consists of the following Metabase artifacts:
 * Segments and Metrics defined in the Data Model
 * Archived collections, dashboards, saved questions, or pulses
 
-It also contains a number of system settings:
+**It also contains a number of system settings:**
 * Admin Panel settings, except for permissions
 * Database connection settings
 * Data Model settings
 
-The dump file does _not_ contain:
+**The dump does _not_ contain:**
 * Permission settings
 * User accounts or settings
 * Alerts on saved questions
 
 ### Before creating or loading a dump
-If your instance is currently running, you will need to stop it first before creating or loading a dump, unless your Metabase application database supports concurrent reads. The default application database type, H2, does not support concurrent reads.
+If your instance is currently running, you will need to stop it first before creating or loading a dump, unless your Metabase application database supports concurrent reads. The default application database type, H2, does not.
 
 ### Creating a data dump
 To create a dump of a Metabase instance, use the following command in your terminal:
 
 `java -jar metabase.jar dump [dump_name] --user [example@example.com]`
 
-The optional `--user` flag is used to specify a default administrator account for cases when this dump file is loaded into a blank Metabase instance. This user will also be marked as the creator of all artifacts that are copied over to the instance. If this flag isn't specified, it's assumed that the instance into which you're loading already has an admin user.
+The optional `--user` flag is used to specify a default administrator account for cases when this dump is loaded into a blank Metabase instance. This user will also be marked as the creator of all artifacts that are copied over to the instance. If this flag isn't specified, it's assumed that the instance into which you're loading already has an admin user.
 
-### Loading a dump file
-To load a dump file into another instance of Metabase, use the following command, where `[my_dump]` is the path to the dump file you want to load:
+### Loading a dump
+To load a dump into another instance of Metabase, use the following command, where `[my_dump]` is the path to the dump you want to load:
 
 `java -jar metabase.jar load [my_dump] --mode [skip/update] --on-error [continue/abort]`
 

--- a/docs/enterprise-guide/serialization.md
+++ b/docs/enterprise-guide/serialization.md
@@ -2,11 +2,11 @@
 
 Metabase's serialization feature allows you to create a snapshot, called a dump, of the contents of a Metabase instance that can then be loaded into another instance.
 
-This lets you do things like create a set of dashboards in one Metabase instance and then easily copy those dashboards to a number of other Metabase instances that you've set up for your customers. You could also use this feature to enable a staging-to-production workflow for important dashboards or reports by dumping from a staging instance of Metabase and then loading that dump into your production instance(s).
+This lets you do things like create a set of dashboards in one Metabase instance and then easily copy those dashboards to a number of other Metabase instances that you've set up for your customers. You could also use this feature to enable a staging-to-production workflow for important dashboards or reports by dumping from a staging instance of Metabase and then loading that dump into your production instance(s). You can even put the dump files into version control and audit changes to them, as the YAML files contained within the dump are pretty readable.
 
 ### What gets dumped and loaded
 
-**Currently a dump consists of the following Metabase artifacts:**
+**Currently, dumps consist of the following Metabase artifacts:**
 
 * Collections
 * Dashboards
@@ -16,13 +16,13 @@ This lets you do things like create a set of dashboards in one Metabase instance
 * Archived collections, dashboards, saved questions, or pulses
 * Public sharing settings for questions and dashboards
 
-**It also contains a number of system settings:**
+**They also contain a number of system settings:**
 
 * Admin Panel settings, except for permissions
 * Database connection settings
 * Data Model settings
 
-**The dump does _not_ contain:**
+**Dumps do _not_ contain:**
 
 * Permission settings
 * User accounts or settings
@@ -39,17 +39,17 @@ To create a dump of a Metabase instance, use the following command in your termi
 
 `java -jar metabase.jar dump [dump_name] --user [example@example.com]`
 
-The optional `--user` flag is used to specify a default administrator account for cases when this dump is loaded into a blank Metabase instance. This user will also be marked as the creator of all artifacts that are copied over to the instance. This user's personal collection and its contents will also be included in the data dump. If this flag isn't specified, it's assumed that the instance into which you're loading already has an admin user.
+The optional `--user` flag is used to specify a default administrator account for cases when this dump is loaded into a blank Metabase instance. This user will also be marked as the creator of all artifacts that are copied over to the instance. This user's personal collection and its contents will also be included in the data dump. If this flag isn't specified, Metabase will assume that the instance into which you're loading already has an admin user (but the load will fail if there isn't an admin user).
 
 ### Loading a dump
 
-To load a dump into another instance of Metabase, use the following command, where `[my_dump]` is the path to the dump you want to load:
+Currently, you can only load dumps into a Metabase instance that were created from the same version of Metabase. To load a dump into a Metabase instance, use the following command, where `[my_dump]` is the path to the dump you want to load:
 
 `java -jar metabase.jar load [my_dump] --mode [skip/update] --on-error [continue/abort]`
 
 The `--mode` flag lets you specify what to do when encountering a duplicate dashboard, question, or any Admin Panel settings that already set (again, except for permissions and user settings, which are not currently included in data dumps). It can either `skip` that item and do nothing to it, or `update` it with the version being loaded. The default is `skip`.
 
-The `--on-error` flag allows you to specify whether the load process should keep going or stop when there's an error. The default is `continue`.
+The `--on-error` flag allows you to specify whether the load process should keep going or stop when there's an error. The default is `continue`. Note that `abort` won't undo any successful artifact loads that happened before an error was encountered.
 
 Both of these flags are optional.
 

--- a/docs/enterprise-guide/serialization.md
+++ b/docs/enterprise-guide/serialization.md
@@ -5,7 +5,9 @@ Metabase's serialization feature allows you to create a snapshot, called a dump,
 This lets you do things like create a set of dashboards in one Metabase instance and then easily copy those dashboards to a number of other Metabase instances that you've set up for your customers. You could also use this feature to enable a staging-to-production workflow for important dashboards or reports by dumping from a staging instance of Metabase and then loading that dump into your production instance(s).
 
 ### What gets dumped and loaded
+
 **Currently a dump consists of the following Metabase artifacts:**
+
 * Collections
 * Dashboards
 * Saved questions
@@ -15,20 +17,24 @@ This lets you do things like create a set of dashboards in one Metabase instance
 * Public sharing settings for questions and dashboards
 
 **It also contains a number of system settings:**
+
 * Admin Panel settings, except for permissions
 * Database connection settings
 * Data Model settings
 
 **The dump does _not_ contain:**
+
 * Permission settings
 * User accounts or settings
 * Alerts on saved questions
 * Personal Collections or their contents (except for the user specified with the `--user` flag; see below)
 
 ### Before creating or loading a dump
+
 If your instance is currently running, you will need to stop it first before creating or loading a dump, unless your Metabase application database supports concurrent reads. The default application database type, H2, does not.
 
 ### Creating a data dump
+
 To create a dump of a Metabase instance, use the following command in your terminal:
 
 `java -jar metabase.jar dump [dump_name] --user [example@example.com]`
@@ -36,6 +42,7 @@ To create a dump of a Metabase instance, use the following command in your termi
 The optional `--user` flag is used to specify a default administrator account for cases when this dump is loaded into a blank Metabase instance. This user will also be marked as the creator of all artifacts that are copied over to the instance. This user's personal collection and its contents will also be included in the data dump. If this flag isn't specified, it's assumed that the instance into which you're loading already has an admin user.
 
 ### Loading a dump
+
 To load a dump into another instance of Metabase, use the following command, where `[my_dump]` is the path to the dump you want to load:
 
 `java -jar metabase.jar load [my_dump] --mode [skip/update] --on-error [continue/abort]`
@@ -49,4 +56,5 @@ Both of these flags are optional.
 ---
 
 ## That's it!
+
 Still need help? Feel free to reach out to us at the support email address you were provided.

--- a/docs/enterprise-guide/serialization.md
+++ b/docs/enterprise-guide/serialization.md
@@ -12,6 +12,7 @@ This lets you do things like create a set of dashboards in one Metabase instance
 * Pulses
 * Segments and Metrics defined in the Data Model
 * Archived collections, dashboards, saved questions, or pulses
+* Public sharing settings for questions and dashboards
 
 **It also contains a number of system settings:**
 * Admin Panel settings, except for permissions
@@ -22,6 +23,7 @@ This lets you do things like create a set of dashboards in one Metabase instance
 * Permission settings
 * User accounts or settings
 * Alerts on saved questions
+* Personal Collections or their contents (except for the user specified with the `--user` flag; see below)
 
 ### Before creating or loading a dump
 If your instance is currently running, you will need to stop it first before creating or loading a dump, unless your Metabase application database supports concurrent reads. The default application database type, H2, does not.
@@ -31,14 +33,14 @@ To create a dump of a Metabase instance, use the following command in your termi
 
 `java -jar metabase.jar dump [dump_name] --user [example@example.com]`
 
-The optional `--user` flag is used to specify a default administrator account for cases when this dump is loaded into a blank Metabase instance. This user will also be marked as the creator of all artifacts that are copied over to the instance. If this flag isn't specified, it's assumed that the instance into which you're loading already has an admin user.
+The optional `--user` flag is used to specify a default administrator account for cases when this dump is loaded into a blank Metabase instance. This user will also be marked as the creator of all artifacts that are copied over to the instance. This user's personal collection and its contents will also be included in the data dump. If this flag isn't specified, it's assumed that the instance into which you're loading already has an admin user.
 
 ### Loading a dump
 To load a dump into another instance of Metabase, use the following command, where `[my_dump]` is the path to the dump you want to load:
 
 `java -jar metabase.jar load [my_dump] --mode [skip/update] --on-error [continue/abort]`
 
-The `--mode` flag lets you specify what to do when encountering a duplicate dashboard, question, etc. It can either `skip` that item and do nothing to it, or `update` it with the version being loaded. The default is `skip`.
+The `--mode` flag lets you specify what to do when encountering a duplicate dashboard, question, or any Admin Panel settings that already set (again, except for permissions and user settings, which are not currently included in data dumps). It can either `skip` that item and do nothing to it, or `update` it with the version being loaded. The default is `skip`.
 
 The `--on-error` flag allows you to specify whether the load process should keep going or stop when there's an error. The default is `continue`.
 

--- a/docs/enterprise-guide/start.md
+++ b/docs/enterprise-guide/start.md
@@ -7,3 +7,4 @@ The Enterprise Edition of Metabase provides added functionality and solutions fo
 * [Customizing drill-through for charts and tables](customizing-drill-through.md)
 * [Authenticating with SAML](authenticating-with-saml.md)
 * [Authenticating with JWT](authenticating-with-jwt.md)
+* [Copying contents of one Metabase instance to another (serialization)](serialization.md)


### PR DESCRIPTION
I vetted this content by @sbelak and asked him some clarifying questions, but I'm realizing I still have some questions about the behavior of this feature when dealing with system settings:

- I know permissions, user, and group settings are not copied over. Are there any other admin settings that are _not_ copied? (E.g. are white-labeling settings copied?)
- Does the `skip` and `update` flag affect admin panel and data model settings? Or will my settings always get changed to match the settings contained in the dump?
- If I have public sharing turned on for a given dashboard, does that setting get carried over to the loaded dashboard?
- Are personal collections copied or ignored?