### PR TITLE
Re: Change SQL Server driver getutcdate to getdate

### DIFF
--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -218,7 +218,7 @@
 (defmethod driver/current-db-time :sqlserver [& args]
   (apply driver.common/current-db-time args))
 
-(defmethod sql.qp/current-datetime-fn :sqlserver [_] :%getutcdate)
+(defmethod sql.qp/current-datetime-fn :sqlserver [_] :%getdate)
 
 ;; SQLServer LIKE clauses are case-sensitive or not based on whether the collation of the server and the columns
 ;; themselves. Since this isn't something we can really change in the query itself don't present the option to the


### PR DESCRIPTION
This is a second patch for #8326 - have been using it in production for a week, no problems noticed.

On 0.32.1 I did a QB filtering on date=Today and didn't get any results, then I checked the SQL:
```
WHERE CAST(CAST("dbo"."Facturas"."fecha" AS date) AS datetime) = CAST(CAST(getutcdate() AS date) AS datetime) 
```
I then tried to compile a driver with `getutcdate` changed to `getdate` and now the SQL is:
```
WHERE CAST(CAST("dbo"."Facturas"."fecha" AS date) AS datetime) = CAST(CAST(getdate() AS date) AS datetime) 
```