### PR TITLE
MBQL sum-where

### DIFF
--- a/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
@@ -459,7 +459,8 @@
 
 (defn- ag:filtered  [filtr aggregator] {:type :filtered, :filter filtr, :aggregator aggregator})
 
-(defn- ag:distinct [field output-name]
+(defn- ag:distinct
+  [field output-name]
   (if (isa? (:base-type field) :type/DruidHyperUnique)
     {:type      :hyperUnique
      :name      output-name
@@ -477,7 +478,12 @@
   ([pred output-name] (ag:filtered (parse-filter pred)
                                    (ag:count output-name))))
 
-(defn- create-aggregation-clause [output-name ag-type ag-field]
+(defn- ag:sumWhere
+  ([field pred output-name] (ag:filtered (parse-filter pred)
+                                         (ag:sum field output-name))))
+
+(defn- create-aggregation-clause
+  [output-name ag-type ag-field args]
   (let [output-name-kwd (keyword output-name)]
     (match [ag-type ag-field]
       ;; For 'distinct values' queries (queries with a breakout by no aggregation) just aggregate by count, but name
@@ -498,6 +504,10 @@
                                                :fn     :/
                                                :fields [{:type :fieldAccess, :fieldName sum-name}
                                                         {:type :fieldAccess, :fieldName count-name}]}]}])
+
+      [:sum-where _]   (let [[pred] args]
+                         [[(or output-name-kwd :sum-where)]
+                          {:aggregations [(ag:sumWhere ag-field pred output-name-kwd)]}])
 
       [:count-where _] [[(or output-name-kwd :count-where)]
                         {:aggregations [(ag:countWhere ag-field output-name-kwd)]}]
@@ -524,12 +534,12 @@
 
 (defn- handle-aggregation [query-type ag-clause updated-query]
   (let [output-name        (annotate/aggregation-name ag-clause)
-        [ag-type ag-field] (mbql.u/match-one ag-clause
-                             [:named ag _] (recur ag)
-                             [_ _]         &match)]
+        [ag-type ag-field & args] (mbql.u/match-one ag-clause
+                                                    [:named ag _] (recur ag)
+                                                    [_ _ & _]     &match)]
     (if-not (isa? query-type ::ag-query)
       updated-query
-      (let [[projections ag-clauses] (create-aggregation-clause output-name ag-type ag-field)]
+      (let [[projections ag-clauses] (create-aggregation-clause output-name ag-type ag-field args)]
         (-> updated-query
             (update :projections #(vec (concat % projections)))
             (update :query #(merge-with concat % ag-clauses)))))))

--- a/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
@@ -480,7 +480,7 @@
 
 (defn- ag:sumWhere
   ([field pred output-name] (ag:filtered (parse-filter pred)
-                                         (ag:sum field output-name))))
+                                         (ag:doubleSum field output-name))))
 
 (defn- create-aggregation-clause
   [output-name ag-type ag-field args]

--- a/modules/drivers/druid/test/metabase/driver/druid_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid_test.clj
@@ -202,13 +202,13 @@
 
 ;; count-where
 (expect-with-driver :druid
-  [[17.0]]
+  [[951]]
   (druid-query-returning-rows
    {:aggregation [[:count-where [:< $venue_price 4]]]}))
 
 ;; sum-where
 (expect-with-driver :druid
-  [[179.0]]
+  [[1796.0]]
   (druid-query-returning-rows
    {:aggregation [[:sum-where $venue_price [:< $venue_price 4]]]}))
 

--- a/modules/drivers/druid/test/metabase/driver/druid_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid_test.clj
@@ -198,7 +198,19 @@
 (expect-with-driver :druid
   [[0.951]]
   (druid-query-returning-rows
-    {:aggregation [[:share [:< $venue_price 4]]]}))
+   {:aggregation [[:share [:< $venue_price 4]]]}))
+
+;; count-where
+(expect-with-driver :druid
+  [[17.0]]
+  (druid-query-returning-rows
+   {:aggregation [[:count-where [:< $venue_price 4]]]}))
+
+;; sum-where
+(expect-with-driver :druid
+  [[179.0]]
+  (druid-query-returning-rows
+   {:aggregation [[:sum-where $venue_price [:< $venue_price 4]]]}))
 
 ;; post-aggregation math w/ 2 args: count + sum
 (expect-with-driver :druid

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -389,7 +389,7 @@
 
 ;;; -------------------------------------------------- aggregation ---------------------------------------------------
 
-(defn- aggregation->rvalue [[aggregation-type arg]]
+(defn- aggregation->rvalue [[aggregation-type arg & args]]
   {:pre [(keyword? aggregation-type)]}
   (if-not arg
     (case aggregation-type
@@ -404,9 +404,11 @@
       :sum         {$sum (->rvalue arg)}
       :min         {$min (->rvalue arg)}
       :max         {$max (->rvalue arg)}
-      :count-where {$sum {$cond {:if   (parse-cond arg)
-                                 :then 1
-                                 :else 0}}})))
+      :sum-where   (let [[pred] args]
+                     {$sum {$cond {:if   (parse-cond pred)
+                                   :then (->rvalue arg)
+                                   :else 0}}})
+      :count-where (recur [:sum-where 1 arg]))))
 
 (defn- unwrap-named-ag [[ag-type arg :as ag]]
   (if (= ag-type :named)

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -408,7 +408,7 @@
                      {$sum {$cond {:if   (parse-cond pred)
                                    :then (->rvalue arg)
                                    :else 0}}})
-      :count-where (recur [:sum-where 1 arg]))))
+      :count-where (recur [:sum-where [:value 1] arg]))))
 
 (defn- unwrap-named-ag [[ag-type arg :as ag]]
   (if (= ag-type :named)

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -244,11 +244,15 @@
                                          (hsql/call := arg 0) nil
                                          :else                arg)))))
 
