### PR TITLE
Migrate C3P0 config settings to c3p0.properties file

### DIFF
--- a/resources/c3p0.properties
+++ b/resources/c3p0.properties
@@ -1,0 +1,2 @@
+c3p0.initialPoolSize=1
+c3p0.minPoolSize=1

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -341,17 +341,11 @@
 ;;; |                                      CONNECTION POOLS & TRANSACTION STUFF                                      |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(def ^:private application-db-connection-pool-properties
-  "c3p0 connection pool properties for the application DB. See
-  https://www.mchange.com/projects/c3p0/#configuration_properties for descriptions of properties."
-  {"minPoolSize"     1
-   "initialPoolSize" 1
-   "maxPoolSize"     15})
-
 (defn- new-connection-pool
-  "Create a C3P0 connection pool for the given database `spec`."
+  "Create a C3P0 connection pool for the given database `spec`. Default c3p0 properties can be found in the
+  c3p0.properties file and are there so users may override them from the system if desired."
   [spec]
-  (connection-pool/connection-pool-spec spec application-db-connection-pool-properties))
+  (connection-pool/connection-pool-spec spec))
 
 (defn- create-connection-pool! [spec]
   (db/set-default-quoting-style! (case (db-type)


### PR DESCRIPTION
As per configuration_precedence document noted in the c3p0 config doc
(https://www.mchange.com/projects/c3p0/#configuration_precedence) any
setting which is specified programmatically may not be overridden by
other external settings such as system properties.  This creates an
issue if an admin wishes to set any of these settings.

In my case I was attempting to have c3p0 shut down all connections
to my  AWS RDS instance so that amazon would spin the instance down while
not in use.  Alas it appears that something else seems to regularly re-establish
connections every few seconds and prevent my desired behavior. But
before I abandon this approach I figured this would be a good PR
for the project as it will enable others to set this settings as they
see fit and not hit the same roadblocks I hit along the way.  Perhaps you
all might have an idea of how I could achieve this goal?

Of note I have removed the maxPoolSize setting as the current value
of 15 is the same as the driver default. The other settings remain.

###### Before submitting the PR, please make sure you do the following
- [x] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.
### Tests
-  [x] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [x] If there are changes to the backend codebase, run the backend tests with `lein test && lein eastwood && lein bikeshed && lein docstring-checker && lein check-namespace-decls && ./bin/reflection-linter`

-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
