### PR TITLE
Reschedule Quartz tasks on launch

### DIFF
--- a/frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx
@@ -24,6 +24,7 @@ const renderTriggersTable = triggers => {
           <th>{t`End Time`}</th>
           <th>{t`Final Fire Time`}</th>
           <th>{t`May Fire Again?`}</th>
+          <th>{t`Misfire Instruction`}</th>
         </tr>
       </thead>
       <tbody>
@@ -40,6 +41,7 @@ const renderTriggersTable = triggers => {
               <td>{trigger["end-time"]}</td>
               <td>{trigger["final-fire-time"]}</td>
               <td>{trigger["may-fire-again?"] ? t`Yes` : t`No`}</td>
+              <td>{trigger["misfire-instruction"]}</td>
             </tr>
           ))}
       </tbody>

--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -31,6 +31,7 @@
 (defonce ^:private quartz-scheduler
   (atom nil))
 
+;; TODO - maybe we should make this a delay instead!
 (defn- scheduler
   "Fetch the instance of our Quartz scheduler. Call this function rather than dereffing the atom directly because there
   are a few places (e.g., in tests) where we swap the instance out."
@@ -159,6 +160,16 @@
 ;;; |                                           SCHEDULING/DELETING TASKS                                            |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
+(s/defn ^:private reschedule-task!
+  [job :- JobDetail, new-trigger :- Trigger]
+  (try
+    (when-let [scheduler (scheduler)]
+      (when-let [[^Trigger old-trigger] (seq (qs/get-triggers-of-job scheduler (.getKey job)))]
+        (log/debug (trs "Rescheduling job {0}" (-> job .getKey .getName)))
+        (.rescheduleJob scheduler (.getKey old-trigger) new-trigger)))
+    (catch Throwable e
+      (log/error e (trs "Error rescheduling job")))))
+
 (s/defn schedule-task!
   "Add a given job and trigger to our scheduler."
   [job :- JobDetail, trigger :- Trigger]
@@ -166,7 +177,8 @@
     (try
       (qs/schedule scheduler job trigger)
       (catch org.quartz.ObjectAlreadyExistsException _
-        (log/debug (trs "Job already exists:") (-> job .getKey .getName))))))
+        (log/debug (trs "Job already exists:") (-> job .getKey .getName))
+        (reschedule-task! job trigger)))))
 
 (s/defn delete-task!
   "delete a task from the scheduler"

--- a/src/metabase/task/send_pulses.clj
+++ b/src/metabase/task/send_pulses.clj
@@ -115,9 +115,11 @@
                    (cron/schedule
                     ;; run at the top of every hour
                     (cron/cron-schedule "0 0 * * * ? *")
-                    ;; If a trigger misfires (i.e., Quartz cannot run our job for one reason or another, such as all
-                    ;; worker threads being busy), attempt to fire the triggers again ASAP. This article does a good
-                    ;; job explaining what this means:
-                    ;; https://www.nurkiewicz.com/2012/04/quartz-scheduler-misfire-instructions.html
-                    (cron/with-misfire-handling-instruction-ignore-misfires))))]
+                    ;; If send-pulses! misfires, don't try to re-send all the misfired Pulses. Retry only the most
+                    ;; recent misfire, discarding all others. This should hopefully cover cases where a misfire
+                    ;; happens while the system is still running; if the system goes down for an extended period of
+                    ;; time we don't want to re-send tons of (possibly duplicate) Pulses.
+                    ;;
+                    ;; See https://www.nurkiewicz.com/2012/04/quartz-scheduler-misfire-instructions.html
+                    (cron/with-misfire-handling-instruction-fire-and-proceed))))]
     (task/schedule-task! job trigger)))

