### PR TITLE
Async QP improvements :racing_car:

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -102,6 +102,7 @@
    [metabase/throttle "1.0.1"]                                        ; Tools for throttling access to API endpoints and other code pathways
    [javax.xml.bind/jaxb-api "2.4.0-b180830.0359"]                     ; add the `javax.xml.bind` classes which we're still using but were removed in Java 11
    [net.sf.cssbox/cssbox "4.12" :exclusions [org.slf4j/slf4j-api]]    ; HTML / CSS rendering
+   [org.apache.commons/commons-lang3 "3.9"]                           ; helper methods for working with java.lang stuff
    [org.clojars.pntblnk/clj-ldap "0.0.16"]                            ; LDAP client
    [org.flatland/ordered "1.5.7"]                                     ; ordered maps & sets
    [org.liquibase/liquibase-core "3.6.3"                              ; migration management (Java lib)

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -19,7 +19,6 @@
             [metabase.models
              [setting :as setting]
              [user :refer [User]]]
-            [metabase.query-processor.middleware.async-wait :as qp.middleware.async-wait]
             [metabase.util.i18n :refer [set-locale trs]]
             [toucan.db :as db]))
 
@@ -49,7 +48,6 @@
   ;; to a Shutdown hook of some sort instead of having here
   (task/stop-scheduler!)
   (server/stop-web-server!)
-  (qp.middleware.async-wait/destroy-all-thread-pools!)
   (log/info (trs "Metabase Shutdown COMPLETE")))
 
 

--- a/src/metabase/db/metadata_queries.clj
+++ b/src/metabase/db/metadata_queries.clj
@@ -62,7 +62,7 @@
   (int 5000))
 
 (s/defn field-distinct-values
-  "Return the distinct values of FIELD.
+  "Return the distinct values of `field`.
    This is used to create a `FieldValues` object for `:type/Category` Fields."
   ([field]
    (field-distinct-values field absolute-max-distinct-values-limit))
@@ -71,14 +71,14 @@
                                    :limit    max-results}))))
 
 (defn field-distinct-count
-  "Return the distinct count of FIELD."
+  "Return the distinct count of `field`."
   [field & [limit]]
   (-> (field-query field {:aggregation [[:distinct [:field-id (u/get-id field)]]]
                           :limit       limit})
       first first int))
 
 (defn field-count
-  "Return the count of FIELD."
+  "Return the count of `field`."
   [field]
   (-> (field-query field {:aggregation [[:count [:field-id (u/get-id field)]]]})
       first first int))

--- a/test/metabase/test/mock/util.clj
+++ b/test/metabase/test/mock/util.clj
@@ -76,16 +76,16 @@
    for any other queries, including ones for determining FieldValues."
   [_ _]
   (fn [query]
-    {:data
-     {:rows
-      (cond
-        (is-table-row-count-query? query)
-        [[1000]]
+    {:status :completed
+     :data   {:rows
+              (cond
+                (is-table-row-count-query? query)
+                [[1000]]
 
-        (is-table-sample-query? query)
-        (let [fields-count (count (get-in query [:query :fields]))]
-          (for [i (range 500)]
-            (repeat fields-count i)))
+                (is-table-sample-query? query)
+                (let [fields-count (count (get-in query [:query :fields]))]
+                  (for [i (range 500)]
+                    (repeat fields-count i)))
 
-        :else
-        nil)}}))
+                :else
+                nil)}}))

--- a/test/metabase/test_setup.clj
+++ b/test/metabase/test_setup.clj
@@ -13,7 +13,6 @@
             [metabase.core.initialization-status :as init-status]
             [metabase.models.setting :as setting]
             [metabase.plugins.initialize :as plugins.init]
-            [metabase.query-processor.middleware.async-wait :as qp.middleware.async-wait]
             [metabase.test.data.env :as tx.env]
             [yaml.core :as yaml]))
 
@@ -83,8 +82,7 @@
   {:expectations-options :after-run}
   []
   (log/info "Shutting down Metabase unit test runner")
-  (server/stop-web-server!)
-  (qp.middleware.async-wait/destroy-all-thread-pools!))
+  (server/stop-web-server!))
 
 (defn call-with-test-scaffolding
   "Runs `test-startup` and ensures `test-teardown` is always called. This function is useful for running a test (or test


### PR DESCRIPTION
*  Use a `org.apache.commons.lang3.concurrent.BasicThreadFactory.Builder` to create a thread factory for our QP thread pools so we can do things like give them nice names (for profiling/debugging) and set the daemon flag on them (so the server does not block shutdown waiting for them to finish)
*  Add a timeout for queries to finish inside the `async-wait` middleware and make this pretty low during tests to catch issues where I accidentally deadlock stuff