### PR TITLE
Adds :datetime-field to possible values for :fields in :join

### DIFF
--- a/src/metabase/mbql/schema.clj
+++ b/src/metabase/mbql/schema.clj
@@ -584,7 +584,7 @@
     ;; with appropriate aliases.
     (s/optional-key :fields)       (s/cond-pre
                                     (s/enum :all :none)
-                                    (su/distinct (su/non-empty [joined-field])))
+                                    (su/distinct (su/non-empty [(s/either joined-field datetime-field)])))
     ;;
     ;; The name used to alias the joined table or query. This is usually generated automatically and generally looks
     ;; like `table__via__field`. You can specify this yourself if you need to reference a joined field in a

--- a/src/metabase/query_processor/middleware/resolve_joins.clj
+++ b/src/metabase/query_processor/middleware/resolve_joins.clj
@@ -87,8 +87,11 @@
    join
    (if (= fields :all)
      (if source-table
-       {:fields (for [field (add-implicit-clauses/sorted-implicit-fields-for-table source-table)]
-                  [:joined-field alias field])}
+       {:fields (for [[op & args :as field] (add-implicit-clauses/sorted-implicit-fields-for-table source-table)]
+                  (if (= op :datetime-field)
+                    (let [[field unit] args]
+                      [:datetime-field [:joined-field alias field] unit])
+                    [:joined-field alias field]))}
        (throw
         (UnsupportedOperationException.
          "TODO - fields = all is not yet implemented for joins with source queries."))))))

--- a/test/metabase/query_processor_test/explicit_joins_test.clj
+++ b/test/metabase/query_processor_test/explicit_joins_test.clj
@@ -163,6 +163,18 @@
                          :fields       :all}]
              :order-by [[:asc [:field-id $name]]]}))))))
 
+;; Make sure we can pull in `:datetime-field`s via `:all`
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :left-join)
+  ["ID" "NAME" "LAST_LOGIN" "ID_2" "DATE" "USER_ID" "VENUE_ID"]
+  (-> (qp/process-query
+        (data/mbql-query users
+          {:joins    [{:source-table $$checkins
+                       :condition    [:= [:field-id $id] [:joined-field "c" [:field-id $checkins.user_id]]]
+                       :alias        "c"
+                       :fields       :all}]
+           }))
+      :data :columns))
+
 ;; Can we include no Fields (with `:none`)
 (datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :left-join)
   {:columns (mapv data/format-name ["id" "name" "flock_id"])


### PR DESCRIPTION
Not 100% this is the right way to go. If my understanding is correct, `:datetime-field` accepts `:joined-field` to support `:fk->` sugar. It might be more correct to rewrite such `:datetime-field`s and keep `:fields` definition simple.