### PR TITLE
Fix race condition where Oracle/Vertica drivers might not load

### DIFF
--- a/src/metabase/plugins/files.clj
+++ b/src/metabase/plugins/files.clj
@@ -122,6 +122,13 @@
 ;;; |                                               JAR FILE CONTENTS                                                |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
+(defn file-exists-in-archive?
+  "True is a file exists in an archive."
+  [^Path archive-path & path-components]
+  (with-open [fs (FileSystems/newFileSystem archive-path (ClassLoader/getSystemClassLoader))]
+    (let [file-path (apply get-path-in-filesystem fs path-components)]
+      (exists? file-path))))
+
 (defn slurp-file-from-archive
   "Read the entire contents of a file from a archive (such as a JAR)."
   [^Path archive-path & path-components]


### PR DESCRIPTION
Oracle and Vertica drivers cannot be initialized unless 3rd-party required dependencies (i.e. Oracle JDBC driver JAR) are present and added to the classpath. Normally, if these drivers cannot be initialized when first encountered, preconditions for initialization are rechecked after subsequent plugins are loaded. However, the recheck was not triggered by non-Metabase-plugin JARs, such as the Oracle JDBC driver JAR.

Thus it is possible that if the Oracle JDBC driver JAR is the very last JAR loaded the Metabase Oracle driver preconditions will not pre rechecked and the driver will not be loaded. If any Metabase plugin JAR is loaded last the preconditions will be properly checked and the Oracle driver will load properly.

Fixes race condition by ensuring all non-Metabase-plugin JARs are loaded first