### PR TITLE
Backport some improved code from Metabase EE

### DIFF
--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -350,9 +350,18 @@
 
      (api/+check-superuser routes)"
   [handler]
-  (fn [request]
-    (check-superuser)
-    (handler request)))
+  (fn
+    ([request]
+     (check-superuser)
+     (handler request))
+    ([request respond raise]
+     (if-let [e (try
+                  (check-superuser)
+                  nil
+                  (catch Throwable e
+                    e))]
+       (raise e)
+       (handler request respond raise)))))
 
 
 ;;; ---------------------------------------- PERMISSIONS CHECKING HELPER FNS -----------------------------------------

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -28,17 +28,34 @@
   (:import com.unboundid.util.LDAPSDKException
            java.util.UUID))
 
-(s/defn ^:private create-session! :- UUID
-  "Generate a new `Session` for a given `User`. Returns the newly generated session ID."
-  [user :- {:id         su/IntGreaterThanZero
-            :last_login s/Any
-            s/Keyword   s/Any}]
+(defmulti create-session!
+  "Generate a new Session for a User. `session-type` is the currently either `:password` (for email + password login) or
+  `:sso` (for other login types). Returns the newly generated session `UUID`."
+  {:arglists '(^java.util.UUID [session-type user])}
+  (fn [session-type & _]
+    session-type))
+
+(def ^:private CreateSessionUserInfo
+  {:id         su/IntGreaterThanZero
+   :last_login s/Any
+   s/Keyword   s/Any})
+
+(s/defmethod create-session! :sso
+  [_, user :- CreateSessionUserInfo]
   (u/prog1 (UUID/randomUUID)
     (db/insert! Session
       :id      (str <>)
-      :user_id (:id user))
+      :user_id (u/get-id user))
     (events/publish-event! :user-login
       {:user_id (:id user), :session_id (str <>), :first_login (nil? (:last_login user))})))
+
+(s/defmethod create-session! :password
+  [session-type, user :- CreateSessionUserInfo]
+  ;; this is actually the same as `create-session!` for `:sso` but we check whether password login is enabled.
+  (when-not (public-settings/enable-password-login)
+    (throw (UnsupportedOperationException. (str (tru "Password login is disabled for this instance.")))))
+  ((get-method create-session! :sso) session-type user))
+
 
 ;;; ## API Endpoints
 
@@ -64,7 +81,7 @@
                    {:status-code 400
                     :errors      {:password password-fail-snippet}})))
         ;; password is ok, return new session
-        (create-session! (ldap/fetch-or-create-user! user-info password)))
+        (create-session! :sso (ldap/fetch-or-create-user! user-info password)))
       (catch LDAPSDKException e
         (log/error e (trs "Problem connecting to LDAP server, will fall back to local authentication"))))))
 
@@ -73,7 +90,7 @@
   [username password]
   (when-let [user (db/select-one [User :id :password_salt :password :last_login], :email username, :is_active true)]
     (when (pass/verify-password password (:password_salt user) (:password user))
-      (create-session! user))))
+      (create-session! :password user))))
 
 (def ^:private throttling-disabled? (config/config-bool :mb-disable-session-throttle))
 
@@ -174,7 +191,7 @@
         (when-not (:last_login user)
           (email/send-user-joined-admin-notification-email! (User user-id)))
         ;; after a successful password update go ahead and offer the client a new session that they can use
