### PR TITLE
Data browse in navbar

### DIFF
--- a/frontend/src/metabase/components/BrowseApp.jsx
+++ b/frontend/src/metabase/components/BrowseApp.jsx
@@ -229,17 +229,17 @@ export class DatabaseBrowser extends React.Component {
 
 function BrowseHeader({ crumbs }) {
   return (
-    <Box mt={3} mb={2}>
+    <Box mt={3} mb={2} className="flex align-center">
       <BrowserCrumbs crumbs={crumbs} analyticsContext={ANALYTICS_CONTEXT} />
-      <div className="flex">
+      <div className="flex flex-align-right">
         <Link
-          className="flex-align-right"
+          className="flex flex-align-right"
           to="reference"
           data-metabase-event={`NavBar;Reference`}
         >
-          <div className="flex flex-align-center">
+          <div className="flex flex-align-center text-medium text-brand-hover">
             <Icon className="flex flex-align-center" size={18} name="reference" />
-            <h3 className="ml1 flex flex-align-center">Learn more about our data</h3>
+            <h3 className="ml1 flex flex-align-center">Learn about our data</h3>
           </div>
         </Link>
       </div>

--- a/frontend/src/metabase/components/BrowseApp.jsx
+++ b/frontend/src/metabase/components/BrowseApp.jsx
@@ -17,7 +17,7 @@ import { getMetadata } from "metabase/selectors/metadata";
 
 import Card from "metabase/components/Card";
 import { Grid, GridItem } from "metabase/components/Grid";
-import Icon from "metabase/components/Icon";
+import Icon, { IconWrapper } from "metabase/components/Icon";
 import Link from "metabase/components/Link";
 import Subhead from "metabase/components/Subhead";
 import Tooltip from "metabase/components/Tooltip";
@@ -194,6 +194,7 @@ export class DatabaseBrowser extends React.Component {
     return (
       <Box>
         <BrowseHeader crumbs={[{ title: t`Our data` }]} />
+
         <Database.ListLoader>
           {({ databases, loading, error }) => {
             return (
@@ -230,6 +231,18 @@ function BrowseHeader({ crumbs }) {
   return (
     <Box mt={3} mb={2}>
       <BrowserCrumbs crumbs={crumbs} analyticsContext={ANALYTICS_CONTEXT} />
+      <div className="flex">
+        <Link
+          className="flex-align-right"
+          to="reference"
+          data-metabase-event={`NavBar;Reference`}
+        >
+          <div className="flex flex-align-center">
+            <Icon className="flex flex-align-center" size={18} name="reference" />
+            <h3 className="ml1 flex flex-align-center">Learn more about our data</h3>
+          </div>
+        </Link>
+      </div>
     </Box>
   );
 }

--- a/frontend/src/metabase/nav/containers/Navbar.jsx
+++ b/frontend/src/metabase/nav/containers/Navbar.jsx
@@ -330,7 +330,7 @@ export default class Navbar extends Component {
                 data-metabase-event={`NavBar;Data Browse`}
               >
                 <IconWrapper>
-                  <Icon size={18} name="table2" />
+                  <Icon size={17} name="table" />
                 </IconWrapper>
               </Link>
             </Tooltip>

--- a/frontend/src/metabase/nav/containers/Navbar.jsx
+++ b/frontend/src/metabase/nav/containers/Navbar.jsx
@@ -295,8 +295,18 @@ export default class Navbar extends Component {
         <Flex ml="auto" align="center" className="relative z2">
           {hasDataAccess && (
             <Link
+              to={"/browse"}
+              mx={1}
+              className="hide sm-show"
+              data-metabase-event={`NavBar;Browse Data`}
+            >
+              <Button dark white>{t`Data`}</Button>
+            </Link>
+          )}
+          {hasDataAccess && (
+            <Link
               to={Urls.newQuestion()}
-              mx={3}
+              mx={2}
               className="hide sm-show"
               data-metabase-event={`NavBar;New Question`}
             >

--- a/frontend/src/metabase/nav/containers/Navbar.jsx
+++ b/frontend/src/metabase/nav/containers/Navbar.jsx
@@ -295,16 +295,6 @@ export default class Navbar extends Component {
         <Flex ml="auto" align="center" className="relative z2">
           {hasDataAccess && (
             <Link
-              to={"/browse"}
-              mx={1}
-              className="hide sm-show"
-              data-metabase-event={`NavBar;Browse Data`}
-            >
-              <Button dark white>{t`Data`}</Button>
-            </Link>
-          )}
-          {hasDataAccess && (
-            <Link
               to={Urls.newQuestion()}
               mx={2}
               className="hide sm-show"
@@ -333,14 +323,14 @@ export default class Navbar extends Component {
             ]}
           />
           {hasDataAccess && (
-            <Tooltip tooltip={t`Reference`}>
+            <Tooltip tooltip={t`Browse data`}>
               <Link
                 ml={2}
-                to="reference"
-                data-metabase-event={`NavBar;Reference`}
+                to="browse"
+                data-metabase-event={`NavBar;Data Browse`}
               >
                 <IconWrapper>
-                  <Icon size={18} name="reference" />
+                  <Icon size={18} name="table2" />
                 </IconWrapper>
               </Link>
             </Tooltip>

--- a/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
+++ b/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
@@ -133,7 +133,7 @@ export class NewQueryOptions extends Component {
     }
 
     {/* Determine how many items will be shown based on permissions etc so we can make sure the layout adapts */}
-    const NUM_ITEMS = showMetricOption + showSQLOption + 2;
+    const NUM_ITEMS = showMetricOption + showSQLOption + 1;
     const ITEM_WIDTHS = [1, 1 / 2, 1 / NUM_ITEMS];
 
     return (
@@ -149,16 +149,6 @@ export class NewQueryOptions extends Component {
               />
             </GridItem>
           )}
-          <GridItem w={ITEM_WIDTHS}>
-            {/*TODO: Move illustrations to the new location in file hierarchy. At the same time put an end to the equal-size-@2x ridicule. */}
-            <NewQueryOption
-              image="app/img/segments_illustration"
-              title={t`Browse data`}
-              description={t`Look through the tables in the databases connected to Metabase.`}
-              width={170}
-              to={dataBrowseUrl}
-            />
-          </GridItem>
           <GridItem w={ITEM_WIDTHS}>
             <NewQueryOption
               image="app/img/query_builder_illustration"


### PR DESCRIPTION
Would like to merge this into the `notebook-mode` branch since the general sentiment is that having data browsing in the navbar is a net improvement, and being able to get to the data reference from `/browse` feels like it makes sense.

This also removes the data browse option from the new question page.

**Before**
![image](https://user-images.githubusercontent.com/2223916/57795911-fae9b580-76fb-11e9-8983-f705a367d564.png)




**After**

![image](https://user-images.githubusercontent.com/2223916/57795841-d1c92500-76fb-11e9-84a7-d22af5736c24.png)

![image](https://user-images.githubusercontent.com/2223916/57795856-de4d7d80-76fb-11e9-91ad-29f18d512bf9.png)
