### PR TITLE
Format compact currency and scientific style values

### DIFF
--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -254,7 +254,10 @@ function formatNumberCompact(value: number, options: FormattingOptions) {
   }
   if (options.number_style === "currency") {
     try {
-      const { value: currency } = numberFormatterForOptions(options)
+      const { value: currency } = numberFormatterForOptions({
+        ...options,
+        currency_style: "symbol",
+      })
         .formatToParts(value)
         .find(p => p.type === "currency");
 

--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -253,15 +253,20 @@ function formatNumberCompact(value: number, options: FormattingOptions) {
     return formatNumberCompactWithoutOptions(value * 100) + "%";
   }
   if (options.number_style === "currency") {
-    const { value: currency } = numberFormatterForOptions(options)
-      .formatToParts(value)
-      .find(p => p.type === "currency");
+    try {
+      const { value: currency } = numberFormatterForOptions(options)
+        .formatToParts(value)
+        .find(p => p.type === "currency");
 
-    // this special case ensures the "~" comes before the currency
-    if (value !== 0 && value >= -0.01 && value <= 0.01) {
-      return `~${currency}0`;
+      // this special case ensures the "~" comes before the currency
+      if (value !== 0 && value >= -0.01 && value <= 0.01) {
+        return `~${currency}0`;
+      }
+      return currency + formatNumberCompactWithoutOptions(value);
+    } catch (e) {
+      // Intl.NumberFormat failed, so we fall back to a non-currency number
+      return formatNumberCompactWithoutOptions(value);
     }
-    return currency + formatNumberCompactWithoutOptions(value);
   }
   if (options.number_style === "scientific") {
     return formatNumberScientific(value, {

--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -252,6 +252,25 @@ function formatNumberCompact(value: number, options: FormattingOptions) {
   if (options.number_style === "percent") {
     return formatNumberCompactWithoutOptions(value * 100) + "%";
   }
+  if (options.number_style === "currency") {
+    const { value: currency } = numberFormatterForOptions(options)
+      .formatToParts(value)
+      .find(p => p.type === "currency");
+
+    // this special case ensures the "~" comes before the currency
+    if (value !== 0 && value >= -0.01 && value <= 0.01) {
+      return `~${currency}0`;
+    }
+    return currency + formatNumberCompactWithoutOptions(value);
+  }
+  if (options.number_style === "scientific") {
+    return formatNumberScientific(value, {
+      ...options,
+      // unsetting maximumFractionDigits prevents truncation of small numbers
+      maximumFractionDigits: undefined,
+      minimumFractionDigits: 1,
+    });
+  }
   return formatNumberCompactWithoutOptions(value);
 }
 

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -83,6 +83,9 @@ describe("formatting", () => {
         expect(
           formatNumber(1234567.89, { ...options, currency: "CNY" }),
         ).toEqual("CN¥1.2M");
+        expect(
+          formatNumber(1234567.89, { ...options, currency_style: "name" }),
+        ).toEqual("$1.2M");
       });
     });
     // FIXME: failing on CI

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -59,6 +59,31 @@ describe("formatting", () => {
         expect(formatNumber(11.11, options)).toEqual("1.1k%");
         expect(formatNumber(-0.22, options)).toEqual("-22%");
       });
+      it("should format compact scientific notation", () => {
+        const options = { compact: true, number_style: "scientific" };
+        expect(formatNumber(0, options)).toEqual("0.0e+0");
+        expect(formatNumber(0.0001, options)).toEqual("1.0e-4");
+        expect(formatNumber(0.01, options)).toEqual("1.0e-2");
+        expect(formatNumber(0.5, options)).toEqual("5.0e-1");
+        expect(formatNumber(123456.78, options)).toEqual("1.2e+5");
+        expect(formatNumber(-123456.78, options)).toEqual("-1.2e+5");
+      });
+      it("should format compact currency values", () => {
+        const options = {
+          compact: true,
+          number_style: "currency",
+          currency: "USD",
+        };
+        expect(formatNumber(0, options)).toEqual("$0");
+        expect(formatNumber(0.001, options)).toEqual("~$0");
+        expect(formatNumber(7.24, options)).toEqual("$7");
+        expect(formatNumber(1234.56, options)).toEqual("$1.2k");
+        expect(formatNumber(1234567.89, options)).toEqual("$1.2M");
+        expect(formatNumber(-1234567.89, options)).toEqual("$-1.2M");
+        expect(
+          formatNumber(1234567.89, { ...options, currency: "CNY" }),
+        ).toEqual("CN¥1.2M");
+      });
     });
     // FIXME: failing on CI
     xit("should format to correct number of decimal places", () => {

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -46,7 +46,7 @@ describe("formatting", () => {
         expect(formatNumber(1000, { compact: true })).toEqual("1.0k");
         expect(formatNumber(1111, { compact: true })).toEqual("1.1k");
       });
-      it("should format compact percentages", () => {
+      it("should format percentages", () => {
         const options = { compact: true, number_style: "percent" };
         expect(formatNumber(0, options)).toEqual("0%");
         expect(formatNumber(0.001, options)).toEqual("0.1%");
@@ -59,7 +59,7 @@ describe("formatting", () => {
         expect(formatNumber(11.11, options)).toEqual("1.1k%");
         expect(formatNumber(-0.22, options)).toEqual("-22%");
       });
-      it("should format compact scientific notation", () => {
+      it("should format scientific notation", () => {
         const options = { compact: true, number_style: "scientific" };
         expect(formatNumber(0, options)).toEqual("0.0e+0");
         expect(formatNumber(0.0001, options)).toEqual("1.0e-4");
@@ -68,7 +68,7 @@ describe("formatting", () => {
         expect(formatNumber(123456.78, options)).toEqual("1.2e+5");
         expect(formatNumber(-123456.78, options)).toEqual("-1.2e+5");
       });
-      it("should format compact currency values", () => {
+      it("should format currency values", () => {
         const options = {
           compact: true,
           number_style: "currency",


### PR DESCRIPTION
Resolves #10055 

When a dashboard card was small enough to trigger compact formatting, values displayed as currency or in scientific notation lost their styling. 

Currency values use Intl.NumberFormat to get the currency symbol and adds it to the compact formatted number.

Numbers in scientific notation are delegated to `formatNumberScientific` but fix the number of decimals at 1.


