### PR TITLE
Adding comma as separator for connection string

### DIFF
--- a/src/metabase/driver/sql_jdbc/common.clj
+++ b/src/metabase/driver/sql_jdbc/common.clj
@@ -12,8 +12,8 @@
    (Some drivers like MySQL provide this details field to allow special behavior where needed).
 
    Optionally specify SEPERATOR-STYLE, which defaults to `:url` (e.g. `?a=1&b=2`). You may instead set it to
-   `:semicolon`, which will separate different options with semicolons instead (e.g. `;a=1;b=2`). (While most drivers
-   require the former style, some require the latter.)"
+   `:semicolon` or `:comma`, which will separate different options with semicolons or commas instead (e.g. `;a=1;b=2`). (While most drivers
+   require the former style, some require semicolon or even comma.)"
   {:arglists '([connection-spec] [connection-spec details & {:keys [seperator-style]}])}
   ;; single arity provided for cases when `connection-spec` is built by applying simple transformations to `details`
   ([connection-spec]
@@ -24,6 +24,7 @@
    (-> (dissoc connection-spec :additional-options)
        (assoc :subname (str connection-string (when (seq additional-options)
                                                 (str (case seperator-style
+                                                       :comma     ","
                                                        :semicolon ";"
                                                        :url       (if (str/includes? connection-string "?")
                                                                     "&"


### PR DESCRIPTION
Support `:comma` as separator as it is required by some drivers, e.g. Teradata.

This is required as the [pull request for a Teradata driver](https://github.com/metabase/metabase/pull/6459) has been closed because community drivers should be published as plugin repositories.

I'm currently working on this migration for the metabase-teradata-driver.

Thanks