### PR TITLE
Remove unsafe-inline directive from CSP :lock:

### DIFF
--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -16,23 +16,34 @@
     <meta name="msapplication-config" content="/app/assets/img/browserconfig.xml">
     <meta name="theme-color" content="#ffffff">
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="base-href" content="{{{baseHref}}}" />
+    <meta name="uri" content="{{{uri}}}" />
 
-    {{{embed_code}}}
+    {{{embedCode}}}
 
     <title>Metabase</title>
 
-    <base href={{{base_href}}} />
+    <base href="{{{baseHref}}}" />
 
+    <script type="application/json" id="_metabaseBootstrap">
+      {{{bootstrapJSON}}}
+    </script>
+
+    <script type="application/json" id="_metabaseLocalization">
+      {{{localizationJSON}}}
+    </script>
+
+    <!-- If you modify this script, make sure you update the whitelisted Content-Security-Policy hash in metabase.middleware.security -->
     <script type="text/javascript">
       (function() {
-        window.MetabaseBootstrap = {{{bootstrap_json}}};
-        window.MetabaseLocalization = {{{localization_json}}};
+        window.MetabaseBootstrap    = JSON.parse(document.getElementById("_metabaseBootstrap").innerHTML);
+        window.MetabaseLocalization = JSON.parse(document.getElementById("_metabaseLocalization").innerHTML);
 
-        var configuredRoot = {{{base_href}}};
+        var configuredRoot = document.head.querySelector("meta[name='base-href']").content;
         var actualRoot = "/";
 
         // Add trailing slashes
-        var backendPathname = {{{uri}}}.replace(/\/*$/, "/");
+        var backendPathname = document.head.querySelector("meta[name='uri']").content.replace(/\/*$/, "/");
         // e.x. "/questions/"
         var frontendPathname = window.location.pathname.replace(/\/*$/, "/");
         // e.x. "/metabase/questions/"
@@ -56,42 +67,39 @@
   <body>
     <div id="root"></div>
 
+    <!-- Using the Web Font Loader lets us load the fonts asynchronously for faster page loads -- see https://github.com/typekit/webfontloader -->
+    <!-- If you modify this script, make sure you update the whitelisted Content-Security-Policy hash in metabase.middleware.security -->
     <script type="text/javascript">
-      // Load scripts asyncronously after the page has finished loading
-      (function () {
-        function loadScript(src, onload) {
-          var script = document.createElement('script');
-          script.type  = "text/javascript";
-          script.async = true;
-          script.src   = src;
-          if (onload) script.onload = onload;
-          document.body.appendChild(script);
+      WebFontConfig = {
+        google: {
+          families: ["Lato:300,400,700,900"]
         }
-        loadScript('https://ajax.googleapis.com/ajax/libs/webfont/1.4.7/webfont.js', function () {
-          WebFont.load({ google: {
-            families: ["Lato:300,400,700,900"] }
-          });
-        });
-        var googleAuthClientID = window.MetabaseBootstrap.google_auth_client_id;
-        if (googleAuthClientID) {
-          loadScript('https://apis.google.com/js/api:client.js');
+      };
+    </script>
+    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js" async></script>
+
+    <!-- If Google Auth is enabled load the Google Auth JS lib -->
+    {{#enableGoogleAuth}}
+      <script type="text/javascript" src="https://apis.google.com/js/api:client.js" async></script>
+    {{/enableGoogleAuth}}
+
+    <!-- Google Analytics -->
+    <!-- If you modify this script, make sure you update the whitelisted Content-Security-Policy hash in metabase.middleware.security -->
+    {{#enableAnonTracking}}
+      <script type="text/javascript">
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+        // if we are not doing tracking then go ahead and disable GA now so we never even track the initial pageview
+        const tracking = window.MetabaseBootstrap.anon_tracking_enabled;
+        const ga_code = window.MetabaseBootstrap.ga_code;
+        if (!tracking) {
+          window['ga-disable-'+ga_code] = true;
         }
-      })();
-    </script>
 
-    <script type="text/javascript">
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-      // if we are not doing tracking then go ahead and disable GA now so we never even track the initial pageview
-      const tracking = window.MetabaseBootstrap.anon_tracking_enabled;
-      const ga_code = window.MetabaseBootstrap.ga_code;
-      if (!tracking) {
-        window['ga-disable-'+ga_code] = true;
-      }
-
-      ga('create', ga_code, 'auto');
-    </script>
+        ga('create', ga_code, 'auto');
+      </script>
+    {{/enableAnonTracking}}
   </body>
 </html>

--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -36,8 +36,8 @@
     <!-- If you modify this script, make sure you update the whitelisted Content-Security-Policy hash in metabase.middleware.security -->
     <script type="text/javascript">
       (function() {
-        window.MetabaseBootstrap    = JSON.parse(document.getElementById("_metabaseBootstrap").innerHTML);
-        window.MetabaseLocalization = JSON.parse(document.getElementById("_metabaseLocalization").innerHTML);
+        window.MetabaseBootstrap    = JSON.parse(document.getElementById("_metabaseBootstrap").textContent);
+        window.MetabaseLocalization = JSON.parse(document.getElementById("_metabaseLocalization").textContent);
 
         var configuredRoot = document.head.querySelector("meta[name='base-href']").content;
         var actualRoot = "/";

--- a/src/metabase/handler.clj
+++ b/src/metabase/handler.clj
@@ -1,6 +1,9 @@
 (ns metabase.handler
   "Top-level Metabase Ring handler."
-  (:require [metabase.middleware
+  (:require [metabase
+             [config :as config]
+             [routes :as routes]]
+            [metabase.middleware
              [auth :as mw.auth]
              [exceptions :as mw.exceptions]
              [json :as mw.json]
@@ -8,7 +11,6 @@
              [misc :as mw.misc]
              [security :as mw.security]
              [session :as mw.session]]
-            [metabase.routes :as routes]
             [ring.middleware
              [cookies :refer [wrap-cookies]]
              [keyword-params :refer [wrap-keyword-params]]
@@ -22,7 +24,11 @@
   "The primary entry point to the Ring HTTP server."
   ;; ▼▼▼ POST-PROCESSING ▼▼▼ happens from TOP-TO-BOTTOM
   (->
-   #'routes/routes                         ; the #' is to allow tests to redefine endpoints
+   ;; when running TESTS use the var so we can redefine routes as needed. No need to waste time with repetitive var
+   ;; lookups when running normally
+   (if config/is-test?
+     #'routes/routes
+     routes/routes)
    mw.exceptions/catch-uncaught-exceptions ; catch any Exceptions that weren't passed to `raise`
    mw.exceptions/catch-api-exceptions      ; catch exceptions and return them in our expected format
    mw.log/log-api-call

--- a/src/metabase/middleware/security.clj
+++ b/src/metabase/middleware/security.clj
@@ -29,45 +29,49 @@
   "`Content-Security-Policy` header. See https://content-security-policy.com for more details."
   {"Content-Security-Policy"
    (str/join
-    (for [[k vs] {:default-src ["'none'"]
-                  :script-src  ["'unsafe-inline'"
-                                "'unsafe-eval'"
-                                "'self'"
-                                "https://maps.google.com"
-                                "https://apis.google.com"
-                                "https://www.google-analytics.com" ; Safari requires the protocol
-                                "https://*.googleapis.com"
-                                "*.gstatic.com"
-                                (when config/is-dev?
-                                  "localhost:8080")]
-                  :child-src   ["'self'"
-                                ;; TODO - double check that we actually need this for Google Auth
-                                "https://accounts.google.com"]
-                  :style-src   ["'unsafe-inline'"
-                                "'self'"
-                                "fonts.googleapis.com"]
-                  :font-src    ["'self'"
-                                "fonts.gstatic.com"
-                                "themes.googleusercontent.com"
-                                (when config/is-dev?
-                                  "localhost:8080")]
-                  :img-src     ["*"
-                                "'self' data:"]
-                  :connect-src ["'self'"
-                                "metabase.us10.list-manage.com"
-                                (when config/is-dev?
-                                  "localhost:8080 ws://localhost:8080")]}]
-      (format "%s %s; " (name k) (apply str (interpose " " vs)))))})
+    (for [[k vs] {:default-src  ["'none'"]
+                  :script-src   ["'self'"
+                                 "'unsafe-eval'" ; TODO - we keep working towards removing this entirely
+                                 "https://maps.google.com"
+                                 "https://apis.google.com"
+                                 "https://www.google-analytics.com" ; Safari requires the protocol
+                                 "https://*.googleapis.com"
+                                 "*.gstatic.com"
+                                 ;; for webpack hot reloading
+                                 (when config/is-dev?
+                                   "localhost:8080")
+                                 ;; inline script in index.html that sets `MetabaseBootstrap` and the like
+                                 "'sha256-dPkijyoRrGWwHu+PrDIMt/5wQPFfVuvhU7vendgcUSQ='"
+                                 ;; Web Font Loader font configuration (WebFontConfig) in index.html
+                                 "'sha256-6xC9z5Dcryu9jbxUZkBJ5yUmSofhJjt7Mbnp/ijPkFs='"
+                                 ;; inline script in index.html that loads Google Analytics
+                                 "'sha256-uKEj/Qp9AmQA2Xv83bZX9mNVV2VWZteZjIsVNVzLkA0='"]
+                  :child-src    ["'self'"
+                                 ;; TODO - double check that we actually need this for Google Auth
+                                 "https://accounts.google.com"]
+                  :style-src    ["'self'"
+                                 "'unsafe-inline'" ; needed for Google Fonts
+                                 "fonts.googleapis.com"]
+                  :font-src     ["'self'"
+                                 "fonts.gstatic.com"
+                                 "themes.googleusercontent.com"
+                                 (when config/is-dev?
+                                   "localhost:8080")]
+                  :img-src      ["*"
+                                 "'self' data:"]
+                  :connect-src  ["'self'"
+                                 ;; MailChimp. So people can sign up for the Metabase mailing list in the sign up process
+                                 "metabase.us10.list-manage.com"
+                                 (when config/is-dev?
+                                   "localhost:8080 ws://localhost:8080")]
+                  :manifest-src ["'self'"]}]
+      (format "%s %s; " (name k) (str/join " " vs))))})
 
 (defsetting ssl-certificate-public-key
   (str (tru "Base-64 encoded public key for this site's SSL certificate.")
        (tru "Specify this to enable HTTP Public Key Pinning.")
        (tru "See {0} for more information." "http://mzl.la/1EnfqBf")))
 ;; TODO - it would be nice if we could make this a proper link in the UI; consider enabling markdown parsing
-
-#_(defn- public-key-pins-header []
-  (when-let [k (ssl-certificate-public-key)]
-    {"Public-Key-Pins" (format "pin-sha256=\"base64==%s\"; max-age=31536000" k)}))
 
 (defn security-headers
   "Fetch a map of security headers that should be added to a response based on the passed options."
@@ -79,7 +83,6 @@
      (cache-prevention-headers))
    strict-transport-security-header
    content-security-policy-header
-   #_(public-key-pins-header)
    (when-not allow-iframes?
      ;; Tell browsers not to render our site as an iframe (prevent clickjacking)
      {"X-Frame-Options"                 "DENY"})

--- a/src/metabase/middleware/security.clj
+++ b/src/metabase/middleware/security.clj
@@ -41,7 +41,7 @@
                                  (when config/is-dev?
                                    "localhost:8080")
                                  ;; inline script in index.html that sets `MetabaseBootstrap` and the like
-                                 "'sha256-dPkijyoRrGWwHu+PrDIMt/5wQPFfVuvhU7vendgcUSQ='"
+                                 "'sha256-xlgrBEvjf72cXGba6bCV/PwIVp1DcbdhY74VIXN8fA4='"
                                  ;; Web Font Loader font configuration (WebFontConfig) in index.html
                                  "'sha256-6xC9z5Dcryu9jbxUZkBJ5yUmSofhJjt7Mbnp/ijPkFs='"
                                  ;; inline script in index.html that loads Google Analytics

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -175,7 +175,7 @@
 
 (def ^:private short-timezone-name (memoize short-timezone-name*))
 
-
+;; TODO - it seems like it would be a nice performance win to cache this a little bit
 (defn public-settings
   "Return a simple map of key/value pairs which represent the public settings (`MetabaseBootstrap`) for the front-end
    application."

--- a/src/metabase/routes.clj
+++ b/src/metabase/routes.clj
@@ -1,14 +1,9 @@
 (ns metabase.routes
   "Main Compojure routes tables. See https://github.com/weavejester/compojure/wiki/Routes-In-Detail for details about
    how these work. `/api/` routes are in `metabase.api.routes`."
-  (:require [cheshire.core :as json]
-            [clojure.java.io :as io]
-            [clojure.string :as str]
-            [clojure.tools.logging :as log]
-            [compojure
+  (:require [compojure
              [core :refer [context defroutes GET]]
              [route :as route]]
-            [hiccup.util :as h.util]
             [metabase
              [public-settings :as public-settings]
              [util :as u]]
@@ -16,80 +11,8 @@
              [dataset :as dataset-api]
              [routes :as api]]
             [metabase.core.initialization-status :as init-status]
-            [metabase.util
-             [embed :as embed]
-             [i18n :refer [trs]]]
-            [puppetlabs.i18n.core :refer [*locale*]]
-            [ring.util.response :as resp]
-            [stencil.core :as stencil]))
-
-(defn- base-href []
-  (let [path (some-> (public-settings/site-url) io/as-url .getPath)]
-    (str path "/")))
-
-(defn- escape-script [s]
-  ;; Escapes text to be included in an inline <script> tag, in particular the string '</script'
-  ;; https://stackoverflow.com/questions/14780858/escape-in-script-tag-contents/23983448#23983448
-  (str/replace s #"(?i)</script" "</scr\\\\ipt"))
-
-(defn- load-template [path variables]
-  (try
-    (stencil/render-file path variables)
-    (catch IllegalArgumentException e
-      (let [message (str (trs "Failed to load template ''{0}''. Did you remember to build the Metabase frontend?" path))]
-        (log/error e message)
-        (throw (Exception. message e))))))
-
-(defn- fallback-localization [locale]
-  (json/generate-string
-   {"headers"
-    {"language"     locale
-     "plural-forms" "nplurals=2; plural=(n != 1);"}
-
-    "translations"
-    {"" {"Metabase" {"msgid"  "Metabase"
-                     "msgstr" ["Metabase"]}}}}))
-
-(defn- load-localization* [locale]
-  (if (or (not locale)
-          (= (str locale) "en"))
-    (fallback-localization locale)
-    (try
-      (load-file-at-path (str "frontend_client/app/locales/" locale ".json"))
-      (catch Throwable e
-        (log/warn (trs "Locale ''{0}'' not found." locale))
-        (fallback-localization locale)))))
-
-(def ^:private ^{:arglists '([])} load-localization
-  (let [memoized-load-localization (memoize load-localization*)]
-    (fn []
-      (memoized-load-localization *locale*))))
-
-(defn- load-entrypoint-template [entrypoint-name embeddable? uri]
-  (load-template
-   (str "frontend_client/" entrypoint-name ".html")
-   (let [{:keys [anon_tracking_enabled google_auth_client_id], :as public-settings} (public-settings/public-settings)]
-     {:bootstrapJSON      (escape-script (json/generate-string public-settings))
-      :localizationJSON   (escape-script (load-localization))
-      :uri                (h.util/escape-html uri)
-      :baseHref           (h.util/escape-html (base-href))
-      :embedCode          (when embeddable? (embed/head uri))
-      :enableGoogleAuth   (boolean google_auth_client_id)
-      :enableAnonTracking (boolean anon_tracking_enabled)})))
-
-(defn- entrypoint
-  "Repsonse that serves up an entrypoint into the Metabase application, e.g. `index.html`."
-  [entrypoint-name embeddable? {:keys [uri]} respond raise]
-  (respond
-   (-> (if (init-status/complete?)
-         (load-entrypoint-template entrypoint-name embeddable? uri)
-         (load-file-at-path "frontend_client/init.html"))
-       resp/response
-       (resp/content-type "text/html; charset=utf-8"))))
-
-(def ^:private index  (partial entrypoint "index"  (not :embeddable)))
-(def ^:private public (partial entrypoint "public" :embeddable))
-(def ^:private embed  (partial entrypoint "embed"  :embeddable))
+            [metabase.routes.index :as index]
+            [ring.util.response :as resp]))
 
 (defn- redirect-including-query-string
   "Like `resp/redirect`, but passes along query string URL params as well. This is important because the public and
@@ -98,24 +21,27 @@
   (fn [{:keys [query-string]} respond _]
     (respond (resp/redirect (str url "?" query-string)))))
 
+
 ;; /public routes. /public/question/:uuid.:export-format redirects to /api/public/card/:uuid/query/:export-format
 (defroutes ^:private public-routes
   (GET ["/question/:uuid.:export-format", :uuid u/uuid-regex, :export-format dataset-api/export-format-regex]
        [uuid export-format]
        (redirect-including-query-string (format "%s/api/public/card/%s/query/%s" (public-settings/site-url) uuid export-format)))
-  (GET "*" [] public))
+  (GET "*" [] index/public))
+
 
 ;; /embed routes. /embed/question/:token.:export-format redirects to /api/public/card/:token/query/:export-format
 (defroutes ^:private embed-routes
   (GET ["/question/:token.:export-format", :export-format dataset-api/export-format-regex]
        [token export-format]
        (redirect-including-query-string (format "%s/api/embed/card/%s/query/%s" (public-settings/site-url) token export-format)))
-  (GET "*" [] embed))
+  (GET "*" [] index/embed))
+
 
 ;; Redirect naughty users who try to visit a page other than setup if setup is not yet complete
 (defroutes ^{:doc "Top-level ring routes for Metabase."} routes
   ;; ^/$ -> index.html
-  (GET "/" [] index)
+  (GET "/" [] index/index)
   (GET "/favicon.ico" [] (resp/resource-response "frontend_client/favicon.ico"))
   ;; ^/api/health -> Health Check Endpoint
   (GET "/api/health" [] (if (init-status/complete?)
@@ -138,4 +64,4 @@
   ;; ^/emebed/ -> Embed frontend and download routes
   (context "/embed" [] embed-routes)
   ;; Anything else (e.g. /user/edit_current) should serve up index.html; React app will handle the rest
-  (GET "*" [] index))
+  (GET "*" [] index/index))

--- a/src/metabase/routes/index.clj
+++ b/src/metabase/routes/index.clj
@@ -1,0 +1,85 @@
+(ns metabase.routes.index
+  "Logic related to loading various versions of the index.html template. The actual template lives in
+  `resources/frontend_client/index_template.html`; when the frontend is built (e.g. via `./bin/build frontend`)
+  different versions that include the FE app are created as `index.html`, `public.html`, and `embed.html`."
+  (:require [cheshire.core :as json]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.tools.logging :as log]
+            [hiccup.util :as h.util]
+            [metabase.core.initialization-status :as init-status]
+            [metabase.public-settings :as public-settings]
+            [metabase.util
+             [embed :as embed]
+             [i18n :refer [trs]]]
+            [puppetlabs.i18n.core :refer [*locale*]]
+            [ring.util.response :as resp]
+            [stencil.core :as stencil]))
+
+(defn- base-href []
+  (let [path (some-> (public-settings/site-url) io/as-url .getPath)]
+    (str path "/")))
+
+(defn- escape-script [s]
+  ;; Escapes text to be included in an inline <script> tag, in particular the string '</script'
+  ;; https://stackoverflow.com/questions/14780858/escape-in-script-tag-contents/23983448#23983448
+  (str/replace s #"(?i)</script" "</scr\\\\ipt"))
+
+
+(defn- fallback-localization [locale]
+  (json/generate-string
+   {"headers"
+    {"language"     locale
+     "plural-forms" "nplurals=2; plural=(n != 1);"}
+
+    "translations"
+    {"" {"Metabase" {"msgid"  "Metabase"
+                     "msgstr" ["Metabase"]}}}}))
+
+(defn- load-localization* [locale]
+  (or
+   (when (and locale (not= locale "en"))
+     (try
+       (slurp (str "frontend_client/app/locales/" locale ".json"))
+       (catch Throwable e
+         (log/warn (trs "Locale ''{0}'' not found." locale)))))
+   (fallback-localization locale)))
+
+(def ^:private ^{:arglists '([])} load-localization
+  (let [memoized-load-localization (memoize load-localization*)]
+    (fn []
+      (memoized-load-localization *locale*))))
+
+
+(defn- load-template [path variables]
+  (try
+    (stencil/render-file path variables)
+    (catch IllegalArgumentException e
+      (let [message (str (trs "Failed to load template ''{0}''. Did you remember to build the Metabase frontend?" path))]
+        (log/error e message)
+        (throw (Exception. message e))))))
+
+(defn- load-entrypoint-template [entrypoint-name embeddable? uri]
+  (load-template
+   (str "frontend_client/" entrypoint-name ".html")
+   (let [{:keys [anon_tracking_enabled google_auth_client_id], :as public-settings} (public-settings/public-settings)]
+     {:bootstrapJSON      (escape-script (json/generate-string public-settings))
+      :localizationJSON   (escape-script (load-localization))
+      :uri                (h.util/escape-html uri)
+      :baseHref           (h.util/escape-html (base-href))
+      :embedCode          (when embeddable? (embed/head uri))
+      :enableGoogleAuth   (boolean google_auth_client_id)
+      :enableAnonTracking (boolean anon_tracking_enabled)})))
+
+(defn- entrypoint
+  "Repsonse that serves up an entrypoint into the Metabase application, e.g. `index.html`."
+  [entrypoint-name embeddable? {:keys [uri]} respond raise]
+  (respond
+   (-> (if (init-status/complete?)
+         (resp/response (load-entrypoint-template entrypoint-name embeddable? uri))
+         (resp/resource-response "frontend_client/init.html"))
+       (resp/content-type "text/html; charset=utf-8"))))
+
+(def index  "main index.html entrypoint."    (partial entrypoint "index"  (not :embeddable)))
+(def public "/public index.html entrypoint." (partial entrypoint "public" :embeddable))
+(def embed  "/embed index.html entrypoint."  (partial entrypoint "embed"  :embeddable))


### PR DESCRIPTION
Big security improvement by removing the `unsafe-inline` directive from our CSP header and manually whitelisting the inline `<script>` tags we generate.

Also fixes #9745