+(defmethod ->honeysql [:sql :sum-where]
+  [driver [_ arg pred]]
+  (hsql/call :sum (hsql/call :case
+                    (->honeysql driver pred) (->honeysql driver arg)
+                    :else                    0.0)))
+
 (defmethod ->honeysql [:sql :count-where]
   [driver [_ pred]]
-  (hsql/call :sum (hsql/call :case
-                    (->honeysql driver pred) 1.0
-                    :else                    0.0)))
+  (->honeysql driver [:sum-where 1 pred]))
 
 (defmethod ->honeysql [:sql :share]
   [driver [_ pred]]

--- a/src/metabase/mbql/normalize.clj
+++ b/src/metabase/mbql/normalize.clj
@@ -367,6 +367,9 @@
     [(ag-type :guard #{:share :count-where}) pred]
     [ag-type (canonicalize-filter pred)]
 
+    [:sum-where field pred]
+    [:sum-where (wrap-implicit-field-id field) (canonicalize-filter pred)]
+
     ;; something with an arg like [:sum [:field-id 41]]
     [ag-type field]
     [ag-type (wrap-implicit-field-id field)]))

--- a/src/metabase/mbql/schema.clj
+++ b/src/metabase/mbql/schema.clj
@@ -407,6 +407,7 @@
 (defclause ^{:requires-features #{:basic-aggregations}} sum,         field-or-expression FieldOrExpressionDef)
 (defclause ^{:requires-features #{:basic-aggregations}} min,         field-or-expression FieldOrExpressionDef)
 (defclause ^{:requires-features #{:basic-aggregations}} max,         field-or-expression FieldOrExpressionDef)
+(defclause ^{:requires-features #{:basic-aggregations}} sum-where,   field-or-expression FieldOrExpressionDef, pred Filter)
 (defclause ^{:requires-features #{:basic-aggregations}} count-where, pred Filter)
 (defclause ^{:requires-features #{:basic-aggregations}} share,       pred Filter)
 
@@ -442,7 +443,7 @@
 ;; ag:/ isn't a valid token
 
 (def ^:private UnnamedAggregation
-  (one-of count avg cum-count cum-sum distinct stddev sum min max ag:+ ag:- ag:* ag:div metric share count-where))
+  (one-of count avg cum-count cum-sum distinct stddev sum min max ag:+ ag:- ag:* ag:div metric share count-where sum-where))
 
 ;; any sort of aggregation can be wrapped in a `[:named <ag> <custom-name>]` clause, but you cannot wrap a `:named` in
 ;; a `:named`

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -193,6 +193,11 @@
             :special_type :type/Number}
            (ag->name-info &match))
 
+    [:share _]
+    (merge {:base_type    :type/Float
+            :special_type :type/Number}
+           (ag->name-info &match))
+
     ;; get info from a Field if we can (theses Fields are matched when ag clauses recursively call
     ;; `col-info-for-ag-clause`, and this info is added into the results)
     [(_ :guard #{:field-id :field-literal :fk-> :datetime-field :expression :binning-strategy}) & _]

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -188,6 +188,11 @@
             :special_type :type/Number}
            (ag->name-info &match))
 
+    [:count-where _]
+    (merge {:base_type    :type/Integer
+            :special_type :type/Number}
+           (ag->name-info &match))
+
     ;; get info from a Field if we can (theses Fields are matched when ag clauses recursively call
     ;; `col-info-for-ag-clause`, and this info is added into the results)
     [(_ :guard #{:field-id :field-literal :fk-> :datetime-field :expression :binning-strategy}) & _]
@@ -204,7 +209,7 @@
              (ag->name-info &match)))
 
     ;; get name/display-name of this ag
-    [(_ :guard keyword?) arg]
+    [(_ :guard keyword?) arg & args]
     (merge (col-info-for-aggregation-clause arg)
            (ag->name-info &match))))
 

--- a/test/metabase/query_processor_test/count_where_test.clj
+++ b/test/metabase/query_processor_test/count_where_test.clj
@@ -14,7 +14,8 @@
   (->> {:aggregation [[:count-where [:< [:field-id (data/id :venues :price)] 4]]]}
        (data/run-mbql-query venues)
        rows
-       ffirst))
+       ffirst
+       long))
 
 ;; Test normalization
 (datasets/expect-with-drivers (non-timeseries-drivers-with-feature :basic-aggregations)
@@ -22,7 +23,8 @@
   (->> {:aggregation [["count-where" ["<" ["field-id" (data/id :venues :price)] 4]]]}
        (data/run-mbql-query venues)
        rows
-       ffirst))
+       ffirst
+       long))
 
 (datasets/expect-with-drivers (non-timeseries-drivers-with-feature :basic-aggregations)
   17
@@ -31,7 +33,8 @@
                                       [:ends-with [:field-id (data/id :venues :name)] "t"]]]]]}
        (data/run-mbql-query venues)
        rows
