### PR TITLE
If request gets canceled don't try to post-process nil results :wrench:

### DIFF
--- a/src/metabase/query_processor/middleware/async.clj
+++ b/src/metabase/query_processor/middleware/async.clj
@@ -16,7 +16,7 @@
     (if (a/poll! canceled-chan)
       (log/debug (trs "Request already canceled, will not run synchronous QP code."))
       (try
-        (respond (qp query))
+        (some-> (qp query) respond)
         (catch Throwable e
           (raise e))))))
 

--- a/src/metabase/query_processor/middleware/async_wait.clj
+++ b/src/metabase/query_processor/middleware/async_wait.clj
@@ -47,7 +47,9 @@
           output-chan    (semaphore-channel/do-after-receiving-permit semaphore-chan
                            qp query respond raise canceled-chan)]
       (a/go
-        (respond (a/<! output-chan))
+        ;; result might be nil if `output-chan` gets prematurely closed. If there's no result there's no need to
+        ;; finish the `respond` post-processing
+        (some-> (a/<! output-chan) respond)
         (a/close! output-chan))
       (a/go
         (when (a/<! canceled-chan)

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -106,8 +106,9 @@
       (respond cached-results)
       (let [start-time (System/currentTimeMillis)
             respond    (fn [results]
-                         (save-results-if-successful! query-hash start-time results)
-                         (respond results))]
+                         (when results
+                           (save-results-if-successful! query-hash start-time results)
+                           (respond results)))]
         (qp query respond raise canceled-chan)))))
 
 (defn maybe-return-cached-results


### PR DESCRIPTION
Fixes misleading/pointless warning log messages in #9818 