### PR TITLE
Disable content-type check middleware for time being

### DIFF
--- a/src/metabase/handler.clj
+++ b/src/metabase/handler.clj
@@ -36,7 +36,8 @@
    mw.session/wrap-session-id              ; looks for a Metabase Session ID and assoc as :metabase-session-id
    mw.auth/wrap-api-key                    ; looks for a Metabase API Key on the request and assocs as :metabase-api-key
    mw.misc/maybe-set-site-url              ; set the value of `site-url` if it hasn't been set yet
-   mw.json/check-application-type-headers  ; Reject non-GET requests without Content-Type: application/json headers, we don't support them
+   ;; Disabled for now because some things like CSV download buttons don't work with this on.
+   #_mw.json/check-application-type-headers  ; Reject non-GET requests without Content-Type: application/json headers, we don't support them
    mw.misc/bind-user-locale                ; Binds *locale* for i18n
    wrap-cookies                            ; Parses cookies in the request map and assocs as :cookies
    mw.misc/add-content-type                ; Adds a Content-Type header for any response that doesn't already have one

--- a/src/metabase/middleware/json.clj
+++ b/src/metabase/middleware/json.clj
@@ -4,7 +4,6 @@
              [core :as json]
              [generate :refer [add-encoder encode-str]]]
             [metabase.util :as u]
-            [metabase.util.i18n :refer [tru]]
             [ring.middleware.json :as ring.json]
             [ring.util
              [io :as rui]
@@ -63,7 +62,7 @@
         (respond ring.json/default-malformed-response))
       (handler request respond raise))))
 
-(defn check-application-type-headers
+#_(defn check-application-type-headers
   "We don't support API requests with any type of content encoding other than JSON so let's be nice and make that
   explicit. Added benefit is that it reduces CSRF surface because POSTing a form with JSON content encoding isn't so
   easy to do."

--- a/test/metabase/middleware/json_test.clj
+++ b/test/metabase/middleware/json_test.clj
@@ -1,10 +1,6 @@
 (ns metabase.middleware.json-test
   (:require [cheshire.core :as json]
-            [clj-http.client :as http]
-            [expectations :refer [expect]]
-            [metabase.http-client :as mb-http]
-            [metabase.test.data.users :as test-users])
-  (:import clojure.lang.ExceptionInfo))
+            [expectations :refer [expect]]))
 
 ;;; JSON encoding tests
 ;; Required here so so custom Cheshire encoders are loaded
@@ -18,7 +14,7 @@
 
 ;; Make sure we send you an informative error message if you try to send an API request without Content-Type:
 ;; application/json headers
-(expect
+#_(expect
   {:body "Metabase only supports JSON requests. Make sure you set a Content-Type: application/json header."
    :status 400}
   (try


### PR DESCRIPTION
Breaks CSV downloads and other such forms