### PR TITLE
Set X-Accel-Buffering header in streaming resp so nginx doesn't buffer

### DIFF
--- a/src/metabase/async/api_response.clj
+++ b/src/metabase/async/api_response.clj
@@ -189,5 +189,9 @@
 (extend-protocol Sendable
   ManyToManyChannel
   (send* [input-chan _ respond _]
-    (respond (assoc (response/response input-chan)
-               :content-type "applicaton/json; charset=utf-8"))))
+    (respond (-> (response/response input-chan)
+                 (assoc :content-type "applicaton/json; charset=utf-8")
+                 ;; tell nginx not to batch streaming responses -- otherwise the keepalive bytes aren't written and
+                 ;; the entire purpose is defeated. See
+                 ;; https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache
+                 (assoc-in [:headers "X-Accel-Buffering"] "no")))))


### PR DESCRIPTION
Holy grail of fixes for #9693 