### PR TITLE
Fix table deactivation to be table-specific

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -34,6 +34,7 @@ frontend-fast() {
 }
 
 translations() {
+    frontend-deps
     echo "Running './bin/i18n/build-translation-resources' to build translation resources..."
     if ! ./bin/i18n/build-translation-resources; then
       echo "Building translation resources failed, please install 'gettext', or build without translations by running './bin/build no-translations'."

--- a/src/metabase/sync/sync_metadata/tables.clj
+++ b/src/metabase/sync/sync_metadata/tables.clj
@@ -117,6 +117,7 @@
   (doseq [{schema :schema, table-name :name, :as table} old-tables]
     (db/update-where! Table {:db_id  (u/get-id database)
                              :schema schema
+                             :name table-name
                              :active true}
       :active false)))
 


### PR DESCRIPTION
Hello,

I believe there is a Synchronization bug in the existing `retire-tables` functionality which currently deactivates all tables that share the same schema as the current table in the `old-tables` sequence.  Therefore, currently the tables that display in the log do not reflect all items being deactivated.

I believe this bug was never caught because the unintended deactivated tables would be found again upon the following Sync.  I believe this is related to existing issues like #6825.

This change adds the `table-name` filter which I believe was the original intention from line 117.

This is my first contribution to the project, so if I am missing some requirements, please forgive me and point me in the right direction.  I have signed the "Contributor License Agreement", but have not added any tests since this is a very small change.