### PR TITLE
Fix Snowflake & Vertica [ci snowflake] [ci vertica]

### DIFF
--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -170,7 +170,9 @@
     ;; This is normally done for us by java.jdbc as a result of our `jdbc/query` call
     (with-open [^PreparedStatement stmt (jdbc/prepare-statement conn sql opts)]
       ;; specifiy that we'd like this statement to close once its dependent result sets are closed
-      (.closeOnCompletion stmt)
+      ;; (Not all drivers support this so ignore Exceptions if they don't)
+      (u/ignore-exceptions
+        (.closeOnCompletion stmt))
       ;; Need to run the query in another thread so that this thread can cancel it if need be
       (try
         (let [query-future (future (jdbc/query conn (into [stmt] params) opts))]


### PR DESCRIPTION
Change introduced in #9504 to fix Oracle open cursors is not supported by Vertica and Snowflake JDBC drivers. Fix this