### PR TITLE
Support unarchiving Metrics & Segments via the API 

### DIFF
--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -368,6 +368,16 @@
   ([entity id & other-conditions]
    (write-check (apply db/select-one entity :id id other-conditions))))
 
+(defn create-check
+  "NEW! Check whether the current user has permissions to CREATE a new instance of an object with properties in map `m`.
+
+  This function was added *years* after `read-check` and `write-check`, and at the time of this writing most models do
+  not implement this method. Most `POST` API endpoints instead have the `can-create?` logic for a given model
+  hardcoded into this -- this should be considered an antipattern and be refactored out going forward."
+  {:added "0.32.0", :style/indent 2}
+  [entity m]
+  (check-403 (mi/can-create? entity m)))
+
 ;;; --------------------------------------------------- STREAMING ----------------------------------------------------
 
 (def ^:private ^:const streaming-response-keep-alive-interval-ms

--- a/src/metabase/api/metric.clj
+++ b/src/metabase/api/metric.clj
@@ -1,38 +1,56 @@
 (ns metabase.api.metric
   "/api/metric endpoints."
   (:require [clojure.data :as data]
+            [clojure.tools.logging :as log]
             [compojure.core :refer [DELETE GET POST PUT]]
+            [metabase
+             [events :as events]
+             [related :as related]
+             [util :as u]]
             [metabase.api.common :as api]
             [metabase.models
              [interface :as mi]
              [metric :as metric :refer [Metric]]
              [revision :as revision]
              [table :refer [Table]]]
-            [metabase.related :as related]
-            [metabase.util.schema :as su]
+            [metabase.util
+             [i18n :refer [trs]]
+             [schema :as su]]
+            [schema.core :as s]
             [toucan
              [db :as db]
              [hydrate :refer [hydrate]]]))
 
 (api/defendpoint POST "/"
   "Create a new `Metric`."
-  [:as {{:keys [name description table_id definition]} :body}]
-  {name       su/NonBlankString
-   table_id   su/IntGreaterThanZero
-   definition su/Map}
-  (api/check-superuser)
-  (api/write-check Table table_id)
-  (api/check-500 (metric/create-metric! table_id name description api/*current-user-id* definition)))
+  [:as {{:keys [name description table_id definition], :as body} :body}]
+  {name        su/NonBlankString
+   table_id    su/IntGreaterThanZero
+   definition  su/Map
+   description (s/maybe s/Str)}
+  ;; TODO - why can't set the other properties like `show_in_getting_started` when you create a Metric?
+  (api/create-check Metric body)
+  (let [metric (api/check-500
+                (db/insert! Metric
+                  :table_id    table_id
+                  :creator_id  api/*current-user-id*
+                  :name        name
+                  :description description
+                  :definition  definition))]
+    (-> (events/publish-event! :metric-create metric)
+        (hydrate :creator))))
 
+(s/defn ^:private hydrated-metric [id :- su/IntGreaterThanZero]
+  (-> (api/read-check (Metric id))
+      (hydrate :creator)))
 
 (api/defendpoint GET "/:id"
   "Fetch `Metric` with ID."
   [id]
-  (api/check-superuser)
-  (api/read-check (metric/retrieve-metric id)))
+  (hydrated-metric id))
 
 (defn- add-db-ids
-  "Add `:database_id` fields to METRICS by looking them up from their `:table_id`."
+  "Add `:database_id` fields to `metrics` by looking them up from their `:table_id`."
   [metrics]
   (when (seq metrics)
     (let [table-id->db-id (db/select-id->field :db_id Table, :id [:in (set (map :table_id metrics))])]
@@ -42,25 +60,43 @@
 (api/defendpoint GET "/"
   "Fetch *all* `Metrics`."
   [id]
-  (as-> (db/select Metric, :archived false, {:order-by [:%lower.name]}) <>
-    (hydrate <> :creator)
-    (add-db-ids <>)
-    (filter mi/can-read? <>)))
+  (as-> (db/select Metric, :archived false, {:order-by [:%lower.name]}) metrics
+    (hydrate metrics :creator)
+    (add-db-ids metrics)
+    (filter mi/can-read? metrics)))
 
+(defn- write-check-and-update-metric!
+  "Check whether current user has write permissions, then update Metric with values in `body`. Publishes appropriate
+  event and returns updated/hydrated Metric."
+  [id {:keys [revision_message archived], :as body}]
+  (let [existing (api/write-check Metric id)
+        [changes] (data/diff
+                   (u/select-keys-when body
+                     :present #{:description :caveats :how_is_this_calculated :points_of_interest}
+                     :non-nil #{:archived :definition :name :show_in_getting_started})
+                   existing)
+        archive? (:archived changes)]
+    (when changes
+      (db/update! Metric id changes))
+    (u/prog1 (hydrated-metric id)
+      (events/publish-event! (if archive? :metric-delete :metric-update)
+        (assoc <> :actor_id api/*current-user-id*, :revision_message revision_message)))))
 
 (api/defendpoint PUT "/:id"
   "Update a `Metric` with ID."
-  [id :as {{:keys [definition name revision_message], :as body} :body}]
-  {name             su/NonBlankString
-   revision_message su/NonBlankString
-   definition       su/Map}
-  (api/check-superuser)
-  (api/write-check Metric id)
-  (metric/update-metric!
-   (assoc (select-keys body #{:caveats :definition :description :how_is_this_calculated :name :points_of_interest
-                              :revision_message :show_in_getting_started})
-     :id id)
-   api/*current-user-id*))
+  [id :as {{:keys [name definition revision_message archived caveats description how_is_this_calculated
+                   points_of_interest show_in_getting_started]
+            :as   body} :body}]
+  {name                    (s/maybe su/NonBlankString)
+   definition              (s/maybe su/Map)
+   revision_message        su/NonBlankString
+   archived                (s/maybe s/Bool)
+   caveats                 (s/maybe s/Str)
+   description             (s/maybe s/Str)
+   how_is_this_calculated  (s/maybe s/Str)
+   points_of_interest      (s/maybe s/Str)
+   show_in_getting_started (s/maybe s/Bool)}
+  (write-check-and-update-metric! id body))
 
 (api/defendpoint PUT "/:id/important_fields"
   "Update the important `Fields` for a `Metric` with ID.
@@ -84,20 +120,19 @@
 
 
 (api/defendpoint DELETE "/:id"
-  "Delete a `Metric`."
+  "Archive a Metric. (DEPRECATED -- Just pass updated value of `:archived` to the `PUT` endpoint instead.)"
   [id revision_message]
   {revision_message su/NonBlankString}
-  (api/check-superuser)
-  (api/write-check Metric id)
-  (metric/delete-metric! id api/*current-user-id* revision_message)
-  {:success true}) ; TODO - why doesn't this return a 204 'No Content'?
+  (log/warn
+   (trs "DELETE /api/metric/:id is deprecated. Instead, change its `archived` value via PUT /api/metric/:id."))
+  (write-check-and-update-metric! id {:archived true, :revision_message revision_message})
+  api/generic-204-no-content)
 
 
 (api/defendpoint GET "/:id/revisions"
   "Fetch `Revisions` for `Metric` with ID."
   [id]
-  (api/check-superuser)
-  (api/write-check Metric id)
+  (api/read-check Metric id)
   (revision/revisions+details Metric id))
 
 
@@ -105,7 +140,6 @@
   "Revert a `Metric` to a prior `Revision`."
   [id :as {{:keys [revision_id]} :body}]
   {revision_id su/IntGreaterThanZero}
-  (api/check-superuser)
   (api/write-check Metric id)
   (revision/revert!
     :entity      Metric
@@ -117,5 +151,6 @@
   "Return related entities."
   [id]
   (-> id Metric api/read-check related/related))
+
 
 (api/define-routes)

--- a/src/metabase/api/segment.clj
+++ b/src/metabase/api/segment.clj
@@ -1,72 +1,106 @@
 (ns metabase.api.segment
   "/api/segment endpoints."
-  (:require [compojure.core :refer [DELETE GET POST PUT]]
+  (:require [clojure.data :as data]
+            [clojure.tools.logging :as log]
+            [compojure.core :refer [DELETE GET POST PUT]]
+            [metabase
+             [events :as events]
+             [related :as related]
+             [util :as u]]
             [metabase.api.common :as api]
             [metabase.models
              [interface :as mi]
              [revision :as revision]
-             [segment :as segment :refer [Segment]]
-             [table :refer [Table]]]
-            [metabase.related :as related]
-            [metabase.util.schema :as su]
+             [segment :as segment :refer [Segment]]]
+            [metabase.util
+             [i18n :refer [trs]]
+             [schema :as su]]
+            [schema.core :as s]
             [toucan
              [db :as db]
              [hydrate :refer [hydrate]]]))
 
 (api/defendpoint POST "/"
   "Create a new `Segment`."
-  [:as {{:keys [name description table_id definition]} :body}]
+  [:as {{:keys [name description table_id definition], :as body} :body}]
   {name       su/NonBlankString
    table_id   su/IntGreaterThanZero
-   definition su/Map}
-  (api/check-superuser)
-  (api/write-check Table table_id)
-  (api/check-500 (segment/create-segment! table_id name description api/*current-user-id* definition)))
+   definition su/Map
+   description (s/maybe s/Str)}
+  ;; TODO - why can't we set other properties like `show_in_getting_started` when we create the Segment?
+  (api/create-check Segment body)
+  (let [segment (api/check-500
+                 (db/insert! Segment
+                   :table_id    table_id
+                   :creator_id  api/*current-user-id*
+                   :name        name
+                   :description description
+                   :definition  definition))]
+    (-> (events/publish-event! :segment-create segment)
+        (hydrate :creator))))
 
+(s/defn ^:private hydrated-segment [id :- su/IntGreaterThanZero]
+  (-> (api/read-check (Segment id))
+      (hydrate :creator)))
 
 (api/defendpoint GET "/:id"
   "Fetch `Segment` with ID."
   [id]
-  (api/check-superuser)
-  (api/read-check (segment/retrieve-segment id)))
+  (hydrated-segment id))
 
-;; TODO - Why do we require superuser status for GET /api/segment/:id but not GET /api/segment?
 (api/defendpoint GET "/"
   "Fetch *all* `Segments`."
   []
-  (filter mi/can-read? (-> (db/select Segment, :archived false, {:order-by [[:%lower.name :asc]]})
-                           (hydrate :creator))))
+  (as-> (db/select Segment, :archived false, {:order-by [[:%lower.name :asc]]}) segments
+    (filter mi/can-read? segments)
+    (hydrate segments :creator)))
 
+
+(defn- write-check-and-update-segment!
+  "Check whether current user has write permissions, then update Segment with values in `body`. Publishes appropriate
+  event and returns updated/hydrated Segment."
+  [id {:keys [revision_message archived], :as body}]
+  (let [existing  (api/write-check Segment id)
+        [changes] (data/diff
+                   (u/select-keys-when body
+                     :present #{:description :caveats :points_of_interest}
+                     :non-nil #{:archived :definition :name :show_in_getting_started})
+                   existing)
+        archive?  (:archived changes)]
+    (when changes
+      (db/update! Segment id changes))
+    (u/prog1 (hydrated-segment id)
+      (events/publish-event! (if archive? :segment-delete :segment-update)
+        (assoc <> :actor_id api/*current-user-id*, :revision_message revision_message)))))
 
 (api/defendpoint PUT "/:id"
   "Update a `Segment` with ID."
-  [id :as {{:keys [name definition revision_message], :as body} :body}]
-  {name             su/NonBlankString
-   revision_message su/NonBlankString
-   definition       su/Map}
-  (api/check-superuser)
-  (api/write-check Segment id)
-  (segment/update-segment!
-   (assoc (select-keys body #{:name :description :caveats :points_of_interest :show_in_getting_started :definition
-                              :revision_message})
-     :id id)
-   api/*current-user-id*))
-
+  [id :as {{:keys [name definition revision_message archived caveats description points_of_interest
+                   show_in_getting_started]
+            :as   body} :body}]
+  {name                    (s/maybe su/NonBlankString)
+   definition              (s/maybe su/Map)
+   revision_message        su/NonBlankString
+   archived                (s/maybe s/Bool)
+   caveats                 (s/maybe s/Str)
+   description             (s/maybe s/Str)
+   points_of_interest      (s/maybe s/Str)
+   show_in_getting_started (s/maybe s/Bool)}
+  (write-check-and-update-segment! id body))
 
 (api/defendpoint DELETE "/:id"
-  "Delete a `Segment`."
+  "Archive a Segment. (DEPRECATED -- Just pass updated value of `:archived` to the `PUT` endpoint instead.)"
   [id revision_message]
   {revision_message su/NonBlankString}
-  (api/check-superuser)
-  (api/write-check Segment id)
-  (segment/delete-segment! id api/*current-user-id* revision_message)
-  {:success true}) ; TODO - why doesn't this return a 204 'No Content'?
+  (log/warn
+   (trs "DELETE /api/segment/:id is deprecated. Instead, change its `archived` value via PUT /api/segment/:id."))
+  (write-check-and-update-segment! id {:archived true, :revision_message revision_message})
+  api/generic-204-no-content)
 
 
 (api/defendpoint GET "/:id/revisions"
   "Fetch `Revisions` for `Segment` with ID."
   [id]
-  (api/check-superuser)
   (api/read-check Segment id)
   (revision/revisions+details Segment id))
 
@@ -75,7 +109,6 @@
   "Revert a `Segement` to a prior `Revision`."
   [id :as {{:keys [revision_id]} :body}]
   {revision_id su/IntGreaterThanZero}
-  (api/check-superuser)
   (api/write-check Segment id)
   (revision/revert!
     :entity      Segment
@@ -87,5 +120,6 @@
   "Return related entities."
   [id]
   (-> id Segment api/read-check related/related))
+
 
 (api/define-routes)

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -203,11 +203,26 @@
      *  `superuser?`
      *  `(partial current-user-has-full-permissions? :write)` (you must also implement `perms-objects-set` to use this)
      *  `(partial current-user-has-partial-permissions? :write)` (you must also implement `perms-objects-set` to use
-        this)"))
+        this)")
+
+  (^{:added "0.32.0"} can-create? ^Boolean [entity m]
+    "NEW! Check whether or not current user is allowed to CREATE a new instance of `entity` with properties in map
+    `m`.
+
+    Because this method was added YEARS after `can-read?` and `can-write?`, most models do not have an implementation
+    for this method, and instead `POST` API endpoints themselves contain the appropriate permissions logic (ick).
+    Implement this method as you come across models that are missing it."))
 
 (def IObjectPermissionsDefaults
   "Default implementations for `IObjectPermissions`."
-  {:perms-objects-set (constantly nil)})
+  {:perms-objects-set
+   (constantly nil)
+
+   :can-create?
+   (fn [entity _]
+     (throw
+      (NoSuchMethodException.
+       (format "%s does not yet have an implementation for `can-create?`. Feel free to add one!" (name entity)))))})
 
 (defn superuser?
   "Is `*current-user*` is a superuser? Ignores args.

--- a/src/metabase/models/metric.clj
+++ b/src/metabase/models/metric.clj
@@ -3,14 +3,16 @@
   It is passed in as an `:aggregation` clause but is replaced by the `expand-macros` middleware with the appropriate
   clauses."
   (:require [medley.core :as m]
-            [metabase
-             [events :as events]
-             [util :as u]]
             [metabase.mbql.util :as mbql.u]
             [metabase.models
              [dependency :as dependency]
              [interface :as i]
              [revision :as revision]]
+            [metabase.util :as u]
+            [metabase.util
+             [i18n :refer [tru]]
+             [schema :as su]]
+            [schema.core :as s]
             [toucan
              [db :as db]
              [hydrate :refer [hydrate]]
@@ -18,25 +20,38 @@
 
 (models/defmodel Metric :metric)
 
+(defn- pre-update [{:keys [creator_id id], :as updates}]
+  (u/prog1 updates
+    ;; throw an Exception if someone tries to update creator_id
+    (when (contains? updates :creator_id)
+      (when (not= creator_id (db/select-one-field :creator_id Metric :id id))
+        (throw (UnsupportedOperationException. (str (tru "You cannot update the creator_id of a Metric."))))))))
+
 (defn- pre-delete [{:keys [id]}]
   (db/delete! 'MetricImportantField :metric_id id))
 
 (defn- perms-objects-set [metric read-or-write]
   (let [table (or (:table metric)
-                  (db/select-one ['Table :db_id :schema :id] :id (:table_id metric)))]
+                  (db/select-one ['Table :db_id :schema :id] :id (u/get-id (:table_id metric))))]
     (i/perms-objects-set table read-or-write)))
 
 (u/strict-extend (class Metric)
   models/IModel
-  (merge models/IModelDefaults
-         {:types      (constantly {:definition :metric-segment-definition, :description :clob})
-          :properties (constantly {:timestamped? true})
-          :pre-delete pre-delete})
+  (merge
+   models/IModelDefaults
+   {:types      (constantly {:definition :metric-segment-definition, :description :clob})
+    :properties (constantly {:timestamped? true})
+    :pre-delete pre-delete
+    :pre-update pre-update})
   i/IObjectPermissions
-  (merge i/IObjectPermissionsDefaults
-         {:perms-objects-set perms-objects-set
-          :can-read?         (partial i/current-user-has-full-permissions? :read)
-          :can-write?        (partial i/current-user-has-full-permissions? :write)}))
+  (merge
+   i/IObjectPermissionsDefaults
+   {:perms-objects-set perms-objects-set
+    :can-read?         (partial i/current-user-has-full-permissions? :read)
+    ;; for the time being you need to be a superuser in order to create or update Metrics because the UI for doing so
+    ;; is only exposed in the admin panel
+    :can-write?        i/superuser?
+    :can-create?       i/superuser?}))
 
 
 ;;; --------------------------------------------------- REVISIONS ----------------------------------------------------
@@ -79,86 +94,20 @@
   {:dependencies metric-dependencies})
 
 
-;; ## Persistence Functions
+;;; ----------------------------------------------------- OTHER ------------------------------------------------------
 
-(defn create-metric!
-  "Create a new Metric.
-
-   Returns the newly created Metric or throws an Exception."
-  [table-id metric-name description creator-id definition]
-  {:pre [(integer? table-id)
-         (string? metric-name)
-         (integer? creator-id)
-         (map? definition)]}
-  (let [metric (db/insert! Metric
-                 :table_id    table-id
-                 :creator_id  creator-id
-                 :name        metric-name
-                 :description description
-                 :definition  definition)]
-    (-> (events/publish-event! :metric-create metric)
-        (hydrate :creator))))
-
-(defn exists?
-  "Does an *active* Metric with ID exist?"
-  ^Boolean [id]
-  {:pre [(integer? id)]}
-  (db/exists? Metric :id id, :archived false))
-
-(defn retrieve-metric
-  "Fetch a single Metric by its ID value. Hydrates its `:creator`."
-  [id]
-  {:pre [(integer? id)]}
-  (-> (Metric id)
-      (hydrate :creator)))
-
-(defn retrieve-metrics
+(s/defn retrieve-metrics :- [MetricInstance]
   "Fetch all `Metrics` for a given `Table`. Optional second argument allows filtering by active state by providing one
   of 3 keyword values: `:active`, `:deleted`, `:all`. Default filtering is for `:active`."
-  ([table-id]
+  ([table-id :- su/IntGreaterThanZero]
    (retrieve-metrics table-id :active))
-  ([table-id state]
-   {:pre [(integer? table-id) (keyword? state)]}
+
+  ([table-id :- su/IntGreaterThanZero, state :- (s/enum :all :active :deleted)]
    (-> (db/select Metric
          {:where    [:and [:= :table_id table-id]
-                          (case state
-                            :all     true
-                            :active  [:= :archived false]
-                            :deleted [:= :archived true])]
+                     (case state
+                       :all     true
+                       :active  [:= :archived false]
+                       :deleted [:= :archived true])]
           :order-by [[:name :asc]]})
        (hydrate :creator))))
-
-(defn update-metric!
-  "Update an existing Metric.
-
-   Returns the updated Metric or throws an Exception."
-  [{:keys [id name definition revision_message], :as body} user-id]
-  {:pre [(integer? id)
-         (string? name)
-         (map? definition)
-         (integer? user-id)
-         (string? revision_message)]}
-  ;; update the metric itself
-  (db/update! Metric id
-    (select-keys body #{:caveats :definition :description :how_is_this_calculated :name :points_of_interest
-                        :show_in_getting_started}))
-  (u/prog1 (retrieve-metric id)
-    (events/publish-event! :metric-update (assoc <> :actor_id user-id, :revision_message revision_message))))
-
-;; TODO - rename to `delete!`
-(defn delete-metric!
-  "Delete a Metric.
-
-  This does a soft delete and simply marks the Metric as deleted but does not actually remove the record from the
-  database at any time.
-
-  Returns the final state of the Metric is successful, or throws an Exception."
-  [id user-id revision-message]
-  {:pre [(integer? id)
-         (integer? user-id)
-         (string? revision-message)]}
-  ;; make Metric not active
-  (db/update! Metric id, :archived true)
-  ;; retrieve the updated metric (now retired)
-  (u/prog1 (retrieve-metric id)
-    (events/publish-event! :metric-delete (assoc <> :actor_id user-id, :revision_message revision-message))))

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -69,14 +69,18 @@
 
 (u/strict-extend (class Pulse)
   models/IModel
-  (merge models/IModelDefaults
-         {:hydration-keys (constantly [:pulse])
-          :properties     (constantly {:timestamped? true})
-          :pre-delete     pre-delete})
+  (merge
+   models/IModelDefaults
+   {:hydration-keys (constantly [:pulse])
+    :properties     (constantly {:timestamped? true})
+    :pre-delete     pre-delete})
   i/IObjectPermissions
-  {:can-read?         (partial i/current-user-has-full-permissions? :read)
-   :can-write?        (partial i/current-user-has-full-permissions? :write)
-   :perms-objects-set perms-objects-set})
+  (merge
+   i/IObjectPermissionsDefaults
+   {:can-read?         (partial i/current-user-has-full-permissions? :read)
+    :can-write?        (partial i/current-user-has-full-permissions? :write)
+    :perms-objects-set perms-objects-set}))
+
 
 ;;; ---------------------------------------------------- Schemas -----------------------------------------------------
 

--- a/src/metabase/models/revision.clj
+++ b/src/metabase/models/revision.clj
@@ -134,6 +134,7 @@
   [& {object :object,
       :keys [entity id user-id is-creation? message],
       :or {id (:id object), is-creation? false}}]
+  ;; TODO - rewrite this to use a schema
   {:pre [(models/model? entity)
          (integer? user-id)
          (db/exists? User :id user-id)

--- a/src/metabase/models/segment.clj
+++ b/src/metabase/models/segment.clj
@@ -2,12 +2,14 @@
   "A Segment is a saved MBQL 'macro', expanding to a `:filter` subclause. It is passed in as a `:filter` subclause but is
   replaced by the `expand-macros` middleware with the appropriate clauses."
   (:require [medley.core :as m]
-            [metabase
-             [events :as events]
-             [util :as u]]
             [metabase.models
              [interface :as i]
              [revision :as revision]]
+            [metabase.util :as u]
+            [metabase.util
+             [i18n :refer [tru]]
+             [schema :as su]]
+            [schema.core :as s]
             [toucan
              [db :as db]
              [hydrate :refer [hydrate]]
@@ -15,26 +17,38 @@
 
 (models/defmodel Segment :segment)
 
+(defn- pre-update [{:keys [creator_id id], :as updates}]
+  (u/prog1 updates
+    ;; throw an Exception if someone tries to update creator_id
+    (when (contains? updates :creator_id)
+      (when (not= creator_id (db/select-one-field :creator_id Segment :id id))
+        (throw (UnsupportedOperationException. (str (tru "You cannot update the creator_id of a Segment."))))))))
+
 (defn- perms-objects-set [segment read-or-write]
   (let [table (or (:table segment)
-                  (db/select-one ['Table :db_id :schema :id] :id (:table_id segment)))]
+                  (db/select-one ['Table :db_id :schema :id] :id (u/get-id (:table_id segment))))]
     (i/perms-objects-set table read-or-write)))
 
 (u/strict-extend (class Segment)
   models/IModel
-  (merge models/IModelDefaults
-         {:types          (constantly {:definition :metric-segment-definition, :description :clob})
-          :properties     (constantly {:timestamped? true})
-          :hydration-keys (constantly [:segment])})
+  (merge
+   models/IModelDefaults
+   {:types          (constantly {:definition :metric-segment-definition, :description :clob})
+    :properties     (constantly {:timestamped? true})
+    :hydration-keys (constantly [:segment])
+    :pre-update     pre-update})
   i/IObjectPermissions
-  (merge i/IObjectPermissionsDefaults
-         {:perms-objects-set perms-objects-set
-          :can-read?         (partial i/current-user-has-full-permissions? :read)
-          :can-write?        (partial i/current-user-has-full-permissions? :write)}))
+  (merge
+   i/IObjectPermissionsDefaults
+   {:perms-objects-set perms-objects-set
+    :can-read?         (partial i/current-user-has-full-permissions? :read)
+    ;; for the time being you need to be a superuser in order to create or update Segments because the UI for
+    ;; doing so is only exposed in the admin panel
+    :can-write?        i/superuser?
+    :can-create?       i/superuser?}))
 
 
-;;; ## ---------------------------------------- REVISIONS ----------------------------------------
-
+;;; --------------------------------------------------- Revisions ----------------------------------------------------
 
 (defn- serialize-segment [_ _ instance]
   (dissoc instance :created_at :updated_at))
@@ -57,88 +71,22 @@
 
 (u/strict-extend (class Segment)
   revision/IRevisioned
-  (merge revision/IRevisionedDefaults
-         {:serialize-instance serialize-segment
-          :diff-map           diff-segments}))
+  (merge
+   revision/IRevisionedDefaults
+   {:serialize-instance serialize-segment
+    :diff-map           diff-segments}))
 
 
-;; ## Persistence Functions
+;;; ------------------------------------------------------ Etc. ------------------------------------------------------
 
-(defn create-segment!
-  "Create a new `Segment`.
+(s/defn retrieve-segments :- [SegmentInstance]
+  "Fetch all `Segments` for a given `Table`. Optional second argument allows filtering by active state by providing
+   one of 3 keyword values: `:active`, `:deleted`, `:all`. Default filtering is for `:active`."
+  ([table-id :- su/IntGreaterThanZero]
+   (retrieve-segments table-id :active))
 
-   Returns the newly created `Segment` or throws an Exception."
-  [table-id segment-name description creator-id definition]
-  {:pre [(integer? table-id)
-         (string? segment-name)
-         (integer? creator-id)
-         (map? definition)]}
-  (let [segment (db/insert! Segment
-                  :table_id    table-id
-                  :creator_id  creator-id
-                  :name        segment-name
-                  :description description
-                  :definition  definition)]
-    (-> (events/publish-event! :segment-create segment)
-        (hydrate :creator))))
-
-(defn exists?
-  "Does an *active* `Segment` with ID exist?"
-  ^Boolean [id]
-  {:pre [(integer? id)]}
-  (db/exists? Segment, :id id, :archived false))
-
-(defn retrieve-segment
-  "Fetch a single `Segment` by its ID value. Hydrates the Segment's `:creator`."
-  [id]
-  {:pre [(integer? id)]}
-  (-> (Segment id)
-      (hydrate :creator)))
-
-(defn retrieve-segments
-  "Fetch all `Segments` for a given `Table`.  Optional second argument allows filtering by active state by
-   providing one of 3 keyword values: `:active`, `:deleted`, `:all`.  Default filtering is for `:active`."
-  ([table-id]
-    (retrieve-segments table-id :active))
-  ([table-id state]
-   {:pre [(integer? table-id) (keyword? state)]}
+  ([table-id :- su/IntGreaterThanZero state :- (s/enum :active :deleted :all)]
    (-> (if (= :all state)
          (db/select Segment, :table_id table-id, {:order-by [[:name :asc]]})
          (db/select Segment, :table_id table-id, :archived (= :deleted state), {:order-by [[:name :asc]]}))
        (hydrate :creator))))
-
-(defn update-segment!
-  "Update an existing `Segment`.
-   Returns the updated `Segment` or throws an Exception."
-  [{:keys [id name description caveats points_of_interest show_in_getting_started definition revision_message]
-    :as   body}
-   user-id]
-  {:pre [(integer? id)
-         (string? name)
-         (map? definition)
-         (integer? user-id)
-         (string? revision_message)]}
-  ;; update the segment itself
-  (db/update! Segment id
-    (u/select-keys-when body
-      :present #{:name :description :caveats :definition}
-      :non-nil #{:points_of_interest :show_in_getting_started}))
-  (u/prog1 (retrieve-segment id)
-    (events/publish-event! :segment-update (assoc <> :actor_id user-id, :revision_message revision_message))))
-
-(defn delete-segment!
-  "Delete a `Segment`.
-
-   This does a soft delete and simply marks the `Segment` as deleted but does not actually remove the
-   record from the database at any time.
-
-   Returns the final state of the `Segment` is successful, or throws an Exception."
-  [id user-id revision-message]
-  {:pre [(integer? id)
-         (integer? user-id)
-         (string? revision-message)]}
-  ;; make Segment not active
-  (db/update! Segment id, :archived true)
-  ;; retrieve the updated segment (now retired)
-  (u/prog1 (retrieve-segment id)
-    (events/publish-event! :segment-delete (assoc <> :actor_id user-id, :revision_message revision-message))))

--- a/test/metabase/api/metric_test.clj
+++ b/test/metabase/api/metric_test.clj
@@ -3,22 +3,27 @@
   (:require [expectations :refer :all]
             [metabase
              [http-client :as http]
-             [middleware :as middleware]]
+             [middleware :as middleware]
+             [util :as u]]
             [metabase.models
              [database :refer [Database]]
              [metric :as metric :refer [Metric]]
+             [permissions :as perms]
+             [permissions-group :as group]
              [revision :refer [Revision]]
              [table :refer [Table]]]
             [metabase.test
              [data :as data :refer :all]
              [util :as tu]]
-            [metabase.test.data.users :refer :all]
-            [toucan.hydrate :refer [hydrate]]
+            [metabase.test.data.users :refer [fetch-user user->client user->id]]
+            [toucan
+             [db :as db]
+             [hydrate :refer [hydrate]]]
             [toucan.util.test :as tt]))
 
 ;; ## Helper Fns
 
-(def ^:private ^:const metric-defaults
+(def ^:private metric-defaults
   {:description             nil
    :show_in_getting_started false
    :caveats                 nil
@@ -30,16 +35,7 @@
    :definition              nil})
 
 (defn- user-details [user]
-  (tu/match-$ user
-    {:id           $
-     :email        $
-     :date_joined  $
-     :first_name   $
-     :last_name    $
-     :last_login   $
-     :is_superuser $
-     :is_qbnewb    $
-     :common_name  $}))
+  (select-keys user [:id :email :date_joined :first_name :last_name :last_login :is_superuser :is_qbnewb :common_name]))
 
 (defn- metric-response [{:keys [created_at updated_at], :as metric}]
   (-> (into {} metric)
@@ -109,19 +105,22 @@
 ;; ## PUT /api/metric
 
 ;; test security.  requires superuser perms
-(expect "You don't have permissions to do that."
-  ((user->client :rasta) :put 403 "metric/1" {:name             "abc"
-                                              :definition       {}
-                                              :revision_message "something different"}))
+(expect
+  "You don't have permissions to do that."
+  (tt/with-temp Metric [metric]
+    ((user->client :rasta) :put 403 (str "metric/" (u/get-id metric))
+     {:name             "abc"
+      :definition       {}
+      :revision_message "something different"})))
 
 ;; test validations
 (expect
-  {:errors {:name "value must be a non-blank string."}}
+  {:errors {:revision_message "value must be a non-blank string."}}
   ((user->client :crowberto) :put 400 "metric/1" {}))
 
 (expect
-  {:errors {:revision_message "value must be a non-blank string."}}
-  ((user->client :crowberto) :put 400 "metric/1" {:name "abc"}))
+  {:errors {:name "value may be nil, or if non-nil, value must be a non-blank string."}}
+  ((user->client :crowberto) :put 400 "metric/1" {:revision_message "Wow", :name ""}))
 
 (expect
   {:errors {:revision_message "value must be a non-blank string."}}
@@ -129,12 +128,7 @@
                                                   :revision_message ""}))
 
 (expect
-  {:errors {:definition "value must be a map."}}
-  ((user->client :crowberto) :put 400 "metric/1" {:name             "abc"
-                                                  :revision_message "123"}))
-
-(expect
-  {:errors {:definition "value must be a map."}}
+  {:errors {:definition "value may be nil, or if non-nil, value must be a map."}}
   ((user->client :crowberto) :put 400 "metric/1" {:name             "abc"
                                                   :revision_message "123"
                                                   :definition       "foobar"}))
@@ -149,24 +143,45 @@
   (tt/with-temp* [Database [{database-id :id}]
                   Table    [{table-id :id} {:db_id database-id}]
                   Metric   [{:keys [id]} {:table_id table-id}]]
-    (metric-response ((user->client :crowberto) :put 200 (format "metric/%d" id) {:id                      id
-                                                                                  :name                    "Costa Rica"
-                                                                                  :description             nil
-                                                                                  :show_in_getting_started false
-                                                                                  :caveats                 nil
-                                                                                  :points_of_interest      nil
-                                                                                  :how_is_this_calculated  nil
-                                                                                  :table_id                456
-                                                                                  :revision_message        "I got me some revisions"
-                                                                                  :definition              {:database 2
-                                                                                                            :query    {:filter ["not" "the toucans you're looking for"]}}}))))
+    (metric-response
+     ((user->client :crowberto) :put 200 (format "metric/%d" id)
+      {:id                      id
+       :name                    "Costa Rica"
+       :description             nil
+       :show_in_getting_started false
+       :caveats                 nil
+       :points_of_interest      nil
+       :how_is_this_calculated  nil
+       :table_id                456
+       :revision_message        "I got me some revisions"
+       :definition              {:database 2
+                                 :query    {:filter ["not" "the toucans you're looking for"]}}}))))
+
+;; Can we archive a Metric with the PUT endpoint?
+
+(expect
+  true
+  (tt/with-temp Metric [{:keys [id]}]
+    ((user->client :crowberto) :put 200 (str "metric/" id)
+     {:archived true, :revision_message "Archive the Metric"})
+    (db/select-one-field :archived Metric :id id)))
+
+;; Can we unarchive a Metric with the PUT endpoint?
+(expect
+  false
+  (tt/with-temp Metric [{:keys [id]} {:archived true}]
+    ((user->client :crowberto) :put 200 (str "metric/" id)
+     {:archived false, :revision_message "Unarchive the Metric"})
+    (db/select-one-field :archived Metric :id id)))
 
 
 ;; ## DELETE /api/metric/:id
 
 ;; test security.  requires superuser perms
-(expect "You don't have permissions to do that."
-  ((user->client :rasta) :delete 403 "metric/1" :revision_message "yeeeehaw!"))
+(expect
+  "You don't have permissions to do that."
+  (tt/with-temp Metric [{:keys [id]}]
+    ((user->client :rasta) :delete 403 (str "metric/" id) :revision_message "yeeeehaw!")))
 
 
 ;; test validations
@@ -177,45 +192,58 @@
   ((user->client :crowberto) :delete 400 "metric/1" :revision_message ""))
 
 (expect
-  [{:success true}
-   (merge metric-defaults
-          {:name        "Toucans in the rainforest"
-           :description "Lookin' for a blueberry"
-           :creator_id  (user->id :rasta)
-           :creator     (user-details (fetch-user :rasta))
-           :archived    true})]
+  (merge
+   metric-defaults
+   {:name        "Toucans in the rainforest"
+    :description "Lookin' for a blueberry"
+    :creator_id  (user->id :rasta)
+    :creator     (user-details (fetch-user :rasta))
+    :archived    true})
   (tt/with-temp* [Database [{database-id :id}]
                   Table    [{table-id :id} {:db_id database-id}]
                   Metric   [{:keys [id]}   {:table_id table-id}]]
-    [((user->client :crowberto) :delete 200 (format "metric/%d" id) :revision_message "carryon")
-     (metric-response (metric/retrieve-metric id))]))
+    ((user->client :crowberto) :delete 204 (format "metric/%d" id) :revision_message "carryon")
+    ;; should still be able to fetch the archived Metric
+    (metric-response
+     ((user->client :crowberto) :get 200 (format "metric/%d" id)))))
 
 
 ;; ## GET /api/metric/:id
 
-;; test security.  requires superuser perms
-(expect "You don't have permissions to do that."
-  ((user->client :rasta) :get 403 "metric/1"))
+;; test security. Requires perms for the Table it references
+(expect
+  "You don't have permissions to do that."
+  (tt/with-temp* [Database [db]
+                  Table    [table  {:db_id (u/get-id db)}]
+                  Metric   [metric {:table_id (u/get-id table)}]]
+    (perms/revoke-permissions! (group/all-users) db)
+    ((user->client :rasta) :get 403 (str "metric/" (u/get-id metric)))))
 
 
 (expect
-  (merge metric-defaults
-         {:name        "Toucans in the rainforest"
-          :description "Lookin' for a blueberry"
-          :creator_id  (user->id :crowberto)
-          :creator     (user-details (fetch-user :crowberto))})
+  (merge
+   metric-defaults
+   {:name        "Toucans in the rainforest"
+    :description "Lookin' for a blueberry"
+    :creator_id  (user->id :crowberto)
+    :creator     (user-details (fetch-user :crowberto))})
   (tt/with-temp* [Database [{database-id :id}]
                   Table    [{table-id :id} {:db_id database-id}]
                   Metric   [{:keys [id]}   {:creator_id  (user->id :crowberto)
                                             :table_id    table-id}]]
-    (metric-response ((user->client :crowberto) :get 200 (format "metric/%d" id)))))
+    (metric-response ((user->client :rasta) :get 200 (format "metric/%d" id)))))
 
 
 ;; ## GET /api/metric/:id/revisions
 
-;; test security.  requires superuser perms
-(expect "You don't have permissions to do that."
-  ((user->client :rasta) :get 403 "metric/1/revisions"))
+;; test security. Requires read perms for Table it references
+(expect
+  "You don't have permissions to do that."
+  (tt/with-temp* [Database [db]
+                  Table    [table  {:db_id (u/get-id db)}]
+                  Metric   [metric {:table_id (u/get-id table)}]]
+    (perms/revoke-permissions! (group/all-users) db)
+    ((user->client :rasta) :get 403 (format "metric/%d/revisions" (u/get-id metric)))))
 
 
 (expect
@@ -257,15 +285,19 @@
                                             :object   {:name "c"
                                                        :definition {:filter [:and [:> 1 25]]}}
                                             :message  "updated"}]]
-    (doall (for [revision ((user->client :crowberto) :get 200 (format "metric/%d/revisions" id))]
-             (dissoc revision :timestamp :id)))))
+    (vec
+     (for [revision ((user->client :rasta) :get 200 (format "metric/%d/revisions" id))]
+       (dissoc revision :timestamp :id)))))
 
 
 ;; ## POST /api/metric/:id/revert
 
 ;; test security.  requires superuser perms
-(expect "You don't have permissions to do that."
-  ((user->client :rasta) :post 403 "metric/1/revert" {:revision_id 56}))
+(expect
+  "You don't have permissions to do that."
+  (tt/with-temp Metric [{:keys [id]}]
+    ((user->client :rasta) :post 403 (format "metric/%d/revert" id)
+     {:revision_id 56})))
 
 
 (expect {:errors {:revision_id "value must be an integer greater than zero."}}

--- a/test/metabase/api/pulse_test.clj
+++ b/test/metabase/api/pulse_test.clj
@@ -47,19 +47,13 @@
                         :created_at]))
 
 (defn- pulse-details [pulse]
-  (tu/match-$ pulse
-    {:id                  $
-     :name                $
-     :created_at          $
-     :updated_at          $
-     :creator_id          $
-     :creator             (user-details (db/select-one 'User :id (:creator_id pulse)))
-     :cards               (map pulse-card-details (:cards pulse))
-     :channels            (map pulse-channel-details (:channels pulse))
-     :collection_id       $
-     :collection_position $
-     :archived            $
-     :skip_if_empty       $}))
+  (merge
+   (select-keys
+    pulse
+    [:id :name :created_at :updated_at :creator_id :collection_id :collection_position :archived :skip_if_empty])
+   {:creator  (user-details (db/select-one 'User :id (:creator_id pulse)))
+    :cards    (map pulse-card-details (:cards pulse))
+    :channels (map pulse-channel-details (:channels pulse))}))
 
 (defn- pulse-response [{:keys [created_at updated_at], :as pulse}]
   (-> pulse

--- a/test/metabase/api/segment_test.clj
+++ b/test/metabase/api/segment_test.clj
@@ -1,12 +1,14 @@
 (ns metabase.api.segment-test
   "Tests for /api/segment endpoints."
-  (:require [expectations :refer :all]
+  (:require [expectations :refer [expect]]
             [metabase
              [http-client :as http]
              [middleware :as middleware]
              [util :as u]]
             [metabase.models
              [database :refer [Database]]
+             [permissions :as perms]
+             [permissions-group :as group]
              [revision :refer [Revision]]
              [segment :as segment :refer [Segment]]
              [table :refer [Table]]]
@@ -14,29 +16,22 @@
              [data :refer :all]
              [util :as tu]]
             [metabase.test.data.users :refer :all]
-            [toucan.hydrate :refer [hydrate]]
+            [toucan
+             [db :as db]
+             [hydrate :refer [hydrate]]]
             [toucan.util.test :as tt]))
 
 ;; ## Helper Fns
 
 (defn- user-details [user]
-  (tu/match-$ user
-    {:id           $
-     :email        $
-     :date_joined  $
-     :first_name   $
-     :last_name    $
-     :last_login   $
-     :is_superuser $
-     :is_qbnewb    $
-     :common_name  $}))
+  (select-keys user [:email :first_name :last_login :is_qbnewb :is_superuser :id :last_name :date_joined :common_name]))
 
-(defn- segment-response [{:keys [created_at updated_at] :as segment}]
+(defn- segment-response [segment]
   (-> (into {} segment)
       (dissoc :id :table_id)
       (update :creator #(into {} %))
-      (assoc :created_at (some? created_at)
-             :updated_at (some? updated_at))))
+      (update :created_at some?)
+      (update :updated_at some?)))
 
 
 ;; ## /api/segment/* AUTHENTICATION Tests
@@ -102,14 +97,17 @@
 ;; ## PUT /api/segment
 
 ;; test security.  requires superuser perms
-(expect "You don't have permissions to do that."
-  ((user->client :rasta) :put 403 "segment/1" {:name             "abc"
-                                               :definition       {}
-                                               :revision_message "something different"}))
+(expect
+  "You don't have permissions to do that."
+  (tt/with-temp Segment [segment]
+    ((user->client :rasta) :put 403 (str "segment/" (:id segment))
+     {:name             "abc"
+      :definition       {}
+      :revision_message "something different"})))
 
 ;; test validations
-(expect {:errors {:name "value must be a non-blank string."}}
-  ((user->client :crowberto) :put 400 "segment/1" {}))
+(expect {:errors {:name "value may be nil, or if non-nil, value must be a non-blank string."}}
+  ((user->client :crowberto) :put 400 "segment/1" {:name ""}))
 
 (expect {:errors {:revision_message "value must be a non-blank string."}}
   ((user->client :crowberto) :put 400 "segment/1" {:name "abc"}))
@@ -118,11 +116,7 @@
   ((user->client :crowberto) :put 400 "segment/1" {:name             "abc"
                                                    :revision_message ""}))
 
-(expect {:errors {:definition "value must be a map."}}
-  ((user->client :crowberto) :put 400 "segment/1" {:name             "abc"
-                                                   :revision_message "123"}))
-
-(expect {:errors {:definition "value must be a map."}}
+(expect {:errors {:definition "value may be nil, or if non-nil, value must be a map."}}
   ((user->client :crowberto) :put 400 "segment/1" {:name             "abc"
                                                    :revision_message "123"
                                                    :definition       "foobar"}))
@@ -142,22 +136,42 @@
   (tt/with-temp* [Database [{database-id :id}]
                   Table    [{table-id :id} {:db_id database-id}]
                   Segment  [{:keys [id]}   {:table_id table-id}]]
-    (segment-response ((user->client :crowberto) :put 200 (format "segment/%d" id) {:id                      id
-                                                                                    :name                    "Costa Rica"
-                                                                                    :description             nil
-                                                                                    :show_in_getting_started false
-                                                                                    :caveats                 nil
-                                                                                    :points_of_interest      nil
-                                                                                    :table_id                456
-                                                                                    :revision_message        "I got me some revisions"
-                                                                                    :definition              {:filter [:!= [:field-id 2] "cans"]}}))))
+    (segment-response ((user->client :crowberto) :put 200 (format "segment/%d" id)
+                       {:id                      id
+                        :name                    "Costa Rica"
+                        :description             nil
+                        :show_in_getting_started false
+                        :caveats                 nil
+                        :points_of_interest      nil
+                        :table_id                456
+                        :revision_message        "I got me some revisions"
+                        :definition              {:filter [:!= [:field-id 2] "cans"]}}))))
+
+;; Can we archive a Segment with the PUT endpoint?
+
+(expect
+  true
+  (tt/with-temp Segment [{:keys [id]}]
+    ((user->client :crowberto) :put 200 (str "segment/" id)
+     {:archived true, :revision_message "Archive the Segment"})
+    (db/select-one-field :archived Segment :id id)))
+
+;; Can we unarchive a Segment with the PUT endpoint?
+(expect
+  false
+  (tt/with-temp Segment [{:keys [id]} {:archived true}]
+    ((user->client :crowberto) :put 200 (str "segment/" id)
+     {:archived false, :revision_message "Unarchive the Segment"})
+    (db/select-one-field :archived Segment :id id)))
 
 
 ;; ## DELETE /api/segment/:id
 
 ;; test security.  requires superuser perms
-(expect "You don't have permissions to do that."
-  ((user->client :rasta) :delete 403 "segment/1" :revision_message "yeeeehaw!"))
+(expect
+  "You don't have permissions to do that."
+  (tt/with-temp Segment [{:keys [id]}]
+    ((user->client :rasta) :delete 403 (str "segment/" id) :revision_message "yeeeehaw!")))
 
 
 ;; test validations
@@ -168,31 +182,36 @@
   ((user->client :crowberto) :delete 400 "segment/1" :revision_message ""))
 
 (expect
-  [{:success true}
-   {:name                    "Toucans in the rainforest"
-    :description             "Lookin' for a blueberry"
-    :show_in_getting_started false
-    :caveats                 nil
-    :points_of_interest      nil
-    :creator_id              (user->id :rasta)
-    :creator                 (user-details (fetch-user :rasta))
-    :created_at              true
-    :updated_at              true
-    :archived                true
-    :definition              nil}]
+  {:name                    "Toucans in the rainforest"
+   :description             "Lookin' for a blueberry"
+   :show_in_getting_started false
+   :caveats                 nil
+   :points_of_interest      nil
+   :creator_id              (user->id :rasta)
+   :creator                 (user-details (fetch-user :rasta))
+   :created_at              true
+   :updated_at              true
+   :archived                true
+   :definition              nil}
   (tt/with-temp* [Database [{database-id :id}]
                   Table    [{table-id :id} {:db_id database-id}]
                   Segment  [{:keys [id]} {:table_id table-id}]]
-    [((user->client :crowberto) :delete 200 (format "segment/%d" id) :revision_message "carryon")
-     (segment-response (segment/retrieve-segment id))]))
+    ((user->client :crowberto) :delete 204 (format "segment/%d" id) :revision_message "carryon")
+    ;; should still be able to fetch the archived segment
+    (segment-response
+     ((user->client :crowberto) :get 200 (format "segment/%d" id)))))
 
 
 ;; ## GET /api/segment/:id
 
-;; test security.  requires superuser perms
-(expect "You don't have permissions to do that."
-  ((user->client :rasta) :get 403 "segment/1"))
-
+;; test security. Requires read perms for the Table it references
+(expect
+  "You don't have permissions to do that."
+  (tt/with-temp* [Database [db]
+                  Table    [table   {:db_id (u/get-id db)}]
+                  Segment  [segment {:table_id (u/get-id table)}]]
+    (perms/revoke-permissions! (group/all-users) db)
+    ((user->client :rasta) :get 403 (str "segment/" (u/get-id segment)))))
 
 (expect
   {:name                    "Toucans in the rainforest"
@@ -211,14 +230,19 @@
                   Segment  [{:keys [id]}   {:creator_id (user->id :crowberto)
                                             :table_id   table-id
                                             :definition {:filter [:= [:field-id 2] "cans"]}}]]
-    (segment-response ((user->client :crowberto) :get 200 (format "segment/%d" id)))))
+    (segment-response ((user->client :rasta) :get 200 (format "segment/%d" id)))))
 
 
 ;; ## GET /api/segment/:id/revisions
 
-;; test security.  requires superuser perms
-(expect "You don't have permissions to do that."
-  ((user->client :rasta) :get 403 "segment/1/revisions"))
+;; test security. Requires read perms for the Table it references
+(expect
+  "You don't have permissions to do that."
+  (tt/with-temp* [Database [db]
+                  Table    [table   {:db_id (u/get-id db)}]
+                  Segment  [segment {:table_id (u/get-id table)}]]
+    (perms/revoke-permissions! (group/all-users) db)
+    ((user->client :rasta) :get 403 (format "segment/%d/revisions" (u/get-id segment)))))
 
 
 (expect
@@ -254,15 +278,18 @@
                                :object   {:name "c"
                                           :definition {:filter [:and [:> 1 25]]}}
                                :message  "updated"}]]
-    (doall (for [revision ((user->client :crowberto) :get 200 (format "segment/%d/revisions" id))]
-             (dissoc revision :timestamp :id)))))
+    (vec
+     (for [revision ((user->client :rasta) :get 200 (format "segment/%d/revisions" id))]
+       (dissoc revision :timestamp :id)))))
 
 
 ;; ## POST /api/segment/:id/revert
 
 ;; test security.  requires superuser perms
-(expect "You don't have permissions to do that."
-  ((user->client :rasta) :post 403 "segment/1/revert" {:revision_id 56}))
+(expect
+  "You don't have permissions to do that."
+  (tt/with-temp Segment [{:keys [id]}]
+    ((user->client :rasta) :post 403 (format "segment/%d/revert" id) {:revision_id 56})))
 
 
 (expect {:errors {:revision_id "value must be an integer greater than zero."}}

--- a/test/metabase/models/metric_test.clj
+++ b/test/metabase/models/metric_test.clj
@@ -2,14 +2,15 @@
   (:require [expectations :refer :all]
             [metabase.models
              [database :refer [Database]]
-             [metric :as metric :refer :all]
+             [metric :as metric :refer [Metric]]
              [table :refer [Table]]]
             [metabase.test.data :refer :all]
             [metabase.test.data.users :refer [fetch-user user->id]]
             [metabase.util :as u]
+            [toucan.db :as db]
             [toucan.util.test :as tt]))
 
-(def ^:private ^:const metric-defaults
+(def ^:private metric-defaults
   {:description             nil
    :how_is_this_calculated  nil
    :show_in_getting_started false
@@ -25,117 +26,45 @@
 (defn- metric-details
   [{:keys [creator] :as metric}]
   (-> (dissoc metric :id :table_id :created_at :updated_at)
-      (update :creator (u/rpartial dissoc :date_joined :last_login))))
-
-(defn- create-metric-then-select!
-  [table name description creator definition]
-  (metric-details (create-metric! table name description creator definition)))
-
-(defn- update-metric-then-select!
-  [metric]
-  (metric-details (update-metric! metric (user->id :crowberto))))
-
-
-;; create-metric!
-(expect
-  (merge metric-defaults
-         {:creator_id (user->id :rasta)
-          :creator    (user-details :rasta)
-          :name       "I only want *these* things"
-          :definition {:filter [:= [:field-id 1] 2]}})
-  (tt/with-temp* [Database [{database-id :id}]
-                  Table    [{:keys [id]}      {:db_id database-id}]]
-    (create-metric-then-select! id "I only want *these* things" nil (user->id :rasta) {:filter [:= [:field-id 1] 2]})))
-
-
-;; exists?
-(expect
-  [true
-   false]
-  (tt/with-temp* [Database [{database-id :id}]
-                  Table    [{table-id :id}    {:db_id database-id}]
-                  Metric   [{metric-id :id}   {:table_id   table-id
-                                               :definition {:filter [:= [:field-id 1] 2]}}]]
-    [(metric/exists? metric-id)
-     (metric/exists? Integer/MAX_VALUE)])) ; a Metric that definitely doesn't exist
-
-
-;; retrieve-metric
-(expect
-  (merge metric-defaults
-         {:creator_id  (user->id :rasta)
-          :creator     (user-details :rasta)
-          :name        "Toucans in the rainforest"
-          :description "Lookin' for a blueberry"
-          :definition  {:filter [:= [:field-id 1] 2]}})
-  (tt/with-temp* [Database [{database-id :id}]
-                  Table    [{table-id :id}    {:db_id database-id}]
-                  Metric   [{metric-id :id}   {:table_id    table-id
-                                               :definition  {:filter [:= [:field-id 1] 2]}}]]
-    (let [{:keys [creator] :as metric} (retrieve-metric metric-id)]
-      (update (dissoc metric :id :table_id :created_at :updated_at)
-              :creator (u/rpartial dissoc :date_joined :last_login)))))
-
+      (update :creator #(dissoc % :date_joined :last_login))))
 
 ;; retrieve-metrics
 (expect
-  [(merge metric-defaults
-          {:creator_id (user->id :rasta)
-           :creator    (user-details :rasta)
-           :name       "Metric 1"})]
+  [(merge
+    metric-defaults
+    {:creator_id (user->id :rasta)
+     :creator    (user-details :rasta)
+     :name       "Metric 1"})]
   (tt/with-temp* [Database [{database-id :id}]
                   Table    [{table-id-1 :id}    {:db_id database-id}]
                   Table    [{table-id-2 :id}    {:db_id database-id}]
                   Metric   [{segement-id-1 :id} {:table_id table-id-1, :name "Metric 1", :description nil}]
                   Metric   [{metric-id-2 :id}   {:table_id table-id-2}]
                   Metric   [{metric-id3 :id}    {:table_id table-id-1, :archived true}]]
-    (doall (for [metric (u/prog1 (retrieve-metrics table-id-1)
-                                 (assert (= 1 (count <>))))]
-             (update (dissoc (into {} metric) :id :table_id :created_at :updated_at)
-                     :creator (u/rpartial dissoc :date_joined :last_login))))))
+    (vec
+     (for [metric (u/prog1 (metric/retrieve-metrics table-id-1)
+                    (assert (= 1 (count <>))))]
+       (update (dissoc (into {} metric) :id :table_id :created_at :updated_at)
+               :creator (u/rpartial dissoc :date_joined :last_login))))))
 
 
-;; update-metric!
-;; basic update.  we are testing several things here
-;;  1. ability to update the Metric name
-;;  2. creator_id cannot be changed
-;;  3. ability to set description, including to nil
-;;  4. ability to modify the definition json
-;;  5. revision is captured along with our commit message
+;; Updating -- you should not be able to change the creator_id of a Metric
 (expect
-  (merge metric-defaults
-         {:creator_id (user->id :rasta)
-          :creator    (user-details :rasta)
-          :name       "Costa Rica"
-          :definition {:filter [:not [:= [:field-id 1] "toucans"]]}})
-  (tt/with-temp* [Database [{database-id :id}]
-                  Table  [{table-id :id}  {:db_id database-id}]
-                  Metric [{metric-id :id} {:table_id table-id}]]
-    (update-metric-then-select! {:id                      metric-id
-                                 :name                    "Costa Rica"
-                                 :description             nil
-                                 :how_is_this_calculated  nil
-                                 :show_in_getting_started false
-                                 :caveats                 nil
-                                 :points_of_interest      nil
-                                 :creator_id              (user->id :crowberto)
-                                 :table_id                456
-                                 :definition              {:filter [:not [:= [:field-id 1] "toucans"]]}
-                                 :revision_message        "Just horsing around"})))
+  UnsupportedOperationException
+  (tt/with-temp Metric [{:keys [id]} {:creator_id (user->id :rasta)}]
+    (db/update! Metric id {:creator_id (user->id :crowberto)})))
 
-;; delete-metric!
+;; you shouldn't be able to set it to `nil` either
 (expect
-  (merge metric-defaults
-         {:creator_id  (user->id :rasta)
-          :creator     (user-details :rasta)
-          :name        "Toucans in the rainforest"
-          :description "Lookin' for a blueberry"
-          :archived    true})
-  (tt/with-temp* [Database [{database-id :id}]
-                  Table    [{table-id :id}  {:db_id database-id}]
-                  Metric   [{metric-id :id} {:table_id table-id}]]
-    (delete-metric! metric-id (user->id :crowberto) "revision message")
-    (metric-details (retrieve-metric metric-id))))
+  UnsupportedOperationException
+  (tt/with-temp Metric [{:keys [id]} {:creator_id (user->id :rasta)}]
+    (db/update! Metric id {:creator_id nil})))
+
+;; However calling `update!` with a value that is the same as the current value shouldn't throw an Exception
+(expect
+  true
+  (tt/with-temp Metric [{:keys [id]} {:creator_id (user->id :rasta)}]
+    (db/update! Metric id {:creator_id (user->id :rasta)})))
 
 
 ;; ## Metric Revisions
@@ -218,24 +147,33 @@
 
 (expect
   {:Segment #{2 3}}
-  (metric-dependencies Metric 12 {:definition {:breakout [[:field-id 4] [:field-id 5]]
-                                               :filter   [:and
-                                                          [:> 4 "2014-10-19"]
-                                                          [:= 5 "yes"]
-                                                          [:segment 2]
-                                                          [:segment 3]]}}))
+  (metric/metric-dependencies
+   Metric
+   12
+   {:definition {:breakout [[:field-id 4] [:field-id 5]]
+                 :filter   [:and
+                            [:> 4 "2014-10-19"]
+                            [:= 5 "yes"]
+                            [:segment 2]
+                            [:segment 3]]}}))
 
 (expect
   {:Segment #{1}}
-  (metric-dependencies Metric 12 {:definition {:aggregation [:metric 7]
-                                               :filter      [:and
-                                                             [:> 4 "2014-10-19"]
-                                                             [:= 5 "yes"]
-                                                             [:or
-                                                              [:segment 1]
-                                                              [:!= 5 "5"]]]}}))
+  (metric/metric-dependencies
+   Metric
+   12
+   {:definition {:aggregation [:metric 7]
+                 :filter      [:and
+                               [:> 4 "2014-10-19"]
+                               [:= 5 "yes"]
+                               [:or
+                                [:segment 1]
+                                [:!= 5 "5"]]]}}))
 
 (expect
   {:Segment #{}}
-  (metric-dependencies Metric 12 {:definition {:aggregation nil
-                                               :filter      nil}}))
+  (metric/metric-dependencies
+   Metric
+   12
+   {:definition {:aggregation nil
+                 :filter      nil}}))

--- a/test/metabase/models/segment_test.clj
+++ b/test/metabase/models/segment_test.clj
@@ -1,12 +1,12 @@
 (ns metabase.models.segment-test
-  (:require [expectations :refer :all]
+  (:require [expectations :refer [expect]]
             [metabase.models
              [database :refer [Database]]
-             [segment :as segment :refer :all]
+             [segment :as segment :refer [Segment]]
              [table :refer [Table]]]
-            [metabase.test.data :refer :all]
-            [metabase.test.data.users :refer :all]
+            [metabase.test.data.users :refer [fetch-user user->id]]
             [metabase.util :as u]
+            [toucan.db :as db]
             [toucan.util.test :as tt]))
 
 (defn- user-details
@@ -19,61 +19,24 @@
       (dissoc :id :table_id :created_at :updated_at)
       (assoc :creator (dissoc creator :date_joined :last_login))))
 
-(defn- create-segment-then-select!
-  [table name description creator definition]
-  (segment-details (create-segment! table name description creator definition)))
 
-(defn- update-segment-then-select!
-  [segment]
-  (segment-details (update-segment! segment (user->id :crowberto))))
-
-
-;; create-segment!
+;; Updating -- you should not be able to change the creator_id of a Segment
 (expect
-  {:creator_id              (user->id :rasta)
-   :creator                 (user-details :rasta)
-   :name                    "I only want *these* things"
-   :description             nil
-   :show_in_getting_started false
-   :caveats                 nil
-   :points_of_interest      nil
-   :archived                false
-   :definition              {:aggregation [[:count]]}}
-  (tt/with-temp* [Database [{database-id :id}]
-                  Table    [{table-id :id} {:db_id database-id}]]
-    (create-segment-then-select! table-id "I only want *these* things" nil (user->id :rasta) {:aggregation [[:count]]})))
+  UnsupportedOperationException
+  (tt/with-temp Segment [{:keys [id]} {:creator_id (user->id :rasta)}]
+    (db/update! Segment id {:creator_id (user->id :crowberto)})))
 
-
-;; exists?
+;; you shouldn't be able to set it to `nil` either
 (expect
-  [true
-   false]
-  (tt/with-temp* [Database [{database-id :id}]
-                  Table    [{table-id :id}   {:db_id database-id}]
-                  Segment  [{segment-id :id} {:table_id table-id}]]
-    [(segment/exists? segment-id)
-     (segment/exists? 3400)]))
+  UnsupportedOperationException
+  (tt/with-temp Segment [{:keys [id]} {:creator_id (user->id :rasta)}]
+    (db/update! Segment id {:creator_id nil})))
 
-
-;; retrieve-segment
+;; However calling `update!` with a value that is the same as the current value shouldn't throw an Exception
 (expect
-  {:creator_id              (user->id :rasta)
-   :creator                 (user-details :rasta)
-   :name                    "Toucans in the rainforest"
-   :description             "Lookin' for a blueberry"
-   :show_in_getting_started false
-   :caveats                 nil
-   :points_of_interest      nil
-   :archived                false
-   :definition              {:filter [:= [:field-id 1] 2]}}
-  (tt/with-temp* [Database [{database-id :id}]
-                  Table    [{table-id :id}   {:db_id database-id}]
-                  Segment  [{segment-id :id} {:table_id   table-id
-                                              :definition {:filter [:= [:field-id 1] 2]}}]]
-    (let [{:keys [creator] :as segment} (retrieve-segment segment-id)]
-      (-> segment
-          (dissoc :id :table_id :created_at :updated_at)
-          (assoc :creator (dissoc creator :date_joined :last_login))))))
+  true
+  (tt/with-temp Segment [{:keys [id]} {:creator_id (user->id :rasta)}]
+    (db/update! Segment id {:creator_id (user->id :rasta)})))
 
 
 ;; retrieve-segements
@@ -93,59 +56,11 @@
                   Segment  [{segement-id-1 :id} {:table_id table-id-1, :name "Segment 1", :description nil}]
                   Segment  [{segment-id-2 :id}  {:table_id table-id-2}]
                   Segment  [{segment-id3 :id}   {:table_id table-id-1, :archived true}]]
-    (doall (for [segment (u/prog1 (retrieve-segments table-id-1)
-                                  (assert (= 1 (count <>))))]
-             (-> (dissoc (into {} segment) :id :table_id :created_at :updated_at)
-                 (update :creator (u/rpartial dissoc :date_joined :last_login)))))))
-
-
-;; update-segment!
-;; basic update.  we are testing several things here
-;;  1. ability to update the Segment name
-;;  2. creator_id cannot be changed
-;;  3. ability to set description, including to nil
-;;  4. ability to modify the definition json
-;;  5. revision is captured along with our commit message
-(expect
-  {:creator_id              (user->id :rasta)
-   :creator                 (user-details :rasta)
-   :name                    "Costa Rica"
-   :description             nil
-   :show_in_getting_started false
-   :caveats                 nil
-   :points_of_interest      nil
-   :archived                false
-   :definition              {:filter [:!= [:field-id 10] "toucans"]}}
-  (tt/with-temp* [Database [{database-id :id}]
-                  Table    [{:keys [id]} {:db_id database-id}]
-                  Segment  [{:keys [id]} {:table_id id}]]
-    (update-segment-then-select! {:id                      id
-                                  :name                    "Costa Rica"
-                                  :description             nil
-                                  :show_in_getting_started false
-                                  :caveats                 nil
-                                  :points_of_interest      nil
-                                  :creator_id              (user->id :crowberto)
-                                  :table_id                456
-                                  :definition              {:filter [:!= [:field-id 10] "toucans"]}
-                                  :revision_message        "Just horsing around"})))
-
-;; delete-segment!
-(expect
-  {:creator_id              (user->id :rasta)
-   :creator                 (user-details :rasta)
-   :name                    "Toucans in the rainforest"
-   :description             "Lookin' for a blueberry"
-   :show_in_getting_started false
-   :caveats                 nil
-   :points_of_interest      nil
-   :archived                true
-   :definition              nil}
-  (tt/with-temp* [Database [{database-id :id}]
-                  Table    [{:keys [id]} {:db_id database-id}]
-                  Segment  [{:keys [id]} {:table_id id}]]
-    (delete-segment! id (user->id :crowberto) "revision message")
-    (segment-details (retrieve-segment id))))
+    (vec
+     (for [segment (u/prog1 (segment/retrieve-segments table-id-1)
+                     (assert (= 1 (count <>))))]
+       (-> (dissoc (into {} segment) :id :table_id :created_at :updated_at)
+           (update :creator #(dissoc % :date_joined :last_login)))))))
 
 
 ;; ## Segment Revisions
@@ -183,42 +98,48 @@
                   Table    [{table-id :id} {:db_id database-id}]
                   Segment  [segment        {:table_id   table-id
                                             :definition {:filter [:and [:> [:field-id 4] "2014-10-19"]]}}]]
-    (#'segment/diff-segments Segment segment (assoc segment
-                                               :name        "Something else"
-                                               :description "BBB"
-                                               :definition  {:filter [:between [:field-id 4] "2014-07-01" "2014-10-19"]}))))
+    (#'segment/diff-segments
+     Segment
+     segment
+     (assoc segment
+       :name        "Something else"
+       :description "BBB"
+       :definition  {:filter [:between [:field-id 4] "2014-07-01" "2014-10-19"]}))))
 
 ;; test case where definition doesn't change
 (expect
   {:name {:before "A"
           :after  "B"}}
-  (#'segment/diff-segments Segment
-                           {:name        "A"
-                            :description "Unchanged"
-                            :definition  {:filter [:and [:> [:field-id 4] "2014-10-19"]]}}
-                           {:name        "B"
-                            :description "Unchanged"
-                            :definition  {:filter [:and [:> [:field-id 4] "2014-10-19"]]}}))
+  (#'segment/diff-segments
+   Segment
+   {:name        "A"
+    :description "Unchanged"
+    :definition  {:filter [:and [:> [:field-id 4] "2014-10-19"]]}}
+   {:name        "B"
+    :description "Unchanged"
+    :definition  {:filter [:and [:> [:field-id 4] "2014-10-19"]]}}))
 
 ;; first version  so comparing against nil
 (expect
   {:name        {:after  "A"}
    :description {:after "Unchanged"}
    :definition  {:after {:filter [:and [:> [:field-id 4] "2014-10-19"]]}}}
-  (#'segment/diff-segments Segment
-                           nil
-                           {:name        "A"
-                            :description "Unchanged"
-                            :definition  {:filter [:and [:> [:field-id 4] "2014-10-19"]]}}))
+  (#'segment/diff-segments
+   Segment
+   nil
+   {:name        "A"
+    :description "Unchanged"
+    :definition  {:filter [:and [:> [:field-id 4] "2014-10-19"]]}}))
 
 ;; removals only
 (expect
   {:definition  {:before {:filter [:and [:> [:field-id 4] "2014-10-19"] [:= 5 "yes"]]}
                  :after  {:filter [:and [:> [:field-id 4] "2014-10-19"]]}}}
-  (#'segment/diff-segments Segment
-                           {:name        "A"
-                            :description "Unchanged"
-                            :definition  {:filter [:and [:> [:field-id 4] "2014-10-19"] [:= 5 "yes"]]}}
-                           {:name        "A"
-                            :description "Unchanged"
-                            :definition  {:filter [:and [:> [:field-id 4] "2014-10-19"]]}}))
+  (#'segment/diff-segments
+   Segment
+   {:name        "A"
+    :description "Unchanged"
+    :definition  {:filter [:and [:> [:field-id 4] "2014-10-19"] [:= 5 "yes"]]}}
+   {:name        "A"
+    :description "Unchanged"
+    :definition  {:filter [:and [:> [:field-id 4] "2014-10-19"]]}}))


### PR DESCRIPTION
*  Add new `can-create?` method  and `api/create-check` function to present a common interface for checking whether the current user has permissions to create a new object with some set of properties. Previously, most logic of this kind was embedded in the relevant `POST` endpoints, which violates the nice separation of concerns we're supposed to have between the API layer and the model layer.
*  Support changing the `archived` property of Metrics and Segments via the API, which for some reason I don't fully understand was never supported.
*  Lots of refactoring of Metric and Segment model and api namespaces to bring them in line with the way other model/api namespaces are written.

TODO:

-  [x] Need to update/add tests for new functionality.
-  [ ] I think `can-write?` needs to be changed as well so the method accepts a map of updates to be made, because whether or not you have permissions to change certain properties of an object often depends on the properties themselves. For example, whether or not you can update the `collection_id` of a Card depends on whether you have write permissions for both the existing value of `collection_id` (the Collection you want to move the Card out of) and the new value of `collection_id`) (the Collection you want to move the Card in to). I would like to see all permissions logic for models either live in the model layer or perhaps a new "permissions" layer, rather than having some in the model layer and some in the API. I would like a clear separation of responsibilities. However this might have to be done as a follow-on PR.