### PR TITLE
Adds table name and foreign key name to more column field options

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
@@ -162,6 +162,7 @@ export default class ChartSettingOrderedColumns extends Component {
             {additionalFieldOptions.fks.map(fk => (
               <div>
                 <div className="my2 text-medium text-bold text-uppercase text-small">
+                  {fk.field.table.display_name}.{fk.field.display_name} ->{" "}
                   {fk.field.target.table.display_name}
                 </div>
                 {fk.dimensions.map((dimension, index) => (


### PR DESCRIPTION
Adds table name and foreign key name to more column field options

Pretty simple. Solves an issue where a table has multiple references to the same table from different keys.

### Tests
-  [ ✅] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [ ✅] If there are changes to the backend codebase, run the backend tests with `lein test && lein eastwood && lein bikeshed && lein docstring-checker && lein check-namespace-decls && ./bin/reflection-linter`


-  [✅ ] Sign the [Contributor License Agreement]