-        (let [session-id (create-session! user)]
+        (let [session-id (create-session! :password user)]
           (mw.session/set-session-cookie
            request
            {:success    true
@@ -228,7 +245,9 @@
   (when-let [domain (google-auth-auto-create-accounts-domain)]
     (email-in-domain? email domain)))
 
-(defn- check-autocreate-user-allowed-for-email [email]
+(defn- check-autocreate-user-allowed-for-email
+  "Throws if an admin needs to intervene in the account creation."
+  [email]
   (when-not (autocreate-user-allowed-for-email? email)
     ;; Use some wacky status code (428 - Precondition Required) so we will know when to so the error screen specific
     ;; to this situation
@@ -250,7 +269,7 @@
                       (google-auth-create-new-user! {:first_name first-name
                                                      :last_name  last-name
                                                      :email      email}))]
-    (create-session! user)))
+    (create-session! :password user)))
 
 (api/defendpoint POST "/google_auth"
   "Login with Google Auth."

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -29,10 +29,11 @@
 
 (def db-file
   "Path to our H2 DB file from env var or app config."
-  ;; see http://h2database.com/html/features.html for explanation of options
+  ;; see https://h2database.com/html/features.html for explanation of options
   (delay
    (if (config/config-bool :mb-db-in-memory)
      ;; In-memory (i.e. test) DB
+     ;; DB_CLOSE_DELAY=-1 = don't close the Database until the JVM shuts down
      "mem:metabase;DB_CLOSE_DELAY=-1"
      ;; File-based DB
      (let [db-file-name (config/config-str :mb-db-file)

--- a/src/metabase/integrations/common.clj
+++ b/src/metabase/integrations/common.clj
@@ -1,0 +1,35 @@
+(ns metabase.integrations.common
+  "Shared functionality used by different integrations."
+  (:require [clojure.data :as data]
+            [clojure.tools.logging :as log]
+            [metabase.models
+             [permissions-group :as group]
+             [permissions-group-membership :refer [PermissionsGroupMembership]]]
+            [metabase.util :as u]
+            [metabase.util.i18n :refer [trs]]
+            [toucan.db :as db]))
+
+(defn sync-group-memberships!
+  "Update the PermissionsGroups a User belongs to, adding or deleting membership entries as needed so that Users is only
+  in `new-groups-or-ids`. Ignores special groups like `admin` and `all-users`."
+  [user-or-id new-groups-or-ids]
+  (let [special-group-ids  #{(u/get-id (group/admin)) (u/get-id (group/all-users))}
+        ;; Get a set of Group IDs the user currently belongs to
+        current-group-ids  (db/select-field :group_id PermissionsGroupMembership
+                             :user_id  (u/get-id user-or-id)
+                             :group_id [:not-in special-group-ids])
+        new-group-ids      (set (map u/get-id new-groups-or-ids))
+        ;; determine what's different between current groups and new groups
+        [to-remove to-add] (data/diff current-group-ids new-group-ids)]
+    ;; remove membership from any groups as needed
+    (when (seq to-remove)
+      (db/delete! PermissionsGroupMembership :group_id [:in to-remove], :user_id (u/get-id user-or-id)))
+    ;; add new memberships for any groups as needed
+    (doseq [id    to-add
+            :when (not (special-group-ids id))]
+      ;; if adding membership fails for one reason or another (i.e. if the group doesn't exist) log the error add the
+      ;; user to the other groups rather than failing entirely
+      (try
+        (db/insert! PermissionsGroupMembership :group_id id, :user_id (u/get-id user-or-id))
+        (catch Throwable e
+          (log/error e (trs "Error adding User {0} to Group {1}" (u/get-id user-or-id) id)))))))

--- a/src/metabase/integrations/ldap.clj
+++ b/src/metabase/integrations/ldap.clj
@@ -1,10 +1,8 @@
 (ns metabase.integrations.ldap
   (:require [clj-ldap.client :as ldap]
-            [clojure
-             [set :as set]
-             [string :as str]]
+            [clojure.string :as str]
+            [metabase.integrations.common :as integrations.common]
             [metabase.models
-             [permissions-group :as group :refer [PermissionsGroup]]
              [setting :as setting :refer [defsetting]]
              [user :as user :refer [User]]]
             [metabase.util :as u]
@@ -70,7 +68,8 @@
   (tru "Search base for groups, not required if your LDAP directory provides a ''memberOf'' overlay. (Will be searched recursively)"))
 
 (defsetting ldap-group-mappings
-  ;; Should be in the form: {"cn=Some Group,dc=...": [1, 2, 3]} where keys are LDAP groups and values are lists of MB groups IDs
+  ;; Should be in the form: {"cn=Some Group,dc=...": [1, 2, 3]} where keys are LDAP groups and values are lists of MB
+  ;; groups IDs
   (tru "JSON containing LDAP to Metabase group mappings.")
   :type    :json
   :default {})
@@ -140,14 +139,15 @@
 (defn test-ldap-connection
   "Test the connection to an LDAP server to determine if we can find the search base.
 
-   Takes in a dictionary of properties such as:
-       {:host       \"localhost\"
-        :port       389
-        :bind-dn    \"cn=Directory Manager\"
-        :password   \"password\"
-        :security   \"none\"
-        :user-base  \"ou=Birds,dc=metabase,dc=com\"
-        :group-base \"ou=Groups,dc=metabase,dc=com\"}"
+  Takes in a dictionary of properties such as:
+
+    {:host       \"localhost\"
+     :port       389
+     :bind-dn    \"cn=Directory Manager\"
+     :password   \"password\"
+     :security   \"none\"
+     :user-base  \"ou=Birds,dc=metabase,dc=com\"
+     :group-base \"ou=Groups,dc=metabase,dc=com\"}"
   [{:keys [user-base group-base], :as details}]
   (try
     (with-open [^LDAPConnectionPool conn (ldap/connect (details->ldap-options details))]
@@ -169,59 +169,55 @@
     (catch Exception e
       {:status :ERROR, :message (.getMessage e)})))
 
+(defn- search [conn username]
+  (first
+   (ldap/search
+    conn
+    (ldap-user-base)
+    {:scope      :sub
+     :filter     (str/replace (ldap-user-filter) filter-placeholder (escape-value username))
+     :size-limit 1})))
+
 (defn find-user
   "Gets user information for the supplied username."
   ([username]
-    (with-connection find-user username))
+   (with-connection find-user username))
+
   ([conn username]
-    (let [fname-attr (keyword (ldap-attribute-firstname))
-          lname-attr (keyword (ldap-attribute-lastname))
-          email-attr (keyword (ldap-attribute-email))]
-      (when-let [[result] (ldap/search conn (ldap-user-base) {:scope      :sub
-                                                              :filter     (str/replace (ldap-user-filter) filter-placeholder (escape-value username))
-                                                              :attributes [:dn :distinguishedName fname-attr lname-attr email-attr :memberOf]
-                                                              :size-limit 1})]
-        (let [dn    (or (:dn result) (:distinguishedName result))
-              fname (get result fname-attr)
-              lname (get result lname-attr)
-              email (get result email-attr)]
-          ;; Make sure we got everything as these are all required for new accounts
-          (when-not (or (empty? dn) (empty? fname) (empty? lname) (empty? email))
-            ;; ActiveDirectory (and others?) will supply a `memberOf` overlay attribute for groups
-            ;; Otherwise we have to make the inverse query to get them
-            (let [groups (when (ldap-group-sync)
-                           (or (:memberOf result) (get-user-groups dn) []))]
-              {:dn         dn
-               :first-name fname
-               :last-name  lname
-               :email      email
-               :groups     groups})))))))
+   (when-let [result (search conn username)]
+     (let [dn                                          (some result [:dn :distinguishedName])
+           {fname (keyword (ldap-attribute-firstname))
+            lname (keyword (ldap-attribute-lastname))
+            email (keyword (ldap-attribute-email))}    result]
+       ;; Make sure we got everything as these are all required for new accounts
+       (when-not (some empty? [dn fname lname email])
+         {:dn         dn
+          :first-name fname
+          :last-name  lname
+          :email      email
+          :groups     (when (ldap-group-sync)
+                        ;; ActiveDirectory (and others?) will supply a `memberOf` overlay attribute for groups
+                        ;; Otherwise we have to make the inverse query to get them
+                        (or (:memberOf result) (get-user-groups dn) []))})))))
 
 (defn verify-password
   "Verifies if the supplied password is valid for the `user-info` (from `find-user`) or DN."
   ([user-info password]
-    (with-connection verify-password user-info password))
+   (with-connection verify-password user-info password))
+
   ([conn user-info password]
-    (if (string? user-info)
-      (ldap/bind? conn user-info password)
-      (ldap/bind? conn (:dn user-info) password))))
+   (let [dn (if (string? user-info) user-info (:dn user-info))]
+     (ldap/bind? conn dn password))))
 
 (defn fetch-or-create-user!
   "Using the `user-info` (from `find-user`) get the corresponding Metabase user, creating it if necessary."
-  [{:keys [first-name last-name email groups]} password]
+  [{:keys [first-name last-name email groups]}]
   (let [user (or (db/select-one [User :id :last_login] :email email)
-                 (user/create-new-ldap-auth-user! {:first_name first-name
-                                                   :last_name  last-name
-                                                   :email      email}))]
+                 (user/create-new-ldap-auth-user!
+                  {:first_name       first-name
+                   :last_name        last-name
+                   :email            email}))]
     (u/prog1 user
       (when (ldap-group-sync)
-        (let [special-ids #{(:id (group/admin)) (:id (group/all-users))}
-              current-ids (set (map :group_id (db/select ['PermissionsGroupMembership :group_id] :user_id (:id user))))
-              ldap-ids    (when-let [ids (seq (ldap-groups->mb-group-ids groups))]
-                            (set (map :id (db/select [PermissionsGroup :id] :id [:in ids]))))
-              to-remove   (set/difference current-ids ldap-ids special-ids)
-              to-add      (set/difference ldap-ids current-ids)]
-          (when (seq to-remove)
-            (db/delete! 'PermissionsGroupMembership :group_id [:in to-remove], :user_id (:id user)))
-          (doseq [id to-add]
-            (db/insert! 'PermissionsGroupMembership :group_id id, :user_id (:id user))))))))
+        (let [group-ids (ldap-groups->mb-group-ids groups)]
+          (integrations.common/sync-group-memberships! user group-ids))))))

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -146,12 +146,12 @@
          {:status-code 400
           :errors      {:location (tru "Invalid Collection location: path is invalid.")}})))
     ;; if this is a Personal Collection it's only allowed to go in the Root Collection: you can't put it anywhere else!
-    (when (contains? collection :personal_owner_id)
-      (when-not (= location "/")
-        (throw
-         (ui18n/ex-info (tru "You cannot move a Personal Collection.")
-           {:status-code 400
-            :errors      {:location (tru "You cannot move a Personal Collection.")}}))))
+    (when (and (:personal_owner_id collection)
+               (not= location "/"))
+      (throw
+       (ui18n/ex-info (tru "You cannot move a Personal Collection.")
+         {:status-code 400
+          :errors      {:location (tru "You cannot move a Personal Collection.")}})))
     ;; Also make sure that all the IDs referenced in the Location path actually correspond to real Collections
     (when-not (all-ids-in-location-path-are-valid? location)
       (throw

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -215,10 +215,11 @@
   "Convenience for creating a new user via LDAP. This account is considered active immediately; thus all active admins
   will receive an email right away."
   [new-user :- NewUser]
-  (insert-new-user! (-> new-user
-                        ;; We should not store LDAP passwords
-                        (dissoc :password)
-                        (assoc :ldap_auth true))))
+  (insert-new-user!
+   (-> new-user
+       ;; We should not store LDAP passwords
+       (dissoc :password)
+       (assoc :ldap_auth true))))
 
 (defn set-password!
   "Updates the stored password for a specified `User` by hashing the password with a random salt."

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -152,6 +152,11 @@
   :type    :integer
   :default 10)
 
+(defsetting enable-password-login
+  (tru "Allow logging in by email and password.")
+  :type    :boolean
+  :default true)
+
 (defsetting breakout-bins-num
   (tru "When using the default binning strategy and a number of bins is not provided, this number will be used as the default.")
   :type :integer

--- a/src/metabase/public_settings/metastore.clj
+++ b/src/metabase/public_settings/metastore.clj
@@ -1,6 +1,7 @@
 (ns metabase.public-settings.metastore
   "Settings related to checking token validity and accessing the MetaStore."
   (:require [cheshire.core :as json]
+            [clj-http.client :as http]
             [clojure.core.memoize :as memoize]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
@@ -58,26 +59,28 @@
   (log/info (trs "Checking with the MetaStore to see whether {0} is valid..." token))
   (deref
    (future
-     (println (u/format-color 'green (trs "Using this URL to check token: {0}" (token-status-url token))))
+     (log/info (u/format-color 'green (trs "Using this URL to check token: {0}" (token-status-url token))))
      (try (some-> (token-status-url token)
-                  slurp
+                  http/get
+                  :body
                   (json/parse-string keyword))
-          ;; slurp will throw a FileNotFoundException for 404s, so in that case just return an appropriate
-          ;; 'Not Found' message
-          (catch java.io.FileNotFoundException e
-            {:valid false, :status (str (tru "Unable to validate token: 404 not found."))})
-          ;; if there was any other error fetching the token, log it and return a generic message about the
+          ;; if there was an error fetching the token, log it and return a generic message about the
           ;; token being invalid. This message will get displayed in the Settings page in the admin panel so
           ;; we do not want something complicated
-          (catch Throwable e
+          (catch clojure.lang.ExceptionInfo e
             (log/error e (trs "Error fetching token status:"))
-            {:valid false, :status (str (tru "There was an error checking whether this token was valid:")
-                                        " "
-                                        (.getMessage e))})))
+            (let [body (u/ignore-exceptions (some-> (ex-data e) :object :body (json/parse-string keyword)))]
+              (or
+               body
+               {:valid         false
+                :status        (str (tru "Unable to validate token"))
+                :error-details (.getMessage e)})))))
    fetch-token-status-timeout-ms
-   {:valid false, :status (str (tru "Token validation timed out."))}))
+   {:valid         false
+    :status        (str (tru "Unable to validate token"))
+    :error-details (str (tru "Token validation timed out."))}))
 
-(def ^:private ^{:arglists '([token])} fetch-token-status
+(def ^{:arglists '([token])} fetch-token-status
   "TTL-memoized version of `fetch-token-status*`. Caches API responses for 5 minutes. This is important to avoid making
   too many API calls to the Store, which will throttle us if we make too many requests; putting in a bad token could
   otherwise put us in a state where `valid-token->features*` made API calls over and over, never itself getting cached
@@ -88,10 +91,11 @@
 
 (s/defn ^:private valid-token->features* :- #{su/NonBlankString}
   [token :- ValidToken]
-  (let [{:keys [valid status features]} (fetch-token-status token)]
+  (let [{:keys [valid status features error-details]} (fetch-token-status token)]
     ;; if token isn't valid throw an Exception with the `:status` message
     (when-not valid
-      (throw (Exception. ^String status)))
+      (throw (ex-info status
+               {:status-code 400, :error-details error-details})))
     ;; otherwise return the features this token supports
     (set features)))
 
@@ -118,14 +122,16 @@
     (try
       (when (seq new-value)
         (when (s/check ValidToken new-value)
-          (throw (ex-info (str (tru "Token format is invalid. Token should be 64 hexadecimal characters."))
-                   {:status-code 400})))
+          (throw (ex-info (str (tru "Token format is invalid."))
+                   {:status-code 400, :error-details "Token should be 64 hexadecimal characters."})))
         (valid-token->features new-value)
         (log/info (trs "Token is valid.")))
       (setting/set-string! :premium-embedding-token new-value)
       (catch Throwable e
         (log/error e (trs "Error setting premium features token"))
-        (throw (ex-info (.getMessage e) {:status-code 400}))))))
+        (throw (ex-info (.getMessage e) (merge
+                                         {:message (.getMessage e), :status-code 400}
+                                         (ex-data e)))))))) ; merge in error-details if present
 
 (s/defn ^:private token-features :- #{su/NonBlankString}
   "Get the features associated with the system's premium features token."

--- a/src/metabase/query_processor/middleware/parameters.clj
+++ b/src/metabase/query_processor/middleware/parameters.clj
@@ -14,11 +14,11 @@
 (defn- expand-parameters*
   "Expand any `:parameters` set on the `query-dict` and apply them to the query definition. This function removes
   the `:parameters` attribute from the `query-dict` as part of its execution."
-  [{:keys [parameters], query-type :type, :as query-dict}]
+  [{:keys [parameters], query-type :type, :as outer-query}]
   ;; params in native queries are currently only supported for SQL drivers
   (if (= query-type :query)
-    (mbql-params/expand (dissoc query-dict :parameters) parameters)
-    (sql-params/expand query-dict)))
+    (mbql-params/expand (dissoc outer-query :parameters) parameters)
+    (sql-params/expand outer-query)))
 
 (defn- expand-params-in-native-source-query
   "Expand parameters in a native source query."

--- a/src/metabase/query_processor/middleware/parameters/mbql.clj
+++ b/src/metabase/query_processor/middleware/parameters/mbql.clj
@@ -36,7 +36,7 @@
     :else
     (Long/parseLong param-value)))
 
-(s/defn ^:private build-filter-clause :- mbql.s/Filter
+(s/defn ^:private build-filter-clause :- (s/maybe mbql.s/Filter)
   [{param-type :type, param-value :value, [_ field :as target] :target, :as param}]
   (cond
     ;; multipe values. Recursively handle them all and glue them all together with an OR clause
@@ -49,6 +49,12 @@
     (date-params/date-type? param-type)
     (date-params/date-string->filter (parse-param-value-for-type param-type param-value (params/field-form->id field))
                                      field)
+
+    ;; TODO - We can't tell the difference between a dashboard parameter (convert to an MBQL filter) and a native
+    ;; query template tag parameter without this. There's should be a better, less fragile way to do this. (Not 100%
+    ;; sure why, but this is needed for GTAPs to work.)
+    (mbql.u/is-clause? :template-tag field)
+    nil
 
     ;; single-value, non-date param. Generate MBQL [= [field-id <field>] <value>] clause
     :else


### PR DESCRIPTION
Unless we really like playing the fix merge conflicts game it's good to periodically diff the shared code between Metabase Enterprise Edition and Metabase Community Edition and try to minimize the differences by consolidating things where drift has occurred. For example in EE I reworked the `+check-superuser` API middleware function to handle either sync or async responses. There's no reason that improvement is enterprise-specific so it makes sense to backport it to CE to shrink the diff a bit.

Other changes from EE code include

*  Improved or more detailed docstrings and comments
*  Simplified LDAP + other login code 