### PR TITLE
Allow omitting port for Postgres and MySQL

### DIFF
--- a/src/metabase/db/spec.clj
+++ b/src/metabase/db/spec.clj
@@ -24,7 +24,7 @@
   (merge
    {:classname                     "org.postgresql.Driver"
     :subprotocol                   "postgresql"
-    :subname                       (make-subname host port db)
+    :subname                       (make-subname host (or port 5432) db)
     ;; I think this is done to prevent conflicts with redshift driver registering itself to handle postgres://
     :OpenSourceSubProtocolOverride true}
    (dissoc opts :host :port :db)))
@@ -37,7 +37,7 @@
   (merge
    {:classname   "org.mariadb.jdbc.Driver"
     :subprotocol "mysql"
-    :subname     (make-subname host port db)}
+    :subname     (make-subname host (or port 3306) db)}
    (dissoc opts :host :port :db)))
 
 

--- a/test/metabase/db/spec_test.clj
+++ b/test/metabase/db/spec_test.clj
@@ -30,7 +30,7 @@
   (assoc (default-pg-spec "") :dbname nil, :somethingrandom nil)
   (db.spec/postgres
    {:host    "localhost"
-    :port            5432
+    :port            nil
     :dbname          nil
     :db              nil
     :somethingrandom nil}))
@@ -39,3 +39,17 @@
 (expect
   (default-pg-spec "")
   (db.spec/postgres {}))
+
+(defn- default-mysql-spec [db]
+  {:classname                     "org.mariadb.jdbc.Driver"
+   :subprotocol                   "mysql"
+   :subname                       (format "//localhost:3306/%s" db)})
+
+;; Check that we default to port 3306 for MySQL databases, if `:port` is `nil`
+(expect
+  (assoc (default-mysql-spec "") :dbname nil)
+  (db.spec/mysql
+   {:host    "localhost"
+    :port            nil
+    :dbname          nil
+    :db              nil}))


### PR DESCRIPTION
Currently, if the port is missing in `MB_DB_CONNECTION_URI` for a Postgres or MySQL database  some hard-to-understand errors are generated.

#### Error if Postgres
<details><summary>Collapsed log output</summary>

