### PR TITLE
fix can not expand string when page too short and text too long

### DIFF
--- a/frontend/src/metabase/query_builder/components/ExpandableString.jsx
+++ b/frontend/src/metabase/query_builder/components/ExpandableString.jsx
@@ -14,13 +14,14 @@ export default class ExpandableString extends Component {
 
   static defaultProps = {
     length: 140,
-    expanded: false,
   };
 
   componentWillReceiveProps(newProps) {
-    this.setState({
-      expanded: newProps.expanded,
-    });
+    if (newProps.expanded !== undefined) {
+      this.setState({
+        expanded: newProps.expanded,
+      });
+    }
   }
 
   toggleExpansion() {


### PR DESCRIPTION
this will fix a bug that make you can't expand string to view in full text.
this bug will occurs when met 2 condition 
1. Object Detail page must fix in windows (no scroll bar)
2. When click "View More" page must height more than 1 page (has a scroll bar)

i think because when i expanded and scroll bar show it trigger resize event and trigger componentWillReceiveProps so it set expanded back to false agian.

actually only `ObjectDetail` component use `ExpandableString` and it never send `expanded` as a props.
but i not sure may be some 3rd party may send `expanded` as a default state. 
or should i remove it?
