### PR TITLE
HttpOnly cookies 2

### DIFF
--- a/frontend/src/metabase/auth/auth.js
+++ b/frontend/src/metabase/auth/auth.js
@@ -6,7 +6,6 @@ import {
 
 import { push } from "react-router-redux";
 
-import MetabaseCookies from "metabase/lib/cookies";
 import MetabaseUtils from "metabase/lib/utils";
 import MetabaseAnalytics from "metabase/lib/analytics";
 import MetabaseSettings from "metabase/lib/settings";
@@ -36,10 +35,8 @@ export const login = createThunkAction(LOGIN, function(
     }
 
     try {
-      let newSession = await SessionApi.create(credentials);
-
-      // since we succeeded, lets set the session cookie
-      MetabaseCookies.setSessionCookie(newSession.id);
+      // NOTE: this request will return a Set-Cookie header for the session
+      await SessionApi.create(credentials);
 
       MetabaseAnalytics.trackEvent("Auth", "Login");
       // TODO: redirect after login (carry user to intended destination)
@@ -59,12 +56,10 @@ export const loginGoogle = createThunkAction(LOGIN_GOOGLE, function(
 ) {
   return async function(dispatch, getState) {
     try {
-      let newSession = await SessionApi.createWithGoogleAuth({
+      // NOTE: this request will return a Set-Cookie header for the session
+      await SessionApi.createWithGoogleAuth({
         token: googleUser.getAuthResponse().id_token,
       });
-
-      // since we succeeded, lets set the session cookie
-      MetabaseCookies.setSessionCookie(newSession.id);
 
       MetabaseAnalytics.trackEvent("Auth", "Google Auth Login");
 
@@ -87,13 +82,12 @@ export const loginGoogle = createThunkAction(LOGIN_GOOGLE, function(
 export const LOGOUT = "metabase/auth/LOGOUT";
 export const logout = createThunkAction(LOGOUT, function() {
   return function(dispatch, getState) {
-    // TODO: as part of a logout we want to clear out any saved state that we have about anything
+    // actively delete the session and remove the cookie
+    SessionApi.delete();
 
-    let sessionId = MetabaseCookies.setSessionCookie();
-    if (sessionId) {
-      // actively delete the session
-      SessionApi.delete({ session_id: sessionId });
-    }
+    // clear Google auth credentials if any are present
+    clearGoogleAuthCredentials();
+
     MetabaseAnalytics.trackEvent("Auth", "Logout");
 
     dispatch(push("/auth/login"));
@@ -118,15 +112,11 @@ export const passwordReset = createThunkAction(PASSWORD_RESET, function(
     }
 
     try {
-      let result = await SessionApi.reset_password({
+      // NOTE: this request will return a Set-Cookie header for the session
+      await SessionApi.reset_password({
         token: token,
         password: credentials.password,
       });
-
-      if (result.session_id) {
-        // we should have a valid session that we can use immediately!
-        MetabaseCookies.setSessionCookie(result.session_id);
-      }
 
       MetabaseAnalytics.trackEvent("Auth", "Password Reset");
 

--- a/frontend/src/metabase/lib/cookies.js
+++ b/frontend/src/metabase/lib/cookies.js
@@ -1,38 +1,11 @@
-import { clearGoogleAuthCredentials } from "metabase/lib/auth";
-
 import Cookies from "js-cookie";
 
-export const METABASE_SESSION_COOKIE = "metabase.SESSION_ID";
+// METABASE_SESSION_COOKIE is only used for e2e tests. In normal usage cookie is set automatically by login endpoints
+export const METABASE_SESSION_COOKIE = "metabase.SESSION";
 export const METABASE_SEEN_ALERT_SPLASH_COOKIE = "metabase.SEEN_ALERT_SPLASH";
 
 // Handles management of Metabase cookie work
 let MetabaseCookies = {
-  // set the session cookie.  if sessionId is null, clears the cookie
-  setSessionCookie: function(sessionId) {
-    const options = {
-      path: window.MetabaseRoot || "/",
-      expires: 14,
-      secure: window.location.protocol === "https:",
-    };
-
-    try {
-      if (sessionId) {
-        // set a session cookie
-        Cookies.set(METABASE_SESSION_COOKIE, sessionId, options);
-      } else {
-        sessionId = Cookies.get(METABASE_SESSION_COOKIE);
-
-        // delete the current session cookie and Google Auth creds
-        Cookies.remove(METABASE_SESSION_COOKIE);
-        clearGoogleAuthCredentials();
-
-        return sessionId;
-      }
-    } catch (e) {
-      console.error("setSessionCookie:", e);
-    }
-  },
-
   setHasSeenAlertSplash: hasSeen => {
     const options = {
       path: window.MetabaseRoot || "/",

--- a/frontend/src/metabase/setup/actions.js
+++ b/frontend/src/metabase/setup/actions.js
@@ -1,9 +1,7 @@
-//import _ from "underscore";
 import { createAction } from "redux-actions";
 import { createThunkAction } from "metabase/lib/redux";
 
 import MetabaseAnalytics from "metabase/lib/analytics";
-import MetabaseCookies from "metabase/lib/cookies";
 import MetabaseSettings from "metabase/lib/settings";
 
 import { SetupApi, UtilApi } from "metabase/services";
@@ -50,6 +48,7 @@ export const submitSetup = createThunkAction(SUBMIT_SETUP, function() {
     let { setup: { allowTracking, databaseDetails, userDetails } } = getState();
 
     try {
+      // NOTE: this request will return a Set-Cookie header for the session
       let response = await SetupApi.create({
         token: MetabaseSettings.get("setup_token"),
         prefs: {
@@ -75,9 +74,6 @@ export const submitSetup = createThunkAction(SUBMIT_SETUP, function() {
 export const completeSetup = createAction(COMPLETE_SETUP, function(
   apiResponse,
 ) {
-  // setup user session
-  MetabaseCookies.setSessionCookie(apiResponse.id);
-
   // clear setup token from settings
   MetabaseSettings.setAll({ setup_token: null });
 

--- a/frontend/test/legacy-selenium/auth/login.spec.js
+++ b/frontend/test/legacy-selenium/auth/login.spec.js
@@ -10,6 +10,8 @@ import {
   describeE2E,
 } from "../support/utils";
 
+import { METABASE_SESSION_COOKIE } from "metabase/lib/cookies";
+
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
 
 describeE2E("auth/login", () => {
@@ -36,7 +38,7 @@ describeE2E("auth/login", () => {
       await waitForUrl(driver, `${server.host}/`);
       const sessionCookie = await driver
         .manage()
-        .getCookie("metabase.SESSION_ID");
+        .getCookie(METABASE_SESSION_COOKIE);
       sessionId = sessionCookie.value;
     });
 
@@ -55,7 +57,7 @@ describeE2E("auth/login", () => {
     beforeEach(async () => {
       await driver.get(`${server.host}/`);
       await driver.manage().deleteAllCookies();
-      await driver.manage().addCookie("metabase.SESSION_ID", sessionId);
+      await driver.manage().addCookie(METABASE_SESSION_COOKIE, sessionId);
     });
 
     it("is logged in", async () => {

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -174,8 +174,11 @@
         (when-not (:last_login user)
           (email/send-user-joined-admin-notification-email! (User user-id)))
         ;; after a successful password update go ahead and offer the client a new session that they can use
-        {:success    true
-         :session_id (create-session! user)})
+        (let [session-id (create-session! user)]
+          (mw.session/set-session-cookie
+           {:success    true
+            :session_id (str session-id)}
+           session-id)))
       (api/throw-invalid-param-exception :password (tru "Invalid reset token"))))
 
 

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -13,6 +13,7 @@
             [metabase.api.common :as api]
             [metabase.email.messages :as email]
             [metabase.integrations.ldap :as ldap]
+            [metabase.middleware.session :as mw.session]
             [metabase.models
              [session :refer [Session]]
              [setting :refer [defsetting]]
@@ -23,19 +24,21 @@
              [schema :as su]]
             [schema.core :as s]
             [throttle.core :as throttle]
-            [toucan.db :as db]))
+            [toucan.db :as db])
+  (:import com.unboundid.util.LDAPSDKException
+           java.util.UUID))
 
-(defn- create-session!
+(s/defn ^:private create-session! :- UUID
   "Generate a new `Session` for a given `User`. Returns the newly generated session ID."
-  [user]
-  {:pre  [(map? user) (integer? (:id user)) (contains? user :last_login)]
-   :post [(string? %)]}
-  (u/prog1 (str (java.util.UUID/randomUUID))
+  [user :- {:id         su/IntGreaterThanZero
+            :last_login s/Any
+            s/Keyword   s/Any}]
+  (u/prog1 (UUID/randomUUID)
     (db/insert! Session
-      :id      <>
+      :id      (str <>)
       :user_id (:id user))
     (events/publish-event! :user-login
-      {:user_id (:id user), :session_id <>, :first_login (not (boolean (:last_login user)))})))
+      {:user_id (:id user), :session_id (str <>), :first_login (nil? (:last_login user))})))
 
 ;;; ## API Endpoints
 
@@ -47,7 +50,7 @@
 (def ^:private password-fail-message (tru "Password did not match stored password."))
 (def ^:private password-fail-snippet (tru "did not match stored password"))
 
-(defn- ldap-login
+(s/defn ^:private ldap-login :- (s/maybe UUID)
   "If LDAP is enabled and a matching user exists return a new Session for them, or `nil` if they couldn't be
   authenticated."
   [username password]
@@ -61,18 +64,16 @@
                    {:status-code 400
                     :errors      {:password password-fail-snippet}})))
         ;; password is ok, return new session
-        {:id (create-session! (ldap/fetch-or-create-user! user-info password))})
-      (catch com.unboundid.util.LDAPSDKException e
-        (log/error
-         (u/format-color 'red
-             (trs "Problem connecting to LDAP server, will fall back to local authentication: {0}" (.getMessage e))))))))
+        (create-session! (ldap/fetch-or-create-user! user-info password)))
+      (catch LDAPSDKException e
+        (log/error e (trs "Problem connecting to LDAP server, will fall back to local authentication"))))))
 
-(defn- email-login
+(s/defn ^:private email-login :- (s/maybe UUID)
   "Find a matching `User` if one exists and return a new Session for them, or `nil` if they couldn't be authenticated."
   [username password]
   (when-let [user (db/select-one [User :id :password_salt :password :last_login], :email username, :is_active true)]
     (when (pass/verify-password password (:password_salt user) (:password user))
-      {:id (create-session! user)})))
+      (create-session! user))))
 
 (def ^:private throttling-disabled? (config/config-bool :mb-disable-session-throttle))
 
@@ -82,6 +83,20 @@
   (when-not throttling-disabled?
     (throttle/check throttler throttle-key)))
 
+(s/defn ^:private login :- UUID
+  "Attempt to login with different avaialable methods with `username` and `password`, returning new Session ID or
+  throwing an Exception if login could not be completed."
+  [username :- su/NonBlankString, password :- su/NonBlankString]
+  ;; Primitive "strategy implementation", should be reworked for modular providers in #3210
+  (or (ldap-login username password)    ; First try LDAP if it's enabled
+      (email-login username password)   ; Then try local authentication
+      ;; If nothing succeeded complain about it
+      ;; Don't leak whether the account doesn't exist or the password was incorrect
+      (throw
+       (ui18n/ex-info password-fail-message
+         {:status-code 400
+          :errors      {:password password-fail-snippet}}))))
+
 (api/defendpoint POST "/"
   "Login."
   [:as {{:keys [username password]} :body, remote-address :remote-addr}]
@@ -89,23 +104,17 @@
    password su/NonBlankString}
   (throttle-check (login-throttlers :ip-address) remote-address)
   (throttle-check (login-throttlers :username)   username)
-  ;; Primitive "strategy implementation", should be reworked for modular providers in #3210
-  (or (ldap-login username password)  ; First try LDAP if it's enabled
-      (email-login username password) ; Then try local authentication
-      ;; If nothing succeeded complain about it
-      ;; Don't leak whether the account doesn't exist or the password was incorrect
-      (throw (ui18n/ex-info password-fail-message
-               {:status-code 400
-                :errors      {:password password-fail-snippet}}))))
+  (let [session-id (login username password)
+        response   {:id session-id}]
+    (mw.session/set-session-cookie response session-id)))
 
 
 (api/defendpoint DELETE "/"
   "Logout."
-  [session_id]
-  {session_id su/NonBlankString}
-  (api/check-exists? Session session_id)
-  (db/delete! Session :id session_id)
-  api/generic-204-no-content)
+  [:as {:keys [metabase-session-id]}]
+  (api/check-exists? Session metabase-session-id)
+  (db/delete! Session :id metabase-session-id)
+  (mw.session/clear-session-cookie api/generic-204-no-content))
 
 ;; Reset tokens: We need some way to match a plaintext token with the a user since the token stored in the DB is
 ;; hashed. So we'll make the plaintext token in the format USER-ID_RANDOM-UUID, e.g.
@@ -231,12 +240,13 @@
   ;; things hairy and only enforce those for non-Google Auth users
   (user/create-new-google-auth-user! new-user))
 
-(defn- google-auth-fetch-or-create-user! [first-name last-name email]
-  (if-let [user (or (db/select-one [User :id :last_login] :email email)
-                    (google-auth-create-new-user! {:first_name first-name
-                                                   :last_name  last-name
-                                                   :email      email}))]
-    {:id (create-session! user)}))
+(s/defn ^:private google-auth-fetch-or-create-user! :- (s/maybe UUID)
+  [first-name last-name email]
+  (when-let [user (or (db/select-one [User :id :last_login] :email email)
+                      (google-auth-create-new-user! {:first_name first-name
+                                                     :last_name  last-name
+                                                     :email      email}))]
+    (create-session! user)))
 
 (api/defendpoint POST "/google_auth"
   "Login with Google Auth."
@@ -246,7 +256,9 @@
   ;; Verify the token is valid with Google
   (let [{:keys [given_name family_name email]} (google-auth-token-info token)]
     (log/info (trs "Successfully authenticated Google Auth token for: {0} {1}" given_name family_name))
-    (google-auth-fetch-or-create-user! given_name family_name email)))
+    (let [session-id (api/check-500 (google-auth-fetch-or-create-user! given_name family_name email))
+          response   {:id session-id}]
+      (mw.session/set-session-cookie response session-id))))
 
 
 (api/define-routes)

--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -10,6 +10,7 @@
              [common :as api]
              [database :as database-api :refer [DBEngineString]]]
             [metabase.integrations.slack :as slack]
+            [metabase.middleware.session :as mw.session]
             [metabase.models
              [database :refer [Database]]
              [session :refer [Session]]
@@ -18,7 +19,8 @@
              [i18n :refer [tru]]
              [schema :as su]]
             [schema.core :as s]
-            [toucan.db :as db]))
+            [toucan.db :as db])
+  (:import java.util.UUID))
 
 (def ^:private SetupToken
   "Schema for a string that matches the instance setup token."
@@ -42,12 +44,12 @@
    allow_tracking (s/maybe (s/cond-pre s/Bool su/BooleanString))
    schedules      (s/maybe database-api/ExpandedSchedulesMap)}
   ;; Now create the user
-  (let [session-id (str (java.util.UUID/randomUUID))
+  (let [session-id (UUID/randomUUID)
         new-user   (db/insert! User
                      :email        email
                      :first_name   first_name
                      :last_name    last_name
-                     :password     (str (java.util.UUID/randomUUID))
+                     :password     (str (UUID/randomUUID))
                      :is_superuser true)]
     ;; this results in a second db call, but it avoids redundant password code so figure it's worth it
     (user/set-password! (:id new-user) password)
@@ -75,12 +77,12 @@
     (setup/clear-token!)
     ;; then we create a session right away because we want our new user logged in to continue the setup process
     (db/insert! Session
-      :id      session-id
+                :id      (str session-id)
       :user_id (:id new-user))
     ;; notify that we've got a new user in the system AND that this user logged in
     (events/publish-event! :user-create {:user_id (:id new-user)})
-    (events/publish-event! :user-login {:user_id (:id new-user), :session_id session-id, :first_login true})
-    {:id session-id}))
+    (events/publish-event! :user-login {:user_id (:id new-user), :session_id (str session-id), :first_login true})
+    (mw.session/set-session-cookie {:id (str session-id)} session-id)))
 
 
 (api/defendpoint POST "/validate"

--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -77,7 +77,7 @@
     (setup/clear-token!)
     ;; then we create a session right away because we want our new user logged in to continue the setup process
     (db/insert! Session
-                :id      (str session-id)
+      :id      (str session-id)
       :user_id (:id new-user))
     ;; notify that we've got a new user in the system AND that this user logged in
     (events/publish-event! :user-create {:user_id (:id new-user)})

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -237,7 +237,8 @@
     (let [reset-token (user/set-password-reset-token! id)
           ;; NOTE: the new user join url is just a password reset with an indicator that this is a first time user
           join-url    (str (user/form-password-reset-url reset-token) "#new")]
-      (email/send-new-user-email! user @api/*current-user* join-url))))
+      (email/send-new-user-email! user @api/*current-user* join-url)))
+  {:success true})
 
 
 (api/define-routes)

--- a/src/metabase/middleware/session.clj
+++ b/src/metabase/middleware/session.clj
@@ -4,7 +4,8 @@
              [config :as config]
              [db :as mdb]
              [public-settings :as public-settings]]
-            [metabase.api.common :refer [*current-user* *current-user-id* *current-user-permissions-set* *is-superuser?*]]
+            [metabase.api.common :refer [*current-user* *current-user-id* *current-user-permissions-set*
+                                         *is-superuser?*]]
             [metabase.core.initialization-status :as init-status]
             [metabase.models
              [session :refer [Session]]
@@ -16,35 +17,63 @@
            java.util.UUID
            org.joda.time.DateTime))
 
-(def ^:private ^String metabase-session-cookie "metabase.SESSION_ID")
-(def ^:private ^String metabase-session-header "x-metabase-session")
+;; How do authenticated API requests work? Metabase first looks for a cookie called `metabase.SESSION`. This is the
+;; normal way of doing things; this cookie gets set automatically upon login. `metabase.SESSION` is an HttpOnly
+;; cookie and thus can't be viewed by FE code.
+;;
+;; If that cookie is isn't present, we look for the `metabase.SESSION_ID`, which is the old session cookie set in
+;; 0.31.x and older. Unlike `metabase.SESSION`, this cookie was set directly by the frontend and thus was not
+;; HttpOnly; for 0.32.x we'll continue to accept it rather than logging every one else out on upgrade. (We've
+;; switched to a new Cookie name for 0.32.x because the new cookie includes a `path` attribute, thus browsers consider
+;; it to be a different Cookie; Ring cookie middleware does not handle multiple cookies with the same name.)
+;;
+;; Finally we'll check for the presence of a `X-Metabase-Session` header. If that isn't present, you don't have a
+;; Session ID and thus are definitely not authenticated
+(def ^:private ^String metabase-session-cookie        "metabase.SESSION")
+(def ^:private ^String metabase-legacy-session-cookie "metabase.SESSION_ID") ; this can be removed in 0.33.x
+(def ^:private ^String metabase-session-header        "x-metabase-session")
+
+(defn- clear-cookie [response cookie-name]
+  (resp/set-cookie response cookie-name nil {:expires (DateTime. 0)}))
+
+(defn- wrap-body-if-needed
+  "You can't add a cookie (by setting the `:cookies` key of a response) if the response is an unwrapped JSON response;
+  wrap `response` if needed."
+  [response]
+  (if (and (map? response) (contains? response :body))
+    response
+    {:body response, :status 200}))
 
 (s/defn set-session-cookie
   "Add a `Set-Cookie` header to `response` to persist the Metabase session."
   [response, session-id :- UUID]
-  (if-not (and (map? response) (:body response))
-    (recur {:body response, :status 200} session-id)
-    (resp/set-cookie
-     response
-     metabase-session-cookie
-     (str session-id)
-     (merge
-      {:same-site :lax
-       :http-only true
-       :path      "/api"
-       :max-age   (config/config-int :max-session-age)}
-      ;; If Metabase is running over HTTPS (hopefully always except for local dev instances) then make sure to make this
-      ;; cookie HTTPS-only
-      (when (some-> (public-settings/site-url) URL. .getProtocol (= "https"))
-        {:secure true})))))
+  (-> response
+      wrap-body-if-needed
+      (clear-cookie metabase-legacy-session-cookie)
+      (resp/set-cookie
+       metabase-session-cookie
+       (str session-id)
+       (merge
+        {:same-site :lax
+         :http-only true
+         :path      "/api"
+         :max-age   (config/config-int :max-session-age)}
+        ;; If Metabase is running over HTTPS (hopefully always except for local dev instances) then make sure to
+        ;; make this cookie HTTPS-only
+        (when (some-> (public-settings/site-url) URL. .getProtocol (= "https"))
+          {:secure true})))))
 
 (defn clear-session-cookie
   "Add a header to `response` to clear the current Metabase session cookie."
   [response]
-  (resp/set-cookie response metabase-session-cookie nil {:expires (DateTime. 0)}))
+  (-> response
+      wrap-body-if-needed
+      (clear-cookie metabase-session-cookie)
+      (clear-cookie metabase-legacy-session-cookie)))
 
 (defn- wrap-session-id* [{:keys [cookies headers] :as request}]
   (let [session-id (or (get-in cookies [metabase-session-cookie :value])
+                       (get-in cookies [metabase-legacy-session-cookie :value])
                        (headers metabase-session-header))]
     (if (seq session-id)
       (assoc request :metabase-session-id session-id)

--- a/test/expectation_options.clj
+++ b/test/expectation_options.clj
@@ -1,5 +1,53 @@
 (ns expectation-options
-  "Namespace expectations will automatically load before running a tests")
+  "Namespace expectations will automatically load before running a tests"
+  (:require [clojure
+             [data :as data]
+             [set :as set]]
+            [expectations :as expectations]
+            [metabase.util :as u]))
+
+;;; ---------------------------------------- Expectations Framework Settings -----------------------------------------
+
+;; ## EXPECTATIONS FORMATTING OVERRIDES
+
+;; These overrides the methods Expectations usually uses for printing failed tests.
+;; These are basically the same as the original implementations, but they colorize and pretty-print the
+;; output, which makes it an order of magnitude easier to read, especially for tests that compare a
+;; lot of data, like Query Processor or API tests.
+(defn- format-failure [e a str-e str-a]
+  {:type             :fail
+   :expected-message (when-let [in-e (first (data/diff e a))]
+                       (format "\nin expected, not actual:\n%s" (u/pprint-to-str 'green in-e)))
+   :actual-message   (when-let [in-a (first (data/diff a e))]
+                       (format "\nin actual, not expected:\n%s" (u/pprint-to-str 'red in-a)))
+   :raw              [str-e str-a]
+   :result           ["\nexpected:\n"
+                      (u/pprint-to-str 'green e)
+                      "\nwas:\n"
+                      (u/pprint-to-str 'red a)]})
+
+(defmethod expectations/compare-expr :expectations/maps [e a str-e str-a]
+  (let [[in-e in-a] (data/diff e a)]
+    (if (and (nil? in-e) (nil? in-a))
+      {:type :pass}
+      (format-failure e a str-e str-a))))
+
+(defmethod expectations/compare-expr :expectations/sets [e a str-e str-a]
+  (format-failure e a str-e str-a))
+
+(defmethod expectations/compare-expr :expectations/sequentials [e a str-e str-a]
+  (let [diff-fn (fn [e a] (seq (set/difference (set e) (set a))))]
+    (assoc (format-failure e a str-e str-a)
+           :message (cond
+                      (and (= (set e) (set a))
+                           (= (count e) (count a))
+                           (= (count e) (count (set a)))) "lists appear to contain the same items with different ordering"
+                      (and (= (set e) (set a))
+                           (< (count e) (count a)))       "some duplicate items in actual are not expected"
+                      (and (= (set e) (set a))
+                           (> (count e) (count a)))       "some duplicate items in expected are not actual"
+                      (< (count e) (count a))             "actual is larger than expected"
+                      (> (count e) (count a))             "expected is larger than actual"))))
 
 ;;; ---------------------------------------------- check-for-slow-tests ----------------------------------------------
 

--- a/test/metabase/http_client.clj
+++ b/test/metabase/http_client.clj
@@ -2,12 +2,14 @@
   "HTTP client for making API calls against the Metabase API. For test/REPL purposes."
   (:require [cheshire.core :as json]
             [clj-http.client :as client]
-            [clojure.string :as s]
+            [clojure.string :as str]
             [clojure.tools.logging :as log]
             [metabase
              [config :as config]
              [util :as u]]
-            [metabase.util.date :as du]))
+            [metabase.middleware.session :as mw.session]
+            [metabase.util.date :as du]
+            [schema.core :as s]))
 
 ;;; build-url
 
@@ -22,7 +24,7 @@
   [url url-param-kwargs]
   {:pre [(string? url) (u/maybe? map? url-param-kwargs)]}
   (str *url-prefix* url (when (seq url-param-kwargs)
-                          (str "?" (s/join \& (for [[k v] url-param-kwargs]
+                          (str "?" (str/join \& (for [[k v] url-param-kwargs]
                                                 (str (if (keyword? k) (name k) k)
                                                      \=
                                                      (if (keyword? v) (name v) v))))))))
@@ -56,7 +58,7 @@
     (try
       (auto-deserialize-dates (json/parse-string body keyword))
       (catch Throwable _
-        (when-not (s/blank? body)
+        (when-not (str/blank? body)
           body)))))
 
 
@@ -64,15 +66,14 @@
 
 (declare client)
 
-(defn authenticate
+(s/defn authenticate
   "Authenticate a test user with USERNAME and PASSWORD, returning their Metabase Session token;
    or throw an Exception if that fails."
-  [{:keys [username password], :as credentials}]
-  {:pre [(string? username) (string? password)]}
+  [credentials :- {:username s/Str, :password s/Str}]
   (try
     (:id (client :post 200 "session" credentials))
     (catch Throwable e
-      (println "Failed to authenticate with username:" username "and password:" password ":" (.getMessage e)))))
+      (println "Failed to authenticate with credentials" credentials e))))
 
 
 ;;; client
@@ -80,10 +81,11 @@
 (defn- build-request-map [credentials http-body]
   (merge
    {:accept       :json
-    :headers      {"X-METABASE-SESSION" (when credentials
-                                          (if (map? credentials)
-                                            (authenticate credentials)
-                                            credentials))}
+    :headers      {@#'mw.session/metabase-session-header
+                   (when credentials
+                     (if (map? credentials)
+                       (authenticate credentials)
+                       credentials))}
     :content-type :json}
    (when (seq http-body)
      {:body (json/generate-string http-body)})))
@@ -119,7 +121,7 @@
   (let [request-map (merge (build-request-map credentials http-body) request-options)
         request-fn  (method->request-fn method)
         url         (build-url url url-param-kwargs)
-        method-name (s/upper-case (name method))
+        method-name (str/upper-case (name method))
         ;; Now perform the HTTP request
         {:keys [status body] :as resp} (try (request-fn url request-map)
                                             (catch clojure.lang.ExceptionInfo e

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -8,8 +8,10 @@
             [metabase.core.initialization-status :as init-status]
             [metabase.middleware.session :as mw.session]
             [metabase.models.user :as user :refer [User]]
+            [schema.core :as s]
             [toucan.db :as db])
-  (:import clojure.lang.ExceptionInfo))
+  (:import clojure.lang.ExceptionInfo
+           metabase.models.user.UserInstance))
 
 ;;; ------------------------------------------------ User Definitions ------------------------------------------------
 
@@ -42,8 +44,11 @@
                :password "birdseed"
                :active   false}})
 
-(def ^:private ^:const usernames
+(def ^:private usernames
   (set (keys user->info)))
+
+(def ^:private TestUserName
+  (apply s/enum usernames))
 
 ;;; ------------------------------------------------- Test User Fns --------------------------------------------------
 
@@ -67,8 +72,8 @@
 (defn- fetch-or-create-user!
   "Create User if they don't already exist and return User."
   [& {:keys [email first last password superuser active]
-      :or {superuser false
-           active    true}}]
+      :or   {superuser false
+             active    true}}]
   {:pre [(string? email) (string? first) (string? last) (string? password) (m/boolean? superuser) (m/boolean? active)]}
   (wait-for-initiailization)
   (or (User :email email)
@@ -82,19 +87,18 @@
         :is_active    active)))
 
 
-(defn fetch-user
+(s/defn fetch-user :- UserInstance
   "Fetch the User object associated with USERNAME. Creates user if needed.
 
     (fetch-user :rasta) -> {:id 100 :first_name \"Rasta\" ...}"
-  [username]
-  {:pre [(contains? usernames username)]}
+  [username :- TestUserName]
   (m/mapply fetch-or-create-user! (user->info username)))
 
-(defn create-users-if-needed!
+(s/defn create-users-if-needed!
   "Force creation of the test users if they don't already exist."
   ([]
    (apply create-users-if-needed! usernames))
-  ([& usernames]
+  ([& usernames :- [TestUserName]]
    (doseq [username usernames]
      ;; fetch-user will force creation of users
      (fetch-user username))))
@@ -104,15 +108,15 @@
 
     (user->id :rasta) -> 4"
   (memoize
-   (fn [username]
+   (s/fn :- s/Int [username :- TestUserName]
      {:pre [(contains? usernames username)]}
-     (:id (fetch-user username)))))
+     (u/get-id (fetch-user username)))))
 
-(defn user->credentials
+(s/defn user->credentials :- {:username (s/pred u/email?), :password s/Str}
   "Return a map with `:username` and `:password` for User with USERNAME.
 
     (user->credentials :rasta) -> {:username \"rasta@metabase.com\", :password \"blueberries\"}"
-  [username]
+  [username :- TestUserName]
   {:pre [(contains? usernames username)]}
   (let [{:keys [email password]} (user->info username)]
     {:username email
@@ -128,9 +132,9 @@
 
 (defonce ^:private tokens (atom {}))
 
-(defn username->token
+(s/defn username->token :- u/uuid-regex
   "Return cached session token for a test User, logging in first if needed."
-  [username]
+  [username :- TestUserName]
   (or (@tokens username)
       (u/prog1 (http/authenticate (user->credentials username))
         (swap! tokens assoc username <>))
@@ -154,18 +158,18 @@
         (clear-cached-session-tokens!)
         (apply client-fn username args)))))
 
-(defn user->client
+(s/defn user->client :- (s/pred fn?)
   "Returns a `metabase.http-client/client` partially bound with the credentials for User with USERNAME.
    In addition, it forces lazy creation of the User if needed.
 
      ((user->client) :get 200 \"meta/table\")"
-  [username]
+  [username :- TestUserName]
   (create-users-if-needed! username)
   (partial client-fn username))
 
-(defn do-with-test-user
+(s/defn do-with-test-user
   "Call `f` with various `metabase.api.common` dynamic vars bound to the test User named by `user-kwd`."
-  [user-kwd f]
+  [user-kwd :- TestUserName, f :- (s/pred fn?)]
   ((mw.session/bind-current-user (fn [_ respond _] (respond (f))))
    (let [user-id (user->id user-kwd)]
      {:metabase-user-id user-id

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -3,11 +3,11 @@
   (:require [cheshire.core :as json]
             [clj-time.core :as time]
             [clojure
-             [string :as s]
+             [string :as str]
              [walk :as walk]]
             [clojure.tools.logging :as log]
             [clojurewerkz.quartzite.scheduler :as qs]
-            [expectations :refer :all]
+            [expectations :as expectations :refer [expect]]
             [metabase
              [driver :as driver]
              [task :as task]
@@ -35,10 +35,34 @@
             [metabase.test.data :as data]
             [metabase.test.data.dataset-definitions :as defs]
             [metabase.util.date :as du]
+            [schema.core :as s]
             [toucan.db :as db]
             [toucan.util.test :as test])
   (:import org.apache.log4j.Logger
            [org.quartz CronTrigger JobDetail JobKey Scheduler Trigger]))
+
+;; record type for testing that results match a Schema
+(defrecord SchemaExpectation [schema]
+  expectations/CustomPred
+  (expect-fn [_ actual]
+    (nil? (s/check schema actual)))
+  (expected-message [_ _ _ _]
+    (str "Result did not match schema:\n"
+         (u/pprint-to-str (s/explain schema))))
+  (actual-message [_ actual _ _]
+    (str "Was:\n"
+         (u/pprint-to-str actual)))
+  (message [_ actual _ _]
+    (u/pprint-to-str (s/check schema actual))))
+
+(defmacro expect-schema
+  "Like `expect`, but checks that results match a schema."
+  {:style/indent 0}
+  [expected actual]
+  `(expect
+     (SchemaExpectation. ~expected)
+     ~actual))
+
 
 ;;; ---------------------------------------------------- match-$ -----------------------------------------------------
 
@@ -108,8 +132,8 @@
     (every-pred (some-fn keyword? string?)
                 (some-fn #{:id :created_at :updated_at :last_analyzed :created-at :updated-at :field-value-id :field-id
                            :fields_hash :date_joined :date-joined :last_login :dimension-id :human-readable-field-id}
-                         #(s/ends-with? % "_id")
-                         #(s/ends-with? % "_at")))
+                         #(str/ends-with? % "_id")
+                         #(str/ends-with? % "_at")))
     data))
   ([pred data]
    (walk/prewalk (fn [maybe-map]

--- a/test/metabase/test_setup.clj
+++ b/test/metabase/test_setup.clj
@@ -1,12 +1,8 @@
 (ns metabase.test-setup
   "Functions that run before + after unit tests (setup DB, start web server, load test data)."
-  (:require [clojure
-             [data :as data]
-             [set :as set]
-             [string :as str]]
-            [clojure.java.io :as io]
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
             [clojure.tools.logging :as log]
-            [expectations :refer :all]
             [metabase
              [db :as mdb]
              [handler :as handler]
@@ -19,50 +15,6 @@
             [metabase.plugins.initialize :as plugins.init]
             [metabase.test.data.env :as tx.env]
             [yaml.core :as yaml]))
-
-;;; ---------------------------------------- Expectations Framework Settings -----------------------------------------
-
-;; ## EXPECTATIONS FORMATTING OVERRIDES
-
-;; These overrides the methods Expectations usually uses for printing failed tests.
-;; These are basically the same as the original implementations, but they colorize and pretty-print the
-;; output, which makes it an order of magnitude easier to read, especially for tests that compare a
-;; lot of data, like Query Processor or API tests.
-(defn- format-failure [e a str-e str-a]
-  {:type             :fail
-   :expected-message (when-let [in-e (first (data/diff e a))]
-                       (format "\nin expected, not actual:\n%s" (u/pprint-to-str 'green in-e)))
-   :actual-message   (when-let [in-a (first (data/diff a e))]
-                       (format "\nin actual, not expected:\n%s" (u/pprint-to-str 'red in-a)))
-   :raw              [str-e str-a]
-   :result           ["\nexpected:\n"
-                      (u/pprint-to-str 'green e)
-                      "\nwas:\n"
-                      (u/pprint-to-str 'red a)]})
-
-(defmethod compare-expr :expectations/maps [e a str-e str-a]
-  (let [[in-e in-a] (data/diff e a)]
-    (if (and (nil? in-e) (nil? in-a))
-      {:type :pass}
-      (format-failure e a str-e str-a))))
-
-(defmethod compare-expr :expectations/sets [e a str-e str-a]
-  (format-failure e a str-e str-a))
-
-(defmethod compare-expr :expectations/sequentials [e a str-e str-a]
-  (let [diff-fn (fn [e a] (seq (set/difference (set e) (set a))))]
-    (assoc (format-failure e a str-e str-a)
-           :message (cond
-                      (and (= (set e) (set a))
-                           (= (count e) (count a))
-                           (= (count e) (count (set a)))) "lists appear to contain the same items with different ordering"
-                      (and (= (set e) (set a))
-                           (< (count e) (count a)))       "some duplicate items in actual are not expected"
-                      (and (= (set e) (set a))
-                           (> (count e) (count a)))       "some duplicate items in expected are not actual"
-                      (< (count e) (count a))             "actual is larger than expected"
-                      (> (count e) (count a))             "expected is larger than actual"))))
-
 
 ;;; ------------------------------- Functions That Get Ran On Test Suite Start / Stop --------------------------------
 

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -65,7 +65,7 @@
 (expect "cam_s_awesome_toucan_emporium" (slugify "Cam's awesome toucan emporium"))
 (expect "frequently_used_cards"         (slugify "Frequently-Used Cards"))
 ;; check that diactrics get removed
-(expect "cam_saul_s_toucannery"         (slugify "Cam Saül's Toucannery"))
+(expect "cam_saul_s_toucannery"         (slugify "Cam Saul's Toucannery"))
 (expect "toucans_dislike_pinatas___"    (slugify "toucans dislike piñatas :("))
 ;; check that non-ASCII characters get URL-encoded (so we can support non-Latin alphabet languages; see #3818)
 (expect "%E5%8B%87%E5%A3%AB"            (slugify "勇士")) ; go dubs


### PR DESCRIPTION
Fixed version of #9550. Change the Metabase cookie name from `metabase.SESSION_ID` to `metabase.SESSION` to avoid issues where our cookie middleware could not differentiate between two cookies of the same.

Legacy cookie is still accepted for the time being to avoid logging everyone out upon upgrade.