### PR TITLE
Update Operations Guides documentation

### DIFF
--- a/docs/operations-guide/start.md
+++ b/docs/operations-guide/start.md
@@ -85,6 +85,8 @@ The application database is where Metabase stores information about users, saved
 
 #### [H2](http://www.h2database.com/) (default)
 
+**For production installations of Metabase we recommend that users replace the H2 database with a more robust option such as Postgres.** This offers a greater degree of performance and reliability when Metabase is running with many users.
+
 To use the H2 database for your Metabase instance you don't need to do anything at all.  When the application is first launched it will attempt to create a new H2 database in the same filesystem location the application is launched from.
 
 You can see these database files from the terminal:
@@ -105,8 +107,6 @@ If for any reason you want to use an H2 database file in a separate location fro
 Note that H2 automatically appends `.mv.db` or `.h2.db` to the path you specify; do not include those in you path! In other words, `MB_DB_FILE` should be something like `/path/to/metabase.db`, rather than something like `/path/to/metabase.db.mv.db` (even though this is the file that actually gets created).
 
 #### [Postgres](http://www.postgresql.org/)
-
-**For production installations of Metabase we recommend that users replace the H2 database with a more robust option such as Postgres.** This offers a greater degree of performance and reliability when Metabase is running with many users.
 
 You can change the application database to use Postgres using a few simple environment variables. For example:
 

--- a/docs/operations-guide/start.md
+++ b/docs/operations-guide/start.md
@@ -83,8 +83,6 @@ The application database is where Metabase stores information about users, saved
 
 **NOTE:** you cannot change the application database while the application is running.  these values are read only once when the application starts up and will remain constant throughout the running of the application.
 
-**NOTE:** currently Metabase does not provide automated support for migrating data from one application database to another, so if you start with H2 and then want to move to Postgres you'll have to dump the data from H2 and import it into Postgres before relaunching the application.
-
 #### [H2](http://www.h2database.com/) (default)
 
 To use the H2 database for your Metabase instance you don't need to do anything at all.  When the application is first launched it will attempt to create a new H2 database in the same filesystem location the application is launched from.
@@ -344,4 +342,4 @@ Diagnosing performance related issues can be a challenge. Luckily the JVM ships 
 
 # Java Versions
 
-Metabase will run on Java version 8, 9, or 10. Java 11 support is still a work in progress, so please be patient while we get everything working.
+Metabase will run on Java 8 and Java 11.


### PR DESCRIPTION
Fixes #9713
- Remove note about manual migration

Also changes
- Java support to 8 and 11
- Move recommendation about not using H2 to the H2 section