### PR TITLE
Better error handling when saving TaskHistory fails 

### DIFF
--- a/src/metabase/task/task_history_cleanup.clj
+++ b/src/metabase/task/task_history_cleanup.clj
@@ -9,7 +9,7 @@
             [metabase.util.i18n :refer [trs]]))
 
 (def ^:private history-rows-to-keep
-  "Maximum number of TaskHistory rows. This is not a `const` so that we can redef it in tests"
+  "Maximum number of TaskHistory rows."
   100000)
 
 (defn- task-history-cleanup! []


### PR DESCRIPTION
On Heroku Hobby dyno DBs are limited to 10k rows per Table and we currently limit TaskHistory to 100k rows, so things break after you've been running for a while.

Add error handling around the DB `insert!` operations because failure to insert row(s) into TaskHistory should not affect anything else as the operation is not critical 