### PR TITLE
Add :joined-field clause to MBQL

### DIFF
--- a/src/metabase/mbql/util.clj
+++ b/src/metabase/mbql/util.clj
@@ -278,14 +278,14 @@
                                  mbql.s/field-id
                                  mbql.s/field-literal)
   "Un-wrap a `Field` clause and return the lowest-level clause it wraps, either a `:field-id` or `:field-literal`."
-  [[clause-name x y, :as clause] :- mbql.s/Field]
-  ;; TODO - could use `match` to do this
-  (case clause-name
-    :field-id         clause
-    :fk->             (recur y)
-    :field-literal    clause
-    :datetime-field   (recur x)
-    :binning-strategy (recur x)))
+  [clause :- mbql.s/Field]
+  (match-one clause
+    :field-id                     &match
+    :field-literal                &match
+    [:fk-> _ dest-field]          (recur dest-field)
+    [:joined-field _ field]       (recur field)
+    [:datetime-field field _]     (recur field)
+    [:binning-strategy field & _] (recur field)))
 
 (defn maybe-unwrap-field-clause
   "Unwrap a Field `clause`, if it's something that can be unwrapped (i.e. something that is, or wraps, a `:field-id` or

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -102,6 +102,7 @@
       annotate/add-column-info
       perms/check-query-permissions
       cumulative-ags/handle-cumulative-aggregations
+      ;; ▲▲▲ NO FK->s POINT ▲▲▲ Everything after this point will not see `:fk->` clauses, only `:joined-field`
       resolve-joined-tables/resolve-joined-tables
       dev/check-results-format
       limit/limit

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -62,23 +62,38 @@
 ;;; |                                       Adding :cols info for MBQL queries                                       |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
+(s/defn ^:private join-with-alias :- (s/maybe mbql.s/JoinInfo)
+  [{{:keys [join-tables]} :query} :- su/Map, join-alias :- su/NonBlankString]
+  (some
+   (fn [{alias :join-alias, :as join}]
+     (when (= alias join-alias)
+       join))
+   join-tables))
+
 ;;; --------------------------------------------------- Field Info ---------------------------------------------------
 
 (s/defn ^:private col-info-for-field-clause :- su/Map
-  [clause :- mbql.s/Field]
+  [query :- su/Map, clause :- mbql.s/Field]
   ;; for various things that can wrap Field clauses recurse on the wrapped Field but include a little bit of info
   ;; about the clause doing the wrapping
   (mbql.u/match-one clause
     [:binning-strategy field strategy _ resolved-options]
-    (assoc (col-info-for-field-clause field) :binning_info (assoc (u/snake-keys resolved-options)
-                                                             :binning_strategy strategy))
+    (assoc (col-info-for-field-clause query field)
+      :binning_info (assoc (u/snake-keys resolved-options)
+                      :binning_strategy strategy))
 
     [:datetime-field field unit]
-    (assoc (col-info-for-field-clause field) :unit unit)
+    (assoc (col-info-for-field-clause query field) :unit unit)
 
+    [:joined-field alias field]
+    (let [{:keys [fk-field-id]} (join-with-alias query alias)]
+      (assoc (col-info-for-field-clause query field) :fk_field_id fk-field-id))
+
+    ;; TODO - should be able to remove this now
     [:fk-> [:field-id source-field-id] field]
-    (assoc (col-info-for-field-clause field) :fk_field_id source-field-id)
+    (assoc (col-info-for-field-clause query field) :fk_field_id source-field-id)
 
+    ;; TODO - should be able to remove this now
     ;; for FKs where source is a :field-literal don't include `:fk_field_id`
     [:fk-> _ field]
     (recur field)
@@ -100,7 +115,7 @@
     (let [{parent-id :parent_id, :as field} (dissoc (qp.store/field id) :database_type)]
       (if-not parent-id
         field
-        (let [parent (col-info-for-field-clause [:field-id parent-id])]
+        (let [parent (col-info-for-field-clause query [:field-id parent-id])]
           (update field :name #(str (:name parent) \. %)))))
 
     ;; we should never reach this if our patterns are written right so this is more to catch code mistakes than
@@ -171,52 +186,61 @@
     {:name         ag-name
      :display_name ag-name}))
 
-(defn- col-info-for-aggregation-clause
+(s/defn ^:private col-info-for-aggregation-clause
   "Return appropriate column metadata for an `:aggregation` clause."
-  [aggregation-clause]
-  (mbql.u/match-one aggregation-clause
+  ; `clause` is normally an aggregation clause but this function can call itself recursively; see comments by the
+  ; `match` pattern for field clauses below
+  [query :- su/Map, clause]
+  (mbql.u/match-one clause
     ;; ok, if this is a named aggregation recurse so we can get information about the ag we are naming
     [:named ag _]
-    (merge (col-info-for-aggregation-clause ag)
-           (ag->name-info &match))
+    (merge
+     (col-info-for-aggregation-clause query ag)
+     (ag->name-info &match))
 
     ;; Always treat count or distinct count as an integer even if the DB in question returns it as something
     ;; wacky like a BigDecimal or Float
     [(_ :guard #{:count :distinct}) & args]
-    (merge (col-info-for-aggregation-clause args)
-           {:base_type    :type/Integer
-            :special_type :type/Number}
-           (ag->name-info &match))
+    (merge
+     (col-info-for-aggregation-clause query args)
+     {:base_type    :type/Integer
+      :special_type :type/Number}
+     (ag->name-info &match))
 
+    ; TODO - should we be doing this for `:sum-where` as well?
     [:count-where _]
-    (merge {:base_type    :type/Integer
-            :special_type :type/Number}
-           (ag->name-info &match))
+    (merge
+     {:base_type    :type/Integer
+      :special_type :type/Number}
+     (ag->name-info &match))
 
     [:share _]
-    (merge {:base_type    :type/Float
-            :special_type :type/Number}
-           (ag->name-info &match))
+    (merge
+     {:base_type    :type/Float
+      :special_type :type/Number}
+     (ag->name-info &match))
 
     ;; get info from a Field if we can (theses Fields are matched when ag clauses recursively call
     ;; `col-info-for-ag-clause`, and this info is added into the results)
-    [(_ :guard #{:field-id :field-literal :fk-> :datetime-field :expression :binning-strategy}) & _]
-    (select-keys (col-info-for-field-clause &match) [:base_type :special_type :settings])
+    (_ :guard mbql.preds/Field?)
+    (select-keys (col-info-for-field-clause query &match) [:base_type :special_type :settings])
 
     ;; For the time being every Expression is an arithmetic operator and returns a floating-point number, so
     ;; hardcoding these types is fine; In the future when we extend Expressions to handle more functionality
     ;; we'll want to introduce logic that associates a return type with a given expression. But this will work
     ;; for the purposes of a patch release.
     [(_ :guard #{:expression :+ :- :/ :*}) & _]
-    (merge {:base_type    :type/Float
-            :special_type :type/Number}
-           (when (mbql.preds/Aggregation? &match)
-             (ag->name-info &match)))
+    (merge
+     {:base_type    :type/Float
+      :special_type :type/Number}
+     (when (mbql.preds/Aggregation? &match)
+       (ag->name-info &match)))
 
     ;; get name/display-name of this ag
     [(_ :guard keyword?) arg & args]
-    (merge (col-info-for-aggregation-clause arg)
-           (ag->name-info &match))))
+    (merge
+     (col-info-for-aggregation-clause query arg)
+     (ag->name-info &match))))
 
 
 ;;; ----------------------------------------- Putting it all together (MBQL) -----------------------------------------
@@ -236,16 +260,18 @@
                "\n"
                (tru "Actual: {0}" (vec (:columns results))))))))))
 
-(defn- cols-for-fields [{{fields-clause :fields} :query, :as query}]
+(s/defn ^:private cols-for-fields
+  [{{fields-clause :fields} :query, :as query} :- su/Map]
   (for [field fields-clause]
-    (assoc (col-info-for-field-clause field) :source :fields)))
+    (assoc (col-info-for-field-clause query field) :source :fields)))
 
-(defn- cols-for-ags-and-breakouts [{{aggregations :aggregation, breakouts :breakout} :query, :as query}]
+(s/defn ^:private cols-for-ags-and-breakouts
+  [{{aggregations :aggregation, breakouts :breakout} :query, :as query} :- su/Map]
   (concat
    (for [breakout breakouts]
-     (assoc (col-info-for-field-clause breakout) :source :breakout))
+     (assoc (col-info-for-field-clause query breakout) :source :breakout))
    (for [aggregation aggregations]
-     (assoc (col-info-for-aggregation-clause aggregation) :source :aggregation))))
+     (assoc (col-info-for-aggregation-clause query aggregation) :source :aggregation))))
 
 (declare mbql-cols)
 
@@ -273,7 +299,7 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (def ^:private ColsWithUniqueNames
-  (s/constrained [Col] #(distinct? (map :name %)) ":cols with unique names"))
+  (s/constrained [Col] #(su/empty-or-distinct? (map :name %)) ":cols with unique names"))
 
 (s/defn ^:private deduplicate-cols-names :- ColsWithUniqueNames
   [cols :- [Col]]

--- a/src/metabase/query_processor/middleware/check_features.clj
+++ b/src/metabase/query_processor/middleware/check_features.clj
@@ -18,8 +18,11 @@
 ;; auto-generate this logic
 (defn- query->required-features [query]
   (mbql.u/match (:query query)
-    [:stddev _] :standard-deviation-aggregations
-    [:fk-> _ _] :foreign-keys))
+    :stddev
+    :standard-deviation-aggregations
+
+    :joined-field
+    :foreign-keys))
 
 (defn- check-features* [{query-type :type, :as query}]
   (if-not (= query-type :query)

--- a/src/metabase/query_processor/middleware/resolve_joined_tables.clj
+++ b/src/metabase/query_processor/middleware/resolve_joined_tables.clj
@@ -11,7 +11,9 @@
              [field :refer [Field]]
              [table :refer [Table]]]
             [metabase.query-processor.store :as qp.store]
-            [metabase.util.schema :as su]
+            [metabase.util
+             [i18n :refer [tru]]
+             [schema :as su]]
             [schema.core :as s]
             [toucan.db :as db]))
 
@@ -27,11 +29,11 @@
 ;;; ------------------------------------------------ Fetching PK Info ------------------------------------------------
 
 (def ^:private PKInfo
-  [{:fk-id     su/IntGreaterThanZero
-    :pk-id    su/IntGreaterThanZero
-    :table-id su/IntGreaterThanZero}])
+  {:fk-id    su/IntGreaterThanZero
+   :pk-id    su/IntGreaterThanZero
+   :table-id su/IntGreaterThanZero})
 
-(s/defn ^:private fk-clauses->pk-info :- PKInfo
+(s/defn ^:private fk-clauses->pk-info :- [PKInfo]
   "Given a `source-table-id` and collection of `fk-field-ids`, return a sequence of maps containing IDs and identifiers
   for those FK fields and their target tables and fields. `fk-field-ids` are IDs of fields that belong to the source
   table. For example, `source-table-id` might be 'checkins' and `fk-field-ids` might have the IDs for 'checkins.user_id'
@@ -69,7 +71,7 @@
 ;;; ------------------------------------ Adding join Table PK fields to the Store ------------------------------------
 
 (s/defn ^:private store-join-table-pk-fields!
-  [pk-info :- PKInfo]
+  [pk-info :- [PKInfo]]
   (let [pk-field-ids (set (map :pk-id pk-info))
         pk-fields    (when (seq pk-field-ids)
                        (db/select (vec (cons Field qp.store/field-columns-to-fetch)) :id [:in pk-field-ids]))]
@@ -77,31 +79,72 @@
       (qp.store/store-field! field))))
 
 
-;;; -------------------------------------- Adding :join-tables key to the query --------------------------------------
+;;; ---------------------------------------- Resolving Join Alias & Condition ----------------------------------------
 
-(s/defn fks->join-information :- [mbql.s/JoinTableInfo]
-  [fk-clauses :- [FKClauseWithFieldIDArgs], pk-info :- PKInfo]
+(def ^:private ResolvedJoinInfo
+  {:fk-clause    FKClauseWithFieldIDArgs
+   :source-table su/IntGreaterThanZero
+   :alias        su/NonBlankString
+   :fk-field-id  su/IntGreaterThanZero
+   :pk-field-id  su/IntGreaterThanZero})
+
+(s/defn ^:private resolve-one-join-info :- ResolvedJoinInfo
+  [[_ [_ source-id] [_ dest-id] :as fk-clause] :- FKClauseWithFieldIDArgs, pk-info :- [PKInfo]]
+  (let [source-field (qp.store/field source-id)
+        dest-field   (qp.store/field dest-id)
+        table-id     (:table_id dest-field)
+        table        (qp.store/table table-id)
+        pk-id        (some (fn [info]
+                             (when (and (= (:table-id info) table-id)
+                                        (= (:fk-id info) source-id))
+                               (:pk-id info)))
+                           pk-info)
+        ;; some DBs like Oracle limit the length of identifiers to 30 characters so only take the first 30 here
+        alias        (apply str (take 30 (str (:name table) "__via__" (:name source-field))))]
+    {:fk-clause    fk-clause
+     :source-table table-id
+     :alias        alias
+     :fk-field-id  source-id
+     :pk-field-id  pk-id}))
+
+(s/defn ^:private resolve-join-info :- [ResolvedJoinInfo]
+  [fk-clauses :- [FKClauseWithFieldIDArgs], pk-info :- [PKInfo]]
   (distinct
-   (for [[_ [_ source-id] [_ dest-id]] fk-clauses
-         :let [source-field (qp.store/field source-id)
-               dest-field   (qp.store/field dest-id)
-               table-id     (:table_id dest-field)
-               table        (qp.store/table table-id)
-               pk-id        (some (fn [info]
-                                    (when (and (= (:table-id info) table-id)
-                                               (= (:fk-id info) source-id))
-                                      (:pk-id info)))
-                                  pk-info)]]
-     ;; some DBs like Oracle limit the length of identifiers to 30 characters so only take
-     ;; the first 30 here
-     {:join-alias  (apply str (take 30 (str (:name table) "__via__" (:name source-field))))
-      :table-id    table-id
-      :fk-field-id source-id
-      :pk-field-id pk-id})))
+   (for [clause (distinct fk-clauses)]
+     (resolve-one-join-info clause pk-info))))
 
-(s/defn ^:private add-join-info-to-query :- mbql.s/Query
-  [query fk-clauses pk-info]
-  (assoc-in query [:query :join-tables] (fks->join-information fk-clauses pk-info)))
+
+;;; ---------------------------------------- Adding :join-tables to the query ----------------------------------------
+
+(s/defn ^:private resolved-join-info->join-clause :- mbql.s/JoinInfo
+  [{:keys [source-table alias fk-field-id pk-field-id]} :- ResolvedJoinInfo]
+  {:table-id    source-table
+   :join-alias  alias
+   :fk-field-id fk-field-id
+   :pk-field-id pk-field-id})
+
+(s/defn ^:private add-implicit-join-clauses :- mbql.s/Query
+  [query, resolved-join-infos :- [ResolvedJoinInfo]]
+  (let [join-clauses (map resolved-join-info->join-clause resolved-join-infos)]
+    (update-in query [:query :join-tables] (comp distinct concat) join-clauses)))
+
+
+;;; --------------------------------------------- Replacing fk-> clauses ---------------------------------------------
+
+(s/defn ^:private matching-resolved-info :- ResolvedJoinInfo
+  [query-fk-clause :- mbql.s/fk->, resolved-join-info :- [ResolvedJoinInfo]]
+  (or (some
+       (fn [{info-fk-clause :fk-clause, :as info}]
+         (when (= query-fk-clause info-fk-clause)
+           info))
+       resolved-join-info)
+      (throw (Exception. (str (tru "Did not find match for {0} in resolved info." query-fk-clause))))))
+
+(s/defn ^:private replace-fk-clauses :- mbql.s/Query
+  [query, resolved-join-info :- [ResolvedJoinInfo]]
+  (mbql.u/replace-in query [:query]
+    [:fk-> _ [_ dest-id]] (let [{:keys [alias]} (matching-resolved-info &match resolved-join-info)]
+                            [:joined-field alias [:field-id dest-id]])))
 
 
 ;;; -------------------------------------------- PUTTING it all together ---------------------------------------------
@@ -120,7 +163,10 @@
       (let [pk-info (fk-clauses->pk-info source-table-id fk-clauses)]
         (store-join-tables! fk-clauses)
         (store-join-table-pk-fields! pk-info)
-        (add-join-info-to-query query fk-clauses pk-info)))))
+        (let [resolved-join-info (resolve-join-info fk-clauses pk-info)]
+          (-> query
+              (add-implicit-join-clauses resolved-join-info)
+              (replace-fk-clauses resolved-join-info)))))))
 
 (defn- resolve-joined-tables-in-query-all-levels
   "Resolve JOINs at all levels of the query, including the top level and nested queries at any level of nesting."

--- a/src/metabase/query_processor/middleware/wrap_value_literals.clj
+++ b/src/metabase/query_processor/middleware/wrap_value_literals.clj
@@ -34,8 +34,8 @@
 (defmethod type-info :field-id [[_ field-id]]
   (type-info (qp.store/field field-id)))
 
-(defmethod type-info :fk-> [[_ _ dest-field]]
-  (type-info dest-field))
+(defmethod type-info :joined-field [[_ _ field]]
+  (type-info field))
 
 (defmethod type-info :datetime-field [[_ field unit]]
   (assoc (type-info field) :unit unit))

--- a/src/metabase/routes/index.clj
+++ b/src/metabase/routes/index.clj
@@ -42,7 +42,8 @@
    (when (and locale (not= locale "en"))
      (try
        (slurp (or (io/resource (str "frontend_client/app/locales/" locale ".json"))
-                  (throw (FileNotFoundException. (str (trs "Locale ''{0}'' not found." locale))))))
+                  ;; don't try to i18n the Exception message below, we have no locale to translate it to!
+                  (throw (FileNotFoundException. (format "Locale '%s' not found." locale)))))
        (catch Throwable e
          (log/warn (.getMessage e)))))
    (fallback-localization locale)))

