### PR TITLE
Handle errors gracefully in log-response server middleware

### DIFF
--- a/src/metabase/middleware/log.clj
+++ b/src/metabase/middleware/log.clj
@@ -5,7 +5,9 @@
              [server :as server]
              [util :as u]]
             [metabase.middleware.util :as middleware.u]
-            [metabase.util.date :as du]
+            [metabase.util
+             [date :as du]
+             [i18n :refer [trs]]]
             [toucan.db :as db])
   (:import org.eclipse.jetty.util.thread.QueuedThreadPool))
 
@@ -63,6 +65,9 @@
       (let [start-time (System/nanoTime)]
         (db/with-call-counting [call-count]
           (let [respond (fn [response]
-                          (log-response request response (du/format-nanoseconds (- (System/nanoTime) start-time)) (call-count))
+                          (try
+                            (log-response request response (du/format-nanoseconds (- (System/nanoTime) start-time)) (call-count))
+                            (catch Throwable e
+                              (log/error e (trs "Error logging API request"))))
                           (respond response))]
             (handler request respond raise)))))))


### PR DESCRIPTION
If an API request is canceled before it gets a status code the log-request server middleware gets confused. Handle exceptions gracefully in that middleware instead of propagating them up to Jetty

Minor change and doesn't affect visible to users other than log messages