### PR TITLE
Always include Path=/ directive in Set-Cookie; fix Google Auth :wrench:

### DIFF
--- a/src/metabase/handler.clj
+++ b/src/metabase/handler.clj
@@ -37,7 +37,6 @@
    mw.auth/wrap-api-key                    ; looks for a Metabase API Key on the request and assocs as :metabase-api-key
    mw.misc/maybe-set-site-url              ; set the value of `site-url` if it hasn't been set yet
    ;; Disabled for now because some things like CSV download buttons don't work with this on.
-   #_mw.json/check-application-type-headers  ; Reject non-GET requests without Content-Type: application/json headers, we don't support them
    mw.misc/bind-user-locale                ; Binds *locale* for i18n
    wrap-cookies                            ; Parses cookies in the request map and assocs as :cookies
    mw.misc/add-content-type                ; Adds a Content-Type header for any response that doesn't already have one

--- a/src/metabase/middleware/session.clj
+++ b/src/metabase/middleware/session.clj
@@ -32,7 +32,7 @@
 (def ^:private ^String metabase-session-header        "x-metabase-session")
 
 (defn- clear-cookie [response cookie-name]
-  (resp/set-cookie response cookie-name nil {:expires (DateTime. 0)}))
+  (resp/set-cookie response cookie-name nil {:expires (DateTime. 0), :path "/"}))
 
 (defn- wrap-body-if-needed
   "You can't add a cookie (by setting the `:cookies` key of a response) if the response is an unwrapped JSON response;
@@ -77,13 +77,14 @@
   (-> response
       wrap-body-if-needed
       (clear-cookie metabase-legacy-session-cookie)
-      ;; See also https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
+      ;; See also https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie and `ring.middleware.cookies`
       (resp/set-cookie
        metabase-session-cookie
        (str session-id)
        (merge
         {:same-site :lax
          :http-only true
+         :path      "/"
          ;; max-session age-is in minutes; Max-Age= directive should be in seconds
          :max-age   (* 60 (config/config-int :max-session-age))}
         ;; If the authentication request request was made over HTTPS (hopefully always except for local dev instances)

--- a/test/metabase/test/util/async.clj
+++ b/test/metabase/test/util/async.clj
@@ -16,8 +16,10 @@
       (throw (TimeoutException. "Timed out."))
 
       :else
-      (throw (ex-info "Waiting for channel to close, but got unexpected result"
-               {:result result})))))
+      (do
+        (println "Waiting for channel to close, but got unexpected result:" result)
+        (throw (ex-info "Waiting for channel to close, but got unexpected result"
+                 {:result result}))))))
 
 (defmacro with-open-channels
   "Like `with-open`, but closes core.async channels at the conclusion of `body`."


### PR DESCRIPTION
Because we didn't include a `Path` directive in the `Set-Cookie` header returned in the `POST /api/session/google_auth` response the browser was defaulting to limiting the scope to the path of the resource requested and thus not including it on other requests. Easy fix once I realized the mistake. I'm not 100% sure I understand why this wasn't the case for `POST /api/session` requests and the like.

Fixes #9738