### PR TITLE
chore: update broken link in contributing.md

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -83,7 +83,7 @@ Some features, eg Database drivers, don't have any user facing pixels. These are
 
 In situations where a design has already been done, we can always use some help. Chime in on a pull request or an issue and offer to help.
 
-Generally speaking, any issue in [Help Wanted](https://github.com/metabase/metabase/labels/Help%20Wanted) is fair game.
+Generally speaking, any issue in [Help Wanted](https://github.com/metabase/metabase/labels/Design%20Needed) is fair game.
 
 ### #YOLO JUST SUBMIT A PR
 


### PR DESCRIPTION
Tiny documentation change to reflect the current label used to identify issues where designs are needed.