### PR TITLE
Line/area/bar performance

### DIFF
--- a/frontend/src/metabase/components/DebouncedFrame.jsx
+++ b/frontend/src/metabase/components/DebouncedFrame.jsx
@@ -1,0 +1,86 @@
+import React from "react";
+
+import cx from "classnames";
+import _ from "underscore";
+
+import ExplicitSize from "metabase/components/ExplicitSize";
+
+const DEBOUNCE_PERIOD = 250;
+
+/**
+ * This component prevents children elements from being rerendered while it's being resized (currently hard-coded debounce period of 250ms)
+ * Useful for rendering components that maybe take a long time to render but you still wnat to allow their container to be resized fluidly
+ * We also fade the component out and block mouse events while it's transitioning
+ */
+@ExplicitSize()
+export default class DebouncedFrame extends React.Component {
+  // NOTE: don't keep `_transition` in component state because we don't want to trigger a rerender when we update it
+  // Instead manually modify the style in _updateTransitionStyle
+  // There's probably a better way to block renders of children though
+  _transition = false;
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      width: props.width,
+      height: props.height,
+    };
+  }
+
+  setSize = (width, height) => {
+    this._transition = false;
+    this.setState({ width, height }, this._updateTransitionStyle);
+  };
+
+  setSizeDebounced = _.debounce(this.setSize, DEBOUNCE_PERIOD);
+
+  componentWillReceiveProps(nextProps) {
+    if (
+      this.props.width !== nextProps.width ||
+      this.props.height !== nextProps.height
+    ) {
+      if (this.state.width == null || this.state.height == null) {
+        this.setSize(nextProps.width, nextProps.height);
+      } else {
+        this.setSizeDebounced(nextProps.width, nextProps.height);
+        this._transition = true;
+        this._updateTransitionStyle();
+      }
+    }
+  }
+
+  componentDidMount() {
+    this._updateTransitionStyle();
+  }
+
+  componentDidUpdate() {
+    this._updateTransitionStyle();
+  }
+
+  _updateTransitionStyle = () => {
+    if (this._container) {
+      this._container.style.opacity = this._transition ? "0.5" : null;
+      this._container.style.pointerEvents = this._transition ? "none" : null;
+    }
+  };
+
+  render() {
+    const { children, className, style = {} } = this.props;
+    const { width, height } = this.state;
+    return (
+      <div
+        ref={r => (this._container = r)}
+        className={cx(className, "relative")}
+        style={{
+          overflow: "hidden",
+          transition: "opacity 0.25s",
+          ...style,
+        }}
+      >
+        <div className="absolute" style={{ width, height }}>
+          {children}
+        </div>
+      </div>
+    );
+  }
+}

--- a/frontend/src/metabase/components/Ellipsified.jsx
+++ b/frontend/src/metabase/components/Ellipsified.jsx
@@ -1,7 +1,8 @@
 import React, { Component } from "react";
-import ReactDOM from "react-dom";
 
