### PR TITLE
Stop loading GA script if Anonymous Tracking is opt-out

### DIFF
--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -80,19 +80,17 @@
         </script>
 
         <script type="text/javascript">
-            (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-            })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-            // if we are not doing tracking then go ahead and disable GA now so we never even track the initial pageview
+            // if Anonymous Tracking is opt-out, then do not load script
             const tracking = window.MetabaseBootstrap.anon_tracking_enabled;
-            const ga_code = window.MetabaseBootstrap.ga_code;
-            if (!tracking) {
-                window['ga-disable-'+ga_code] = true;
-            }
+            if (tracking) {
+                (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+                })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-            ga('create', ga_code, 'auto');
+                const ga_code = window.MetabaseBootstrap.ga_code;
+                ga('create', ga_code, 'auto');
+            }
         </script>
     </body>
 </html>


### PR DESCRIPTION
Fixes #9464 
By default, tracking is opt-in and will load the script at setup, but changing to opt-out will disable tracking on that browser session and on browser reload, it will stop loading the script.
It will take a browser reload to activate tracking if changed from opt-out to opt-in.