### PR TITLE
LDAP test cleanup [backported from EE] :shower:

### DIFF
--- a/test/metabase/integrations/ldap_test.clj
+++ b/test/metabase/integrations/ldap_test.clj
@@ -1,11 +1,11 @@
 (ns metabase.integrations.ldap-test
-  (:require [expectations :refer :all]
+  (:require [expectations :refer [expect]]
             [metabase.integrations.ldap :as ldap]
-            [metabase.test.integrations.ldap :refer [expect-with-ldap-server get-ldap-port]]))
+            [metabase.test.integrations.ldap :as ldap.test]))
 
 (defn- get-ldap-details []
   {:host       "localhost"
-   :port       (get-ldap-port)
+   :port       (ldap.test/get-ldap-port)
    :bind-dn    "cn=Directory Manager"
    :password   "password"
    :security   "none"
@@ -23,79 +23,91 @@
   (#'ldap/escape-value "John+Smith@metabase.com"))
 
 ;; The connection test should pass with valid settings
-(expect-with-ldap-server
+(expect
   {:status :SUCCESS}
-  (ldap/test-ldap-connection (get-ldap-details)))
+  (ldap.test/with-ldap-server
+    (ldap/test-ldap-connection (get-ldap-details))))
 
 ;; The connection test should allow anonymous binds
-(expect-with-ldap-server
+(expect
   {:status :SUCCESS}
-  (ldap/test-ldap-connection (dissoc (get-ldap-details) :bind-dn)))
+  (ldap.test/with-ldap-server
+    (ldap/test-ldap-connection (dissoc (get-ldap-details) :bind-dn))))
 
 ;; The connection test should fail with an invalid user search base
-(expect-with-ldap-server
+(expect
   :ERROR
-  (:status (ldap/test-ldap-connection (assoc (get-ldap-details) :user-base "dc=example,dc=com"))))
+  (ldap.test/with-ldap-server
+    (:status (ldap/test-ldap-connection (assoc (get-ldap-details) :user-base "dc=example,dc=com")))))
 
 ;; The connection test should fail with an invalid group search base
-(expect-with-ldap-server
+(expect
   :ERROR
-  (:status (ldap/test-ldap-connection (assoc (get-ldap-details) :group-base "dc=example,dc=com"))))
+  (ldap.test/with-ldap-server
+    (:status (ldap/test-ldap-connection (assoc (get-ldap-details) :group-base "dc=example,dc=com")))))
 
 ;; The connection test should fail with an invalid bind DN
-(expect-with-ldap-server
+(expect
   :ERROR
-  (:status (ldap/test-ldap-connection (assoc (get-ldap-details) :bind-dn "cn=Not Directory Manager"))))
+  (ldap.test/with-ldap-server
+    (:status (ldap/test-ldap-connection (assoc (get-ldap-details) :bind-dn "cn=Not Directory Manager")))))
 
 ;; The connection test should fail with an invalid bind password
-(expect-with-ldap-server
+(expect
   :ERROR
-  (:status (ldap/test-ldap-connection (assoc (get-ldap-details) :password "wrong"))))
+  (ldap.test/with-ldap-server
+    (:status (ldap/test-ldap-connection (assoc (get-ldap-details) :password "wrong")))))
 
 ;; Make sure the basic connection stuff works, this will throw otherwise
-(expect-with-ldap-server
- nil
- (.close (#'ldap/get-connection)))
+(expect
+  nil
+  (ldap.test/with-ldap-server
+    (.close (#'ldap/get-connection))))
 
 ;; Login with everything right should succeed
-(expect-with-ldap-server
-  true
-  (ldap/verify-password "cn=Directory Manager" "password"))
+(expect
+  (ldap.test/with-ldap-server
+    (ldap/verify-password "cn=Directory Manager" "password")))
 
 ;; Login with wrong password should fail
-(expect-with-ldap-server
+(expect
   false
-  (ldap/verify-password "cn=Directory Manager" "wrongpassword"))
+  (ldap.test/with-ldap-server
+    (ldap/verify-password "cn=Directory Manager" "wrongpassword")))
 
 ;; Login with invalid DN should fail
-(expect-with-ldap-server
+(expect
   false
-  (ldap/verify-password "cn=Nobody,ou=nowhere,dc=metabase,dc=com" "password"))
+  (ldap.test/with-ldap-server
+    (ldap/verify-password "cn=Nobody,ou=nowhere,dc=metabase,dc=com" "password")))
 
 ;; Login for regular users should also work
-(expect-with-ldap-server
-  true
-  (ldap/verify-password "cn=Sally Brown,ou=People,dc=metabase,dc=com" "1234"))
+(expect
+  (ldap.test/with-ldap-server
+    (ldap/verify-password "cn=Sally Brown,ou=People,dc=metabase,dc=com" "1234")))
 
 ;; Login for regular users should also fail for the wrong password
-(expect-with-ldap-server
+(expect
   false
-  (ldap/verify-password "cn=Sally Brown,ou=People,dc=metabase,dc=com" "password"))
+  (ldap.test/with-ldap-server
+    (ldap/verify-password "cn=Sally Brown,ou=People,dc=metabase,dc=com" "password")))
 
 ;; Find by username should work (given the default LDAP filter and test fixtures)
-(expect-with-ldap-server
+(expect
   {:dn         "cn=John Smith,ou=People,dc=metabase,dc=com"
    :first-name "John"
    :last-name  "Smith"
    :email      "John.Smith@metabase.com"
    :groups     ["cn=Accounting,ou=Groups,dc=metabase,dc=com"]}
-  (ldap/find-user "jsmith1"))
+  (ldap.test/with-ldap-server
+    (ldap/find-user "jsmith1")))
 
 ;; Find by email should also work (also given our default settings and fixtures)
-(expect-with-ldap-server
+(expect
   {:dn         "cn=John Smith,ou=People,dc=metabase,dc=com"
    :first-name "John"
    :last-name  "Smith"
    :email      "John.Smith@metabase.com"
    :groups     ["cn=Accounting,ou=Groups,dc=metabase,dc=com"]}
-  (ldap/find-user "John.Smith@metabase.com"))
+  (ldap.test/with-ldap-server
+    (ldap/find-user "John.Smith@metabase.com")))

--- a/test/metabase/test/integrations/ldap.clj
+++ b/test/metabase/test/integrations/ldap.clj
@@ -1,11 +1,10 @@
 (ns metabase.test.integrations.ldap
   (:require [clojure.java.io :as io]
-            [expectations :refer [expect]]
             [metabase.test.util :as tu])
-  (:import (com.unboundid.ldap.listener InMemoryDirectoryServer InMemoryDirectoryServerConfig InMemoryListenerConfig)
+  (:import [com.unboundid.ldap.listener InMemoryDirectoryServer InMemoryDirectoryServerConfig InMemoryListenerConfig]
            com.unboundid.ldap.sdk.schema.Schema
-           com.unboundid.ldif.LDIFReader))
-
+           com.unboundid.ldif.LDIFReader
+           java.io.FileNotFoundException))
 
 (def ^:dynamic *ldap-server*
   "An in-memory LDAP testing server."
@@ -13,15 +12,18 @@
 
 (defn- get-server-config []
   (doto (InMemoryDirectoryServerConfig. (into-array String ["dc=metabase,dc=com"]))
-          (.addAdditionalBindCredentials "cn=Directory Manager" "password")
-          (.setSchema (Schema/getDefaultStandardSchema))
-          (.setListenerConfigs (into-array InMemoryListenerConfig [(InMemoryListenerConfig/createLDAPConfig "LDAP" 0)]))))
+    (.addAdditionalBindCredentials "cn=Directory Manager" "password")
+    (.setSchema (Schema/getDefaultStandardSchema))
+    (.setListenerConfigs (into-array InMemoryListenerConfig [(InMemoryListenerConfig/createLDAPConfig "LDAP" 0)]))))
 
 (defn- start-ldap-server! []
-  (with-open [ldif (LDIFReader. (io/file (io/resource "ldap.ldif")))]
+  (with-open [ldif (LDIFReader. (or (io/file (io/resource "ldap.ldif"))
+                                    (throw
+                                     (FileNotFoundException.
+                                      "ldap.ldif does not exist! (You may need to copy it into your resources dir.)"))))]
     (doto (InMemoryDirectoryServer. (get-server-config))
-            (.importFromLDIF true ldif)
-            (.startListening))))
+      (.importFromLDIF true ldif)
+      (.startListening))))
 
 (defn get-ldap-port
   "Get the port for the bound in-memory LDAP testing server."
@@ -45,11 +47,6 @@
       (finally (.shutDown *ldap-server* true)))))
 
 (defmacro with-ldap-server
-  "Bind `*ldap-server*` and the relevant settings to an in-memory LDAP testing server and executes BODY."
+  "Bind `*ldap-server*` and the relevant settings to an in-memory LDAP testing server and executes `body`."
   [& body]
   `(do-with-ldap-server (fn [] ~@body)))
-
-(defmacro expect-with-ldap-server
-  "Generate a unit test that runs ACTUAL with a bound `*ldap-server*` and relevant settings."
-  [expected actual]
-  `(expect ~expected (with-ldap-server ~actual)))


### PR DESCRIPTION
Minor test cleanup backported from EE such as removing unnecessary `expect-with-ldap-server` macro 