### PR TITLE
Add CSV setting type; Settings framework improvements

### DIFF
--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -33,10 +33,13 @@
 
 (defn sign [claims] (jwt/sign claims *secret-key*))
 
+(defn do-with-new-secret-key [f]
+  (binding [*secret-key* (random-embedding-secret-key)]
+    (tu/with-temporary-setting-values [embedding-secret-key *secret-key*]
+      (f))))
+
 (defmacro with-new-secret-key {:style/indent 0} [& body]
-  `(binding [*secret-key* (random-embedding-secret-key)]
-     (tu/with-temporary-setting-values [~'embedding-secret-key *secret-key*]
-       ~@body)))
+  `(do-with-new-secret-key (fn [] ~@body)))
 
 (defn card-token {:style/indent 1} [card-or-id & [additional-token-params]]
   (sign (merge {:resource {:question (u/get-id card-or-id)}

--- a/test/metabase/api/setting_test.clj
+++ b/test/metabase/api/setting_test.clj
@@ -1,6 +1,6 @@
 (ns metabase.api.setting-test
   (:require [expectations :refer [expect]]
-            [metabase.models.setting-test :refer [set-settings! test-sensitive-setting test-setting-1 test-setting-2]]
+            [metabase.models.setting-test :refer [test-sensitive-setting test-setting-1 test-setting-2]]
             [metabase.test.data.users :refer [user->client]]))
 
 ;; ## Helper Fns
@@ -27,8 +27,10 @@
     :env_name       "MB_TEST_SETTING_2"
     :description    "Test setting - this only shows up in dev (2)"
     :default        "[Default Value]"}]
- (do (set-settings! nil "FANCY")
-     (fetch-test-settings)))
+  (do
+    (test-setting-1 nil)
+    (test-setting-2 "FANCY")
+    (fetch-test-settings)))
 
 ;; Check that non-superusers are denied access
 (expect "You don't have permissions to do that."

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -299,18 +299,23 @@
 
 
 (defn do-with-temporary-setting-value
-  "Temporarily set the value of the `Setting` named by keyword SETTING-K to VALUE and execute F, then re-establish the
-  original value. This works much the same way as `binding`.
+  "Temporarily set the value of the Setting named by keyword `setting-k` to `value` and execute `f`, then re-establish
+  the original value. This works much the same way as `binding`.
 
    Prefer the macro `with-temporary-setting-values` over using this function directly."
   {:style/indent 2}
   [setting-k value f]
-  (let [original-value (setting/get setting-k)]
+  ;; for saving & restoring the original values we're using `get-string` and `set-string!` to bypass the magic getters
+  ;; & setters which might have some restrictions or other unexpected behavior. We're using these functions rather
+  ;; than manipulating values in the DB directly so we don't have to worry about invalidating the Settings cache
+  ;; ourselves
+  (let [original-value     (setting/get-string setting-k)
+        value-was-default? (not (db/select-one setting/Setting :key (u/keyword->qualified-name setting-k)))]
     (try
       (setting/set! setting-k value)
       (f)
       (finally
-        (setting/set! setting-k original-value)))))
+        (setting/set-string! setting-k (when-not value-was-default? original-value))))))
 
 (defmacro with-temporary-setting-values
   "Temporarily bind the values of one or more `Settings`, execute body, and re-establish the original values. This
@@ -350,9 +355,9 @@
   in the DB for 'permanent' rows (rows that live for the life of the test suite, rather than just a single test). For
   example, Database/Table/Field rows related to the test DBs can be temporarily tweaked in this way.
 
-      ;; temporarily make Field 100 a FK to Field 200 and call (do-something)
-      (with-temp-vals-in-db Field 100 {:fk_target_field_id 200, :special_type \"type/FK\"}
-        (do-something))"
+    ;; temporarily make Field 100 a FK to Field 200 and call (do-something)
+    (with-temp-vals-in-db Field 100 {:fk_target_field_id 200, :special_type \"type/FK\"}
+      (do-something))"
   {:style/indent 3}
   [model object-or-id column->temp-value & body]
   `(do-with-temp-vals-in-db ~model ~object-or-id ~column->temp-value (fn [] ~@body)))

--- a/test/metabase/test/util_test.clj
+++ b/test/metabase/test/util_test.clj
@@ -1,7 +1,9 @@
 (ns metabase.test.util-test
   "Tests for the test utils!"
-  (:require [expectations :refer :all]
-            [metabase.models.field :refer [Field]]
+  (:require [expectations :refer [expect]]
+            [metabase.models
+             [field :refer [Field]]
+             [setting :as setting]]
             [metabase.test
              [data :as data]
              [util :as tu]]
@@ -23,3 +25,24 @@
       (tu/with-temp-vals-in-db Field (data/id :venues :price) {:position -1}
         (throw (Exception.))))
     (db/select-one-field :position Field :id (data/id :venues :price))))
+
+
+(setting/defsetting test-util-test-setting
+  "Another internal test setting"
+  :internal? true
+  :default "A,B,C"
+  :type :csv)
+
+;; `with-temporary-setting-values` should do its thing
+(expect
+  ["D" "E" "F"]
+  (tu/with-temporary-setting-values [test-util-test-setting ["D" "E" "F"]]
+    (test-util-test-setting)))
+
+;; `with-temporary-setting-values` shouldn't stomp over default values
+(expect
+  ["A" "B" "C"]
+  (do
+    (tu/with-temporary-setting-values [test-util-test-setting ["D" "E" "F"]]
+      (test-util-test-setting))
+    (test-util-test-setting)))


### PR DESCRIPTION
*  Add CSV Setting type
*  Fix some issues where `user-facing-setting` would not correctly recognize certain parsed Settings as default values
*  Fix `with-temporary-setting-values` test macro to properly reset default setting values to `nil` into the DB (instead of saving the default values)
*  Lots of additional tests