### PR TITLE
Process userland query middleware

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 - [ ] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.
 ### Tests
 -  [ ] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
--  [ ] If there are changes to the backend codebase, run the backend tests with `lein test && lein eastwood && lein bikeshed && lein docstring-checker && lein check-namespace-decls && ./bin/reflection-linter`
+-  [ ] If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`
 
 -  [ ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
 (unless it's a tiny documentation change).

--- a/modules/drivers/bigquery/test/metabase/driver/bigquery_test.clj
+++ b/modules/drivers/bigquery/test/metabase/driver/bigquery_test.clj
@@ -227,7 +227,6 @@
                          :query    {:source-table (data/id :venues)
                                     :limit        1}
                          :info     {:executed-by 1000
-                                    :query-type  "MBQL"
                                     :query-hash  (byte-array [1 2 3 4])}})
       @native-query)))
 
@@ -248,5 +247,4 @@
     :query    {:source-table (data/id :venues)
                :limit        1}
     :info     {:executed-by 1000
-               :query-type  "MBQL"
                :query-hash  (byte-array [1 2 3 4])}}))

--- a/project.clj
+++ b/project.clj
@@ -194,7 +194,8 @@
        :exclusions [expectations]]]
 
      :injections
-     [(require 'metabase.test-setup                                   ; for test setup stuff
+     [(require 'expectation-options                                   ; expectations customizations
+               'metabase.test-setup                                   ; for test setup stuff
                'metabase.test.util)]                                  ; for the toucan.util.test default values for temp models
 
      :resource-paths

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -8,7 +8,6 @@
             [metabase
              [events :as events]
              [public-settings :as public-settings]
-             [query-processor :as qp]
              [related :as related]
              [util :as u]]
             [metabase.api
@@ -32,6 +31,7 @@
              [util :as qputil]]
             [metabase.query-processor.middleware
              [cache :as cache]
+             [constraints :as constraints]
              [results-metadata :as results-metadata]]
             [metabase.sync.analyze.query-results :as qr]
             [metabase.util
@@ -610,7 +610,7 @@
   Exception if preconditions (such as read perms) are not met before returning a channel."
   {:style/indent 1}
   [card-id & {:keys [parameters constraints context dashboard-id middleware]
-              :or   {constraints qp/default-query-constraints
+              :or   {constraints constraints/default-query-constraints
                      context     :question}}]
   {:pre [(u/maybe? sequential? parameters)]}
   (let [card    (api/read-check (Card card-id))

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -4,7 +4,6 @@
             [compojure.core :refer [DELETE GET POST PUT]]
             [metabase
              [events :as events]
-             [query-processor :as qp]
              [related :as related]
              [util :as u]]
             [metabase.api.common :as api]
@@ -18,6 +17,7 @@
              [interface :as mi]
              [query :as query :refer [Query]]
              [revision :as revision]]
+            [metabase.query-processor.middleware.constraints :as constraints]
             [metabase.query-processor.util :as qp-util]
             [metabase.util.schema :as su]
             [schema.core :as s]
@@ -59,7 +59,7 @@
 
 
 (api/defendpoint POST "/"
-  "Create a new `Dashboard`."
+  "Create a new Dashboard."
   [:as {{:keys [name description parameters collection_id collection_position], :as dashboard} :body}]
   {name                su/NonBlankString
    parameters          [su/Map]
@@ -137,10 +137,10 @@
   [{:keys [dataset_query]}]
   (u/ignore-exceptions
     [(qp-util/query-hash dataset_query)
-     (qp-util/query-hash (assoc dataset_query :constraints qp/default-query-constraints))]))
+     (qp-util/query-hash (assoc dataset_query :constraints constraints/default-query-constraints))]))
 
 (defn- dashcard->query-hashes
-  "Return a sequence of all the query hashes for this DASHCARD, including the top-level Card and any Series."
+  "Return a sequence of all the query hashes for this `dashcard`, including the top-level Card and any Series."
   [{:keys [card series]}]
   (reduce concat
           (card->query-hashes card)
@@ -148,13 +148,13 @@
             (card->query-hashes card))))
 
 (defn- dashcards->query-hashes
-  "Return a sequence of all the query hashes used in a DASHCARDS."
+  "Return a sequence of all the query hashes used in a `dashcards`."
   [dashcards]
   (apply concat (for [dashcard dashcards]
                   (dashcard->query-hashes dashcard))))
 
 (defn- hashes->hash-vec->avg-time
-  "Given some query HASHES, return a map of hashes (as normal Clojure vectors) to the average query durations.
+  "Given some query `hashes`, return a map of hashes (as normal Clojure vectors) to the average query durations.
   (The hashes are represented as normal Clojure vectors because identical byte arrays aren't considered equal to one
   another, and thus do not work as one would expect when used as map keys.)"
   [hashes]
@@ -163,7 +163,7 @@
                {(vec k) v}))))
 
 (defn- add-query-average-duration-to-card
-  "Add `:query_average_duration` info to a CARD (i.e., the `:card` property of a DashCard or an entry in its `:series`
+  "Add `:query_average_duration` info to a `card` (i.e., the `:card` property of a DashCard or an entry in its `:series`
   array)."
   [card hash-vec->avg-time]
   (assoc card :query_average_duration (some (fn [query-hash]
@@ -171,7 +171,7 @@
                                             (card->query-hashes card))))
 
 (defn- add-query-average-duration-to-dashcards
-  "Add `:query_average_duration` to the top-level Card and any Series in a sequence of DASHCARDS."
+  "Add `:query_average_duration` to the top-level Card and any Series in a sequence of `dashcards`."
   ([dashcards]
    (add-query-average-duration-to-dashcards dashcards (hashes->hash-vec->avg-time (dashcards->query-hashes dashcards))))
   ([dashcards hash-vec->avg-time]
@@ -183,13 +183,13 @@
                              (add-query-average-duration-to-card card hash-vec->avg-time))))))))
 
 (defn add-query-average-durations
-  "Add a `average_execution_time` field to each card (and series) belonging to DASHBOARD."
+  "Add a `average_execution_time` field to each card (and series) belonging to `dashboard`."
   [dashboard]
   (update dashboard :ordered_cards add-query-average-duration-to-dashcards))
 
 
 (defn- get-dashboard
-  "Get `Dashboard` with ID."
+  "Get Dashboard with ID."
   [id]
   (-> (Dashboard id)
       api/check-404
@@ -201,7 +201,7 @@
 
 
 (api/defendpoint POST "/:from-dashboard-id/copy"
-  "Copy a `Dashboard`."
+  "Copy a Dashboard."
   [from-dashboard-id :as {{:keys [name description collection_id collection_position], :as dashboard} :body}]
   {name                (s/maybe su/NonBlankString)
    description         (s/maybe s/Str)
@@ -231,7 +231,7 @@
 ;;; --------------------------------------------- Fetching/Updating/Etc. ---------------------------------------------
 
 (api/defendpoint GET "/:id"
-  "Get `Dashboard` with ID."
+  "Get Dashboard with ID."
   [id]
   (u/prog1 (get-dashboard id)
     (events/publish-event! :dashboard-read (assoc <> :actor_id api/*current-user-id*))))
@@ -247,7 +247,7 @@
     (api/check-superuser)))
 
 (api/defendpoint PUT "/:id"
-  "Update a `Dashboard`.
+  "Update a Dashboard.
 
   Usually, you just need write permissions for this Dashboard to do this (which means you have appropriate
   permissions for the Cards belonging to this Dashboard), but to change the value of `enable_embedding` you must be a
@@ -293,7 +293,7 @@
 ;; TODO - We can probably remove this in the near future since it should no longer be needed now that we're going to
 ;; be setting `:archived` to `true` via the `PUT` endpoint instead
 (api/defendpoint DELETE "/:id"
-  "Delete a `Dashboard`."
+  "Delete a Dashboard."
   [id]
   (log/warn (str "DELETE /api/dashboard/:id is deprecated. Instead of deleting a Dashboard, you should change its "
                  "`archived` value via PUT /api/dashboard/:id."))
@@ -305,7 +305,7 @@
 
 ;; TODO - param should be `card_id`, not `cardId` (fix here + on frontend at the same time)
 (api/defendpoint POST "/:id/cards"
-  "Add a `Card` to a `Dashboard`."
+  "Add a `Card` to a Dashboard."
   [id :as {{:keys [cardId parameter_mappings series], :as dashboard-card} :body}]
   {cardId             (s/maybe su/IntGreaterThanZero)
    parameter_mappings [su/Map]}
@@ -320,7 +320,7 @@
 
 ;; TODO - we should use schema to validate the format of the Cards :D
 (api/defendpoint PUT "/:id/cards"
-  "Update `Cards` on a `Dashboard`. Request body should have the form:
+  "Update `Cards` on a Dashboard. Request body should have the form:
 
     {:cards [{:id     ...
               :sizeX  ...
@@ -337,7 +337,7 @@
 
 
 (api/defendpoint DELETE "/:id/cards"
-  "Remove a `DashboardCard` from a `Dashboard`."
+  "Remove a `DashboardCard` from a Dashboard."
   [id dashcardId]
   {dashcardId su/IntStringGreaterThanZero}
   (api/check-not-archived (api/write-check Dashboard id))
@@ -347,14 +347,14 @@
 
 
 (api/defendpoint GET "/:id/revisions"
-  "Fetch `Revisions` for `Dashboard` with ID."
+  "Fetch `Revisions` for Dashboard with ID."
   [id]
   (api/read-check Dashboard id)
   (revision/revisions+details Dashboard id))
 
 
 (api/defendpoint POST "/:id/revert"
-  "Revert a `Dashboard` to a prior `Revision`."
+  "Revert a Dashboard to a prior `Revision`."
   [id :as {{:keys [revision_id]} :body}]
   {revision_id su/IntGreaterThanZero}
   (api/write-check Dashboard id)

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -10,10 +10,10 @@
              [card :refer [Card]]
              [database :as database :refer [Database]]
              [query :as query]]
-            [metabase.query-processor :as qp]
             [metabase.query-processor
              [async :as qp.async]
              [util :as qputil]]
+            [metabase.query-processor.middleware.constraints :as constraints]
             [metabase.util
              [date :as du]
              [export :as ex]
@@ -21,7 +21,6 @@
              [schema :as su]]
             [schema.core :as s])
   (:import clojure.core.async.impl.channels.ManyToManyChannel))
-
 
 ;;; -------------------------------------------- Running a Query Normally --------------------------------------------
 
@@ -164,7 +163,7 @@
   {:average (or
              (some (comp query/average-execution-time-ms qputil/query-hash)
                    [query
-                    (assoc query :constraints qp/default-query-constraints)])
+                    (assoc query :constraints constraints/default-query-constraints)])
              0)})
 
 

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -6,7 +6,6 @@
             [medley.core :as m]
             [metabase
              [db :as mdb]
-             [query-processor :as qp]
              [util :as u]]
             [metabase.api
              [card :as card-api]
@@ -80,9 +79,11 @@
   {:style/indent 2}
   [card-id parameters & options]
   ;; run this query with full superuser perms
-  (let [in-chan  (binding [api/*current-user-permissions-set*     (atom #{"/"})
-                           qp/*allow-queries-with-no-executor-id* true]
-                   (apply card-api/run-query-for-card-async card-id, :parameters parameters, :context :public-question, options))
+  (let [in-chan  (binding [api/*current-user-permissions-set* (atom #{"/"})]
+                   (apply card-api/run-query-for-card-async card-id
+                          :parameters parameters
+                          :context    :public-question
+                          options))
         out-chan (a/chan 1 (map transform-results))]
     (async.u/single-value-pipe in-chan out-chan)
     out-chan))

--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -2,13 +2,13 @@
   (:require [clojure.java
              [io :as io]
              [shell :as shell]]
-            [clojure.string :as s]
+            [clojure.string :as str]
             [environ.core :as environ])
   (:import clojure.lang.Keyword))
 
 (def ^Boolean is-windows?
   "Are we running on a Windows machine?"
-  (s/includes? (s/lower-case (System/getProperty "os.name")) "win"))
+  (str/includes? (str/lower-case (System/getProperty "os.name")) "win"))
 
 (def ^:private app-defaults
   "Global application defaults"
@@ -60,12 +60,13 @@
 
 (defn- version-info-from-shell-script []
   (try
-    (let [[tag hash branch date] (-> (shell/sh "./bin/version") :out s/trim (s/split #" "))]
+    (let [[tag hash branch date] (-> (shell/sh "./bin/version") :out str/trim (str/split #" "))]
       {:tag    (or tag "?")
        :hash   (or hash "?")
        :branch (or branch "?")
        :date   (or date "?")})
-    ;; if ./bin/version fails (e.g., if we are developing on Windows) just return something so the whole thing doesn't barf
+    ;; if ./bin/version fails (e.g., if we are developing on Windows) just return something so the whole thing doesn't
+    ;; barf
     (catch Throwable _
       {:tag "?", :hash "?", :branch "?", :date "?"})))
 

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -34,8 +34,8 @@
       (let [{:keys [creator_id dataset_query]} card]
         {:card   card
          :result (qp/process-query-and-save-with-max-results-constraints! dataset_query
-                   (merge {:executed-by creator_id,
-                           :context     :pulse,
+                   (merge {:executed-by creator_id
+                           :context     :pulse
                            :card-id     card-id}
                           options))}))
     (catch Throwable t

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -22,6 +22,7 @@
             [metabase.query-processor.util :as qputil]
             [metabase.util.date :as du]))
 
+;; TODO - Why not make this an option in the query itself? :confused:
 (def ^:dynamic ^Boolean *ignore-cached-results*
   "Should we force the query to run, ignoring cached results even if they're available?
   Setting this to `true` will run the query again and will still save the updated results."
@@ -104,7 +105,7 @@
     results))
 
 (defn- run-query-with-cache [qp {:keys [cache-ttl], :as query}]
-  ;; TODO - Query should already have a `info.hash`, shouldn't it?
+  ;; TODO - Query will already have `info.hash` if it's a userland query. I'm not 100% sure it will be the same hash.
   (let [query-hash (qputil/query-hash query)]
     (or (cached-results query-hash cache-ttl)
         (run-query-and-save-results-if-successful! query-hash qp query))))

--- a/src/metabase/query_processor/middleware/catch_exceptions.clj
+++ b/src/metabase/query_processor/middleware/catch_exceptions.clj
@@ -32,29 +32,34 @@
   "Return a nice error message to explain the schema validation error."
   [error]
   (cond
-    (instance? NamedError error)      (let [nested-error (.error ^NamedError error)]
-                                        ;; recurse until we find the innermost nested named error, which is the reason
-                                        ;; we actually failed
-                                        (if (instance? NamedError nested-error)
-                                          (recur nested-error)
-                                          (or (when (map? nested-error)
-                                                (explain-schema-validation-error nested-error))
-                                              (.name ^NamedError error))))
-    (map? error)                      (first (for [e     (vals error)
-                                                   :when (or (instance? NamedError e)
-                                                             (instance? ValidationError e))
-                                                   :let  [explanation (explain-schema-validation-error e)]
-                                                   :when explanation]
-                                               explanation))
+    (instance? NamedError error)
+    (let [nested-error (.error ^NamedError error)]
+      ;; recurse until we find the innermost nested named error, which is the reason
+      ;; we actually failed
+      (if (instance? NamedError nested-error)
+        (recur nested-error)
+        (or (when (map? nested-error)
+              (explain-schema-validation-error nested-error))
+            (.name ^NamedError error))))
+
+    (map? error)
+    (first (for [e     (vals error)
+                 :when (or (instance? NamedError e)
+                           (instance? ValidationError e))
+                 :let  [explanation (explain-schema-validation-error e)]
+                 :when explanation]
+             explanation))
+
     ;; When an exception is thrown, a ValidationError comes back like
     ;;    (throws? ("foreign-keys is not supported by this driver." 10))
     ;; Extract the message if applicable
-    (instance? ValidationError error) (let [explanation (schema.utils/validation-error-explain error)]
-                                        (or (when (list? explanation)
-                                              (let [[reason [msg]] explanation]
-                                                (when (= reason 'throws?)
-                                                  msg)))
-                                            explanation))))
+    (instance? ValidationError error)
+    (let [explanation (schema.utils/validation-error-explain error)]
+      (or (when (list? explanation)
+            (let [[reason [msg]] explanation]
+              (when (= reason 'throws?)
+                msg)))
+          explanation))))
 
 (defn catch-exceptions
   "Middleware for catching exceptions thrown by the query processor and returning them in a normal format."

--- a/src/metabase/query_processor/middleware/constraints.clj
+++ b/src/metabase/query_processor/middleware/constraints.clj
@@ -1,0 +1,36 @@
+(ns metabase.query-processor.middleware.constraints)
+
+(def ^:private max-results-bare-rows
+  "Maximum number of rows to return specifically on :rows type queries via the API."
+  2000)
+
+(def ^:private max-results
+  "General maximum number of rows to return from an API query."
+  10000)
+
+(def default-query-constraints
+  "Default map of constraints that we apply on dataset queries executed by the api."
+  {:max-results           max-results
+   :max-results-bare-rows max-results-bare-rows})
+
+(defn- merge-default-constraints [{:keys [max-results], :as constraints}]
+  (merge
+   default-query-constraints
+   ;; `:max-results-bare-rows` must be less than or equal to `:max-results`, so if someone sets `:max-results` but not
+   ;; `:max-results-bare-rows` use the same value for both. Otherwise the default bare rows value could end up being
+   ;; higher than the custom `:max-rows` value, causing an error
+   (when max-results
+     {:max-results-bare-rows max-results})
+   constraints))
+
+(defn- add-default-userland-constraints*
+  "Add default values of `:max-results` and `:max-results-bare-rows` to `:constraints` map `m`."
+  [{{:keys [add-default-userland-constraints?]} :middleware, :as query}]
+  (cond-> query
+    add-default-userland-constraints? (update :constraints merge-default-constraints)))
+
+(defn add-default-userland-constraints
+  "Middleware that optionally adds default `max-results` and `max-results-bare-rows` constraints to queries, meant for
+  use with `process-query-and-save-with-max-results-constraints!`, which ultimately powers most QP API endpoints."
+  [qp]
+  (comp qp add-default-userland-constraints*))

--- a/src/metabase/query_processor/middleware/process_userland_query.clj
+++ b/src/metabase/query_processor/middleware/process_userland_query.clj
@@ -1,0 +1,141 @@
+(ns metabase.query-processor.middleware.process-userland-query
+  "Middleware related to doing extra steps for queries that are ran via API endpoints (i.e., most of them -- as opposed
+  to queries ran internally e.g. as part of the sync process). These include things like saving QueryExecutions and
+  formatting the results."
+  (:require [clojure.tools.logging :as log]
+            [medley.core :as m]
+            [metabase.models
+             [query :as query]
+             [query-execution :as query-execution :refer [QueryExecution]]]
+            [metabase.query-processor.util :as qputil]
+            [metabase.util :as u]
+            [metabase.util
+             [date :as du]
+             [i18n :refer [trs tru]]]
+            [toucan.db :as db]))
+
+(defn- add-running-time [{start-time-ms :start_time_millis, :as query-execution}]
+  (-> query-execution
+      (assoc :running_time (- (System/currentTimeMillis) start-time-ms))
+      (dissoc :start_time_millis)))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                              Save Query Execution                                              |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defn- save-query-execution!
+  "Save a `QueryExecution` and update the average execution time for the corresponding `Query`."
+  [{query :json_query, :as query-execution}]
+  (let [query-execution (add-running-time query-execution)]
+    (query/save-query-and-update-average-execution-time! query (:hash query-execution) (:running_time query-execution))
+    (db/insert! QueryExecution (dissoc query-execution :json_query))))
+
+(defn- save-successful-query-execution! [query-execution {cached? :cached, result-rows :row_count}]
+  ;; only insert a new record into QueryExecution if the results *were not* cached (i.e., only if a Query was
+  ;; actually ran)
+  (when-not cached?
+    (save-query-execution! (assoc query-execution :result_rows (or result-rows 0)))))
+
+(defn- save-failed-query-execution! [query-execution message]
+  (save-query-execution! (assoc query-execution :error (str message))))
+
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                                Format Response                                                 |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defn- success-response [{query-hash :hash, :as query-execution} {cached? :cached, :as result}]
+  (merge
+   (-> query-execution
+       add-running-time
+       (dissoc :error :hash :executor_id :card_id :dashboard_id :pulse_id :result_rows :native))
+   result
+   {:status                 :completed
+    :average_execution_time (when cached?
+                              (query/average-execution-time-ms query-hash))}))
+
+(defn- failure-response [query-execution message result]
+  (merge
+   (-> query-execution
+       add-running-time
+       (dissoc :result_rows :hash :executor_id :card_id :dashboard_id :pulse_id :native))
+   {:status    :failed
+    :error     message
+    :row_count 0
+    :data      {:rows    []
+                :cols    []
+                :columns []}}
+   ;; include stacktrace and preprocessed/native stages of the query if available in the response which should
+   ;; make debugging queries a bit easier
+   (-> (select-keys result [:stacktrace :preprocessed :native])
+       (m/dissoc-in [:preprocessed :info]))))
+
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                                Handle Response                                                 |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defn- succeed [query-execution result]
+  (save-successful-query-execution! query-execution result)
+  (success-response query-execution result))
+
+(defn- fail [query-execution message result]
+  (save-failed-query-execution! query-execution message)
+  (failure-response query-execution message result))
+
+(defn- format-userland-query-result
+  "Make sure `query-result` `:status` is something other than `nil`or `:failed`, or throw an Exception."
+  [query-execution {:keys [status], :as result}]
+  (cond
+    (not status)
+    (fail query-execution (tru "Invalid response from database driver. No :status provided.") result)
+
+    (and (= status :failed)
+         (instance? InterruptedException (:class result)))
+    (log/info (trs "Query canceled"))
+
+    (= status :failed)
+    (do
+      (log/warn (trs "Query failure") (u/pprint-to-str 'red result))
+      (fail query-execution (get result :error (tru "Unknown error")) result))
+
+    (= status :completed)
+    (succeed query-execution result)))
+
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                                   Middleware                                                   |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defn- query-execution-info
+  "Return the info for the QueryExecution entry for this `query`."
+  {:arglists '([query])}
+  [{{:keys [executed-by query-hash context card-id dashboard-id pulse-id]} :info
+    database-id                                                            :database
+    query-type                                                             :type
+    :as                                                                    query}]
+  {:pre [(instance? (Class/forName "[B") query-hash)]}
+  {:database_id       database-id
+   :executor_id       executed-by
+   :card_id           card-id
+   :dashboard_id      dashboard-id
+   :pulse_id          pulse-id
+   :context           context
+   :hash              query-hash
+   :native            (= (keyword query-type) :native)
+   :json_query        (dissoc query :info)
+   :started_at        (du/new-sql-timestamp)
+   :running_time      0
+   :result_rows       0
+   :start_time_millis (System/currentTimeMillis)})
+
+(defn process-userland-query
+  "Do extra handling 'userland' queries (i.e. ones ran as a result of a user action, e.g. an API call, scheduled Pulse,
+  etc.). This includes recording QueryExecution entries and returning the results in an FE-client-friendly format."
+  [qp]
+  (fn [{{:keys [userland-query?]} :middleware, :as query}]
+    (if-not userland-query?
+      (qp query)
+      ;; add calculated hash to query
+      (let [query (assoc-in query [:info :query-hash] (qputil/query-hash query))]
+        (format-userland-query-result (query-execution-info query) (qp query))))))

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -27,11 +27,15 @@
   "Generate an approparite REMARK to be prepended to a query to give DBAs additional information about the query being
   executed. See documentation for `mbql->native` and [issue #2386](https://github.com/metabase/metabase/issues/2386)
   for more information."
-  ^String [{{:keys [executed-by query-hash query-type], :as info} :info}]
-  (str "Metabase" (when info
+  ^String [{{:keys [executed-by query-hash], :as info} :info, query-type :type}]
+  (str "Metabase" (when executed-by
                     (assert (instance? (Class/forName "[B") query-hash))
                     (format ":: userID: %s queryType: %s queryHash: %s"
-                            executed-by query-type (codecs/bytes->hex query-hash)))))
+                            executed-by
+                            (case (keyword query-type)
+                              :query  "MBQL"
+                              :native "native")
+                            (codecs/bytes->hex query-hash)))))
 
 
 ;;; ------------------------------------------------- Normalization --------------------------------------------------
@@ -74,7 +78,7 @@
       (empty? constraints) (dissoc :constraints)
       (empty? parameters)  (dissoc :parameters))))
 
-(defn query-hash
+(s/defn query-hash :- (Class/forName "[B")
   "Return a 256-bit SHA3 hash of QUERY as a key for the cache. (This is returned as a byte array.)"
   [query]
   (hash/sha3-256 (json/generate-string (select-keys-for-hashing query))))


### PR DESCRIPTION
Part 1 of 2-part fix for #9693

32.x async QP is really just an async wrapper around synchronous QP code. To fix the “slow response” issue I need to move the async->sync transition point up a bit so the cache has an opportunity to respond before being subject to async waiting for a semaphore permit. Right now cached queries may still be stuck waiting for a permit even tho they don’t require one. 

To do this I need to rework a small part of the QP middleware to be async. To do that I need to finally move the “userland” QP functions’ logic into middleware. That is what this PR does. After this is merged the first few QP middleware functions can be made async and then the query-processor.async semaphore permit stuff can be moved into middleware after the caching middleware in the QP pipeline. Problem solved.

Actually there should probably be a part 3 where I tweak the Elastic Beanstalk templates to generate nginx configs so it doesn’t buffer our keepalive bytes and to bump the ELB timeout up a bit but that isn’t a regression so it can be done at a later date 💀