### PR TITLE
Make filter operator selector non-gray

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx
@@ -341,9 +341,9 @@ export default class FilterPopover extends Component {
           }}
         >
           {showHeader && (
-            <div className="FilterPopover-header border-bottom text-medium p1 flex align-center">
+            <div className="FilterPopover-header border-bottom p1 flex align-center">
               {showFieldPicker && (
-                <div className="flex py1">
+                <div className="flex py1 text-medium">
                   <span
                     className="cursor-pointer text-purple-hover transition-color flex align-center"
                     onClick={this.clearField}


### PR DESCRIPTION
Fixes #7429, so now it looks like this:
![image](https://user-images.githubusercontent.com/1447303/55663217-1e6f3580-580b-11e9-9d5a-cff1b686e022.png)

*Had to redo the PR, since I had pushed the commit on master instead of a branch, so every time I synced master it would add those commits to the PR - still trying to figure out Git*