### PR TITLE
Always set Content-Type of request body; minor logging & i18n tweaks

### DIFF
--- a/frontend/src/metabase/lib/api.js
+++ b/frontend/src/metabase/lib/api.js
@@ -103,11 +103,11 @@ export class Api extends EventEmitter {
 
         let headers: { [key: string]: string } = {
           Accept: "application/json",
+          "Content-Type": "application/json",
         };
 
         let body;
         if (options.hasBody) {
-          headers["Content-Type"] = "application/json";
           body = JSON.stringify(data);
         } else {
           let qs = querystring.stringify(data);

--- a/src/metabase/middleware/log.clj
+++ b/src/metabase/middleware/log.clj
@@ -33,13 +33,14 @@
                                        (=  status 403) [true  'red   log-warn false]
                                        (>= status 400) [true  'red   log-debug false]
                                        :else           [false 'green log-debug true])]
-    (log-fn (str (apply u/format-color color (str "%s %s %d (%s) (%d DB calls)."
-                                                  (when stats?
-                                                    " Jetty threads: %s/%s (%s busy, %s idle, %s queued)"))
+    (log-fn (str (apply u/format-color color
+                        (str "%s %s %d (%s) (%d DB calls)."
+                             (when stats?
+                               " Jetty threads: %s/%s (%s busy, %s idle, %s queued) (%d total active threads)"))
                         (.toUpperCase (name request-method)) uri status elapsed-time db-call-count
                         (when stats?
-                          (jetty-stats-coll (jetty-stats))))
-                 (format " active threads: %d" (Thread/activeCount))
+                          (conj (vec (jetty-stats-coll (jetty-stats)))
+                                (Thread/activeCount))))
                  ;; only print body on error so we don't pollute our environment by over-logging
                  (when (and error?
                             (or (string? body) (coll? body)))

--- a/src/metabase/middleware/misc.clj
+++ b/src/metabase/middleware/misc.clj
@@ -5,6 +5,7 @@
              [db :as mdb]
              [public-settings :as public-settings]]
             [metabase.middleware.util :as middleware.u]
+            [metabase.util.i18n :refer [trs]]
             [puppetlabs.i18n.core :as puppet-i18n]
             [ring.middleware.gzip :as ring.gzip])
   (:import [java.io File InputStream]))
@@ -42,7 +43,7 @@
   (when (mdb/db-is-setup?)
     (when-not (public-settings/site-url)
       (when-let [site-url (or origin host)]
-        (log/info "Setting Metabase site URL to" site-url)
+        (log/info (trs "Setting Metabase site URL to {0}" site-url))
         (public-settings/site-url site-url)))))
 
 (defn maybe-set-site-url


### PR DESCRIPTION
Always set the Content-Type header on requests now that it's required.
Also add a missing i18n tag and minor log message tweaks