### PR TITLE
Add file: prefix if needed when running load-from-h2 

### DIFF
--- a/src/metabase/cmd/load_from_h2.clj
+++ b/src/metabase/cmd/load_from_h2.clj
@@ -14,7 +14,10 @@
    mysql -u root -e 'DROP DATABASE IF EXISTS metabase; CREATE DATABASE metabase;'
    MB_DB_TYPE=mysql MB_DB_HOST=localhost MB_DB_PORT=3305 MB_DB_USER=root MB_DB_DBNAME=metabase lein run load-from-h2
    ```"
-  (:require [clojure.java.jdbc :as jdbc]
+  (:require [clojure.java
+             [io :as io]
+             [jdbc :as jdbc]]
+            [clojure.string :as str]
             [colorize.core :as color]
             [medley.core :as m]
             [metabase
@@ -99,9 +102,13 @@
    ;; above this line)
    DataMigrations])
 
+(defn- add-file-prefix-if-needed [connection-string-or-filename]
+  (if (str/starts-with? connection-string-or-filename "file:")
+    connection-string-or-filename
+    (str "file:" (.getAbsolutePath (io/file connection-string-or-filename)))))
 
 (defn- h2-details [h2-connection-string-or-nil]
-  (let [h2-filename (or h2-connection-string-or-nil @metabase.db/db-file)]
+  (let [h2-filename (add-file-prefix-if-needed (or h2-connection-string-or-nil @metabase.db/db-file))]
     (mdb/jdbc-details {:type :h2, :db (str h2-filename ";IFEXISTS=TRUE")})))
 
 

--- a/test/metabase/cmd/load_from_h2_test.clj
+++ b/test/metabase/cmd/load_from_h2_test.clj
@@ -1,8 +1,24 @@
 (ns metabase.cmd.load-from-h2-test
-  (:require [expectations :refer :all]
-            metabase.cmd.load-from-h2
+  (:require [expectations :refer [expect]]
+            [metabase.cmd.load-from-h2 :as load-from-h2]
             [metabase.util :as u]
             [toucan.models :as models]))
+
+;; Make sure load-from-h2 works with or without `file:` prefix
+(expect
+  {:classname   "org.h2.Driver"
+   :subprotocol "h2"
+   :subname     "file:/path/to/metabase.db;IFEXISTS=TRUE"
+   :type        :h2}
+  (#'load-from-h2/h2-details "/path/to/metabase.db"))
+
+(expect
+  {:classname "org.h2.Driver"
+   :subprotocol "h2"
+   :subname     "file:/path/to/metabase.db;IFEXISTS=TRUE"
+   :type        :h2}
+  (#'load-from-h2/h2-details "file:/path/to/metabase.db"))
+
 
 ;; Check to make sure we're migrating all of our entities.
 ;; This fetches the `metabase.cmd.load-from-h2/entities` and compares it all existing entities


### PR DESCRIPTION
Not sure H2 actually cares but if someone runs `load-from-h2` and doesn't include the `file:` prefix in front of the H2 DB filename add it for them. Includes tests