-       ffirst))
+       ffirst
+       long))
 
 (datasets/expect-with-drivers (non-timeseries-drivers-with-feature :basic-aggregations)
   nil
@@ -53,14 +56,15 @@
        (tu/round-all-decimals 2)
        rows
        (map (fn [[k v]]
-              [(long k) v]))))
+              [(long k) (long v)]))))
 
 (datasets/expect-with-drivers (non-timeseries-drivers-with-feature :basic-aggregations :expressions)
   48
   (->> {:aggregation [[:+ [:/ [:count-where [:< [:field-id (data/id :venues :price)] 4]] 2] 1]]}
        (data/run-mbql-query venues)
        rows
-       ffirst))
+       ffirst
+       long))
 
 (datasets/expect-with-drivers (non-timeseries-drivers-with-feature :basic-aggregations)
   94
@@ -70,7 +74,8 @@
     (->> {:aggregation [[:count-where [:segment segment-id]]]}
          (data/run-mbql-query venues)
          rows
-         ffirst)))
+         ffirst
+         long)))
 
 (datasets/expect-with-drivers (non-timeseries-drivers-with-feature :basic-aggregations)
   94
@@ -80,4 +85,5 @@
     (->> {:aggregation [[:metric metric-id]]}
          (data/run-mbql-query venues)
          rows
-         ffirst)))
+         ffirst
+         long)))