--- a/src/metabase/util/honeysql_extensions.clj
+++ b/src/metabase/util/honeysql_extensions.clj
@@ -26,10 +26,8 @@
   (-> s str (.toUpperCase Locale/ENGLISH)))
 
 ;; Add an `:h2` quote style that uppercases the identifier
-(let [quote-fns     @(resolve 'honeysql.format/quote-fns)
-      ansi-quote-fn (:ansi quote-fns)]
-  (intern 'honeysql.format 'quote-fns
-          (assoc quote-fns :h2 (comp english-upper-case ansi-quote-fn))))
+(let [{ansi-quote-fn :ansi} @#'honeysql.format/quote-fns]
+  (alter-var-root #'honeysql.format/quote-fns assoc :h2 (comp english-upper-case ansi-quote-fn)))
 
 ;; register the `extract` function with HoneySQL
 ;; (hsql/format (hsql/call :extract :a :b)) -> "extract(a from b)"

--- a/src/metabase/util/schema.clj
+++ b/src/metabase/util/schema.clj
@@ -1,5 +1,6 @@
 (ns metabase.util.schema
   "Various schemas that are useful throughout the app."
+  (:refer-clojure :exclude [distinct])
   (:require [cheshire.core :as json]
             [clojure.string :as str]
             [medley.core :as m]
@@ -116,11 +117,24 @@
 
 
 (defn non-empty
-  "Add an addditonal constraint to SCHEMA (presumably an array) that requires it to be non-empty
+  "Add an addditonal constraint to `schema` (presumably an array) that requires it to be non-empty
    (i.e., it must satisfy `seq`)."
   [schema]
   (with-api-error-message (s/constrained schema seq "Non-empty")
     (str (api-error-message schema) " " (tru "The array cannot be empty."))))
+
+(defn empty-or-distinct?
+  "True if `coll` is either empty or distinct."
+  [coll]
+  (if (seq coll)
+    (apply distinct? coll)
+    true))
+
+(defn distinct
+  "Add an additional constraint to `schema` (presumably an array) that requires all elements to be distinct."
+  [schema]
+  (with-api-error-message (s/constrained schema empty-or-distinct? "distinct")
+    (str (api-error-message schema) " " (tru "All elements must be distinct."))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/test/metabase/query_processor/middleware/resolve_joined_tables_test.clj
+++ b/test/metabase/query_processor/middleware/resolve_joined_tables_test.clj
@@ -1,5 +1,5 @@
 (ns metabase.query-processor.middleware.resolve-joined-tables-test
-  (:require [expectations :refer :all]
+  (:require [expectations :refer [expect]]
             [metabase.query-processor.middleware.resolve-joined-tables :as resolve-joined-tables]
             [metabase.query-processor.test-util :as qp.test-util]
             [metabase.test.data :as data]))
@@ -17,7 +17,7 @@
    :query    (data/$ids venues
                {:source-table $$table
                 :fields       [[:field-id $name]
-                               [:fk-> [:field-id $category_id] [:field-id $categories.name]]]
+                               [:joined-field "CATEGORIES__via__CATEGORY_ID" [:field-id $categories.name]]]
                 :join-tables  [{:join-alias  "CATEGORIES__via__CATEGORY_ID"
                                 :table-id    (data/id :categories)
                                 :fk-field-id $category_id
@@ -37,7 +37,7 @@
               (data/$ids venues
                 {:source-table $$table
                  :fields       [[:field-id $name]
-                                [:fk-> [:field-id $category_id] [:field-id $categories.name]]]
+                                [:joined-field "CATEGORIES__via__CATEGORY_ID" [:field-id $categories.name]]]
                  :join-tables  [{:join-alias  "CATEGORIES__via__CATEGORY_ID"
                                  :table-id    (data/id :categories)
                                  :fk-field-id $category_id
@@ -58,7 +58,7 @@
                (data/$ids venues
                  {:source-table $$table
                   :fields       [[:field-id $name]
-                                 [:fk-> [:field-id $category_id] [:field-id $categories.name]]]
+                                 [:joined-field "CATEGORIES__via__CATEGORY_ID" [:field-id $categories.name]]]
                   :join-tables  [{:join-alias  "CATEGORIES__via__CATEGORY_ID"
                                   :table-id    (data/id :categories)
                                   :fk-field-id $category_id
@@ -82,8 +82,8 @@
                {:source-query {:source-table $$table
                                :filter       [:> [:field-id $date] "2014-01-01"]}
                 :aggregation  [[:count]]
-                :breakout     [[:fk-> [:field-id $venue_id] [:field-id $venues.price]]]
-                :order-by     [[:asc [:fk-> [:field-id $venue_id] [:field-id $venues.price]]]]
+                :breakout     [[:joined-field "VENUES__via__VENUE_ID" [:field-id $venues.price]]]
+                :order-by     [[:asc [:joined-field "VENUES__via__VENUE_ID" [:field-id $venues.price]]]]
                 :join-tables  [{:join-alias  "VENUES__via__VENUE_ID"
                                 :table-id    (data/id :venues)
                                 :fk-field-id $venue_id

--- a/test/metabase/query_processor_test/joins_test.clj
+++ b/test/metabase/query_processor_test/joins_test.clj
@@ -1,12 +1,12 @@
 (ns metabase.query-processor-test.joins-test
   "Test for JOIN behavior."
-  (:require [metabase.query-processor-test :refer :all]
+  (:require [metabase.query-processor-test :as qp.test]
             [metabase.test.data :as data]
             [metabase.test.data.datasets :as datasets]))
 
 ;; The top 10 cities by number of Tupac sightings
 ;; Test that we can breakout on an FK field (Note how the FK Field is returned in the results)
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :foreign-keys)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :foreign-keys)
   [["Arlington"    16]
    ["Albany"       15]
    ["Portland"     14]
@@ -23,25 +23,27 @@
             :breakout    [$city_id->cities.name]
             :order-by    [[:desc [:aggregation 0]]]
             :limit       10}))
-       rows (format-rows-by [str int])))
+       qp.test/rows
+       (qp.test/format-rows-by [str int])))
 
 
 ;; Number of Tupac sightings in the Expa office
 ;; (he was spotted here 60 times)
 ;; Test that we can filter on an FK field
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :foreign-keys)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :foreign-keys)
   [[60]]
   (->> (data/dataset tupac-sightings
          (data/run-mbql-query sightings
            {:aggregation [[:count]]
             :filter      [:= $category_id->categories.id 8]}))
-       rows (format-rows-by [int])))
+       qp.test/rows
+       (qp.test/format-rows-by [int])))
 
 
 ;; THE 10 MOST RECENT TUPAC SIGHTINGS (!)
 ;; (What he was doing when we saw him, sighting ID)
 ;; Check that we can include an FK field in the :fields clause
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :foreign-keys)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :foreign-keys)
   [[772 "In the Park"]
    [894 "Working at a Pet Store"]
    [684 "At the Airport"]
@@ -57,14 +59,15 @@
            {:fields   [$id $category_id->categories.name]
             :order-by [[:desc $timestamp]]
             :limit    10}))
-       rows (format-rows-by [int str])))
+       qp.test/rows
+       (qp.test/format-rows-by [int str])))
 
 
 ;; 1. Check that we can order by Foreign Keys
 ;;    (this query targets sightings and orders by cities.name and categories.name)
 ;; 2. Check that we can join MULTIPLE tables in a single query
 ;;    (this query joins both cities and categories)
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :foreign-keys)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :foreign-keys)
   ;; CITY_ID, CATEGORY_ID, ID
   ;; Cities are already alphabetized in the source data which is why CITY_ID is sorted
   [[1 12   6]
@@ -84,20 +87,24 @@
                        [:asc $id]]
             :limit    10}))
        ;; drop timestamps. reverse ordering to make the results columns order match order-by
