### PR TITLE
Set X-Accel-Buffering header in streaming resp so nginx doesn't buffer

### DIFF
--- a/src/metabase/async/api_response.clj
+++ b/src/metabase/async/api_response.clj
@@ -186,12 +186,10 @@
     (log/debug (u/format-color 'green (trs "starting streaming response")))
     (write-chan-vals-to-writer! (async-keepalive-channel chan) (io/writer output-stream))))
 
+;; `defendpoint-async` responses
 (extend-protocol Sendable
   ManyToManyChannel
   (send* [input-chan _ respond _]
-    (respond (-> (response/response input-chan)
-                 (assoc :content-type "applicaton/json; charset=utf-8")
-                 ;; tell nginx not to batch streaming responses -- otherwise the keepalive bytes aren't written and
-                 ;; the entire purpose is defeated. See
-                 ;; https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache
-                 (assoc-in [:headers "X-Accel-Buffering"] "no")))))
+    (respond
+     (assoc (response/response input-chan)
+       :content-type "applicaton/json; charset=utf-8"))))

--- a/src/metabase/handler.clj
+++ b/src/metabase/handler.clj
@@ -40,5 +40,6 @@
    mw.misc/bind-user-locale                ; Binds *locale* for i18n
    wrap-cookies                            ; Parses cookies in the request map and assocs as :cookies
    mw.misc/add-content-type                ; Adds a Content-Type header for any response that doesn't already have one
+   mw.misc/disable-streaming-buffering     ; Add header to streaming (async) responses so ngnix doesn't buffer keepalive bytes
    mw.misc/wrap-gzip))                     ; GZIP response if client can handle it
 ;; ▲▲▲ PRE-PROCESSING ▲▲▲ happens from BOTTOM-TO-TOP


### PR DESCRIPTION
Follow-on to #9815 but added to all endpoints returning `core.async` channels. Final & ultimate holy grail of fixes
