### PR TITLE
move public question visualization to z-index: 1

### DIFF
--- a/frontend/src/metabase/public/containers/PublicQuestion.jsx
+++ b/frontend/src/metabase/public/containers/PublicQuestion.jsx
@@ -197,7 +197,7 @@ export default class PublicQuestion extends Component {
           {() => (
             <Visualization
               rawSeries={[{ card: card, data: result && result.data }]}
-              className="full flex-full"
+              className="full flex-full z1"
               onUpdateVisualizationSettings={settings =>
                 this.setState({
                   // $FlowFixMe


### PR DESCRIPTION
Adds a class to move the visualization beneath the tooltip.

Resolves #8188 

### Before
![image](https://user-images.githubusercontent.com/691495/57407341-e879f400-71b0-11e9-9e14-6d0b24e26a1d.png)

### After
![image](https://user-images.githubusercontent.com/691495/57407350-ed3ea800-71b0-11e9-919f-db27be708159.png)