-       rows (map butlast) (map reverse) (format-rows-by [int int int])))
+       qp.test/rows
+       (map butlast)
+       (map reverse)
+       (qp.test/format-rows-by [int int int])))
 
 
 ;; Check that trying to use a Foreign Key fails for Mongo
-(datasets/expect-with-drivers (non-timeseries-drivers-without-feature :foreign-keys)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-without-feature :foreign-keys)
   {:status :failed
    :error  "foreign-keys is not supported by this driver."}
-  (select-keys (data/dataset tupac-sightings
-                 (data/run-mbql-query sightings
-                   {:order-by [[:asc $city_id->cities.name]
-                               [:desc $category_id->categories.name]
-                               [:asc $id]]
-                    :limit    10}))
-               [:status :error]))
+  (select-keys
+   (data/dataset tupac-sightings
+     (data/run-mbql-query sightings
+       {:order-by [[:asc $city_id->cities.name]
+                   [:desc $category_id->categories.name]
+                   [:asc $id]]
+        :limit    10}))
+   [:status :error]))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -115,15 +122,16 @@
 ;; WHERE USERS__via__RECIEVER_ID.NAME = 'Rasta Toucan'
 ;; GROUP BY USERS__via__SENDER_ID.NAME
 ;; ORDER BY USERS__via__SENDER_ID.NAME ASC
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :foreign-keys)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :foreign-keys)
   [["Bob the Sea Gull" 2]
    ["Brenda Blackbird" 2]
    ["Lucky Pigeon"     2]
    ["Peter Pelican"    5]
    ["Ronald Raven"     1]]
   (data/dataset avian-singles
-    (format-rows-by [str int]
-      (rows (data/run-mbql-query messages
-              {:aggregation [[:count]]
-               :breakout    [$sender_id->users.name]
-               :filter      [:= $reciever_id->users.name "Rasta Toucan"]})))))
+    (qp.test/format-rows-by [str int]
+      (qp.test/rows
+        (data/run-mbql-query messages
+          {:aggregation [[:count]]
+           :breakout    [$sender_id->users.name]
+           :filter      [:= $reciever_id->users.name "Rasta Toucan"]})))))

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -5,7 +5,7 @@
             [metabase
              [driver :as driver]
              [query-processor :as qp]
-             [query-processor-test :refer :all]
+             [query-processor-test :as qp.test]
              [util :as u]]
             [metabase.models
              [card :as card :refer [Card]]
@@ -31,14 +31,14 @@
    (This is used to keep the output of various tests below focused and manageable.)"
   {:style/indent 0}
   [results]
-  {:rows (rows results)
+  {:rows (qp.test/rows results)
    :cols (for [col (get-in results [:data :cols])]
            {:name      (str/lower-case (:name col))
             :base_type (:base_type col)})})
 
 
 ;; make sure we can do a basic query with MBQL source-query
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :nested-queries)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :nested-queries)
   {:rows [[1 "Red Medicine"                  4 10.0646 -165.374 3]
           [2 "Stout Burgers & Beers"        11 34.0996 -118.329 2]
           [3 "The Apple Pan"                11 34.0406 -118.428 2]
@@ -50,18 +50,18 @@
           {:name "latitude",    :base_type :type/Float}
           {:name "longitude",   :base_type :type/Float}
           {:name "price",       :base_type (data/expected-base-type->actual :type/Integer)}]}
