### PR TITLE
Region map: k-means choropleth coloring fix for small number of rows

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -239,7 +239,11 @@ export default class ChoroplethMap extends Component {
       domain.push(getRowValue(row));
     }
 
-    const heatMapColors = settings["map.colors"] || HEAT_MAP_COLORS;
+    const _heatMapColors = settings["map.colors"] || HEAT_MAP_COLORS;
+    const heatMapColors =
+      domain.length < _heatMapColors.length
+        ? _heatMapColors.slice(_heatMapColors.length - domain.length)
+        : _heatMapColors;
 
     const groups = ss.ckmeans(domain, heatMapColors.length);
 


### PR DESCRIPTION
Hi! This PR is trying to fix https://github.com/metabase/metabase/issues/4684

I'm picking colors from the end to make map brighter. 