### PR TITLE
Fix missing args in do-after-receiving-permit

### DIFF
--- a/src/metabase/async/semaphore_channel.clj
+++ b/src/metabase/async/semaphore_channel.clj
@@ -118,6 +118,6 @@
   (if (get *permits* semaphore-chan)
     (do
       (log/debug (trs "Current thread already has a permit for {0}, will not wait to acquire another" semaphore-chan))
-      (async.u/do-on-separate-thread f))
+      (apply async.u/do-on-separate-thread f args))
     ;; otherwise wait for a permit
     (apply do-after-waiting-for-new-permit semaphore-chan f args)))


### PR DESCRIPTION
Fix minor logic error in async function. Did not affect anything since it was only used with 0-arity functions but should still be fixed