### PR TITLE
Fixed #9250: Auto Resize Native Query Results

### DIFF
--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -63,6 +63,8 @@ type Props = {
   question: Question,
   query: NativeQuery,
 
+  handleResize: () => void,
+
   runQuestionQuery: (options?: RunQueryParams) => void,
   setDatasetQuery: (datasetQuery: DatasetQuery) => void,
 
@@ -391,6 +393,7 @@ export default class NativeQueryEditor extends Component {
             minConstraints={[Infinity, getEditorLineHeight(MIN_HEIGHT_LINES)]}
             axis="y"
             onResizeStop={(e, data) => {
+              this.props.handleResize();
               this._editor.resize();
             }}
           >

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -222,7 +222,9 @@ export default class QueryBuilder extends Component {
   };
 
   render() {
-    return <LegacyQueryBuilder {...this.props} />;
+    return (
+      <LegacyQueryBuilder {...this.props} handleResize={this.handleResize} />
+    );
   }
 }
 


### PR DESCRIPTION
Native Query Builder page not resizing the Visualization Result area after user resizes the Native Query
Editor.
The solution here is calling a resize operation on QueryBuilder after the resizing of Native Query Editor stops.