### PR TITLE
Properly clone/restore thread binding frames in async QP

### DIFF
--- a/test/metabase/query_processor/middleware/async_wait_test.clj
+++ b/test/metabase/query_processor/middleware/async_wait_test.clj
@@ -1,0 +1,49 @@
+(ns metabase.query-processor.middleware.async-wait-test
+  (:require [clojure.core.async :as a]
+            [expectations :refer [expect]]
+            [metabase.models.database :refer [Database]]
+            [metabase.query-processor.middleware.async-wait :as async-wait]
+            [metabase.test.util.async :as tu.async]
+            [metabase.util :as u]
+            [toucan.util.test :as tt])
+  (:import java.util.concurrent.Executors))
+
+(def ^:private ^:dynamic *dynamic-var* false)
+
+(defn- async-wait-bound-value
+  "Check the bound value of `*dynamic-var*` when a function is executed after the `async-wait` using the thread pool for
+  Database with `db-id`."
+  [db-id]
+  (let [bound-value (promise)]
+    (tu.async/with-open-channels [canceled-chan (a/promise-chan)]
+      ((async-wait/wait-for-turn
+        (fn [& _]
+          (deliver bound-value *dynamic-var*)))
+       {:database db-id}
+       identity
+       identity
+       canceled-chan))
+    (u/deref-with-timeout bound-value 1000)))
+
+;; basic sanity check: bound value of `*dynamic-var*` should be `false`
+(expect
+  false
+  (tt/with-temp Database [{db-id :id}]
+    (async-wait-bound-value db-id)))
+
+;; bound dynamic vars should get re-bound by in the async wait fn
+(expect
+  ::wow
+  (tt/with-temp Database [{db-id :id}]
+    (binding [*dynamic-var* ::wow]
+      (async-wait-bound-value db-id))))
+
+;; binding should not be persisted between executions -- should be reset when we reuse a thread
+(expect
+  false
+  (let [thread-pool (Executors/newSingleThreadExecutor)]
+    (with-redefs [async-wait/db-thread-pool (constantly thread-pool)]
+      (tt/with-temp Database [{db-id :id}]
+        (binding [*dynamic-var* true]
+          (async-wait-bound-value db-id))
+        (async-wait-bound-value db-id)))))

--- a/test/metabase/query_processor/middleware/permissions_test.clj
+++ b/test/metabase/query_processor/middleware/permissions_test.clj
@@ -1,25 +1,32 @@
 (ns metabase.query-processor.middleware.permissions-test
   "Tests for the middleware that checks whether the current user has permissions to run a given query."
   (:require [expectations :refer :all]
+            [metabase
+             [query-processor :as qp]
+             [util :as u]]
+            [metabase.api.common :as api]
             [metabase.models
              [database :refer [Database]]
              [permissions :as perms]
              [permissions-group :as perms-group]
              [table :refer [Table]]]
             [metabase.query-processor.middleware.permissions :refer [check-query-permissions]]
+            [metabase.test
+             [data :as data]
+             [util :as tu]]
             [metabase.test.data.users :as users]
-            [metabase.util :as u]
+            [schema.core :as s]
             [toucan.util.test :as tt]))
 
 (def ^:private ^{:arglists '([query]), :style/indent 0} check-perms (check-query-permissions identity))
 
 (defn- do-with-rasta
-  "Call F with rasta as the current user."
+  "Call `f` with Rasta as the current user."
   [f]
   (users/do-with-test-user :rasta f))
 
 (defn- check-perms-for-rasta
-  "Check permissions for QUERY with rasta as the current user."
+  "Check permissions for `query` with rasta as the current user."
   {:style/indent 0}
   [query]
   (do-with-rasta (fn [] (check-perms query))))
@@ -113,3 +120,19 @@
     {:database (u/get-id db)
      :type     :query
      :query    {:source-query {:source-table (u/get-id table)}}}))
+
+
+;; Make sure it works end-to-end: make sure bound `*current-user-id*` and `*current-user-permissions-set*` are used to
+;; permissions check queries
+(tu/expect-schema
+ {:status    (s/eq :failed)
+  :class     (s/eq Exception)
+  :error    (s/eq "You do not have permissions to run this query.")
+  s/Keyword s/Any}
+ (binding [api/*current-user-id*              (users/user->id :rasta)
+           api/*current-user-permissions-set* (delay #{})]
+   (qp/process-query
+    {:database (data/id)
+     :type     :query
+     :query    {:source-table (data/id :venues)
+                :limit        1}})))


### PR DESCRIPTION
Fix issue where updated async QP code did not properly clone & restore the current thread dynamic variable binding state in functions executed by async thread pools