### PR TITLE
Disable "." log in CI since it break's CircleCI's no_output_timeout

### DIFF
--- a/frontend/test/__runner__/backend.js
+++ b/frontend/test/__runner__/backend.js
@@ -76,7 +76,10 @@ export const BackendResource = createSharedResource("BackendResource", {
           ")",
       );
       while (!await isReady(server.host)) {
-        process.stdout.write(".");
+        if (!process.env["CI"]) {
+          // disable for CI since it break's CircleCI's no_output_timeout
+          process.stdout.write(".");
+        }
         await delay(500);
       }
       process.stdout.write("\n");


### PR DESCRIPTION
As requested by @camsaul 