--- a/test/metabase/query_processor_test/sum_where_test.clj
+++ b/test/metabase/query_processor_test/sum_where_test.clj
@@ -61,7 +61,7 @@
               [(long k) (double v)]))))
 
 (datasets/expect-with-drivers (non-timeseries-drivers-with-feature :basic-aggregations :expressions)
-  90.5M
+  90.5
   (->> {:aggregation [[:+ [:/ [:sum-where [:field-id (data/id :venues :price)] [:< [:field-id (data/id :venues :price)] 4]] 2] 1]]}
        (data/run-mbql-query venues)
        rows
@@ -69,7 +69,7 @@
        double))
 
 (datasets/expect-with-drivers (non-timeseries-drivers-with-feature :basic-aggregations)
-  179.0M
+  179.0
   (tt/with-temp* [Segment [{segment-id :id} {:table_id   (data/id :venues)
                                              :definition {:source-table (data/id :venues)
                                                           :filter       [:< [:field-id (data/id :venues :price)] 4]}}]]
@@ -80,7 +80,7 @@
          double)))
 
 (datasets/expect-with-drivers (non-timeseries-drivers-with-feature :basic-aggregations)
-  179.0M
+  179.0
   (tt/with-temp* [Metric [{metric-id :id} {:table_id   (data/id :venues)
                                            :definition {:source-table (data/id :venues)
                                                         :aggregation  [:sum-where [:field-id (data/id :venues :price)] [:< [:field-id (data/id :venues :price)] 4]]}}]]

--- a/test/metabase/query_processor_test/sum_where_test.clj
+++ b/test/metabase/query_processor_test/sum_where_test.clj
@@ -1,4 +1,4 @@
-(ns metabase.query-processor-test.count-where-test
+(ns metabase.query-processor-test.sum-where-test
   (:require [metabase.models
              [metric :refer [Metric]]
              [segment :refer [Segment]]]
@@ -10,43 +10,45 @@
             [toucan.util.test :as tt]))
 
 (datasets/expect-with-drivers (non-timeseries-drivers-with-feature :basic-aggregations)
-  94
-  (->> {:aggregation [[:count-where [:< [:field-id (data/id :venues :price)] 4]]]}
+  179.0M
+  (->> {:aggregation [[:sum-where [:field-id (data/id :venues :price)] [:< [:field-id (data/id :venues :price)] 4]]]}
        (data/run-mbql-query venues)
        rows
        ffirst))
 
 ;; Test normalization
 (datasets/expect-with-drivers (non-timeseries-drivers-with-feature :basic-aggregations)
-  94
-  (->> {:aggregation [["count-where" ["<" ["field-id" (data/id :venues :price)] 4]]]}
+  179.0M
+  (->> {:aggregation [["sum-where" ["field-id" (data/id :venues :price)] ["<" ["field-id" (data/id :venues :price)] 4]]]}
        (data/run-mbql-query venues)
        rows
        ffirst))
 
 (datasets/expect-with-drivers (non-timeseries-drivers-with-feature :basic-aggregations)
-  17
-  (->> {:aggregation [[:count-where [:and [:< [:field-id (data/id :venues :price)] 4]
-                                     [:or [:starts-with [:field-id (data/id :venues :name)] "M"]
-                                      [:ends-with [:field-id (data/id :venues :name)] "t"]]]]]}
+  34.0M
+  (->> {:aggregation [[:sum-where
+                       [:field-id (data/id :venues :price)]
+                       [:and [:< [:field-id (data/id :venues :price)] 4]
+                        [:or [:starts-with [:field-id (data/id :venues :name)] "M"]
+                         [:ends-with [:field-id (data/id :venues :name)] "t"]]]]]}
        (data/run-mbql-query venues)
        rows
        ffirst))
 
 (datasets/expect-with-drivers (non-timeseries-drivers-with-feature :basic-aggregations)
   nil
-  (->> {:aggregation [[:count-where [:< [:field-id (data/id :venues :price)] 4]]]
+  (->> {:aggregation [[:sum-where [:field-id (data/id :venues :price)] [:< [:field-id (data/id :venues :price)] 4]]]
         :filter      [:> [:field-id (data/id :venues :price)] Long/MAX_VALUE]}
        (data/run-mbql-query venues)
        rows
        ffirst))
 
 (datasets/expect-with-drivers (non-timeseries-drivers-with-feature :basic-aggregations)
-  [[2 0]
-   [3 0]
-   [4 1]
-   [5 1]]
-  (->> {:aggregation [[:count-where [:< [:field-id (data/id :venues :price)] 2]]]
+  [[2 0.0]
+   [3 0.0]
+   [4 1.0]
+   [5 1.0]]
+  (->> {:aggregation [[:sum-where [:field-id (data/id :venues :price)] [:< [:field-id (data/id :venues :price)] 2]]]
         :breakout    [[:field-id (data/id :venues :category_id)]]
         :limit       4}
        (data/run-mbql-query venues)
@@ -56,27 +58,27 @@
               [(long k) v]))))
 
 (datasets/expect-with-drivers (non-timeseries-drivers-with-feature :basic-aggregations :expressions)
-  48
-  (->> {:aggregation [[:+ [:/ [:count-where [:< [:field-id (data/id :venues :price)] 4]] 2] 1]]}
+  90.5M
+  (->> {:aggregation [[:+ [:/ [:sum-where [:field-id (data/id :venues :price)] [:< [:field-id (data/id :venues :price)] 4]] 2] 1]]}
        (data/run-mbql-query venues)
        rows
        ffirst))
 
 (datasets/expect-with-drivers (non-timeseries-drivers-with-feature :basic-aggregations)
-  94
+  179.0M
   (tt/with-temp* [Segment [{segment-id :id} {:table_id   (data/id :venues)
                                              :definition {:source-table (data/id :venues)
                                                           :filter       [:< [:field-id (data/id :venues :price)] 4]}}]]
-    (->> {:aggregation [[:count-where [:segment segment-id]]]}
+    (->> {:aggregation [[:sum-where [:field-id (data/id :venues :price)] [:segment segment-id]]]}
          (data/run-mbql-query venues)
          rows
          ffirst)))
 
 (datasets/expect-with-drivers (non-timeseries-drivers-with-feature :basic-aggregations)
-  94
+  179.0M
   (tt/with-temp* [Metric [{metric-id :id} {:table_id   (data/id :venues)
                                            :definition {:source-table (data/id :venues)
-                                                        :aggregation  [:count-where [:< [:field-id (data/id :venues :price)] 4]]}}]]
+                                                        :aggregation  [:sum-where [:field-id (data/id :venues :price)] [:< [:field-id (data/id :venues :price)] 4]]}}]]
     (->> {:aggregation [[:metric metric-id]]}
          (data/run-mbql-query venues)
          rows

--- a/test/metabase/query_processor_test/sum_where_test.clj
+++ b/test/metabase/query_processor_test/sum_where_test.clj
@@ -10,22 +10,24 @@
             [toucan.util.test :as tt]))
 
 (datasets/expect-with-drivers (non-timeseries-drivers-with-feature :basic-aggregations)
-  179.0M
+  179.0
   (->> {:aggregation [[:sum-where [:field-id (data/id :venues :price)] [:< [:field-id (data/id :venues :price)] 4]]]}
        (data/run-mbql-query venues)
        rows
-       ffirst))
+       ffirst
+       double))
 
 ;; Test normalization
 (datasets/expect-with-drivers (non-timeseries-drivers-with-feature :basic-aggregations)
-  179.0M
+  179.0
   (->> {:aggregation [["sum-where" ["field-id" (data/id :venues :price)] ["<" ["field-id" (data/id :venues :price)] 4]]]}
        (data/run-mbql-query venues)
        rows
-       ffirst))
+       ffirst
+       double))
 
 (datasets/expect-with-drivers (non-timeseries-drivers-with-feature :basic-aggregations)
-  34.0M
+  34.0
   (->> {:aggregation [[:sum-where
                        [:field-id (data/id :venues :price)]
                        [:and [:< [:field-id (data/id :venues :price)] 4]
@@ -33,7 +35,8 @@
                          [:ends-with [:field-id (data/id :venues :name)] "t"]]]]]}
        (data/run-mbql-query venues)
        rows
-       ffirst))
+       ffirst
+       double))
 
 (datasets/expect-with-drivers (non-timeseries-drivers-with-feature :basic-aggregations)
   nil
@@ -55,14 +58,15 @@
        (tu/round-all-decimals 2)
        rows
        (map (fn [[k v]]
-              [(long k) v]))))
+              [(long k) (double v)]))))
 
 (datasets/expect-with-drivers (non-timeseries-drivers-with-feature :basic-aggregations :expressions)
   90.5M
   (->> {:aggregation [[:+ [:/ [:sum-where [:field-id (data/id :venues :price)] [:< [:field-id (data/id :venues :price)] 4]] 2] 1]]}
        (data/run-mbql-query venues)
        rows
-       ffirst))
+       ffirst
+       double))
 
 (datasets/expect-with-drivers (non-timeseries-drivers-with-feature :basic-aggregations)
   179.0M
@@ -72,7 +76,8 @@
     (->> {:aggregation [[:sum-where [:field-id (data/id :venues :price)] [:segment segment-id]]]}
          (data/run-mbql-query venues)
          rows
-         ffirst)))
+         ffirst
+         double)))
 
 (datasets/expect-with-drivers (non-timeseries-drivers-with-feature :basic-aggregations)
   179.0M
@@ -82,4 +87,5 @@
     (->> {:aggregation [[:metric metric-id]]}
          (data/run-mbql-query venues)
          rows
-         ffirst)))
+         ffirst
+         double)))


### PR DESCRIPTION
Adds `sum-where` MBQL clause with the following semantics:

`[:sum-where concrete-field filter-clause]`

- [x] Update the docs