### PR TITLE
Dont migrate task_history from H2 -> Postgres/MySQL

### DIFF
--- a/src/metabase/cmd/load_from_h2.clj
+++ b/src/metabase/cmd/load_from_h2.clj
@@ -52,7 +52,6 @@
              [session :refer [Session]]
              [setting :refer [Setting]]
              [table :refer [Table]]
-             [task-history :refer [TaskHistory]]
              [user :refer [User]]
              [view-log :refer [ViewLog]]]))
 
@@ -94,7 +93,6 @@
    CollectionRevision
    DashboardFavorite
    Dimension
-   TaskHistory
    ;; migrate the list of finished DataMigrations as the very last thing (all models to copy over should be listed
    ;; above this line)
    DataMigrations])

--- a/test/metabase/cmd/load_from_h2_test.clj
+++ b/test/metabase/cmd/load_from_h2_test.clj
@@ -12,7 +12,8 @@
 
 (def ^:private models-to-exclude
   "Models that should *not* be migrated in `load-from-h2`."
-  #{"Query"
+  #{"TaskHistory"
+    "Query"
     "QueryCache"
     "QueryExecution"})
 


### PR DESCRIPTION
This table isn't something that needs to be migrated by the H2 -> Postgres/MySQL tool