```plaintext
> env MB_DB_CONNECTION_URI='postgres://postgres@localhost/metabase' lein run
Warning: implicit hook found: lein-environ.plugin/hooks
Hooks are deprecated and will be removed in a future version.
03-31 23:22:55 INFO metabase.util :: Loading Metabase...
03-31 23:22:55 INFO metabase.util :: Maximum memory available to JVM: 1.8 GB
03-31 23:23:04 DEBUG plugins.classloader :: Using Clojure base loader as shared context classloader: clojure.lang.DynamicClassLoader@167eab4
03-31 23:23:09 INFO util.encryption :: Saved credentials encryption is DISABLED for this Metabase instance. 🔓
 For more information, see https://www.metabase.com/docs/latest/operations-guide/start.html#encrypting-your-database-connection-details-at-rest
03-31 23:23:18 INFO metabase.driver :: Registered abstract driver :sql  🚚
03-31 23:23:35 INFO metabase.core :: Starting Metabase in STANDALONE mode
03-31 23:23:35 INFO metabase.server :: Launching Embedded Jetty Webserver with config:
 {:async? true, :port 3000}

03-31 23:23:35 INFO metabase.core :: Starting Metabase version v0.32.0-snapshot (a24756a master) ...
03-31 23:23:35 INFO metabase.core :: System timezone is 'Europe/Copenhagen' ...
03-31 23:23:35 INFO metabase.plugins :: Loading plugins in /Users/malthe/OneDrive/Programming/Java/metabase/plugins...
03-31 23:23:36 INFO plugins.dependencies :: Plugin 'Metabase BigQuery Driver' depends on plugin 'Metabase Google Drivers Shared Dependencies'
03-31 23:23:36 INFO plugins.dependencies :: Metabase BigQuery Driver dependency {:plugin Metabase Google Drivers Shared Dependencies} satisfied? false
03-31 23:23:36 INFO plugins.dependencies :: Plugins with unsatisfied deps: ["Metabase BigQuery Driver"]
03-31 23:23:36 INFO plugins.lazy-loaded-driver :: Registering lazy loading driver :druid...
03-31 23:23:36 INFO metabase.driver :: Registered driver :druid  🚚
03-31 23:23:36 INFO plugins.lazy-loaded-driver :: Registering lazy loading driver :google...
03-31 23:23:36 INFO metabase.driver :: Registered abstract driver :google  🚚
03-31 23:23:36 INFO plugins.dependencies :: Metabase BigQuery Driver dependency {:plugin Metabase Google Drivers Shared Dependencies} satisfied? true
03-31 23:23:36 DEBUG plugins.initialize :: Dependencies satisfied; these plugins will now be loaded: ["Metabase BigQuery Driver"]
03-31 23:23:36 INFO plugins.lazy-loaded-driver :: Registering lazy loading driver :bigquery...
03-31 23:23:36 INFO metabase.driver :: Registered driver :bigquery (parents: #{:sql :google}) 🚚
03-31 23:23:36 INFO plugins.dependencies :: Plugin 'Metabase Google Analytics Driver' depends on plugin 'Metabase Google Drivers Shared Dependencies'
03-31 23:23:36 INFO plugins.dependencies :: Metabase Google Analytics Driver dependency {:plugin Metabase Google Drivers Shared Dependencies} satisfied? true
03-31 23:23:36 INFO plugins.lazy-loaded-driver :: Registering lazy loading driver :googleanalytics...
03-31 23:23:36 INFO metabase.driver :: Registered driver :googleanalytics (parents: #{:google}) 🚚
03-31 23:23:36 INFO plugins.lazy-loaded-driver :: Registering lazy loading driver :mongo...
03-31 23:23:36 INFO metabase.driver :: Registered driver :mongo  🚚
03-31 23:23:36 DEBUG plugins.classloader :: Setting current thread context classloader to shared classloader clojure.lang.DynamicClassLoader@167eab4...
03-31 23:23:36 INFO plugins.dependencies :: Metabase cannot initialize plugin Metabase Oracle Driver due to required dependencies. Metabase requires the Oracle JDBC driver in order to connect to Oracle databases, but we can't ship it as part of Metabase due to licensing restrictions. See https://metabase.com/docs/latest/administration-guide/databases/oracle.html for more details.

03-31 23:23:36 INFO plugins.dependencies :: Metabase Oracle Driver dependency {:class oracle.jdbc.OracleDriver} satisfied? false
03-31 23:23:36 INFO plugins.dependencies :: Plugins with unsatisfied deps: ["Metabase Oracle Driver"]
03-31 23:23:36 INFO plugins.lazy-loaded-driver :: Registering lazy loading driver :presto...
03-31 23:23:36 INFO metabase.driver :: Registered driver :presto (parents: #{:sql}) 🚚
03-31 23:23:36 INFO plugins.lazy-loaded-driver :: Registering lazy loading driver :redshift...
03-31 23:23:36 INFO metabase.driver :: Registered abstract driver :sql-jdbc (parents: :sql) 🚚
Load driver :sql-jdbc took 34 ms
03-31 23:23:36 INFO metabase.driver :: Registered driver :postgres (parents: :sql-jdbc) 🚚
Load driver :postgres took 383 ms
03-31 23:23:36 INFO metabase.driver :: Registered driver :redshift (parents: #{:postgres}) 🚚
03-31 23:23:36 INFO plugins.lazy-loaded-driver :: Registering lazy loading driver :snowflake...
03-31 23:23:36 INFO metabase.driver :: Registered driver :snowflake (parents: #{:sql-jdbc}) 🚚
03-31 23:23:36 INFO plugins.lazy-loaded-driver :: Registering lazy loading driver :hive-like...
03-31 23:23:36 INFO metabase.driver :: Registered abstract driver :hive-like (parents: #{:sql-jdbc}) 🚚
03-31 23:23:36 INFO plugins.lazy-loaded-driver :: Registering lazy loading driver :sparksql...
03-31 23:23:36 INFO metabase.driver :: Registered driver :sparksql (parents: #{:hive-like}) 🚚
03-31 23:23:36 INFO plugins.lazy-loaded-driver :: Registering lazy loading driver :sqlite...
03-31 23:23:36 INFO metabase.driver :: Registered driver :sqlite (parents: #{:sql-jdbc}) 🚚
03-31 23:23:36 INFO plugins.lazy-loaded-driver :: Registering lazy loading driver :sqlserver...
03-31 23:23:36 INFO metabase.driver :: Registered driver :sqlserver (parents: #{:sql-jdbc}) 🚚
03-31 23:23:36 INFO plugins.dependencies :: Metabase cannot initialize plugin Metabase Vertica Driver due to required dependencies. Metabase requires the Vertica JDBC driver in order to connect to Vertica databases, but we can't ship it as part of Metabase due to licensing restrictions. See https://metabase.com/docs/latest/administration-guide/databases/vertica.html for more details.

03-31 23:23:36 INFO plugins.dependencies :: Metabase Vertica Driver dependency {:class com.vertica.jdbc.Driver} satisfied? false
03-31 23:23:36 INFO plugins.dependencies :: Plugins with unsatisfied deps: ["Metabase Oracle Driver" "Metabase Vertica Driver"]
03-31 23:23:37 INFO metabase.driver :: Registered driver :h2 (parents: :sql-jdbc) 🚚
Load driver :h2 took 120 ms
03-31 23:23:37 INFO metabase.driver :: Registered driver :mysql (parents: :sql-jdbc) 🚚
Load driver :mysql took 150 ms
03-31 23:23:37 INFO metabase.core :: Setting up and migrating Metabase DB. Please sit tight, this may take a minute...
03-31 23:23:37 INFO metabase.db :: Verifying postgres Database Connection ...
03-31 23:23:37 INFO metabase.driver :: Initializing driver :sql...
03-31 23:23:37 INFO metabase.driver :: Initializing driver :sql-jdbc...
03-31 23:23:37 INFO metabase.driver :: Initializing driver :postgres...
Mar 31, 2019 11:23:37 PM org.postgresql.Driver parseURL
WARNING: JDBC URL invalid port number:
03-31 23:23:37 ERROR metabase.core :: Metabase Initialization FAILED
java.lang.Exception: java.sql.SQLException: No suitable driver found for jdbc:postgresql://localhost:/metabase
	at metabase.driver.util$can_connect_with_details_QMARK_.invokeStatic(util.clj:34)
	at metabase.driver.util$can_connect_with_details_QMARK_.doInvoke(util.clj:18)
	at clojure.lang.RestFn.invoke(RestFn.java:442)
	at clojure.lang.Var.invoke(Var.java:393)
	at metabase.db$verify_db_connection$fn__7726.invoke(db.clj:400)
	at metabase.db$verify_db_connection.invokeStatic(db.clj:398)
	at metabase.db$verify_db_connection.invoke(db.clj:391)
	at metabase.db$verify_db_connection.invokeStatic(db.clj:394)
	at metabase.db$verify_db_connection.invoke(db.clj:391)
	at metabase.db$setup_db_BANG_$fn__7743.invoke(db.clj:464)
	at metabase.util$do_with_us_locale.invokeStatic(util.clj:683)
	at metabase.util$do_with_us_locale.invoke(util.clj:669)
	at metabase.db$setup_db_BANG_.invokeStatic(db.clj:463)
	at metabase.db$setup_db_BANG_.doInvoke(db.clj:457)
	at clojure.lang.RestFn.invoke(RestFn.java:421)
	at metabase.core$init_BANG_.invokeStatic(core.clj:72)
	at metabase.core$init_BANG_.invoke(core.clj:51)
	at metabase.core$start_normally.invokeStatic(core.clj:118)
	at metabase.core$start_normally.invoke(core.clj:112)
	at metabase.core$_main.invokeStatic(core.clj:138)
	at metabase.core$_main.doInvoke(core.clj:133)
	at clojure.lang.RestFn.invoke(RestFn.java:397)
	at clojure.lang.Var.invoke(Var.java:380)
	at user$eval140.invokeStatic(form-init5718813295432078225.clj:1)
	at user$eval140.invoke(form-init5718813295432078225.clj:1)
	at clojure.lang.Compiler.eval(Compiler.java:7176)
	at clojure.lang.Compiler.eval(Compiler.java:7166)
	at clojure.lang.Compiler.load(Compiler.java:7635)
	at clojure.lang.Compiler.loadFile(Compiler.java:7573)
	at clojure.main$load_script.invokeStatic(main.clj:452)
	at clojure.main$init_opt.invokeStatic(main.clj:454)
	at clojure.main$init_opt.invoke(main.clj:454)
	at clojure.main$initialize.invokeStatic(main.clj:485)
	at clojure.main$null_opt.invokeStatic(main.clj:519)
	at clojure.main$null_opt.invoke(main.clj:516)
	at clojure.main$main.invokeStatic(main.clj:598)
	at clojure.main$main.doInvoke(main.clj:561)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.lang.Var.applyTo(Var.java:705)
	at clojure.main.main(main.java:37)
Caused by: java.util.concurrent.ExecutionException: java.sql.SQLException: No suitable driver found for jdbc:postgresql://localhost:/metabase
	at java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.util.concurrent.FutureTask.get(FutureTask.java:206)
	at clojure.core$deref_future.invokeStatic(core.clj:2302)
	at clojure.core$future_call$reify__8439.deref(core.clj:6974)
	at clojure.core$deref.invokeStatic(core.clj:2324)
	at clojure.core$deref.invoke(core.clj:2306)
	at metabase.util$deref_with_timeout.invokeStatic(util.clj:326)
	at metabase.util$deref_with_timeout.invoke(util.clj:323)
	at metabase.driver.util$can_connect_with_details_QMARK_.invokeStatic(util.clj:29)
	... 39 more
Caused by: java.sql.SQLException: No suitable driver found for jdbc:postgresql://localhost:/metabase
	at java.sql.DriverManager.getConnection(DriverManager.java:689)
	at java.sql.DriverManager.getConnection(DriverManager.java:208)
	at clojure.java.jdbc$get_driver_connection.invokeStatic(jdbc.clj:271)
	at clojure.java.jdbc$get_driver_connection.invoke(jdbc.clj:250)
	at clojure.java.jdbc$get_connection.invokeStatic(jdbc.clj:411)
	at clojure.java.jdbc$get_connection.invoke(jdbc.clj:274)
	at clojure.java.jdbc$db_query_with_resultset_STAR_.invokeStatic(jdbc.clj:1093)
	at clojure.java.jdbc$db_query_with_resultset_STAR_.invoke(jdbc.clj:1075)
	at clojure.java.jdbc$query.invokeStatic(jdbc.clj:1164)
	at clojure.java.jdbc$query.invoke(jdbc.clj:1126)
	at clojure.java.jdbc$query.invokeStatic(jdbc.clj:1142)
	at clojure.java.jdbc$query.invoke(jdbc.clj:1126)
	at metabase.driver.sql_jdbc.connection$can_connect_QMARK_.invokeStatic(connection.clj:123)
	at metabase.driver.sql_jdbc.connection$can_connect_QMARK_.invoke(connection.clj:118)
	at metabase.driver.sql_jdbc$eval69349$fn__69350.invoke(sql_jdbc.clj:39)
	at clojure.lang.MultiFn.invoke(MultiFn.java:234)
	at metabase.driver.util$can_connect_with_details_QMARK_$fn__19827.invoke(util.clj:30)
	at clojure.core$binding_conveyor_fn$fn__5739.invoke(core.clj:2030)
	at clojure.lang.AFn.call(AFn.java:18)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
03-31 23:23:37 INFO metabase.core :: Metabase Shutting Down ...
03-31 23:23:37 INFO metabase.core :: Metabase Shutdown COMPLETE
Error encountered performing task 'run' with profile(s): 'base,system,user,provided,dev,run'
Suppressed exit
```

