### PR TITLE
Fix table/field display names in Data Reference

### DIFF
--- a/frontend/src/metabase/query_builder/components/dataref/DatabasePane.jsx
+++ b/frontend/src/metabase/query_builder/components/dataref/DatabasePane.jsx
@@ -24,7 +24,7 @@ const DatabasePane = ({ database, show, ...props }) => (
             className="flex-full flex p1 text-bold text-brand no-decoration bg-medium-hover"
             onClick={() => show("table", table)}
           >
-            {table.name}
+            {table.display_name}
           </a>
         </li>
       ))}

--- a/frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx
+++ b/frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx
@@ -19,7 +19,7 @@ const DetailPane = ({ name, description, extra, values }) => (
     {values &&
       values.length > 0 && (
         <div>
-          <h5 className="text-uppercase mt4 mb2">Sample values</h5>
+          <h5 className="text-uppercase mt4 mb2">{t`Sample values`}</h5>
           <Card>
             <ul>
               {values.map((value, i) => (

--- a/frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx
+++ b/frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx
@@ -136,8 +136,8 @@ export default class FieldPane extends Component {
       query.metadata().fields[field.id] &&
       query.metadata().fields[field.id].values;
 
-    let fieldName = field.name;
-    let tableName = query.table() ? query.table().name : "";
+    let fieldName = field.display_name;
+    let tableName = query.table() ? query.table().display_name : "";
 
     let useForCurrentQuestion = [],
       usefulQuestions = [];

--- a/frontend/src/metabase/query_builder/components/dataref/TablePane.jsx
+++ b/frontend/src/metabase/query_builder/components/dataref/TablePane.jsx
@@ -138,7 +138,7 @@ export default class TablePane extends Component {
                   onClick={() => this.props.show(itemType, item)}
                   className="flex-full flex p1 text-bold text-brand no-decoration bg-medium-hover"
                 >
-                  {item.name}
+                  {item.display_name}
                 </a>
               </li>
             ))}
@@ -151,7 +151,7 @@ export default class TablePane extends Component {
           <div className="ml1">
             <div className="flex align-center">
               <Icon name="table2" className="text-medium pr1" size={16} />
-              <h3>{table.name}</h3>
+              <h3>{table.display_name}</h3>
             </div>
             {description}
             <div className="my2 Button-group Button-group--brand text-uppercase">


### PR DESCRIPTION
The Data Reference shows table/field as `name` instead of `display_name` + a missing translation.