### PR TITLE
Fix MySQL connections with SSL 

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -7,6 +7,7 @@
             [clojure
              [set :as set]
              [string :as str]]
+            [clojure.tools.logging :as log]
             [honeysql.core :as hsql]
             [metabase.db.spec :as dbspec]
             [metabase.driver :as driver]
@@ -22,6 +23,7 @@
             [metabase.util
              [date :as du]
              [honeysql-extensions :as hx]
+             [i18n :refer [trs]]
              [ssh :as ssh]]
             [schema.core :as s])
   (:import [java.sql ResultSet Time Timestamp Types]
@@ -45,6 +47,7 @@
      driver.common/default-dbname-details
      driver.common/default-user-details
      driver.common/default-password-details
+     driver.common/default-ssl-details
      (assoc driver.common/default-additional-options-details
        :placeholder  "tinyInt1isBit=false")]))
 
@@ -282,14 +285,21 @@
    ;; but we still want to test that we can handle it correctly for older ones
    :sessionVariables     "sql_mode='ALLOW_INVALID_DATES'"})
 
-(defmethod sql-jdbc.conn/connection-details->spec :mysql [_ {ssl? :ssl, :as details}]
-  (merge
-   default-connection-args
-   ;; newer versions of MySQL will complain if you don't specify this when not using SSL
-   (when-not ssl?
-     {:useSSL false})
-   (-> (dbspec/mysql (set/rename-keys details {:dbname :db}))
-       (sql-jdbc.common/handle-additional-options details))))
+(defmethod sql-jdbc.conn/connection-details->spec :mysql [_ {ssl? :ssl, :keys [additional-options], :as details}]
+  ;; In versions older than 0.32.0 the MySQL driver did not correctly save `ssl?` connection status. Users worked
+  ;; around this by including `useSSL=true`. Check if that's there, and if it is, assume SSL status. See #9629
+  ;;
+  ;; TODO - should this be fixed by a data migration instead?
+  (let [ssl? (or ssl? (some-> additional-options (str/includes? "useSSL=true")))]
+    (when (and ssl?
+               (not (some->  additional-options (str/includes? "trustServerCertificate"))))
+      (log/info (trs "You may need to add 'trustServerCertificate=true' to the additional connection options to connect with SSL.")))
+    (merge
+     default-connection-args
+     ;; newer versions of MySQL will complain if you don't specify this when not using SSL
+     {:useSSL (boolean ssl?)}
+     (-> (dbspec/mysql (set/rename-keys details {:dbname :db}))
+         (sql-jdbc.common/handle-additional-options details)))))
 
 
 (defmethod sql-jdbc.sync/active-tables :mysql [& args]


### PR DESCRIPTION
When Metabase attempts to connect to a new database, it first attempts to try to connect to the database with SSL, iff the Metabase driver advertises that it supports SSL. If that fails, or the database doesn't support SSL, it tries to connect without SSL. It then saves whether it needs to use SSL to connect.

Normally this works great (for other DBs), however **our Metabase driver for MySQL never was marked as supporting SSL**. 

This is news to me, but **apparently in all prior versions of Metabase the only way to get MySQL with SSL to work was with a hack**: by adding `useSSL=true` as additional connection option. However, Metabase would still save the connection as not needing SSL. So this worked through sheer accident.

**For a while Metabase has added a`useSSL=false` option to connections that were saved as not using SSL (i.e., all of them**); this was done because newer versions of MySQL complain repeatedly (i.e., every time you connect) if you do not. In prior versions this was added to the connection URL before "additional connection args". Thus a connection string would look something like:

```
db@host:port?useSSL=false&useSSL=true
<user and password set separately as Properties>
```

So **in prior versions the user-supplied option overrode the Metabase-supplied one**; MySQL did not complain about multiple conflicting options. I think this situation is undefined with JDBC, and I've definitely seen other databases throw an Exception if you provide multiple conflicting values of the same property.

Generally, setting JDBC connection options with a [`Properties`](https://docs.oracle.com/javase/8/docs/api/java/util/Properties.html) object instead of jamming them all together in query args in a connection string is preferable, especially for things like passwords that might contain special characters like `?` or `&` that do not play nicely in URLs. **In Metabase 0.32.0 I made some tweaks and the `useSSL=false` is now set in the Properties object**, meaning connections would look like:

```
db@host:port?useSSL=true
<user, password, and useSSL=false set separately as Properties>
```

I don't believe the behavior is defined when the same option is specified in both the connection string and in the connection `Properties`, however it appears MariaDB/MySQL prefers the Properties option to the connection string query param one. Thus **the hack stopped working**.

I fixed this by properly advertising that the MySQL driver supports SSL, fixing new connection; to fix legacy connections we now check whether additional connection options contains `useSSL=true`. 

**Going forward, people will not need to set `useSSL=true` in order to use SSL with MySQL. However, you may still need to set `trustServerCertificate=true`**; I added a helpful log message to that effect if this applies to you. This was the case for me when testing with a database on RDS (I created an additional user with a `REQUIRE SSL` condition for their privileges  [as suggested here](https://mariadb.com/kb/en/library/using-tls-ssl-with-mariadb-java-connector/) to test this.)