Here the error actually starts with the meaningful `WARNING: JDBC URL invalid port number:`, however that was not printed in my production environment (Heroku) -- only the `java.lang.Exception: java.sql.SQLException: No suitable driver found for jdbc:postgresql://localhost:/metabase` error was printed.

</details>

#### Error if MySQL
<details><summary>Collapsed log output</summary>

```plaintext
> env MB_DB_CONNECTION_URI='mysql://root@localhost/metabase' lein run
Warning: implicit hook found: lein-environ.plugin/hooks
Hooks are deprecated and will be removed in a future version.
03-31 23:20:38 INFO metabase.util :: Loading Metabase...
03-31 23:20:38 INFO metabase.util :: Maximum memory available to JVM: 1.8 GB
03-31 23:20:47 DEBUG plugins.classloader :: Using Clojure base loader as shared context classloader: clojure.lang.DynamicClassLoader@525dd5af
03-31 23:20:52 INFO util.encryption :: Saved credentials encryption is DISABLED for this Metabase instance. 🔓
 For more information, see https://www.metabase.com/docs/latest/operations-guide/start.html#encrypting-your-database-connection-details-at-rest
03-31 23:21:01 INFO metabase.driver :: Registered abstract driver :sql  🚚
03-31 23:21:19 INFO metabase.core :: Starting Metabase in STANDALONE mode
03-31 23:21:19 INFO metabase.server :: Launching Embedded Jetty Webserver with config:
 {:async? true, :port 3000}

03-31 23:21:19 INFO metabase.core :: Starting Metabase version v0.32.0-snapshot (a24756a master) ...
03-31 23:21:19 INFO metabase.core :: System timezone is 'Europe/Copenhagen' ...
03-31 23:21:19 INFO metabase.plugins :: Loading plugins in /Users/malthe/OneDrive/Programming/Java/metabase/plugins...
03-31 23:21:19 INFO plugins.dependencies :: Plugin 'Metabase BigQuery Driver' depends on plugin 'Metabase Google Drivers Shared Dependencies'
03-31 23:21:19 INFO plugins.dependencies :: Metabase BigQuery Driver dependency {:plugin Metabase Google Drivers Shared Dependencies} satisfied? false
03-31 23:21:19 INFO plugins.dependencies :: Plugins with unsatisfied deps: ["Metabase BigQuery Driver"]
03-31 23:21:19 INFO plugins.lazy-loaded-driver :: Registering lazy loading driver :druid...
03-31 23:21:19 INFO metabase.driver :: Registered driver :druid  🚚
03-31 23:21:19 INFO plugins.lazy-loaded-driver :: Registering lazy loading driver :google...
03-31 23:21:19 INFO metabase.driver :: Registered abstract driver :google  🚚
03-31 23:21:19 INFO plugins.dependencies :: Metabase BigQuery Driver dependency {:plugin Metabase Google Drivers Shared Dependencies} satisfied? true
03-31 23:21:19 DEBUG plugins.initialize :: Dependencies satisfied; these plugins will now be loaded: ["Metabase BigQuery Driver"]
03-31 23:21:19 INFO plugins.lazy-loaded-driver :: Registering lazy loading driver :bigquery...
03-31 23:21:19 INFO metabase.driver :: Registered driver :bigquery (parents: #{:sql :google}) 🚚
03-31 23:21:19 INFO plugins.dependencies :: Plugin 'Metabase Google Analytics Driver' depends on plugin 'Metabase Google Drivers Shared Dependencies'
03-31 23:21:19 INFO plugins.dependencies :: Metabase Google Analytics Driver dependency {:plugin Metabase Google Drivers Shared Dependencies} satisfied? true
03-31 23:21:19 INFO plugins.lazy-loaded-driver :: Registering lazy loading driver :googleanalytics...
03-31 23:21:19 INFO metabase.driver :: Registered driver :googleanalytics (parents: #{:google}) 🚚
03-31 23:21:19 INFO plugins.lazy-loaded-driver :: Registering lazy loading driver :mongo...
03-31 23:21:19 INFO metabase.driver :: Registered driver :mongo  🚚
03-31 23:21:19 DEBUG plugins.classloader :: Setting current thread context classloader to shared classloader clojure.lang.DynamicClassLoader@525dd5af...
03-31 23:21:19 INFO plugins.dependencies :: Metabase cannot initialize plugin Metabase Oracle Driver due to required dependencies. Metabase requires the Oracle JDBC driver in order to connect to Oracle databases, but we can't ship it as part of Metabase due to licensing restrictions. See https://metabase.com/docs/latest/administration-guide/databases/oracle.html for more details.

03-31 23:21:19 INFO plugins.dependencies :: Metabase Oracle Driver dependency {:class oracle.jdbc.OracleDriver} satisfied? false
03-31 23:21:19 INFO plugins.dependencies :: Plugins with unsatisfied deps: ["Metabase Oracle Driver"]
03-31 23:21:19 INFO plugins.lazy-loaded-driver :: Registering lazy loading driver :presto...
03-31 23:21:19 INFO metabase.driver :: Registered driver :presto (parents: #{:sql}) 🚚
03-31 23:21:19 INFO plugins.lazy-loaded-driver :: Registering lazy loading driver :redshift...
03-31 23:21:19 INFO metabase.driver :: Registered abstract driver :sql-jdbc (parents: :sql) 🚚
Load driver :sql-jdbc took 45 ms
03-31 23:21:19 INFO metabase.driver :: Registered driver :postgres (parents: :sql-jdbc) 🚚
Load driver :postgres took 556 ms
03-31 23:21:20 INFO metabase.driver :: Registered driver :redshift (parents: #{:postgres}) 🚚
03-31 23:21:20 INFO plugins.lazy-loaded-driver :: Registering lazy loading driver :snowflake...
03-31 23:21:20 INFO metabase.driver :: Registered driver :snowflake (parents: #{:sql-jdbc}) 🚚
03-31 23:21:20 INFO plugins.lazy-loaded-driver :: Registering lazy loading driver :hive-like...
03-31 23:21:20 INFO metabase.driver :: Registered abstract driver :hive-like (parents: #{:sql-jdbc}) 🚚
03-31 23:21:20 INFO plugins.lazy-loaded-driver :: Registering lazy loading driver :sparksql...
03-31 23:21:20 INFO metabase.driver :: Registered driver :sparksql (parents: #{:hive-like}) 🚚
03-31 23:21:20 INFO plugins.lazy-loaded-driver :: Registering lazy loading driver :sqlite...
03-31 23:21:20 INFO metabase.driver :: Registered driver :sqlite (parents: #{:sql-jdbc}) 🚚
03-31 23:21:20 INFO plugins.lazy-loaded-driver :: Registering lazy loading driver :sqlserver...
03-31 23:21:20 INFO metabase.driver :: Registered driver :sqlserver (parents: #{:sql-jdbc}) 🚚
03-31 23:21:20 INFO plugins.dependencies :: Metabase cannot initialize plugin Metabase Vertica Driver due to required dependencies. Metabase requires the Vertica JDBC driver in order to connect to Vertica databases, but we can't ship it as part of Metabase due to licensing restrictions. See https://metabase.com/docs/latest/administration-guide/databases/vertica.html for more details.

03-31 23:21:20 INFO plugins.dependencies :: Metabase Vertica Driver dependency {:class com.vertica.jdbc.Driver} satisfied? false
03-31 23:21:20 INFO plugins.dependencies :: Plugins with unsatisfied deps: ["Metabase Oracle Driver" "Metabase Vertica Driver"]
03-31 23:21:20 INFO metabase.driver :: Registered driver :h2 (parents: :sql-jdbc) 🚚
Load driver :h2 took 131 ms
03-31 23:21:20 INFO metabase.driver :: Registered driver :mysql (parents: :sql-jdbc) 🚚
Load driver :mysql took 176 ms
03-31 23:21:20 INFO metabase.core :: Setting up and migrating Metabase DB. Please sit tight, this may take a minute...
03-31 23:21:20 INFO metabase.db :: Verifying mysql Database Connection ...
03-31 23:21:20 INFO metabase.driver :: Initializing driver :sql...
03-31 23:21:20 INFO metabase.driver :: Initializing driver :sql-jdbc...
03-31 23:21:20 INFO metabase.driver :: Initializing driver :mysql...
03-31 23:21:20 ERROR metabase.core :: Metabase Initialization FAILED
java.lang.Exception: java.lang.ArrayIndexOutOfBoundsException: 1
	at metabase.driver.util$can_connect_with_details_QMARK_.invokeStatic(util.clj:34)
	at metabase.driver.util$can_connect_with_details_QMARK_.doInvoke(util.clj:18)
	at clojure.lang.RestFn.invoke(RestFn.java:442)
	at clojure.lang.Var.invoke(Var.java:393)
	at metabase.db$verify_db_connection$fn__7726.invoke(db.clj:400)
	at metabase.db$verify_db_connection.invokeStatic(db.clj:398)
	at metabase.db$verify_db_connection.invoke(db.clj:391)
	at metabase.db$verify_db_connection.invokeStatic(db.clj:394)
	at metabase.db$verify_db_connection.invoke(db.clj:391)
	at metabase.db$setup_db_BANG_$fn__7743.invoke(db.clj:464)
	at metabase.util$do_with_us_locale.invokeStatic(util.clj:683)
	at metabase.util$do_with_us_locale.invoke(util.clj:669)
	at metabase.db$setup_db_BANG_.invokeStatic(db.clj:463)
	at metabase.db$setup_db_BANG_.doInvoke(db.clj:457)
	at clojure.lang.RestFn.invoke(RestFn.java:421)
	at metabase.core$init_BANG_.invokeStatic(core.clj:72)
	at metabase.core$init_BANG_.invoke(core.clj:51)
	at metabase.core$start_normally.invokeStatic(core.clj:118)
	at metabase.core$start_normally.invoke(core.clj:112)
	at metabase.core$_main.invokeStatic(core.clj:138)
	at metabase.core$_main.doInvoke(core.clj:133)
	at clojure.lang.RestFn.invoke(RestFn.java:397)
	at clojure.lang.Var.invoke(Var.java:380)
	at user$eval140.invokeStatic(form-init2562989835553408732.clj:1)
	at user$eval140.invoke(form-init2562989835553408732.clj:1)
	at clojure.lang.Compiler.eval(Compiler.java:7176)
	at clojure.lang.Compiler.eval(Compiler.java:7166)
	at clojure.lang.Compiler.load(Compiler.java:7635)
	at clojure.lang.Compiler.loadFile(Compiler.java:7573)
	at clojure.main$load_script.invokeStatic(main.clj:452)
	at clojure.main$init_opt.invokeStatic(main.clj:454)
	at clojure.main$init_opt.invoke(main.clj:454)
	at clojure.main$initialize.invokeStatic(main.clj:485)
	at clojure.main$null_opt.invokeStatic(main.clj:519)
	at clojure.main$null_opt.invoke(main.clj:516)
	at clojure.main$main.invokeStatic(main.clj:598)
	at clojure.main$main.doInvoke(main.clj:561)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.lang.Var.applyTo(Var.java:705)
	at clojure.main.main(main.java:37)
Caused by: java.util.concurrent.ExecutionException: java.lang.ArrayIndexOutOfBoundsException: 1
	at java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.util.concurrent.FutureTask.get(FutureTask.java:206)
	at clojure.core$deref_future.invokeStatic(core.clj:2302)
	at clojure.core$future_call$reify__8439.deref(core.clj:6974)
	at clojure.core$deref.invokeStatic(core.clj:2324)
	at clojure.core$deref.invoke(core.clj:2306)
	at metabase.util$deref_with_timeout.invokeStatic(util.clj:326)
	at metabase.util$deref_with_timeout.invoke(util.clj:323)
	at metabase.driver.util$can_connect_with_details_QMARK_.invokeStatic(util.clj:29)
	... 39 more
Caused by: java.lang.ArrayIndexOutOfBoundsException: 1
	at org.mariadb.jdbc.HostAddress.parseSimpleHostAddress(HostAddress.java:167)
	at org.mariadb.jdbc.HostAddress.parse(HostAddress.java:138)
	at org.mariadb.jdbc.UrlParser.defineUrlParserParameters(UrlParser.java:268)
	at org.mariadb.jdbc.UrlParser.parseInternal(UrlParser.java:205)
	at org.mariadb.jdbc.UrlParser.parse(UrlParser.java:160)
	at org.mariadb.jdbc.Driver.connect(Driver.java:88)
	at java.sql.DriverManager.getConnection(DriverManager.java:664)
	at java.sql.DriverManager.getConnection(DriverManager.java:208)
	at clojure.java.jdbc$get_driver_connection.invokeStatic(jdbc.clj:271)
	at clojure.java.jdbc$get_driver_connection.invoke(jdbc.clj:250)
	at clojure.java.jdbc$get_connection.invokeStatic(jdbc.clj:411)
	at clojure.java.jdbc$get_connection.invoke(jdbc.clj:274)
	at clojure.java.jdbc$db_query_with_resultset_STAR_.invokeStatic(jdbc.clj:1093)
	at clojure.java.jdbc$db_query_with_resultset_STAR_.invoke(jdbc.clj:1075)
	at clojure.java.jdbc$query.invokeStatic(jdbc.clj:1164)
	at clojure.java.jdbc$query.invoke(jdbc.clj:1126)
	at clojure.java.jdbc$query.invokeStatic(jdbc.clj:1142)
	at clojure.java.jdbc$query.invoke(jdbc.clj:1126)
	at metabase.driver.sql_jdbc.connection$can_connect_QMARK_.invokeStatic(connection.clj:123)
	at metabase.driver.sql_jdbc.connection$can_connect_QMARK_.invoke(connection.clj:118)
	at metabase.driver.sql_jdbc$eval69349$fn__69350.invoke(sql_jdbc.clj:39)
	at clojure.lang.MultiFn.invoke(MultiFn.java:234)
	at metabase.driver.util$can_connect_with_details_QMARK_$fn__19827.invoke(util.clj:30)
	at clojure.core$binding_conveyor_fn$fn__5739.invoke(core.clj:2030)
	at clojure.lang.AFn.call(AFn.java:18)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
03-31 23:21:20 INFO metabase.core :: Metabase Shutting Down ...
03-31 23:21:20 INFO metabase.core :: Metabase Shutdown COMPLETE
Error encountered performing task 'run' with profile(s): 'base,system,user,provided,dev,run'
Suppressed exit
```

</details>

### Solutions

A couple of solutions are possible:

- Disallow omitting the port for these databases. By that I mean -- fail earlier (around `jdbc-connection-regex`) -- which should allow improving the error message
- Allow omitting the port

This PR implements the latter, making it such that the port _can_ be omitted, defaulting to port 5432 for Postgres and 3306 for MySQL.

### Tests
-  [x] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [x] If there are changes to the backend codebase, run the backend tests with `lein test && lein eastwood && lein bikeshed && lein docstring-checker && lein check-namespace-decls && ./bin/reflection-linter`

-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
