### PR TITLE
Round the number correctly before sending it off

### DIFF
--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -261,7 +261,7 @@ function formatNumberCompact(value: number) {
   } else {
     // 1 => 1
     // 1000 => 1K
-    return Humanize.compactInteger(value, 1);
+    return Humanize.compactInteger(Math.round(value), 1);
   }
 }
 

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -35,6 +35,12 @@ describe("formatting", () => {
         expect(formatNumber(0.01, { compact: true })).toEqual("~ 0");
         expect(formatNumber(-0.01, { compact: true })).toEqual("~ 0");
       });
+      it("should round up and down", () => {
+        expect(formatNumber(1.01, { compact: true })).toEqual("1");
+        expect(formatNumber(-1.01, { compact: true })).toEqual("-1");
+        expect(formatNumber(1.9, { compact: true })).toEqual("2");
+        expect(formatNumber(-1.9, { compact: true })).toEqual("-2");
+      });
       it("should format large numbers with metric units", () => {
         expect(formatNumber(1, { compact: true })).toEqual("1");
         expect(formatNumber(1000, { compact: true })).toEqual("1.0k");


### PR DESCRIPTION
This fix https://github.com/metabase/metabase/issues/9072

The bug is inside the lib:
https://github.com/HubSpot/humanize/blob/master/src/humanize.js#L86
```
const number = parseInt(input, 10);
```



###### Before submitting the PR, please make sure you do the following
- [x] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.
### Tests
-  [x] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [x] If there are changes to the backend codebase, run the backend tests with `lein test && lein eastwood && lein bikeshed && lein docstring-checker && lein check-namespace-decls && ./bin/reflection-linter`

-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
