### PR TITLE
clean up UX on SSO login

### DIFF
--- a/frontend/src/metabase/auth/components/SSOLoginButton.jsx
+++ b/frontend/src/metabase/auth/components/SSOLoginButton.jsx
@@ -12,8 +12,8 @@ class SSOLoginButton extends Component {
   render() {
     const { provider } = this.props;
     return (
-      <div className="relative z2 bg-white p2 cursor-pointer shadow-hover text-centered sm-text-left rounded block sm-inline-block bordered shadowed">
-        <div className="flex align-center">
+      <div className="relative z2 bg-white p2 cursor-pointer shadow-hover text-centered sm-text-left rounded bordered shadowed flex">
+        <div className="flex align-center ml-auto mr-auto">
           <Icon className="mr1" name={provider} />
           <h4>{t`Sign in with ${capitalize(provider)}`}</h4>
         </div>

--- a/frontend/src/metabase/auth/containers/LoginApp.jsx
+++ b/frontend/src/metabase/auth/containers/LoginApp.jsx
@@ -147,7 +147,7 @@ export default class LoginApp extends Component {
                   <div className="py3">
                     <Link to="/auth/login?useMBLogin=true">
                       <Button className="EmailSignIn full">
-                        {t`Sign in with Metabase`}
+                        {t`Sign in with email`}
                       </Button>
                     </Link>
                   </div>

--- a/frontend/src/metabase/auth/containers/LoginApp.jsx
+++ b/frontend/src/metabase/auth/containers/LoginApp.jsx
@@ -39,6 +39,7 @@ export default class LoginApp extends Component {
       credentials: {},
       valid: false,
       rememberMe: true,
+      expanded: !Settings.ssoEnabled(),
     };
   }
 
@@ -117,7 +118,7 @@ export default class LoginApp extends Component {
     const ldapEnabled = Settings.ldapEnabled();
 
     return (
-      <div className="full bg-white flex flex-column flex-full md-layout-centered">
+      <div className="bg-white flex flex-column flex-full md-layout-centered">
         <div className="Login-wrapper wrapper Grid Grid--full md-Grid--1of2 relative z2">
           <div className="Grid-cell flex layout-centered text-brand">
             <LogoIcon className="Logo my4 sm-my0" width={66} height={85} />
@@ -130,108 +131,125 @@ export default class LoginApp extends Component {
             >
               <h3 className="Login-header Form-offset">{t`Sign in to Metabase`}</h3>
 
-              {Settings.ssoEnabled() && (
-                <div className="mx4 mb4 py3 border-bottom relative">
-                  <SSOLoginButton provider="google" ref="ssoLoginButton" />
-                  {/*<div className="g-signin2 ml1 relative z2" id="g-signin2"></div>*/}
-                  <div
-                    className="mx1 absolute text-centered left right"
-                    style={{ bottom: -8 }}
-                  >
-                    <span className="text-bold px3 py2 text-medium bg-white">{t`OR`}</span>
+              {Settings.ssoEnabled() && !this.state.expanded && (
+                <div className="mx4 py3 relative my4">
+                  <div className="relative border-bottom pb4">
+                    <SSOLoginButton provider="google" ref="ssoLoginButton" />
+                    {/*<div className="g-signin2 ml1 relative z2" id="g-signin2"></div>*/}
+                    <div
+                      className="mx1 absolute text-centered left right"
+                      style={{ bottom: -8 }}
+                    >
+                      <span className="text-bold px3 py2 text-medium bg-white">{t`OR`}</span>
+                    </div>
+                  </div>
+                  <div className="py3">
+                    <Button
+                      className="EmailSignIn full"
+                      onClick={() => this.setState({ expanded: true })}
+                    >
+                      {t`Sign in with Metabase`}
+                    </Button>
                   </div>
                 </div>
               )}
 
-              <FormMessage
-                formError={
-                  loginError && loginError.data.message ? loginError : null
-                }
-              />
-
-              <FormField
-                key="username"
-                fieldName="username"
-                formError={loginError}
-              >
-                <FormLabel
-                  title={
-                    Settings.ldapEnabled()
-                      ? t`Username or email address`
-                      : t`Email address`
-                  }
-                  fieldName={"username"}
-                  formError={loginError}
-                />
-                <input
-                  className="Form-input Form-offset full py1"
-                  name="username"
-                  placeholder="youlooknicetoday@email.com"
-                  type={
-                    /*
-                     * if a user has ldap enabled, use a text input to allow for
-                     * ldap username && schemes. if not and they're using built
-                     * in auth, set the input type to email so we get built in
-                     * validation in modern browsers
-                     * */
-                    ldapEnabled ? "text" : "email"
-                  }
-                  onChange={e => this.onChange("username", e.target.value)}
-                  autoFocus
-                />
-                <span className="Form-charm" />
-              </FormField>
-
-              <FormField
-                key="password"
-                fieldName="password"
-                formError={loginError}
-              >
-                <FormLabel
-                  title={t`Password`}
-                  fieldName={"password"}
-                  formError={loginError}
-                />
-                <input
-                  className="Form-input Form-offset full py1"
-                  name="password"
-                  placeholder="Shh..."
-                  type="password"
-                  onChange={e => this.onChange("password", e.target.value)}
-                />
-                <span className="Form-charm" />
-              </FormField>
-
-              <div className="Form-field">
-                <div className="Form-offset flex align-center">
-                  <CheckBox
-                    name="remember"
-                    checked={this.state.rememberMe}
-                    onChange={() =>
-                      this.setState({ rememberMe: !this.state.rememberMe })
+              {this.state.expanded && (
+                <div>
+                  <FormMessage
+                    formError={
+                      loginError && loginError.data.message ? loginError : null
                     }
                   />
-                  <span className="ml1">{t`Remember Me`}</span>
-                </div>
-              </div>
 
-              <div className="Form-actions p4">
-                <Button primary={this.state.valid} disabled={!this.state.valid}>
-                  {t`Sign in`}
-                </Button>
-                <Link
-                  to={
-                    "/auth/forgot_password" +
-                    (Utils.validEmail(this.state.credentials.username)
-                      ? "?email=" + this.state.credentials.username
-                      : "")
-                  }
-                  className="Grid-cell py2 sm-py0 md-text-right text-centered flex-full link"
-                  onClick={e => {
-                    window.OSX ? window.OSX.resetPassword() : null;
-                  }}
-                >{t`I seem to have forgotten my password`}</Link>
-              </div>
+                  <FormField
+                    key="username"
+                    fieldName="username"
+                    formError={loginError}
+                  >
+                    <FormLabel
+                      title={
+                        Settings.ldapEnabled()
+                          ? t`Username or email address`
+                          : t`Email address`
+                      }
+                      fieldName={"username"}
+                      formError={loginError}
+                    />
+                    <input
+                      className="Form-input Form-offset full py1"
+                      name="username"
+                      placeholder="youlooknicetoday@email.com"
+                      type={
+                        /*
+                         * if a user has ldap enabled, use a text input to allow for
+                         * ldap username && schemes. if not and they're using built
+                         * in auth, set the input type to email so we get built in
+                         * validation in modern browsers
+                         * */
+                        ldapEnabled ? "text" : "email"
+                      }
+                      onChange={e => this.onChange("username", e.target.value)}
+                      autoFocus
+                    />
+                    <span className="Form-charm" />
+                  </FormField>
+
+                  <FormField
+                    key="password"
+                    fieldName="password"
+                    formError={loginError}
+                  >
+                    <FormLabel
+                      title={t`Password`}
+                      fieldName={"password"}
+                      formError={loginError}
+                    />
+                    <input
+                      className="Form-input Form-offset full py1"
+                      name="password"
+                      placeholder="Shh..."
+                      type="password"
+                      onChange={e => this.onChange("password", e.target.value)}
+                    />
+                    <span className="Form-charm" />
+                  </FormField>
+
+                  <div className="Form-field">
+                    <div className="Form-offset flex align-center">
+                      <CheckBox
+                        name="remember"
+                        checked={this.state.rememberMe}
+                        onChange={() =>
+                          this.setState({ rememberMe: !this.state.rememberMe })
+                        }
+                      />
+                      <span className="ml1">{t`Remember Me`}</span>
+                    </div>
+                  </div>
+
+                  <div className="Form-actions p4">
+                    <Button
+                      primary={this.state.valid}
+                      disabled={!this.state.valid}
+                    >
+                      {t`Sign in`}
+                    </Button>
+                    <Link
+                      to={
+                        "/auth/forgot_password" +
+                        (Utils.validEmail(this.state.credentials.username)
+                          ? "?email=" + this.state.credentials.username
+                          : "")
+                      }
+                      className="Grid-cell py2 sm-py0 md-text-right text-centered flex-full link"
+                      onClick={e => {
+                        window.OSX ? window.OSX.resetPassword() : null;
+                      }}
+                    >{t`I seem to have forgotten my password`}</Link>
+                  </div>
+                </div>
+              )}
             </form>
           </div>
         </div>

--- a/frontend/src/metabase/auth/containers/LoginApp.jsx
+++ b/frontend/src/metabase/auth/containers/LoginApp.jsx
@@ -39,7 +39,6 @@ export default class LoginApp extends Component {
       credentials: {},
       valid: false,
       rememberMe: true,
-      expanded: !Settings.ssoEnabled(),
     };
   }
 
@@ -114,8 +113,10 @@ export default class LoginApp extends Component {
   }
 
   render() {
-    const { loginError } = this.props;
+    const { loginError, location } = this.props;
     const ldapEnabled = Settings.ldapEnabled();
+
+    const preferUsernameAndPassword = location.query.useMBLogin;
 
     return (
       <div className="bg-white flex flex-column flex-full md-layout-centered">
@@ -131,7 +132,7 @@ export default class LoginApp extends Component {
             >
               <h3 className="Login-header Form-offset">{t`Sign in to Metabase`}</h3>
 
-              {Settings.ssoEnabled() && !this.state.expanded && (
+              {Settings.ssoEnabled() && !preferUsernameAndPassword && (
                 <div className="mx4 py3 relative my4">
                   <div className="relative border-bottom pb4">
                     <SSOLoginButton provider="google" ref="ssoLoginButton" />
@@ -144,17 +145,16 @@ export default class LoginApp extends Component {
                     </div>
                   </div>
                   <div className="py3">
-                    <Button
-                      className="EmailSignIn full"
-                      onClick={() => this.setState({ expanded: true })}
-                    >
-                      {t`Sign in with Metabase`}
-                    </Button>
+                    <Link to="/auth/login?useMBLogin=true">
+                      <Button className="EmailSignIn full">
+                        {t`Sign in with Metabase`}
+                      </Button>
+                    </Link>
                   </div>
                 </div>
               )}
 
-              {this.state.expanded && (
+              {(!Settings.ssoEnabled() || preferUsernameAndPassword) && (
                 <div>
                   <FormMessage
                     formError={
@@ -221,7 +221,9 @@ export default class LoginApp extends Component {
                         name="remember"
                         checked={this.state.rememberMe}
                         onChange={() =>
-                          this.setState({ rememberMe: !this.state.rememberMe })
+                          this.setState({
+                            rememberMe: !this.state.rememberMe,
+                          })
                         }
                       />
                       <span className="ml1">{t`Remember Me`}</span>

--- a/frontend/test/metabase/auth/containers/LoginApp.unit.spec.js
+++ b/frontend/test/metabase/auth/containers/LoginApp.unit.spec.js
@@ -3,7 +3,6 @@ import React from "react";
 import LoginApp from "metabase/auth/containers/LoginApp";
 
 import { mountWithStore } from "__support__/integration_tests";
-import { click, clickButton } from "__support__/enzyme_utils";
 
 jest.mock("metabase/lib/settings", () => ({
   get: () => ({

--- a/frontend/test/metabase/auth/containers/LoginApp.unit.spec.js
+++ b/frontend/test/metabase/auth/containers/LoginApp.unit.spec.js
@@ -49,6 +49,16 @@ describe("LoginApp", () => {
         expect(wrapper.find("FormField").length).toBe(2);
         expect(wrapper.find("SSOLoginButton").length).toBe(0);
       });
+      it("should show the login form if the url param is set", () => {
+        const { wrapper } = mountWithStore(<LoginApp />);
+        const withEmail = wrapper.find(".Button.EmailSignIn");
+        expect(withEmail.length).toBe(1);
+
+        click(withEmail);
+
+        expect(wrapper.find("FormField").length).toBe(2);
+        expect(wrapper.find("SSOLoginButton").length).toBe(0);
+      });
     });
   });
 });

--- a/frontend/test/metabase/auth/containers/LoginApp.unit.spec.js
+++ b/frontend/test/metabase/auth/containers/LoginApp.unit.spec.js
@@ -3,7 +3,7 @@ import React from "react";
 import LoginApp from "metabase/auth/containers/LoginApp";
 
 import { mountWithStore } from "__support__/integration_tests";
-import { click } from "__support__/enzyme_utils";
+import { click, clickButton } from "__support__/enzyme_utils";
 
 jest.mock("metabase/lib/settings", () => ({
   get: () => ({
@@ -20,7 +20,9 @@ describe("LoginApp", () => {
   describe("initial state", () => {
     describe("without SSO", () => {
       it("should show the login form", () => {
-        const { wrapper } = mountWithStore(<LoginApp />);
+        const { wrapper } = mountWithStore(
+          <LoginApp location={{ query: {} }} />,
+        );
         expect(wrapper.find("FormField").length).toBe(2);
       });
     });
@@ -29,32 +31,24 @@ describe("LoginApp", () => {
         Settings.ssoEnabled.mockReturnValue(true);
       });
       it("should show the SSO button", () => {
-        const { wrapper } = mountWithStore(<LoginApp />);
+        const { wrapper } = mountWithStore(
+          <LoginApp location={{ query: {} }} />,
+        );
         expect(wrapper.find("SSOLoginButton").length).toBe(1);
         expect(wrapper.find(".Button.EmailSignIn").length).toBe(1);
       });
 
       it("should hide the login form initially", () => {
-        const { wrapper } = mountWithStore(<LoginApp />);
+        const { wrapper } = mountWithStore(
+          <LoginApp location={{ query: {} }} />,
+        );
         expect(wrapper.find("FormField").length).toBe(0);
       });
 
-      it("should show the login form if the user clicks the email button", () => {
-        const { wrapper } = mountWithStore(<LoginApp />);
-        const withEmail = wrapper.find(".Button.EmailSignIn");
-        expect(withEmail.length).toBe(1);
-
-        click(withEmail);
-
-        expect(wrapper.find("FormField").length).toBe(2);
-        expect(wrapper.find("SSOLoginButton").length).toBe(0);
-      });
       it("should show the login form if the url param is set", () => {
-        const { wrapper } = mountWithStore(<LoginApp />);
-        const withEmail = wrapper.find(".Button.EmailSignIn");
-        expect(withEmail.length).toBe(1);
-
-        click(withEmail);
+        const { wrapper } = mountWithStore(
+          <LoginApp location={{ query: { useMBLogin: true } }} />,
+        );
 
         expect(wrapper.find("FormField").length).toBe(2);
         expect(wrapper.find("SSOLoginButton").length).toBe(0);

--- a/frontend/test/metabase/auth/containers/LoginApp.unit.spec.js
+++ b/frontend/test/metabase/auth/containers/LoginApp.unit.spec.js
@@ -1,0 +1,54 @@
+import React from "react";
+
+import LoginApp from "metabase/auth/containers/LoginApp";
+
+import { mountWithStore } from "__support__/integration_tests";
+import { click } from "__support__/enzyme_utils";
+
+jest.mock("metabase/lib/settings", () => ({
+  get: () => ({
+    tag: 1,
+    version: 1,
+  }),
+  ssoEnabled: jest.fn(),
+  ldapEnabled: jest.fn(),
+}));
+
+import Settings from "metabase/lib/settings";
+
+describe("LoginApp", () => {
+  describe("initial state", () => {
+    describe("without SSO", () => {
+      it("should show the login form", () => {
+        const { wrapper } = mountWithStore(<LoginApp />);
+        expect(wrapper.find("FormField").length).toBe(2);
+      });
+    });
+    describe("with SSO", () => {
+      beforeEach(() => {
+        Settings.ssoEnabled.mockReturnValue(true);
+      });
+      it("should show the SSO button", () => {
+        const { wrapper } = mountWithStore(<LoginApp />);
+        expect(wrapper.find("SSOLoginButton").length).toBe(1);
+        expect(wrapper.find(".Button.EmailSignIn").length).toBe(1);
+      });
+
+      it("should hide the login form initially", () => {
+        const { wrapper } = mountWithStore(<LoginApp />);
+        expect(wrapper.find("FormField").length).toBe(0);
+      });
+
+      it("should show the login form if the user clicks the email button", () => {
+        const { wrapper } = mountWithStore(<LoginApp />);
+        const withEmail = wrapper.find(".Button.EmailSignIn");
+        expect(withEmail.length).toBe(1);
+
+        click(withEmail);
+
+        expect(wrapper.find("FormField").length).toBe(2);
+        expect(wrapper.find("SSOLoginButton").length).toBe(0);
+      });
+    });
+  });
+});


### PR DESCRIPTION
resolves #10009 

Present folks with a clearer choice of SSO vs email / password when SSO is enabled. 

if SSO is set up the user gets two options
<img width="1424" alt="Screen Shot 2019-05-22 at 12 36 55 PM" src="https://user-images.githubusercontent.com/5248953/58203439-ec1c7900-7c8e-11e9-90c5-86472c21b52c.png">

if the user clicks "Sign in with Metabase" they're taken to our usual email / password form.
<img width="1424" alt="Screen Shot 2019-05-22 at 12 37 13 PM" src="https://user-images.githubusercontent.com/5248953/58203604-5c2aff00-7c8f-11e9-876c-ebd22e4e2e7e.png">

(also adds tests to make sure the login form is behaving in either case)

I'm definitely open to feedback on the verbiage of "Sign in with Metabase." if people have feelings on that.

I'm hoping that this is enough to help folks out without having to add instructional text but we might also want to add a note that you can use your "@domain" email here. A back button from the email form also might be a good idea.

