### PR TITLE
set min-width in admin panel to prevent weird gear overlap

### DIFF
--- a/frontend/src/metabase/css/admin.css
+++ b/frontend/src/metabase/css/admin.css
@@ -219,6 +219,10 @@
   margin-left: 0;
 }
 
+.MetadataTable {
+  min-width: 800px;
+}
+
 .MetadataTable-title {
   background-color: var(--color-bg-white);
 }


### PR DESCRIPTION
Resolves #5536

This fix isn't great, but solves the immediate bug until we have a longer-term more responsive design for this page.