### PR TITLE
Add exp to embed snippets, switch backend unsigning to use :leeway

### DIFF
--- a/frontend/src/metabase/public/lib/code.js
+++ b/frontend/src/metabase/public/lib/code.js
@@ -100,7 +100,8 @@ var payload = {
   resource: { ${resourceType}: ${resourceId} },
   params: ${JSON.stringify(params, null, 2)
     .split("\n")
-    .join("\n  ")}
+    .join("\n  ")},
+  exp: Math.round(Date.now() / 1000) + (10 * 60) // 10 minute expiration
 };
 var token = jwt.sign(payload, METABASE_SECRET_KEY);
 
@@ -132,7 +133,8 @@ payload = {
       .map(
         ([key, value]) => JSON.stringify(key) + " => " + JSON.stringify(value),
       )
-      .join(",\n    ")}
+      .join(",\n    ")},
+  :exp => Time.now.to_i + (60 * 10) # 10 minute expiration
   }
 }
 token = JWT.encode payload, METABASE_SECRET_KEY
@@ -154,6 +156,7 @@ const python = ({
   `# You'll need to install PyJWT via pip 'pip install PyJWT' or your project packages file
 
 import jwt
+import time
 
 METABASE_SITE_URL = ${JSON.stringify(siteUrl)}
 METABASE_SECRET_KEY = ${JSON.stringify(secretKey)}
@@ -164,7 +167,8 @@ payload = {
     ${Object.entries(params)
       .map(([key, value]) => JSON.stringify(key) + ": " + JSON.stringify(value))
       .join(",\n    ")}
-  }
+  },
+  "exp": round(time.time()) + (60 * 10) # 10 minute expiration
 }
 token = jwt.encode(payload, METABASE_SECRET_KEY, algorithm="HS256")
 
@@ -191,7 +195,8 @@ const clojure = ({
   {:resource {:${resourceType} ${resourceId}}
    :params   {${Object.entries(params)
      .map(([key, value]) => JSON.stringify(key) + " " + JSON.stringify(value))
-     .join(",\n              ")}}})
+     .join(",\n              ")}}
+   :exp      (+ (int (/ (System/currentTimeMillis) 1000)) (* 60 10))}) ; 10 minute expiration
 
 (def token (jwt/sign payload metabase-secret-key))
 

--- a/src/metabase/util/embed.clj
+++ b/src/metabase/util/embed.clj
@@ -1,9 +1,7 @@
 (ns metabase.util.embed
   "Utility functions for public links and embedding."
   (:require [buddy.core.codecs :as codecs]
-            [buddy.sign
-             [jwt :as jwt]
-             [util :as buddy-util]]
+            [buddy.sign.jwt :as jwt]
             [cheshire.core :as json]
             [clojure.string :as str]
             [hiccup.core :refer [html]]
@@ -92,9 +90,8 @@
                   (or (embedding-secret-key)
                       (throw (ex-info (str (tru "The embedding secret key has not been set.")) {:status-code 400})))
                   ;; The library will reject tokens with a created at timestamp in the future, so to account for clock
-                  ;; skew tell the library that "now" is actually two minutes ahead of whatever the system time is so
-                  ;; tokens don't get inappropriately rejected
-                  {:now (+ (buddy-util/now) 120)})
+                  ;; skew tell the library to allow for 60 seconds of leeway
+                  {:leeway 60})
       ;; if `jwt/unsign` throws an Exception rethrow it in a format that's friendlier to our API
       (catch Throwable e
         (throw (ex-info (.getMessage e) {:status-code 400}))))))


### PR DESCRIPTION
We should encourage people to include expirations when generating JWT tokens.