### PR TITLE
Notebook mode chart selection minor improvements

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx
@@ -19,44 +19,46 @@ const ChartSettingsSidebar = ({
   ...props
 }) =>
   result && (
-    <div className="full-height">
-      <div className="flex align-center px4 py2 mb1 bg-medium">
-        <div
-          className="flex align-center cursor-pointer text-brand-hover"
-          onClick={() =>
-            setUIControls({
-              isShowingChartSettingsSidebar: false,
-              isShowingChartTypeSidebar: true,
-            })
-          }
-        >
-          <Icon name="chevronleft" />
-          <h3 className="text-heavy ml1">
-            {visualizations.get(question.display()).uiName} {t`options`}
-          </h3>
+    <div className="flex flex-column full-height justify-between">
+      <div className="scroll-y">
+        <div className="flex px4 py3 mb1 bg-medium">
+          <div
+            className="flex align-center cursor-pointer text-brand-hover"
+            onClick={() =>
+              setUIControls({
+                isShowingChartSettingsSidebar: false,
+                isShowingChartTypeSidebar: true,
+              })
+            }
+          >
+            <Icon name="chevronleft" />
+            <h3 className="text-heavy ml1">
+              {visualizations.get(question.display()).uiName} {t`options`}
+            </h3>
+          </div>
         </div>
-        <Button
-          primary
-          className="flex-align-right"
-          onClick={onClose}
-        >
-          {t`Done`}
-        </Button>
+        <ChartSettings
+          question={question}
+          addField={addField}
+          series={[
+            {
+              card: question.card(),
+              data: result.data,
+            },
+          ]}
+          onChange={onReplaceAllVisualizationSettings}
+          onClose={onClose}
+          noPreview
+          initial={initialChartSetting}
+        />
       </div>
-      <ChartSettings
-        question={question}
-        addField={addField}
-        series={[
-          {
-            card: question.card(),
-            data: result.data,
-          },
-        ]}
-        onChange={onReplaceAllVisualizationSettings}
-        onClose={onClose}
-        noPreview
-        initial={initialChartSetting}
-      />
+      <Button
+        primary
+        className="m2 text-centered"
+        onClick={onClose}
+      >
+        {t`Done`}
+      </Button>
     </div>
   );
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx
@@ -20,9 +20,9 @@ const ChartSettingsSidebar = ({
 }) =>
   result && (
     <div className="full-height">
-      <div className="flex align-center px4 py2 mb1 bg-brand text-white">
+      <div className="flex align-center px4 py2 mb1 bg-medium">
         <div
-          className="flex align-center cursor-pointer"
+          className="flex align-center cursor-pointer text-brand-hover"
           onClick={() =>
             setUIControls({
               isShowingChartSettingsSidebar: false,
@@ -36,7 +36,7 @@ const ChartSettingsSidebar = ({
           </h3>
         </div>
         <Button
-          white
+          primary
           className="flex-align-right"
           onClick={onClose}
         >

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx
@@ -20,23 +20,28 @@ const ChartSettingsSidebar = ({
 }) =>
   result && (
     <div className="full-height">
-      <div
-        className="mx4 flex align-center mt3 mb1 text-brand-hover cursor-pointer"
-        onClick={() =>
-          setUIControls({
-            isShowingChartSettingsSidebar: false,
-            isShowingChartTypeSidebar: true,
-          })
-        }
-      >
-        <Icon name="chevronleft" className="text-medium" />
-        <Icon
-          name={getIconForVisualizationType(question.display())}
-          className="ml2 mr1"
-        />
-        <h3 className="text-heavy">
-          {visualizations.get(question.display()).uiName} {t`options`}
-        </h3>
+      <div className="flex align-center px4 py2 mb1 bg-brand text-white">
+        <div
+          className="flex align-center cursor-pointer"
+          onClick={() =>
+            setUIControls({
+              isShowingChartSettingsSidebar: false,
+              isShowingChartTypeSidebar: true,
+            })
+          }
+        >
+          <Icon name="chevronleft" />
+          <h3 className="text-heavy ml1">
+            {visualizations.get(question.display()).uiName} {t`options`}
+          </h3>
+        </div>
+        <Button
+          white
+          className="flex-align-right"
+          onClick={onClose}
+        >
+          {t`Done`}
+        </Button>
       </div>
       <ChartSettings
         question={question}
@@ -52,11 +57,6 @@ const ChartSettingsSidebar = ({
         noPreview
         initial={initialChartSetting}
       />
-      <div className="flex">
-        <Button medium primary onClick={onClose} className="mx4 mb3 flex-full">
-          {t`Done`}
-        </Button>
-      </div>
     </div>
   );
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx
@@ -37,47 +37,49 @@ const ChartTypeSidebar = ({
   const layout = [...FIXED_LAYOUT, ...otherGrouped];
 
   return (
-    <div className="scroll-y">
-      <div className="flex align-center px4 py2 bg-medium">
-        <h3 className="text-heavy">{t`Choose a visualization`}</h3>
-        <Button
-          primary
-          className="flex-align-right"
-          onClick={() =>
-            setUIControls({
-              isShowingChartTypeSidebar: false, // TODO: move to reducer
-            })
-          }
-        >
-          {t`Done`}
-        </Button>
-      </div>
-      {layout.map(row => (
-        <div className="flex border-row-divider py2 px4">
-          {row.map(type => {
-            const visualization = visualizations.get(type);
-            return (
-              visualization && (
-                <ChartTypeOption
-                  className="mx2"
-                  visualization={visualization}
-                  isSelected={type === question.display()}
-                  isSensible={
-                    result &&
-                    result.data &&
-                    visualization.isSensible &&
-                    visualization.isSensible(result.data)
-                  }
-                  onClick={() => {
-                    question.setDisplay(type).update(null, { reload: false });
-                    onOpenChartSettings({ section: t`Data` });
-                  }}
-                />
-              )
-            );
-          })}
+    <div className="flex flex-column full-height justify-between">
+      <div className="scroll-y">
+        <div className="flex align-center px4 py3 bg-medium">
+          <h3 className="text-heavy">{t`Choose a visualization`}</h3>
         </div>
-      ))}
+        {layout.map(row => (
+          <div className="flex border-row-divider py2 px3">
+            {row.map(type => {
+              const visualization = visualizations.get(type);
+              return (
+                visualization && (
+                  <ChartTypeOption
+                    className="mx2"
+                    visualization={visualization}
+                    isSelected={type === question.display()}
+                    isSensible={
+                      result &&
+                      result.data &&
+                      visualization.isSensible &&
+                      visualization.isSensible(result.data)
+                    }
+                    onClick={() => {
+                      question.setDisplay(type).update(null, { reload: false });
+                      onOpenChartSettings({ section: t`Data` });
+                    }}
+                  />
+                )
+              );
+            })}
+          </div>
+        ))}
+      </div>
+      <Button
+        primary
+        className="m2 text-centered"
+        onClick={() =>
+          setUIControls({
+            isShowingChartTypeSidebar: false, // TODO: move to reducer
+          })
+        }
+      >
+        {t`Done`}
+      </Button>
     </div>
   );
 };

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx
@@ -4,15 +4,15 @@ import _ from "underscore";
 import { t } from "ttag";
 
 import Icon from "metabase/components/Icon";
+import Button from "metabase/components/Button";
 
 import visualizations from "metabase/visualizations";
 
 const FIXED_LAYOUT = [
-  ["table"],
-  ["line", "bar", "combo", "area"],
-  ["scatter", "row", "pie", "funnel"],
+  ["table", "map"],
   ["scalar", "smartscalar", "progress", "gauge"],
-  ["map"],
+  ["scatter", "row", "pie", "funnel"],
+  ["line", "bar", "combo", "area"],
 ];
 const FIXED_TYPES = new Set(_.flatten(FIXED_LAYOUT));
 
@@ -37,27 +37,15 @@ const ChartTypeSidebar = ({
   const layout = [...FIXED_LAYOUT, ...otherGrouped];
 
   return (
-    <div>
-      <div className="flex px4 pt3 pb2">
-        <h3 className="text-heavy ">{t`How do you want to view this data?`}</h3>
-        <Icon
-          name="close"
-          className="flex-align-right text-medium text-brand-hover cursor-pointer"
-          onClick={() =>
-            setUIControls({
-              isShowingChartTypeSidebar: false, // TODO: move to reducer
-            })
-          }
-          size={20}
-        />
-      </div>
+    <div className="absolute bottom scroll-y" style={{width: 420}}>
       {layout.map(row => (
-        <div className="flex justify-between border-row-divider py1 pl2 pr3">
+        <div className="flex border-row-divider py2 px4">
           {row.map(type => {
             const visualization = visualizations.get(type);
             return (
               visualization && (
                 <ChartTypeOption
+                  className="mx2"
                   visualization={visualization}
                   isSelected={type === question.display()}
                   isSensible={
@@ -76,6 +64,20 @@ const ChartTypeSidebar = ({
           })}
         </div>
       ))}
+      <div className="flex align-center px4 py2 bg-brand">
+        <h3 className="text-heavy text-white">{t`Choose a visualization`}</h3>
+        <Button
+          white
+          className="flex-align-right"
+          onClick={() =>
+            setUIControls({
+              isShowingChartTypeSidebar: false, // TODO: move to reducer
+            })
+          }
+        >
+          {t`Done`}
+        </Button>
+      </div>
     </div>
   );
 };
@@ -93,8 +95,8 @@ const ChartTypeOption = ({
       "text-dark bg-medium-hover": !isSelected,
     })}
     style={{
-      width: 60,
-      height: 60,
+      width: 70,
+      height: 70,
       borderRadius: 8,
       opacity: !isSensible ? 0.35 : 1,
     }}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx
@@ -9,10 +9,10 @@ import Button from "metabase/components/Button";
 import visualizations from "metabase/visualizations";
 
 const FIXED_LAYOUT = [
-  ["table", "map"],
-  ["scalar", "smartscalar", "progress", "gauge"],
-  ["scatter", "row", "pie", "funnel"],
   ["line", "bar", "combo", "area"],
+  ["scatter", "row", "pie", "funnel"],
+  ["scalar", "smartscalar", "progress", "gauge"],
+  ["table", "map"],
 ];
 const FIXED_TYPES = new Set(_.flatten(FIXED_LAYOUT));
 
@@ -37,7 +37,21 @@ const ChartTypeSidebar = ({
   const layout = [...FIXED_LAYOUT, ...otherGrouped];
 
   return (
-    <div className="absolute bottom scroll-y" style={{width: 420}}>
+    <div className="scroll-y">
+      <div className="flex align-center px4 py2 bg-brand">
+        <h3 className="text-heavy text-white">{t`Choose a visualization`}</h3>
+        <Button
+          white
+          className="flex-align-right"
+          onClick={() =>
+            setUIControls({
+              isShowingChartTypeSidebar: false, // TODO: move to reducer
+            })
+          }
+        >
+          {t`Done`}
+        </Button>
+      </div>
       {layout.map(row => (
         <div className="flex border-row-divider py2 px4">
           {row.map(type => {
@@ -64,20 +78,6 @@ const ChartTypeSidebar = ({
           })}
         </div>
       ))}
-      <div className="flex align-center px4 py2 bg-brand">
-        <h3 className="text-heavy text-white">{t`Choose a visualization`}</h3>
-        <Button
-          white
-          className="flex-align-right"
-          onClick={() =>
-            setUIControls({
-              isShowingChartTypeSidebar: false, // TODO: move to reducer
-            })
-          }
-        >
-          {t`Done`}
-        </Button>
-      </div>
     </div>
   );
 };

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx
@@ -38,10 +38,10 @@ const ChartTypeSidebar = ({
 
   return (
     <div className="scroll-y">
-      <div className="flex align-center px4 py2 bg-brand">
-        <h3 className="text-heavy text-white">{t`Choose a visualization`}</h3>
+      <div className="flex align-center px4 py2 bg-medium">
+        <h3 className="text-heavy">{t`Choose a visualization`}</h3>
         <Button
-          white
+          primary
           className="flex-align-right"
           onClick={() =>
             setUIControls({


### PR DESCRIPTION
Some small improvements to the chart selection and options side panels that I'd like to bring into `notebook-mode`:
- More consistent sidebar header with added contrast
- Consistent Done button for both sidebars, which sticks to the bottom of the panel


## Before

![Screen Shot 2019-05-15 at 2 49 10 PM](https://user-images.githubusercontent.com/2223916/57812068-d18f5080-7720-11e9-9fb2-3334a59ed814.png)

![Screen Shot 2019-05-15 at 2 49 17 PM](https://user-images.githubusercontent.com/2223916/57812070-d2c07d80-7720-11e9-9e50-1a42e634bad6.png)


## After

![Screen Shot 2019-05-15 at 2 45 21 PM](https://user-images.githubusercontent.com/2223916/57812080-dbb14f00-7720-11e9-83c9-fb6a2e6b97ca.png)

![Screen Shot 2019-05-15 at 2 45 29 PM](https://user-images.githubusercontent.com/2223916/57812088-df44d600-7720-11e9-89c5-1bf6d5ecc04e.png)
