### PR TITLE
Move Logs to Troubleshooting tab

### DIFF
--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -33,6 +33,7 @@ import TasksApp from "metabase/admin/tasks/containers/TasksApp";
 import TaskModal from "metabase/admin/tasks/containers/TaskModal";
 import JobInfoApp from "metabase/admin/tasks/containers/JobInfoApp";
 import JobTriggersModal from "metabase/admin/tasks/containers/JobTriggersModal";
+import Logs from "metabase/admin/tasks/containers/Logs";
 
 // People
 import PeopleListingApp from "metabase/admin/people/containers/PeopleListingApp.jsx";
@@ -119,6 +120,7 @@ const getRoutes = (store, IsAdmin) => (
           modalProps={{ wide: true }}
         />
       </Route>
+      <Route path="logs" component={Logs} />
     </Route>
 
     {/* SETTINGS */}

--- a/frontend/src/metabase/admin/tasks/containers/Logs.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/Logs.jsx
@@ -3,12 +3,30 @@ import ReactDOM from "react-dom";
 
 import { UtilApi } from "metabase/services";
 
-import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper.jsx";
+import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 
 import reactAnsiStyle from "react-ansi-style";
 import "react-ansi-style/inject-css";
 
 import _ from "underscore";
+
+import { addCSSRule } from "metabase/lib/dom";
+import colors from "metabase/lib/colors";
+
+const ANSI_COLORS = {
+  black: colors["text-black"],
+  white: colors["text-white"],
+  gray: colors["text-medium"],
+  red: colors["saturated-red"],
+  green: colors["saturated-green"],
+  yellow: colors["saturated-yellow"],
+  blue: colors["saturated-blue"],
+  magenta: colors["saturated-purple"],
+  cyan: "cyan",
+};
+for (const [name, color] of Object.entries(ANSI_COLORS)) {
+  addCSSRule(`.react-ansi-style-${name}`, `color: ${color} !important`);
+}
 
 export default class Logs extends Component {
   constructor() {
@@ -67,12 +85,12 @@ export default class Logs extends Component {
       <LoadingAndErrorWrapper loading={!logs || logs.length === 0}>
         {() => (
           <div
+            className="rounded bordered bg-light"
             style={{
-              backgroundColor: "black",
-              fontFamily: "monospace",
+              fontFamily: '"Lucida Console", Monaco, monospace',
               fontSize: "14px",
               whiteSpace: "pre-line",
-              padding: "0.5em",
+              padding: "1em",
             }}
           >
             {reactAnsiStyle(React, logs.join("\n"))}

--- a/frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx
@@ -30,6 +30,10 @@ export default class TroubleshootingApp extends Component {
               name={t`Jobs`}
               path="/admin/troubleshooting/jobs"
             />
+            <LeftNavPaneItem
+              name={t`Logs`}
+              path="/admin/troubleshooting/logs"
+            />
           </LeftNavPane>
         }
       >

--- a/frontend/src/metabase/nav/components/ProfileLink.jsx
+++ b/frontend/src/metabase/nav/components/ProfileLink.jsx
@@ -9,7 +9,6 @@ import { capitalize } from "metabase/lib/formatting";
 import MetabaseSettings from "metabase/lib/settings";
 import * as Urls from "metabase/lib/urls";
 import Modal from "metabase/components/Modal";
-import Logs from "metabase/components/Logs";
 
 import LogoIcon from "metabase/components/LogoIcon";
 import EntityMenu from "metabase/components/EntityMenu";
@@ -53,14 +52,6 @@ export default class ProfileLink extends Component {
           event: `Navbar;Profile Dropdown;${
             adminContext ? "Exit Admin" : "Enter Admin"
           }`,
-        },
-      ]),
-      ...(admin && [
-        {
-          title: t`Logs`,
-          icon: null,
-          action: () => this.openModal("logs"),
-          event: `Navbar;Profile Dropdown;Debugging ${tag}`,
         },
       ]),
       {
@@ -134,10 +125,6 @@ export default class ProfileLink extends Component {
               </span>
               <span>{t`and is built with care in San Francisco, CA`}</span>
             </div>
-          </Modal>
-        ) : modalOpen === "logs" ? (
-          <Modal wide onClose={this.closeModal}>
-            <Logs onClose={this.closeModal} />
           </Modal>
         ) : null}
       </Box>

--- a/frontend/test/metabase/admin/tasks/containers/Logs.unit.spec.js
+++ b/frontend/test/metabase/admin/tasks/containers/Logs.unit.spec.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Logs from "metabase/components/Logs";
+import Logs from "metabase/admin/tasks/containers/Logs";
 import { mount } from "enzyme";
 
 import { UtilApi } from "metabase/services";

--- a/frontend/test/metabase/nav/ProfileLink.unit.spec.js
+++ b/frontend/test/metabase/nav/ProfileLink.unit.spec.js
@@ -24,7 +24,7 @@ describe("ProfileLink", () => {
         const admin = { is_superuser: true };
         const wrapper = shallow(<ProfileLink user={admin} context={""} />);
 
-        expect(wrapper.instance().generateOptionsForUser().length).toBe(6);
+        expect(wrapper.instance().generateOptionsForUser().length).toBe(5);
       });
     });
   });


### PR DESCRIPTION
This moves the `Logs` component to its more natural home in the Troubleshooting tab, and tweaks the styling a bit to feel more Metabasey (@kdoh feel free to suggest / make other improvements):

![screenshot 2019-02-27 13 53 02](https://user-images.githubusercontent.com/18193/53525661-24008f80-3a97-11e9-9ccb-4439aa66907e.png)