### PR TITLE
Fix GA date off by one errors + limited support for AND with GA dates

### DIFF
--- a/modules/drivers/googleanalytics/test/metabase/driver/googleanalytics_test.clj
+++ b/modules/drivers/googleanalytics/test/metabase/driver/googleanalytics_test.clj
@@ -17,7 +17,8 @@
             [metabase.test.util :as tu]
             [metabase.util.date :as du]
             [toucan.db :as db]
-            [toucan.util.test :as tt]))
+            [toucan.util.test :as tt]
+            [clj-time.core :as t]))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                        MBQL->NATIVE (QUERY -> GA QUERY)                                        |
@@ -87,6 +88,31 @@
   (ga-query {:start-date "2016-11-08", :end-date "2016-11-08"})
   (mbql->native {:query {:filter [:= (ga-date-field :day) [:absolute-datetime #inst "2016-11-08" :day]]}}))
 
+;; tests day-off correction for gt/lt operators (GA doesn't support exclusive ranges)
+(expect
+  (ga-query {:start-date "2016-11-09", :end-date "today"})
+  (mbql->native {:query {:filter [:> (ga-date-field :day) [:absolute-datetime #inst "2016-11-08" :day]]}}))
+
+(expect
+  (ga-query {:start-date "2005-01-01", :end-date "2016-10-01"})
+  (mbql->native {:query {:filter [:< (ga-date-field :day) [:absolute-datetime #inst "2016-10-02" :day]]}}))
+
+(expect
+  (ga-query {:start-date "2005-01-01", :end-date "2016-10-02"})
+  (mbql->native {:query {:filter [:<= (ga-date-field :day) [:absolute-datetime #inst "2016-10-02" :day]]}}))
+
+(expect
+  (ga-query {:start-date "2016-09-10", :end-date "2016-10-01"})
+  (mbql->native {:query {:filter [:and
+                                  [:< (ga-date-field :day) [:absolute-datetime #inst "2016-10-02" :day]]
+                                  [:> (ga-date-field :day) [:absolute-datetime #inst "2016-09-09" :day]]]}}))
+
+(expect
+  (ga-query {:start-date "2016-09-10", :end-date "2016-10-02"})
+  (mbql->native {:query {:filter [:and
+                                  [:<= (ga-date-field :day) [:absolute-datetime #inst "2016-10-02" :day]]
+                                  [:> (ga-date-field :day) [:absolute-datetime #inst "2016-09-09" :day]]]}}))
+
 ;; relative date -- last month
 (expect
   (ga-query {:start-date (du/format-date "yyyy-MM-01" (du/relative-date :month -1))
@@ -116,6 +142,22 @@
   (ga-query {:start-date (du/format-date "yyyy-01-01" (du/relative-date :year -1))
              :end-date   (du/format-date "yyyy-01-01")})
   (mbql->native {:query {:filter [:= (ga-date-field :year) [:relative-datetime -1 :year]]}}))
+
+;; a range starting from 30 days ago excluding that first day until today
+(expect
+  (ga-query {:start-date "29daysAgo"
+             :end-date   "today"})
+  (mbql->native {:query {:filter [:> (ga-date-field :day) [:relative-datetime -30 :day]]}}))
+
+(expect
+  (ga-query {:start-date "30daysAgo"
+             :end-date   "today"})
+  (mbql->native {:query {:filter [:>= (ga-date-field :day) [:relative-datetime -30 :day]]}}))
+
+(expect
+  (ga-query {:start-date (du/format-date "yyyy-MM-dd" (du/relative-date :day 1 (du/date-trunc :year (du/relative-date :year -1))))
+             :end-date   "today"})
+  (mbql->native {:query {:filter [:> (ga-date-field :year) [:relative-datetime -1 :year]]}}))
 
 ;; limit
 (expect

--- a/modules/drivers/googleanalytics/test/metabase/driver/googleanalytics_test.clj
+++ b/modules/drivers/googleanalytics/test/metabase/driver/googleanalytics_test.clj
@@ -17,8 +17,7 @@
             [metabase.test.util :as tu]
             [metabase.util.date :as du]
             [toucan.db :as db]
-            [toucan.util.test :as tt]
-            [clj-time.core :as t]))
+            [toucan.util.test :as tt]))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                        MBQL->NATIVE (QUERY -> GA QUERY)                                        |
@@ -88,7 +87,7 @@
   (ga-query {:start-date "2016-11-08", :end-date "2016-11-08"})
   (mbql->native {:query {:filter [:= (ga-date-field :day) [:absolute-datetime #inst "2016-11-08" :day]]}}))
 
-;; tests day-off correction for gt/lt operators (GA doesn't support exclusive ranges)
+;; tests off by one day correction for gt/lt operators (GA doesn't support exclusive ranges)
 (expect
   (ga-query {:start-date "2016-11-09", :end-date "today"})
   (mbql->native {:query {:filter [:> (ga-date-field :day) [:absolute-datetime #inst "2016-11-08" :day]]}}))
@@ -154,6 +153,7 @@
              :end-date   "today"})
   (mbql->native {:query {:filter [:>= (ga-date-field :day) [:relative-datetime -30 :day]]}}))
 
+;; last year excluding the first day of the range
 (expect
   (ga-query {:start-date (du/format-date "yyyy-MM-dd" (du/relative-date :day 1 (du/date-trunc :year (du/relative-date :year -1))))
              :end-date   "today"})


### PR DESCRIPTION
##### Problem:

`>` and `<` MBQL operators are incorrectly converted to GA's `start-date` and `end-date` without taking into account inclusivity of the latter ones.
This results in for example MBQL filter `[:> [:datetime-field ...] #inst "2018-01-25"]` being converted to `start_date=2018-01-25` predicate in GA. Effectively `>` and `<` MBQL operators, when used with GA, work as if they were `>=` and `<=` respectively instead. 

##### Solution:

This PR does some date arithmetic for `>` and `<` to adjust the date. (for `>` the resulting date will be `plus 1 day`, for `<` it will be `minus 1 day`)
Defines `:>=` and `:<=` operators for GA.
Makes it possible to use multiple date predicates conjoined with `and` as long as they never yield conflicting filters, for example the following will work: (`...` stands for the date field)
```
> [:and [:> ... #inst "2018-01-01"] [:< ... #inst "2018-01-10"]]
start_date=2018-01-02&end_date=2018-01-09

> [:and [:> ... #inst "2018-01-01"] [:<= ... #inst "2019-01-01"]]
start_date=2018-01-02&end_date=2019-01-01
```
where for example this will not work `[:and [:> ... #inst "2018-01-01"] [:>= ... #inst "2018-01-10"]]`. Although it is possible to reduce these sorts of expressions but I decided not to go with it for now. `or` expressions however cannot be used due to GA's limitations.
This feature is a prerequisite to performance fixes that will be pushed later in #9860 , if you think it makes sense to split this PR into two as well let me know please (the off by one fix, and using `and` in date predicates).

Fixes #9475
If we do add folding for intersecting periods conjoined with `and` then we will fix #7387 and I think #6272 