### PR TITLE
Fix world map crop issue

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -146,11 +146,14 @@ export default class ChoroplethMap extends Component {
     let { geoJson, minimalBounds } = this.state;
 
     // special case builtin maps to use legacy choropleth map
-    let projection;
+    let projection, projectionFrame;
+    // projectionFrame is the lng/lat of the top left and bottom right corners
     if (settings["map.region"] === "us_states") {
       projection = d3.geo.albersUsa();
+      projectionFrame = [[-135.0, 46.6], [-69.1, 21.7]];
     } else if (settings["map.region"] === "world_countries") {
       projection = d3.geo.mercator();
+      projectionFrame = [[-170, 78], [180, -60]];
     } else {
       projection = null;
     }
@@ -264,10 +267,8 @@ export default class ChoroplethMap extends Component {
 
     let aspectRatio;
     if (projection) {
-      let translate = projection.translate();
-      let width = translate[0] * 2;
-      let height = translate[1] * 2;
-      aspectRatio = width / height;
+      const [[minX, minY], [maxX, maxY]] = projectionFrame.map(projection);
+      aspectRatio = (maxX - minX) / (maxY - minY);
     } else {
       aspectRatio =
         (minimalBounds.getEast() - minimalBounds.getWest()) /
@@ -292,6 +293,7 @@ export default class ChoroplethMap extends Component {
             onHoverFeature={onHoverFeature}
             onClickFeature={onClickFeature}
             projection={projection}
+            projectionFrame={projectionFrame}
           />
         ) : (
           <LeafletChoropleth

--- a/frontend/src/metabase/visualizations/components/LegacyChoropleth.jsx
+++ b/frontend/src/metabase/visualizations/components/LegacyChoropleth.jsx
@@ -8,15 +8,16 @@ const LegacyChoropleth = ({
   series,
   geoJson,
   projection,
+  projectionFrame,
   getColor,
   onHoverFeature,
   onClickFeature,
 }) => {
   let geo = d3.geo.path().projection(projection);
 
-  let translate = projection.translate();
-  let width = translate[0] * 2;
-  let height = translate[1] * 2;
+  const [[minX, minY], [maxX, maxY]] = projectionFrame.map(projection);
+  const width = maxX - minX;
+  const height = maxY - minY;
 
   return (
     <div className="absolute top bottom left right flex layout-centered">
@@ -28,7 +29,10 @@ const LegacyChoropleth = ({
       >
         {() => (
           // eslint-disable-line react/display-name
-          <svg className="flex-full m1" viewBox={`0 0 ${width} ${height}`}>
+          <svg
+            className="flex-full m1"
+            viewBox={`${minX} ${minY} ${width} ${height}`}
+          >
             {geoJson.features.map((feature, index) => (
               <path
                 d={geo(feature, index)}


### PR DESCRIPTION
Resolves #4378

## What does this do?

This PR fixes a bug where northern countries were cropped in the world map. It does this by adding an explicit longitude/latitude based frame for each map.

## How did it work before?

Previously, we used the default framing of the projection itself. This would leave the default dimensions of 960x500px and the default zoom of 150 in place. This worked well for the Albers US projection, but the default framing for the Mercator-projected world map cropped important regions.

## How did the world map view change?

### Before
<img width="1440" alt="Screen Shot 2019-05-07 at 3 01 40 PM" src="https://user-images.githubusercontent.com/691495/57328146-9f596f80-70de-11e9-8aca-6fa305969179.png">

### After
<img width="1440" alt="Screen Shot 2019-05-07 at 3 00 43 PM" src="https://user-images.githubusercontent.com/691495/57328162-abddc800-70de-11e9-996a-7f3a8508316d.png">



