### PR TITLE
Allow JDBC additional-options in Redshift plugin

### DIFF
--- a/modules/drivers/redshift/resources/metabase-plugin.yaml
+++ b/modules/drivers/redshift/resources/metabase-plugin.yaml
@@ -20,6 +20,8 @@ driver:
           placeholder: toucan_sightings
     - user
     - password
+    - merge:
+        - additional-options
   connection-properties-include-tunnel-config: true
 init:
   - step: load-namespace

--- a/modules/drivers/redshift/resources/metabase-plugin.yaml
+++ b/modules/drivers/redshift/resources/metabase-plugin.yaml
@@ -20,7 +20,9 @@ driver:
           placeholder: toucan_sightings
     - user
     - password
-    - additional-options
+    - merge:
+      - additional-options
+      - placeholder: 'ssl=false'
   connection-properties-include-tunnel-config: true
 init:
   - step: load-namespace

--- a/modules/drivers/redshift/resources/metabase-plugin.yaml
+++ b/modules/drivers/redshift/resources/metabase-plugin.yaml
@@ -20,8 +20,7 @@ driver:
           placeholder: toucan_sightings
     - user
     - password
-    - merge:
-        - additional-options
+    - additional-options
   connection-properties-include-tunnel-config: true
 init:
   - step: load-namespace

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -8,6 +8,7 @@
              [driver :as driver]]
             [metabase.driver.common :as driver.common]
             [metabase.driver.sql-jdbc
+             [common :as sql-jdbc.common]
              [connection :as sql-jdbc.conn]
              [execute :as sql-jdbc.execute]
              [sync :as sql-jdbc.sync]]
@@ -94,14 +95,14 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defmethod sql-jdbc.conn/connection-details->spec :redshift [_ {:keys [host port db], :as opts}]
-  (-> (merge
-       {:classname                     "com.amazon.redshift.jdbc.Driver" ; must be in classpath
-        :subprotocol                   "redshift"
-        :subname                       (str "//" host ":" port "/" db)
-        :ssl                           true
-        :OpenSourceSubProtocolOverride false}
-       (dissoc opts :host :port :db))
-    (sql-jdbc.common/handle-additional-options opts))
+  (let [redshift-details (merge
+                          {:classname                     "com.amazon.redshift.jdbc.Driver" ; must be in classpath
+                           :subprotocol                   "redshift"
+                           :subname                       (str "//" host ":" port "/" db)
+                           :ssl                           true
+                           :OpenSourceSubProtocolOverride false}
+                          (dissoc opts :host :port :db))]
+    (sql-jdbc.common/handle-additional-options redshift-details opts)))
 
 ;; HACK ! When we test against Redshift we use a session-unique schema so we can run simultaneous tests
 ;; against a single remote host; when running tests tell the sync process to ignore all the other schemas

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -94,13 +94,14 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defmethod sql-jdbc.conn/connection-details->spec :redshift [_ {:keys [host port db], :as opts}]
-  (merge
-   {:classname                     "com.amazon.redshift.jdbc.Driver" ; must be in classpath
-    :subprotocol                   "redshift"
-    :subname                       (str "//" host ":" port "/" db)
-    :ssl                           true
-    :OpenSourceSubProtocolOverride false}
-   (dissoc opts :host :port :db)))
+  (-> (merge
+       {:classname                     "com.amazon.redshift.jdbc.Driver" ; must be in classpath
+        :subprotocol                   "redshift"
+        :subname                       (str "//" host ":" port "/" db)
+        :ssl                           true
+        :OpenSourceSubProtocolOverride false}
+       (dissoc opts :host :port :db))
+    (sql-jdbc.common/handle-additional-options opts))
 
 ;; HACK ! When we test against Redshift we use a session-unique schema so we can run simultaneous tests
 ;; against a single remote host; when running tests tell the sync process to ignore all the other schemas


### PR DESCRIPTION
This PR introduces JDBC additional options to the Redshift plugin. Discussed in #9695

###### Before submitting the PR, please make sure you do the following
### Tests
-  [X] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [X] If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`

-  [X] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
