### PR TITLE
Fix arity exception running lein ring server

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -180,6 +180,7 @@
      :ring
      {:handler      metabase.handler/app
       :init         metabase.core/init!
+      :async?       true
       :destroy      metabase.core/destroy
       :reload-paths ["src"]}}]
 


### PR DESCRIPTION
As @GirishKotra notes in https://github.com/metabase/metabase/issues/9561, there's an arity exception when running lein ring server.  I traced this problem back to commit 502a09c which switches the server to be asynchronous. Because server now runs in async mode, lein ring server also has to.

These changes can be tested by first running on HEAD commit `lein ring server` to observe the error, and then running the same with this one-line patch to project.clj.

This is my first PR submitted to metabase project, so I've just signed the contributor agreement.