### PR TITLE
Add SQL QP *join-alias* dynamic var :new:

### DIFF
--- a/modules/drivers/bigquery/src/metabase/driver/bigquery.clj
+++ b/modules/drivers/bigquery/src/metabase/driver/bigquery.clj
@@ -8,7 +8,6 @@
              [string :as str]]
             [honeysql
              [core :as hsql]
-             [format :as hformat]
              [helpers :as h]]
             [metabase
              [config :as config]
@@ -22,9 +21,7 @@
             [metabase.mbql
              [schema :as mbql.s]
              [util :as mbql.u]]
-            [metabase.models
-             [field :refer [Field]]
-             [table :as table]]
+            [metabase.models.table :as table]
             [metabase.query-processor
              [store :as qp.store]
              [util :as qputil]]
@@ -41,21 +38,24 @@
            [com.google.api.services.bigquery Bigquery Bigquery$Builder BigqueryScopes]
            [com.google.api.services.bigquery.model QueryRequest QueryResponse Table TableCell TableFieldSchema TableList
             TableList$Tables TableReference TableRow TableSchema]
-           honeysql.format.ToSql
            java.sql.Time
-           [java.util Collections Date]))
+           [java.util Collections Date]
+           metabase.util.honeysql_extensions.Identifier))
 
 (driver/register! :bigquery, :parent #{:google :sql})
 
 (defn- valid-bigquery-identifier?
-  "Is String `s` a valid BigQuery identifiers? Identifiers are only allowed to contain letters, numbers, and
-  underscores; cannot start with a number; and can be at most 128 characters long."
+  "Is String `s` a valid BigQuery identifier? Identifiers are only allowed to contain letters, numbers, and underscores;
+  cannot start with a number; and can be at most 128 characters long."
   [s]
   (boolean
    (and (string? s)
         (re-matches #"^([a-zA-Z_][a-zA-Z_0-9]*){1,128}$" s))))
 
-(defn- dataset-name-for-current-query
+(def ^:private BigQueryIdentifierString
+  (s/pred valid-bigquery-identifier? "Valid BigQuery identifier"))
+
+(s/defn ^:private dataset-name-for-current-query :- BigQueryIdentifierString
   "Fetch the dataset name for the database associated with this query, needed because BigQuery requires you to qualify
   identifiers with it. This is primarily called automatically for the `to-sql` implementation of the
   `BigQueryIdentifier` record type; see its definition for more details.
@@ -63,7 +63,7 @@
   This looks for the value inside the SQL QP's `*query*` dynamic var; since this won't be bound for non-MBQL queries,
   you will want to avoid this function for SQL queries."
   []
-  {:pre [(map? sql.qp/*query*)], :post [(valid-bigquery-identifier? %)]}
+  {:pre [(map? sql.qp/*query*)]}
   (:dataset-id sql.qp/*query*))
 
 
@@ -109,7 +109,6 @@
                      (.setPageToken <> page-token-or-nil)))))
 
 (defmethod driver/describe-database :bigquery [_ database]
-  {:pre [(map? database)]}
   ;; first page through all the 50-table pages until we stop getting "next page tokens"
   (let [tables (loop [tables [], ^TableList table-list (list-tables database)]
                  (let [tables (concat tables (.getTables table-list))]
@@ -122,7 +121,6 @@
                     {:schema nil, :name (.getTableId tableref)}))}))
 
 (defmethod driver/can-connect? :bigquery [_ details-map]
-  {:pre [(map? details-map)]}
   ;; check whether we can connect by just fetching the first page of tables for the database. If that succeeds we're
   ;; g2g
   (boolean (list-tables {:details details-map})))
@@ -308,40 +306,16 @@
 ;;; |                                                Query Processor                                                 |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-;; This record type used for BigQuery table and field identifiers, since BigQuery has some stupid rules about how to
-;; quote them (tables are like `dataset.table` and fields are like `dataset.table`.`field`)
-;; This implements HoneySql's ToSql protocol, so we can just output this directly in most of our QP code below
-;;
-;; TODO - this is totally unnecessary now, we can just override `->honeysql` for `Field` and `Table` instead. FIXME!
-(defrecord ^:private BigQueryIdentifier [dataset-name ; optional; will use (dataset-name-for-current-query) otherwise
-                                         table-name
-                                         field-name
-                                         alias?]
-  honeysql.format/ToSql
-  (to-sql [{:keys [dataset-name table-name field-name], :as bq-id}]
-    ;; Check to make sure the identifiers are valid and don't contain any sorts of escape characters since we are
-    ;; constructing raw SQL here, and would like to avoid potential SQL injection vectors (even though this is not
-    ;; direct user input, but instead would require someone to go in and purposely corrupt their Table names/Field names
-    ;; to do so)
-    (when dataset-name
-      (assert (valid-bigquery-identifier? dataset-name)
-        (tru "Invalid BigQuery identifier: ''{0}''" dataset-name)))
-    (assert (valid-bigquery-identifier? table-name)
-      (tru "Invalid BigQuery identifier: ''{0}''" table-name))
-    (when (seq field-name)
-      (assert (valid-bigquery-identifier? field-name)
-        (tru "Invalid BigQuery identifier: ''{0}''" field-name)))
-    ;; BigQuery identifiers should look like `dataset.table` or `dataset.table`.`field` (SAD!)
-    (let [dataset-name (or dataset-name (dataset-name-for-current-query))]
-      (str
-       (if alias?
-         (format "`%s`" table-name)
-         (format "`%s.%s`" dataset-name table-name))
-       (when (seq field-name)
-         (format ".`%s`" field-name))))))
+(defmethod sql.qp/->honeysql [:bigquery Identifier]
+  [_ identifier]
+  ;; if we're currently using a `*table-alias`, we can leave `identifer` as-is; otherwise, we need to qualify it with
+  ;; the dataset name. It needs to be part of the same string because
+  (if sql.qp/*table-alias*
+    identifier
+    (update-in identifier [:components 0] (partial str (dataset-name-for-current-query) \.))))
 
-(defn- honeysql-form->sql ^String [honeysql-form]
-  {:pre [(map? honeysql-form)]}
+(s/defn ^:private honeysql-form->sql :- s/Str
+  [honeysql-form :- su/Map]
   (let [[sql & args] (sql.qp/honeysql-form->sql+args :bigquery honeysql-form)]
     (when (seq args)
       (throw (Exception. (str (tru "BigQuery statements can''t be parameterized!")))))
@@ -374,7 +348,6 @@
 ;; parameters (`?` symbols)
 (defmethod sql.qp/->honeysql [:bigquery String]
   [_ s]
-  ;; TODO - what happens if `s` contains single-quotes? Shouldn't we be escaping them somehow?
   (hx/literal s))
 
 (defmethod sql.qp/->honeysql [:bigquery Boolean]
@@ -393,27 +366,13 @@
        (sql.qp/date driver unit)
        hx/->time))
 
-(defmethod sql.qp/->honeysql [Object :datetime-field]
-  [driver [_ field unit]]
-  (sql.qp/date driver unit (sql.qp/->honeysql driver field)))
-
-(defmethod sql.qp/->honeysql [:bigquery (class Field)]
-  [driver field]
-  (let [{table-name :name, :as table} (qp.store/table (:table_id field))
-        field-identifier              (map->BigQueryIdentifier
-                                       {:table-name table-name
-                                        :field-name (:name field)
-                                        :alias?     (:alias? table)})]
-    (sql.qp/cast-unix-timestamp-field-if-needed driver field field-identifier)))
-
-(defmethod sql.qp/field->identifier :bigquery [_ {table-id :table_id, :as field}]
+(defmethod sql.qp/field->identifier :bigquery [_ {table-id :table_id, field-name :name, :as field}]
   ;; TODO - Making a DB call for each field to fetch its Table is inefficient and makes me cry, but this method is
   ;; currently only used for SQL params so it's not a huge deal at this point
   ;;
   ;; TODO - we should make sure these are in the QP store somewhere and then could at least batch the calls
-  (let [table-name (db/select-one-field :name table/Table :id (u/get-id table-id))
-        details    (:details (qp.store/database))]
-    (map->BigQueryIdentifier {:dataset-name (:dataset-id details), :table-name table-name, :field-name (:name field)})))
+  (let [table-name (db/select-one-field :name table/Table :id (u/get-id table-id))]
+    (hx/identifier table-name field-name)))
 
 (defmethod sql.qp/apply-top-level-clause [:bigquery :breakout]
   [driver _ honeysql-form {breakout-field-clauses :breakout, fields-field-clauses :fields}]
@@ -428,32 +387,6 @@
       ((partial apply h/merge-select) (for [field-clause breakout-field-clauses
                                             :when        (not (contains? (set fields-field-clauses) field-clause))]
                                         (sql.qp/as driver field-clause)))))
-
-;; Copy of the SQL implementation, but prepends the current dataset ID to the table name.
-(defmethod sql.qp/apply-top-level-clause [:bigquery :source-table] [_ _ honeysql-form {source-table-id :source-table}]
-  (let [{table-name :name} (qp.store/table source-table-id)]
-    (h/from honeysql-form (map->BigQueryIdentifier {:table-name table-name}))))
-
-;; Copy of the SQL implementation, but prepends the current dataset ID to join-alias.
-(defmethod sql.qp/apply-top-level-clause [:bigquery :join-tables]
-  [_ _ honeysql-form {join-tables :join-tables, source-table-id :source-table}]
-  (let [{source-table-name :name} (qp.store/table source-table-id)]
-    (loop [honeysql-form honeysql-form, [{:keys [table-id pk-field-id fk-field-id join-alias]} & more] join-tables]
-      (let [{table-name :name} (qp.store/table table-id)
-            source-field       (qp.store/field fk-field-id)
-            pk-field           (qp.store/field pk-field-id)
-
-            honeysql-form
-            (h/merge-left-join honeysql-form
-              [(map->BigQueryIdentifier {:table-name table-name})
-               (map->BigQueryIdentifier {:table-name join-alias, :alias? true})]
-              [:=
-               (map->BigQueryIdentifier {:table-name source-table-name, :field-name (:name source-field)})
-               (map->BigQueryIdentifier {:table-name join-alias, :field-name (:name pk-field), :alias? true})])]
-        (if (seq more)
-          (recur honeysql-form more)
-          honeysql-form)))))
-
 (defn- ag-ref->alias [[_ index]]
   (let [{{aggregations :aggregation} :query} sql.qp/*query*
         [ag-type :as ag]                     (nth aggregations index)]

--- a/modules/drivers/bigquery/test/metabase/driver/bigquery_test.clj
+++ b/modules/drivers/bigquery/test/metabase/driver/bigquery_test.clj
@@ -1,6 +1,6 @@
 (ns metabase.driver.bigquery-test
   (:require [clj-time.core :as time]
-            [expectations :refer :all]
+            [expectations :refer [expect]]
             [honeysql.core :as hsql]
             [metabase
              [driver :as driver]
@@ -170,16 +170,6 @@
                                  :aggregation  [:count]
                                  :breakout     [[:fk-> (data/id :venues :category_id) (data/id :categories :name)]]}})]
         (get-in results [:data :native_form :query] results)))))
-
-;; Make sure the BigQueryIdentifier class works as expected
-(expect
-  ["SELECT `dataset.table`.`field`"]
-  (hsql/format {:select [(#'bigquery/map->BigQueryIdentifier
-                          {:dataset-name "dataset", :table-name "table", :field-name "field"})]}))
-
-(expect
-  ["SELECT `dataset.table`"]
-  (hsql/format {:select [(#'bigquery/map->BigQueryIdentifier {:dataset-name "dataset", :table-name "table"})]}))
 
 (defn- native-timestamp-query [db-or-db-id timestamp-str timezone-str]
   (-> (qp/process-query

--- a/modules/drivers/oracle/src/metabase/driver/oracle.clj
+++ b/modules/drivers/oracle/src/metabase/driver/oracle.clj
@@ -196,12 +196,11 @@
       col
 
       ;; otherwise we *should* be dealing with an Identifier. If so, take the last component of the Identifier and use
-      ;; that as the alias. Because Identifiers can be nested, check if the last part is an `Identifier` and recurse
-      ;; if needed.
+      ;; that as the alias.
       ;;
-      ;; TODO - could this be done using `->honeysql` instead?
+      ;; TODO - could this be done using `->honeysql` or `field->alias` instead?
       (instance? Identifier col)
-      [col (hx/identifier (last (:components col)))]
+      [col (hx/identifier :field-alias (last (:components col)))]
 
       :else
       (do

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -72,31 +72,31 @@
 ;; `deduplicate-identifiers` should use the last component of an identifier as the alias if it does not already have
 ;; one
 (expect
-  [[(hx/identifier "A" "B" "C" "D") (hx/identifier "D")]
-   [(hx/identifier "F")             (hx/identifier "G")]]
+  [[(hx/identifier :field "A" "B" "C" "D") (hx/identifier :field-alias "D")]
+   [(hx/identifier :field "F")             (hx/identifier :field-alias "G")]]
   (#'oracle/deduplicate-identifiers
-   [(hx/identifier "A" "B" "C" "D")
-    [(hx/identifier "F")            (hx/identifier "G")]]))
+   [(hx/identifier :field "A" "B" "C" "D")
+    [(hx/identifier :field "F")            (hx/identifier :field-alias "G")]]))
 
 ;; `deduplicate-identifiers` should append numeric suffixes to duplicate aliases
 (expect
-  [[(hx/identifier "A" "B" "C" "D") (hx/identifier "D")]
-   [(hx/identifier "E" "D")         (hx/identifier "D_2")]
-   [(hx/identifier "F")             (hx/identifier "G")]]
+  [[(hx/identifier :field "A" "B" "C" "D") (hx/identifier :field-alias "D")]
+   [(hx/identifier :field "E" "D")         (hx/identifier :field-alias "D_2")]
+   [(hx/identifier :field "F")             (hx/identifier :field-alias "G")]]
   (#'oracle/deduplicate-identifiers
-   [(hx/identifier "A" "B" "C" "D")
-    (hx/identifier "E" "D")
-    [(hx/identifier "F")            (hx/identifier "G")]]))
+   [(hx/identifier :field "A" "B" "C" "D")
+    (hx/identifier :field "E" "D")
+    [(hx/identifier :field "F")            (hx/identifier :field-alias "G")]]))
 
 ;; `deduplicate-identifiers` should handle aliases that are already suffixed gracefully
 (expect
-  [[(hx/identifier "A" "B" "C" "D") (hx/identifier "D")]
-   [(hx/identifier "E" "D")         (hx/identifier "D_2")]
-   [(hx/identifier "F")             (hx/identifier "D_3")]]
+  [[(hx/identifier :field "A" "B" "C" "D") (hx/identifier :field-alias "D")]
+   [(hx/identifier :field "E" "D")         (hx/identifier :field-alias "D_2")]
+   [(hx/identifier :field "F")             (hx/identifier :field-alias "D_3")]]
   (#'oracle/deduplicate-identifiers
-   [(hx/identifier "A" "B" "C" "D")
-    (hx/identifier "E" "D")
-    [(hx/identifier "F")            (hx/identifier "D_2")]]))
+   [(hx/identifier :field "A" "B" "C" "D")
+    (hx/identifier :field "E" "D")
+    [(hx/identifier :field "F")            (hx/identifier :field-alias "D_2")]]))
 
 
 (expect

--- a/modules/drivers/presto/src/metabase/driver/presto.clj
+++ b/modules/drivers/presto/src/metabase/driver/presto.clj
@@ -154,7 +154,7 @@
 (s/defmethod driver/can-connect? :presto
   [driver {:keys [catalog] :as details} :- PrestoConnectionDetails]
   (let [{[[v]] :rows} (execute-presto-query! details
-                        (format "SHOW SCHEMAS FROM %s LIKE 'information_schema'" (sql.u/quote-name driver catalog)))]
+                        (format "SHOW SCHEMAS FROM %s LIKE 'information_schema'" (sql.u/quote-name driver :database catalog)))]
     (= v "information_schema")))
 
 (defmethod driver/date-interval :presto
@@ -164,12 +164,12 @@
 (s/defn ^:private database->all-schemas :- #{su/NonBlankString}
   "Return a set of all schema names in this `database`."
   [driver {{:keys [catalog schema] :as details} :details :as database}]
-  (let [sql            (str "SHOW SCHEMAS FROM " (sql.u/quote-name driver catalog))
+  (let [sql            (str "SHOW SCHEMAS FROM " (sql.u/quote-name driver :database catalog))
         {:keys [rows]} (execute-presto-query! details sql)]
     (set (map first rows))))
 
 (defn- describe-schema [driver {{:keys [catalog] :as details} :details} {:keys [schema]}]
-  (let [sql            (str "SHOW TABLES FROM " (sql.u/quote-name driver catalog schema))
+  (let [sql            (str "SHOW TABLES FROM " (sql.u/quote-name driver :schema catalog schema))
         {:keys [rows]} (execute-presto-query! details sql)
         tables         (map first rows)]
     (set (for [table-name tables]
@@ -207,7 +207,7 @@
 
 (defmethod driver/describe-table :presto
   [driver {{:keys [catalog] :as details} :details} {schema :schema, table-name :name}]
-  (let [sql            (str "DESCRIBE " (sql.u/quote-name driver catalog schema table-name))
+  (let [sql            (str "DESCRIBE " (sql.u/quote-name driver :table catalog schema table-name))
         {:keys [rows]} (execute-presto-query! details sql)]
     {:schema schema
      :name   table-name

--- a/modules/drivers/presto/test/metabase/test/data/presto.clj
+++ b/modules/drivers/presto/test/metabase/test/data/presto.clj
@@ -62,7 +62,7 @@
             (sql.tx/qualify-and-quote driver database-name table-name)
             (str/join \, dummy-values)
             (str/join \, (for [column columns]
-                           (sql.u/quote-name driver (tx/format-name driver column)))))))
+                           (sql.u/quote-name driver :field (tx/format-name driver column)))))))
 
 (defmethod sql.tx/drop-table-if-exists-sql :presto [driver {:keys [database-name]} {:keys [table-name]}]
   (str "DROP TABLE IF EXISTS " (sql.tx/qualify-and-quote driver database-name table-name)))

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -19,9 +19,7 @@
              [sync :as sql-jdbc.sync]]
             [metabase.driver.sql.query-processor :as sql.qp]
             [metabase.driver.sql.util.unprepare :as unprepare]
-            [metabase.models
-             [field :refer [Field]]
-             [table :refer [Table]]]
+            [metabase.models.table :refer [Table]]
             [metabase.query-processor.store :as qp.store]
             [metabase.util
              [date :as du]
@@ -30,6 +28,7 @@
             [toucan.db :as db])
   (:import java.sql.Time
            java.util.Date
+           metabase.util.honeysql_extensions.Identifier
            net.snowflake.client.jdbc.SnowflakeSQLException))
 
 (driver/register! :snowflake, :parent :sql-jdbc)
@@ -140,18 +139,13 @@
   (or (-> (qp.store/database) db-name)
       (throw (Exception. "Missing DB name"))))
 
-(defmethod sql.qp/->honeysql [:snowflake (class Field)]
-  [driver field]
-  (let [table            (qp.store/table (:table_id field))
-        db-name          (when-not (:alias? table)
-                           (query-db-name))
-        field-identifier (sql.qp/->honeysql driver (hx/identifier db-name (:schema table) (:name table) (:name field)))]
-    (sql.qp/cast-unix-timestamp-field-if-needed driver field field-identifier)))
-
-(defmethod sql.qp/->honeysql [:snowflake (class Table)]
-  [driver table]
-  (let [{table-name :name, schema :schema} table]
-    (sql.qp/->honeysql driver (hx/identifier (query-db-name) schema table-name))))
+;; unless we're currently using a table alias, we need to prepend Table and Field identifiers with the DB name for the
+;; query
+(defmethod sql.qp/->honeysql [:snowflake Identifier]
+  [_ identifier]
+  (if sql.qp/*table-alias*
+    identifier
+    (update identifier :components (partial cons (query-db-name)))))
 
 (defmethod sql.qp/->honeysql [:snowflake :time]
   [driver [_ value unit]]

--- a/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
+++ b/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
@@ -58,8 +58,8 @@
 (defmethod sql.qp/apply-top-level-clause [:sparksql :source-table]
   [driver _ honeysql-form {source-table-id :source-table}]
   (let [{table-name :name, schema :schema} (qp.store/table source-table-id)]
-    (h/from honeysql-form [(sql.qp/->honeysql driver (hx/identifier schema table-name))
-                           source-table-alias])))
+    (h/from honeysql-form [(sql.qp/->honeysql driver (hx/identifier :table schema table-name))
+                           (sql.qp/->honeysql driver (hx/identifier :table-alias source-table-alias))])))
 
 
 ;;; ------------------------------------------- Other Driver Method Impls --------------------------------------------
@@ -109,7 +109,7 @@
    (with-open [conn (jdbc/get-connection (sql-jdbc.conn/db->pooled-connection-spec database))]
      (let [results (jdbc/query {:connection conn} [(format
                                                     "describe %s"
-                                                    (sql.u/quote-name driver
+                                                    (sql.u/quote-name driver :table
                                                       (dash-to-underscore schema)
                                                       (dash-to-underscore table-name)))])]
        (set

--- a/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
+++ b/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
@@ -34,14 +34,11 @@
   "Default alias for all source tables. (Not for source queries; those still use the default SQL QP alias of `source`.)"
   "t1")
 
+;; use `source-table-alias` for the source Table, e.g. `t1.field` instead of the normal `schema.table.field`
 (defmethod sql.qp/->honeysql [:sparksql (class Field)]
   [driver field]
-  (let [table            (qp.store/table (:table_id field))
-        table-name       (if (:alias? table)
-                           (:name table)
-                           source-table-alias)
-        field-identifier (sql.qp/->honeysql driver (hx/identifier table-name (:name field)))]
-    (sql.qp/cast-unix-timestamp-field-if-needed driver field field-identifier)))
+  (binding [sql.qp/*table-alias* (or sql.qp/*table-alias* source-table-alias)]
+    ((get-method sql.qp/->honeysql [:hive-like (class Field)]) driver field)))
 
 (defmethod sql.qp/apply-top-level-clause [:sparksql :page] [_ _ honeysql-form {{:keys [items page]} :page}]
   (let [offset (* (dec page) items)]

--- a/modules/drivers/sparksql/test/metabase/test/data/sparksql.clj
+++ b/modules/drivers/sparksql/test/metabase/test/data/sparksql.clj
@@ -88,7 +88,7 @@
 
 (defmethod sql.tx/create-table-sql :sparksql
   [driver {:keys [database-name], :as dbdef} {:keys [table-name field-definitions]}]
-  (let [quote-name    #(sql.u/quote-name driver (tx/format-name driver %))
+  (let [quote-name    #(sql.u/quote-name driver :field (tx/format-name driver %))
         pk-field-name (quote-name (sql.tx/pk-field-name driver))]
     (format "CREATE TABLE %s (%s, %s %s)"
             (sql.tx/qualify-and-quote driver database-name table-name)

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -181,7 +181,7 @@
                      [*table-alias*]
                      (let [{schema :schema, table-name :name} (qp.store/table table-id)]
                        [schema table-name]))
-        identifier (->honeysql driver (apply hx/identifier (concat qualifiers [field-name])))]
+        identifier (->honeysql driver (apply hx/identifier :field (concat qualifiers [field-name])))]
     (cast-unix-timestamp-field-if-needed driver field identifier)))
 
 (defmethod ->honeysql [:sql :field-id]
@@ -190,7 +190,7 @@
 
 (defmethod ->honeysql [:sql :field-literal]
   [driver [_ field-name]]
-  (->honeysql driver (hx/identifier *table-alias* field-name)))
+  (->honeysql driver (hx/identifier :field *table-alias* field-name)))
 
 (defmethod ->honeysql [:sql :joined-field]
   [driver [_ alias field]]
@@ -317,7 +317,7 @@
                        expression-name      expression-name
                        field                (field->alias driver field)
                        (string? id-or-name) id-or-name)]
-      (->honeysql driver (hx/identifier alias)))))
+      (->honeysql driver (hx/identifier :field-alias alias)))))
 
 (defn as
   "Generate HoneySQL for an `AS` form (e.g. `<form> AS <field>`) using the name information of a `field-clause`. The
@@ -355,6 +355,7 @@
                 form
                 [(->honeysql driver ag)
                  (->honeysql driver (hx/identifier
+                                     :field-alias
                                      (driver/format-custom-field-name driver (annotate/aggregation-name ag))))])]
       (if-not (seq more)
         form
@@ -498,7 +499,7 @@
 (defmethod ->honeysql [:sql (class Table)]
   [driver table]
   (let [{table-name :name, schema :schema} table]
-    (->honeysql driver (hx/identifier schema table-name))))
+    (->honeysql driver (hx/identifier :table schema table-name))))
 
 (defmethod apply-top-level-clause [:sql :source-table]
   [driver _ honeysql-form {source-table-id :source-table}]

--- a/src/metabase/driver/sql/util.clj
+++ b/src/metabase/driver/sql/util.clj
@@ -2,9 +2,10 @@
   "Utility functions for writing SQL drivers."
   (:require [honeysql.core :as hsql]
             [metabase.driver.sql.query-processor :as sql.qp]
-            [metabase.util.honeysql-extensions :as hx]))
+            [metabase.util.honeysql-extensions :as hx]
+            [schema.core :as s]))
 
-(defn quote-name
+(s/defn quote-name
   "Quote unqualified string or keyword identifier(s) by passing them to `hx/identifier`, then calling HoneySQL `format`
   on the resulting `Identifier`. Uses the `sql.qp/quote-style` of the current driver. You can implement `->honeysql`
   for `Identifier` if you need custom behavior here.
@@ -14,9 +15,9 @@
 
   You should only use this function for places where you are not using HoneySQL, such as queries written directly in
   SQL. For HoneySQL forms, `Identifier` is converted to SQL automatically when it is compiled."
-  {:style/indent 1}
-  [driver & identifiers]
+  {:style/indent 2}
+  [driver :- s/Keyword, identifier-type :- hx/IdentifierType, & components]
   (first
-   (hsql/format (sql.qp/->honeysql driver (apply hx/identifier identifiers))
+   (hsql/format (sql.qp/->honeysql driver (apply hx/identifier identifier-type components))
      :quoting             (sql.qp/quote-style driver)
      :allow-dashed-names? true)))

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -23,7 +23,7 @@
    (jdbc/query (sql-jdbc.conn/db->pooled-connection-spec database)
                (sql.qp/honeysql-form->sql+args driver honeysql-form)))
   ([driver database table honeysql-form]
-   (query driver database (merge {:from [(sql.qp/->honeysql driver (hx/identifier (:schema table) (:name table)))]}
+   (query driver database (merge {:from [(sql.qp/->honeysql driver (hx/identifier :table (:schema table) (:name table)))]}
                                  honeysql-form))))
 
 

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -23,9 +23,8 @@
             [toucan.db :as db])
   (:import [java.io File IOException]))
 
-(when-not *compile-files*
-  (when config/is-dev?
-    (alter-meta! #'stencil.core/render-file assoc :style/indent 1)))
+(when config/is-dev?
+  (alter-meta! #'stencil.core/render-file assoc :style/indent 1))
 
 ;; Dev only -- disable template caching
 (when config/is-dev?

--- a/src/metabase/mbql/util.clj
+++ b/src/metabase/mbql/util.clj
@@ -340,29 +340,6 @@
     (class x)))
 
 
-(s/defn fk-clause->join-info :- (s/maybe mbql.s/JoinInfo)
-  "Return the matching info about the JOINed for the 'destination' Field in an `fk->` clause, for the current level of
-  nesting (`0` meaning this `fk->` clause was found in the top-level query; `1` meaning it was found in the first
-  `source-query`, and so forth.)
-
-     (fk-clause->join-info query [:fk-> [:field-id 1] [:field-id 2]] 0)
-     ;; -> \"orders__via__order_id\""
-  [query :- mbql.s/Query, nested-query-level :- su/NonNegativeInt, [_ source-field-clause :as fk-clause] :- mbql.s/fk->]
-  ;; if we're dealing with something that's not at the top-level go ahead and recurse a level until we get to the
-  ;; query we want to work with
-  (if (pos? nested-query-level)
-    (recur {:query (or (get-in query [:query :source-query])
-                       (throw (Exception. (str (tru "Bad nested-query-level: query does not have a source query")))))}
-           (dec nested-query-level)
-           fk-clause)
-    ;; ok, when we've reached the right level of nesting, look in `:join-tables` to find the appropriate info
-    (let [source-field-id (field-clause->id-or-literal source-field-clause)]
-      (some (fn [{:keys [fk-field-id], :as info}]
-              (when (= fk-field-id source-field-id)
-                info))
-            (-> query :query :join-tables)))))
-
-
 (s/defn expression-with-name :- mbql.s/FieldOrExpressionDef
   "Return the `Expression` referenced by a given `expression-name`."
   [query :- mbql.s/Query, expression-name :- su/NonBlankString]

--- a/src/metabase/metabot/command.clj
+++ b/src/metabase/metabot/command.clj
@@ -99,11 +99,11 @@
 
 ;;; ------------------------------------------------------ list ------------------------------------------------------
 
-(defn- formar-cards-list
+(defn- format-cards-list
   "Format a sequence of Cards as a nice multiline list for use in responses."
   [cards]
-  (apply str (interpose "\n" (for [{id :id, card-name :name} cards]
-                               (format "%d.  <%s|\"%s\">" id (urls/card-url id) card-name)))))
+  (str/join "\n" (for [{id :id, card-name :name} cards]
+                   (format "%d.  <%s|\"%s\">" id (urls/card-url id) card-name))))
 
 (defn- list-cards []
   (filter-metabot-readable
@@ -127,7 +127,7 @@
   (let [cards (list-cards)]
     (str (tru "Here''s your {0} most recent cards:" (count cards))
          "\n"
-          (formar-cards-list cards))))
+          (format-cards-list cards))))
 
 
 ;;; ------------------------------------------------------ show ------------------------------------------------------
@@ -135,7 +135,9 @@
 (defn- cards-with-name [card-name]
   (db/select [Card :id :name]
     :%lower.name [:like (str \% (str/lower-case card-name) \%)]
-    :archived false))
+    :archived false
+    {:order-by [[:%lower.name :asc]]
+     :limit    10}))
 
 (defn- card-with-name [card-name]
   (let [[first-card & more, :as cards] (cards-with-name card-name)]
@@ -145,7 +147,7 @@
         (str
          (tru "Could you be a little more specific, or use the ID? I found these cards with names that matched:")
          "\n"
-         (formar-cards-list cards)))))
+         (format-cards-list cards)))))
     first-card))
 
 (defn- id-or-name->card [card-id-or-name]

--- a/src/metabase/query_processor/middleware/check_features.clj
+++ b/src/metabase/query_processor/middleware/check_features.clj
@@ -21,7 +21,9 @@
     :stddev
     :standard-deviation-aggregations
 
-    :joined-field
+    ;; `:fk->` is normally replaced by `:joined-field` already but the middleware that does the replacement won't run
+    ;; if the driver doesn't support foreign keys, meaning the clauses can leak thru
+    #{:joined-field :fk->}
     :foreign-keys))
 
 (defn- check-features* [{query-type :type, :as query}]

--- a/src/metabase/query_processor/store.clj
+++ b/src/metabase/query_processor/store.clj
@@ -41,36 +41,6 @@
   [& body]
   `(do-with-new-store (fn [] ~@body)))
 
-(defn do-with-pushed-store
-  "Execute bind a *copy* of the current store and execute `f`."
-  [f]
-  (binding [*store* (atom @*store*)]
-    (f)))
-
-(defmacro with-pushed-store
-  "Bind a temporary copy of the current store (presumably so you can make temporary changes) for the duration of `body`.
-  All changes to this 'pushed' copy will be discarded after the duration of `body`.
-
-  This is used to make it easily to write downstream clause-handling functions in driver QP implementations without
-  needing to code them in a way where they are explicitly aware of the context in which they are called. For example,
-  we use this to temporarily give Tables a different `:name` in the SQL QP when we need to use an alias for them in
-  `fk->` forms.
-
-  Pushing stores is cumulative: nesting a `with-pushed-store` form inside another will make a copy of the copy.
-
-    (with-pushed-store
-      ;; store is now a temporary copy of original
-      (store-table! (assoc (table table-id) :name \"Temporary New Name\"))
-      (with-pushed-store
-        ;; store is now a temporary copy of the copy
-        (:name (table table-id)) ; -> \"Temporary New Name\"
-        ...)
-    ...)
-    (:name (table table-id)) ; -> \"Original Name\""
-  {:style/indent 0}
-  [& body]
-  `(do-with-pushed-store (fn [] ~@body)))
-
 (def database-columns-to-fetch
   "Columns you should fetch for the Database referenced by the query before stashing in the store."
   [:id

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -294,12 +294,10 @@
   IFilteredStacktrace {:filtered-stacktrace (constantly nil)})
 
 (extend Throwable
-  IFilteredStacktrace {:filtered-stacktrace (fn [this]
-                                             (filtered-stacktrace (throwable-get-stack-trace this)))})
+  IFilteredStacktrace {:filtered-stacktrace (comp filtered-stacktrace throwable-get-stack-trace)})
 
 (extend Thread
-  IFilteredStacktrace {:filtered-stacktrace (fn [this]
-                                              (filtered-stacktrace (thread-get-stack-trace this)))})
+  IFilteredStacktrace {:filtered-stacktrace (comp filtered-stacktrace thread-get-stack-trace)})
 
 (defn- metabase-frame? [frame]
   (re-find #"metabase" (str frame)))

--- a/src/metabase/util/honeysql_extensions.clj
+++ b/src/metabase/util/honeysql_extensions.clj
@@ -77,7 +77,7 @@
                      component (if (instance? Identifier component)
                                  (:components component)
                                  [component])]
-                 component)))
+                 (u/keyword->qualified-name component))))
 
 ;; Single-quoted string literal
 (defrecord Literal [literal]

--- a/src/metabase/util/pretty.clj
+++ b/src/metabase/util/pretty.clj
@@ -5,7 +5,9 @@
            java.util.Map))
 
 (defprotocol PrettyPrintable
-  "Implmement this protocol to return custom representations of objects when printing them."
+  "Implmement this protocol to return custom representations of objects when printing them. This only seems to work if
+  it's done as part of the type declaration (`defrecord`); it doesn't seem to be respected if you use
+  `extend-protocol` for an existing type. Not sure why this is :("
   (pretty [_]
     "Return an appropriate representation of this object to be used when printing it, such as in the REPL or in log
     messages."))

--- a/test/expectation_options.clj
+++ b/test/expectation_options.clj
@@ -65,9 +65,11 @@
       (u/prog1 (run test-fn)
         (let [duration-ms (- (System/currentTimeMillis) start-time-ms)]
           (when (> duration-ms slow-test-threshold-ms)
-            (let [{:keys [file line]} (-> test-fn meta :the-var meta)]
-              (println (u/format-color 'red "%s %s is a slow test! It took %s to finish."
-                         file line (du/format-milliseconds duration-ms))))))))))
+            (println
+             (let [{:keys [file line]} (-> test-fn meta :the-var meta)]
+               (u/format-color 'red "%s %s is a slow test! It took %s to finish."
+                 file line (du/format-milliseconds duration-ms)))
+             "(This may have been because it was loading test data.)")))))))
 
 
 ;;; ------------------------------------------------ enforce-timeout -------------------------------------------------

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -294,7 +294,8 @@
   this behavior."
   {:style/indent 1}
   ([format-fns rows]
-   (format-rows-by format-fns (not :format-nil-values?) rows))
+   (format-rows-by format-fns false rows))
+
   ([format-fns format-nil-values? rows]
    (cond
      (= (:status rows) :failed)
@@ -308,13 +309,16 @@
      (update rows :rows (partial format-rows-by format-fns))
 
      :else
-     (vec (for [row rows]
-            (vec (for [[f v] (partition 2 (interleave format-fns row))]
-                   (when (or v format-nil-values?)
-                     (try (f v)
-                          (catch Throwable e
-                            (printf "(%s %s) failed: %s" f v (.getMessage e))
-                            (throw e)))))))))))
+     (vec
+      (for [row rows]
+        (vec
+         (for [[f v] (partition 2 (interleave format-fns row))]
+           (when (or v format-nil-values?)
+             (try
+               (f v)
+               (catch Throwable e
+                 (printf "(%s %s) failed: %s" f v (.getMessage e))
+                 (throw e)))))))))))
 
 (def ^{:arglists '([results])} formatted-venues-rows
   "Helper function to format the rows in `results` when running a 'raw data' query against the Venues test table."

--- a/test/metabase/query_processor_test/fields_test.clj
+++ b/test/metabase/query_processor_test/fields_test.clj
@@ -1,11 +1,11 @@
 (ns metabase.query-processor-test.fields-test
   "Tests for the `:fields` clause."
-  (:require [metabase.query-processor-test :refer :all]
+  (:require [metabase.query-processor-test :as qp.test]
             [metabase.test.data :as data]))
 
 ;; Test that we can restrict the Fields that get returned to the ones specified, and that results come back in the
 ;; order of the IDs in the `fields` clause
-(qp-expect-with-all-drivers
+(qp.test/qp-expect-with-all-drivers
   {:rows        [["Red Medicine"                  1]
                  ["Stout Burgers & Beers"         2]
                  ["The Apple Pan"                 3]
@@ -16,13 +16,13 @@
                  ["25°"                           8]
                  ["Krua Siri"                     9]
                  ["Fred 62"                      10]]
-   :columns     (->columns "name" "id")
-   :cols        [(venues-col :name)
-                 (venues-col :id)]
+   :columns     (qp.test/->columns "name" "id")
+   :cols        [(qp.test/venues-col :name)
+                 (qp.test/venues-col :id)]
    :native_form true}
-    (->> (data/run-mbql-query venues
-           {:fields   [$name $id]
-            :limit    10
-            :order-by [[:asc $id]]})
-       booleanize-native-form
-       (format-rows-by [str int])))
+  (->> (data/run-mbql-query venues
+         {:fields   [$name $id]
+          :limit    10
+          :order-by [[:asc $id]]})
+       qp.test/booleanize-native-form
+       (qp.test/format-rows-by [str int])))

--- a/test/metabase/query_processor_test/joins_test.clj
+++ b/test/metabase/query_processor_test/joins_test.clj
@@ -93,7 +93,7 @@
        (qp.test/format-rows-by [int int int])))
 
 
-;; Check that trying to use a Foreign Key fails for Mongo
+;; Check that trying to use a Foreign Key fails for Mongo and other DBs
 (datasets/expect-with-drivers (qp.test/non-timeseries-drivers-without-feature :foreign-keys)
   {:status :failed
    :error  "foreign-keys is not supported by this driver."}

--- a/test/metabase/test/data/datasets.clj
+++ b/test/metabase/test/data/datasets.clj
@@ -10,7 +10,7 @@
 ;; # Helper Macros
 
 (defn do-when-testing-driver
-  "Call function F (always with no arguments) *only* if we are currently testing against ENGINE.
+  "Call function `f` (always with no arguments) *only* if we are currently testing against `driver`.
    (This does NOT bind `*driver*`; use `driver/with-driver` if you want to do that.)"
   {:style/indent 1}
   [driver f]
@@ -25,7 +25,8 @@
   `(do-when-testing-driver ~driver (fn [] ~@body)))
 
 (defmacro with-driver-when-testing
-  "When `driver` is specified in `DRIVERS`, bins `*driver*` and executes `body`."
+  "When `driver` is specified in `DRIVERS` env var, binds `metabase.driver/*driver*` and executes `body`. The currently
+  bound driver is used for calls like `(data/db)` and `(data/id)`."
   {:style/indent 1}
   [driver & body]
   `(let [driver# ~driver]
@@ -34,8 +35,8 @@
          ~@body))))
 
 (defmacro expect-with-driver
-  "Generate a unit test that only runs if we're currently testing against ENGINE, and that binds `*driver*` to the
-  driver for ENGINE."
+  "Generate a unit test that only runs if we're currently testing against `driver`, and that binds `*driver*` when it
+  runs."
   {:style/indent 1}
   [driver expected actual]
   `(when-testing-driver ~driver
@@ -70,8 +71,8 @@
       nil)))
 
 (defmacro expect-with-drivers
-  "Generate unit tests for all drivers in `DRIVERS`; each test will only run if we're currently testing the
-  corresponding dataset. `*driver*` is bound to the current dataset inside each test."
+  "Generate unit tests for all drivers in env var `DRIVERS`; each test will only run if we're currently testing the
+  corresponding driver. `*driver*` is bound to the current driver inside each test."
   {:style/indent 1}
   [drivers expected actual]
   ;; Make functions to get expected/actual so the code is only compiled one time instead of for every single driver
@@ -84,8 +85,8 @@
        (doexpect-with-drivers (get-drivers-or-fail (fn [] ~drivers)) get-e# get-a# '~expected '~actual))))
 
 (defmacro expect-with-all-drivers
-  "Generate unit tests for all drivers specified in `DRIVERS`. `*driver*` is bound to the current driver inside each
-  test."
+  "Generate unit tests for all drivers specified in env var `DRIVERS`. `*driver*` is bound to the current driver inside
+  each test."
   {:style/indent 0}
   [expected actual]
   `(expect-with-drivers tx.env/test-drivers ~expected ~actual))

--- a/test/metabase/test/data/h2.clj
+++ b/test/metabase/test/data/h2.clj
@@ -53,7 +53,7 @@
    ((get-method sql.tx/create-table-sql :sql-jdbc/test-extensions) driver dbdef tabledef)
    ";\n"
    ;; Grant the GUEST account r/w permissions for this table
-   (format "GRANT ALL ON %s TO GUEST;" (sql.u/quote-name driver (tx/format-name driver table-name)))))
+   (format "GRANT ALL ON %s TO GUEST;" (sql.u/quote-name driver :table (tx/format-name driver table-name)))))
 
 (defmethod tx/has-questionable-timezone-support? :h2 [_] true)
 

--- a/test/metabase/test/data/sql/ddl.clj
+++ b/test/metabase/test/data/sql/ddl.clj
@@ -82,7 +82,7 @@
                     (sql.qp/->honeysql driver value)))]
     (-> (apply h/columns (for [column columns]
                            (sql.qp/->honeysql driver
-                             (hx/identifier (tx/format-name driver (u/keyword->qualified-name column))))))
+                             (hx/identifier :field (tx/format-name driver (u/keyword->qualified-name column))))))
         (h/insert-into table-identifier)
         (h/values values))))
 

--- a/test/metabase/test/data/sql_jdbc/load_data.clj
+++ b/test/metabase/test/data/sql_jdbc/load_data.clj
@@ -112,7 +112,7 @@
   [driver conn {:keys [database-name], :as dbdef} {:keys [table-name], :as tabledef}]
   (let [components       (for [component (sql.tx/qualified-name-components driver database-name table-name)]
                            (tx/format-name driver (u/keyword->qualified-name component)))
-        table-identifier (sql.qp/->honeysql driver (apply hx/identifier components))]
+        table-identifier (sql.qp/->honeysql driver (apply hx/identifier :table components))]
     (partial do-insert! driver conn table-identifier)))
 
 (defn make-load-data-fn

--- a/test/metabase/util/honeysql_extensions_test.clj
+++ b/test/metabase/util/honeysql_extensions_test.clj
@@ -4,7 +4,8 @@
              [core :as hsql]
              [format :as hformat]]
             [metabase.util.honeysql-extensions :as hx])
-  (:import java.util.Locale))
+  (:import java.util.Locale
+           metabase.util.honeysql_extensions.Identifier))
 
 ;; Basic format test not including a specific quoting option
 (expect
@@ -50,52 +51,70 @@
 ;; make sure `identifier` properly handles components with dots and both strings & keywords
 (expect
   ["`A`.`B`.`C.D`.`E.F`"]
-  (hsql/format (hx/identifier "A" :B "C.D" :E.F)
+  (hsql/format (hx/identifier :field "A" :B "C.D" :E.F)
     :quoting :mysql))
 
 ;; `identifer` should handle slashes
 (expect
   ["`A/B`.`C\\D`.`E/F`"]
-  (hsql/format (hx/identifier "A/B" "C\\D" :E/F)
+  (hsql/format (hx/identifier :field "A/B" "C\\D" :E/F)
     :quoting :mysql))
 
 ;; `identifier` should also handle strings with quotes in them (ANSI)
 (expect
   ;; two double-quotes to escape, e.g. "A""B"
   ["\"A\"\"B\""]
-  (hsql/format (hx/identifier "A\"B")
+  (hsql/format (hx/identifier :field "A\"B")
     :quoting :ansi))
 
 ;; `identifier` should also handle strings with quotes in them (MySQL)
 (expect
   ;; double-backticks to escape backticks seems to be the way to do it
   ["`A``B`"]
-  (hsql/format (hx/identifier "A`B")
+  (hsql/format (hx/identifier :field "A`B")
     :quoting :mysql))
 
 ;; `identifier` shouldn't try to change `lisp-case` to `snake-case` or vice-versa
 (expect
   ["A-B.c-d.D_E.f_g"]
-  (hsql/format (hx/identifier "A-B" :c-d "D_E" :f_g)))
+  (hsql/format (hx/identifier :field "A-B" :c-d "D_E" :f_g)))
 
 (expect
   ["\"A-B\".\"c-d\".\"D_E\".\"f_g\""]
-  (hsql/format (hx/identifier "A-B" :c-d "D_E" :f_g)
+  (hsql/format (hx/identifier :field "A-B" :c-d "D_E" :f_g)
     :quoting :ansi))
 
 ;; `identifier` should ignore `nil` or empty components.
 (expect
   ["A.B.C"]
-  (hsql/format (hx/identifier "A" "B" nil "C")))
+  (hsql/format (hx/identifier :field "A" "B" nil "C")))
 
 ;; `identifier` should handle nested identifiers
 (expect
-  (hx/identifier "A" "B" "C" "D")
-  (hx/identifier "A" (hx/identifier "B" "C") "D"))
+  (hx/identifier :field "A" "B" "C" "D")
+  (hx/identifier :field "A" (hx/identifier :field "B" "C") "D"))
 
 (expect
   ["A.B.C.D"]
-  (hsql/format (hx/identifier "A" (hx/identifier "B" "C") "D")))
+  (hsql/format (hx/identifier :field "A" (hx/identifier :field "B" "C") "D")))
+
+;; the `identifier` function should unnest identifiers for you so drivers that manipulate `:components` don't need to
+;; worry about that
+(expect
+  (Identifier. :field ["A" "B" "C" "D"])
+  (hx/identifier :field "A" (hx/identifier :field "B" "C") "D"))
+
+;; the `identifier` function should remove nils so drivers that manipulate `:components` don't need to
+;; worry about that
+(expect
+  (Identifier. :field ["table" "field"])
+  (hx/identifier :field nil "table" "field"))
+
+;; the `identifier` function should convert everything to strings so drivers that manipulate `:components` don't need
+;; to worry about that
+(expect
+  (Identifier. :field ["keyword" "qualified/keyword"])
+  (hx/identifier :field :keyword :qualified/keyword))
 
 (defn- call-with-locale
   "Sets the default locale temporarily to `locale-tag`, then invokes `f` and reverts the locale change"


### PR DESCRIPTION
Breaking part of #9987 into separate PR. 

Add `*join-alias* dynamic var to the SQL QP which eliminates the need for BigQuery to implement a custom `BigQueryIdentifier` class and simplifies code for a few other drivers too.

Prereq for new joins support