-import Tooltip from "metabase/components/Tooltip.jsx";
+import Tooltip from "metabase/components/Tooltip";
+
+import ResizeObserver from "resize-observer-polyfill";
 
 export default class Ellipsified extends Component {
   constructor(props, context) {
@@ -18,10 +19,21 @@ export default class Ellipsified extends Component {
     showTooltip: true,
   };
 
-  componentDidUpdate() {
-    // Only show tooltip if title is hidden or ellipsified
-    const element = ReactDOM.findDOMNode(this.refs.content);
-    const isTruncated = element && element.offsetWidth < element.scrollWidth;
+  componentDidMount() {
+    // NOTE: Assumes _content won't change. Is this safe?
+    this._ro = new ResizeObserver((entries, observer) => {
+      this._updateTruncated();
+    });
+    this._ro.observe(this._content);
+    this._updateTruncated();
+  }
+
+  componentWillUnmount() {
+    this._ro.disconnect();
+  }
+
+  _updateTruncated() {
+    const isTruncated = this._content.offsetWidth < this._content.scrollWidth;
     if (this.state.isTruncated !== isTruncated) {
       this.setState({ isTruncated });
     }
@@ -46,7 +58,7 @@ export default class Ellipsified extends Component {
         maxWidth={tooltipMaxWidth}
       >
         <div
-          ref="content"
+          ref={r => (this._content = r)}
           className={className}
           style={{
             ...style,

--- a/frontend/src/metabase/lib/time.js
+++ b/frontend/src/metabase/lib/time.js
@@ -1,4 +1,5 @@
 import moment from "moment";
+import memoize from "lodash.memoize";
 
 const NUMERIC_UNIT_FORMATS = {
   // workaround for https://github.com/metabase/metabase/issues/1992
@@ -40,13 +41,15 @@ const NUMERIC_UNIT_FORMATS = {
       .startOf("quarter"),
 };
 
+const parseTimestampWithTimezone = memoize(value => moment.parseZone(value));
+
 // only attempt to parse the timezone if we're sure we have one (either Z or ±hh:mm or +-hhmm)
 // moment normally interprets the DD in YYYY-MM-DD as an offset :-/
 export function parseTimestamp(value, unit) {
   if (moment.isMoment(value)) {
     return value;
   } else if (typeof value === "string" && /(Z|[+-]\d\d:?\d\d)$/.test(value)) {
-    return moment.parseZone(value);
+    return parseTimestampWithTimezone(value);
   } else if (unit in NUMERIC_UNIT_FORMATS) {
     return NUMERIC_UNIT_FORMATS[unit](value);
   } else {

--- a/frontend/src/metabase/visualizations/components/CardRenderer.jsx
+++ b/frontend/src/metabase/visualizations/components/CardRenderer.jsx
@@ -59,34 +59,35 @@ export default class CardRenderer extends Component {
   }
 
   renderChart() {
-    if (this.props.width == null || this.props.height == null) {
+    const { renderer, onRenderError, width, height } = this.props;
+    if (width == null || height == null) {
       return;
     }
 
-    let parent = ReactDOM.findDOMNode(this);
-
-    // deregister previous chart:
+    // deregister previous chart, if any:
     this._deregisterChart();
 
     // reset the DOM:
-    let element = parent.firstChild;
+    let element = this._parent.firstChild;
     if (element) {
-      parent.removeChild(element);
+      this._parent.removeChild(element);
     }
 
     // create a new container element
     element = document.createElement("div");
-    parent.appendChild(element);
+    this._parent.appendChild(element);
 
     try {
-      this._deregister = this.props.renderer(element, this.props);
+      this._deregister = renderer(element, this.props);
     } catch (err) {
       console.error(err);
-      this.props.onRenderError(err.message || err);
+      onRenderError(err.message || err);
     }
   }
 
   render() {
-    return <div className={this.props.className} />;
+    return (
+      <div ref={r => (this._parent = r)} className={this.props.className} />
+    );
   }
 }

--- a/frontend/src/metabase/visualizations/components/LegendHeader.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendHeader.jsx
@@ -1,25 +1,20 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import ReactDOM from "react-dom";
 import styles from "./Legend.css";
 
-import Icon from "metabase/components/Icon.jsx";
-import LegendItem from "./LegendItem.jsx";
+import ExplicitSize from "../../components/ExplicitSize";
+import Icon from "metabase/components/Icon";
+import LegendItem from "./LegendItem";
 
 import cx from "classnames";
 
 import { normal } from "metabase/lib/colors";
 
 const DEFAULT_COLORS = Object.values(normal);
+const MIN_WIDTH_PER_SERIES = 100;
 
+@ExplicitSize()
 export default class LegendHeader extends Component {
-  constructor(props, context) {
-    super(props, context);
-    this.state = {
-      width: 0,
-    };
-  }
-
   static propTypes = {
     series: PropTypes.array.isRequired,
     hovered: PropTypes.object,
@@ -37,17 +32,6 @@ export default class LegendHeader extends Component {
     visualizationIsClickable: () => false,
   };
 
-  componentDidMount() {
-    this.componentDidUpdate();
-  }
-
-  componentDidUpdate() {
-    let width = ReactDOM.findDOMNode(this).offsetWidth;
-    if (width !== this.state.width) {
-      this.setState({ width });
-    }
-  }
-
   render() {
     const {
       series,
@@ -61,9 +45,11 @@ export default class LegendHeader extends Component {
       onVisualizationClick,
       visualizationIsClickable,
       classNameWidgets,
+      width,
     } = this.props;
+
     const showDots = series.length > 1;
-    const isNarrow = this.state.width < 150;
+    const isNarrow = width < MIN_WIDTH_PER_SERIES * series.length;
     const showTitles = !showDots || !isNarrow;
     // const colors = settings["graph.colors"] || DEFAULT_COLORS;
     // const customTitles = settings["graph.series_labels"];

--- a/frontend/src/metabase/visualizations/components/LegendItem.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendItem.jsx
@@ -73,10 +73,8 @@ export default class LegendItem extends Component {
           </Tooltip>
         )}
         {showTitle && (
-          <div className="flex align-center">
-            <span className="mr1">
-              <Ellipsified showTooltip={showTooltip}>{title}</Ellipsified>
-            </span>
+          <div className="flex align-center overflow-hidden">
+            <Ellipsified showTooltip={showTooltip}>{title}</Ellipsified>
             {description && (
               <div className="hover-child">
                 <Tooltip tooltip={description} maxWidth={"22em"}>

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
@@ -126,6 +126,17 @@
   stroke-width: 3px;
 }
 
+.LineAreaBarChart .dc-tooltip .xRef,
+.LineAreaBarChart .dc-tooltip .yRef {
+  display: none;
+}
+
+.LineAreaBarChart .dc-chart .enable-drill .dot,
+.LineAreaBarChart .dc-chart .enable-drill .bubble,
+.LineAreaBarChart .dc-chart .enable-drill .bar {
+  cursor: pointer;
+}
+
 .LineAreaBarChart .dc-chart .enable-dots .dc-tooltip .dot,
 .LineAreaBarChart .dc-chart .dc-tooltip .dot.selected,
 .LineAreaBarChart .dc-chart .enable-dots-onhover .dc-tooltip .dot:hover,

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -602,5 +602,4 @@ export default function lineAndBarOnRender(
   chart.on("renderlet.on-render", () =>
     onRender(chart, onGoalHover, isSplitAxis, isStacked),
   );
-  chart.render();
 }

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -88,18 +88,25 @@ function onRenderSetDotStyle(chart) {
   }
 }
 
-function onRenderSetLineWidth(chart) {
-  const min = getMinElementSpacing(chart.svg().selectAll(".dot")[0]);
-  if (min > 150) {
-    chart.svg().classed("line--heavy", true);
-  } else if (min > 75) {
-    chart.svg().classed("line--medium", true);
-  }
-}
+// more than 500 dots is almost certainly too dense, don't waste time computing the voronoi map or figuring out if we should adjust the line width
+const MAX_DOTS_FOR_VORONOI = 500;
+const MAX_DOTS_FOR_LINE_WIDTH_ADJUSTMENT = 500;
 
 const DOT_OVERLAP_COUNT_LIMIT = 8;
 const DOT_OVERLAP_RATIO = 0.1;
 const DOT_OVERLAP_DISTANCE = 8;
+
+function onRenderSetLineWidth(chart) {
+  const dots = chart.svg()[0][0].getElementsByClassName("dot");
+  if (dots.length < MAX_DOTS_FOR_LINE_WIDTH_ADJUSTMENT) {
+    const min = getMinElementSpacing(dots);
+    if (min > 150) {
+      chart.svg().classed("line--heavy", true);
+    } else if (min > 75) {
+      chart.svg().classed("line--medium", true);
+    }
+  }
+}
 
 function onRenderEnableDots(chart) {
   const markerEnabledByIndex = chart.series.map(
@@ -118,8 +125,7 @@ function onRenderEnableDots(chart) {
           : chart.svg().selectAll(`.sub._${index} .dc-tooltip .dot`)[0],
       ),
     );
-    if (dots.length > 500) {
-      // more than 500 dots is almost certainly too dense, don't waste time computing the voronoi map
+    if (dots.length > MAX_DOTS_FOR_VORONOI) {
       enableDotsAuto = false;
     } else {
       const vertices = dots.map((e, index) => {

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -852,8 +852,8 @@ export default function lineAreaBar(
   );
 
   // render with customizations
-  // parent.render();
-  parent.redraw();
+  parent.render();
+  // parent.redraw();
 
   // only ordinal axis can display "null" values
   if (isOrdinal(parent.settings)) {

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -837,9 +837,11 @@ export default function lineAreaBar(
 
   applyYAxisSettings(parent, yAxisProps);
 
-  setupTooltips(props, datas, parent, brushChangeFunctions);
-
+  // render once just to measure various things
   parent.render();
+
+  // TODO: move to beforeRender
+  setupTooltips(props, datas, parent, brushChangeFunctions);
 
   // apply any on-rendering functions (this code lives in `LineAreaBarPostRenderer`)
   lineAndBarOnRender(
@@ -848,6 +850,10 @@ export default function lineAreaBar(
     yAxisProps.isSplit,
     isStacked(parent.settings, datas),
   );
+
+  // render with customizations
+  // parent.render();
+  parent.redraw();
 
   // only ordinal axis can display "null" values
   if (isOrdinal(parent.settings)) {

--- a/frontend/src/metabase/visualizations/lib/utils.js
+++ b/frontend/src/metabase/visualizations/lib/utils.js
@@ -143,24 +143,26 @@ export function getFriendlyName(column) {
 }
 
 export function getXValues(datas) {
-  let xValues = _.chain(datas)
-    .map(data => _.pluck(data, "0"))
-    .flatten(true)
-    .uniq()
-    .value();
-
+  // get all xValues
+  const xValuesSet = new Set();
   // detect if every series' dimension is strictly ascending or descending and use that to sort xValues
   let isAscending = true;
   let isDescending = true;
-  outer: for (const rows of datas) {
-    for (let i = 1; i < rows.length; i++) {
-      isAscending = isAscending && rows[i - 1][0] <= rows[i][0];
-      isDescending = isDescending && rows[i - 1][0] >= rows[i][0];
-      if (!isAscending && !isDescending) {
-        break outer;
-      }
+  // this is fairly optimized since it iterates over every row in the results
+  for (let i = 0, datasLength = datas.length; i < datasLength; i++) {
+    const rows = datas[i];
+    let lastValue = rows[0][0];
+    xValuesSet.add(lastValue);
+    // skip the first row so we can compare
+    for (let j = 1, rowsLength = rows.length; j < rowsLength; j++) {
+      const value = rows[j][0];
+      xValuesSet.add(value);
+      isAscending = isAscending && lastValue <= value;
+      isDescending = isDescending && lastValue >= value;
+      lastValue = value;
     }
   }
+  let xValues = Array.from(xValuesSet);
   if (isDescending) {
     // JavaScript's .sort() sorts lexicographically by default (e.x. 1, 10, 2)
     // We could implement a comparator but _.sortBy handles strings, numbers, and dates correctly

--- a/frontend/test/metabase/visualizations/lib/utils.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/utils.unit.spec.js
@@ -163,7 +163,7 @@ describe("metabase/visualization/lib/utils", () => {
       expect(getXValues([[[1], [2], [11]]])).toEqual([1, 2, 11]);
     });
     it("should not change the order of a single series of descending numbers", () => {
-      expect(getXValues([[[1], [2], [11]]])).toEqual([1, 2, 11]);
+      expect(getXValues([[[11], [2], [1]]])).toEqual([11, 2, 1]);
     });
     it("should not change the order of a single series of non-ordered numbers", () => {
       expect(getXValues([[[2], [1], [11]]])).toEqual([2, 1, 11]);


### PR DESCRIPTION
Various performance improvements that speed up line/area/bar rendering with a large number of data points by ~50%.

before, with 10,000 points:

![old-line](https://user-images.githubusercontent.com/18193/58595075-56e82a00-8224-11e9-9135-238d4ea08af3.png)

after, with 10,000 points:

![line-new2](https://user-images.githubusercontent.com/18193/58595086-60719200-8224-11e9-854b-4f1445313fa5.png)

Obviously 1.5 seconds of blocking rendering is still not great, but it's an improvment.