### PR TITLE
fix safari public table display issue

### DIFF
--- a/frontend/src/metabase/css/core/flex.css
+++ b/frontend/src/metabase/css/core/flex.css
@@ -7,7 +7,7 @@
 
 .flex-full,
 :local(.flex-full) {
-  flex: 1 0 auto;
+  flex: 1 0 0;
 }
 
 .flex-half,

--- a/frontend/src/metabase/css/core/flex.css
+++ b/frontend/src/metabase/css/core/flex.css
@@ -7,7 +7,7 @@
 
 .flex-full,
 :local(.flex-full) {
-  flex: 1 0 0;
+  flex: 1 0 auto;
 }
 
 .flex-half,

--- a/frontend/src/metabase/public/containers/PublicQuestion.jsx
+++ b/frontend/src/metabase/public/containers/PublicQuestion.jsx
@@ -193,7 +193,7 @@ export default class PublicQuestion extends Component {
         parameterValues={parameterValues}
         setParameterValue={this.setParameterValue}
       >
-        <LoadingAndErrorWrapper loading={!result} className="flex flex-full">
+        <LoadingAndErrorWrapper loading={!result} noWrapper>
           {() => (
             <Visualization
               rawSeries={[{ card: card, data: result && result.data }]}


### PR DESCRIPTION
Resolves #10024 

The core issue seems to be Safari not respecting `height: 100%` for flex children. Setting `flex-basis` to `0` rather than `auto` fixes that issue.

I made the update on the `flex-full` class to avoid similar Safari issues elsewhere in the app, but this does increase the risk of unintended consequences from the change. For example, here is a diagram from the spec showing different behavior for how extra space is distributed.

![image](https://user-images.githubusercontent.com/691495/58495057-8a538780-8144-11e9-9587-2b7311e38471.png)

Is `flex-full` the right place to make the change? Or, should I do it in a more targeted way that only affects the current bug?
