### PR TITLE
fix text card scroll issue

### DIFF
--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -426,7 +426,7 @@ export default class Visualization extends Component {
     }
 
     return (
-      <div className={cx(className, "flex flex-column")}>
+      <div className={cx(className, "flex flex-column full-height")}>
         {(showTitle &&
           (settings["card.title"] || extra) &&
           (loading ||

--- a/frontend/src/metabase/visualizations/visualizations/Text.css
+++ b/frontend/src/metabase/visualizations/visualizations/Text.css
@@ -7,6 +7,7 @@
   flex-direction: column;
   justify-content: center;
   padding: 1em 0 1em 1.5em;
+  height: 100%;
 }
 :local .Text.dashboard-is-editing {
   padding: 2.8em 1.3em var(--text-card-padding) 1.3em;
@@ -26,6 +27,7 @@
   box-shadow: 0 1px 7px var(--color-shadow);
 }
 :local .Text .text-card-markdown {
+  height: 100%;
   overflow: auto;
   pointer-events: all;
 }


### PR DESCRIPTION
# The Problem

Long text areas cant be scrolled. To reuse @mazameli's illustrative gif:

![](https://user-images.githubusercontent.com/2223916/44159435-33286e80-a06c-11e8-9a5e-ddb5c871f0d7.gif)

It looks like this issue was duplicated twice for Firefox and once for all browsers. Prior to this commit, I experienced the same behavior in Firefox and Chrome.

Resolves #6910 
Resolves #8333
Resolves #7159

# The Solution

The fix I went with feels a bit hacky, so please suggest other solutions! I set `height: 100%` on every element between the dashboard card and the text. There are three elements in total.

Another thing I tried was to change the `overflow: hidden` to `overflow: auto` on the card itself. This works, but likely has unintended consequences on other types of cards.