### PR TITLE
Fix no_results image paths

### DIFF
--- a/frontend/src/metabase/containers/ErrorPages.jsx
+++ b/frontend/src/metabase/containers/ErrorPages.jsx
@@ -40,7 +40,7 @@ export const GenericError = ({
 export const NotFound = () => (
   <ErrorPageWrapper>
     <EmptyState
-      illustrationElement={<img src="../app/assets/img/no_results.svg" />}
+      illustrationElement={<img src="app/assets/img/no_results.svg" />}
       title={t`We're a little lost...`}
       message={t`The page you asked for couldn't be found.`}
       link={Urls.question()}

--- a/frontend/src/metabase/home/containers/SearchApp.jsx
+++ b/frontend/src/metabase/home/containers/SearchApp.jsx
@@ -46,7 +46,7 @@ export default class SearchApp extends React.Component {
                       title={t`No results`}
                       message={t`Metabase couldn't find any results for your search.`}
                       illustrationElement={
-                        <img src="../app/assets/img/no_results.svg" />
+                        <img src="app/assets/img/no_results.svg" />
                       }
                     />
                   </Card>

--- a/frontend/src/metabase/visualizations/components/ColumnSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ColumnSettings.jsx
@@ -88,7 +88,7 @@ const ColumnSettings = ({
       ) : (
         <EmptyState
           message={t`No formatting settings`}
-          illustrationElement={<img src="../app/assets/img/no_results.svg" />}
+          illustrationElement={<img src="app/assets/img/no_results.svg" />}
         />
       )}
     </div>

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -467,7 +467,7 @@ export default class Visualization extends Component {
             }
           >
             <Tooltip tooltip={t`No results!`} isEnabled={small}>
-              <img src="../app/assets/img/no_results.svg" />
+              <img src="app/assets/img/no_results.svg" />
             </Tooltip>
             {!small && <span className="h4 text-bold">No results!</span>}
           </div>


### PR DESCRIPTION
All image paths should be relative to root. This may appear broken in dev / hot reloading mode, but that's due to a configuration error and should be fixed that way rather than by reverting these changes.