### PR TITLE
Fix migration 10 valid checksums :wrench:

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -1465,12 +1465,14 @@ databaseChangeLog:
       id: 10
       author: cammsaul
       validCheckSum:
-        - 7:97fec69516d0dfe424ea7365f51bb87e
         - 7:3b90e2fe0ac8e617a1f30ef95d39319b
-        - 8:431360d062cb82d8b27960b3a0abb98c
-        - 8:9f03a236be31f54e8e5c894fe5fc7f00
+        - 7:97fec69516d0dfe424ea7365f51bb87e
         - 8:2e03a495932b4a9aebb9d58a6ad87ca9
+        - 8:431360d062cb82d8b27960b3a0abb98c
+        - 8:5297214d1788d964675d8c6336ac9b6d
         - 8:532075ff1717d4a16bb9f27c606db46b
+        - 8:96e54d9100db3f9cdcc00eaeccc200a3
+        - 8:9f03a236be31f54e8e5c894fe5fc7f00
       changes:
         - createTable:
             tableName: revision


### PR DESCRIPTION
Fixes #9612. Same as #9619 but I accidentally applied that to `master` instead of `release-0.32.0`