--- a/src/metabase/task/sync_databases.clj
+++ b/src/metabase/task/sync_databases.clj
@@ -150,11 +150,11 @@
    (triggers/with-schedule
      (cron/schedule
       (cron/cron-schedule (cron-schedule database task-info))
-      ;; If we miss a trigger, try again at the next opportunity, but only try it once. If we miss two triggers in a
-      ;; row (i.e. more than an hour goes by) then the job should still execute, but drop the additional occurrences
-      ;; of the same trigger (i.e. no need to run the job 3 times because it was missed three times, once is all we
-      ;; need)
-      (cron/with-misfire-handling-instruction-fire-and-proceed)))))
+      ;; if we miss a sync for one reason or another (such as system being down) do not try to run the sync again.
+      ;; Just wait until the next sync cycle.
+      ;;
+      ;; See https://www.nurkiewicz.com/2012/04/quartz-scheduler-misfire-instructions.html for more info
+      (cron/with-misfire-handling-instruction-do-nothing)))))
 
 (s/defn ^:private schedule-tasks-for-db!
   "Schedule a new Quartz job for `database` and `task-info`."

--- a/test/metabase/task/sync_databases_test.clj
+++ b/test/metabase/task/sync_databases_test.clj
@@ -36,7 +36,9 @@
                                             (update-in [:data "db-id"] replace-trailing-id-with-<id>))))))))))
 
 (defn- current-tasks []
-  (replace-ids-with-<id> (tu/scheduler-current-tasks)))
+  (->> (tu/scheduler-current-tasks)
+       (filter #(#{"metabase.task.sync-and-analyze.job" "metabase.task.update-field-values.job"} (:key %)))
+       replace-ids-with-<id>))
 
 (defmacro ^:private with-scheduler-setup [& body]
   `(tu/with-temp-scheduler

--- a/test/metabase/task/sync_databases_test.clj
+++ b/test/metabase/task/sync_databases_test.clj
@@ -22,7 +22,7 @@
   (.isAnnotationPresent UpdateFieldValues org.quartz.DisallowConcurrentExecution))
 
 (defn- replace-trailing-id-with-<id> [s]
-  (str/replace s #"\d+$" "<id>"))
+  (some-> s (str/replace #"\d+$" "<id>")))
 
 (defn- replace-ids-with-<id> [current-tasks]
   (vec (for [task current-tasks]

--- a/test/metabase/task_test.clj
+++ b/test/metabase/task_test.clj
@@ -1,0 +1,80 @@
+(ns metabase.task-test
+  (:require [clojurewerkz.quartzite
+             [jobs :as jobs]
+             [scheduler :as qs]
+             [triggers :as triggers]]
+            [clojurewerkz.quartzite.schedule.cron :as cron]
+            [expectations :refer [expect]]
+            [metabase.task :as task]
+            [metabase.test.util :as tu])
+  (:import [org.quartz CronTrigger JobDetail]))
+
+;; make sure we attempt to reschedule tasks so changes made in source are propogated to JDBC backend
+
+(jobs/defjob TestJob [_])
+
+(defn- job ^JobDetail []
+  (jobs/build
+    (jobs/of-type TestJob)
+    (jobs/with-identity (jobs/key "metabase.task-test.job"))))
+
+(defn- trigger-1 ^CronTrigger []
+  (triggers/build
+   (triggers/with-identity (triggers/key "metabase.task-test.trigger"))
+   (triggers/start-now)
+   (triggers/with-schedule
+     (cron/schedule
+      (cron/cron-schedule "0 0 * * * ? *") ; every hour
+      (cron/with-misfire-handling-instruction-do-nothing)))))
+
+(defn- trigger-2 ^CronTrigger []
+  (triggers/build
+   (triggers/with-identity (triggers/key "metabase.task-test.trigger"))
+   (triggers/start-now)
+   (triggers/with-schedule
+     (cron/schedule
+      (cron/cron-schedule "0 0 6 * * ? *") ; at 6 AM every day
+      (cron/with-misfire-handling-instruction-ignore-misfires)))))
+
+(defn- do-with-temp-scheduler-and-cleanup [f]
+  (try
+    (tu/with-temp-scheduler
+      (f))
+    (finally
+      (task/delete-task! (.getKey (job)) (.getKey (trigger-1)))
+      (task/delete-task! (.getKey (job)) (.getKey (trigger-2))))))
+
+(defmacro ^:private with-temp-scheduler-and-cleanup [& body]
+  `(do-with-temp-scheduler-and-cleanup (fn [] ~@body)))
+
+(defn- triggers []
+  (set
+   (for [^CronTrigger trigger (qs/get-triggers-of-job (#'metabase.task/scheduler) (.getKey (job)))]
+     {:cron-expression     (.getCronExpression trigger)
+      :misfire-instruction (.getMisfireInstruction trigger)})))
+
+;; can we schedule a job?
+(expect
+  #{{:cron-expression     "0 0 * * * ? *"
+     :misfire-instruction CronTrigger/MISFIRE_INSTRUCTION_DO_NOTHING}}
+  (with-temp-scheduler-and-cleanup
+    (task/schedule-task! (job) (trigger-1))
+    (triggers)))
+
+;; does scheduling a job a second time work without throwing errors?
+(expect
+  #{{:cron-expression     "0 0 * * * ? *"
+     :misfire-instruction CronTrigger/MISFIRE_INSTRUCTION_DO_NOTHING}}
+  (with-temp-scheduler-and-cleanup
+    (task/schedule-task! (job) (trigger-1))
+    (task/schedule-task! (job) (trigger-1))
+    (triggers)))
+
+;; does scheduling a job with a *new* trigger replace the original? (can we reschedule a job?)
+(expect
+  #{{:cron-expression     "0 0 6 * * ? *"
+     :misfire-instruction CronTrigger/MISFIRE_INSTRUCTION_IGNORE_MISFIRE_POLICY}}
+  (with-temp-scheduler-and-cleanup
+    (task/schedule-task! (job) (trigger-1))
+    (task/schedule-task! (job) (trigger-2))
+    (triggers)))

--- a/test/metabase/task_test.clj
+++ b/test/metabase/task_test.clj
@@ -37,12 +37,11 @@
       (cron/with-misfire-handling-instruction-ignore-misfires)))))
 
 (defn- do-with-temp-scheduler-and-cleanup [f]
-  (try
-    (tu/with-temp-scheduler
-      (f))
-    (finally
-      (task/delete-task! (.getKey (job)) (.getKey (trigger-1)))
-      (task/delete-task! (.getKey (job)) (.getKey (trigger-2))))))
+  (tu/with-temp-scheduler
+    (try
+      (f)
+      (finally
+        (task/delete-task! (.getKey (job)) (.getKey (trigger-1)))))))
 
 (defmacro ^:private with-temp-scheduler-and-cleanup [& body]
   `(do-with-temp-scheduler-and-cleanup (fn [] ~@body)))


### PR DESCRIPTION
Reschedule existing Quartz scheduler tasks on launch so changes in the codebase will be reflected in the scheduler behavior. 

This will fix issues where Metabase attempts to send *all* Pulses that "misfired" when restarting. E.g. if you are running locally and restart Metabase after 2 days it previously would re-send all Pulses that should have been sent over the last 2 days all at once. 

Fixed