### PR TITLE
Faster test launch

### DIFF
--- a/modules/drivers/bigquery/src/metabase/driver/bigquery.clj
+++ b/modules/drivers/bigquery/src/metabase/driver/bigquery.clj
@@ -48,8 +48,8 @@
 (driver/register! :bigquery, :parent #{:google :sql})
 
 (defn- valid-bigquery-identifier?
-  "Is String `s` a valid BigQuery identifiers? Identifiers are only allowed to contain letters, numbers, and
-  underscores; cannot start with a number; and can be at most 128 characters long."
+  "Is String `s` a valid BigQuery identifier? Identifiers are only allowed to contain letters, numbers, and underscores;
+  cannot start with a number; and can be at most 128 characters long."
   [s]
   (boolean
    (and (string? s)
@@ -109,7 +109,6 @@
                      (.setPageToken <> page-token-or-nil)))))
 
 (defmethod driver/describe-database :bigquery [_ database]
-  {:pre [(map? database)]}
   ;; first page through all the 50-table pages until we stop getting "next page tokens"
   (let [tables (loop [tables [], ^TableList table-list (list-tables database)]
                  (let [tables (concat tables (.getTables table-list))]
@@ -122,18 +121,16 @@
                     {:schema nil, :name (.getTableId tableref)}))}))
 
 (defmethod driver/can-connect? :bigquery [_ details-map]
-  {:pre [(map? details-map)]}
   ;; check whether we can connect by just fetching the first page of tables for the database. If that succeeds we're
   ;; g2g
   (boolean (list-tables {:details details-map})))
 
 
-(defn- ^Table get-table
+(s/defn get-table :- Table
   ([{{:keys [project-id dataset-id]} :details, :as database} table-id]
    (get-table (database->client database) project-id dataset-id table-id))
 
-  ([^Bigquery client, ^String project-id, ^String dataset-id, ^String table-id]
-   {:pre [client (seq project-id) (seq dataset-id) (seq table-id)]}
+  ([client :- Bigquery, project-id :- su/NonBlankString, dataset-id :- su/NonBlankString, table-id :- su/NonBlankString]
    (google/execute (.get (.tables client) project-id dataset-id table-id))))
 
 (defn- bigquery-type->base-type [field-type]
@@ -374,7 +371,6 @@
 ;; parameters (`?` symbols)
 (defmethod sql.qp/->honeysql [:bigquery String]
   [_ s]
-  ;; TODO - what happens if `s` contains single-quotes? Shouldn't we be escaping them somehow?
   (hx/literal s))
 
 (defmethod sql.qp/->honeysql [:bigquery Boolean]

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -74,7 +74,7 @@
 
   ;; startup database.  validates connection & runs any necessary migrations
   (log/info (trs "Setting up and migrating Metabase DB. Please sit tight, this may take a minute..."))
-  (mdb/setup-db! :auto-migrate (config/config-bool :mb-db-automigrate))
+  (mdb/setup-db!)
   (init-status/set-progress! 0.5)
 
   ;; run a very quick check to see if we are doing a first time installation

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -210,7 +210,7 @@
 (defmethod metabase-instance DatabaseDefinition [{:keys [database-name]} driver-kw]
   (assert (string? database-name))
   (assert (keyword? driver-kw))
-  (db/setup-db-if-needed!, :auto-migrate true)
+  (db/setup-db!)
   (Database :name database-name, :engine (name driver-kw)))
 
 

--- a/test/metabase/test_setup.clj
+++ b/test/metabase/test_setup.clj
@@ -60,7 +60,7 @@
               (System/exit -2))))]
     (try
       (log/info (format "Setting up %s test DB and running migrations..." (name (mdb/db-type))))
-      (mdb/setup-db! :auto-migrate true)
+      (mdb/setup-db!)
 
       (plugins/load-plugins!)
       (load-plugin-manifests!)
@@ -78,7 +78,6 @@
 
     (u/deref-with-timeout start-web-server! 10000)
     nil))
-
 
 (defn test-teardown
   {:expectations-options :after-run}


### PR DESCRIPTION
Consolidate `metabase.db/setup-db!` and `metabase.db/setup-db-if-needed!` into a single thread-safe function that guarantees DB setup functions will be called once and only once. Several test functions were calling `setup-db!` to ensure the DB was set up which didn't hurt anything but is quite slow.