-  (format-rows-by [int str int (partial u/round-to-decimals 4) (partial u/round-to-decimals 4) int]
+  (qp.test/format-rows-by [int str int (partial u/round-to-decimals 4) (partial u/round-to-decimals 4) int]
     (rows+cols
-      (qp/process-query
-        {:database (data/id)
-         :type     :query
-         :query    {:source-query {:source-table (data/id :venues)
-                                   :order-by     [[:asc (data/id :venues :id)]]
-                                   :limit        10}
-                    :limit        5}}))))
+     (qp/process-query
+       {:database (data/id)
+        :type     :query
+        :query    {:source-query {:source-table (data/id :venues)
+                                  :order-by     [[:asc (data/id :venues :id)]]
+                                  :limit        10}
+                   :limit        5}}))))
 
 ;; make sure we can do a basic query with a SQL source-query
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :nested-queries)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :nested-queries)
   {:rows [[1 -165.374  4 3 "Red Medicine"                 10.0646]
           [2 -118.329 11 2 "Stout Burgers & Beers"        34.0996]
           [3 -118.428 11 2 "The Apple Pan"                34.0406]
@@ -74,22 +74,22 @@
           {:name "price",       :base_type (case driver/*driver* :oracle :type/Decimal :type/Integer)}
           {:name "name",        :base_type :type/Text}
           {:name "latitude",    :base_type :type/Float}]}
-  (format-rows-by [int (partial u/round-to-decimals 4) int int str (partial u/round-to-decimals 4)]
+  (qp.test/format-rows-by [int (partial u/round-to-decimals 4) int int str (partial u/round-to-decimals 4)]
     (rows+cols
-      (qp/process-query
-        {:database (data/id)
-         :type     :query
-         :query    {:source-query {:native (:query
-                                            (qp/query->native
-                                              (data/mbql-query venues
-                                                {:fields [[:field-id $id]
-                                                          [:field-id $longitude]
-                                                          [:field-id $category_id]
-                                                          [:field-id $price]
-                                                          [:field-id $name]
-                                                          [:field-id $latitude]]})))}
-                    :order-by     [[:asc [:field-literal (data/format-name :id) :type/Integer]]]
-                    :limit        5}}))))
+     (qp/process-query
+       {:database (data/id)
+        :type     :query
+        :query    {:source-query {:native (:query
+                                           (qp/query->native
+                                             (data/mbql-query venues
+                                               {:fields [[:field-id $id]
+                                                         [:field-id $longitude]
+                                                         [:field-id $category_id]
+                                                         [:field-id $price]
+                                                         [:field-id $name]
+                                                         [:field-id $latitude]]})))}
+                   :order-by     [[:asc [:field-literal (data/format-name :id) :type/Integer]]]
+                   :limit        5}}))))
 
 
 (def ^:private breakout-results
@@ -101,36 +101,36 @@
           {:name "count", :base_type :type/Integer}]})
 
 ;; make sure we can do a query with breakout and aggregation using an MBQL source query
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :nested-queries)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :nested-queries)
   breakout-results
   (rows+cols
-    (format-rows-by [int int]
-      (qp/process-query
-        {:database (data/id)
-         :type     :query
-         :query    {:source-query {:source-table (data/id :venues)}
-                    :aggregation  [:count]
-                    :breakout     [[:field-literal (keyword (data/format-name :price)) :type/Integer]]}}))))
+   (qp.test/format-rows-by [int int]
+     (qp/process-query
+       {:database (data/id)
+        :type     :query
+        :query    {:source-query {:source-table (data/id :venues)}
+                   :aggregation  [:count]
+                   :breakout     [[:field-literal (keyword (data/format-name :price)) :type/Integer]]}}))))
 
 ;; Test including a breakout of a nested query column that follows an FK
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :nested-queries :foreign-keys)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :nested-queries :foreign-keys)
   {:rows [[1 174] [2 474] [3 78] [4 39]]
    :cols [{:name "price", :base_type (data/expected-base-type->actual :type/Integer)}
           {:name "count", :base_type :type/Integer}]}
   (rows+cols
-    (format-rows-by [int int]
-      (qp/process-query
-        {:database (data/id)
-         :type     :query
-         :query    {:source-query {:source-table (data/id :checkins)
-                                   :filter       [:> (data/id :checkins :date) "2014-01-01"]}
-                    :aggregation  [:count]
-                    :order-by     [[:asc [:fk-> (data/id :checkins :venue_id) (data/id :venues :price)]]]
-                    :breakout     [[:fk-> (data/id :checkins :venue_id) (data/id :venues :price)]]}}))))
+   (qp.test/format-rows-by [int int]
+     (qp/process-query
+       {:database (data/id)
+        :type     :query
+        :query    {:source-query {:source-table (data/id :checkins)
+                                  :filter       [:> (data/id :checkins :date) "2014-01-01"]}
+                   :aggregation  [:count]
+                   :order-by     [[:asc [:fk-> (data/id :checkins :venue_id) (data/id :venues :price)]]]
+                   :breakout     [[:fk-> (data/id :checkins :venue_id) (data/id :venues :price)]]}}))))
 
 
 ;; Test two breakout columns from the nested query, both following an FK
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :nested-queries :foreign-keys)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :nested-queries :foreign-keys)
   {:rows [[2 33.7701 7]
           [2 33.8894 8]
           [2 33.9997 7]
@@ -140,20 +140,20 @@
           {:name "latitude", :base_type :type/Float}
           {:name "count", :base_type :type/Integer}]}
   (rows+cols
-    (format-rows-by [int (partial u/round-to-decimals 4) int]
-      (qp/process-query
-        {:database (data/id)
-         :type     :query
-         :query    {:source-query {:source-table (data/id :checkins)
-                                   :filter       [:> (data/id :checkins :date) "2014-01-01"]}
-                    :filter       [:< [:fk-> (data/id :checkins :venue_id) (data/id :venues :latitude)] 34]
-                    :aggregation  [:count]
-                    :order-by     [[:asc [:fk-> (data/id :checkins :venue_id) (data/id :venues :price)]]]
-                    :breakout     [[:fk-> (data/id :checkins :venue_id) (data/id :venues :price)]
-                                   [:fk-> (data/id :checkins :venue_id) (data/id :venues :latitude)]]}}))))
+   (qp.test/format-rows-by [int (partial u/round-to-decimals 4) int]
+     (qp/process-query
+       {:database (data/id)
+        :type     :query
+        :query    {:source-query {:source-table (data/id :checkins)
+                                  :filter       [:> (data/id :checkins :date) "2014-01-01"]}
+                   :filter       [:< [:fk-> (data/id :checkins :venue_id) (data/id :venues :latitude)] 34]
+                   :aggregation  [:count]
+                   :order-by     [[:asc [:fk-> (data/id :checkins :venue_id) (data/id :venues :price)]]]
+                   :breakout     [[:fk-> (data/id :checkins :venue_id) (data/id :venues :price)]
+                                  [:fk-> (data/id :checkins :venue_id) (data/id :venues :latitude)]]}}))))
 
 ;; Test two breakout columns from the nested query, one following an FK the other from the source table
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :nested-queries :foreign-keys)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :nested-queries :foreign-keys)
   {:rows [[1 1 6]
           [1 2 14]
           [1 3 13]
@@ -163,7 +163,7 @@
           {:name "user_id", :base_type :type/Integer}
           {:name "count",   :base_type :type/Integer}]}
   (rows+cols
-    (format-rows-by [int int int]
+    (qp.test/format-rows-by [int int int]
       (qp/process-query
         {:database (data/id)
          :type     :query
@@ -177,16 +177,16 @@
                     :limit        5}}))))
 
 ;; make sure we can do a query with breakout and aggregation using a SQL source query
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :nested-queries)
-   breakout-results
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :nested-queries)
+  breakout-results
   (rows+cols
-    (format-rows-by [int int]
-      (qp/process-query
-        {:database (data/id)
-         :type     :query
-         :query    {:source-query {:native (:query (qp/query->native (data/mbql-query venues)))}
-                    :aggregation  [:count]
-                    :breakout     [[:field-literal (keyword (data/format-name :price)) :type/Integer]]}}))))
+   (qp.test/format-rows-by [int int]
+     (qp/process-query
+       {:database (data/id)
+        :type     :query
+        :query    {:source-query {:native (:query (qp/query->native (data/mbql-query venues)))}
+                   :aggregation  [:count]
+                   :breakout     [[:field-literal (keyword (data/format-name :price)) :type/Integer]]}}))))
 
 
 (defn- mbql-card-def
@@ -218,11 +218,11 @@
   breakout-results
   (tt/with-temp Card [card (venues-mbql-card-def)]
     (rows+cols
-      (format-rows-by [int int]
-        (qp/process-query
-          (query-with-source-card card
-            :aggregation [:count]
-            :breakout    [[:field-literal (keyword (data/format-name :price)) :type/Integer]]))))))
+     (qp.test/format-rows-by [int int]
+       (qp/process-query
+         (query-with-source-card card
+           :aggregation [:count]
+           :breakout    [[:field-literal (keyword (data/format-name :price)) :type/Integer]]))))))
 
 ;; make sure `card__id`-style queries work with native source queries as well
 (expect
@@ -231,11 +231,11 @@
                                             :type     :native
                                             :native   {:query "SELECT * FROM VENUES"}}}]
     (rows+cols
-      (format-rows-by [int int]
-        (qp/process-query
-          (query-with-source-card card
-            :aggregation [:count]
-            :breakout    [[:field-literal (keyword (data/format-name :price)) :type/Integer]]))))))
+     (qp.test/format-rows-by [int int]
+       (qp/process-query
+         (query-with-source-card card
+           :aggregation [:count]
+           :breakout    [[:field-literal (keyword (data/format-name :price)) :type/Integer]]))))))
 
 ;; Ensure trailing comments are trimmed and don't cause a wrapping SQL query to fail
 (expect
@@ -244,11 +244,11 @@
                                             :type     :native
                                             :native   {:query "SELECT * FROM VENUES -- small comment here"}}}]
     (rows+cols
-      (format-rows-by [int int]
-        (qp/process-query
-          (query-with-source-card card
-            :aggregation [:count]
-            :breakout    [[:field-literal (keyword (data/format-name :price)) :type/Integer]]))))))
+     (qp.test/format-rows-by [int int]
+       (qp/process-query
+         (query-with-source-card card
+           :aggregation [:count]
+           :breakout    [[:field-literal (keyword (data/format-name :price)) :type/Integer]]))))))
 
 ;; Ensure trailing comments followed by a newline are trimmed and don't cause a wrapping SQL query to fail
 (expect
@@ -257,11 +257,11 @@
                                             :type     :native
                                             :native   {:query "SELECT * FROM VENUES -- small comment here\n"}}}]
     (rows+cols
-      (format-rows-by [int int]
-        (qp/process-query
-          (query-with-source-card card
-            :aggregation [:count]
-            :breakout    [[:field-literal (keyword (data/format-name :price)) :type/Integer]]))))))
+     (qp.test/format-rows-by [int int]
+       (qp/process-query
+         (query-with-source-card card
+           :aggregation [:count]
+           :breakout    [[:field-literal (keyword (data/format-name :price)) :type/Integer]]))))))
 
 
 ;; make sure we can filter by a field literal
@@ -274,11 +274,11 @@
           {:name "longitude",   :base_type :type/Float}
           {:name "price",       :base_type :type/Integer}]}
   (rows+cols
-    (qp/process-query
-      {:database (data/id)
-       :type     :query
-       :query    {:source-query {:source-table (data/id :venues)}
-                  :filter       [:= [:field-literal (data/format-name :id) :type/Integer] 1]}})))
+   (qp/process-query
+     {:database (data/id)
+      :type     :query
+      :query    {:source-query {:source-table (data/id :venues)}
+                 :filter       [:= [:field-literal (data/format-name :id) :type/Integer] 1]}})))
 
 (def ^:private ^:const ^String venues-source-sql
   (str "(SELECT \"PUBLIC\".\"VENUES\".\"ID\" AS \"ID\", \"PUBLIC\".\"VENUES\".\"NAME\" AS \"NAME\", "
@@ -493,7 +493,7 @@
     results))
 
 ;; make sure using a time interval filter works
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :nested-queries)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :nested-queries)
   :completed
   (tt/with-temp Card [card (mbql-card-def
                              :source-table (data/id :checkins))]
@@ -503,7 +503,7 @@
         completed-status)))
 
 ;; make sure that wrapping a field literal in a datetime-field clause works correctly in filters & breakouts
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :nested-queries)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :nested-queries)
   :completed
   (tt/with-temp Card [card (mbql-card-def
                              :source-table (data/id :checkins))]
@@ -540,7 +540,7 @@
     (-> (query-with-source-card card
           :aggregation [:count])
         qp/process-query
-        rows)))
+        qp.test/rows)))
 
 
 ;; Make suer you're allowed to save a query that uses a SQL-based source query even if you don't have SQL *write*1337
@@ -652,10 +652,10 @@
 
 ;; make sure that if we refer to a Field that is actually inside the source query, the QP is smart enough to figure
 ;; out what you were referring to and behave appropriately
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :nested-queries)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :nested-queries)
   [[10]]
-  (format-rows-by [int]
-    (rows
+  (qp.test/format-rows-by [int]
+    (qp.test/rows
       (qp/process-query
         {:database (data/id)
          :type     :query
@@ -670,7 +670,7 @@
                     :filter       [:= [:field-id (data/id :venues :category_id)] 50]}}))))
 
 ;; make sure that if a nested query includes joins queries based on it still work correctly (#8972)
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :nested-queries :foreign-keys)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :nested-queries :foreign-keys)
   [[31 "Bludso's BBQ"         5 33.8894 -118.207 2]
    [32 "Boneyard Bistro"      5 34.1477 -118.428 3]
    [33 "My Brother's Bar-B-Q" 5 34.167  -118.595 2]
@@ -678,8 +678,8 @@
    [37 "bigmista's barbecue"  5 34.118  -118.26  2]
    [38 "Zeke's Smokehouse"    5 34.2053 -118.226 2]
    [39 "Baby Blues BBQ"       5 34.0003 -118.465 2]]
-  (format-rows-by [int str int (partial u/round-to-decimals 4) (partial u/round-to-decimals 4) int]
-    (rows
+  (qp.test/format-rows-by [int str int (partial u/round-to-decimals 4) (partial u/round-to-decimals 4) int]
+    (qp.test/rows
       (qp/process-query
         (data/$ids [venues {:wrap-field-ids? true}]
           {:type     :query
@@ -689,11 +689,11 @@
                                      :order-by     [[:asc $id]]}}})))))
 
 ;; Make sure we parse datetime strings when compared against type/DateTime field literals (#9007)
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :nested-queries :foreign-keys)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :nested-queries :foreign-keys)
   [[395]
    [980]]
-  (format-rows-by [int]
-    (rows
+  (qp.test/format-rows-by [int]
+    (qp.test/rows
       (qp/process-query
         (data/$ids checkins
           {:type     :query

--- a/test/metabase/routes/index_test.clj
+++ b/test/metabase/routes/index_test.clj
@@ -2,6 +2,7 @@
   (:require [cheshire.core :as json]
             [expectations :refer [expect]]
             [metabase.routes.index :as index]
+            [metabase.test.util.log :as tu.log]
             [puppetlabs.i18n.core :refer [*locale*]]))
 
 ;; make sure `load-localization` is correctly loading i18n files (#9938)
@@ -24,10 +25,11 @@
 (expect
   {"headers"      {"language" "xx", "plural-forms" "nplurals=2; plural=(n != 1);"}
    "translations" {"" {"Metabase" {"msgid" "Metabase", "msgstr" ["Metabase"]}}}}
-  (some->
-   (binding [*locale* "xx"]
-     (#'index/load-localization))
-   json/parse-string))
+  (tu.log/suppress-output
+    (some->
+     (binding [*locale* "xx"]
+       (#'index/load-localization))
+     json/parse-string)))
 
 ;; english should return the fallback localization (english)
 (expect

--- a/test/metabase/util/schema_test.clj
+++ b/test/metabase/util/schema_test.clj
@@ -1,7 +1,7 @@
 (ns metabase.util.schema-test
   "Tests for utility schemas and various API helper functions."
   (:require [compojure.core :refer [POST]]
-            [expectations :refer [expect]]
+            [expectations :refer :all]
             [metabase.api.common :as api]
             [metabase.util.schema :as su]
             [puppetlabs.i18n.core :as i18n]
@@ -47,3 +47,18 @@
   (let [zz (i18n/string-as-locale "zz")]
     (i18n/with-user-locale zz
       (ex-info-msg #(s/validate su/IntGreaterThanZero -1)))))
+
+(expect
+  nil
+  (s/check (su/distinct [s/Int]) []))
+
+(expect
+  nil
+  (s/check (su/distinct [s/Int]) [1]))
+
+(expect
+  nil
+  (s/check (su/distinct [s/Int]) [1 2]))
+
+(expect
+  (some? (s/check (su/distinct [s/Int]) [1 2 1])))


### PR DESCRIPTION
*  Add support for new `[:joined-field "table_alias" field-id-or-literal-clause]` which will be used to implement the improved JOIN support shipping as part of 0.33.0. This clause wraps a `:field-id` or `:field-literal` clause and tells the driver what alias it should use to qualify the Field in question (e.g. generate SQL like `table_alias.field` instead of `schema.table.field`)
*  `fk->` clauses are now considered syntactic sugar and converted to appropriate `joined-field` clauses by QP middleware. This simplifies the implementation of the `:sql` query processor code somewhat