### PR TITLE
Fix log4j error messages on startup :wrench:

### DIFF
--- a/resources/log4j.properties
+++ b/resources/log4j.properties
@@ -1,4 +1,4 @@
-log4j.rootLogger=WARN, console, metabase
+log4j.rootLogger=WARN, console
 
 # log to the console
 log4j.appender.console=org.apache.log4j.ConsoleAppender


### PR DESCRIPTION
Fixes these two error message lines on launch

```
log4j:ERROR Could not find value for key log4j.appender.metabase
log4j:ERROR Could not instantiate appender named "metabase".
```