### PR TITLE
Bump Redshift JDBC driver version 

### DIFF
--- a/modules/drivers/redshift/project.clj
+++ b/modules/drivers/redshift/project.clj
@@ -6,7 +6,7 @@
 
 
   :dependencies
-  [[com.amazon.redshift/redshift-jdbc42-no-awssdk "1.2.18.1036"]]
+  [[com.amazon.redshift/redshift-jdbc42-no-awssdk "1.2.27.1051"]]
 
   :profiles
   {:provided


### PR DESCRIPTION
Bump Redshift driver to latest. There are no known issues with 1051 though it is relatively new. 💯 