### PR TITLE
Document yarn hot reload polling fallback

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -105,6 +105,8 @@ There is also an option to reload changes on save without hot reloading if you p
 $ yarn build-watch
 ```
 
+Some systems may have trouble detecting changes to frontend files. You can enable filesystem polling by uncommenting the `watchOptions` clause in `webpack.config.js`. If you do this it may be worth making git ignore changes to webpack config, using `git update-index --assume-unchanged webpack.config.js`
+
 ### Frontend testing
 
 All frontend tests are located in `frontend/test` directory. Run all frontend tests with


### PR DESCRIPTION
I had trouble getting hot reloading set up (Ubuntu 18.04) and have ended up relying on the filesystem polling provided in webpack.config.js after a bit of Googling and codebase searching. I wanted to make this option clearer to other devs.

If there's a suggested way of getting `build-hot` working without FS polling I'm all for it - but couldn't find docs on this anywhere.