### PR TITLE
Increase yarn network-timeout

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .babel_cache/*
-.git/*
 docs/*
 OSX/*
 target/*

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+network-timeout 600000

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ADD project.clj .
 RUN lein deps
 
 # frontend dependencies
-ADD yarn.lock package.json ./
+ADD yarn.lock package.json .yarnrc ./
 RUN yarn
 
 # add the rest of the source


### PR DESCRIPTION
* increase yarn's `network-timeout` parameter to try to fix DockerHub builds
* include `.git` directory so that `bin/version` works correct and captures version info.