### PR TITLE
Metabase© Joins 2.0™ improvements

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,4 +1,6 @@
-((clojure-mode . ((eval . (progn
+((nil . ((indent-tabs-mode . nil)         ; always use spaces for tabs
+         (require-final-newline . nil)))  ; add final newline on save
+ (clojure-mode . ((eval . (progn
                             ;; Specify which arg is the docstring for certain macros
                             ;; (Add more as needed)
                             (put 'defendpoint 'clojure-doc-string-elt 3)
@@ -18,4 +20,10 @@
                               (expect 0)
                               (match 1)
                               (merge-with 1)
-                              (with-redefs-fn 1)))))))
+                              (with-redefs-fn 1))))
+                  ;; if you're using clj-refactor (highly recommended!), prefer prefix notation when cleaning the ns form
+                  (cljr-favor-prefix-notation . t)
+                  ;; prefer keeping source width about ~118, GitHub seems to cut off stuff at either 119 or 120 and
+                  ;; it's nicer to look at code in GH when you don't have to scroll back and forth
+                  (fill-column . 118)
+                  (clojure-docstring-fill-column . 118))))

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,5 +1,5 @@
-((nil . ((indent-tabs-mode . nil)         ; always use spaces for tabs
-         (require-final-newline . nil)))  ; add final newline on save
+((nil . ((indent-tabs-mode . nil)       ; always use spaces for tabs
+         (require-final-newline . t)))  ; add final newline on save
  (clojure-mode . ((eval . (progn
                             ;; Specify which arg is the docstring for certain macros
                             ;; (Add more as needed)

--- a/frontend/test/__runner__/backend.js
+++ b/frontend/test/__runner__/backend.js
@@ -54,6 +54,7 @@ export const BackendResource = createSharedResource("BackendResource", {
           "-Xverify:none", // Skip bytecode verification for the JAR so it launches faster
           "-Djava.awt.headless=true", // when running on macOS prevent little Java icon from popping up in Dock
           "-Duser.timezone=US/Pacific",
+          `-Dlog4j.configuration=file:${__dirname}/log4j.properties`,
           "-jar",
           "target/uberjar/metabase.jar",
         ],

--- a/frontend/test/__runner__/log4j.properties
+++ b/frontend/test/__runner__/log4j.properties
@@ -1,0 +1,11 @@
+log4j.rootLogger=ERROR, console
+
+# log to the console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.Target=System.out
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=\u001b[1m%p %c{2}\u001b[0m :: %m%n
+
+# Not sure if we need to specify this if ERROR is already the root logger?
+log4j.logger.metabase=ERROR
+log4j.logger.com.mchange=ERROR

--- a/frontend/test/metabase-lib/lib/Question.e2e.spec.js
+++ b/frontend/test/metabase-lib/lib/Question.e2e.spec.js
@@ -46,6 +46,7 @@ describe("Question", () => {
       question._parameterValues = { [templateTagId]: "5" };
       const results2 = await question.apiGetResults({ ignoreCache: true });
       expect(results2[0]).toBeDefined();
+      expect(results2[0].status).toBe("completed");
       expect(results2[0].data.rows[0][0]).toEqual(127.88197029833711);
     });
 
@@ -74,6 +75,7 @@ describe("Question", () => {
 
       const results1 = await question.apiGetResults({ ignoreCache: true });
       expect(results1[0]).toBeDefined();
+      expect(results1[0].status).toBe("completed");
       expect(results1[0].data.rows.length).toEqual(2000);
 
       question._parameterValues = { [templateTagId]: "5" };

--- a/lein-commands/sample-dataset/metabase/sample_dataset/generate.clj
+++ b/lein-commands/sample-dataset/metabase/sample_dataset/generate.clj
@@ -3,7 +3,7 @@
    Run this with `lein generate-sample-dataset`."
   (:require [clojure
              [edn :as edn]
-             [string :as s]]
+             [string :as str]]
             [clojure.java
              [io :as io]
              [jdbc :as jdbc]]
@@ -393,9 +393,9 @@
          (every? string? (vals field->type))]
    :post [(string? %)]}
   (format "CREATE TABLE \"%s\" (\"ID\" BIGINT AUTO_INCREMENT, %s, PRIMARY KEY (\"ID\"));"
-          (s/upper-case (name table-name))
+          (str/upper-case (name table-name))
           (apply str (->> (for [[field type] (seq field->type)]
-                            (format "\"%s\" %s" (s/upper-case (name field)) type))
+                            (format "\"%s\" %s" (str/upper-case (name field)) type))
                           (interpose ", ")))))
 
 (def ^:private ^:const tables
@@ -518,20 +518,20 @@
      (doseq [[table rows] (seq data)]
        (assert (keyword? table))
        (assert (sequential? rows))
-       (let [table-name (s/upper-case (name table))]
+       (let [table-name (str/upper-case (name table))]
          (println (format "Inserting %d rows into %s..." (count rows) table-name))
          (jdbc/insert-multi! db table-name (for [row rows]
                                              (into {} (for [[k v] (seq row)]
-                                                        {(s/upper-case (name k)) v}))))))
+                                                        {(str/upper-case (name k)) v}))))))
 
      ;; Insert the _metabase_metadata table
      (println "Inserting _metabase_metadata...")
      (jdbc/execute! db ["CREATE TABLE \"_METABASE_METADATA\" (\"KEYPATH\" VARCHAR(255), \"VALUE\" VARCHAR(255), PRIMARY KEY (\"KEYPATH\"));"])
      (jdbc/insert-multi! db "_METABASE_METADATA" (reduce concat (for [[table-name {table-description :description, columns :columns}] metabase-metadata]
-                                                                  (let [table-name (s/upper-case (name table-name))]
+                                                                  (let [table-name (str/upper-case (name table-name))]
                                                                     (conj (for [[column-name kvs] columns
                                                                                 [k v]             kvs]
-                                                                            {:keypath (format "%s.%s.%s" table-name (s/upper-case (name column-name)) (name k))
+                                                                            {:keypath (format "%s.%s.%s" table-name (str/upper-case (name column-name)) (name k))
                                                                              :value   v})
                                                                           {:keypath (format "%s.description" table-name)
                                                                            :value table-description})))))
@@ -540,7 +540,7 @@
      (println "Preparing database for export...")
      (jdbc/execute! db ["CREATE USER GUEST PASSWORD 'guest';"])
      (doseq [table (conj (keys data) "_METABASE_METADATA")]
-       (jdbc/execute! db [(format "GRANT SELECT ON %s TO GUEST;" (s/upper-case (name table)))]))
+       (jdbc/execute! db [(format "GRANT SELECT ON %s TO GUEST;" (str/upper-case (name table)))]))
 
      (println "Done."))))
 

--- a/modules/drivers/bigquery/src/metabase/driver/bigquery.clj
+++ b/modules/drivers/bigquery/src/metabase/driver/bigquery.clj
@@ -396,17 +396,17 @@
     (hx/identifier :field table-name field-name)))
 
 (defmethod sql.qp/apply-top-level-clause [:bigquery :breakout]
-  [driver _ honeysql-form {breakout-field-clauses :breakout, fields-field-clauses :fields}]
+  [driver _ honeysql-form {breakouts :breakout, fields :fields}]
   (-> honeysql-form
       ;; Group by all the breakout fields.
       ;;
       ;; Unlike other SQL drivers, BigQuery requires that we refer to Fields using the alias we gave them in the
       ;; `SELECT` clause, rather than repeating their definitions.
-      ((partial apply h/group) (map (partial sql.qp/field-clause->alias driver) breakout-field-clauses))
+      ((partial apply h/group) (map (partial sql.qp/field-clause->alias driver) breakouts))
       ;; Add fields form only for fields that weren't specified in :fields clause -- we don't want to include it
       ;; twice, or HoneySQL will barf
-      ((partial apply h/merge-select) (for [field-clause breakout-field-clauses
-                                            :when        (not (contains? (set fields-field-clauses) field-clause))]
+      ((partial apply h/merge-select) (for [field-clause breakouts
+                                            :when        (not (contains? (set fields) field-clause))]
                                         (sql.qp/as driver field-clause)))))
 
 ;; as with breakouts BigQuery requires that you use the Field aliases in order by clauses, so override the methods for

--- a/modules/drivers/bigquery/test/metabase/driver/bigquery_test.clj
+++ b/modules/drivers/bigquery/test/metabase/driver/bigquery_test.clj
@@ -196,7 +196,7 @@
   "2018-08-31T00:00:00.000-05:00"
    (tu.tz/with-jvm-tz (time/time-zone-for-id "America/Chicago")
     (tt/with-temp* [Database [db {:engine :bigquery
-                                  :details (assoc (:details (Database (data/id)))
+                                  :details (assoc (:details (data/db))
                                              :use-jvm-timezone true)}]]
       (native-timestamp-query db "2018-08-31 00:00:00-05" "America/Chicago"))))
 
@@ -205,7 +205,7 @@
   "2018-08-31T00:00:00.000+07:00"
   (tu.tz/with-jvm-tz (time/time-zone-for-id "Asia/Jakarta")
     (tt/with-temp* [Database [db {:engine :bigquery
-                                  :details (assoc (:details (Database (data/id)))
+                                  :details (assoc (:details (data/db))
                                              :use-jvm-timezone true)}]]
       (native-timestamp-query db "2018-08-31 00:00:00+07" "Asia/Jakarta"))))
 

--- a/modules/drivers/druid/src/metabase/driver/druid/js.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/js.clj
@@ -1,7 +1,7 @@
 (ns metabase.driver.druid.js
   "Util fns for creating Javascript functions."
   (:refer-clojure :exclude [+ - * / or])
-  (:require [clojure.string :as s]))
+  (:require [clojure.string :as str]))
 
 (defn- ->js [x]
   {:pre [(not (coll? x))]}
@@ -20,7 +20,7 @@
 
      (argslist [:x :y]) -> \"(x, y)\""
   ^String [args]
-  (parens (s/join ", " (map ->js args))))
+  (parens (str/join ", " (map ->js args))))
 
 (defn return
   "Generate a javascript `return` statement. STATEMENT-PARTS are combined directly into a single string.
@@ -40,8 +40,8 @@
 (defn- arithmetic-operator
   "Interpose artihmetic OPERATOR between ARGS, and wrap the entire expression in parens."
   ^String [operator & args]
-  (parens (s/join (str " " (name operator) " ")
-                  (map ->js args))))
+  (parens (str/join (str " " (name operator) " ")
+                    (map ->js args))))
 
 (def ^{:arglists '([& args])} ^String + "Interpose `+` between ARGS, and wrap the entire expression in parens." (partial arithmetic-operator :+))
 (def ^{:arglists '([& args])} ^String - "Interpose `-` between ARGS, and wrap the entire expression in parens." (partial arithmetic-operator :-))
@@ -65,4 +65,4 @@
 
      (or :x :y) -> \"(x || y)\""
   ^String [& args]
-  (parens (s/join " || " (map ->js args))))
+  (parens (str/join " || " (map ->js args))))

--- a/modules/drivers/googleanalytics/src/metabase/driver/googleanalytics.clj
+++ b/modules/drivers/googleanalytics/src/metabase/driver/googleanalytics.clj
@@ -1,6 +1,6 @@
 (ns metabase.driver.googleanalytics
   (:require [cheshire.core :as json]
-            [clojure.string :as s]
+            [clojure.string :as str]
             [metabase
              [driver :as driver]
              [util :as u]]
@@ -128,8 +128,8 @@
 (defn- property+profile->display-name
   "Format a table name for a GA property and GA profile"
   [^Webproperty property, ^Profile profile]
-  (let [property-name (s/replace (.getName property) #"^https?://" "")
-        profile-name  (s/replace (.getName profile)  #"^https?://" "")]
+  (let [property-name (str/replace (.getName property) #"^https?://" "")
+        profile-name  (str/replace (.getName profile)  #"^https?://" "")]
     ;; don't include the profile if it's the same as property-name or is the default "All Web Site Data"
     (if (or (.contains property-name profile-name)
             (= profile-name "All Web Site Data"))
@@ -206,13 +206,13 @@
                    (:start-date query)
                    (:end-date query)
                    (:metrics query))
-      (when-not (s/blank? (:dimensions query))
+      (when-not (str/blank? (:dimensions query))
         (.setDimensions <> (:dimensions query)))
-      (when-not (s/blank? (:sort query))
+      (when-not (str/blank? (:sort query))
         (.setSort <> (:sort query)))
-      (when-not (s/blank? (:filters query))
+      (when-not (str/blank? (:filters query))
         (.setFilters <> (:filters query)))
-      (when-not (s/blank? (:segment query))
+      (when-not (str/blank? (:segment query))
         (.setSegment <> (:segment query)))
       (when-not (nil? (:max-results query))
         (.setMaxResults <> (:max-results query)))

--- a/modules/drivers/googleanalytics/test/metabase/driver/googleanalytics_test.clj
+++ b/modules/drivers/googleanalytics/test/metabase/driver/googleanalytics_test.clj
@@ -14,7 +14,9 @@
              [table :refer [Table]]]
             [metabase.query-processor.store :as qp.store]
             [metabase.test.data.users :as users]
-            [metabase.test.util :as tu]
+            [metabase.test
+             [data :as data]
+             [util :as tu]]
             [metabase.util.date :as du]
             [toucan.db :as db]
             [toucan.util.test :as tt]))
@@ -173,11 +175,12 @@
                   Field    [event-action-field {:name "ga:eventAction", :base_type "type/Text", :table_id (u/get-id table)}]
                   Field    [event-label-field  {:name "ga:eventLabel", :base_type "type/Text", :table_id (u/get-id table)}]
                   Field    [date-field         {:name "ga:date", :base_type "type/Date", :table_id (u/get-id table)}]]
-    (f {:db                 db
-        :table              table
-        :event-action-field event-action-field
-        :event-label-field  event-label-field
-        :date-field         date-field})))
+    (data/with-db db
+      (f {:db                 db
+          :table              table
+          :event-action-field event-action-field
+          :event-label-field  event-label-field
+          :date-field         date-field}))))
 
 ;; let's try a real-life GA query and see how it looks when it's all put together. This one has already been
 ;; preprocessed, so we're just checking it gets converted to the correct native query
@@ -229,11 +232,11 @@
 (expect
   expected-ga-query
   (do-with-some-fields
-   (fn [{:keys [table event-action-field event-label-field date-field], :as objects}]
+   (fn [{:keys [db table event-action-field event-label-field date-field], :as objects}]
      (qp.store/with-store
-       (qp.store/store-table! table)
-       (doseq [field [event-action-field event-label-field date-field]]
-         (qp.store/store-field! field))
+       (qp.store/fetch-and-store-database! (u/get-id db))
+       (qp.store/fetch-and-store-tables! [(u/get-id table)])
+       (qp.store/fetch-and-store-fields! (map u/get-id [event-action-field event-label-field date-field]))
        (ga.qp/mbql->native (preprocessed-query-with-some-fields objects))))))
 
 ;; this was the above query before it was preprocessed. Make sure we actually handle everything correctly end-to-end
@@ -253,7 +256,7 @@
 (expect
   expected-ga-query
   (do-with-some-fields
-   (comp metabase.query-processor/query->native query-with-some-fields)))
+   (comp qp/query->native query-with-some-fields)))
 
 ;; ok, now do the same query again, but run the entire QP pipeline, swapping out a few things so nothing is actually
 ;; run externally.
@@ -288,7 +291,7 @@
        (let [results {:columns [:ga:eventLabel :ga:totalEvents]
                       :cols    [{}, {:base_type :type/Text}]
                       :rows    [["Toucan Sighting" 1000]]}
-             qp      (#'metabase.query-processor/qp-pipeline (constantly results))
+             qp      (#'metabase.query-processor/build-pipeline (constantly results))
              query   (query-with-some-fields objects)]
          (-> (tu/doall-recursive (qp query))
              (update-in [:data :cols] #(for [col %]

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -592,8 +592,8 @@
      [k (keyword unescaped)])))
 
 (defn- unescape-names
-  "Restore the original, unescaped nested Field names in the keys of RESULTS.
-   E.g. `:source___service` becomes `:source.service`"
+  "Restore the original, unescaped nested Field names in the keys of `results`.
+  e.g. `:source___service` becomes `:source.service`"
   [results]
   ;; Build a map of escaped key -> unescaped key by looking at the keys in the first result
   ;; e.g. {:source___username :source.username}
@@ -608,7 +608,7 @@
 
 (defn- unstringify-dates
   "Convert string dates, which we wrap in dictionaries like `{:___date <str>}`, back to `Timestamps`.
-   This can't be done within the Mongo aggregation framework itself."
+  This can't be done within the Mongo aggregation framework itself."
   [results]
   (for [row results]
     (into
@@ -647,8 +647,8 @@
 ;; we're missing NumberDecimal but not sure how that's supposed to be converted to a Java type
 
 (defn- form->encoded-fn-name
-  "If FORM is an encoded fn call form return the key representing the fn call that was encoded.
-   If it doesn't represent an encoded fn, return `nil`.
+  "If `form` is an encoded fn call form return the key representing the fn call that was encoded.
+  If it doesn't represent an encoded fn, return `nil`.
 
      (form->encoded-fn-name [:___ObjectId \"583327789137b2700a1621fb\"]) -> :ObjectId"
   [form]
@@ -668,7 +668,7 @@
   (walk/postwalk maybe-decode-fncall query))
 
 (defn- encode-fncalls-for-fn
-  "Walk QUERY-STRING and replace fncalls to fn with FN-NAME with encoded forms that can be parsed as valid JSON.
+  "Walk `query-string` and replace fncalls to fn with `fn-name` with encoded forms that can be parsed as valid JSON.
 
      (encode-fncalls-for-fn \"ObjectId\" \"{\\\"$match\\\":ObjectId(\\\"583327789137b2700a1621fb\\\")}\")
      ;; -> \"{\\\"$match\\\":[\\\"___ObjectId\\\", \\\"583327789137b2700a1621fb\\\"]}\""
@@ -683,7 +683,7 @@
   "Replace occurances of `ISODate(...)` and similary function calls (invalid JSON, but legal in Mongo)
    with legal JSON forms like `[:___ISODate ...]` that we can decode later.
 
-   Walks QUERY-STRING and encodes all the various fncalls we support."
+   Walks `query-string` and encodes all the various fncalls we support."
   [query-string]
   (loop [query-string query-string, [fn-name & more] (keys fn-name->decoder)]
     (if-not fn-name

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -19,13 +19,11 @@
              [sync :as sql-jdbc.sync]]
             [metabase.driver.sql.query-processor :as sql.qp]
             [metabase.driver.sql.util.unprepare :as unprepare]
-            [metabase.models.table :refer [Table]]
             [metabase.query-processor.store :as qp.store]
             [metabase.util
              [date :as du]
              [honeysql-extensions :as hx]
-             [i18n :refer [tru]]]
-            [toucan.db :as db])
+             [i18n :refer [tru]]])
   (:import java.sql.Time
            java.util.Date
            metabase.util.honeysql_extensions.Identifier
@@ -189,14 +187,14 @@
   ;; currently only used for SQL params so it's not a huge deal at this point
   ;;
   ;; TODO - we should make sure these are in the QP store somewhere and then could at least batch the calls
-  (qp.store/store-table! (db/select-one [Table :id :name :schema], :id (u/get-id table-id)))
+  (qp.store/fetch-and-store-tables! [(u/get-id table-id)])
   (sql.qp/->honeysql driver field))
 
 
 (defmethod driver/table-rows-seq :snowflake [driver database table]
   (sql-jdbc/query driver database {:select [:*]
                                    :from   [(qp.store/with-store
-                                              (qp.store/store-database! database)
+                                              (qp.store/fetch-and-store-database! (u/get-id database))
                                               (sql.qp/->honeysql driver table))]}))
 
 (defmethod driver/describe-database :snowflake [driver database]

--- a/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
+++ b/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
@@ -1,7 +1,7 @@
 (ns metabase.driver.sparksql
   (:require [clojure
              [set :as set]
-             [string :as s]]
+             [string :as str]]
             [clojure.java.jdbc :as jdbc]
             [honeysql
              [core :as hsql]
@@ -87,7 +87,7 @@
 
 (defn- dash-to-underscore [s]
   (when s
-    (s/replace s #"-" "_")))
+    (str/replace s #"-" "_")))
 
 ;; workaround for SPARK-9686 Spark Thrift server doesn't return correct JDBC metadata
 (defmethod driver/describe-database :sparksql

--- a/modules/drivers/sparksql/test/metabase/test/data/sparksql.clj
+++ b/modules/drivers/sparksql/test/metabase/test/data/sparksql.clj
@@ -1,6 +1,6 @@
 (ns metabase.test.data.sparksql
   (:require [clojure.java.jdbc :as jdbc]
-            [clojure.string :as s]
+            [clojure.string :as str]
             [honeysql
              [core :as hsql]
              [format :as hformat]
@@ -39,7 +39,7 @@
 
 (defmethod tx/format-name :sparksql
   [_ s]
-  (s/replace s #"-" "_"))
+  (str/replace s #"-" "_"))
 
 (defmethod sql.tx/qualified-name-components :sparksql
   [driver & args]

--- a/project.clj
+++ b/project.clj
@@ -175,10 +175,14 @@
    :run
    [:exclude-tests {}]
 
-   ;; start the HTTP server with 'lein ring server'
+   ;; start the dev HTTP server with 'lein ring server'
    :ring
    [:exclude-tests
-    {:plugins
+    {:dependencies
+     ;; used internally by lein ring to track namespace changes. Newer version contains fix by yours truly with 1000x faster launch time
+     [[ns-tracker "0.4.0"]]
+
+     :plugins
      [[lein-ring "0.12.5" :exclusions [org.clojure/clojure]]]
 
      :ring

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -197,7 +197,7 @@
      (cond
        valid-metadata? (trs "Card results metadata passed in to API is VALID. Thanks!")
        metadata        (trs "Card results metadata passed in to API is INVALID. Running query to fetch correct metadata.")
-       :else           (trs "Card results metadata passed in to API is  ISSING. Running query to fetch correct metadata.")))
+       :else           (trs "Card results metadata passed in to API is MISSING. Running query to fetch correct metadata.")))
     (if valid-metadata?
       (a/to-chan [metadata])
       (qp.async/result-metadata-for-query-async query))))

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -14,7 +14,9 @@
              [common :as api]
              [table :as table-api]]
             [metabase.driver.util :as driver.u]
-            [metabase.mbql.util :as mbql.u]
+            [metabase.mbql
+             [schema :as mbql.s]
+             [util :as mbql.u]]
             [metabase.models
              [card :refer [Card]]
              [database :as database :refer [Database protected-password]]
@@ -127,7 +129,7 @@
   (when (public-settings/enable-nested-queries)
     (when-let [virtual-tables (seq (cards-virtual-tables :include-fields? include-fields?))]
       {:name               "Saved Questions"
-       :id                 database/virtual-id
+       :id                 mbql.s/saved-questions-virtual-database-id
        :features           #{:basic-aggregations}
        :tables             virtual-tables
        :is_saved_questions true})))
@@ -190,7 +192,7 @@
 ;; we'll create another endpoint to specifically match the ID of the 'virtual' database. The `defendpoint` macro
 ;; requires either strings or vectors for the route so we'll have to use a vector and create a regex to only
 ;; match the virtual ID (and nothing else).
-(api/defendpoint GET ["/:virtual-db/metadata" :virtual-db (re-pattern (str database/virtual-id))]
+(api/defendpoint GET ["/:virtual-db/metadata" :virtual-db (re-pattern (str mbql.s/saved-questions-virtual-database-id))]
   "Endpoint that provides metadata for the Saved Questions 'virtual' database. Used for fooling the frontend
    and allowing it to treat the Saved Questions virtual DB just like any other database."
   []

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -7,6 +7,7 @@
             [compojure.core :refer [POST]]
             [medley.core :as m]
             [metabase.api.common :as api]
+            [metabase.mbql.schema :as mbql.s]
             [metabase.models
              [card :refer [Card]]
              [database :as database :refer [Database]]
@@ -41,7 +42,7 @@
   [:as {{:keys [database], :as query} :body}]
   {database s/Int}
   ;; don't permissions check the 'database' if it's the virtual database. That database doesn't actually exist :-)
-  (when-not (= database database/virtual-id)
+  (when-not (= database mbql.s/saved-questions-virtual-database-id)
     (api/read-check Database database))
   ;; add sensible constraints for results limits on our query
   (let [source-card-id (query->source-card-id query)
@@ -142,7 +143,7 @@
   {query         su/JSONString
    export-format ExportFormat}
   (let [{:keys [database] :as query} (json/parse-string query keyword)]
-    (when-not (= database database/virtual-id)
+    (when-not (= database mbql.s/saved-questions-virtual-database-id)
       (api/read-check Database database))
     (as-format-async export-format respond raise
       (qp.async/process-query-and-save-execution!

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -10,10 +10,11 @@
              [util :as u]]
             [metabase.api.common :as api]
             [metabase.driver.util :as driver.u]
-            [metabase.mbql.util :as mbql.u]
+            [metabase.mbql
+             [schema :as mbql.s]
+             [util :as mbql.u]]
             [metabase.models
              [card :refer [Card]]
-             [database :as database]
              [field :refer [Field]]
              [field-values :as fv :refer [FieldValues]]
              [interface :as mi]
@@ -265,7 +266,7 @@
   ;; if collection isn't already hydrated then do so
   (let [card (hydrate card :collection)]
     (cond-> {:id           (str "card__" (u/get-id card))
-             :db_id        database/virtual-id
+             :db_id        mbql.s/saved-questions-virtual-database-id
              :display_name (:name card)
              :schema       (get-in card [:collection :name] "Everything else")
              :description  (:description card)}

--- a/src/metabase/db/migrations.clj
+++ b/src/metabase/db/migrations.clj
@@ -15,11 +15,12 @@
              [db :as mdb]
              [public-settings :as public-settings]
              [util :as u]]
+            [metabase.mbql.schema :as mbql.s]
             [metabase.models
              [card :refer [Card]]
              [collection :as collection :refer [Collection]]
              [dashboard :refer [Dashboard]]
-             [database :refer [Database virtual-id]]
+             [database :refer [Database]]
              [field :refer [Field]]
              [humanization :as humanization]
              [permissions :as perms :refer [Permissions]]
@@ -226,7 +227,7 @@
 (defmigration ^{:author "senior", :added "0.27.0"} populate-card-database-id
   (doseq [[db-id cards] (group-by #(get-in % [:dataset_query :database])
                                   (db/select [Card :dataset_query :id :name] :database_id [:= nil]))
-          :when (not= db-id virtual-id)]
+          :when (not= db-id mbql.s/saved-questions-virtual-database-id)]
     (if (and (seq cards)
              (db/exists? Database :id db-id))
       (db/update-where! Card {:id [:in (map :id cards)]}

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -175,7 +175,7 @@
                           ;; need to initialize the store sicne we're calling `execute-query` directly instead of
                           ;; going thru normal QP pipeline
                           (qp.store/with-store
-                            (qp.store/store-database! database)
+                            (qp.store/fetch-and-store-database! (u/get-id database))
                             (->
                              (driver/execute-query driver
                                (merge settings {:database (u/get-id database), :native {:query native-query}}))

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -35,7 +35,7 @@
     :required     true}])
 
 (defn- connection-string->file+options
-  "Explode a CONNECTION-STRING like `file:my-db;OPTION=100;OPTION_2=TRUE` to a pair of file and an options map.
+  "Explode a `connection-string` like `file:my-db;OPTION=100;OPTION_2=TRUE` to a pair of file and an options map.
 
     (connection-string->file+options \"file:my-crazy-db;OPTION=100;OPTION_X=TRUE\")
       -> [\"file:my-crazy-db\" {\"OPTION\" \"100\", \"OPTION_X\" \"TRUE\"}]"
@@ -46,19 +46,22 @@
                                     (str/split option #"=")))]
     [file options]))
 
+(defn- db-details->user [{:keys [db], :as details}]
+  {:pre [(string? db)]}
+  (or (some (partial get details) ["USER" :USER])
+      (let [[_ {:strs [USER]}] (connection-string->file+options db)]
+        USER)))
+
 (defn- check-native-query-not-using-default-user [{query-type :type, database-id :database, :as query}]
-  {:pre [(integer? database-id)]}
   (u/prog1 query
     ;; For :native queries check to make sure the DB in question has a (non-default) NAME property specified in the
     ;; connection string. We don't allow SQL execution on H2 databases for the default admin account for security
     ;; reasons
     (when (= (keyword query-type) :native)
-      (let [{:keys [db]}   (:details (qp.store/database))
-            _              (assert db)
-            [_ options]    (connection-string->file+options db)
-            {:strs [USER]} options]
-        (when (or (str/blank? USER)
-                  (= USER "sa"))        ; "sa" is the default USER
+      (let [{:keys [details]} (qp.store/database)
+            user              (db-details->user details)]
+        (when (or (str/blank? user)
+                  (= user "sa"))        ; "sa" is the default USER
           (throw
            (Exception.
             (str (tru "Running SQL queries against H2 databases using the default (admin) database user is forbidden.")))))))))
@@ -240,7 +243,7 @@
                     (str ";" k "=" v))))
 
 (defn- connection-string-set-safe-options
-  "Add Metabase Security Settings™ to this CONNECTION-STRING (i.e. try to keep shady users from writing nasty SQL)."
+  "Add Metabase Security Settings™ to this `connection-string` (i.e. try to keep shady users from writing nasty SQL)."
   [connection-string]
   (let [[file options] (connection-string->file+options connection-string)]
     (file+options->connection-string file (merge options {"IFEXISTS"         "TRUE"

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -2,8 +2,8 @@
   "Database driver for PostgreSQL databases. Builds on top of the SQL JDBC driver, which implements most functionality
   for JDBC-based drivers."
   (:require [clojure
-             [set :as set :refer [rename-keys]]
-             [string :as s]]
+             [set :as set]
+            [string :as str]]
             [clojure.java.jdbc :as jdbc]
             [honeysql.core :as hsql]
             [metabase.db.spec :as db.spec]
@@ -54,7 +54,7 @@
 
     #"^FATAL: .*$" ; all other FATAL messages: strip off the 'FATAL' part, capitalize, and add a period
     (let [[_ message] (re-matches #"^FATAL: (.*$)" message)]
-      (str (s/capitalize message) \.))
+      (str (str/capitalize message) \.))
 
     #".*" ; default
     message))
@@ -259,7 +259,7 @@
       (merge (if ssl?
                ssl-params
                disable-ssl-params))
-      (rename-keys {:dbname :db})
+      (set/rename-keys {:dbname :db})
       db.spec/postgres
       (sql-jdbc.common/handle-additional-options details-map)))
 

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -309,19 +309,19 @@
 
 (s/defn field-clause->alias
   "Generate HoneySQL for an approriate alias (e.g., for use with SQL `AN`) for a Field clause of any type, or `nil` if
-  the Field should not be aliased (e.g. if `field->alias` returns `nil`)."
-  [driver, field-clause :- mbql.s/Field]
-  (let [expression-name (when (mbql.u/is-clause? :expression field-clause)
-                          (second field-clause))
-        id-or-name      (when-not expression-name
-                          (mbql.u/field-clause->id-or-literal field-clause))
-        field           (when (integer? id-or-name)
-                          (qp.store/field id-or-name))]
-    (when-let [alias (cond
-                       expression-name      expression-name
-                       field                (field->alias driver field)
-                       (string? id-or-name) id-or-name)]
-      (->honeysql driver (hx/identifier :field-alias alias)))))
+  the Field should not be aliased (e.g. if `field->alias` returns `nil`).
+
+  Optionally pass a state-maintaining `unique-name-fn`, such as `mbql.u/unique-name-generator`, to guarantee that each
+  alias generated is unique when generating a sequence of aliases, such as for a `SELECT` clause."
+  ([driver field-clause]
+   (field-clause->alias driver field-clause identity))
+
+  ([driver, field-clause :- mbql.s/Field, unique-name-fn :- (s/pred fn?)]
+   (when-let [alias (mbql.u/match-one field-clause
+                      [:expression expression-name] expression-name
+                      [:field-literal field-name _] field-name
+                      [:field-id id]                (field->alias driver (qp.store/field id)))]
+     (->honeysql driver (hx/identifier :field-alias (unique-name-fn alias))))))
 
 (defn as
   "Generate HoneySQL for an `AS` form (e.g. `<form> AS <field>`) using the name information of a `field-clause`. The
@@ -335,15 +335,18 @@
 
     (as [:datetime-field [:field-literal \"x\" :type/Text] :month])
     ;; -> [<compiled-form> :x]
-    ;; -> SELECT date_extract(\"x\", 'month') AS \"x\""
+    ;; -> SELECT date_extract(\"x\", 'month') AS \"x\"
+
+  As with `field-clause->alias`, you can pass a `unique-name-fn` to generate unique names for a sequence of aliases,
+  such as for a `SELECT` clause."
   ([driver field-clause]
-   (as driver (->honeysql driver field-clause) field-clause))
-  ([driver form field-clause]
-   (if (mbql.u/is-clause? :field-literal field-clause)
-     form
-     (if-let [alias (field-clause->alias driver field-clause)]
-       [form alias]
-       form))))
+   (as driver field-clause identity))
+
+  ([driver field-clause unique-name-fn]
+   (let [honeysql-form (->honeysql driver field-clause)]
+     (if-let [alias (field-clause->alias driver field-clause unique-name-fn)]
+       [honeysql-form alias]
+       honeysql-form))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -373,8 +376,9 @@
 
 (defmethod apply-top-level-clause [:sql :fields]
   [driver _ honeysql-form {fields :fields}]
-  (apply h/merge-select honeysql-form (for [field fields]
-                                        (as driver field))))
+  (let [unique-name-fn (mbql.u/unique-name-generator)]
+    (apply h/merge-select honeysql-form (for [field-clause fields]
+                                          (as driver field-clause unique-name-fn)))))
 
 
 ;;; ----------------------------------------------------- filter -----------------------------------------------------
@@ -460,14 +464,23 @@
 
 (defmethod join-source :sql
   [driver {:keys [source-table source-query]}]
-  (if source-query
-    (build-honeysql-form driver source-query)
-    (binding [*table-alias* nil]
+  (binding [*table-alias* nil]
+    (if source-query
+      (build-honeysql-form driver {:query source-query})
       (->honeysql driver (qp.store/table source-table)))))
 
-(s/defmethod join->honeysql :sql
+(def ^:private HoneySQLJoin
+  "Schema for HoneySQL for a single JOIN. Used to validate that our join-handling code generates correct clauses."
+  [(s/one
+    [(s/one (s/pred some?) "join source")
+     (s/one (s/pred some?) "join alias")]
+    "join source and alias")
+   (s/one (s/pred sequential?) "join condition")])
+
+(s/defmethod join->honeysql :sql :- HoneySQLJoin
   [driver, {:keys [condition alias], :as join} :- mbql.s/Join]
-  [[(join-source driver join) (->honeysql driver (hx/identifier :table-alias alias))]
+  [[(join-source driver join)
+    (->honeysql driver (hx/identifier :table-alias alias))]
    (->honeysql driver condition)])
 
 (def ^:private join-strategy->merge-fn
@@ -548,22 +561,43 @@
   (sort-by (fn [clause] [(get top-level-clause-application-order clause Integer/MAX_VALUE) clause])
            (keys inner-query)))
 
+(defn- format-honeysql [driver honeysql-form]
+  (try
+    (binding [hformat/*subquery?* false]
+      (hsql/format honeysql-form
+        :quoting             (quote-style driver)
+        :allow-dashed-names? true))
+    (catch Throwable e
+      (log/error (u/format-color 'red
+                     (str (tru "Invalid HoneySQL form:")
+                          "\n"
+                          (u/pprint-to-str honeysql-form))))
+      (throw e))))
+
 (defn- add-default-select
   "Add `SELECT *` to `honeysql-form` if no `:select` clause is present."
-  [{:keys [select], :as honeysql-form}]
+  [driver {:keys [select], [from] :from, :as honeysql-form}]
+  ;; TODO - this is hacky -- we should ideally never need to add `SELECT *`, because we should know what fields to
+  ;; expect from the source query, and middleware should be handling that for us
   (cond-> honeysql-form
-    (empty? select) (assoc :select [:*])))
+    (empty? select) (assoc :select (let [table-identifier (if (sequential? from)
+                                                            (second from)
+                                                            from)
+                                         [raw-identifier] (format-honeysql driver table-identifier)]
+                                     (if (seq raw-identifier)
+                                       [(hsql/raw (format "%s.*" raw-identifier))]
+                                       [:*])))))
 
 (defn- apply-top-level-clauses
   "`apply-top-level-clause` for all of the top-level clauses in `inner-query`, progressively building a HoneySQL form.
   Clauses are applied according to the order in `top-level-clause-application-order`."
   [driver honeysql-form inner-query]
-  (-> (reduce
-       (fn [honeysql-form k]
-         (apply-top-level-clause driver k honeysql-form inner-query))
-       honeysql-form
-       (query->keys-in-application-order inner-query))
-      add-default-select))
+  (->> (reduce
+        (fn [honeysql-form k]
+          (apply-top-level-clause driver k honeysql-form inner-query))
+        honeysql-form
+        (query->keys-in-application-order inner-query))
+       (add-default-select driver)))
 
 
 ;;; -------------------------------------------- Handling source queries ---------------------------------------------
@@ -628,16 +662,7 @@
   "Convert `honeysql-form` to a vector of SQL string and params, like you'd pass to JDBC."
   {:style/indent 1}
   [driver, honeysql-form :- su/Map]
-  (let [[sql & args] (try (binding [hformat/*subquery?* false]
-                            (hsql/format honeysql-form
-                              :quoting             (quote-style driver)
-                              :allow-dashed-names? true))
-                          (catch Throwable e
-                            (log/error (u/format-color 'red
-                                           (str (tru "Invalid HoneySQL form:")
-                                                "\n"
-                                                (u/pprint-to-str honeysql-form))))
-                            (throw e)))]
+  (let [[sql & args] (format-honeysql driver honeysql-form)]
     (into [sql] args)))
 
 (defn- mbql->honeysql [driver outer-query]

--- a/src/metabase/events.clj
+++ b/src/metabase/events.clj
@@ -9,7 +9,7 @@
   when the application goes through normal startup procedures. Inside this function you can do any work needed and add
   your events subscribers to the bus as usual via `start-event-listener!`."
   (:require [clojure.core.async :as async]
-            [clojure.string :as s]
+            [clojure.string :as str]
             [clojure.tools.logging :as log]
             [metabase
              [config :as config]
@@ -103,7 +103,7 @@
   "Determine a valid `model` identifier for the given TOPIC."
   [topic]
   ;; just take the first part of the topic name after splitting on dashes.
-  (first (s/split (name topic) #"-")))
+  (first (str/split (name topic) #"-")))
 
 (defn object->model-id
   "Determine the appropriate `model_id` (if possible) for a given OBJECT."

--- a/src/metabase/mbql/schema.clj
+++ b/src/metabase/mbql/schema.clj
@@ -5,6 +5,7 @@
              [core :as core]
              [set :as set]]
             [metabase.mbql.schema.helpers :refer [defclause is-clause? one-of]]
+            [metabase.mbql.util.match :as match]
             [metabase.util :as u]
             [metabase.util
              [date :as du]
@@ -373,7 +374,7 @@
 ;;
 ;; SUGAR: This is automatically rewritten as a filter clause with a relative-datetime value
 (defclause ^:sugar time-interval
-  field   (one-of field-id fk-> field-literal)
+  field   (one-of field-id fk-> field-literal joined-field)
   n       (s/cond-pre
            s/Int
            (s/enum :current :last :next))
@@ -503,7 +504,7 @@
 (def ^:private TemplateTag
   s/Any) ; s/Any for now until we move over the stuff from the parameters middleware
 
-(def ^:private NativeQuery
+(def NativeQuery
   "Schema for a valid, normalized native [inner] query."
   {:query                          s/Any
    (s/optional-key :template-tags) {su/NonBlankString TemplateTag}
@@ -518,14 +519,32 @@
 
 (declare Query MBQLQuery)
 
-(def ^:private SourceQuery
+(def SourceQuery
   "Schema for a valid value for a `:source-query` clause."
-  (s/if :native
+  (s/if (every-pred map? :native)
     ;; when using native queries as source queries the schema is exactly the same except use `:native` in place of
     ;; `:query` for reasons I do not fully remember (perhaps to make it easier to differentiate them from MBQL source
     ;; queries).
     (set/rename-keys NativeQuery {:query :native})
     (s/recursive #'MBQLQuery)))
+
+(def SourceQueryMetadata
+  "Schema for the expected keys for a single column in `:source-metadata` (`:source-metadata` is a sequence of these
+  entries), if it is passed in to the query.
+
+  This metadata automatically gets added for all source queries that are referenced via the `card__id` `:source-table`
+  form; for explicit `:source-query`s you should usually include this information yourself when specifying explicit
+  `:source-query`s."
+  ;; TODO - there is a very similar schema in `metabase.sync.analyze.query-results`; see if we can merge them
+  {:name                          su/NonBlankString
+   :base_type                     su/FieldType
+   ;; this is only used by the annotate post-processing stage, not really needed at all for pre-processing, might be
+   ;; able to remove this as a requirement
+   :display_name                  su/NonBlankString
+   (s/optional-key :special_type) (s/maybe su/FieldType)
+   ;; you'll need to provide this in order to use BINNING
+   (s/optional-key :fingerprint)  (s/maybe su/Map)
+   s/Any                          s/Any})
 
 (def ^java.util.regex.Pattern source-table-card-id-regex
   "Pattern that matches `card__id` strings that can be used as the `:source-table` of MBQL queries."
@@ -534,6 +553,20 @@
 (def SourceTable
   "Schema for a valid value for the `:source-table` clause of an MBQL query."
   (s/cond-pre su/IntGreaterThanZero source-table-card-id-regex))
+
+(def JoinField
+  "Schema for any valid `Field` that is, or wraps, a `:joined-field` clause."
+  (s/constrained
+   Field
+   (fn [field-clause]
+     (seq (match/match field-clause [:joined-field true])))
+   "`:joined-field` clause or Field clause wrapping a `:joined-field` clause"))
+
+(def JoinFields
+  "Schema for valid values of a join `:fields` clause."
+  (s/named
+   (su/distinct (su/non-empty [JoinField]))
+   "Distinct, non-empty sequence of `:joined-field` clauses or Field clauses wrapping `:joined-field` clauses"))
 
 (def JoinStrategy
   "Strategy that should be used to perform the equivalent of a SQL `JOIN` against another table or a nested query.
@@ -551,22 +584,22 @@
     [:joined-field \"my_join_alias\" [:field-id 1]]                 ; for joins against other Tabless
     [:joined-field \"my_join_alias\" [:field-literal \"my_field\"]] ; for joins against nested queries"
   (->
-   {;; *What* to JOIN. Self-joins can be done by using the same `:source-table` as in the query where this is specified.
+   { ;; *What* to JOIN. Self-joins can be done by using the same `:source-table` as in the query where this is specified.
     ;; YOU MUST SUPPLY EITHER `:source-table` OR `:source-query`, BUT NOT BOTH!
-    (s/optional-key :source-table) SourceTable
-    (s/optional-key :source-query) SourceQuery
+    (s/optional-key :source-table)    SourceTable
+    (s/optional-key :source-query)    SourceQuery
     ;;
     ;; The condition on which to JOIN. Can be anything that is a valid `:filter` clause. For automatically-generated
     ;; JOINs this is always
     ;;
     ;;    [:= <source-table-fk-field> [:joined-field <join-table-alias> <dest-table-pk-field>]]
     ;;
-    :condition                     Filter
+    :condition                        Filter
     ;;
     ;; Defaults to `:left-join`; used for all automatically-generated JOINs
     ;;
     ;; Driver implementations: this is guaranteed to be present after pre-processing.
-    (s/optional-key :strategy)     JoinStrategy
+    (s/optional-key :strategy)        JoinStrategy
     ;;
     ;; The Fields to include in the results *if* a top-level `:fields` clause *is not* specified. This can be either
     ;; `:none`, `:all`, or a sequence of Field clauses.
@@ -582,16 +615,20 @@
     ;;
     ;; Driver implementations: you can ignore this clause. Relevant fields will be added to top-level `:fields` clause
     ;; with appropriate aliases.
-    (s/optional-key :fields)       (s/cond-pre
-                                    (s/enum :all :none)
-                                    (su/distinct (su/non-empty [joined-field])))
+    (s/optional-key :fields)          (s/named
+                                       (s/cond-pre
+                                        (s/enum :all :none)
+                                        JoinFields)
+                                       (str
+                                        "Valid Join `:fields`: `:all`, `:none`, or a sequence of `:joined-field` clauses,"
+                                        " or clauses wrapping `:joined-field`."))
     ;;
     ;; The name used to alias the joined table or query. This is usually generated automatically and generally looks
     ;; like `table__via__field`. You can specify this yourself if you need to reference a joined field in a
     ;; `:joined-field` clause.
     ;;
     ;; Driver implementations: This is guaranteed to be present after pre-processing.
-    (s/optional-key :alias)        su/NonBlankString
+    (s/optional-key :alias)           su/NonBlankString
     ;;
     ;; Used internally, only for annotation purposes in post-processing. When a join is implicitly generated via an
     ;; `:fk->` clause, the ID of the foreign key field in the source Table will be recorded here. This information is
@@ -599,10 +636,13 @@
     ;; drill-thru? :shrug:
     ;;
     ;; Don't set this information yourself. It will have no effect.
-    (s/optional-key :fk-field-id)  (s/maybe su/IntGreaterThanZero)}
+    (s/optional-key :fk-field-id)     (s/maybe su/IntGreaterThanZero)
+    ;;
+    ;; Metadata about the source query being used, if pulled in from a Card via the `:source-table "card__id"` syntax.
+    ;; added automatically by the `resolve-card-id-source-tables` middleware.
+    (s/optional-key :source-metadata) (s/maybe [SourceQueryMetadata])}
    (s/constrained
-    (fn [{:keys [source-table source-query]}]
-      (u/xor source-table source-query))
+    (u/xor-pred :source-table :source-query)
     "Joins can must have either a `source-table` or `source-query`, but not both.")))
 
 (def Joins
@@ -613,8 +653,10 @@
    "All join aliases must be unique."))
 
 (def Fields
-  "Schema for valid values of the `:fields` clause."
-  (su/distinct (su/non-empty [Field])))
+  "Schema for valid values of the MBQL `:fields` clause."
+  (s/named
+   (su/distinct (su/non-empty [Field]))
+   "Distinct, non-empty sequence of Field clauses"))
 
 (def MBQLQuery
   "Schema for a valid, normalized MBQL [inner] query."
@@ -635,9 +677,16 @@
     ;; {:page 2, :items 10} = items 11-20
     (s/optional-key :page)         {:page  su/IntGreaterThanZero
                                     :items su/IntGreaterThanZero}
+    ;;
     ;; Various bits of middleware add additonal keys, such as `fields-is-implicit?`, to record bits of state or pass
     ;; info to other pieces of middleware. Everyone else can ignore them.
     (s/optional-key :joins)        Joins
+    ;;
+    ;; Info about the columns of the source query. Added in automatically by middleware. This metadata is primarily
+    ;; used to let power things like binning when used with Field Literals instead of normal Fields
+    (s/optional-key :source-metadata) (s/maybe [SourceQueryMetadata])
+    ;;
+    ;; Other keys are added by middleware or frontend client for various purposes
     s/Keyword                      s/Any}
 
    (s/constrained
@@ -765,27 +814,37 @@
    ;; and have the code that saves QueryExceutions figure out their values when it goes to save them
    (s/optional-key :query-hash)   (s/maybe (Class/forName "[B"))})
 
-(def SourceQueryMetadata
-  "Schema for the expected keys in metadata about source query columns if it is passed in to the query."
-  ;; TODO - there is a very similar schema in `metabase.sync.analyze.query-results`; see if we can merge them
-  {:name                          su/NonBlankString
-   :display_name                  su/NonBlankString
-   :base_type                     su/FieldType
-   (s/optional-key :special_type) (s/maybe su/FieldType)
-   ;; you'll need to provide this in order to use BINNING
-   (s/optional-key :fingerprint)  (s/maybe su/Map)
-   s/Any                          s/Any})
-
 
 ;;; --------------------------------------------- Metabase [Outer] Query ---------------------------------------------
+
+(def ^Integer saved-questions-virtual-database-id
+  "The ID used to signify that a database is 'virtual' rather than physical.
+
+   A fake integer ID is used so as to minimize the number of changes that need to be made on the frontend -- by using
+   something that would otherwise be a legal ID, *nothing* need change there, and the frontend can query against this
+   'database' none the wiser. (This integer ID is negative which means it will never conflict with a *real* database
+   ID.)
+
+   This ID acts as a sort of flag. The relevant places in the middleware can check whether the DB we're querying is
+   this 'virtual' database and take the appropriate actions."
+  -1337)
+;; To the reader: yes, this seems sort of hacky, but one of the goals of the Nested Query Initiative™ was to minimize
+;; if not completely eliminate any changes to the frontend. After experimenting with several possible ways to do this
+;; implementation seemed simplest and best met the goal. Luckily this is the only place this "magic number" is defined
+;; and the entire frontend can remain blissfully unaware of its value.
+
+(def DatabaseID
+  "Schema for a valid `:database` ID, in the top-level 'outer' query. Either a positive integer (referring to an
+  actual Database), or the saved questions virtual ID, which is a placeholder used for queries using the
+  `:source-table \"card__id\"` shorthand for a source query resolved by middleware (since clients might not know the
+  actual DB for that source query.)"
+  (s/cond-pre (s/eq saved-questions-virtual-database-id) su/IntGreaterThanZero))
 
 (def Query
   "Schema for an [outer] query, e.g. the sort of thing you'd pass to the query processor or save in
   `Card.dataset_query`."
-  (s/constrained
-   ;; TODO - move database/virtual-id into this namespace so we don't have to use the magic number here
-   ;; Something like `metabase.mbql.constants`
-   {:database                         (s/cond-pre (s/eq -1337) su/IntGreaterThanZero)
+  (->
+   {:database                         DatabaseID
     ;; Type of query. `:query` = MBQL; `:native` = native. TODO - consider normalizing `:query` to `:mbql`
     :type                             (s/enum :query :native)
     (s/optional-key :native)          NativeQuery
@@ -806,20 +865,36 @@
     ;; Used when recording info about this run in the QueryExecution log; things like context query was ran in and
     ;; User who ran it
     (s/optional-key :info)            (s/maybe Info)
-    ;; Info about the columns of the source query. Added in automatically by middleware. This metadata is primarily
-    ;; used to let power things like binning when used with Field Literals instead of normal Fields
-    (s/optional-key :source-metadata) (s/maybe [SourceQueryMetadata])
-    #_:fk-field-ids
-    #_:table-ids
     ;;
     ;; Other various keys get stuck in the query dictionary at some point or another by various pieces of QP
     ;; middleware to record bits of state. Everyone else can ignore them.
     s/Keyword                         s/Any}
-   (fn [{native :native, mbql :query, query-type :type}]
-     (case query-type
-       :native (core/and native (core/not mbql))
-       :query  (core/and mbql   (core/not native))))
-   "Native queries should specify `:native` but not `:query`; MBQL queries should specify `:query` but not `:native`."))
+   ;;
+   ;; CONSTRAINTS
+   ;;
+   ;; Make sure we have the combo of query `:type` and `:native`/`:query`
+   (s/constrained
+    (u/xor-pred :native :query)
+    "Query must specify either `:native` or `:query`, but not both.")
+   (s/constrained
+    (fn [{native :native, mbql :query, query-type :type}]
+      (case query-type
+        :native native
+        :query  mbql))
+    "Native queries must specify `:native`; MBQL queries must specify `:query`.")
+   ;;
+   ;; `:source-metadata` is added to queries when `card__id` source queries are resolved. It contains info about the
+   ;; columns in the source query.
+   ;;
+   ;; Where this is added was changed in Metabase 0.33.0 -- previously, when `card__id` source queries were resolved,
+   ;; the middleware would add `:source-metadata` to the top-level; to support joins against source queries, this has
+   ;; been changed so it is always added at the same level the resolved `:source-query` is added.
+   ;;
+   ;; This should automatically be fixed by `normalize`; if we encounter it, it means some middleware is not
+   ;; functioning properly
+   (s/constrained
+    (complement :source-metadata)
+    "`:source-metadata` should be added in the same level as `:source-query` (i.e., the 'inner' MBQL query.)")))
 
 
 ;;; --------------------------------------------------- Validators ---------------------------------------------------

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -11,41 +11,26 @@
              [interface :as i]
              [permissions :as perms]
              [permissions-group :as perm-group]]
+            [metabase.plugins.classloader :as classloader]
             [metabase.util.i18n :refer [trs]]
             [toucan
              [db :as db]
              [models :as models]]))
 
-;;; --------------------------------------------------- Constants ---------------------------------------------------
-
-;; TODO - should this be renamed `saved-cards-virtual-id`?
-(def ^Integer virtual-id
-  "The ID used to signify that a database is 'virtual' rather than physical.
-
-   A fake integer ID is used so as to minimize the number of changes that need to be made on the frontend -- by using
-   something that would otherwise be a legal ID, *nothing* need change there, and the frontend can query against this
-   'database' none the wiser. (This integer ID is negative which means it will never conflict with a *real* database
-   ID.)
-
-   This ID acts as a sort of flag. The relevant places in the middleware can check whether the DB we're querying is
-   this 'virtual' database and take the appropriate actions."
-  -1337)
-;; To the reader: yes, this seems sort of hacky, but one of the goals of the Nested Query Initiative™ was to minimize
-;; if not completely eliminate any changes to the frontend. After experimenting with several possible ways to do this
-;; implementation seemed simplest and best met the goal. Luckily this is the only place this "magic number" is defined
-;; and the entire frontend can remain blissfully unaware of its value.
-
-
 ;;; ----------------------------------------------- Entity & Lifecycle -----------------------------------------------
 
 (models/defmodel Database :metabase_database)
-
 
 (defn- schedule-tasks!
   "(Re)schedule sync operation tasks for `database`. (Existing scheduled tasks will be deleted first.)"
   [database]
   (try
     ;; this is done this way to avoid circular dependencies
+    ;;
+    ;; TODO - I really need to audit all the places we call `require` and make sure they call `the-classloader` first,
+    ;; to make sure the classes get loaded into the right classloader. Actually maybe we should consider adding an
+    ;; injection into each `ns` to remove the mapping for `clojure.core/require` so you have to use the right one
+    (classloader/the-classloader)
     (require 'metabase.task.sync-databases)
     ((resolve 'metabase.task.sync-databases/schedule-tasks-for-db!) database)
     (catch Throwable e
@@ -58,6 +43,7 @@
   "Unschedule any currently pending sync operation tasks for `database`."
   [database]
   (try
+    (classloader/the-classloader)
     (require 'metabase.task.sync-databases)
     ((resolve 'metabase.task.sync-databases/unschedule-tasks-for-db!) database)
     (catch Throwable e
@@ -66,6 +52,7 @@
 (defn- destroy-qp-thread-pool!
   [database]
   (try
+    (classloader/the-classloader)
     (require 'metabase.query-processor.middleware.async-wait)
     ((resolve 'metabase.query-processor.middleware.async-wait/destroy-thread-pool!) database)
     (catch Throwable e
@@ -185,9 +172,10 @@
 (add-encoder
  DatabaseInstance
  (fn [db json-generator]
-   (encode-map (cond
-                 (not (:is_superuser @*current-user*)) (dissoc db :details)
-                 (get-in db [:details :password])      (assoc-in db [:details :password] protected-password)
-                 (get-in db [:details :pass])          (assoc-in db [:details :pass] protected-password) ; MongoDB uses "pass" instead of password
-                 :else                                 db)
-               json-generator)))
+   (encode-map
+    (cond
+      (not (:is_superuser @*current-user*)) (dissoc db :details)
+      (get-in db [:details :password])      (assoc-in db [:details :password] protected-password)
+      (get-in db [:details :pass])          (assoc-in db [:details :pass] protected-password) ; MongoDB uses "pass" instead of password
+      :else                                 db)
+    json-generator)))

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -1,6 +1,6 @@
 (ns metabase.models.field
   (:require [clojure.core.memoize :as memoize]
-            [clojure.string :as s]
+            [clojure.string :as str]
             [metabase.models
              [dimension :refer [Dimension]]
              [field-values :as fv :refer [FieldValues]]
@@ -268,7 +268,7 @@
 (defn qualified-name
   "Return a combined qualified name for FIELD, e.g. `table_name.parent_field_name.field_name`."
   [field]
-  (s/join \. (qualified-name-components field)))
+  (str/join \. (qualified-name-components field)))
 
 (defn table
   "Return the `Table` associated with this `Field`."

--- a/src/metabase/models/humanization.clj
+++ b/src/metabase/models/humanization.clj
@@ -13,7 +13,7 @@
             [clojure.tools.logging :as log]
             [metabase.models.setting :as setting :refer [defsetting]]
             [metabase.util
-             [i18n :refer [tru]]
+             [i18n :refer [tru trs]]
              [infer-spaces :refer [infer-spaces]]]
             [toucan.db :as db]))
 
@@ -71,47 +71,43 @@
   ([_ s] s))
 
 
-(defn- custom-display-name?
-  "Is `display-name` a custom name that was set manually by the user in the metadata edit screen?"
-  [internal-name display-name]
-  ;; Try all the different implementations of name->human-readable-name. If any (f internal-name) is equal to
-  ;; display-name we can safely assume that display-name was set automatically using that strategy and stop there.
-  ;; Otherwise if none of the strategies match (i.e. `some` returns `nil`) we can assume a custom name was set.
-  (nil? (some #(= display-name (% internal-name))
-              (vals (methods name->human-readable-name)))))
-
 (defn- re-humanize-names!
   "Update all non-custom display names of all instances of `model` (e.g. Table or Field)."
-  [model]
+  [old-strategy model]
   (run! (fn [{id :id, internal-name :name, display-name :display_name}]
-          (let [new-display-name (name->human-readable-name internal-name)]
-            (when (and (not= display-name new-display-name)
-                       (not (custom-display-name? internal-name display-name)))
-              (log/info (format "Updating display name for %s '%s': '%s' -> '%s'"
-                                (name model) internal-name display-name new-display-name))
+          (let [old-strategy-display-name (name->human-readable-name old-strategy internal-name)
+                new-strategy-display-name (name->human-readable-name internal-name)
+                custom-display-name?      (not= old-strategy-display-name display-name)]
+            (when (and (not= display-name new-strategy-display-name)
+                       (not custom-display-name?))
+              (log/info (trs "Updating display name for {0} ''{1}'': ''{2}'' -> ''{3}''"
+                             (name model) internal-name display-name new-strategy-display-name))
               (db/update! model id
-                :display_name new-display-name))))
+                :display_name new-strategy-display-name))))
         (db/select-reducible [model :id :name :display_name])))
 
 (defn- re-humanize-table-and-field-names!
   "Update the non-custom display names of all Tables & Fields in the database using new values obtained from
   the (obstensibly swapped implementation of) `name->human-readable-name`."
-  []
-  (re-humanize-names! 'Table)
-  (re-humanize-names! 'Field))
+  [old-strategy]
+  (doseq [model ['Table 'Field]]
+    (re-humanize-names! old-strategy model)))
 
 
-(defn- set-humanization-strategy! [new-strategy]
-  ;; check to make sure `new-strategy` is a valid strategy, or throw an Exception it is it not.
-  (when-not (get-method name->human-readable-name (keyword new-strategy))
-    (throw (IllegalArgumentException. (format "Invalid humanization strategy %s. Valid strategies are: %s"
-                                              new-strategy (keys (methods name->human-readable-name))))))
-  ;; ok, now set the new value
-  (setting/set-string! :humanization-strategy (name new-strategy))
-  ;; now rehumanize all the Tables and Fields using the new strategy.
-  ;; TODO: Should we do this in a background thread because it is potentially slow?
-  (log/info (format "Now using %s table name humanization." new-strategy))
-  (re-humanize-table-and-field-names!))
+(defn- set-humanization-strategy! [new-value]
+  (let [new-strategy (or new-value "advanced")]
+    ;; check to make sure `new-strategy` is a valid strategy, or throw an Exception it is it not.
+    (when-not (get-method name->human-readable-name (keyword new-strategy))
+      (throw (IllegalArgumentException.
+              (str (tru "Invalid humanization strategy ''{0}''. Valid strategies are: {1}"
+                        new-strategy (keys (methods name->human-readable-name)))))))
+    (let [old-strategy (setting/get-string :humanization-strategy)]
+      ;; ok, now set the new value
+      (setting/set-string! :humanization-strategy (some-> new-value name))
+      ;; now rehumanize all the Tables and Fields using the new strategy.
+      ;; TODO: Should we do this in a background thread because it is potentially slow?
+      (log/info (trs "Chaning Table & Field names humanization strategy from ''{0}'' to ''{1}''" old-strategy new-strategy))
+      (re-humanize-table-and-field-names! old-strategy))))
 
 (defsetting ^{:added "0.28.0"} humanization-strategy
   (str (tru "Metabase can attempt to transform your table and field names into more sensible, human-readable versions, e.g. \"somehorriblename\" becomes \"Some Horrible Name\".")

--- a/src/metabase/models/humanization.clj
+++ b/src/metabase/models/humanization.clj
@@ -13,7 +13,7 @@
             [clojure.tools.logging :as log]
             [metabase.models.setting :as setting :refer [defsetting]]
             [metabase.util
-             [i18n :refer [tru trs]]
+             [i18n :refer [trs tru]]
              [infer-spaces :refer [infer-spaces]]]
             [toucan.db :as db]))
 

--- a/src/metabase/models/query/permissions.clj
+++ b/src/metabase/models/query/permissions.clj
@@ -4,6 +4,7 @@
   as a Card. Saved Cards are subject to the permissions of the Collection to which they belong."
   (:require [clojure.tools.logging :as log]
             [metabase.api.common :as api]
+            [metabase.mbql.util :as mbql.u]
             [metabase.models
              [interface :as i]
              [permissions :as perms]
@@ -33,17 +34,21 @@
 ;;                        ↓                          ↓
 ;;          tables->permissions-path-set   source-card-read-perms
 
-(defn- query->source-and-joins
-  "Return a sequence of all Tables (as TableInstance maps, or IDs) referenced by `query`."
-  [{:keys [source-table joins source-query native], :as query}]
-  (cond
-    ;; if we come across a native query just put a placeholder (`::native`) there so we know we need to add native
-    ;; permissions to the complete set below.
-    native       [::native]
-    ;; if we have a source-query just recur until we hit either the native source or the MBQL source
-    source-query (recur source-query)
-    ;; for root MBQL queries just return source-table + joins
-    :else        (cons source-table (map :source-table joins))))
+(s/defn ^:private query->source-table-ids :- #{(s/cond-pre (s/eq ::native) su/IntGreaterThanZero)}
+  "Return a sequence of all Table IDs referenced by `query`."
+  [query]
+  (set
+   (flatten
+    (mbql.u/match query
+      ;; if we come across a native query just put a placeholder (`::native`) there so we know we need to
+      ;; add native permissions to the complete set below.
+      (m :guard (every-pred map? :native))
+      [::native]
+
+      (m :guard (every-pred map? :source-table))
+      (cons
+       (:source-table m)
+       (query->source-table-ids (dissoc m :source-table)))))))
 
 (def ^:private PermsOptions
   "Map of options to be passed to the permissions checking functions."
@@ -54,14 +59,11 @@
 (def ^:private TableOrIDOrNativePlaceholder
   (s/cond-pre
    (s/eq ::native)
-   su/IntGreaterThanZero
-   {:id                      su/IntStringGreaterThanZero
-    (s/optional-key :schema) (s/maybe su/NonBlankString)
-    s/Keyword                s/Any}))
+   su/IntGreaterThanZero))
 
 (s/defn ^:private tables->permissions-path-set :- #{perms/ObjectPath}
   "Given a sequence of `tables-or-ids` referenced by a query, return a set of required permissions."
-  [database-or-id :- (s/cond-pre su/IntGreaterThanZero su/Map), tables-or-ids :- [TableOrIDOrNativePlaceholder]]
+  [database-or-id :- (s/cond-pre su/IntGreaterThanZero su/Map), tables-or-ids :- #{TableOrIDOrNativePlaceholder}]
   (let [table-ids           (filter integer? tables-or-ids)
         table-id->schema    (when (seq table-ids)
                               (db/select-id->field :schema Table :id [:in table-ids]))
@@ -92,7 +94,6 @@
   (binding [api/*current-user-id* nil]
     ((resolve 'metabase.query-processor/query->preprocessed) query)))
 
-;; TODO - not sure how we can prevent circular source Cards if source Cards permissions are just collection perms now???
 (s/defn ^:private mbql-permissions-path-set :- #{perms/ObjectPath}
   "Return the set of required permissions needed to run an adhoc `query`.
 
@@ -109,7 +110,7 @@
       ;; otherwise if there's no source card then calculate perms based on the Tables referenced in the query
       (let [{:keys [query database]} (cond-> query
                                        (not already-preprocessed?) preprocess-query)]
-        (tables->permissions-path-set database (query->source-and-joins query))))
+        (tables->permissions-path-set database (query->source-table-ids query))))
     ;; if for some reason we can't expand the Card (i.e. it's an invalid legacy card) just return a set of permissions
     ;; that means no one will ever get to see it (except for superusers who get to see everything)
     (catch Throwable e

--- a/src/metabase/models/revision/diff.clj
+++ b/src/metabase/models/revision/diff.clj
@@ -1,6 +1,6 @@
 (ns metabase.models.revision.diff
   (:require [clojure.core.match :refer [match]]
-            [clojure.string :as s]))
+            [clojure.string :as str]))
 
 (defn- diff-string* [k v1 v2]
   (match [k v1 v2]
@@ -46,4 +46,4 @@
       (some-> (filter identity (for [k ks]
                                  (diff-string* k (k before) (k after))))
               build-sentence
-              (s/replace-first #" it " (format " this %s " t))))))
+              (str/replace-first #" it " (format " this %s " t))))))

--- a/src/metabase/plugins.clj
+++ b/src/metabase/plugins.clj
@@ -100,7 +100,7 @@
                             ;; ignore it but let people know they can get rid of it.
                             (log/warn
                              (u/format-color 'red
-                                 (trs "spark-deps.jar is no longer needed by Metabase 1.0+. You can delete it from the plugins directory.")))))]
+                                 (trs "spark-deps.jar is no longer needed by Metabase 0.32.0+. You can delete it from the plugins directory.")))))]
     path))
 
 (defn- has-manifest? ^Boolean [^Path path]

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -88,7 +88,7 @@
 
 (defsetting map-tile-server-url
   (tru "The map tile server URL template used in map visualizations, for example from OpenStreetMaps or MapBox.")
-  :default "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png")
+  :default "http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png")
 
 (defsetting enable-public-sharing
   (tru "Enable admins to create publicly viewable links (and embeddable iframes) for Questions and Dashboards?")

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -5,12 +5,14 @@
             [metabase.driver :as driver]
             [metabase.driver.util :as driver.u]
             [metabase.mbql.schema :as mbql.s]
+            [metabase.query-processor.debug :as debug]
             [metabase.query-processor.middleware
              [add-dimension-projections :as add-dim]
              [add-implicit-clauses :as implicit-clauses]
              [add-implicit-joins :as add-implicit-joins]
              [add-row-count-and-status :as row-count-and-status]
              [add-settings :as add-settings]
+             [add-source-metadata :as add-source-metadata]
              [annotate :as annotate]
              [async :as async]
              [async-wait :as async-wait]
@@ -63,102 +65,131 @@
   (driver/execute-query (:driver query) query))
 
 ;; The way these functions are applied is actually straight-forward; it matches the middleware pattern used by
-;; Compojure.
+;; Ring.
 ;;
-;; (defn- qp-middleware-fn [qp]
-;;   (fn [query]
-;;     (do-some-postprocessing (qp (do-some-preprocessing query)))))
+;;    (defn- qp-middleware-fn [qp]
+;;      (fn [query]
+;;        (do-some-postprocessing (qp (do-some-preprocessing query)))))
 ;;
-;; Each query processor function is passed a single arg, QP, and returns a function that accepts a single arg, QUERY.
+;; (For most of the middleware.) We are currently in the process to converting all middleware to an async pattern,
+;; which is similar to async Ring, with an added `canceled-chan` param:
 ;;
-;; This returned function *pre-processes* QUERY as needed, and then passes it to QP.
-;; The function may then *post-process* the results of (QP QUERY) as neeeded, and returns the results.
+;;    (defn- async-qp-middleware-fn [qp]
+;;      (fn [query respond raise canceled-chan]
+;;        (qp (do-some-preprocessing query)
+;;            (fn [results]
+;;              (respond (do-some-post-processing results)))
+;;            raise
+;;            canceled-chan)))
 ;;
-;; Many functions do both pre and post-processing; this middleware pattern allows them to return closures that
-;; maintain some sort of internal state. For example, `cumulative-sum` can determine if it needs to perform cumulative
-;; summing, and, if so, modify the query before passing it to QP; once the query is processed, it can use modify the
-;; results as needed.
+;; `canceled-chan` is a core.async promise channel that will recieve a single message if the connection or thread
+;; waiting for the query result is canceled before the QP returns a response; middleware can listen for this message
+;; to cancel pending queries if supported by the database. This channel will also close whenever the QP finishes, so
+;; you can use it in core.async go blocks to schedule other async actions as well.
+;;
+;;
+;; The majority of middleware functions do only pre-processing, fewer still do only post-processing, and even fewer
+;; still do a combination of both. The middleware pattern allows individual pieces of middleware to return closures
+;; that maintain some sort of internal state. For example, `cumulative-sum` can determine if it needs to perform
+;; cumulative summing, and, if so, modify the query before passing it to QP; once the query is processed, it can use
+;; modify the results as needed.
 ;;
 ;; PRE-PROCESSING fns are applied from bottom to top, and POST-PROCESSING from top to bottom;
 ;; the easiest way to wrap your head around this is picturing a the query as a ball being thrown in the air
 ;; (up through the preprocessing fns, back down through the post-processing ones)
-(defn- qp-pipeline
-  "Construct a new Query Processor pipeline with F as the final 'piviotal' function. e.g.:
-
-     All PRE-PROCESSING (query) --> F --> All POST-PROCESSING (result)
-
-   Or another way of looking at it is
-
-     (post-process (f (pre-process query)))
-
-   Normally F is something that runs the query, like the `execute-query` function above, but this can be swapped out
-   when we want to do things like process a query without actually running it."
-  [f]
+(def ^:private pipeline
   ;; ▼▼▼ POST-PROCESSING ▼▼▼  happens from TOP-TO-BOTTOM, e.g. the results of `f` are (eventually) passed to `limit`
-  (-> f
-      ;; ▲▲▲ NATIVE-ONLY POINT ▲▲▲ Query converted from MBQL to native here; f will see a native query instead of MBQL
-      mbql-to-native/mbql->native
-      annotate/result-rows-maps->vectors
-      check-features/check-features
-      wrap-value-literals/wrap-value-literals
-      annotate/add-column-info
-      perms/check-query-permissions
-      cumulative-ags/handle-cumulative-aggregations
-      ;; ▲▲▲ NO FK->s POINT ▲▲▲ Everything after this point will not see `:fk->` clauses, only `:joined-field`
-      resolve-joins/resolve-joins
-      add-implicit-joins/add-implicit-joins
-      dev/check-results-format
-      limit/limit
-      results-metadata/record-and-return-metadata!
-      format-rows/format-rows
-      desugar/desugar
-      binning/update-binning-strategy
-      resolve-fields/resolve-fields
-      add-dim/add-remapping
-      implicit-clauses/add-implicit-clauses
-      reconcile-bucketing/reconcile-breakout-and-order-by-bucketing
-      bucket-datetime/auto-bucket-datetimes
-      resolve-source-table/resolve-source-table
-      row-count-and-status/add-row-count-and-status
-      ;; ▼▼▼ RESULTS WRAPPING POINT ▼▼▼ All functions *below* will see results WRAPPED in `:data` during POST-PROCESSING
-      ;;
-      ;; TODO - I think we should add row count and status much later, perhaps at the very end right before
-      ;; `catch-exceptions`
-      parameters/substitute-parameters
-      expand-macros/expand-macros
-      ;; (drivers can inject custom middleware if they implement IDriver's `process-query-in-context`)
-      driver-specific/process-query-in-context
-      add-settings/add-settings
-      splice-params-in-response/splice-params-in-response
-      ;; ▲▲▲ DRIVER RESOLUTION POINT ▲▲▲
-      ;; All functions *above* will have access to the driver during PRE- *and* POST-PROCESSING
-      ;; TODO - I think we should do this much earlier
-      resolve-driver/resolve-driver
-      bind-timezone/bind-effective-timezone
-      resolve-database/resolve-database
-      fetch-source-query/fetch-source-query
-      store/initialize-store
-      log-query/log-query
-      ;; ▲▲▲ SYNC MIDDLEWARE ▲▲▲
-      ;;
-      ;; All middleware above this point is written in the synchronous 1-arg style. All middleware below is written in
-      ;; async 4-arg style. Eventually the entire QP middleware stack will be rewritten in the async style. But not yet
-      ;;
-      ;; TODO - `async-wait` should be moved way up the stack, at least after the DB is resolved, right now for nested
-      ;; queries it creates a thread pool for the nested query placeholder DB ID
-      ;;
-      ;; ▼▼▼ ASYNC MIDDLEWARE ▼▼▼
-      async/async->sync
-      async-wait/wait-for-turn
-      cache/maybe-return-cached-results
-      validate/validate-query
-      normalize/normalize
-      catch-exceptions/catch-exceptions
-      process-userland-query/process-userland-query
-      constraints/add-default-userland-constraints
-      async/async-setup))
+  [#'mbql-to-native/mbql->native
+   #'annotate/result-rows-maps->vectors
+   #'check-features/check-features
+   #'wrap-value-literals/wrap-value-literals
+   #'annotate/add-column-info
+   #'perms/check-query-permissions
+   #'cumulative-ags/handle-cumulative-aggregations
+   ;; ▲▲▲ NO FK->s POINT ▲▲▲ Everything after this point will not see `:fk->` clauses, only `:joined-field`
+   #'resolve-joins/resolve-joins
+   #'add-implicit-joins/add-implicit-joins
+   #'dev/check-results-format
+   #'limit/limit
+   #'results-metadata/record-and-return-metadata!
+   #'format-rows/format-rows
+   #'desugar/desugar
+   #'binning/update-binning-strategy
+   #'resolve-fields/resolve-fields
+   #'add-dim/add-remapping
+   #'implicit-clauses/add-implicit-clauses
+   #'add-source-metadata/add-source-metadata-for-source-queries
+   #'reconcile-bucketing/reconcile-breakout-and-order-by-bucketing
+   #'bucket-datetime/auto-bucket-datetimes
+   #'resolve-source-table/resolve-source-tables
+   #'row-count-and-status/add-row-count-and-status
+   ;; ▼▼▼ RESULTS WRAPPING POINT ▼▼▼ All functions *below* will see results WRAPPED in `:data` during POST-PROCESSING
+   ;;
+   ;; TODO - I think we should add row count and status much later, perhaps at the very end right before
+   ;; `catch-exceptions`
+   #'parameters/substitute-parameters
+   #'expand-macros/expand-macros
+   ;; (drivers can inject custom middleware if they implement `process-query-in-context`)
+   #'driver-specific/process-query-in-context
+   #'add-settings/add-settings
+   #'splice-params-in-response/splice-params-in-response
+   ;; ▲▲▲ DRIVER RESOLUTION POINT ▲▲▲
+   ;; All functions *above* will have access to the driver during PRE- *and* POST-PROCESSING
+   ;;
+   ;; TODO - `resolve-driver` and `resolve-database` can be combined into a single step, so we don't need to fetch
+   ;; DB twice
+   #'resolve-driver/resolve-driver
+   #'bind-timezone/bind-effective-timezone
+   #'resolve-database/resolve-database
+   #'fetch-source-query/resolve-card-id-source-tables
+   #'store/initialize-store
+   #'log-query/log-query
+   ;; ▲▲▲ SYNC MIDDLEWARE ▲▲▲
+   ;;
+   ;; All middleware above this point is written in the synchronous 1-arg style. All middleware below is written in
+   ;; async 4-arg style. Eventually the entire QP middleware stack will be rewritten in the async style. But not yet
+   ;;
+   ;; TODO - `async-wait` should be moved way up the stack, at least after the DB is resolved, right now for nested
+   ;; queries it creates a thread pool for the nested query placeholder DB ID
+   ;;
+   ;; ▼▼▼ ASYNC MIDDLEWARE ▼▼▼
+   #'async/async->sync
+   #'async-wait/wait-for-turn
+   #'cache/maybe-return-cached-results
+   #'validate/validate-query
+   #'normalize/normalize
+   #'catch-exceptions/catch-exceptions
+   #'process-userland-query/process-userland-query
+   #'constraints/add-default-userland-constraints
+   #'async/async-setup])
 ;; ▲▲▲ PRE-PROCESSING ▲▲▲ happens from BOTTOM-TO-TOP, e.g. the results of `expand-macros` are passed to
 ;; `substitute-parameters`
+
+(defn- build-pipeline
+  "Construct a new Query Processor pipeline with `f` as the final 'piviotal' function. e.g.:
+
+    All PRE-PROCESSING (query) --> f --> All POST-PROCESSING (result)
+
+  Or another way of looking at it is
+
+    (post-process (f (pre-process query)))
+
+  Normally `f` is something that runs the query, like the `execute-query` function above, but this can be swapped out
+  when we want to do things like process a query without actually running it.
+
+  Normally the middleware is combined as if threading the underlying functions thru `->`, e.g.
+
+    ;; with pipeline [#'middleware-1 #'middleware-2]
+    (build-pipeline f) ; -> (middleware-2 (middleware-1 f))
+
+  However you can supply a custom `reducing-fn` to build modify various pieces of middleware as needed."
+  ([f]
+   (build-pipeline f (fn [qp middleware-var]
+                       ((var-get middleware-var) qp))))
+
+  ([f reducing-fn]
+   (reduce reducing-fn f pipeline)))
+
 
 (def ^:private ^{:arglists '([query])} preprocess
   "Run all the preprocessing steps on a query, returning it in the shape it looks immediately before it would normally
@@ -194,7 +225,7 @@
                 ;; everyone a favor and throw an Exception
                 (let [results (m/dissoc-in results [:query :results-promise])]
                   (throw (ex-info (str (tru "Error preprocessing query")) results)))))))]
-    (receive-native-query (qp-pipeline deliver-native-query))))
+    (receive-native-query (build-pipeline deliver-native-query))))
 
 (defn query->preprocessed
   "Return the fully preprocessed form for `query`, the way it would look immediately before `mbql->native` is called.
@@ -232,7 +263,10 @@
     (driver/splice-parameters-into-native-query driver
       (query->native query))))
 
-(def ^:private default-pipeline (qp-pipeline execute-query))
+(def ^:private default-pipeline (build-pipeline execute-query))
+
+(def ^:private debugging-pipeline
+  (build-pipeline execute-query debug/debug-middleware))
 
 (def ^:private QueryResponse
   (s/named
@@ -241,13 +275,19 @@
     {:status (s/enum :completed :failed :canceled), s/Any s/Any})
    "Valid query response (core.async channel or map with :status)"))
 
+(def ^:dynamic *debug*
+  "Bind this to `true` to print debugging messages when processing the query."
+  false)
+
 (s/defn process-query :- QueryResponse
   "Process an MBQL query. This is the main entrypoint to the magical realm of the Query Processor. Returns a
   core.async channel if option `:async?` is true; otherwise returns results in the usual format. For async queries, if
   the core.async channel is closed, the query will be canceled."
   {:style/indent 0}
   [query]
-  (default-pipeline query))
+  ((if *debug*
+     debugging-pipeline
+     default-pipeline) query))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/query_processor/debug.clj
+++ b/src/metabase/query_processor/debug.clj
@@ -1,0 +1,38 @@
+(ns metabase.query-processor.debug
+  "Functions for debugging QP code. Enable QP debugging by binding `qp/*debug*`; the `debug-middlewaer` function below
+  wraps each middleware function for debugging purposes."
+  (:require [clojure.data :as data]
+            [metabase.mbql.schema :as mbql.s]
+            [metabase.query-processor.middleware.mbql-to-native :as mbql-to-native]
+            [metabase.util :as u]
+            [schema.core :as s]))
+
+(defn debug-middleware
+  "Reducing function used to build the debugging QP pipeline. Bind `qp/*debug*` to use this.
+
+  This does a few things to make QP debugging easier:
+
+  *  Logs any changes in the query during preprocessing, along with the middleware that changed it
+  *  Validates the results of the query after each step against the MBQL schema."
+  [qp middleware-var]
+  (let [middleware      (var-get middleware-var)
+        middleware-name (:name (meta middleware-var))]
+    (fn
+      ([before-query & args]
+       (let [qp (^:once fn* [after-query & args]
+                 (when-not (= before-query after-query)
+                   (let [[only-in-before only-in-after] (data/diff before-query after-query)]
+                     (println "Middleware" (u/format-color 'yellow middleware-name) "modified query:\n"
+                              "before" (u/pprint-to-str 'blue before-query)
+                              "after " (u/pprint-to-str 'green after-query)
+                              (if only-in-before
+                                (str "only in before: " (u/pprint-to-str 'cyan only-in-before))
+                                "")
+                              (if only-in-after
+                                (str "only in after: " (u/pprint-to-str 'magenta only-in-after))
+                                "")))
+                   ;; mbql->native is allowed to have both a `:query` and a `:native` key for whatever reason
+                   (when-not (= middleware-var #'mbql-to-native/mbql->native)
+                     (s/validate mbql.s/Query after-query)))
+                 (apply qp after-query args))]
+         (apply (middleware qp) before-query args))))))

--- a/src/metabase/query_processor/middleware/add_implicit_clauses.clj
+++ b/src/metabase/query_processor/middleware/add_implicit_clauses.clj
@@ -1,6 +1,7 @@
 (ns metabase.query-processor.middleware.add-implicit-clauses
   "Middlware for adding an implicit `:fields` and `:order-by` clauses to certain queries."
-  (:require [honeysql.core :as hsql]
+  (:require [clojure.tools.logging :as log]
+            [honeysql.core :as hsql]
             [metabase
              [db :as mdb]
              [util :as u]]
@@ -8,9 +9,11 @@
              [schema :as mbql.s]
              [util :as mbql.u]]
             [metabase.models.field :refer [Field]]
-            [metabase.query-processor.store :as qp.store]
+            [metabase.query-processor
+             [interface :as qp.i]
+             [store :as qp.store]]
             [metabase.util
-             [i18n :refer [tru]]
+             [i18n :refer [trs tru]]
              [schema :as su]]
             [schema.core :as s]
             [toucan.db :as db]))
@@ -52,27 +55,44 @@
       [:datetime-field [:field-id (u/get-id field)] :default]
       [:field-id (u/get-id field)])))
 
+(s/defn ^:private source-metadata->fields :- [mbql.s/Field]
+  "Get implicit Fields for a query with a `:source-query` that has `source-metadata`."
+  [source-metadata :- (su/non-empty [mbql.s/SourceQueryMetadata])]
+  (for [{field-name :name, base-type :base_type} source-metadata]
+    [:field-literal field-name base-type]))
+
 
 (s/defn ^:private should-add-implicit-fields?
-  [{:keys [fields breakout source-table], aggregations :aggregation} :- mbql.s/MBQLQuery]
-  ;; if query is using another query as its source then there will be no table to add nested fields for
-  (and source-table
-       (not (or (seq aggregations)
-                (seq breakout)
-                (seq fields)))))
+  "Whether we should add implicit Fields to this query. True if all of the following are true:
 
-(s/defn ^:private add-implicit-fields :- mbql.s/Query
-  "For MBQL queries with no aggregation, add a `:fields` containing all Fields in the source Table as well as any
+  *  The query has either a `:source-table`, *or* a `:source-query` with `:source-metadata` for it
+  *  The query has no breakouts
+  *  The query has no aggregations"
+  [{:keys        [fields source-table source-query source-metadata]
+    breakouts    :breakout
+    aggregations :aggregation} :- mbql.s/MBQLQuery]
+  ;; if someone is trying to include an explicit `source-query` but isn't specifiying `source-metadata` warn that
+  ;; there's nothing we can do to help them
+  (when (and source-query (empty? source-metadata))
+    (when-not qp.i/*disable-qp-logging*
+      (log/warn
+       (trs "Warining: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."))))
+  ;; Determine whether we can add the implicit `:fields`
+  (and (or source-table
+           (and source-query (seq source-metadata)))
+       (every? empty? [aggregations breakouts fields])))
+
+(s/defn ^:private add-implicit-fields :- mbql.s/MBQLQuery
+  "For MBQL queries with no aggregation, add a `:fields` key containing all Fields in the source Table as well as any
   expressions definied in the query."
-  [{{source-table-id :source-table, :as inner-query} :query, :as query} :- mbql.s/Query]
+  [{source-table-id :source-table, :keys [expressions source-metadata], :as inner-query} :- mbql.s/MBQLQuery]
   (if-not (should-add-implicit-fields? inner-query)
-    query
-    ;; add a `fields-is-implict` key to the query, which is used to determine how Fields are sorted in the `sort`
-    ;; middleware.
-    (let [inner-query (assoc inner-query :fields-is-implicit true)
-          fields      (sorted-implicit-fields-for-table source-table-id)
+    inner-query
+    (let [fields      (if source-table-id
+                        (sorted-implicit-fields-for-table source-table-id)
+                        (source-metadata->fields source-metadata))
           ;; generate a new expression ref clause for each expression defined in the query.
-          expressions (for [[expression-name] (:expressions inner-query)]
+          expressions (for [[expression-name] expressions]
                         ;; TODO - we need to wrap this in `u/keyword->qualified-name` because `:expressions` uses
                         ;; keywords as keys. We can remove this call once we fix that.
                         [:expression (u/keyword->qualified-name expression-name)])]
@@ -81,40 +101,43 @@
         (throw (Exception. (str (tru "Table ''{0}'' has no Fields associated with it."
                                      (:name (qp.store/table source-table-id)))))))
       ;; add the fields & expressions under the `:fields` clause
-      (assoc-in query [:query :fields] (vec (concat fields expressions))))))
+      (assoc inner-query :fields (vec (concat fields expressions))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                        Add Implicit Breakout Order Bys                                         |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(s/defn ^:private add-implicit-breakout-order-by :- mbql.s/Query
+(s/defn ^:private add-implicit-breakout-order-by :- mbql.s/MBQLQuery
   "Fields specified in `breakout` should add an implicit ascending `order-by` subclause *unless* that Field is already
   *explicitly* referenced in `order-by`."
-  [{{breakouts :breakout} :query, :as query} :- mbql.s/Query]
+  [{breakouts :breakout, :as inner-query} :- mbql.s/MBQLQuery]
   ;; Add a new [:asc <breakout-field>] clause for each breakout. The cool thing is `add-order-by-clause` will
   ;; automatically ignore new ones that are reference Fields already in the order-by clause
-  (reduce mbql.u/add-order-by-clause query (for [breakout breakouts]
-                                             [:asc breakout])))
+  (reduce mbql.u/add-order-by-clause inner-query (for [breakout breakouts]
+                                                   [:asc breakout])))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                   Middleware                                                   |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(s/defn ^:private add-implicit-mbql-clauses :- mbql.s/Query
-  [{{:keys [source-query]} :query, :as query} :- mbql.s/Query]
-  (cond-> (-> query add-implicit-breakout-order-by add-implicit-fields)
-    ;; if query has an MBQL source query recursively add implicit clauses to that too as needed
-    (and source-query (not (:native source-query)))
-    (update-in [:query :source-query] (fn [source-query]
-                                        (:query (add-implicit-mbql-clauses
-                                                 (assoc query :query source-query)))))))
+(s/defn add-implicit-mbql-clauses :- mbql.s/MBQLQuery
+  "Add implicit clauses such as `:fields` and `:order-by` to an 'inner' MBQL query as needed."
+  [{:keys [source-query], :as inner-query} :- mbql.s/MBQLQuery]
+  (let [mbql-source-query? (and source-query (not (:native source-query)))
+        inner-query        (-> inner-query add-implicit-breakout-order-by add-implicit-fields)]
+    (if mbql-source-query?
+      ;; if query has an MBQL source query recursively add implicit clauses to that too as needed
+      (update inner-query :source-query add-implicit-mbql-clauses)
+      ;; otherwise we're done
+      inner-query)))
 
 (defn- maybe-add-implicit-clauses
   [{query-type :type, :as query}]
-  (cond-> query
-    (= query-type :query) add-implicit-mbql-clauses))
+  (if (= query-type :native)
+    query
+    (update query :query add-implicit-mbql-clauses)))
 
 (defn add-implicit-clauses
   "Add an implicit `fields` clause to queries with no `:aggregation`, `breakout`, or explicit `:fields` clauses.

--- a/src/metabase/query_processor/middleware/add_implicit_joins.clj
+++ b/src/metabase/query_processor/middleware/add_implicit_joins.clj
@@ -1,6 +1,7 @@
 (ns metabase.query-processor.middleware.add-implicit-joins
   "Middleware that creates corresponding `:joins` for Tables referred to by `:fk->` clauses and replaces those clauses
   with `:joined-field` clauses."
+  (:refer-clojure :exclude [alias])
   (:require [metabase
              [db :as mdb]
              [driver :as driver]
@@ -18,182 +19,219 @@
             [schema.core :as s]
             [toucan.db :as db]))
 
-(defn- both-args-are-field-id-clauses? [[_ x y]]
-  (and
-   (mbql.u/is-clause? :field-id x)
-   (mbql.u/is-clause? :field-id y)))
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                              Resolving Join Info                                               |
+;;; +----------------------------------------------------------------------------------------------------------------+
 
-(def ^:private FKClauseWithFieldIDArgs
-  (s/constrained mbql.s/fk-> both-args-are-field-id-clauses? "fk-> clause where both args are field-id clauses"))
+(def ^:private JoinInfo
+  {:fk-id      su/IntGreaterThanZero
+   :fk-name    su/NonBlankString
+   :pk-id      su/IntGreaterThanZero
+   :table-id   su/IntGreaterThanZero
+   :table-name su/NonBlankString
+   :alias      su/NonBlankString})
 
+(defn- join-alias [dest-table-name source-fk-field-name]
+  (apply str (take 30 (str dest-table-name "__via__" source-fk-field-name))))
 
-;;; ------------------------------------------------ Fetching PK Info ------------------------------------------------
-
-(def ^:private PKInfo
-  {:fk-id    su/IntGreaterThanZero
-   :pk-id    su/IntGreaterThanZero
-   :table-id su/IntGreaterThanZero})
-
-(s/defn ^:private fk-clauses->pk-info :- [PKInfo]
-  "Given a `source-table-id` and collection of `fk-field-ids`, return a sequence of maps containing IDs and identifiers
-  for those FK fields and their target tables and fields. `fk-field-ids` are IDs of fields that belong to the source
-  table. For example, `source-table-id` might be 'checkins' and `fk-field-ids` might have the IDs for 'checkins.user_id'
-  and the like."
-  [source-table-id :- su/IntGreaterThanZero, fk-clauses :- [FKClauseWithFieldIDArgs]]
-  (let [fk-field-ids (set (for [[_ [_ source-id]] fk-clauses]
-                            source-id))]
-    (when (seq fk-field-ids)
-      (db/query {:select    [[:source-fk.id    :fk-id]
-                             [:target-pk.id    :pk-id]
-                             [:target-table.id :table-id]]
-                 :from      [[Field :source-fk]]
-                 :left-join [[Field :target-pk]    [:= :source-fk.fk_target_field_id :target-pk.id]
-                             [Table :target-table] [:= :target-pk.table_id :target-table.id]]
-                 :where     [:and
-                             [:in :source-fk.id (set fk-field-ids)]
-                             [:=  :source-fk.table_id source-table-id]
-                             (mdb/isa :source-fk.special_type :type/FK)]}))))
-
-
-;;; -------------------------------- Fetching join Tables & adding them to the Store  --------------------------------
-
-(s/defn ^:private fks->dest-table-ids :- #{su/IntGreaterThanZero}
-  [fk-clauses :- [FKClauseWithFieldIDArgs]]
-  (set (for [[_ _ [_ dest-id]] fk-clauses]
-         (:table_id (qp.store/field dest-id)))))
-
-(s/defn ^:private store-join-tables! [fk-clauses :- [FKClauseWithFieldIDArgs]]
-  (let [table-ids-to-fetch (fks->dest-table-ids fk-clauses)]
-    (when (seq table-ids-to-fetch)
-      (doseq [table (db/select (into [Table] qp.store/table-columns-to-fetch)
-                      :db_id (u/get-id (qp.store/database))
-                      :id    [:in table-ids-to-fetch])]
-        (qp.store/store-table! table)))))
+(s/defn ^:private fk-ids->join-infos :- (s/maybe [JoinInfo])
+  "Given `fk-field-ids`, return a sequence of maps containing IDs and and other info needed to generate corresponding
+  `joined-field` and `:joins` clauses."
+  [fk-field-ids]
+  (when (seq fk-field-ids)
+    (let [infos (db/query {:select    [[:source-fk.id    :fk-id]
+                                       [:source-fk.name  :fk-name]
+                                       [:target-pk.id    :pk-id]
+                                       [:target-table.id :table-id]
+                                       [:target-table.name :table-name]]
+                           :from      [[Field :source-fk]]
+                           :left-join [[Field :target-pk]    [:= :source-fk.fk_target_field_id :target-pk.id]
+                                       [Table :target-table] [:= :target-pk.table_id :target-table.id]]
+                           :where     [:and
+                                       [:in :source-fk.id (set fk-field-ids)]
+                                       [:= :target-table.db_id (u/get-id (qp.store/database))]
+                                       #_(if source-table-id
+                                           [:= :source-fk.table_id source-table-id]
+                                           true)
+                                       (mdb/isa :source-fk.special_type :type/FK)]})]
+      (for [{:keys [fk-name table-name], :as info} infos]
+        (assoc info :alias (join-alias table-name fk-name))))))
 
 
-;;; ------------------------------------ Adding join Table PK fields to the Store ------------------------------------
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                         Building the matching-info fn                                          |
+;;; +----------------------------------------------------------------------------------------------------------------+
 
-(s/defn ^:private store-join-table-pk-fields!
-  [pk-info :- [PKInfo]]
-  (let [pk-field-ids (set (map :pk-id pk-info))
-        pk-fields    (when (seq pk-field-ids)
-                       (db/select (into [Field] qp.store/field-columns-to-fetch) :id [:in pk-field-ids]))]
-    (doseq [field pk-fields]
-      (qp.store/store-field! field))))
+(defn- query->fk-clause-ids [query]
+  (let [ids (mbql.u/match query
+              [:fk-> fk dest]
+              [(mbql.u/field-clause->id-or-literal fk) (mbql.u/field-clause->id-or-literal dest)])]
+    {:fk-ids   (filter integer? (map first  ids))
+     :dest-ids (filter integer? (map second ids))}))
 
+(defn- dest-ids->dest-id->table-id
+  "Given a sequence of `dest-ids` (the IDs of Destination Fields in `fk->` clauses), return a map of `dest-id` -> its
+  `table-id`."
+  [dest-ids]
+  (when (seq dest-ids)
+    (let [results     (db/query {:select    [[:field.id :id] [:field.table_id :table]]
+                                 :from      [[Field :field]]
+                                 :left-join [[Table :table] [:= :field.table_id :table.id]]
+                                 :where     [:and
+                                             [:in :field.id (set dest-ids)]
+                                             [:= :table.db_id (u/get-id (qp.store/database))]]})
+          dest->table (zipmap (map :id results) (map :table results))]
+      ;; validate that all our Fields are in the map
+      (doseq [dest-id dest-ids]
+        (when-not (get dest->table dest-id)
+          (throw
+           (ex-info (str (tru "Cannot resolve {0}: Field does not exist, or its Table belongs to a different Database."
+                              [:fk '_ dest-id]))
+             {:dest-id dest-id}))))
+      ;; ok, we're good to go
+      dest->table)))
 
-;;; ---------------------------------------- Resolving Join Alias & Condition ----------------------------------------
+(defn- fields->ids [dest-id->table-id fk-field dest-field]
+  (let [fk-id         (mbql.u/field-clause->id-or-literal fk-field)
+        dest-id       (mbql.u/field-clause->id-or-literal dest-field)
+        dest-table-id (dest-id->table-id dest-id)]
+    (assert (and (integer? fk-id) (integer? dest-id))
+      (str (tru "Cannot resolve :field-literal inside :fk-> unless inside join with explicit :alias.")))
+    (assert dest-table-id
+      (str (tru "Cannot find Table ID for {0}" dest-field)))
+    {:fk-id fk-id, :dest-id dest-id, :dest-table-id dest-table-id}))
 
-(def ^:private ResolvedJoinInfo
-  {:fk-clause    FKClauseWithFieldIDArgs
-   :source-table su/IntGreaterThanZero
-   :alias        su/NonBlankString
-   :fk-field-id  su/IntGreaterThanZero
-   :pk-field-id  su/IntGreaterThanZero})
+(defn- matching-info* [infos dest-id->table-id fk-field dest-field]
+  (let [{:keys [fk-id dest-id dest-table-id]} (fields->ids dest-id->table-id fk-field dest-field)]
+    (or
+     (some
+      (fn [{an-fk-id :fk-id, a-table-id :table-id, :as info}]
+        (when (and (= fk-id an-fk-id)
+                   (= dest-table-id a-table-id))
+          info))
+      infos)
+     (throw
+      (ex-info (str (tru "No matching info found."))
+        {:fk-id fk-id, :dest-id dest-id, :dest-table-id dest-table-id})))))
 
-(s/defn ^:private resolve-one-join-info :- ResolvedJoinInfo
-  [[_ [_ source-id] [_ dest-id] :as fk-clause] :- FKClauseWithFieldIDArgs, pk-info :- [PKInfo]]
-  (let [source-field (qp.store/field source-id)
-        dest-field   (qp.store/field dest-id)
-        table-id     (:table_id dest-field)
-        table        (qp.store/table table-id)
-        pk-id        (some (fn [info]
-                             (when (and (= (:table-id info) table-id)
-                                        (= (:fk-id info) source-id))
-                               (:pk-id info)))
-                           pk-info)
-        ;; some DBs like Oracle limit the length of identifiers to 30 characters so only take the first 30 here
-        alias        (apply str (take 30 (str (:name table) "__via__" (:name source-field))))]
-    {:fk-clause    fk-clause
-     :source-table table-id
-     :alias        alias
-     :fk-field-id  source-id
-     :pk-field-id  pk-id}))
-
-(s/defn ^:private resolve-join-info :- [ResolvedJoinInfo]
-  [fk-clauses :- [FKClauseWithFieldIDArgs], pk-info :- [PKInfo]]
-  (distinct
-   (for [clause (distinct fk-clauses)]
-     (resolve-one-join-info clause pk-info))))
-
-
-;;; ------------------------------------------- Adding :joins to the query -------------------------------------------
-
-(s/defn ^:private resolved-join-info->join-clause :- mbql.s/Join
-  [{:keys [source-table alias fk-field-id pk-field-id]} :- ResolvedJoinInfo]
-  {:source-table source-table
-   :alias        alias
-   :strategy     :left-join
-   :condition    [:= [:field-id fk-field-id] [:joined-field alias [:field-id pk-field-id]]]
-
-   :fk-field-id fk-field-id
-   :fields      :none})
-
-(s/defn ^:private add-implicit-join-clauses :- mbql.s/Query
-  [query, resolved-join-infos :- [ResolvedJoinInfo]]
-  (let [join-clauses (map resolved-join-info->join-clause resolved-join-infos)]
-    (update-in query [:query :joins] (comp distinct concat) join-clauses)))
-
-
-;;; --------------------------------------------- Replacing fk-> clauses ---------------------------------------------
-
-(s/defn ^:private matching-resolved-info :- ResolvedJoinInfo
-  [query-fk-clause :- mbql.s/fk->, resolved-join-info :- [ResolvedJoinInfo]]
-  (or (some
-       (fn [{info-fk-clause :fk-clause, :as info}]
-         (when (= query-fk-clause info-fk-clause)
-           info))
-       resolved-join-info)
-      (throw (Exception. (str (tru "Did not find match for {0} in resolved info." query-fk-clause))))))
-
-(s/defn ^:private replace-fk-clauses :- mbql.s/Query
-  [query, resolved-join-info :- [ResolvedJoinInfo]]
-  (mbql.u/replace-in query [:query]
-    [:fk-> _ [_ dest-id]] (let [{:keys [alias]} (matching-resolved-info &match resolved-join-info)]
-                            [:joined-field alias [:field-id dest-id]])))
+(defn- matching-info-fn
+  "Given a `query`, return a function that takes the `fk-field` and `dest-field` from an `fk->` clause and returns the
+  corresponding `JoinInfo` for the clause, if any."
+  [query]
+  (let [{:keys [fk-ids dest-ids]} (query->fk-clause-ids query)
+        infos                     (fk-ids->join-infos fk-ids)
+        dest-id->table-id         (dest-ids->dest-id->table-id dest-ids)
+        matching-info             (partial matching-info* infos dest-id->table-id)]
+    (fn [fk-field dest-field]
+      (try
+        (matching-info fk-field dest-field)
+        ;; add a bunch of info to any Exceptions that get thrown here, useful for debugging things that go wrong
+        (catch Exception e
+          (throw
+           (ex-info (str (tru "Could not resolve {0}" [:fk-> fk-field dest-field]))
+             {:clause                           [:fk-> fk-field dest-field]
+              :resolved-info                    infos
+              :resolved-dest-field-id->table-id dest-id->table-id}
+             e)))))))
 
 
-;;; -------------------------------------------- PUTTING it all together ---------------------------------------------
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                         Converting fk-> :joined-field                                          |
+;;; +----------------------------------------------------------------------------------------------------------------+
 
-(defn- add-implicit-joins-in-top-level-query
-  "Resolve JOINs at the top-level of the query."
-  [{mbql-query :query, :as query}]
-  ;; find fk-> clauses in the query AT THE TOP LEVEL
-  (let [fk-clauses      (mbql.u/match (dissoc mbql-query :source-query) [:fk-> [:field-id _] [:field-id _]])
-        source-table-id (mbql.u/query->source-table-id query)]
-    ;; if there are none, or `source-table` isn't resolved for some reason or another (which we need in order to fetch
-    ;; FK info), return query as-is
-    (if-not (and (seq fk-clauses) source-table-id)
-      query
-      ;; otherwise fetch PK info, add relevant Tables & Fields to QP store, and add the `:join-tables` key to the query
-      (let [pk-info (fk-clauses->pk-info source-table-id fk-clauses)]
-        (store-join-tables! fk-clauses)
-        (store-join-table-pk-fields! pk-info)
-        (let [resolved-join-info (resolve-join-info fk-clauses pk-info)]
-          (-> query
-              (add-implicit-join-clauses resolved-join-info)
-              (replace-fk-clauses resolved-join-info)))))))
+(s/defn ^:private resolve-fk :- mbql.s/joined-field
+  "Resolve a single `fk->` clause, returning a `:joined-field` clause to replace it, and adding a new join entry if
+  appropriate."
+  [{:keys [matching-info current-alias add-join!]} [_ source-field dest-field, :as fk-clause]]
+  (if current-alias
+    [:joined-field current-alias dest-field]
+    (let [{:keys [alias], :as info} (matching-info source-field dest-field)]
+      (add-join! info)
+      [:joined-field alias dest-field])))
 
-(defn- add-implicit-joins-in-query-all-levels
-  "Resolve JOINs at all levels of the query, including the top level and nested queries at any level of nesting."
-  [{{source-query :source-query} :query, :as query}]
-  ;; first, resolve JOINs for the top-level
-  (let [query                          (add-implicit-joins-in-top-level-query query)
-        ;; then recursively resolve JOINs for any nested queries by pulling the query up a level and then getting the
-        ;; result
-        {resolved-source-query :query} (when source-query
-                                         (add-implicit-joins-in-query-all-levels (assoc query :query source-query)))]
-    ;; finally, merge the resolved source-query into the top-level query as appropriate
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                               Generating :joins                                                |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(s/defn ^:private add-joins :- mbql.s/MBQLQuery
+  "Add `:joins` to a `query` by converting `join-infos` to the appropriate format."
+  [query, join-infos :- [JoinInfo]]
+  (let [joins (distinct
+               (for [{:keys [fk-id pk-id table-id alias]} join-infos]
+                 {:source-table table-id
+                  :alias        alias
+                  :fields       :none
+                  :strategy     :left-join
+                  :fk-field-id  fk-id
+                  :condition    [:= [:field-id fk-id] [:joined-field alias [:field-id pk-id]]]}))]
     (cond-> query
-      resolved-source-query (assoc-in [:query :source-query] resolved-source-query))))
+      (seq joins) (update :joins #(mbql.u/deduplicate-join-aliases (concat % joins))))))
 
-(defn- add-implicit-joins* [{query-type :type, :as query}]
-  ;; if this is a native query, or if `driver/*driver*` is bound *and* it DOES NOT support `:foreign-keys`, return
-  ;; query as is. Otherwise add implicit joins for `fk->` clauses
-  (if (or (= query-type :native)
-          (some-> driver/*driver* ((complement driver/supports?) :foreign-keys)))
-    query
-    (add-implicit-joins-in-query-all-levels query)))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                          Transforming the whole query                                          |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defn- can-add-joins-here? [m]
+  (and (map? m)
+       ((some-fn :source-table :source-query) m)
+       (not (:condition m))))
+
+(defn- join? [m]
+  (and (map? m)
+       (every? m [:condition :alias])))
+
+(defn- default-context [query]
+  {:matching-info (matching-info-fn query)
+   :current-alias nil
+   :add-join!     (fn [join-info]
+                    (throw (ex-info (str (tru "Invalid fk-> clause: nowhere to add corresponding join."))
+                             {:join-info join-info})))})
+
+(declare resolve-fk-clauses)
+
+(defn- recursive-resolve [form context]
+  (-> (assoc form ::recursive? true)
+      (resolve-fk-clauses context)
+      (dissoc form ::recursive?)))
+
+(s/defn ^:private resolve-fk-clauses
+  "Resolve all `fk->` clauses in `query`. The basic idea is to recurse thru the query the usual way, using
+  `mbql.u/replace`, keeping a little bit of state"
+  ([query :- mbql.s/MBQLQuery]
+   (resolve-fk-clauses query (default-context query)))
+
+  ([form context]
+   (mbql.u/replace form
+     (query :guard (every-pred can-add-joins-here? (complement ::recursive?)))
+     (let [joins     (atom [])
+           add-join! (partial swap! joins conj)]
+       (-> (recursive-resolve query (assoc context :add-join! add-join!))
+           (add-joins @joins)))
+
+     ;; join with an alias
+     (join-clause :guard (every-pred join? (complement ::recursive?)))
+     (recursive-resolve join-clause (assoc context :current-alias (:alias join-clause)))
+
+     :fk->
+     (resolve-fk context &match))))
+
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                                   Middleware                                                   |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defn- add-implicit-joins* [query]
+  (if (mbql.u/match-one (:query query) :fk->)
+    (do
+      (when-not (driver/supports? driver/*driver* :foreign-keys)
+        (throw (ex-info (str (tru "{0} driver does not support foreign keys." driver/*driver*))
+                 {:driver driver/*driver*})))
+      (update query :query resolve-fk-clauses))
+    query))
+
+
 
 (defn add-implicit-joins
   "Fetch and store any Tables other than the source Table referred to by `fk->` clauses in an MBQL query, and add a

--- a/src/metabase/query_processor/middleware/add_source_metadata.clj
+++ b/src/metabase/query_processor/middleware/add_source_metadata.clj
@@ -1,0 +1,135 @@
+(ns metabase.query-processor.middleware.add-source-metadata
+  (:require [clojure.tools.logging :as log]
+            [clojure.walk :as walk]
+            [metabase.mbql
+             [schema :as mbql.s]
+             [util :as mbql.u]]
+            [metabase.query-processor
+             [interface :as qp.i]
+             [store :as qp.store]]
+            [metabase.query-processor.middleware
+             [add-implicit-clauses :as add-implicit-clauses]
+             [annotate :as annotate]]
+            [metabase.util.i18n :refer [trs]]
+            [schema.core :as s]))
+
+(s/defn ^:private mbql-source-query->metadata :- [mbql.s/SourceQueryMetadata]
+  [{breakouts    :breakout
+    aggregations :aggregation
+    fields       :fields
+    :as          source-query} :- mbql.s/SourceQuery]
+  (let [field-ids (mbql.u/match (concat breakouts aggregations fields) [:field-id id] id)]
+    (qp.store/fetch-and-store-fields! field-ids))
+  (for [col (annotate/cols-for-mbql-query source-query)]
+    (select-keys col [:name :id :table_id :display_name :base_type :special_type :unit :fingerprint])))
+
+(defn- has-same-fields-as-nested-source?
+  "Whether this source query itself has a nested source query, and will have the exact same fields in the results as its
+  nested source. If this is the case, we can return the `source-metadata` for the nested source as-is, if it is
+  present."
+  [{nested-source-query    :source-query
+    nested-source-metadata :source-metadata
+    breakouts              :breakout
+    aggregations           :aggregation
+    fields                 :fields}]
+  (when nested-source-query
+    (and (every? empty? [breakouts aggregations])
+         (or (empty? fields)
+             (and (= (count fields) (count nested-source-metadata))
+                  (every? #(mbql.u/is-clause? :field-literal (mbql.u/unwrap-field-clause %)) fields))))))
+
+(defn- can-determine-fields?
+  "Whether we can determine the Fields that will come back in the results because at least one of `:breakout`,
+  `:aggregation`, and/or `:fields` is present.
+
+  When one or more of these is present, the QP will always return `breakouts + aggreagtions + fields`; if none are
+  present, QP implementations fall back to the equivalent of `SELECT *`. Because we're calling
+  `add-implicit-clauses/add-implicit-mbql-clauses` on the source query below, `:fields` should get added automatically
+  to any MBQL source query or to any native source query with source metadata. Thus this should be true for every case
+  except for native source queries with no source metadata, e.g.
+
+    {:source-query {:native \"SELECT *\"}}"
+  [{breakouts :breakout, aggregations :aggregation, fields :fields}]
+  (some seq [breakouts aggregations fields]))
+
+(s/defn ^:private source-query->metadata :- (s/maybe [mbql.s/SourceQueryMetadata])
+  "Given a `source-query`, return the source metadata that should be added at the parent level (i.e., at the same
+  level where this `source-query` was present.) This metadata is used by other middleware to determine what Fields to
+  expect from the source query."
+  [{nested-source-metadata :source-metadata, :as source-query} :- mbql.s/SourceQuery]
+  (cond
+    ;; If the source query has a nested source with metadata and does not change the fields that come back, return
+    ;; metadata as-is
+    (has-same-fields-as-nested-source? source-query)
+    nested-source-metadata
+    ;;
+    ;; otherwise if this query has at least one of `:breakout`, `:aggregation`, or `:fields`, the results are
+    ;; determinate and we can generate appropriate metadata about the Fields that we can expect in the results
+    (can-determine-fields? source-query)
+    (mbql-source-query->metadata source-query)
+    ;;
+    ;; Otherwise we cannot determine the metadata automatically; usually, this is because the source query itself
+    ;; has a native source query
+    :else
+    (do
+      (when-not qp.i/*disable-qp-logging*
+        (log/warn
+         (trs "Cannot infer `:source-metadata` for source query with native source query without source metadata.")
+         {:source-query source-query}))
+      nil)))
+
+(s/defn ^:private add-source-metadata :- {:source-metadata [mbql.s/SourceQueryMetadata], s/Keyword s/Any}
+  [{{native-source-query? :native, :as source-query} :source-query, :as inner-query}]
+  (let [source-query (if native-source-query?
+                       source-query
+                       (add-implicit-clauses/add-implicit-mbql-clauses source-query))
+        metadata     (source-query->metadata source-query)]
+    (assoc inner-query :source-metadata metadata)))
+
+(defn- can-add-source-metadata?
+  "Can we add `:source-metadata` about the `:source-query` in this map? True if all of the following are true:
+
+  *  The map (e.g. an 'inner' MBQL query or a Join) has a `:source-query`
+  *  The `:source-query` is an MBQL query, or a native source query with `:source-metadata`"
+  [{{native-source-query?              :native
+     source-query-has-source-metadata? :source-metadata
+     :as                               source-query} :source-query
+    :keys                                            [source-metadata]}]
+  (and source-query
+       (not source-metadata)
+       (or (not native-source-query?)
+           source-query-has-source-metadata?)))
+
+(defn- add-source-metadata-at-all-levels [inner-query]
+  (walk/postwalk
+   #(if-not ((every-pred map? can-add-source-metadata?) %)
+      %
+      (add-source-metadata %))
+   inner-query))
+
+(defn- add-source-metadata-for-source-queries* [{query-type :type, :as query}]
+  (if-not (= query-type :query)
+    query
+    (update query :query add-source-metadata-at-all-levels)))
+
+(defn add-source-metadata-for-source-queries
+  "Middleware that attempts to recursively add `:source-metadata`, if not already present, to any maps with a
+  `:source-query`.
+
+  `:source-metadata` is information about the columns we can expect to come back from the source
+  query; this is added automatically for source queries added via the `card__id` source table form, but for *explicit*
+  source queries that do not specify this information, we can often infer it by looking at the shape of the source
+  query."
+  [qp]
+  ;; this middleware works as both sync and async style to make our lives easier when we convert the QP to full async
+  (fn
+    ([query]
+     (qp (add-source-metadata-for-source-queries* query)))
+
+    ([query respond raise canceled-chan]
+     (when-let [query (try
+                        (add-source-metadata-for-source-queries* query)
+                        (catch Throwable e
+                          (raise e)
+                          nil))]
+       (qp query respond raise canceled-chan)))))

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -63,7 +63,7 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (s/defn ^:private join-with-alias :- (s/maybe mbql.s/Join)
-  [{{:keys [joins]} :query} :- su/Map, join-alias :- su/NonBlankString]
+  [{:keys [joins]} :- su/Map, join-alias :- su/NonBlankString]
   (some
    (fn [{:keys [alias], :as join}]
      (when (= alias join-alias)
@@ -73,25 +73,25 @@
 ;;; --------------------------------------------------- Field Info ---------------------------------------------------
 
 (s/defn ^:private col-info-for-field-clause :- su/Map
-  [query :- su/Map, clause :- mbql.s/Field]
+  [inner-query :- su/Map, clause :- mbql.s/Field]
   ;; for various things that can wrap Field clauses recurse on the wrapped Field but include a little bit of info
   ;; about the clause doing the wrapping
   (mbql.u/match-one clause
     [:binning-strategy field strategy _ resolved-options]
-    (assoc (col-info-for-field-clause query field)
+    (assoc (col-info-for-field-clause inner-query field)
       :binning_info (assoc (u/snake-keys resolved-options)
                       :binning_strategy strategy))
 
     [:datetime-field field unit]
-    (assoc (col-info-for-field-clause query field) :unit unit)
+    (assoc (col-info-for-field-clause inner-query field) :unit unit)
 
     [:joined-field alias field]
-    (let [{:keys [fk-field-id]} (join-with-alias query alias)]
-      (assoc (col-info-for-field-clause query field) :fk_field_id fk-field-id))
+    (let [{:keys [fk-field-id]} (join-with-alias inner-query alias)]
+      (assoc (col-info-for-field-clause inner-query field) :fk_field_id fk-field-id))
 
     ;; TODO - should be able to remove this now
     [:fk-> [:field-id source-field-id] field]
-    (assoc (col-info-for-field-clause query field) :fk_field_id source-field-id)
+    (assoc (col-info-for-field-clause inner-query field) :fk_field_id source-field-id)
 
     ;; TODO - should be able to remove this now
     ;; for FKs where source is a :field-literal don't include `:fk_field_id`
@@ -115,12 +115,13 @@
     (let [{parent-id :parent_id, :as field} (dissoc (qp.store/field id) :database_type)]
       (if-not parent-id
         field
-        (let [parent (col-info-for-field-clause query [:field-id parent-id])]
+        (let [parent (col-info-for-field-clause inner-query [:field-id parent-id])]
           (update field :name #(str (:name parent) \. %)))))
 
     ;; we should never reach this if our patterns are written right so this is more to catch code mistakes than
     ;; something the user should expect to see
-    _ (throw (Exception. (str (tru "Don't know how to get information about Field:") " " &match)))))
+    _ (throw (ex-info (str (tru "Don't know how to get information about Field:") " " &match)
+               {:field &match}))))
 
 
 ;;; ---------------------------------------------- Aggregate Field Info ----------------------------------------------
@@ -190,19 +191,19 @@
   "Return appropriate column metadata for an `:aggregation` clause."
   ; `clause` is normally an aggregation clause but this function can call itself recursively; see comments by the
   ; `match` pattern for field clauses below
-  [query :- su/Map, clause]
+  [inner-query :- su/Map, clause]
   (mbql.u/match-one clause
     ;; ok, if this is a named aggregation recurse so we can get information about the ag we are naming
     [:named ag _]
     (merge
-     (col-info-for-aggregation-clause query ag)
+     (col-info-for-aggregation-clause inner-query ag)
      (ag->name-info &match))
 
     ;; Always treat count or distinct count as an integer even if the DB in question returns it as something
     ;; wacky like a BigDecimal or Float
     [(_ :guard #{:count :distinct}) & args]
     (merge
-     (col-info-for-aggregation-clause query args)
+     (col-info-for-aggregation-clause inner-query args)
      {:base_type    :type/Integer
       :special_type :type/Number}
      (ag->name-info &match))
@@ -223,7 +224,7 @@
     ;; get info from a Field if we can (theses Fields are matched when ag clauses recursively call
     ;; `col-info-for-ag-clause`, and this info is added into the results)
     (_ :guard mbql.preds/Field?)
-    (select-keys (col-info-for-field-clause query &match) [:base_type :special_type :settings])
+    (select-keys (col-info-for-field-clause inner-query &match) [:base_type :special_type :settings])
 
     ;; For the time being every Expression is an arithmetic operator and returns a floating-point number, so
     ;; hardcoding these types is fine; In the future when we extend Expressions to handle more functionality
@@ -239,14 +240,14 @@
     ;; get name/display-name of this ag
     [(_ :guard keyword?) arg & args]
     (merge
-     (col-info-for-aggregation-clause query arg)
+     (col-info-for-aggregation-clause inner-query arg)
      (ag->name-info &match))))
 
 
 ;;; ----------------------------------------- Putting it all together (MBQL) -----------------------------------------
 
-(defn- check-correct-number-of-columns-returned [mbql-cols results]
-  (let [expected-count (count mbql-cols)
+(defn- check-correct-number-of-columns-returned [returned-mbql-columns results]
+  (let [expected-count (count returned-mbql-columns)
         actual-count   (count (:columns results))]
     (when (seq (:rows results))
       (when-not (= expected-count actual-count)
@@ -256,40 +257,63 @@
                " "
                (tru "Expected {0} fields, got {1}" expected-count actual-count)
                "\n"
-               (tru "Expected: {0}" (mapv :name mbql-cols))
+               (tru "Expected: {0}" (mapv :name returned-mbql-columns))
                "\n"
                (tru "Actual: {0}" (vec (:columns results))))))))))
 
 (s/defn ^:private cols-for-fields
-  [{{fields-clause :fields} :query, :as query} :- su/Map]
-  (for [field fields-clause]
-    (assoc (col-info-for-field-clause query field) :source :fields)))
+  [{:keys [fields], :as inner-query} :- su/Map]
+  (for [field fields]
+    (assoc (col-info-for-field-clause inner-query field) :source :fields)))
 
 (s/defn ^:private cols-for-ags-and-breakouts
-  [{{aggregations :aggregation, breakouts :breakout} :query, :as query} :- su/Map]
+  [{aggregations :aggregation, breakouts :breakout, :as inner-query} :- su/Map]
   (concat
    (for [breakout breakouts]
-     (assoc (col-info-for-field-clause query breakout) :source :breakout))
+     (assoc (col-info-for-field-clause inner-query breakout) :source :breakout))
    (for [aggregation aggregations]
-     (assoc (col-info-for-aggregation-clause query aggregation) :source :aggregation))))
+     (assoc (col-info-for-aggregation-clause inner-query aggregation) :source :aggregation))))
+
+(s/defn cols-for-mbql-query
+  "Return results metadata about the expected columns in an 'inner' MBQL query."
+  [inner-query :- su/Map]
+  (concat
+   (cols-for-ags-and-breakouts inner-query)
+   (cols-for-fields inner-query)))
 
 (declare mbql-cols)
 
-(defn- cols-for-source-query [{native-source-query :native, :as source-query} results]
-  (if native-source-query
-    (native-cols results)
-    (mbql-cols {:query source-query} results)))
+(defn- maybe-merge-source-metadata
+  "Merge information from `source-metadata` into the returned `cols` for queries that return the columns of a source
+  query as-is (i.e., the parent query does not have breakouts, aggregations, or an explicit`:fields` clause --
+  excluding the one added automatically by `add-source-metadata`)."
+  [source-metadata cols]
+  (if (= (count cols) (count source-metadata))
+    (map merge source-metadata cols)
+    cols))
 
-(defn- mbql-cols [{{:keys [source-query]} :query, :as query}, results]
-  (let [cols (concat
-              (cols-for-ags-and-breakouts query)
-              (cols-for-fields query))]
-    (if (and (empty? cols) source-query)
-      (cols-for-source-query source-query results)
+(defn- cols-for-source-query
+  [{:keys [source-metadata], {native-source-query :native, :as source-query} :source-query} results]
+  (if native-source-query
+    (maybe-merge-source-metadata source-metadata (native-cols results))
+    (mbql-cols source-query results)))
+
+(defn ^:private mbql-cols
+  "Return the `:cols` result metadata for an 'inner' MBQL query based on the fields/breakouts/aggregations in the query."
+  [{:keys [source-metadata source-query fields], :as inner-query} results]
+  (let [cols (cols-for-mbql-query inner-query)]
+    (cond
+      (and (empty? cols) source-query)
+      (cols-for-source-query inner-query results)
+
+      (every? (partial mbql.u/is-clause? :field-literal) fields)
+      (maybe-merge-source-metadata source-metadata cols)
+
+      :else
       cols)))
 
-(defn- add-mbql-column-info [query results]
-  (let [cols (mbql-cols query results)]
+(defn- add-mbql-column-info [{inner-query :query, :as query} results]
+  (let [cols (mbql-cols inner-query results)]
     (check-correct-number-of-columns-returned cols results)
     (assoc results :cols cols)))
 
@@ -343,14 +367,14 @@
 ;;; |                                     result-rows-maps-to-vectors middleware                                     |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(defn- uniquify-aggregations [query]
-  (update-in query [:query :aggregation] (partial mbql.u/pre-alias-and-uniquify-aggregations aggregation-name)))
+(defn- uniquify-aggregations [inner-query]
+  (update inner-query :aggregation (partial mbql.u/pre-alias-and-uniquify-aggregations aggregation-name)))
 
 (s/defn ^:private expected-column-sort-order :- [s/Keyword]
   "Determine query result row column names (as keywords) sorted in the appropriate order based on a `query`."
-  [{query-type :type, :as query} {[first-row] :rows, :as results}]
+  [{query-type :type, inner-query :query, :as query} {[first-row] :rows, :as results}]
   (if (= query-type :query)
-    (map (comp keyword :name) (mbql-cols (uniquify-aggregations query) results))
+    (map (comp keyword :name) (mbql-cols (uniquify-aggregations inner-query) results))
     (map keyword (keys first-row))))
 
 (defn- result-rows-maps->vectors* [query {[first-row :as rows] :rows, columns :columns, :as results}]

--- a/src/metabase/query_processor/middleware/binning.clj
+++ b/src/metabase/query_processor/middleware/binning.clj
@@ -48,7 +48,8 @@
                                                  (apply min user-maxes))
                                                global-max)]
     (when-not (and min-value max-value)
-      (throw (Exception. (str (tru "Unable to bin Field without a min/max value")))))
+      (throw (ex-info (str (tru "Unable to bin Field without a min/max value"))
+               {:field-id field-id, :fingerprint fingerprint})))
     {:min-value min-value, :max-value max-value}))
 
 
@@ -158,36 +159,57 @@
     :default
     (resolve-default-strategy metadata min-value max-value)))
 
+(defn- matching-metadata [field-id-or-name source-metadata]
+  (if (integer? field-id-or-name)
+    ;; for Field IDs, just fetch the Field from the Store
+    (qp.store/field field-id-or-name)
+    ;; for field literals, we require `source-metadata` from the source query
+    (do
+      ;; make sure source-metadata exists
+      (when-not source-metadata
+        (throw (ex-info (str (tru "Cannot update binned field: query is missing source-metadata"))
+                 {:field-literal field-id-or-name})))
+      ;; try to find field in source-metadata with matching name
+      (or
+       (some
+        (fn [metadata]
+          (when (= (:name metadata) field-id-or-name)
+            metadata))
+        source-metadata)
+       (throw (ex-info (str (tru "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
+                                 field-id-or-name))
+                {:field-literal field-id-or-name, :resolved-metadata source-metadata}))))))
+
 (s/defn ^:private update-binned-field :- mbql.s/binning-strategy
   "Given a `binning-strategy` clause, resolve the binning strategy (either provided or found if default is specified)
   and calculate the number of bins and bin width for this field. `field-id->filters` contains related criteria that
   could narrow the domain for the field. This info is saved as part of each `binning-strategy` clause."
-  [query, field-id->filters :- FieldID->Filters, [_ field-clause strategy strategy-param] :- mbql.s/binning-strategy]
+  [{:keys [source-metadata], :as inner-query}
+   field-id->filters                        :- FieldID->Filters
+   [_ field-clause strategy strategy-param] :- mbql.s/binning-strategy]
   (let [field-id-or-name                (mbql.u/field-clause->id-or-literal field-clause)
-        metadata                        (if (integer? field-id-or-name)
-                                          (qp.store/field field-id-or-name)
-                                          (some (fn [metadata]
-                                                  (when (= (:name metadata) field-id-or-name)
-                                                    metadata))
-                                                (:source-metadata query)))
+        metadata                        (matching-metadata field-id-or-name source-metadata)
         {:keys [min-value max-value]
          :as   min-max}                 (extract-bounds (when (integer? field-id-or-name) field-id-or-name)
-                                                        (:fingerprint metadata)
-                                                        field-id->filters)
+         (:fingerprint metadata)
+         field-id->filters)
         [new-strategy resolved-options] (resolve-options strategy strategy-param metadata min-value max-value)
-        resolved-options (merge min-max resolved-options)]
+        resolved-options                (merge min-max resolved-options)]
     ;; Bail out and use unmodifed version if we can't converge on a nice version.
     [:binning-strategy field-clause new-strategy strategy-param (or (nicer-breakout new-strategy resolved-options)
                                                                     resolved-options)]))
 
 
-(defn- update-binning-strategy* [{query-type :type, :as query}]
+(defn- update-binning-strategy* [{query-type :type, inner-query :query, :as query}]
   (if (= query-type :native)
     query
     (let [field-id->filters (filter->field-map (get-in query [:query :filter]))]
       (mbql.u/replace-in query [:query]
         :binning-strategy
-        (update-binned-field query field-id->filters &match)))))
+        (try
+          (update-binned-field inner-query field-id->filters &match)
+          (catch Throwable e
+            (throw (ex-info (.getMessage e) {:clause &match} e))))))))
 
 (defn update-binning-strategy
   "When a binned field is found, it might need to be updated if a relevant query criteria affects the min/max value of

--- a/src/metabase/query_processor/middleware/catch_exceptions.clj
+++ b/src/metabase/query_processor/middleware/catch_exceptions.clj
@@ -1,6 +1,7 @@
 (ns metabase.query-processor.middleware.catch-exceptions
   "Middleware for catching exceptions thrown by the query processor and returning them in a friendlier format."
-  (:require [metabase.util :as u]
+  (:require [metabase.query-processor.interface :as qp.i]
+            [metabase.util :as u]
             schema.utils)
   (:import clojure.lang.ExceptionInfo
            [schema.utils NamedError ValidationError]))
@@ -31,11 +32,16 @@
      ;; obviously we do not want to get core.async channels back for preprocessed & native, so run the preprocessing
      ;; steps synchronously
      (let [query (dissoc query :async?)]
-       (binding [*add-preprocessed-queries?* false]
+       (binding [*add-preprocessed-queries?* false
+                 qp.i/*disable-qp-logging*   true]
          {:preprocessed (u/ignore-exceptions
                           ((resolve 'metabase.query-processor/query->preprocessed) query))
           :native       (u/ignore-exceptions
-                          ((resolve 'metabase.query-processor/query->native) query))})))))
+                          ((resolve 'metabase.query-processor/query->native) query))})))
+   ;; if the Exception has a cause, add that in as well, because a lot of times we add relevant context to Exceptions
+   ;; and rethrow
+   (when-let [cause (.getCause e)]
+     {:cause (dissoc (format-exception nil cause) :status :query :stacktrace)})))
 
 
 (defn- explain-schema-validation-error

--- a/src/metabase/query_processor/middleware/fetch_source_query.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query.clj
@@ -1,21 +1,86 @@
 (ns metabase.query-processor.middleware.fetch-source-query
-  "Middleware responsible for 'hydrating' the source query for queries that use another query as their source."
+  "Middleware responsible for 'hydrating' the source query for queries that use another query as their source. This
+  middleware looks for MBQL queries like
+
+    {:source-table \"card__1\" ; Shorthand for using Card 1 as source query
+     ...}
+
+  and resolves the referenced source query, transforming the query to look like the following:
+
+    {:source-query    {...} ; Query for Card 1
+     :source-metadata [...] ; metadata about columns in Card 1
+     ...}
+
+  This middleware resolves Card ID `:source-table`s at all levels of the query, but the top-level query often uses the
+  so-called `virtual-id`, because the frontend client might not know the original Database; this middleware will
+  replace that ID with the approiate ID, e.g.
+
+    {:database <virtual-id>, :type :query, :query {:source-table \"card__1\"}}
+    ->
+    {:database 1, :type :query, :query {:source-query {...}, :source-metadata {...}}}
+
+  TODO - consider renaming this namespace to `metabase.query-processor.middleware.resolve-card-id-source-tables`"
   (:require [clojure.string :as str]
             [clojure.tools.logging :as log]
             [metabase.mbql
              [normalize :as normalize]
-             [schema :as mbql.s]]
+             [schema :as mbql.s]
+             [util :as mbql.u]]
+            [metabase.models.card :refer [Card]]
             [metabase.query-processor.interface :as i]
             [metabase.util :as u]
-            [metabase.util.i18n :refer [trs tru]]
+            [metabase.util
+             [i18n :refer [trs tru]]
+             [schema :as su]]
             [schema.core :as s]
             [toucan.db :as db]))
 
-(defn- trim-query
+;; These next two schemas are for validating the intermediate stages of the middleware. We don't need to validate the
+;; entire query
+(def ^:private SourceQueryAndMetadata
+  {:source-query    mbql.s/SourceQuery
+   :database        mbql.s/DatabaseID
+   :source-metadata [mbql.s/SourceQueryMetadata]})
+
+(def ^:private MapWithResolvedSourceQuery
+  (s/constrained
+   {:database        mbql.s/DatabaseID
+    :source-metadata [mbql.s/SourceQueryMetadata]
+    :source-query    mbql.s/SourceQuery
+    s/Keyword        s/Any}
+   (complement :source-table)
+   "`:source-table` should be removed"))
+
+(defn- query-has-unresolved-card-id-source-tables? [{inner-mbql-query :query}]
+  (when inner-mbql-query
+    (mbql.u/match-one inner-mbql-query
+      (&match :guard (every-pred map? (comp string? :source-table))))))
+
+(defn- query-has-resolved-database-id? [{:keys [database]}]
+  ((every-pred integer? pos?) database))
+
+(def ^:private FullyResolvedQuery
+  "Schema for a MBQL query where all `card__id` `:source-tables` have been removes and appropriate `:source-query`s have
+  been added instead, and where the top-level `:database` ID, if it was the 'source query placeholder`, is replaced by
+  the actual database ID of the source query.
+
+  This schema represents the way the query should look after this middleware finishes preprocessing it."
+  (-> mbql.s/Query
+      (s/constrained (complement query-has-unresolved-card-id-source-tables?)
+                     "Query where all card__id :source-tables are fully resolved")
+      (s/constrained query-has-resolved-database-id?
+                     "Query where source-query virtual `:database` has been replaced with actual Database ID")))
+
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                       Resolving card__id -> source query                                       |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(s/defn ^:private trim-query :- su/NonBlankString
   "Native queries can have trailing SQL comments. This works when executed directly, but when we use the query in a
   nested query, we wrap it in another query, which can cause the last part of the query to be unintentionally
   commented out, causing it to fail. This function removes any trailing SQL comment."
-  [card-id query-str]
+  [card-id :- su/IntGreaterThanZero, query-str :- su/NonBlankString]
   (let [trimmed-string (str/replace query-str #"--.*(\n|$)" "")]
     (if (= query-str trimmed-string)
       query-str
@@ -23,86 +88,143 @@
         (log/info (trs "Trimming trailing comment from card with id {0}" card-id))
         trimmed-string))))
 
-(defn- card-id->source-query
+(s/defn ^:private card-id->source-query-and-metadata :- SourceQueryAndMetadata
   "Return the source query info for Card with `card-id`."
-  [card-id]
-  (let [card       (db/select-one ['Card :dataset_query :database_id :result_metadata] :id card-id)
-        card-query (:dataset_query card)]
-    (assoc (or (:query card-query)
-               (when-let [native (:native card-query)]
-                 (merge
-                  {:native (trim-query card-id (:query native))}
-                  (when (seq (:template-tags native))
-                    {:template-tags (:template-tags native)})))
-               (throw (Exception. (str (tru "Missing source query in Card {0}" card-id)))))
-      ;; include database ID as well; we'll pass that up the chain so it eventually gets put in its spot in the
-      ;; outer-query
-      :database        (:database card-query)
-      :source-metadata (normalize/normalize-fragment [:source-metadata] (:result_metadata card)))))
+  [card-id :- su/IntGreaterThanZero]
+  (let [card
+        (or (db/select-one [Card :dataset_query :database_id :result_metadata] :id card-id)
+            (throw (ex-info (str (tru "Card {0} does not exist." card-id))
+                     {:card-id card-id})))
 
-(defn- source-table-str->source-query
-  "Given a `source-table-str` like `card__100` return the appropriate source query."
-  [source-table-str]
-  (let [[_ card-id-str] (re-find #"^card__(\d+)$" source-table-str)]
-    (u/prog1 (card-id->source-query (Integer/parseInt card-id-str))
-      (when-not i/*disable-qp-logging*
-        (log/info (trs "Fetched source query from Card {0}:" card-id-str)
-                  "\n"
-                  ;; No need to include result metadata here, it can be large and will clutter the logs
-                  (u/pprint-to-str 'yellow (dissoc <> :result_metadata)))))))
+        {{mbql-query                     :query
+          database-id                    :database
+          {native-query  :query,
+           template-tags :template-tags} :native} :dataset_query
+         result-metadata                          :result_metadata}
+        card
+
+        source-query
+        (or mbql-query
+            (when native-query
+              (cond-> {:native (trim-query card-id native-query)}
+                (seq template-tags) (assoc :template-tags template-tags)))
+            (throw (ex-info (str (tru "Missing source query in Card {0}" card-id))
+                     {:card card})))]
+    ;; log the query at this point, it's useful for some purposes
+    ;;
+    ;; TODO - it would be nicer if we could just have some sort of debug function to store useful bits of context
+    ;; somewhere, then if the query fails we can dump it all out
+    (when-not i/*disable-qp-logging*
+      (log/info (trs "Fetched source query from Card {0}:" card-id)
+                "\n"
+                (u/pprint-to-str 'yellow source-query)))
+    {:source-query    source-query
+     :database        database-id
+     :source-metadata (normalize/normalize-fragment [:query :source-metadata] result-metadata)}))
+
+(s/defn ^:private source-table-str->card-id :- su/IntGreaterThanZero
+  [source-table-str :- mbql.s/source-table-card-id-regex]
+  (when-let [[_ card-id-str] (re-find #"^card__(\d+)$" source-table-str)]
+    (Integer/parseInt card-id-str)))
 
 
-(declare resolve-card-id-source-tables)
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                         Logic for traversing the query                                         |
+;;; +----------------------------------------------------------------------------------------------------------------+
 
-(defn- resolve-top-level-card-id-source-tables
-  "If `source-table` is a Card reference (a string like `card__100`) then replace that with appropriate
-  `:source-query` information. Does nothing if `source-table` is a normal ID. Recurses for nested-nested queries."
-  [{:keys [source-table], :as inner-query}]
-  (if-not (string? source-table)
-    inner-query
-    ;; (recursively) expand the source query
-    (let [source-query (resolve-card-id-source-tables (source-table-str->source-query source-table))]
-      (-> inner-query
-          ;; remove `source-table` `card__id` key
-          (dissoc :source-table)
-          ;; Add new `source-query` info in its place. Pass the database ID up the chain, removing it from the
-          ;; source query
-          (assoc
-              :source-query    (dissoc source-query :database :source-metadata)
-              :database        (:database source-query)
-              :source-metadata (:source-metadata source-query))))))
+(def ^:private ^{:arglists '([x])} map-with-card-id-source-table?
+  "Is `x` a map with a \"card__id\" `:source-table`, i.e., something this middleware needs to resolve?"
+  (every-pred
+   map?
+   (comp string? :source-table)
+   (comp (partial re-matches mbql.s/source-table-card-id-regex) :source-table)))
 
-(s/defn ^:private resolve-joins-card-id-source-tables :- mbql.s/Joins
-  [joins :- mbql.s/Joins]
-  (for [{:keys [source-table], :as join} joins]
-    (if (string? source-table)
-      (let [source-query (resolve-card-id-source-tables (source-table-str->source-query source-table))]
-        (-> join
-            (dissoc :source-table)
-            (assoc :source-query source-query)))
-      join)))
+(s/defn ^:private resolve-one :- MapWithResolvedSourceQuery
+  [{:keys [source-table], :as m} :- {:source-table mbql.s/source-table-card-id-regex, s/Keyword s/Any}]
+  (let [source-query-and-metadata (-> source-table source-table-str->card-id card-id->source-query-and-metadata)]
+    (merge
+     (dissoc m :source-table)
+     source-query-and-metadata)))
 
-(defn- resolve-card-id-source-tables [{:keys [joins], :as inner-query}]
-  (cond-> (resolve-top-level-card-id-source-tables inner-query)
-    (seq joins) (update :joins resolve-joins-card-id-source-tables)))
+(defn- check-for-circular-references
+  "Make sure we aren't trying to resolve circular references such as a card whose source query is itself."
+  [card-id already-resolved]
+  (when (contains? (set already-resolved) card-id)
+    (throw (ex-info (str (tru "Cannot resolve source query for Card {0}: circular references between source queries."
+                              card-id))
+             {:resolving card-id, :already-resolved already-resolved}))))
 
-(s/defn ^:private fetch-source-query* :- mbql.s/Query
+(defn- resolve-all*
+  ([m]
+   (resolve-all* m nil))
+
+  ([m already-resolved]
+   (mbql.u/replace m
+     map-with-card-id-source-table?
+     ;; if this is a map that has a Card ID `:source-table`, resolve that (replacing it with the appropriate
+     ;; `:source-query`, then recurse and resolve any nested-nested queries that need to be resolved too
+     (let [source-table-str (:source-table &match)
+           card-id          (source-table-str->card-id source-table-str)]
+       (check-for-circular-references card-id already-resolved)
+       ;; ok, now actually resolve the Card ID, then recursively resolve all the Card ID source tables inside the
+       ;; newly resolved source query
+       ;;
+       (let [resolved (resolve-one &match)]
+         ;; wrap the recursive call in a try-catch; if the recursive resolution fails, add context about the
+         ;; resolution that were we in the process of
+         (try
+           (resolve-all* resolved (conj already-resolved card-id))
+           (catch Throwable e
+             (throw (ex-info (.getMessage e)
+                      {:resolving &match, :resolved resolved}
+                      e)))))))))
+
+(defn- copy-source-query-database-ids
+  "If `m` has the saved questions virtual `:database` ID, (recursively) look for actual resolved Database IDs in the
+  next level down and copy it to our level."
+  [{:keys [database], :as m}]
+  (if (and database (not= database mbql.s/saved-questions-virtual-database-id))
+    m
+    (let [{:keys [query source-query], :as m}
+          (cond-> m
+            (:query m)        (update :query        copy-source-query-database-ids)
+            (:source-query m) (update :source-query copy-source-query-database-ids))
+
+          db-id
+          (some (fn [{:keys [database]}]
+                  (when (some-> database (not= mbql.s/saved-questions-virtual-database-id))
+                    database))
+                [source-query query])]
+      (cond-> m
+        db-id (assoc :database db-id)))))
+
+(defn- remove-unneeded-database-ids
+  "Remove `:database` from all levels besides the top level."
+  [m]
+  (mbql.u/replace-in m [:query]
+    (&match :guard (every-pred map? :database (comp integer? :database)))
+    (recur (dissoc &match :database))))
+
+(s/defn ^:private resolve-all :- su/Map
+  "Recursively replace all Card ID source tables in `m` with resolved `:source-query` and `:source-metadata`. Since
+  the `:database` is only useful for top-level source queries, we'll remove it from all other levels."
+  [query :- su/Map]
+  (-> (resolve-all* query)
+      copy-source-query-database-ids
+      remove-unneeded-database-ids))
+
+
+(s/defn ^:private resolve-card-id-source-tables* :- FullyResolvedQuery
   [{inner-query :query, :as outer-query} :- mbql.s/Query]
   (if-not inner-query
     ;; for non-MBQL queries there's nothing to do since they have nested queries
     outer-query
-    ;; otherwise attempt to expand any source queries as needed
-    (let [expanded-inner-query (resolve-card-id-source-tables inner-query)]
-      (merge
-       outer-query
-       {:query (dissoc expanded-inner-query :database :source-metadata)}
-       (when-let [database (:database expanded-inner-query)]
-         {:database database})
-       (when-let [source-metadata (:source-metadata expanded-inner-query)]
-         {:source-metadata source-metadata})))))
+    ;; Otherwise attempt to expand any source queries as needed. Pull the `:database` key up into the top-level if it
+    ;; exists
+    (resolve-all outer-query)))
 
-(defn fetch-source-query
+(defn resolve-card-id-source-tables
   "Middleware that assocs the `:source-query` for this query if it was specified using the shorthand `:source-table`
   `card__n` format."
   [qp]
-  (comp qp fetch-source-query*))
+  (comp qp resolve-card-id-source-tables*))

--- a/src/metabase/query_processor/middleware/process_userland_query.clj
+++ b/src/metabase/query_processor/middleware/process_userland_query.clj
@@ -7,7 +7,9 @@
             [metabase.models
              [query :as query]
              [query-execution :as query-execution :refer [QueryExecution]]]
-            [metabase.query-processor.util :as qputil]
+            [metabase.query-processor
+             [interface :as qp.i]
+             [util :as qputil]]
             [metabase.util :as u]
             [metabase.util
              [date :as du]
@@ -103,14 +105,16 @@
     (and (= status :failed)
          (instance? InterruptedException (:class result)))
     (do
-      (log/info (trs "Query canceled"))
+      (when-not qp.i/*disable-qp-logging*
+        (log/info (trs "Query canceled")))
       (respond {:status :interrupted}))
 
     ;; 'Normal' query failures are usually caused by invalid queries -- equivalent of a HTTP 400. Save QueryExecution
     ;; & return a "status = failed" response
     (= status :failed)
     (do
-      (log/warn (trs "Query failure") (u/pprint-to-str 'red result))
+      (when-not qp.i/*disable-qp-logging*
+        (log/warn (trs "Query failure") (u/pprint-to-str 'red result)))
       (respond (fail query-execution result)))
 
     ;; Successful query (~= HTTP 200): save QueryExecution & return "status = completed" response

--- a/src/metabase/query_processor/middleware/resolve_database.clj
+++ b/src/metabase/query_processor/middleware/resolve_database.clj
@@ -1,16 +1,12 @@
 (ns metabase.query-processor.middleware.resolve-database
-  (:require [metabase.models.database :as database :refer [Database]]
+  (:require [metabase.mbql.schema :as mbql.s]
             [metabase.query-processor.store :as qp.store]
-            [metabase.util :as u]
-            [metabase.util.i18n :refer [tru]]
-            [toucan.db :as db]))
+            [metabase.util :as u]))
 
 (defn- resolve-database* [{database-id :database, :as query}]
   (u/prog1 query
-    (when-not (= database-id database/virtual-id)
-      (qp.store/store-database! (or (db/select-one (apply vector Database qp.store/database-columns-to-fetch)
-                                      :id (u/get-id database-id))
-                                    (throw (Exception. (str (tru "Database {0} does not exist." database-id)))))))))
+    (when-not (= database-id mbql.s/saved-questions-virtual-database-id)
+      (qp.store/fetch-and-store-database! database-id))))
 
 (defn resolve-database
   "Middleware that resolves the Database referenced by the query under that `:database` key and stores it in the QP

--- a/src/metabase/query_processor/middleware/resolve_driver.clj
+++ b/src/metabase/query_processor/middleware/resolve_driver.clj
@@ -1,15 +1,23 @@
 (ns metabase.query-processor.middleware.resolve-driver
   "Middleware for resolving the appropriate driver to use for processing a query."
   (:require [metabase.driver :as driver]
-            [metabase.driver.util :as driver.u]))
+            [metabase.driver.util :as driver.u]
+            [metabase.util.i18n :refer [tru]]))
 
 (defn resolve-driver
   "Middleware that resolves the driver associated with a query, binds it to `*driver*`, and associates it in the query
   under the key `:driver`."
   [qp]
-  (fn [query]
-    (let [driver (or (driver.u/database->driver (:database query))
-                     (throw (Exception. "Unable to resolve driver for query.")))
-          query  (assoc query :driver driver)]
+  (fn [{:keys [database], :as query}]
+    ;; Make sure the `:database` key is present and that it's a positive int (the nested query placeholder should have
+    ;; been replaced by relevant middleware by now)
+    (when-not ((every-pred integer? pos?) database)
+      (throw (ex-info (str (tru "Unable to resolve driver for query: missing or invalid `:database` ID."))
+               {:database database})))
+    ;; ok, now make sure the Database exists in the DB
+    (let [driver (or (driver.u/database->driver database)
+                     (throw (ex-info (str (tru "Unable to resolve driver for query: Database {0} does not exist."
+                                               database))
+                              {:database database})))]
       (binding [driver/*driver* driver]
-        (qp query)))))
+        (qp (assoc query :driver driver))))))

--- a/src/metabase/query_processor/middleware/resolve_fields.clj
+++ b/src/metabase/query_processor/middleware/resolve_fields.clj
@@ -1,25 +1,17 @@
 (ns metabase.query-processor.middleware.resolve-fields
   "Middleware that resolves the Fields referenced by a query."
   (:require [metabase.mbql.util :as mbql.u]
-            [metabase.models.field :refer [Field]]
             [metabase.query-processor.store :as qp.store]
-            [metabase.util :as u]
-            [toucan.db :as db]))
+            [metabase.util :as u]))
 
 (defn- resolve-fields-with-ids! [field-ids]
-  (let [fetched-fields (db/select (apply vector Field qp.store/field-columns-to-fetch) :id [:in (set field-ids)])]
-    ;; store the new fields
-    (doseq [field fetched-fields]
-      (qp.store/store-field! field))
-    ;; now recursively fetch parents if needed
-    (when-let [parent-ids (seq (filter some? (map :parent_id fetched-fields)))]
-      (recur parent-ids))))
+  (qp.store/fetch-and-store-fields! field-ids)
+  (when-let [parent-ids (seq (filter some? (map (comp :parent_id qp.store/field) field-ids)))]
+    (recur parent-ids)))
 
 (defn- resolve-fields* [query]
   (u/prog1 query
-    (when-let [field-ids (seq (remove (qp.store/already-fetched-field-ids)
-                                      (mbql.u/match (:query query) [:field-id id] id)))]
-      (resolve-fields-with-ids! field-ids))))
+    (resolve-fields-with-ids! (mbql.u/match (:query query) [:field-id id] id))))
 
 (defn resolve-fields
   "Fetch the Fields referenced by `:field-id` clauses in a query and store them in the Query Processor Store for the

--- a/src/metabase/query_processor/middleware/resolve_joins.clj
+++ b/src/metabase/query_processor/middleware/resolve_joins.clj
@@ -5,29 +5,38 @@
   (:require [metabase.mbql
              [schema :as mbql.s]
              [util :as mbql.u]]
-            [metabase.models
-             [field :refer [Field]]
-             [table :refer [Table]]]
             [metabase.query-processor.middleware.add-implicit-clauses :as add-implicit-clauses]
             [metabase.query-processor.store :as qp.store]
             [metabase.util :as u]
             [metabase.util
              [i18n :refer [tru]]
              [schema :as su]]
-            [schema.core :as s]
-            [toucan.db :as db]))
+            [schema.core :as s]))
 
 (def ^:private Joins
   "Schema for a non-empty sequence of Joins. Unlike `mbql.s/Joins`, this does not enforce the constraint that all join
-  aliases be unique; that is not guaranteeded until `deduplicate-aliases` transforms the joins."
+  aliases be unique; that is not guaranteeded until `mbql.u/deduplicate-join-aliases` transforms the joins."
   (su/non-empty [mbql.s/Join]))
 
-(def ^:private MBQLQuery
-  "Schema for the parts of the 'inner' query we're transforming in this middleware that we care about validating (no
-  point in validating stuff we're not changing.)"
-  {:joins                   (s/constrained mbql.s/Joins vector?)
-   (s/optional-key :fields) (s/constrained mbql.s/Fields vector?)
+(def ^:private UnresolvedMBQLQuery
+  "Schema for the parts of the query we're modifying. For use in the various intermediate transformations in the
+  middleware."
+  {:joins                   [mbql.s/Join]
+   (s/optional-key :fields) mbql.s/Fields
    s/Keyword                s/Any})
+
+(def ^:private ResolvedMBQLQuery
+  "Schema for the final results of this middleware."
+  (s/constrained
+   mbql.s/MBQLQuery
+   (fn [{:keys [joins]}]
+     (every?
+      (fn [{:keys [fields]}]
+        (or
+         (empty? fields)
+         (sequential? fields)))
+      joins))
+   "Valid MBQL query where `:joins` `:fields` is sequence of Fields or removed"))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                 Resolving Tables & Fields / Saving in QP Store                                 |
@@ -35,95 +44,90 @@
 
 (s/defn ^:private resolve-fields! :- (s/eq nil)
   [joins :- Joins]
-  (when-let [field-ids (->> (mbql.u/match joins [:field-id id] id)
-                            (remove qp.store/has-field?)
-                            seq)]
-    (doseq [field (db/select (into [Field] qp.store/field-columns-to-fetch) :id [:in field-ids])]
-      (qp.store/store-field! field))))
+  (qp.store/fetch-and-store-fields! (mbql.u/match joins [:field-id id] id)))
 
 (s/defn ^:private resolve-tables! :- (s/eq nil)
+  "Add Tables referenced by `:joins` to the Query Processor Store. This is only really needed for implicit joins,
+  because their Table references are added after `resolve-source-tables` runs."
   [joins :- Joins]
-  (when-let [source-table-ids (->> (map :source-table joins)
-                                   (filter some?)
-                                   (remove qp.store/has-table?)
-                                   seq)]
-    (let [resolved-tables (db/select (into [Table] qp.store/table-columns-to-fetch)
-                            :id    [:in source-table-ids]
-                            :db_id (u/get-id (qp.store/database)))
-          resolved-ids (set (map :id resolved-tables))]
-      ;; make sure all IDs were resolved, otherwise someone is probably trying to Join a table that doesn't exist
-      (doseq [id source-table-ids
-              :when (not (resolved-ids id))]
-        (throw
-         (IllegalArgumentException.
-          (str (tru "Could not find Table {0} in Database {1}." id (u/get-id (qp.store/database)))))))
-      ;; cool, now store the Tables in the DB
-      (doseq [table resolved-tables]
-        (qp.store/store-table! table)))))
+  (qp.store/fetch-and-store-tables! (remove nil? (map :source-table joins))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                             :joins Transformations                                             |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(s/defn ^:private deduplicate-aliases :- mbql.s/Joins
-  [joins :- Joins]
-  (let [joins          (for [join joins]
-                         (update join :alias #(or % "source")))
-        unique-aliases (mbql.u/uniquify-names (map :alias joins))]
-    (mapv
-     (fn [join alias]
-       (assoc join :alias alias))
-     joins
-     unique-aliases)))
-
 (s/defn ^:private merge-defaults :- mbql.s/Join
   [join]
   (merge {:strategy :left-join} join))
 
+(defn- source-metadata->fields [{:keys [alias], :as join} source-metadata]
+  (when-not (seq source-metadata)
+    (throw (ex-info (str (tru "Cannot use :fields :all in join against source query unless it has :source-metadata."))
+             {:join join})))
+  (for [{field-name :name, base-type :base_type} source-metadata]
+    [:joined-field alias [:field-literal field-name base-type]]))
+
 (s/defn ^:private handle-all-fields :- mbql.s/Join
-  [{:keys [source-table alias fields], :as join} :- mbql.s/Join]
+  "Replace `:fields :all` in a join with an appropriate list of Fields."
+  [{:keys [source-table source-query alias fields source-metadata], :as join} :- mbql.s/Join]
   (merge
    join
-   (if (= fields :all)
-     (if source-table
-       {:fields (for [field (add-implicit-clauses/sorted-implicit-fields-for-table source-table)]
-                  [:joined-field alias field])}
-       (throw
-        (UnsupportedOperationException.
-         "TODO - fields = all is not yet implemented for joins with source queries."))))))
+   (when (= fields :all)
+     {:fields (if source-query
+               (source-metadata->fields join source-metadata)
+               (for [field (add-implicit-clauses/sorted-implicit-fields-for-table source-table)]
+                 (mbql.u/->joined-field alias field)))})))
 
 
 (s/defn ^:private resolve-references-and-deduplicate :- mbql.s/Joins
   [joins :- Joins]
   (resolve-tables! joins)
-  (let [joins (->> joins
-                   deduplicate-aliases
-                   (map merge-defaults)
-                   (mapv handle-all-fields))]
-    (resolve-fields! joins)
-    joins))
+  (u/prog1 (->> joins
+                mbql.u/deduplicate-join-aliases
+                (map merge-defaults)
+                (mapv handle-all-fields))
+    (resolve-fields! <>)))
+
+(declare resolve-joins-in-mbql-query-all-levels)
+
+(s/defn ^:private resolve-join-source-queries :- mbql.s/Joins
+  [joins :- mbql.s/Joins]
+  (for [{:keys [source-query], :as join} joins]
+    (cond-> join
+      source-query resolve-joins-in-mbql-query-all-levels)))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                           MBQL-Query Transformations                                           |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(defn- joins->fields [joins]
-  (for [{:keys [fields]} joins
-        :when            (sequential? fields)
-        field            fields]
-    field))
+(defn- joins->fields
+  "Return a flattened list of all `:fields` referenced in `joins`."
+  [joins]
+  (reduce concat (filter sequential? (map :fields joins))))
 
 (defn- remove-joins-fields [joins]
   (vec (for [join joins]
          (dissoc join :fields))))
 
-(s/defn ^:private merge-joins-fields :- MBQLQuery
-  [{:keys [joins], :as query} :- MBQLQuery]
-  (let [join-fields (joins->fields joins)
-        query       (update query :joins remove-joins-fields)]
-    (cond-> query
+(defn- should-add-join-fields?
+  "Should we append the `:fields` from `:joins` to the parent-level query's `:fields`? True unless the parent-level
+  query has breakouts or aggregations."
+  [{breakouts :breakout, aggregations :aggregation}]
+  (every? empty? [aggregations breakouts]))
+
+(s/defn ^:private merge-joins-fields :- UnresolvedMBQLQuery
+  "Append the `:fields` from `:joins` into their parent level as appropriate so joined columns appear in the final
+  query results, and remove the `:fields` entry for all joins.
+
+  If the parent-level query has breakouts and/or aggregations, this function won't append the joins fields to the
+  parent level, because we should only be returning the ones from the ags and breakouts in the final results."
+  [{:keys [joins], :as inner-query} :- UnresolvedMBQLQuery]
+  (let [join-fields (when (should-add-join-fields? inner-query)
+                      (joins->fields joins))
+        inner-query(update inner-query :joins remove-joins-fields)]
+    (cond-> inner-query
       (seq join-fields) (update :fields (comp vec distinct concat) join-fields))))
 
 (defn- check-join-aliases [{:keys [joins], :as query}]
@@ -135,23 +139,35 @@
           (str (tru "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found: {1}"
                     alias aliases))))))))
 
-(s/defn ^:private resolve-joins-in-mbql-query :- MBQLQuery
-  [{:keys [joins], :as query} :- MBQLQuery]
+(s/defn ^:private resolve-joins-in-mbql-query :- ResolvedMBQLQuery
+  [{:keys [joins], :as query} :- mbql.s/MBQLQuery]
   (u/prog1 (-> query
                (update :joins resolve-references-and-deduplicate)
+               (update :joins resolve-join-source-queries)
                merge-joins-fields)
-    (check-join-aliases <>)))
+    (check-join-aliases (dissoc <> :source-query))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                Middleware & Boring Recursive Application Stuff                                 |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
+(defn- ^:deprecated maybe-resolve-source-table
+  "Resolve the `source-table` of any `source-query` inside a join.
+
+  TODO - this is no longer needed. `resolve-source-tables` middleware handles all table resolution."
+  [{:keys [source-table], :as query}]
+  (qp.store/fetch-and-store-tables! [source-table])
+  query)
+
 (defn- resolve-joins-in-mbql-query-all-levels
-  [{:keys [joins source-query], :as query}]
+  [{:keys [joins source-query source-table], :as query}]
   (cond-> query
     (seq joins)
     resolve-joins-in-mbql-query
+
+    source-table
+    maybe-resolve-source-table
 
     source-query
     (update :source-query resolve-joins-in-mbql-query-all-levels)))
@@ -167,5 +183,11 @@
     ([query]
      (qp (resolve-joins* query)))
 
+    ;; async-capable version of the middleware for the future when the entire QP is fully async
     ([query respond raise canceled-chan]
-     (qp (resolve-joins* query) respond raise canceled-chan))))
+     (when-let [query (try
+                        (resolve-joins* query)
+                        (catch Throwable e
+                          (raise e)
+                          nil))]
+       (qp query respond raise canceled-chan)))))

--- a/src/metabase/query_processor/middleware/resolve_source_table.clj
+++ b/src/metabase/query_processor/middleware/resolve_source_table.clj
@@ -1,24 +1,48 @@
 (ns metabase.query-processor.middleware.resolve-source-table
-  "TODO - maybe rename this `resolve-source-table` so it matches the other ones"
+  "Fetches Tables corresponding to any `:source-table` IDs anywhere in the query."
   (:require [metabase.mbql.util :as mbql.u]
-            [metabase.models.table :refer [Table]]
             [metabase.query-processor.store :as qp.store]
-            [metabase.util :as u]
-            [metabase.util.i18n :refer [trs]]
-            [toucan.db :as db]))
+            [metabase.util
+             [i18n :refer [tru]]
+             [schema :as su]]
+            [schema.core :as s]))
 
-(defn- resolve-source-table* [query]
-  (when-let [source-table-id (mbql.u/query->source-table-id query)]
-    (let [source-table (or (db/select-one (into [Table] qp.store/table-columns-to-fetch)
-                             :db_id (u/get-id (qp.store/database))
-                             :id    source-table-id)
-                           (throw (Exception. (str (trs "Cannot run query: could not find source table {0}."
-                                                        source-table-id)))))]
-      (qp.store/store-table! source-table)))
-  query)
+(def ^:private ^{:arglists '([x])} positive-int? (every-pred integer? pos?))
 
-(defn resolve-source-table
-  "Middleware that will take the source-table (an integer) and hydrate that source table from the the database and
-  attach it as `:source-table`"
+(defn- check-all-source-table-ids-are-valid
+  "Sanity check: Any non-positive-integer value of `:source-table` should have been resolved by now. The
+  `resolve-card-id-source-tables` middleware should have already taken care of it."
+  [query]
+  (mbql.u/match-one query
+    (m :guard (every-pred map? :source-table (comp (complement positive-int?) :source-table)))
+    (throw
+     (ex-info
+         (str (tru "Invalid :source-table ''{0}'': should be resolved to a Table ID by now." (:source-table m)))
+       {:form m}))))
+
+(s/defn ^:private query->source-table-ids :- (s/maybe (su/non-empty #{su/IntGreaterThanZero}))
+  "Fetch a set of all `:source-table` IDs anywhere in `query`."
+  [query]
+  (some->
+   (mbql.u/match query
+     (m :guard (every-pred map? (comp positive-int? :source-table)))
+     ;; Recursively look in the rest of `m` for any other source tables
+     (cons
+      (:source-table m)
+      (filter some? (recur (dissoc m :source-table)))))
+   flatten
+   set))
+
+(defn- resolve-source-tables*
+  "Resolve all Tables referenced in the `query`, and store them in the QP Store."
+  [query]
+  (check-all-source-table-ids-are-valid query)
+  (qp.store/fetch-and-store-tables! (query->source-table-ids query)))
+
+(defn resolve-source-tables
+  "Middleware that will take any `:source-table`s (integer IDs) anywhere in the query and fetch and save the
+  corresponding Table in the Query Processor Store."
   [qp]
-  (comp qp resolve-source-table*))
+  (fn [query]
+    (resolve-source-tables* query)
+    (qp query)))

--- a/src/metabase/query_processor/store.clj
+++ b/src/metabase/query_processor/store.clj
@@ -20,7 +20,8 @@
             [metabase.util
              [i18n :refer [tru]]
              [schema :as su]]
-            [schema.core :as s]))
+            [schema.core :as s]
+            [toucan.db :as db]))
 
 ;;; ---------------------------------------------- Setting up the Store ----------------------------------------------
 
@@ -46,7 +47,7 @@
   [& body]
   `(do-with-new-store (fn [] ~@body)))
 
-(def database-columns-to-fetch
+(def ^:private database-columns-to-fetch
   "Columns you should fetch for the Database referenced by the query before stashing in the store."
   [:id
    :engine
@@ -62,7 +63,7 @@
     :details su/Map
     s/Any    s/Any}))
 
-(def table-columns-to-fetch
+(def ^:private table-columns-to-fetch
   "Columns you should fetch for any Table you want to stash in the Store."
   [:id
    :name
@@ -76,7 +77,7 @@
     s/Any   s/Any}))
 
 
-(def field-columns-to-fetch
+(def ^:private field-columns-to-fetch
   "Columns to fetch for and Field you want to stash in the Store. These get returned as part of the `:cols` metadata in
   query results. Try to keep this set pared down to just what's needed by the QP and frontend, since it has to be done
   for every MBQL query."
@@ -109,7 +110,7 @@
 
 ;;; ------------------------------------------ Saving objects in the Store -------------------------------------------
 
-(s/defn store-database!
+(s/defn ^:private store-database!
   "Store the Database referenced by this query for the duration of the current query execution. Throws an Exception if
   database is invalid or doesn't have all the required keys."
   [database :- DatabaseInstanceWithRequiredStoreKeys]
@@ -127,10 +128,81 @@
   [field :- FieldInstanceWithRequiredStorekeys]
   (swap! *store* assoc-in [:fields (u/get-id field)] field))
 
-(s/defn already-fetched-field-ids :- #{su/IntGreaterThanZero}
-  "Get a set of all the IDs of Fields that have already been fetched -- which means you don't have to do it again."
+
+;;; ----------------------- Fetching objects from application DB, and saving them in the store -----------------------
+
+(s/defn ^:private db-id :- su/IntGreaterThanZero
   []
-  (set (keys (:fields @*store*))))
+  (or (get-in @*store* [:database :id])
+      (throw (Exception. (str (tru "Cannot store Tables or Fields before Database is stored."))))))
+
+(s/defn fetch-and-store-database!
+  "Fetch the Database this query will run against from the application database, and store it in the QP Store for the
+  duration of the current query execution. If Database has already been fetched, this function will no-op. Throws an
+  Exception if Table does not exist."
+  [database-id :- su/IntGreaterThanZero]
+  (if-let [existing-db-id (get-in @*store* [:database :id])]
+    ;; if there's already a DB in the Store, double-check it has the same ID as the one that we were asked to fetch
+    (when-not (= existing-db-id database-id)
+      (throw (ex-info (str (tru "Attempting to fetch second Database. Queries can only reference one Database."))
+               {:existing-id existing-db-id, :attempted-to-fetch database-id})))
+    ;; if there's no DB, fetch + save
+    (store-database! (db/select-one (into [Database] database-columns-to-fetch) :id database-id))))
+
+(def ^:private IDs
+  (s/maybe
+   (s/cond-pre
+    #{su/IntGreaterThanZero}
+    [su/IntGreaterThanZero])))
+
+(s/defn fetch-and-store-tables!
+  "Fetch Table(s) from the application database, and store them in the QP Store for the duration of the current query
+  execution. If Table(s) have already been fetched, this function will no-op. Throws an Exception if Table(s) do not
+  exist."
+  [table-ids :- IDs]
+  ;; remove any IDs for Tables that have already been fetched
+  (when-let [ids-to-fetch (seq (remove (set (keys (:tables @*store*))) table-ids))]
+    (let [fetched-tables (db/select (into [Table] table-columns-to-fetch)
+                           :id    [:in (set ids-to-fetch)]
+                           :db_id (db-id))
+          fetched-ids    (set (map :id fetched-tables))]
+      ;; make sure all Tables in table-ids were fetched, or throw an Exception
+      (doseq [id ids-to-fetch]
+        (when-not (fetched-ids id)
+          (throw
+           (ex-info (str (tru "Failed to fetch Table {0}: Table does not exist, or belongs to a different Database." id))
+             {:table id, :database (db-id)}))))
+      ;; ok, now store them all in the Store
+      (doseq [table fetched-tables]
+        (store-table! table)))))
+
+(s/defn fetch-and-store-fields!
+  "Fetch Field(s) from the application database, and store them in the QP Store for the duration of the current query
+  execution. If Field(s) have already been fetched, this function will no-op. Throws an Exception if Field(s) do not
+  exist."
+  [field-ids :- IDs]
+  ;; remove any IDs for Fields that have already been fetched
+  (when-let [ids-to-fetch (seq (remove (set (keys (:fields @*store*))) field-ids))]
+    (let [fetched-fields (db/do-post-select Field
+                           (db/query
+                            {:select    (for [column-kw field-columns-to-fetch]
+                                          [(keyword (str "field." (name column-kw)))
+                                           column-kw])
+                             :from      [[Field :field]]
+                             :left-join [[Table :table] [:= :field.table_id :table.id]]
+                             :where     [:and
+                                         [:in :field.id (set ids-to-fetch)]
+                                         [:= :table.db_id (db-id)]]}))
+          fetched-ids    (set (map :id fetched-fields))]
+      ;; make sure all Fields in field-ids were fetched, or throw an Exception
+      (doseq [id ids-to-fetch]
+        (when-not (fetched-ids id)
+          (throw
+           (ex-info (str (tru "Failed to fetch Field {0}: Field does not exist, or belongs to a different Database." id))
+             {:field id, :database (db-id)}))))
+      ;; ok, now store them all in the Store
+      (doseq [field fetched-fields]
+        (store-field! field)))))
 
 
 ;;; ---------------------------------------- Fetching objects from the Store -----------------------------------------
@@ -153,13 +225,3 @@
   [field-id :- su/IntGreaterThanZero]
   (or (get-in @*store* [:fields field-id])
       (throw (Exception. (str (tru "Error: Field {0} is not present in the Query Processor Store." field-id))))))
-
-(s/defn has-table?
-  "True if the store already has Table with `table-id`."
-  [table-id :- su/IntGreaterThanZero]
-  (boolean (get-in @*store* [:tables table-id])))
-
-(s/defn has-field?
-  "True if the store already has Field with `field-id`."
-  [field-id :- su/IntGreaterThanZero]
-  (boolean (get-in @*store* [:fields field-id])))

--- a/src/metabase/sample_data.clj
+++ b/src/metabase/sample_data.clj
@@ -1,24 +1,24 @@
 (ns metabase.sample-data
   (:require [clojure.java.io :as io]
-            [clojure.string :as s]
+            [clojure.string :as str]
             [clojure.tools.logging :as log]
-            [metabase
-             [sync :as sync]
-             [util :as u]]
             [metabase.models.database :refer [Database]]
+            [metabase.sync :as sync]
+            [metabase.util.i18n :refer [trs]]
             [toucan.db :as db]))
 
-(def ^:private ^:const ^String sample-dataset-name     "Sample Dataset")
-(def ^:private ^:const ^String sample-dataset-filename "sample-dataset.db.mv.db")
+(def ^:private ^String sample-dataset-name     "Sample Dataset")
+(def ^:private ^String sample-dataset-filename "sample-dataset.db.mv.db")
 
 (defn- db-details []
   (let [resource (io/resource sample-dataset-filename)]
     (when-not resource
-      (throw (Exception. (format "Can't load sample dataset: the DB file '%s' can't be found." sample-dataset-filename))))
+      (throw (Exception. (str (trs "Sample dataset DB file ''{0}'' cannot be found."
+                                   sample-dataset-filename)))))
     {:db (-> (.getPath resource)
-             (s/replace #"^file:" "zip:")           ; to connect to an H2 DB inside a JAR just replace file: with zip: (this doesn't do anything when running from `lein`, which has no `file:` prefix)
-             (s/replace #"\.mv\.db$" "")            ; strip the .mv.db suffix from the path
-             (s/replace #"%20" " ")                 ; for some reason the path can get URL-encoded and replace spaces with `%20`; this breaks things so switch them back to spaces
+             (str/replace #"^file:" "zip:") ; to connect to an H2 DB inside a JAR just replace file: with zip: (this doesn't do anything when running from `lein`, which has no `file:` prefix)
+             (str/replace #"\.mv\.db$" "")  ; strip the .mv.db suffix from the path
+             (str/replace #"%20" " ") ; for some reason the path can get URL-encoded and replace spaces with `%20`; this breaks things so switch them back to spaces
              (str ";USER=GUEST;PASSWORD=guest"))})) ; specify the GUEST user account created for the DB
 
 (defn add-sample-dataset!
@@ -26,14 +26,14 @@
   []
   (when-not (db/exists? Database :is_sample true)
     (try
-      (log/info "Loading sample dataset...")
+      (log/info (trs "Loading sample dataset..."))
       (sync/sync-database! (db/insert! Database
                              :name      sample-dataset-name
                              :details   (db-details)
                              :engine    :h2
                              :is_sample true))
       (catch Throwable e
-        (log/error (u/format-color 'red "Failed to load sample dataset: %s\n%s" (.getMessage e) (u/pprint-to-str (u/filtered-stacktrace e))))))))
+        (log/error e (trs "Failed to load sample dataset"))))))
 
 (defn update-sample-dataset-if-needed!
   "Update the path to the sample dataset DB if it exists in case the JAR has moved."

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -693,7 +693,8 @@
   `(do-with-us-locale (fn [] ~@body)))
 
 (defn xor
-  "Exclusive or. Hopefully this is self-explanatory ;)"
+  "Exclusive or. (Because this is implemented as a function, rather than a macro, it is not short-circuting the way `or`
+  is.)"
   [x y & more]
   (loop [[x y & more] (into [x y] more)]
     (cond
@@ -705,3 +706,11 @@
 
       :else
       (or x y))))
+
+(defn xor-pred
+  "Takes a set of predicates and returns a function that is true if *exactly one* of its composing predicates returns a
+  logically true value. Compare to `every-pred`."
+  [& preds]
+  (fn [& args]
+    (apply xor (for [pred preds]
+                 (apply pred args)))))

--- a/src/metabase/util/infer_spaces.clj
+++ b/src/metabase/util/infer_spaces.clj
@@ -3,7 +3,7 @@
    https://stackoverflow.com/questions/8870261/how-to-split-text-without-spaces-into-list-of-words/11642687#11642687."
   ;; TODO - The code in this namespace is very hard to understand. We should clean it up and make it readable.
   (:require [clojure.java.io :as io]
-            [clojure.string :as s])
+            [clojure.string :as str])
   (:import java.lang.Math
            java.util.Arrays))
 
@@ -11,7 +11,7 @@
 (def ^:const ^:private special-words ["checkins"])
 
 (defn- slurp-words-by-frequency []
-  (concat special-words (s/split-lines (slurp (io/resource "words-by-frequency.txt")))))
+  (concat special-words (str/split-lines (slurp (io/resource "words-by-frequency.txt")))))
 
 ;; wordcost = dict((k, log((i+1)*log(len(words)))) for i,k in enumerate(words))
 (defn- make-cost-map
@@ -95,7 +95,7 @@
 (defn infer-spaces
   "Splits a string with no spaces into words using magic" ; what a great explanation. TODO - make this code readable
   [input]
-  (let [s (s/lower-case input)
+  (let [s (str/lower-case input)
         cost (build-cost-array s)]
     (loop [i (float (count s))
            out []]

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -80,7 +80,7 @@
 (defn- do-with-temp-native-card
   {:style/indent 0}
   [f]
-  (tt/with-temp* [Database   [db    {:details (:details (Database (data/id))), :engine :h2}]
+  (tt/with-temp* [Database   [db    {:details (:details (data/db)), :engine :h2}]
                   Table      [table {:db_id (u/get-id db), :name "CATEGORIES"}]
                   Card       [card  {:dataset_query {:database (u/get-id db)
                                                      :type     :native
@@ -123,7 +123,7 @@
 
 (defn- do-with-temp-native-card-with-params {:style/indent 0} [f]
   (tt/with-temp*
-    [Database   [db    {:details (:details (Database (data/id))), :engine :h2}]
+    [Database   [db    {:details (:details (data/db)), :engine :h2}]
      Table      [table {:db_id (u/get-id db), :name "VENUES"}]
      Card       [card  {:dataset_query
                         {:database (u/get-id db)

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -7,6 +7,7 @@
              [util :as u]]
             [metabase.api.database :as database-api]
             [metabase.driver.util :as driver.u]
+            [metabase.mbql.schema :as mbql.s]
             [metabase.models
              [card :refer [Card]]
              [collection :refer [Collection]]
@@ -364,14 +365,14 @@
 
 (defn- saved-questions-virtual-db {:style/indent 0} [& card-tables]
   {:name               "Saved Questions"
-   :id                 database/virtual-id
+   :id                 mbql.s/saved-questions-virtual-database-id
    :features           ["basic-aggregations"]
    :tables             card-tables
    :is_saved_questions true})
 
 (defn- virtual-table-for-card [card & {:as kvs}]
   (merge {:id           (format "card__%d" (u/get-id card))
-          :db_id        database/virtual-id
+          :db_id        mbql.s/saved-questions-virtual-database-id
           :display_name (:name card)
           :schema       "Everything else"
           :description  nil}
@@ -395,7 +396,7 @@
       ((user->client :crowberto) :post 200 (format "card/%d/query" (u/get-id card)))
       ;; Now fetch the database list. The 'Saved Questions' DB should NOT be in the list
       (some (fn [database]
-              (when (= (u/get-id database) database/virtual-id)
+              (when (= (u/get-id database) mbql.s/saved-questions-virtual-database-id)
                 database))
             ((user->client :crowberto) :get 200 "database" :include_cards true)))))
 
@@ -490,12 +491,12 @@
                 :base_type                nil
                 :default_dimension_option nil
                 :dimension_options        []}]))
-  ((user->client :crowberto) :get 200 (format "database/%d/metadata" database/virtual-id)))
+  ((user->client :crowberto) :get 200 (format "database/%d/metadata" mbql.s/saved-questions-virtual-database-id)))
 
 ;; if no eligible Saved Questions exist the virtual DB metadata endpoint should just return `nil`
 (expect
   nil
-  ((user->client :crowberto) :get 200 (format "database/%d/metadata" database/virtual-id)))
+  ((user->client :crowberto) :get 200 (format "database/%d/metadata" mbql.s/saved-questions-virtual-database-id)))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -7,6 +7,7 @@
             [dk.ative.docjure.spreadsheet :as spreadsheet]
             [expectations :refer :all]
             [medley.core :as m]
+            [metabase.mbql.schema :as mbql.s]
             [metabase.models
              [card :refer [Card]]
              [database :as database :refer [Database]]
@@ -238,7 +239,7 @@
                                             :native   {:query "SELECT * FROM USERS;"}}}]
     (let [result ((test-users/user->client :rasta) :post 200 "dataset/csv"
                   :query (json/generate-string
-                          {:database database/virtual-id
+                          {:database mbql.s/saved-questions-virtual-database-id
                            :type     :query
                            :query    {:source-table (str "card__" (u/get-id card))}}))]
       (count (csv/read-csv result)))))

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -328,7 +328,7 @@
 (expect
   4
   (with-rasta
-    (->> (Database (data/id)) candidate-tables first :tables count)))
+    (->> (data/db) candidate-tables first :tables count)))
 
 ;; /candidates should work with unanalyzed tables
 (expect

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -1,17 +1,20 @@
 (ns metabase.driver.mysql-test
   (:require [clj-time.core :as t]
             [clojure.java.jdbc :as jdbc]
-            [expectations :refer :all]
+            [expectations :refer [expect]]
             [honeysql.core :as hsql]
             [metabase
+             [driver :as driver]
              [query-processor :as qp]
-             [query-processor-test :as qpt]
+             [query-processor-test :as qp.test]
              [sync :as sync]
              [util :as u]]
             [metabase.driver.mysql :as mysql]
             [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
             [metabase.driver.sql.query-processor :as sql.qp]
-            [metabase.models.database :refer [Database]]
+            [metabase.models
+             [database :refer [Database]]
+             [field :refer [Field]]]
             [metabase.test
              [data :as data]
              [util :as tu]]
@@ -47,8 +50,8 @@
           (sync/sync-database! database)
           (data/with-db database
             ;; run the query
-            (-> (data/run-mbql-query exciting-moments-in-history)
-                qpt/rows)))))))
+            (qp.test/rows
+             (data/run-mbql-query exciting-moments-in-history))))))))
 
 
 ;; Test how TINYINT(1) columns are interpreted. By default, they should be interpreted as integers, but with the
@@ -64,7 +67,7 @@
 
 (defn- db->fields [db]
   (let [table-ids (db/select-ids 'Table :db_id (u/get-id db))]
-    (set (map (partial into {}) (db/select ['Field :name :base_type :special_type] :table_id [:in table-ids])))))
+    (set (map (partial into {}) (db/select [Field :name :base_type :special_type] :table_id [:in table-ids])))))
 
 ;; By default TINYINT(1) should be a boolean
 (expect-with-driver :mysql
@@ -92,12 +95,12 @@
 
 (expect-with-driver :mysql
   "-02:00"
-  (with-redefs [metabase.driver/execute-query (constantly {:rows [["2018-01-09 18:39:08.000000 -02"]]})]
+  (with-redefs [driver/execute-query (constantly {:rows [["2018-01-09 18:39:08.000000 -02"]]})]
     (tu/db-timezone-id)))
 
 (expect-with-driver :mysql
   "Europe/Paris"
-  (with-redefs [metabase.driver/execute-query (constantly {:rows [["2018-01-08 23:00:00.008 CET"]]})]
+  (with-redefs [driver/execute-query (constantly {:rows [["2018-01-08 23:00:00.008 CET"]]})]
     (tu/db-timezone-id)))
 
 
@@ -145,9 +148,9 @@
   ["2018-04-18T00:00:00.000+08:00"]
   (tu.tz/with-jvm-tz (t/time-zone-for-id "Asia/Hong_Kong")
     (tu/with-temporary-setting-values [report-timezone "Asia/Hong_Kong"]
-      (qpt/first-row
-        (du/with-effective-timezone (Database (data/id))
-          (qp/process-query
+      (qp.test/first-row
+       (du/with-effective-timezone (data/db)
+         (qp/process-query
            {:database   (data/id)
             :type       :native
             :settings   {:report-timezone "UTC"}
@@ -168,15 +171,15 @@
   ["2018-04-18T00:00:00.000-07:00"]
   (tu.tz/with-jvm-tz (t/time-zone-for-id "Asia/Hong_Kong")
     (tu/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
-      (qpt/first-row
-        (du/with-effective-timezone (Database (data/id))
-          (qp/process-query
-            {:database   (data/id)
-             :type       :native
-             :settings   {:report-timezone "UTC"}
-             :native     {:query         "SELECT cast({{date}} as date)"
-                          :template-tags {:date {:name "date" :display_name "Date" :type "date" }}}
-             :parameters [{:type "date/single" :target ["variable" ["template-tag" "date"]] :value "2018-04-18"}]}))))))
+      (qp.test/first-row
+       (du/with-effective-timezone (data/db)
+         (qp/process-query
+           {:database   (data/id)
+            :type       :native
+            :settings   {:report-timezone "UTC"}
+            :native     {:query         "SELECT cast({{date}} as date)"
+                         :template-tags {:date {:name "date" :display_name "Date" :type "date" }}}
+            :parameters [{:type "date/single" :target ["variable" ["template-tag" "date"]] :value "2018-04-18"}]}))))))
 
 (def ^:private sample-connection-details
   {:db "my_db", :host "localhost", :port "3306", :user "cam", :password "bad-password"})

--- a/test/metabase/driver/sql_jdbc/execute_test.clj
+++ b/test/metabase/driver/sql_jdbc/execute_test.clj
@@ -8,9 +8,7 @@
              [util :as u]]
             [metabase.driver.sql-jdbc-test :as sql-jdbc-test]
             [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
-            [metabase.query-processor
-             [store :as qp.store]
-             [test-util :as qp.tu]]
+            [metabase.query-processor.test-util :as qp.tu]
             [metabase.test
              [data :as data]
              [util :as tu]]
@@ -197,7 +195,9 @@
    :class      (s/eq java.lang.Exception)
    :error      (s/eq "Column \"ADSASDASD\" not found")
    :stacktrace [s/Str]
-   :query      s/Any}
+   :query      s/Any
+   :cause      {:class (s/eq org.h2.jdbc.JdbcSQLException)
+                :error #"Column \"ADSASDASD\" not found; SQL statement:.*"}}
   (qp/process-query
     {:database (data/id)
      :type     :native
@@ -226,7 +226,6 @@
                       (deliver timezone report-timezone)
                       (orig driver settings connection)))]
       (qp.tu/with-everything-store
-        (qp.store/store-database! (data/db))
         (sql-jdbc.execute/execute-query driver query))
       {:ran-with-timezone? (u/deref-with-timeout ran-with-timezone? 1000)
        :timezone           (u/deref-with-timeout timezone 1000)})))

--- a/test/metabase/driver/sql_jdbc_test.clj
+++ b/test/metabase/driver/sql_jdbc_test.clj
@@ -1,5 +1,5 @@
 (ns metabase.driver.sql-jdbc-test
-  (:require [expectations :refer :all]
+  (:require [expectations :refer [expect]]
             [metabase
              [driver :as driver]
              [query-processor :as qp]
@@ -9,19 +9,14 @@
             [metabase.models
              [field :refer [Field]]
              [table :as table :refer [Table]]]
-            [metabase.test.data :as data :refer :all]
+            [metabase.test.data :as data]
             [metabase.test.data
              [datasets :as datasets]
              [env :as tx.env]
              [interface :as tx]]
             [metabase.test.util.log :as tu.log]
-            [metabase.util.date :as du]
-            [toucan.db :as db])
+            [metabase.util.date :as du])
   (:import java.sql.Time))
-
-(def ^:private users-table      (delay (Table :name "USERS")))
-(def ^:private venues-table     (delay (Table (id :venues))))
-(def ^:private users-name-field (delay (Field (id :users :name))))
 
 (defonce ^{:doc "Set of drivers descending from `:sql-jdbc`, for test purposes (i.e. `expect-with-drivers`)"}
   sql-jdbc-drivers
@@ -29,8 +24,7 @@
    (du/profile "resolve @metabase.driver.sql-jdbc-test/sql-jdbc-drivers"
      (set
       (for [driver tx.env/test-drivers
-            :when  ((descendants driver/hierarchy (driver/the-driver :sql-jdbc))
-                    (driver/the-driver driver))]
+            :when  (isa? driver/hierarchy (driver/the-driver driver) (driver/the-driver :sql-jdbc))]
         (tx/the-driver-with-test-extensions driver))))))
 
 
@@ -38,7 +32,7 @@
 (expect
   {:tables (set (for [table ["CATEGORIES" "VENUES" "CHECKINS" "USERS"]]
                   {:name table, :schema "PUBLIC", :description nil}))}
-  (driver/describe-database :h2 (db)))
+  (driver/describe-database :h2 (data/db)))
 
 ;; DESCRIBE-TABLE
 (expect
@@ -63,7 +57,7 @@
               :database-type "BIGINT"
               :base-type     :type/BigInteger
               :pk?           true}}}
-  (driver/describe-table :h2 (db) @venues-table))
+  (driver/describe-table :h2 (data/db) (Table (data/id :venues))))
 
 ;; DESCRIBE-TABLE-FKS
 (expect
@@ -71,7 +65,7 @@
      :dest-table       {:name   "CATEGORIES"
                         :schema "PUBLIC"}
      :dest-column-name "ID"}}
-  (driver/describe-table-fks :h2 (db) @venues-table))
+  (driver/describe-table-fks :h2 (data/db) (Table (data/id :venues))))
 
 ;;; TABLE-ROWS-SAMPLE
 (datasets/expect-with-drivers @sql-jdbc-drivers
@@ -95,8 +89,8 @@
    {:name "Wurstküche",                   :price 2, :category_id 29, :id 4}
    {:name "Brite Spot Family Restaurant", :price 2, :category_id 20, :id 5}]
   (for [row (take 5 (sort-by :id (driver/table-rows-seq driver/*driver*
-                                                        (db/select-one 'Database :id (id))
-                                                        (db/select-one 'Table :id (id :venues)))))]
+                                                        (data/db)
+                                                        (Table (data/id :venues)))))]
     ;; different DBs use different precisions for these
     (-> (dissoc row :latitude :longitude)
         (update :price int)
@@ -107,8 +101,7 @@
 ;;; Make sure invalid ssh credentials are detected if a direct connection is possible
 (expect
   #"com.jcraft.jsch.JSchException:"
-  (try (let [engine  :postgres
-             details {:ssl            false
+  (try (let [details {:ssl            false
                       :password       "changeme"
                       :tunnel-host    "localhost" ; this test works if sshd is running or not
                       :tunnel-pass    "BOGUS-BOGUS-BOGUS"
@@ -121,7 +114,7 @@
                       :user           "postgres"
                       :tunnel-user    "example"}]
          (tu.log/suppress-output
-           (driver.u/can-connect-with-details? engine details :throw-exceptions)))
+           (driver.u/can-connect-with-details? :postgres details :throw-exceptions)))
        (catch Exception e
          (.getMessage e))))
 
@@ -180,8 +173,7 @@
 (defmacro ^:private process-spliced-count-query [table filter-clause]
   `(process-spliced-count-query*
     {:source-table (data/id ~table)
-     :filter       (data/$ids [~table {:wrap-field-ids? true}]
-                     ~filter-clause)}))
+     :filter       (data/$ids ~table ~filter-clause)}))
 
 ;; test splicing a string -- is resulting query correct?
 (datasets/expect-with-drivers @sql-jdbc-drivers

--- a/test/metabase/events/activity_feed_test.clj
+++ b/test/metabase/events/activity_feed_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.events.activity-feed-test
   (:require [expectations :refer [expect]]
             [metabase.events.activity-feed :refer :all]
+            [metabase.mbql.schema :as mbql.s]
             [metabase.models
              [activity :refer [Activity]]
              [card :refer [Card]]
@@ -54,7 +55,7 @@
                                                 :type     :query
                                                 :query    {:source-table (data/id :venues)}}}]
                   Card [card-2 {:name          "My Cool NESTED Card"
-                                :dataset_query {:database metabase.models.database/virtual-id
+                                :dataset_query {:database mbql.s/saved-questions-virtual-database-id
                                                 :type     :query
                                                 :query    {:source-table (str "card__" (u/get-id card-1))}}}]]
     (with-temp-activities

--- a/test/metabase/mbql/normalize_test.clj
+++ b/test/metabase/mbql/normalize_test.clj
@@ -957,18 +957,45 @@
     :parameters [{:type "id", :target ["dimension" ["fk->" 3265 4575]], :value ["field-id"]}
                  {:type "date/all-options", :target ["dimension" ["field-id" 3270]], :value "thismonth"}]}))
 
-;; make sure source-metadata gets normalized the way we'd expect (just the type names in this case)
+;; make sure `:source-metadata` gets normalized the way we'd expect:
+
+;; 1. Type names should get converted to keywords
 (expect
-  {:source-metadata
-   [{:name         "name"
-     :display_name "Name"
-     :base_type    :type/Text
-     :special_type :type/Name
-     :fingerprint {:global {:distinct-count 100}
-                   :type   {:type/Text {:percent-json   0.0
-                                        :percent-url    0.0
-                                        :percent-email  0.0
-                                        :average-length 15.63}}}}]}
+  {:query {:source-metadata
+           [{:name         "name"
+             :display_name "Name"
+             :base_type    :type/Text
+             :special_type :type/Name
+             :fingerprint  {:global {:distinct-count 100}
+                            :type   {:type/Text {:percent-json   0.0
+                                                 :percent-url    0.0
+                                                 :percent-email  0.0
+                                                 :average-length 15.63}}}}]}}
+  (normalize/normalize
+   {:query {:source-metadata [{:name         "name"
+                               :display_name "Name"
+                               :description  nil
+                               :base_type    "type/Text"
+                               :special_type "type/Name"
+                               :fingerprint  {"global" {"distinct-count" 100}
+                                              "type"   {"type/Text" {"percent-json"   0.0
+                                                                     "percent-url"    0.0
+                                                                     "percent-email"  0.0
+                                                                     "average-length" 15.63}}}}]}}))
+
+;; 2. if `:source-metadata` is at the top-level, it should get moved to the correct location inside the 'inner' MBQL
+;; query
+(expect
+  {:query {:source-metadata
+           [{:name         "name"
+             :display_name "Name"
+             :base_type    :type/Text
+             :special_type :type/Name
+             :fingerprint  {:global {:distinct-count 100}
+                            :type   {:type/Text {:percent-json   0.0
+                                                 :percent-url    0.0
+                                                 :percent-email  0.0
+                                                 :average-length 15.63}}}}]}}
   (normalize/normalize
    {:source-metadata [{:name         "name"
                        :display_name "Name"

--- a/test/metabase/models/query/permissions_test.clj
+++ b/test/metabase/models/query/permissions_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.models.query.permissions-test
   (:require [expectations :refer :all]
             [metabase.api.common :refer [*current-user-id* *current-user-permissions-set*]]
+            [metabase.mbql.schema :as mbql.s]
             [metabase.models
              [card :as card :refer :all]
              [collection :refer [Collection]]
@@ -11,6 +12,7 @@
              [permissions-group :as perms-group]
              [table :refer [Table]]]
             [metabase.models.query.permissions :as query-perms]
+            [metabase.query-processor.test-util :as qp.test-util]
             [metabase.test.data :as data]
             [metabase.test.data.users :as users]
             [metabase.test.util.log :as tu.log]
@@ -122,14 +124,16 @@
 
 (expect
   #{"/db/1/native/"}
-  (query-perms/perms-set (native "SELECT count(*) FROM toucan_sightings;")))
+  (query-perms/perms-set
+   (native "SELECT count(*) FROM toucan_sightings;")))
 
 
 ;;; ------------------------------------------------- MBQL w/o JOIN --------------------------------------------------
 
 (expect
   #{(perms/object-path (data/id) "PUBLIC" (data/id :venues))}
-  (query-perms/perms-set (data/mbql-query venues)))
+  (query-perms/perms-set
+   (data/mbql-query venues)))
 
 (expect
   #{(perms/object-path (data/id) "PUBLIC" (data/id :venues))}
@@ -176,7 +180,7 @@
 ;;; ------------------------------------------- MBQL w/ nested MBQL query --------------------------------------------
 
 (defn- query-with-source-card [card]
-  {:database database/virtual-id, :type "query", :query {:source-table (str "card__" (u/get-id card))}})
+  {:database mbql.s/saved-questions-virtual-database-id, :type "query", :query {:source-table (str "card__" (u/get-id card))}})
 
 ;; if source card is *not* in a Collection, we require Root Collection read perms
 (expect
@@ -184,7 +188,8 @@
   (tt/with-temp Card [card {:dataset_query {:database (data/id)
                                             :type     :query
                                             :query    {:source-table (data/id :venues)}}}]
-    (query-perms/perms-set (query-with-source-card card))))
+    (query-perms/perms-set
+     (query-with-source-card card))))
 
 ;; if source Card *is* in a Collection, we require read perms for that Collection
 (tt/expect-with-temp [Collection [collection {}]]
@@ -193,7 +198,8 @@
                             :dataset_query {:database (data/id)
                                             :type     :query
                                             :query    {:source-table (data/id :venues)}}}]
-    (query-perms/perms-set (query-with-source-card card))))
+    (query-perms/perms-set
+     (query-with-source-card card))))
 
 
 ;;; ----------------------------------- MBQL w/ nested MBQL query including a JOIN -----------------------------------
@@ -207,7 +213,8 @@
                              :type     :query
                              :query    {:source-table (data/id :checkins)
                                         :order-by     [[:asc [:fk-> (data/id :checkins :user_id) (data/id :users :id)]]]}}}]
-    (query-perms/perms-set (query-with-source-card card))))
+    (query-perms/perms-set
+     (query-with-source-card card))))
 
 
 ;;; ------------------------------------------ MBQL w/ nested NATIVE query -------------------------------------------
@@ -218,15 +225,18 @@
   (tt/with-temp Card [card {:dataset_query {:database (data/id)
                                             :type     :native
                                             :native   {:query "SELECT * FROM CHECKINS"}}}]
-    (query-perms/perms-set (query-with-source-card card))))
+    (query-perms/perms-set
+     (query-with-source-card card))))
 
 ;; However if you just pass in the same query directly as a `:source-query` you will still require READWRITE
 ;; permissions to save the query since we can't verify that it belongs to a Card that you can view.
 (expect
   #{(perms/adhoc-native-query-path (data/id))}
-  (query-perms/perms-set {:database (data/id)
-                          :type     :query
-                          :query    {:source-query {:native "SELECT * FROM CHECKINS"}}}))
+  (query-perms/perms-set
+   {:database (data/id)
+    :type     :query
+    :query    {:source-query {:native "SELECT * FROM CHECKINS"}}}
+   :throw-exceptions? true))
 
 
 ;;; --------------------------------------------- invalid/legacy queries ---------------------------------------------
@@ -235,5 +245,30 @@
 (expect
   #{"/db/0/"}
   (tu.log/suppress-output
-    (query-perms/perms-set (data/mbql-query venues
-                             {:filter [:WOW 100 200]}))))
+    (query-perms/perms-set
+     (data/mbql-query venues
+       {:filter [:WOW 100 200]}))))
+
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                                   JOINS 2.0                                                    |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+;; Are permissions calculated correctly for JOINs?
+(expect
+  #{(perms/object-path (data/id) "PUBLIC" (data/id :checkins))
+    (perms/object-path (data/id) "PUBLIC" (data/id :users))}
+  (tt/with-temp Card [{card-id :id} (qp.test-util/card-with-source-metadata-for-query
+                                     (data/mbql-query checkins
+                                       {:aggregation [[:sum $id]]
+                                        :breakout    [$user_id]}))]
+    (query-perms/perms-set
+     (data/mbql-query users
+       {:joins [{:fields       :all
+                 :alias        "__alias__"
+                 :source-table (str "card__" card-id)
+                 :condition    [:=
+                                $id
+                                ["joined-field" "__alias__" ["field-literal" "USER_ID" "type/Integer"]]]}]
+        :limit 10})
+     :throw-exceptions? true)))

--- a/test/metabase/query_processor/middleware/add_implicit_clauses_test.clj
+++ b/test/metabase/query_processor/middleware/add_implicit_clauses_test.clj
@@ -1,11 +1,13 @@
 (ns metabase.query-processor.middleware.add-implicit-clauses-test
-  (:require [expectations :refer :all]
+  (:require [expectations :refer [expect]]
             [metabase.models.field :refer [Field]]
             [metabase.query-processor.middleware.add-implicit-clauses :as add-implicit-clauses]
+            [metabase.query-processor.test-util :as qp.test-util]
             [metabase.test
              [data :as data]
              [util :as tu]]
             [metabase.util :as u]
+            [schema.core :as s]
             [toucan.db :as db]
             [toucan.util.test :as tt]))
 
@@ -29,126 +31,100 @@
 
 ;; we should add order-bys for breakout clauses
 (expect
-  {:database 1
-   :type     :query
-   :query    {:source-table 1
-              :breakout     [[:field-id 1]]
-              :order-by     [[:asc [:field-id 1]]]}}
+  {:source-table 1
+   :breakout     [[:field-id 1]]
+   :order-by     [[:asc [:field-id 1]]]}
   (#'add-implicit-clauses/add-implicit-breakout-order-by
-   {:database 1
-    :type     :query
-    :query    {:source-table 1
-               :breakout     [[:field-id 1]]}}))
+   {:source-table 1
+    :breakout     [[:field-id 1]]}))
 
 (expect
-  {:database 1
-   :type     :query
-   :query    {:source-table 1
-              :breakout     [[:field-id 2]]
-              :order-by     [[:asc [:field-id 1]]
-                             [:asc [:field-id 2]]]}}
+  {:source-table 1
+   :breakout     [[:field-id 2]]
+   :order-by     [[:asc [:field-id 1]]
+                  [:asc [:field-id 2]]]}
   (#'add-implicit-clauses/add-implicit-breakout-order-by
-   {:database 1
-    :type     :query
-    :query    {:source-table 1
-               :breakout     [[:field-id 2]]
-               :order-by     [[:asc [:field-id 1]]]}}))
+   {:source-table 1
+    :breakout     [[:field-id 2]]
+    :order-by     [[:asc [:field-id 1]]]}))
 
 ;; ...but not if the Field is already in an order-by
 (expect
-  {:database 1
-   :type    :query
-   :query   {:source-table 1
-             :breakout     [[:field-id 1]]
-             :order-by     [[:asc [:field-id 1]]]}}
+  {:source-table 1
+   :breakout     [[:field-id 1]]
+   :order-by     [[:asc [:field-id 1]]]}
   (#'add-implicit-clauses/add-implicit-breakout-order-by
-   {:database 1
-    :type    :query
-    :query   {:source-table 1
-              :breakout     [[:field-id 1]]
-              :order-by     [[:asc [:field-id 1]]]}}))
+   {:source-table 1
+    :breakout     [[:field-id 1]]
+    :order-by     [[:asc [:field-id 1]]]}))
 
 (expect
-  {:database 1
-   :type     :query
-   :query    {:source-table 1
-              :breakout     [[:field-id 1]]
-              :order-by     [[:desc [:field-id 1]]]}}
+  {:source-table 1
+   :breakout     [[:field-id 1]]
+   :order-by     [[:desc [:field-id 1]]]}
   (#'add-implicit-clauses/add-implicit-breakout-order-by
-   {:database 1
-    :type     :query
-    :query    {:source-table 1
-               :breakout     [[:field-id 1]]
-               :order-by     [[:desc [:field-id 1]]]}}))
+   {:source-table 1
+    :breakout     [[:field-id 1]]
+    :order-by     [[:desc [:field-id 1]]]}))
 
 (expect
-  {:database 1
-   :type     :query
-   :query    {:source-table 1
-              :breakout     [[:datetime-field [:field-id 1] :day]]
-              :order-by     [[:asc [:field-id 1]]]}}
+  {:source-table 1
+   :breakout     [[:datetime-field [:field-id 1] :day]]
+   :order-by     [[:asc [:field-id 1]]]}
   (#'add-implicit-clauses/add-implicit-breakout-order-by
-   {:database 1
-    :type     :query
-    :query    {:source-table 1
-               :breakout     [[:datetime-field [:field-id 1] :day]]
-               :order-by     [[:asc [:field-id 1]]]}}))
+   {:source-table 1
+    :breakout     [[:datetime-field [:field-id 1] :day]]
+    :order-by     [[:asc [:field-id 1]]]}))
 
 
 ;; We should add sorted implicit Fields for a query with no aggregations
 (expect
-  {:database (data/id)
-   :type     :query
-   :query    {:source-table (data/id :venues)
-              :fields       [ ;; :type/PK Fields should get sorted first
-                             [:field-id (data/id :venues :id)]
-                             ;; followed by :type/Name Fields
-                             [:field-id (data/id :venues :name)]
-                             ;; followed by other Fields sorted by name
-                             [:field-id (data/id :venues :category_id)]
-                             [:field-id (data/id :venues :latitude)]
-                             [:field-id (data/id :venues :longitude)]
-                             [:field-id (data/id :venues :price)]]}}
-  (#'add-implicit-clauses/add-implicit-fields
-   {:database (data/id)
-    :type     :query
-    :query    {:source-table (data/id :venues)}}))
+  (:query
+   (data/mbql-query venues
+     {:fields [ ;; :type/PK Fields should get sorted first
+               $id
+               ;; followed by :type/Name Fields
+               $name
+               ;; followed by other Fields sorted by name
+               $category_id $latitude $longitude $price]}))
+  (#'add-implicit-clauses/add-implicit-fields (:query (data/mbql-query venues))))
 
 ;; when adding sorted implicit Fields, Field positions should be taken into account
 (tt/expect-with-temp [Field [field-1 {:table_id (data/id :venues), :position 1, :name "bbbbb"}]
                       Field [field-2 {:table_id (data/id :venues), :position 2, :name "aaaaa"}]]
-  {:database (data/id)
-   :type     :query
-   :query    {:source-table (data/id :venues)
-              :fields       [;; all fields with position = 0 should get sorted first according to rules above
-                             [:field-id (data/id :venues :id)]
-                             [:field-id (data/id :venues :name)]
-                             [:field-id (data/id :venues :category_id)]
-                             [:field-id (data/id :venues :latitude)]
-                             [:field-id (data/id :venues :longitude)]
-                             [:field-id (data/id :venues :price)]
-                             ;; followed by position = 1
-                             [:field-id (u/get-id field-1)]
-                             ;; followed by position = 2
-                             [:field-id (u/get-id field-2)]]}}
-  (#'add-implicit-clauses/add-implicit-fields
-   {:database (data/id)
-    :type     :query
-    :query    {:source-table (data/id :venues)}}))
+  (:query
+   (data/mbql-query venues
+     {:fields [ ;; all fields with position = 0 should get sorted first according to rules above
+               $id $name $category_id $latitude $longitude $price
+               ;; followed by position = 1, then position = 2
+               [:field-id (u/get-id field-1)]
+               [:field-id (u/get-id field-2)]]}))
+  (#'add-implicit-clauses/add-implicit-fields (:query (data/mbql-query venues))))
 
 ;; datetime Fields should get default bucketing of :day
 (tt/expect-with-temp [Field [field {:table_id (data/id :venues), :position 0, :name "aaaaa", :base_type :type/DateTime}]]
-  {:database (data/id)
-   :type     :query
-   :query    {:source-table (data/id :venues)
-              :fields       [[:field-id (data/id :venues :id)]
-                             [:field-id (data/id :venues :name)]
-                             [:datetime-field [:field-id (u/get-id field)] :default]
-                             [:field-id (data/id :venues :category_id)]
-                             [:field-id (data/id :venues :latitude)]
-                             [:field-id (data/id :venues :longitude)]
-                             [:field-id (data/id :venues :price)]]}}
-  (#'add-implicit-clauses/add-implicit-fields
-   {:database (data/id)
-    :type     :query
-    :query    {:source-table (data/id :venues)}}))
+  (:query
+   (data/mbql-query venues
+     {:fields [[:field-id (data/id :venues :id)]
+               [:field-id (data/id :venues :name)]
+               [:datetime-field [:field-id (u/get-id field)] :default]
+               [:field-id (data/id :venues :category_id)]
+               [:field-id (data/id :venues :latitude)]
+               [:field-id (data/id :venues :longitude)]
+               [:field-id (data/id :venues :price)]]}))
+  (#'add-implicit-clauses/add-implicit-fields (:query (data/mbql-query venues))))
+
+;; We should add implicit Fields for source queries that have source-metadata as appropriate
+(tu/expect-schema
+  {:fields   (s/eq [[:field-literal "DATE" :type/Date]
+                    [:field-literal "count" :type/Integer]])
+   s/Keyword s/Any}
+  (let [{{source-query :query} :dataset_query
+         source-metadata       :result_metadata} (qp.test-util/card-with-source-metadata-for-query
+                                                  (data/mbql-query checkins
+                                                    {:aggregation [[:count]]
+                                                     :breakout    [[:datetime-field $date :month]]}))]
+    (#'add-implicit-clauses/add-implicit-fields
+     (:query (data/mbql-query checkins
+               {:source-query    source-query
+                :source-metadata source-metadata})))))

--- a/test/metabase/query_processor/middleware/add_implicit_joins_test.clj
+++ b/test/metabase/query_processor/middleware/add_implicit_joins_test.clj
@@ -1,141 +1,101 @@
 (ns metabase.query-processor.middleware.add-implicit-joins-test
   (:require [expectations :refer [expect]]
+            [metabase.driver :as driver]
             [metabase.models
              [database :refer [Database]]
              [field :refer [Field]]
              [table :refer [Table]]]
-            [metabase.query-processor
-             [store :as qp.store]
-             [test-util :as qp.test-util]]
             [metabase.query-processor.middleware.add-implicit-joins :as add-implicit-joins]
+            [metabase.query-processor.store :as qp.store]
             [metabase.test.data :as data]
-            [toucan.db :as db]
+            [metabase.test.data.interface :as tx]
             [toucan.util.test :as tt]))
 
 (defn- add-implicit-joins [query]
-  (qp.test-util/with-everything-store
-    ((add-implicit-joins/add-implicit-joins identity) {:database (data/id)
-                                                       :type     :query
-                                                       :query    query})))
+  (driver/with-driver (tx/driver)
+    (qp.store/with-store
+      (qp.store/fetch-and-store-database! (data/id))
+      ((add-implicit-joins/add-implicit-joins identity) query))))
 
 ;; make sure `:joins` get added automatically for `:fk->` clauses
 (expect
-  {:database (data/id)
-   :type     :query
-   :query    (data/$ids venues
-               {:source-table $$table
-                :fields       [[:field-id $name]
-                               [:joined-field "CATEGORIES__via__CATEGORY_ID" [:field-id $categories.name]]]
-                :joins        [{:source-table (data/id :categories)
-                                :alias        "CATEGORIES__via__CATEGORY_ID"
-                                :condition    [:=
-                                               [:field-id $category_id]
-                                               [:joined-field "CATEGORIES__via__CATEGORY_ID" [:field-id $categories.id]]]
-                                :strategy     :left-join
-                                :fields       :none
-                                :fk-field-id  $category_id}]})}
+  (data/mbql-query venues
+    {:source-table $$venues
+     :fields       [$name &CATEGORIES__via__CATEGORY_ID.categories.name]
+     :joins        [{:source-table $$categories
+                     :alias        "CATEGORIES__via__CATEGORY_ID"
+                     :condition    [:= $category_id &CATEGORIES__via__CATEGORY_ID.categories.id]
+                     :strategy     :left-join
+                     :fields       :none
+                     :fk-field-id  %category_id}]})
   (add-implicit-joins
-   (data/$ids venues
-     {:source-table $$table
-      :fields       [[:field-id $name]
-                     [:fk-> [:field-id $category_id] [:field-id $categories.name]]]})))
+   (data/mbql-query venues
+     {:source-table $$venues
+      :fields [$name $category_id->categories.name]})))
 
 ;; For FK clauses inside nested source queries, we should add the `:joins` info to the nested query instead of
 ;; at the top level (#8972)
 (expect
-  {:database (data/id)
-   :type     :query
-   :query    {:source-query
-              (data/$ids venues
-                {:source-table $$table
-                 :fields       [[:field-id $name]
-                                [:joined-field "CATEGORIES__via__CATEGORY_ID" [:field-id $categories.name]]]
-                 :joins        [{:source-table (data/id :categories)
-                                 :alias        "CATEGORIES__via__CATEGORY_ID"
-                                 :condition    [:=
-                                                [:field-id $category_id]
-                                                [:joined-field "CATEGORIES__via__CATEGORY_ID" [:field-id $categories.id]]]
-                                 :strategy     :left-join
-                                 :fields       :none
-                                 :fk-field-id  $category_id}]})}}
+  (data/mbql-query venues
+    {:source-query
+     {:source-table $$venues
+      :fields       [$name &CATEGORIES__via__CATEGORY_ID.categories.name]
+      :joins        [{:source-table $$categories
+                      :alias        "CATEGORIES__via__CATEGORY_ID"
+                      :condition    [:= $category_id &CATEGORIES__via__CATEGORY_ID.categories.id]
+                      :strategy     :left-join
+                      :fields       :none
+                      :fk-field-id  %category_id}]}})
   (add-implicit-joins
-   {:source-query
-    (data/$ids venues
-      {:source-table $$table
-       :fields       [[:field-id $name]
-                      [:fk-> [:field-id $category_id] [:field-id $categories.name]]]})}))
+   (data/mbql-query venues
+     {:source-query
+      {:source-table $$venues
+       :fields       [$name $category_id->categories.name]}})))
 
 ;; we should handle nested-nested queries correctly as well
 (expect
-  {:database (data/id)
-   :type     :query
-   :query    {:source-query
-              {:source-query
-               (data/$ids venues
-                 {:source-table $$table
-                  :fields       [[:field-id $name]
-                                 [:joined-field "CATEGORIES__via__CATEGORY_ID" [:field-id $categories.name]]]
-                  :joins        [{:source-table (data/id :categories)
-                                  :alias        "CATEGORIES__via__CATEGORY_ID"
-                                  :condition    [:=
-                                                 [:field-id $category_id]
-                                                 [:joined-field "CATEGORIES__via__CATEGORY_ID" [:field-id $categories.id]]]
-                                  :strategy     :left-join
-                                  :fields       :none
-                                  :fk-field-id  $category_id}]})}}}
-  (add-implicit-joins
-   {:source-query
+  (data/mbql-query venues
     {:source-query
-     (data/$ids venues
-       {:source-table $$table
-        :fields       [[:field-id $name]
-                       [:fk-> [:field-id $category_id] [:field-id $categories.name]]]})}}))
+     {:source-query
+      {:source-table $$venues
+       :fields       [$name &CATEGORIES__via__CATEGORY_ID.categories.name]
+       :joins        [{:source-table $$categories
+                       :alias        "CATEGORIES__via__CATEGORY_ID"
+                       :condition    [:= $category_id &CATEGORIES__via__CATEGORY_ID.categories.id]
+                       :strategy     :left-join
+                       :fields       :none
+                       :fk-field-id  %category_id}]}}})
+  (add-implicit-joins
+   (data/mbql-query venues
+     {:source-query
+      {:source-query
+       {:source-table $$venues
+        :fields       [$name $category_id->categories.name]}}})))
 
 ;; ok, so apparently if you specify a source table at a deeper level of nesting we should still add JOINs as
 ;; appropriate for that Table if you specify an `fk->` clause in an a higher level. Does this make any sense at all?
 ;;
 ;; TODO - I'm not sure I understand why we add the JOIN to the outer level in this case. Does it make sense?
 (expect
-  {:database (data/id)
-   :type     :query
-   :query    (data/$ids checkins
-               {:source-query {:source-table $$table
-                               :filter       [:> [:field-id $date] "2014-01-01"]}
-                :aggregation  [[:count]]
-                :breakout     [[:joined-field "VENUES__via__VENUE_ID" [:field-id $venues.price]]]
-                :order-by     [[:asc [:joined-field "VENUES__via__VENUE_ID" [:field-id $venues.price]]]]
-                :joins        [{:source-table (data/id :venues)
-                                :alias        "VENUES__via__VENUE_ID"
-                                :condition    [:=
-                                               [:field-id $venue_id]
-                                               [:joined-field "VENUES__via__VENUE_ID" [:field-id $venues.id]]]
-                                :strategy     :left-join
-                                :fields       :none
-                                :fk-field-id  $venue_id}]})}
+  (data/mbql-query checkins
+    {:source-query {:source-table $$checkins
+                    :filter       [:> $date "2014-01-01"]}
+     :aggregation  [[:count]]
+     :breakout     [&VENUES__via__VENUE_ID.venues.price]
+     :order-by     [[:asc &VENUES__via__VENUE_ID.venues.price]]
+     :joins        [{:source-table $$venues
+                     :alias        "VENUES__via__VENUE_ID"
+                     :condition    [:= $venue_id &VENUES__via__VENUE_ID.venues.id]
+                     :strategy     :left-join
+                     :fields       :none
+                     :fk-field-id  %venue_id}]})
   (add-implicit-joins
-   (data/$ids [checkins {:wrap-field-ids? true}]
-     {:source-query {:source-table $$table
+   (data/mbql-query checkins
+     {:source-query {:source-table $$checkins
                      :filter       [:> $date "2014-01-01"]}
       :aggregation  [[:count]]
       :breakout     [$venue_id->venues.price]
       :order-by     [[:asc $venue_id->venues.price]]})))
-
-;; Test that middleware stores joined tables in QP store
-(expect
-  {:database "test-data"
-   :tables   #{"CATEGORIES" "VENUES"}
-   :fields   #{["VENUES" "CATEGORY_ID"]
-               ["CATEGORIES" "ID"]
-               ["CATEGORIES" "NAME"]}}
-  (qp.store/with-store
-    (qp.store/store-database! (db/select-one (into [Database] qp.store/database-columns-to-fetch) :id (data/id)))
-    (qp.store/store-table!    (db/select-one (into [Table] qp.store/table-columns-to-fetch) :id (data/id :venues)))
-    (doseq [field-id [(data/id :categories :name) (data/id :venues :category_id)]]
-      (qp.store/store-field!    (db/select-one (into [Field] qp.store/field-columns-to-fetch) :id field-id)))
-    ((add-implicit-joins/add-implicit-joins identity)
-     (data/mbql-query venues
-       {:fields [$name $category_id->categories.name]}))
-    (qp.test-util/store-contents)))
 
 ;; Test that joining against a table in a different DB throws and Exception
 (expect
@@ -144,9 +104,62 @@
                   Table    [{table-id :id}    {:db_id database-id}]
                   Field    [{field-id :id}    {:table_id table-id}]]
     (add-implicit-joins
-     (data/$ids [checkins {:wrap-field-ids? true}]
-       {:source-query {:source-table $$table
+     (data/mbql-query checkins
+       {:source-query {:source-table $$checkins
                        :filter       [:> $date "2014-01-01"]}
         :aggregation  [[:count]]
-        :breakout     [[:fk-> $venue_id [:field-id field-id]]]
+        :breakout     [[:fk-> $venue_id field-id]]
         :order-by     [[:asc $venue_id->venues.price]]}))))
+
+;; Test that adding implicit joins still works correctly if the query also contains explicit joins
+(expect
+  (data/mbql-query checkins
+    {:source-table $$checkins
+     :aggregation  [[:sum [:joined-field "USERS__via__USER_ID" $users.id]]]
+     :breakout     [$id]
+     :joins        [{:alias        "u"
+                     :source-table $$users
+                     :condition    [:= *user_id &u.users.id]}
+                    {:source-table $$users
+                     :alias        "USERS__via__USER_ID"
+                     :strategy     :left-join
+                     :condition    [:= $user_id &USERS__via__USER_ID.users.id]
+                     :fk-field-id  %checkins.user_id
+                     :fields       :none}]
+     :limit        10})
+  (add-implicit-joins
+   (data/mbql-query checkins
+     {:source-table $$checkins
+      :aggregation  [[:sum $user_id->users.id]]
+      :breakout     [$id]
+      :joins        [{:alias        "u"
+                      :source-table $$users
+                      :condition    [:= *user_id &u.users.id]}]
+      :limit        10})))
+
+;; Test that adding implicit joins still works correctly if the query also contains explicit joins in nested source
+;; queries
+(expect
+  (data/mbql-query checkins
+    {:source-query {:source-table $$checkins
+                    :aggregation  [[:sum &USERS__via__USER_ID.users.id]]
+                    :breakout     [$id]
+                    :joins        [{:source-table $$users
+                                    :alias        "USERS__via__USER_ID"
+                                    :strategy     :left-join
+                                    :condition    [:= $user_id &USERS__via__USER_ID.users.id]
+                                    :fk-field-id  %checkins.user_id
+                                    :fields       :none}]}
+     :joins        [{:alias        "u"
+                     :source-table $$users
+                     :condition    [:= *user_id &u.users.id]}]
+     :limit        10})
+  (add-implicit-joins
+   (data/mbql-query checkins
+     {:source-query {:source-table $$checkins
+                     :aggregation  [[:sum $user_id->users.id]]
+                     :breakout     [$id]}
+      :joins        [{:alias        "u"
+                      :source-table $$users
+                      :condition    [:= *user_id &u.users.id]}]
+      :limit        10})))

--- a/test/metabase/query_processor/middleware/add_source_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/add_source_metadata_test.clj
@@ -1,0 +1,211 @@
+(ns metabase.query-processor.middleware.add-source-metadata-test
+  (:require [clojure.string :as str]
+            [expectations :refer [expect]]
+            [metabase.driver :as driver]
+            [metabase.models.field :refer [Field]]
+            [metabase.query-processor
+             [store :as qp.store]
+             [test-util :as qp.test-util]]
+            [metabase.query-processor.middleware.add-source-metadata :as add-source-metadata]
+            [metabase.test.data :as data]))
+
+(defn- add-source-metadata [query]
+  (driver/with-driver :h2
+    (qp.store/with-store
+      (qp.test-util/store-referenced-database! query)
+      (qp.test-util/store-referenced-tables! query)
+      ((add-source-metadata/add-source-metadata-for-source-queries identity) query))))
+
+(defn- venues-metadata [field-name]
+  (select-keys
+   (Field (data/id :venues field-name))
+   [:id :table_id :name :display_name :base_type :special_type :unit :fingerprint]))
+
+(defn- venues-source-metadata
+  ([]
+   (venues-source-metadata :id :name :category_id :latitude :longitude :price))
+
+  ([& field-names]
+   (for [field-name field-names]
+     (venues-metadata (keyword (str/lower-case (name field-name)))))))
+
+(defn- venues-source-metadata-for-field-literals
+  "Metadata we'd expect to see from a `:field-literal` clause. The same as normal metadata, but field literals don't
+  include special-type info."
+  [& field-names]
+  (for [field (apply venues-source-metadata field-names)]
+    (dissoc field :special_type)))
+
+;; Can we automatically add source metadata to the parent level of a query? If the source query has `:fields`
+(expect
+  (data/mbql-query venues
+    {:source-query    {:source-table $$venues
+                       :fields       [$id $name]}
+     :source-metadata (venues-source-metadata :id :name)})
+  (add-source-metadata
+   (data/mbql-query venues
+     {:source-query {:source-table $$venues
+                     :fields       [$id $name]}})))
+
+;; Can we automatically add source metadata to the parent level of a query? If the source query does not have `:fields`
+(expect
+  (data/mbql-query venues
+    {:source-query {:source-table $$venues}
+     :source-metadata (venues-source-metadata)})
+  (add-source-metadata
+   (data/mbql-query venues
+     {:source-query {:source-table $$venues}})))
+
+;; Can we add source metadata for a source query that has breakouts/aggregations?
+(expect
+  (data/mbql-query venues
+    {:source-query    {:source-table $$venues
+                       :aggregation  [[:count]]
+                       :breakout     [$price]}
+     :source-metadata (concat
+                       (venues-source-metadata :price)
+                       [{:name         "count"
+                         :display_name "count"
+                         :base_type    :type/Integer
+                         :special_type :type/Number}])})
+  (add-source-metadata
+   (data/mbql-query venues
+     {:source-query {:source-table $$venues
+                     :aggregation  [[:count]]
+                     :breakout     [$price]}})))
+
+;; Can we add source metadata for a source query that has an aggregation for a specific Field?
+(expect
+  (data/mbql-query venues
+    {:source-query    {:source-table $$venues
+                       :aggregation  [[:avg $id]]
+                       :breakout     [$price]}
+     :source-metadata (concat
+                       (venues-source-metadata :price)
+                       [{:name         "avg"
+                         :display_name "avg"
+                         :base_type    :type/BigInteger
+                         :special_type :type/PK}])})
+  (add-source-metadata
+   (data/mbql-query venues
+     {:source-query {:source-table $$venues
+                     :aggregation  [[:avg $id]]
+                     :breakout     [$price]}})))
+
+;; Can we add source metadata for a source query that has a named aggregation?
+(expect
+  (data/mbql-query venues
+    {:source-query    {:source-table $$venues
+                       :aggregation  [[:named [:avg $id] "my_cool_aggregation"]]
+                       :breakout     [$price]}
+     :source-metadata (concat
+                       (venues-source-metadata :price)
+                       [{:name         "my_cool_aggregation"
+                         :display_name "my_cool_aggregation"
+                         :base_type    :type/BigInteger
+                         :special_type :type/PK}])})
+  (add-source-metadata
+   (data/mbql-query venues
+     {:source-query {:source-table $$venues
+                     :aggregation  [[:named [:avg $id] "my_cool_aggregation"]]
+                     :breakout     [$price]}})))
+
+;; Can we automatically add source metadata to the parent level of a query? If the source query has a source query
+;; with source metadata
+(expect
+  (data/mbql-query venues
+    {:source-query    {:source-query    {:source-table $$venues
+                                         :fields       [$id $name]}
+                       :source-metadata (venues-source-metadata :id :name)}
+     :source-metadata (venues-source-metadata :id :name)})
+  (add-source-metadata
+   (data/mbql-query venues
+     {:source-query {:source-query    {:source-table $$venues
+                                       :fields       [$id $name]}
+                     :source-metadata (venues-source-metadata :id :name)}})))
+
+;; Can we automatically add source metadata if a source-query nested 3 levels has `:source-metadata`?
+(expect
+  (data/mbql-query venues
+    {:source-query    {:source-query    {:source-query    {:source-table $$venues
+                                                           :fields       [$id $name]}
+                                         :source-metadata (venues-source-metadata :id :name)}
+                       :source-metadata (venues-source-metadata :id :name)}
+     :source-metadata (venues-source-metadata :id :name)})
+  (add-source-metadata
+   (data/mbql-query venues
+     {:source-query
+      {:source-query
+       {:source-query    {:source-table $$venues
+                          :fields       [$id $name]}
+        :source-metadata (venues-source-metadata :id :name)}}})))
+
+;; Ok, how about a source query nested 3 levels with no `source-metadata`?
+  (expect
+    (data/mbql-query venues
+      {:source-query    {:source-query    {:source-query    {:source-table $$venues}
+                                           :source-metadata (venues-source-metadata)}
+                         :source-metadata (venues-source-metadata)}
+       :source-metadata (venues-source-metadata)})
+    (add-source-metadata
+     (data/mbql-query venues
+       {:source-query {:source-query {:source-query {:source-table $$venues}}}})))
+
+;; Ok, how about a source query nested 3 levels with no `source-metadata`, but with `fields`
+(expect
+  (data/mbql-query venues
+    {:source-query    {:source-query    {:source-query    {:source-table $$venues
+                                                           :fields       [$id $name]}
+                                         :source-metadata (venues-source-metadata :id :name)}
+                       :source-metadata (venues-source-metadata :id :name)}
+     :source-metadata (venues-source-metadata :id :name)})
+  (add-source-metadata
+   (data/mbql-query venues
+     {:source-query {:source-query {:source-query {:source-table $$venues
+                                                   :fields       [$id $name]}}}})))
+
+;; Ok, how about a source query nested 3 levels with no `source-metadata`, but with breakouts/aggregations
+(expect
+  (let [metadata (concat
+                  (venues-source-metadata :price)
+                  [{:name         "count"
+                    :display_name "count"
+                    :base_type    :type/Integer
+                    :special_type :type/Number}])]
+    (data/mbql-query venues
+      {:source-query    {:source-query    {:source-query    {:source-table $$venues
+                                                             :aggregation  [[:count]]
+                                                             :breakout     [$price]}
+                                           :source-metadata metadata}
+                         :source-metadata metadata}
+       :source-metadata metadata}))
+  (add-source-metadata
+   (data/mbql-query venues
+     {:source-query {:source-query {:source-query {:source-table $$venues
+                                                   :aggregation  [[:count]]
+                                                   :breakout     [$price]}}}})))
+
+;; can we add source-metadata to the parent level if the source query has a native source query, but has
+;; `source-metadata`?
+(expect
+  (data/mbql-query venues
+    {:source-query    {:source-query    {:native "SELECT \"ID\", \"NAME\" FROM \"VENUES\";"}
+                       :source-metadata (venues-source-metadata :id :name)}
+     :source-metadata (venues-source-metadata :id :name)})
+  (add-source-metadata
+   (data/mbql-query venues
+     {:source-query {:source-query    {:native "SELECT \"ID\", \"NAME\" FROM \"VENUES\";"}
+                     :source-metadata (venues-source-metadata :id :name)}})))
+
+;; should work inside JOINS as well
+(expect
+  (data/mbql-query venues
+    {:source-table $$venues
+     :joins        [{:source-query    {:source-table $$venues
+                                       :fields       [$id $name]}
+                     :source-metadata (venues-source-metadata :id :name)}]})
+  (add-source-metadata
+   (data/mbql-query venues
+     {:source-table $$venues
+      :joins        [{:source-query {:source-table $$venues
+                                     :fields       [$id $name]}}]})))

--- a/test/metabase/query_processor/middleware/annotate_test.clj
+++ b/test/metabase/query_processor/middleware/annotate_test.clj
@@ -40,7 +40,7 @@
 
 (defn- info-for-field
   ([field-id]
-   (db/select-one (into [Field] (disj (set qp.store/field-columns-to-fetch) :database_type)) :id field-id))
+   (db/select-one (into [Field] (disj (set @#'qp.store/field-columns-to-fetch) :database_type)) :id field-id))
   ([table-key field-key]
    (info-for-field (data/id table-key field-key))))
 
@@ -75,17 +75,15 @@
 (expect
   [(assoc (info-for-field :categories :name)
      :fk_field_id (data/id :venues :category_id), :source :fields)]
-  (data/$ids venues
-    (qp.test-util/with-everything-store
+  (qp.test-util/with-everything-store
+    (data/$ids venues
       (-> (#'annotate/add-mbql-column-info
-           {:query {:fields [[:joined-field "CATEGORIES__via__CATEGORY_ID" [:field-id $categories.name]]]
+           {:query {:fields [&CATEGORIES__via__CATEGORY_ID.categories.name]
                     :joins  [{:alias        "CATEGORIES__via__CATEGORY_ID"
-                              :source-table $$table
-                              :condition    [:=
-                                             [:field-id $category_id]
-                                             [:joined-field "CATEGORIES__via__CATEGORY_ID" [:field-id $categories.id]]]
+                              :source-table $$venues
+                              :condition    [:= $category_id &CATEGORIES__via__CATEGORY_ID.categories.id]
                               :strategy     :left-join
-                              :fk-field-id  $category_id}]}}
+                              :fk-field-id  %category_id}]}}
            {:columns [:name]})
           :cols
           vec))))
@@ -204,7 +202,7 @@
    :display_name "sum"}
   (qp.test-util/with-everything-store
     (data/$ids venues
-      (col-info-for-aggregation-clause [:sum [:+ [:field-id $price] 1]]))))
+      (col-info-for-aggregation-clause [:sum [:+ $price 1]]))))
 
 ;; if a driver is kind enough to supply us with some information about the `:cols` that come back, we should include
 ;; that information in the results. Their information should be preferred over ours
@@ -219,10 +217,8 @@
                                                        :display_name "Total Events"
                                                        :base_type    :type/Text}]
                                             :columns ["totalEvents"]}))
-     {:database (data/id)
-      :type     :query
-      :query    {:source-table (data/id :venues)
-                 :aggregation  [[:metric "ga:totalEvents"]]}})))
+     (data/mbql-query venues
+       {:aggregation [[:metric "ga:totalEvents"]]}))))
 
 ;; Make sure columns always come back with a unique `:name` key (#8759)
 (expect
@@ -276,13 +272,11 @@
    :source          :fields}
   (-> (qp.test-util/with-everything-store
         ((annotate/add-column-info (constantly {}))
-         {:database (data/id)
-          :type     :query
-          :query    (data/$ids [venues {:wrap-field-ids? true}]
-                      {:source-table $$table
-                       :expressions  {"discount_price" [:* 0.9 [:field-id $price]]}
-                       :fields       [$name [:expression "discount_price"]]
-                       :limit        10})}))
+         (data/mbql-query venues
+           {:source-table $$venues
+            :expressions  {"discount_price" [:* 0.9 [:field-id $price]]}
+            :fields       [$name [:expression "discount_price"]]
+            :limit        10})))
       :cols
       second))
 
@@ -305,12 +299,10 @@
                              :NAME        "Red Medicine"
                              :PRICE       3}]}]
         ((annotate/result-rows-maps->vectors (constantly results))
-         {:database (data/id)
-          :type     :query
-          :query    (data/$ids [venues {:wrap-field-ids? true}]
-                               {:source-table $$table
-                                :fields       [$id $name $category_id $latitude $longitude $price]
-                                :limit        1})})))))
+         (data/mbql-query venues
+           {:source-table $$venues
+            :fields       [$id $name $category_id $latitude $longitude $price]
+            :limit        1}))))))
 
 ;; if a driver would have returned result rows as a sequence of maps, but query returned no results, middleware should
 ;; still add `:columns` info
@@ -321,12 +313,10 @@
     (driver/with-driver :h2
       (let [results {:rows []}]
         ((annotate/result-rows-maps->vectors (constantly results))
-         {:database (data/id)
-          :type     :query
-          :query    (data/$ids [venues {:wrap-field-ids? true}]
-                      {:source-table $$table
-                       :fields       [$id $name $category_id $latitude $longitude $price]
-                       :limit        1})})))))
+         (data/mbql-query venues
+           {:source-table $$venues
+            :fields       [$id $name $category_id $latitude $longitude $price]
+            :limit        1}))))))
 
 ;; `result-rows-maps->vectors` should preserve sort order of columns in the first result row for native queries
 ;; (hopefully the driver is using Flatland `ordered-map` as suggested)
@@ -360,14 +350,12 @@
                              :sum         56
                              :sum_2       4}]}]
         ((annotate/result-rows-maps->vectors (constantly results))
-         {:database (data/id)
-          :type     :query
-          :query    (data/$ids [venues {:wrap-field-ids? true}]
-                      {:source-table $$table
-                       :aggregation  [[:sum $id]
-                                      [:sum $price]]
-                       :breakout     [$category_id]
-                       :limit        2})})))))
+         (data/mbql-query venues
+           {:source-table $$venues
+            :aggregation  [[:sum $id]
+                           [:sum $price]]
+            :breakout     [$category_id]
+            :limit        2}))))))
 
 ;; For fields with parents we should return them with a combined name including parent's name
 (tt/expect-with-temp [Field [parent {:name "parent", :table_id (data/id :venues)}]

--- a/test/metabase/query_processor/middleware/auto_bucket_datetimes_test.clj
+++ b/test/metabase/query_processor/middleware/auto_bucket_datetimes_test.clj
@@ -177,10 +177,10 @@
 (expect
   (data/dataset sad-toucan-incidents
     (data/$ids incidents
-      {:source-table $$table
-       :breakout     [[:datetime-field [:field-id $timestamp] :day]]}))
+      {:source-table $$incidents
+       :breakout     [!day.timestamp]}))
   (data/dataset sad-toucan-incidents
     (data/$ids incidents
       (auto-bucket-mbql
-       {:source-table $$table
-        :breakout     [[:field-id $timestamp]]}))))
+       {:source-table $$incidents
+        :breakout     [$timestamp]}))))

--- a/test/metabase/query_processor/middleware/fetch_source_query_test.clj
+++ b/test/metabase/query_processor/middleware/fetch_source_query_test.clj
@@ -1,26 +1,28 @@
 (ns metabase.query-processor.middleware.fetch-source-query-test
-  (:require [expectations :refer [expect]]
-            [metabase.models
-             [card :refer [Card]]
-             [database :as database]]
+  (:require [cheshire.core :as json]
+            [expectations :refer [expect]]
+            [metabase.mbql.schema :as mbql.s]
+            [metabase.models.card :refer [Card]]
             [metabase.query-processor.middleware.fetch-source-query :as fetch-source-query]
             [metabase.test.data :as data]
             [metabase.util :as u]
+            [toucan.db :as db]
             [toucan.util.test :as tt]))
 
-(def ^:private ^{:arglists '([query])} fetch-source-query (fetch-source-query/fetch-source-query identity))
+(def ^:private ^{:arglists '([query])} resolve-card-id-source-tables
+  (fetch-source-query/resolve-card-id-source-tables identity))
 
 (defn- wrap-inner-query [query]
-  {:database     database/virtual-id
+  {:database     mbql.s/saved-questions-virtual-database-id
    :type         :query
    :query        query})
 
 (defn- default-result-with-inner-query [inner-query]
   {:database (data/id)
    :type     :query
-   :query    inner-query})
+   :query    (assoc inner-query :source-metadata nil)})
 
-;; make sure that the `fetch-source-query` middleware correctly resolves MBQL queries
+;; make sure that the `resolve-card-id-source-tables` middleware correctly resolves MBQL queries
 (expect
   (default-result-with-inner-query
    {:aggregation  [[:count]]
@@ -29,13 +31,13 @@
   (tt/with-temp Card [card {:dataset_query {:database (data/id)
                                             :type     :query
                                             :query    {:source-table (data/id :venues)}}}]
-    (fetch-source-query
+    (resolve-card-id-source-tables
      (wrap-inner-query
       {:source-table (str "card__" (u/get-id card))
        :aggregation  [[:count]]
        :breakout     [[:field-literal "price" :type/Integer]]}))))
 
-;; make sure that the `fetch-source-query` middleware correctly resolves native queries
+;; make sure that the `resolve-card-id-source-tables` middleware correctly resolves native queries
 (expect
   (default-result-with-inner-query
    {:aggregation  [[:count]]
@@ -44,7 +46,7 @@
   (tt/with-temp Card [card {:dataset_query {:database (data/id)
                                             :type     :native
                                             :native   {:query (format "SELECT * FROM %s" (data/format-name "venues"))}}}]
-    (fetch-source-query
+    (resolve-card-id-source-tables
      (wrap-inner-query
       {:source-table (str "card__" (u/get-id card))
        :aggregation  [[:count]]
@@ -56,7 +58,7 @@
   (tt/with-temp Card [card {:dataset_query {:database (data/id)
                                             :type     :query
                                             :query    {:source-table (data/id :venues)}}}]
-    (fetch-source-query
+    (resolve-card-id-source-tables
      (wrap-inner-query
       {:source-table (str "card__" (u/get-id card))}))))
 
@@ -67,7 +69,7 @@
   (tt/with-temp Card [card {:dataset_query {:database (data/id)
                                             :type     :query
                                             :query    {:source-table (data/id :checkins)}}}]
-    (fetch-source-query
+    (resolve-card-id-source-tables
      (wrap-inner-query
       {:source-table (str "card__" (u/get-id card))
        :filter       [:between
@@ -79,32 +81,34 @@
 (expect
   (default-result-with-inner-query
    {:limit        25
-    :source-query {:limit        50
-                   :source-query {:source-table (data/id :venues)
-                                  :limit        100}}})
+    :source-query {:limit           50
+                   :source-query    {:source-table (data/id :venues)
+                                     :limit        100}
+                   :source-metadata nil}})
   (tt/with-temp* [Card [card-1 {:dataset_query {:database (data/id)
                                                 :type     :query
                                                 :query    {:source-table (data/id :venues), :limit 100}}}]
-                  Card [card-2 {:dataset_query {:database database/virtual-id
+                  Card [card-2 {:dataset_query {:database mbql.s/saved-questions-virtual-database-id
                                                 :type     :query
                                                 :query    {:source-table (str "card__" (u/get-id card-1)), :limit 50}}}]]
-    (fetch-source-query
+    (resolve-card-id-source-tables
      (wrap-inner-query
       {:source-table (str "card__" (u/get-id card-2)), :limit 25}))))
 
 (expect
   (default-result-with-inner-query
-   {:limit        25
-    :source-query {:limit 50
-                   :source-query {:source-table (data/id :venues)
-                                  :limit        100}}})
+   {:source-query {:source-query    {:source-table (data/id :venues)
+                                     :limit        100}
+                   :source-metadata nil
+                   :limit           50}
+    :limit        25})
   (tt/with-temp* [Card [card-1 {:dataset_query {:database (data/id)
                                                 :type     :query
                                                 :query    {:source-table (data/id :venues), :limit 100}}}]
-                  Card [card-2 {:dataset_query {:database database/virtual-id
+                  Card [card-2 {:dataset_query {:database mbql.s/saved-questions-virtual-database-id
                                                 :type     :query
                                                 :query    {:source-table (str "card__" (u/get-id card-1)), :limit 50}}}]]
-    (fetch-source-query
+    (resolve-card-id-source-tables
      (wrap-inner-query
       {:source-table (str "card__" (u/get-id card-2)), :limit 25}))))
 
@@ -113,27 +117,122 @@
 ;;; |                                                   JOINS 2.0                                                    |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-;; are `card__id` source tables resolved in `:joins`
-
+;; Are `card__id` source tables resolved in `:joins`?
 (expect
-  {:database (data/id)
-   :type     :query
-   :query    (data/$ids venues
-               {:source-table $$venues
-                :joins        [{:alias        "c",
-                                :condition    [:= [:field-id $category_id] [:joined-field "c" [:field-id $categories.id]]]
-                                :source-query {:limit           100
-                                               :source-table    $$categories
-                                               :database        (data/id)
-                                               :source-metadata nil}}]})}
-  (tt/with-temp Card [{card-id :id} {:dataset_query
-                                     (data/mbql-query categories
-                                       {:source-table $$table, :limit 100})}]
-    (fetch-source-query
+  (data/mbql-query venues
+    {:joins [{:source-query    {:source-table $$categories, :limit 100}
+              :alias           "c",
+              :condition       [:= $category_id [:joined-field "c" $categories.id]]
+              :source-metadata [{:name "name", :display_name "Card Name", :base_type :type/Text}]}]})
+  (tt/with-temp Card [{card-id :id} {:dataset_query   (data/mbql-query categories {:limit 100})
+                                     :result_metadata [{:name         "name"
+                                                        :display_name "Card Name"
+                                                        :base_type    "type/Text"}]}]
+    (resolve-card-id-source-tables
      (data/mbql-query venues
-       {:source-table $$table
-        :joins        [{:source-table (str "card__" card-id)
-                        :alias        "c"
-                        :condition    [:= $category_id [:joined-field "c" $categories.id]]}]}))))
+       {:joins [{:source-table (str "card__" card-id)
+                 :alias        "c"
+                 :condition    [:= $category_id [:joined-field "c" $categories.id]]}]}))))
 
-;; TODO - are `card__id` source tables resolved in *nested* JOINs?
+;; Are `card__id` source tables resolved in JOINs against a source query?
+(expect
+  (data/mbql-query venues
+    {:joins [{:source-query {:source-query    {:source-table $$categories, :limit 100}
+                             :source-metadata [{:name "name", :display_name "Card Name", :base_type :type/Text}]}
+              :alias        "c",
+              :condition    [:= $category_id [:joined-field "c" $categories.id]]}]})
+  (tt/with-temp Card [{card-id :id} {:dataset_query   (data/mbql-query categories {:limit 100})
+                                     :result_metadata [{:name         "name"
+                                                        :display_name "Card Name"
+                                                        :base_type    "type/Text"}]}]
+    (resolve-card-id-source-tables
+     (data/mbql-query venues
+       {:joins [{:source-query {:source-table (str "card__" card-id)}
+                 :alias        "c"
+                 :condition    [:= $category_id [:joined-field "c" $categories.id]]}]}))))
+
+;; ;; Are `card__id` source tables resolved in JOINs inside nested source queries?
+(expect
+  (data/mbql-query venues
+    {:source-query {:source-table $$venues
+                    :joins        [{:source-query    {:source-table $$categories
+                                                      :limit        100}
+                                    :alias           "c"
+                                    :condition       [:= $category_id [:joined-field "c" $categories.id]]
+                                    :source-metadata [{:name "name", :display_name "Card Name", :base_type :type/Text}]}]}})
+  (tt/with-temp Card [{card-id :id} {:dataset_query   (data/mbql-query categories {:limit 100})
+                                     :result_metadata [{:name         "name"
+                                                        :display_name "Card Name"
+                                                        :base_type    "type/Text"}]}]
+    (resolve-card-id-source-tables
+     (data/mbql-query venues
+       {:source-query
+        {:source-table $$venues
+         :joins        [{:source-table (str "card__" card-id)
+                         :alias        "c"
+                         :condition    [:= $category_id [:joined-field "c" $categories.id]]}]}}))))
+
+
+;; Can we recursively resolve multiple card ID `:source-table`s in Joins?
+(expect
+  (data/mbql-query venues
+    {:joins [{:alias           "c"
+              :condition       [:= $category_id &c.$categories.id]
+              :source-query    {:source-query    {:source-table $$categories :limit 20}
+                                :source-metadata [{:name "name", :display_name "Card Name", :base_type :type/Text}]
+                                :limit           100}
+              :source-metadata nil}]})
+  (tt/with-temp* [Card [{card-1-id :id} {:dataset_query   (data/mbql-query categories {:limit 20})
+                                         :result_metadata [{:name         "name"
+                                                            :display_name "Card Name"
+                                                            :base_type    "type/Text"}]}]
+                  Card [{card-2-id :id} {:dataset_query
+                                         (data/mbql-query nil
+                                           {:source-table (str "card__" card-1-id), :limit 100})}]]
+    (resolve-card-id-source-tables
+     (data/mbql-query venues
+       {:joins [{:source-table (str "card__" card-2-id)
+                 :alias        "c"
+                 :condition    [:= $category_id &c.categories.id]}]}))))
+
+;; Middleware should throw an Exception if we try to resolve a source query for a card whose source query is itself
+(expect
+  clojure.lang.ExceptionInfo
+  (tt/with-temp Card [{card-id :id}]
+    (let [circular-source-query {:database (data/id)
+                                 :type     :query
+                                 :query    {:source-table (str "card__" card-id)}}]
+      ;; Make sure save isn't the thing throwing the Exception
+      (let [save-error (try
+                         ;; `db/update!` will fail because it will try to validate the query when it saves
+                         (db/execute! {:update Card
+                                       :set    {:dataset_query (json/generate-string circular-source-query)}
+                                       :where  [:= :id card-id]})
+                         nil
+                         (catch Throwable e
+                           (str "Failed to save Card:" e)))]
+        (or save-error
+            (resolve-card-id-source-tables circular-source-query))))))
+
+;; middleware should throw an Exception if we try to resolve a source query card with a source query that refers back
+;; to the original
+(expect
+  clojure.lang.ExceptionInfo
+  (let [circular-source-query (fn [card-id]
+                                {:database (data/id)
+                                 :type     :query
+                                 :query    {:source-table (str "card__" card-id)}})]
+    ;; Card 1 refers to Card 2, and Card 2 refers to Card 1
+    (tt/with-temp* [Card [{card-1-id :id}]
+                    Card [{card-2-id :id} {:dataset_query (circular-source-query card-1-id)}]]
+      ;; Make sure save isn't the thing throwing the Exception
+      (let [save-error (try
+                         ;; `db/update!` will fail because it will try to validate the query when it saves,
+                         (db/execute! {:update Card
+                                       :set    {:dataset_query (json/generate-string (circular-source-query card-2-id))}
+                                       :where  [:= :id card-1-id]})
+                         nil
+                         (catch Throwable e
+                           (str "Failed to save Card:" e)))]
+        (or save-error
+            (resolve-card-id-source-tables (circular-source-query card-1-id)))))))

--- a/test/metabase/query_processor/middleware/format_rows_test.clj
+++ b/test/metabase/query_processor/middleware/format_rows_test.clj
@@ -11,7 +11,8 @@
             [metabase.test.data.dataset-definitions :as defs]))
 
 (def ^:private dbs-exempt-from-format-rows-tests
-  "DBs to skip the tests below for. TODO - why are so many databases not running these tests?"
+  "DBs to skip the tests below for. TODO - why are so many databases not running these tests? Most of these should be
+  able to pass with a few tweaks."
   #{:oracle :mongo :redshift :presto :sparksql :snowflake})
 
 (qpt/expect-with-non-timeseries-dbs-except dbs-exempt-from-format-rows-tests

--- a/test/metabase/query_processor/middleware/parameters/mbql_test.clj
+++ b/test/metabase/query_processor/middleware/parameters/mbql_test.clj
@@ -4,7 +4,7 @@
             [metabase
              [driver :as driver]
              [query-processor :as qp]
-             [query-processor-test :as qp.test :refer [first-row format-rows-by non-timeseries-drivers rows]]
+             [query-processor-test :as qp.test]
              [util :as u]]
             [metabase.mbql.normalize :as normalize]
             [metabase.query-processor.middleware.parameters.mbql :as mbql-params]
@@ -24,15 +24,16 @@
    :query    {:source-table 1000
               :filter       [:= [:field-id (data/id :venues :name)] "Cam's Toucannery"]
               :breakout     [[:field-id 17]]}}
-  (expand-parameters {:database   1
-                      :type       :query
-                      :query      {:source-table 1000
-                                   :breakout     [[:field-id 17]]}
-                      :parameters [{:hash   "abc123"
-                                    :name   "foo"
-                                    :type   "id"
-                                    :target [:dimension [:field-id (data/id :venues :name)]]
-                                    :value  "Cam's Toucannery"}]}))
+  (expand-parameters
+   {:database   1
+    :type       :query
+    :query      {:source-table 1000
+                 :breakout     [[:field-id 17]]}
+    :parameters [{:hash   "abc123"
+                  :name   "foo"
+                  :type   "id"
+                  :target [:dimension [:field-id (data/id :venues :name)]]
+                  :value  "Cam's Toucannery"}]}))
 
 ;; multiple filters are conjoined by an "AND"
 (expect
@@ -44,21 +45,22 @@
                              [:= [:field-id (data/id :venues :name)] "Cam's Toucannery"]
                              [:= [:field-id (data/id :venues :id)] 999]]
               :breakout     [[:field-id 17]]}}
-  (expand-parameters {:database   1
-                      :type       :query
-                      :query      {:source-table 1000
-                                   :filter       ["AND" [:= (data/id :venues :id) 12]]
-                                   :breakout     [[:field-id 17]]}
-                      :parameters [{:hash   "abc123"
-                                    :name   "foo"
-                                    :type   :id
-                                    :target [:dimension [:field-id (data/id :venues :name)]]
-                                    :value  "Cam's Toucannery"}
-                                   {:hash   "def456"
-                                    :name   "bar"
-                                    :type   :category
-                                    :target [:dimension [:field-id (data/id :venues :id)]]
-                                    :value  999}]}))
+  (expand-parameters
+   {:database   1
+    :type       :query
+    :query      {:source-table 1000
+                 :filter       ["AND" [:= (data/id :venues :id) 12]]
+                 :breakout     [[:field-id 17]]}
+    :parameters [{:hash   "abc123"
+                  :name   "foo"
+                  :type   :id
+                  :target [:dimension [:field-id (data/id :venues :name)]]
+                  :value  "Cam's Toucannery"}
+                 {:hash   "def456"
+                  :name   "bar"
+                  :type   :category
+                  :target [:dimension [:field-id (data/id :venues :id)]]
+                  :value  999}]}))
 
 ;; date range parameters
 (expect
@@ -67,15 +69,16 @@
    :query    {:source-table 1000
               :filter       [:time-interval [:field-id (data/id :users :last_login)] -30 :day {:include-current false}]
               :breakout     [[:field-id 17]]}}
-  (expand-parameters {:database   1
-                      :type       :query
-                      :query      {:source-table 1000
-                                   :breakout     [[:field-id 17]]}
-                      :parameters [{:hash   "abc123"
-                                    :name   "foo"
-                                    :type   :date
-                                    :target [:dimension [:field-id (data/id :users :last_login)]]
-                                    :value  "past30days"}]}))
+  (expand-parameters
+   {:database   1
+    :type       :query
+    :query      {:source-table 1000
+                 :breakout     [[:field-id 17]]}
+    :parameters [{:hash   "abc123"
+                  :name   "foo"
+                  :type   :date
+                  :target [:dimension [:field-id (data/id :users :last_login)]]
+                  :value  "past30days"}]}))
 
 (expect
   {:database 1
@@ -83,15 +86,16 @@
    :query    {:source-table 1000
               :filter       [:time-interval [:field-id (data/id :users :last_login)] -30 :day {:include-current true}]
               :breakout     [[:field-id 17]]}}
-  (expand-parameters {:database   1
-                      :type       :query
-                      :query      {:source-table 1000
-                                   :breakout     [[:field-id 17]]}
-                      :parameters [{:hash   "abc123"
-                                    :name   "foo"
-                                    :type   :date
-                                    :target [:dimension [:field-id (data/id :users :last_login)]]
-                                    :value  "past30days~"}]}))
+  (expand-parameters
+   {:database   1
+    :type       :query
+    :query      {:source-table 1000
+                 :breakout     [[:field-id 17]]}
+    :parameters [{:hash   "abc123"
+                  :name   "foo"
+                  :type   :date
+                  :target [:dimension [:field-id (data/id :users :last_login)]]
+                  :value  "past30days~"}]}))
 
 (expect
   {:database 1
@@ -101,15 +105,16 @@
                              [:datetime-field [:field-id (data/id :users :last_login)] :day]
                              [:relative-datetime -1 :day]]
               :breakout     [[:field-id 17]]}}
-  (expand-parameters {:database   1
-                      :type       :query
-                      :query      {:source-table 1000
-                                   :breakout     [[:field-id 17]]}
-                      :parameters [{:hash   "abc123"
-                                    :name   "foo"
-                                    :type   "date"
-                                    :target [:dimension [:field-id (data/id :users :last_login)]]
-                                    :value  "yesterday"}]}))
+  (expand-parameters
+   {:database   1
+    :type       :query
+    :query      {:source-table 1000
+                 :breakout     [[:field-id 17]]}
+    :parameters [{:hash   "abc123"
+                  :name   "foo"
+                  :type   "date"
+                  :target [:dimension [:field-id (data/id :users :last_login)]]
+                  :value  "yesterday"}]}))
 
 (expect
   {:database 1
@@ -119,15 +124,16 @@
                              "2014-05-10"
                              "2014-05-16"]
               :breakout     [[:field-id 17]]}}
-  (expand-parameters {:database   1
-                      :type       :query
-                      :query      {:source-table 1000
-                                   :breakout     [[:field-id 17]]}
-                      :parameters [{:hash   "abc123"
-                                    :name   "foo"
-                                    :type   "date"
-                                    :target [:dimension [:field-id (data/id :users :last_login)]]
-                                    :value  "2014-05-10~2014-05-16"}]}))
+  (expand-parameters
+   {:database   1
+    :type       :query
+    :query      {:source-table 1000
+                 :breakout     [[:field-id 17]]}
+    :parameters [{:hash   "abc123"
+                  :name   "foo"
+                  :type   "date"
+                  :target [:dimension [:field-id (data/id :users :last_login)]]
+                  :value  "2014-05-10~2014-05-16"}]}))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -135,7 +141,7 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 ;; for some reason param substitution tests fail on Redshift so just don't run those for now
-(def ^:private params-test-drivers (disj non-timeseries-drivers :redshift))
+(def ^:private params-test-drivers (disj qp.test/non-timeseries-drivers :redshift))
 
 ;; check that date ranges work correctly
 (datasets/expect-with-drivers params-test-drivers
@@ -144,70 +150,69 @@
     ;; Prevent an issue with Snowflake were a previous connection's report-timezone setting can affect this test's results
     (when (= :snowflake driver/*driver*)
       (driver/notify-database-updated driver/*driver* (data/id)))
-    (first-row
-      (format-rows-by [int]
-        (qp/process-query {:database   (data/id)
-                           :type       :query
-                           :query      {:source-table (data/id :checkins)
-                                        :aggregation  [[:count]]}
-                           :parameters [{:hash   "abc123"
-                                         :name   "foo"
-                                         :type   "date"
-                                         :target [:dimension [:field-id (data/id :checkins :date)]]
-                                         :value  "2015-04-01~2015-05-01"}]})))))
+    (qp.test/first-row
+      (qp.test/format-rows-by [int]
+        (qp/process-query
+          (data/query checkins
+            {:query      {:aggregation [[:count]]}
+             :parameters [{:hash   "abc123"
+                           :name   "foo"
+                           :type   "date"
+                           :target [:dimension $date]
+                           :value  "2015-04-01~2015-05-01"}]}))))))
 
 ;; check that IDs work correctly (passed in as numbers)
 (datasets/expect-with-drivers params-test-drivers
   [1]
-  (first-row
-    (format-rows-by [int]
-      (qp/process-query {:database   (data/id)
-                         :type       :query
-                         :query      {:source-table (data/id :checkins)
-                                      :aggregation  [[:count]]}
-                         :parameters [{:hash   "abc123"
-                                       :name   "foo"
-                                       :type   :number
-                                       :target [:dimension [:field-id (data/id :checkins :id)]]
-                                       :value  100}]}))))
+  (qp.test/first-row
+    (qp.test/format-rows-by [int]
+      (qp/process-query
+        (data/query checkins
+          {:query      {:aggregation [[:count]]}
+           :parameters [{:hash   "abc123"
+                         :name   "foo"
+                         :type   :number
+                         :target [:dimension $id]
+                         :value  100}]})))))
 
 ;; check that IDs work correctly (passed in as strings, as the frontend is wont to do; should get converted)
 (datasets/expect-with-drivers params-test-drivers
   [1]
-  (first-row
-    (format-rows-by [int]
-      (qp/process-query {:database   (data/id)
-                         :type       :query
-                         :query      {:source-table (data/id :checkins)
-                                      :aggregation  [[:count]]}
-                         :parameters [{:hash   "abc123"
-                                       :name   "foo"
-                                       :type   :number
-                                       :target [:dimension [:field-id (data/id :checkins :id)]]
-                                       :value  "100"}]}))))
+  (qp.test/first-row
+    (qp.test/format-rows-by [int]
+      (qp/process-query
+        (data/query checkins
+          {:query      {:aggregation [[:count]]}
+           :parameters [{:hash   "abc123"
+                         :name   "foo"
+                         :type   :number
+                         :target [:dimension $id]
+                         :value  "100"}]})))))
 
-;; test that we can injuect a basic `WHERE id = 9` type param (`id` type)
+;; test that we can inject a basic `WHERE id = 9` type param (`id` type)
 (datasets/expect-with-drivers params-test-drivers
   [[9 "Nils Gotam"]]
-  (format-rows-by [int str]
-    (let [outer-query (-> (data/mbql-query users)
-                          (assoc :parameters [{:name   "id"
-                                               :type   "id"
-                                               :target [:field-id (data/id :users :id)]
-                                               :value  9}]))]
-      (rows (qp/process-query outer-query)))))
+  (qp.test/format-rows-by [int str]
+    (qp.test/rows
+      (qp/process-query
+        (data/query users
+          {:parameters [{:name   "id"
+                         :type   "id"
+                         :target $id
+                         :value  9}]})))))
 
 ;; test that we can do the same thing but with a `category` type
 (datasets/expect-with-drivers params-test-drivers
   [[6]]
-  (format-rows-by [int]
-    (let [outer-query (-> (data/mbql-query venues
-                           {:aggregation [[:count]]})
-                          (assoc :parameters [{:name   "price"
-                                               :type   :category
-                                               :target [:field-id (data/id :venues :price)]
-                                               :value  4}]))]
-      (rows (qp/process-query outer-query)))))
+  (qp.test/format-rows-by [int]
+    (qp.test/rows
+      (qp/process-query
+        (data/query venues
+          {:query      {:aggregation [[:count]]}
+           :parameters [{:name   "price"
+                         :type   :category
+                         :target $price
+                         :value  4}]})))))
 
 
 ;; Make sure that *multiple* values work. This feature was added in 0.28.0. You are now allowed to pass in an array of
@@ -215,14 +220,15 @@
 ;; ends up generating a SQL `*or*` clause
 (datasets/expect-with-drivers params-test-drivers
   [[19]]
-  (format-rows-by [int]
-    (let [outer-query (-> (data/mbql-query venues
-                           {:aggregation [[:count]]})
-                          (assoc :parameters [{:name   "price"
-                                               :type   :category
-                                               :target [:field-id (data/id :venues :price)]
-                                               :value  [3 4]}]))]
-      (rows (qp/process-query outer-query)))))
+  (qp.test/format-rows-by [int]
+    (qp.test/rows
+      (qp/process-query
+        (data/query venues
+          {:query      {:aggregation [[:count]]}
+           :parameters [{:name   "price"
+                         :type   :category
+                         :target $price
+                         :value  [3 4]}]})))))
 
 ;; now let's make sure the correct query is actually being generated for the same thing above...
 ;; (NOTE: We're only testing this with H2 because the SQL generated is simply too different between various SQL drivers.
@@ -234,12 +240,12 @@
                 "WHERE (\"PUBLIC\".\"VENUES\".\"PRICE\" = 3 OR \"PUBLIC\".\"VENUES\".\"PRICE\" = 4)")
    :params nil}
   (qp/query->native
-    (-> (data/mbql-query venues
-          {:aggregation [[:count]]})
-        (assoc :parameters [{:name   "price"
-                             :type   :category
-                             :target [:field-id (data/id :venues :price)]
-                             :value  [3 4]}]))))
+    (data/query venues
+      {:query      {:aggregation [[:count]]}
+       :parameters [{:name   "price"
+                     :type   :category
+                     :target $price
+                     :value  [3 4]}]})))
 
 ;; try it with date params as well. Even though there's no way to do this in the frontend AFAIK there's no reason we
 ;; can't handle it on the backend
@@ -258,22 +264,24 @@
             (du/->Timestamp #inst "2015-06-01")
             (du/->Timestamp #inst "2015-06-30")]}
   (qp/query->native
-    (-> (data/mbql-query checkins
-          {:aggregation [[:count]]})
-        (assoc :parameters [{:name   "date"
-                             :type   "date/month"
-                             :target [:field-id (data/id :checkins :date)]
-                             :value  ["2014-06" "2015-06"]}]))))
+    (data/query checkins
+      {:query      {:aggregation [[:count]]}
+       :parameters [{:name   "date"
+                     :type   "date/month"
+                     :target $date
+                     :value  ["2014-06" "2015-06"]}]})))
 
 ;; make sure that "ID" type params get converted to numbers when appropriate
 (expect
-  [:= [:field-id (data/id :venues :id)] 1]
+  (data/$ids venues
+    [:= $id 1])
   (#'mbql-params/build-filter-clause
-   {:type   :id
-    :target [:dimension [:field-id (data/id :venues :id)]]
-    :slug   "venue_id"
-    :value  "1"
-    :name   "Venue ID"}))
+   (data/$ids venues
+     {:type   :id
+      :target [:dimension $id]
+      :slug   "venue_id"
+      :value  "1"
+      :name   "Venue ID"})))
 
 ;; Make sure we properly handle paramters that have `fk->` forms in `:dimension` targets (#9017)
 (datasets/expect-with-drivers (filter #(driver/supports? % :foreign-keys) params-test-drivers)
@@ -287,11 +295,8 @@
   (qp.test/format-rows-by [int str int (partial u/round-to-decimals 4) (partial u/round-to-decimals 4) int]
     (qp.test/rows
       (qp/process-query
-        (data/$ids venues
-          {:database   (data/id)
-           :type       :query
-           :query      {:source-table $$table
-                        :order-by     [[:asc $id]]}
+        (data/query venues
+          {:query      {:order-by [[:asc $id]]}
            :parameters [{:type   :id
-                         :target [:dimension [:fk-> $category_id $categories.name]]
+                         :target [:dimension $category_id->categories.name]
                          :value  ["BBQ"]}]})))))

--- a/test/metabase/query_processor/middleware/parameters/sql_test.clj
+++ b/test/metabase/query_processor/middleware/parameters/sql_test.clj
@@ -1,13 +1,12 @@
 (ns metabase.query-processor.middleware.parameters.sql-test
   "Tests for parameters in native SQL queries, which are of the `{{param}}` form."
   (:require [clj-time.core :as t]
-            [expectations :refer :all]
+            [expectations :refer [expect]]
             [metabase
              [driver :as driver]
              [query-processor :as qp]
              [query-processor-test :as qpt :refer [first-row format-rows-by]]]
             [metabase.mbql.normalize :as normalize]
-            [metabase.models.database :refer [Database]]
             [metabase.query-processor.middleware.parameters.sql :as sql]
             [metabase.test
              [data :as data]
@@ -575,7 +574,7 @@
   (delay (disj (qpt/non-timeseries-drivers-with-feature :native-parameters) :redshift)))
 
 (defn- process-native {:style/indent 0} [& kvs]
-  (du/with-effective-timezone (Database (data/id))
+  (du/with-effective-timezone (data/db)
     (qp/process-query
       (apply assoc {:database (data/id), :type :native, :settings {:report-timezone "UTC"}} kvs))))
 

--- a/test/metabase/query_processor/middleware/resolve_joins_test.clj
+++ b/test/metabase/query_processor/middleware/resolve_joins_test.clj
@@ -3,12 +3,12 @@
             [metabase.models
              [database :refer [Database]]
              [table :refer [Table]]]
+            [metabase.query-processor :as qp]
             [metabase.query-processor
              [store :as qp.store]
              [test-util :as qp.test-util]]
             [metabase.query-processor.middleware.resolve-joins :as resolve-joins]
             [metabase.test.data :as data]
-            [toucan.db :as db]
             [toucan.util.test :as tt]))
 
 (defn- resolve-joins [{{:keys [source-table]} :query, :as query}]
@@ -16,8 +16,8 @@
     (qp.store/with-store
       (resolve-joins query))
     (do
-      (qp.store/store-database! (db/select-one (into [Database] qp.store/database-columns-to-fetch) :id (data/id)))
-      (qp.store/store-table! (db/select-one (into [Table] qp.store/table-columns-to-fetch) :id source-table))
+      (qp.test-util/store-referenced-database! query)
+      (qp.store/fetch-and-store-tables! [source-table])
       (#'resolve-joins/resolve-joins* query))))
 
 ;; Does the middleware function if the query has no joins?
@@ -28,6 +28,7 @@
 
 (defn- resolve-joins-and-inspect-store [query]
   (qp.store/with-store
+    (qp.test-util/store-referenced-database! query)
     {:resolved (resolve-joins query)
      :store    (qp.test-util/store-contents)}))
 
@@ -131,9 +132,9 @@
      {:joins [{:source-table $$categories
                :condition    [:= $category_id [:joined-field "x" $categories.id]]}]})))
 
-;; Test that joining against a table in a different DB throws and Exception
+;; Test that joining against a table in a different DB throws an Exception
 (expect
-  IllegalArgumentException
+  clojure.lang.ExceptionInfo
   (tt/with-temp* [Database [{database-id :id}]
                   Table    [{table-id :id}    {:db_id database-id}]]
     (resolve-joins
@@ -141,3 +142,117 @@
        {:joins [{:source-table table-id
                  :alias        "t"
                  :condition    [:= $category_id 1]}]}))))
+
+;; test that resolving explicit joins still works if implict joins are present
+(expect
+  (data/mbql-query checkins
+    {:source-table $$checkins
+     :aggregation  [[:sum [:joined-field "USERS__via__USER_ID" $users.id]]]
+     :breakout     [$id]
+     :joins        [{:source-table $$users
+                     :alias        "USERS__via__USER_ID"
+                     :strategy     :left-join
+                     :condition    [:= $user_id [:joined-field "USERS__via__USER_ID" $users.id]]
+                     :fk-field-id  (data/id :checkins :user_id)}
+                    {:alias        "u"
+                     :source-table $$users
+                     :strategy     :left-join
+                     :condition    [:=
+                                    [:field-literal "ID" :type/BigInteger]
+                                    [:joined-field "u" $users.id]]}]
+     :limit        10})
+  (resolve-joins
+   (data/mbql-query checkins
+     {:source-table $$checkins
+      :aggregation  [[:sum [:joined-field "USERS__via__USER_ID" $users.id]]]
+      :breakout     [$id]
+      :joins        [{:source-table $$users
+                      :alias        "USERS__via__USER_ID"
+                      :strategy     :left-join
+                      :condition    [:= $user_id [:joined-field "USERS__via__USER_ID" $users.id]]
+                      :fk-field-id  (data/id :checkins :user_id)
+                      :fields       :none}
+                     {:alias        "u"
+                      :source-table $$users
+                      :condition    [:=
+                                     [:field-literal "ID" :type/BigInteger]
+                                     [:joined-field "u" $users.id]]}]
+      :limit        10})))
+
+;; Does a join using a source query get its Tables resolved?
+(expect
+  {:store
+   {:database "test-data",
+    :tables   #{"VENUES" "CATEGORIES"}
+    :fields   #{["VENUES" "CATEGORY_ID"]}}
+
+   :resolved
+   (data/mbql-query venues
+     {:joins    [{:alias        "cat"
+                  :source-query {:source-table $$categories}
+                  :strategy     :left-join
+                  :condition    [:=
+                                 $category_id
+                                 [:joined-field "cat" [:field-literal "ID" :type/BigInteger]]]}]
+      :order-by [[:asc $name]]
+      :limit    3})}
+  (resolve-joins-and-inspect-store
+   (data/mbql-query venues
+     {:joins    [{:alias        "cat"
+                  :source-query {:source-table $$categories}
+                  :condition    [:=
+                                 $category_id
+                                 [:joined-field "cat" [:field-literal "ID" :type/BigInteger]]]}]
+      :order-by [[:asc $name]]
+      :limit    3})))
+
+;; Can we resolve joins using a `:source-query` and `:fields` `:all`??
+(let [source-metadata (delay (get-in (qp/process-query (data/mbql-query categories {:limit 1}))
+                                     [:data :results_metadata :columns]))]
+  (expect
+    {:resolved
+     (data/mbql-query venues
+       {:fields   [[:joined-field "cat" [:field-literal "ID" :type/BigInteger]]
+                   [:joined-field "cat" [:field-literal "NAME" :type/Text]]]
+        :joins    [{:alias           "cat"
+                    :source-query    {:source-table $$categories}
+                    :source-metadata @source-metadata
+                    :strategy        :left-join
+                    :condition       [:=
+                                      $category_id
+                                      [:joined-field "cat" [:field-literal "ID" :type/BigInteger]]]}]
+        :order-by [[:asc $name]]
+        :limit    3})
+     :store
+     {:database "test-data",
+      :tables   #{"CATEGORIES" "VENUES"},
+      :fields   #{["VENUES" "CATEGORY_ID"]}}}
+    (resolve-joins-and-inspect-store
+     (data/mbql-query venues
+       {:joins    [{:alias           "cat"
+                    :source-query    {:source-table $$categories}
+                    :source-metadata @source-metadata
+                    :fields          :all
+                    :condition       [:=
+                                      $category_id
+                                      [:joined-field "cat" [:field-literal "ID" :type/BigInteger]]]}]
+        :order-by [[:asc $name]]
+        :limit    3}))))
+
+;; if the parent level has a breakout or aggregation, we shouldn't append Join fields to the parent level
+(expect
+  (data/mbql-query users
+    {:joins       [{:source-table $$checkins
+                    :alias        "c"
+                    :strategy     :left-join
+                    :condition    [:= $id [:joined-field "c" [:field-literal "USER_ID" :type/Integer]]]}],
+     :aggregation [[:sum [:joined-field "c" [:field-literal "id" :type/Float]]]]
+     :breakout    [[:datetime-field $last_login :month]]})
+  (resolve-joins
+   (data/mbql-query users
+     {:joins       [{:fields       :all
+                     :alias        "c"
+                     :source-table $$checkins
+                     :condition    [:= $id [:joined-field "c" [:field-literal "USER_ID" :type/Integer]]]}]
+      :aggregation [[:sum [:joined-field "c" [:field-literal "id" :type/Float]]]]
+      :breakout    [[:datetime-field $last_login :month]]})))

--- a/test/metabase/query_processor/middleware/resolve_source_table_test.clj
+++ b/test/metabase/query_processor/middleware/resolve_source_table_test.clj
@@ -3,32 +3,110 @@
             [metabase.models
              [database :refer [Database]]
              [table :refer [Table]]]
+            [metabase.query-processor
+             [store :as qp.store]
+             [test-util :as qp.test-util]]
             [metabase.query-processor.middleware.resolve-source-table :as resolve-source-table]
-            [metabase.query-processor.store :as qp.store]
             [metabase.test.data :as data]
             [toucan.util.test :as tt]))
 
-(defn- resolve-source-table [query]
-  ((resolve-source-table/resolve-source-table identity) query))
+(defn- resolve-source-tables [query]
+  ((resolve-source-table/resolve-source-tables identity) query))
 
-;; does `resolve-source-table` resolve source tables?
-(expect
-  {:id (data/id :venues), :name "VENUES", :schema "PUBLIC"}
+(defn- do-with-store-contents [f]
   (qp.store/with-store
-    (qp.store/store-database! (data/db))
-    (resolve-source-table {:database (data/id)
-                           :type     :query
-                           :query    {:source-table (data/id :venues)}})
-    (qp.store/table (data/id :venues))))
+    (qp.store/fetch-and-store-database! (data/id))
+    (f)
+    (qp.test-util/store-contents)))
+
+(defmacro ^:private with-store-contents {:style/indent 0} [& body]
+  `(do-with-store-contents (fn [] ~@body)))
+
+;; does `resolve-source-tables` resolve source tables?
+(expect
+  {:database "test-data", :tables #{"VENUES"}, :fields #{}}
+  (with-store-contents
+    (resolve-source-tables (data/mbql-query venues))))
 
 ;; If the Table does not belong to the current Database, does it throw an Exception?
 (expect
   Exception
-  (qp.store/with-store
-    (qp.store/store-database! (data/db))
+  (with-store-contents
     (tt/with-temp* [Database [{database-id :id}]
                     Table    [{table-id :id}    {:db_id database-id}]]
-      (resolve-source-table {:database (data/id)
-                             :type     :query
-                             :query    {:source-table table-id}})
-      (qp.store/table table-id))))
+      (resolve-source-tables {:database (data/id)
+                              :type     :query
+                              :query     {:source-table table-id}}))))
+
+;; Should throw an Exception if there's a `:source-table` in the query that IS NOT a positive int
+(expect
+  Exception
+  (resolve-source-tables
+   {:database (data/id)
+    :type     :query
+    :query    {:source-table "ABC"}}))
+
+(expect
+  Exception
+  (resolve-source-tables
+   {:database (data/id)
+    :type     :query
+    :query    {:source-table 0}}))
+
+;; Does `resolve-source-tables` resolve source tables in nested source queries?
+(expect
+  {:database "test-data", :tables #{"VENUES"}, :fields #{}}
+  (with-store-contents
+    (resolve-source-tables
+     (data/mbql-query nil
+       {:source-query {:source-table $$venues}}))))
+
+(expect
+  {:database "test-data", :tables #{"VENUES"}, :fields #{}}
+  (with-store-contents
+    (resolve-source-tables
+     (data/mbql-query nil
+       {:source-query {:source-query {:source-table $$venues}}}))))
+
+;; Does `resolve-source-tables` resolve source tables in joins?
+(expect
+  {:database "test-data", :tables #{"CATEGORIES" "VENUES"}, :fields #{}}
+  (with-store-contents
+    (resolve-source-tables
+     (data/mbql-query venues
+       {:joins [{:source-table $$categories
+                 :alias        "c"
+                 :condition    [:= $category_id [:joined-field "c" $categories.id]]}]}))))
+
+;; Does `resolve-source-tables` resolve source tables in joins inside nested source queries?
+(expect
+  {:database "test-data", :tables #{"CATEGORIES" "VENUES"}, :fields #{}}
+  (with-store-contents
+    (resolve-source-tables
+     (data/mbql-query venues
+       {:source-query {:source-table $$venues
+                       :joins        [{:source-table $$categories
+                                       :alias        "c"
+                                       :condition    [:= $category_id [:joined-field "c" $categories.id]]}]}}))))
+
+;; Does `resolve-source-tables` resolve source tables inside nested source queries inside joins?
+(expect
+  {:database "test-data", :tables #{"CATEGORIES" "VENUES"}, :fields #{}}
+  (with-store-contents
+    (resolve-source-tables
+     (data/mbql-query venues
+       {:joins [{:source-query {:source-table $$categories}
+                 :alias        "c"
+                 :condition    [:= $category_id [:joined-field "c" $categories.id]]}]}))))
+
+;; Does `resolve-source-tables` resolve source tables inside nested source queries inside joins inside nested source
+;; queries?
+(expect
+  {:database "test-data", :tables #{"CATEGORIES" "VENUES"}, :fields #{}}
+  (with-store-contents
+    (resolve-source-tables
+     (data/mbql-query venues
+       {:source-table $$venues
+        :source-query {:joins [{:source-query {:source-table $$categories}
+                                :alias        "c"
+                                :condition    [:= $category_id [:joined-field "c" $categories.id]]}]}}))))

--- a/test/metabase/query_processor/middleware/wrap_value_literals_test.clj
+++ b/test/metabase/query_processor/middleware/wrap_value_literals_test.clj
@@ -1,155 +1,124 @@
 (ns metabase.query-processor.middleware.wrap-value-literals-test
-  (:require [expectations :refer :all]
-            [metabase.models.field :refer [Field]]
+  (:require [expectations :refer [expect]]
             [metabase.query-processor.middleware.wrap-value-literals :as wrap-value-literals]
             [metabase.query-processor.test-util :as qp.test-util]
             [metabase.test.data :as data]
-            [metabase.util.date :as du]
-            [toucan.db :as db]))
+            [metabase.util.date :as du]))
 
-(defn- wrap-value-literals {:style/indent 0} [inner-query]
+(defn- wrap-value-literals {:style/indent 0} [query]
   (qp.test-util/with-everything-store
     (binding [du/*report-timezone* (java.util.TimeZone/getTimeZone "UTC")]
-      (-> ((wrap-value-literals/wrap-value-literals identity)
-           {:database (data/id)
-            :type     :query
-            :query    inner-query})
-          :query))))
+      ((wrap-value-literals/wrap-value-literals identity)
+       query))))
 
 (expect
-  (data/$ids venues
-    {:source-table (data/id :venues)
-     :filter       [:>
-                    [:field-id $id]
-                    [:value 50 {:base_type     :type/BigInteger
-                                :special_type  :type/PK
-                                :database_type "BIGINT"}]]})
-  (data/$ids venues
-    (wrap-value-literals
-      {:source-table (data/id :venues)
-       :filter       [:> [:field-id $id] 50]})))
+  (data/mbql-query venues
+    {:filter [:>
+              $id
+              [:value 50 {:base_type     :type/BigInteger
+                          :special_type  :type/PK
+                          :database_type "BIGINT"}]]})
+  (wrap-value-literals
+    (data/mbql-query venues
+      {:filter [:> $id 50]})))
 
 (expect
-  (data/$ids venues
-    {:source-table (data/id :venues)
-     :filter       [:and
-                    [:> [:field-id $id] [:value 50 {:base_type     :type/BigInteger
-                                                    :special_type  :type/PK
-                                                    :database_type "BIGINT"}]]
-                    [:< [:field-id $price] [:value 5 {:base_type     :type/Integer
-                                                      :special_type  :type/Category
-                                                      :database_type "INTEGER"}]]]})
-  (data/$ids venues
-    (wrap-value-literals
-      {:source-table (data/id :venues)
-       :filter       [:and
-                      [:> [:field-id $id] 50]
-                      [:< [:field-id $price] 5]]})))
+  (data/mbql-query venues
+    {:filter [:and
+              [:> $id [:value 50 {:base_type     :type/BigInteger
+                                  :special_type  :type/PK
+                                  :database_type "BIGINT"}]]
+              [:< $price [:value 5 {:base_type     :type/Integer
+                                    :special_type  :type/Category
+                                    :database_type "INTEGER"}]]]})
+  (wrap-value-literals
+    (data/mbql-query venues
+      {:filter [:and
+                [:> $id 50]
+                [:< $price 5]]})))
 
 ;; do datetime literal strings get wrapped in `absolute-datetime` clauses when in appropriate filters?
 (expect
-  (data/$ids checkins
-    {:source-table (data/id :checkins)
-     :filter       [:=
-                    [:datetime-field [:field-id $date] :month]
-                    [:absolute-datetime (du/->Timestamp "2018-10-01" "UTC") :month]]})
+  (data/mbql-query checkins
+    {:filter [:= !month.date [:absolute-datetime (du/->Timestamp "2018-10-01" "UTC") :month]]})
   (data/$ids checkins
     (wrap-value-literals
-      {:source-table (data/id :checkins)
-       :filter       [:= [:datetime-field [:field-id $date] :month] "2018-10-01"]})))
+      (data/mbql-query checkins
+        {:filter [:= !month.date "2018-10-01"]}))))
 
 ;; make sure datetime literal strings should also get wrapped in `absolute-datetime` clauses if they are being
 ;; compared against a type/DateTime `field-literal`
 (expect
-  (data/$ids checkins
-    {:source-query {:source-table $$table}
+  (data/mbql-query checkins
+    {:source-query {:source-table $$checkins}
      :filter       [:=
-                    [:datetime-field
-                     [:field-literal (db/select-one-field :name Field :id $date) :type/DateTime]
-                     :month]
+                    !month.*date
                     [:absolute-datetime (du/->Timestamp "2018-10-01" "UTC") :month]]})
-  (data/$ids checkins
-    (wrap-value-literals
-      {:source-query {:source-table $$table}
-       :filter       [:=
-                      [:datetime-field
-                       [:field-literal (db/select-one-field :name Field :id $date) :type/DateTime]
-                       :month]
-                      "2018-10-01"]})))
+  (wrap-value-literals
+    (data/mbql-query checkins
+      {:source-query {:source-table $$checkins}
+       :filter       [:= !month.*date "2018-10-01"]})))
 
 ;; even if the Field in question is not wrapped in a datetime-field clause, we should still auto-bucket the value, but
 ;; we should give it a `:default` unit
 (expect
-  (data/$ids checkins
-    {:source-table (data/id :checkins)
-     :filter       [:=
-                    [:field-id $date]
-                    [:absolute-datetime (du/->Timestamp "2018-10-01" "UTC") :default]]})
-  (data/$ids checkins
-    (wrap-value-literals
-      {:source-table (data/id :checkins)
-       :filter       [:= [:field-id $date] "2018-10-01"]})))
+  (data/mbql-query checkins
+    {:filter [:= $date [:absolute-datetime (du/->Timestamp "2018-10-01" "UTC") :default]]})
+  (wrap-value-literals
+    (data/mbql-query checkins
+      {:filter [:= $date "2018-10-01"]})))
 
 ;; should also apply if the Fields are UNIX timestamps or other things with special type of :type/Datetime
 (expect
   (data/dataset sad-toucan-incidents
-    (data/$ids incidents
-      {:source-table (data/id :incidents)
-       :filter       [:and
-                      [:>
-                       [:datetime-field [:field-id $timestamp] :day]
-                       [:absolute-datetime #inst "2015-06-01T00:00:00.000000000-00:00" :day]]
-                      [:<
-                       [:datetime-field [:field-id $timestamp] :day]
-                       [:absolute-datetime #inst "2015-06-03T00:00:00.000000000-00:00" :day]]]}))
-
+    (data/mbql-query incidents
+      {:filter [:and
+                [:>
+                 !day.timestamp
+                 [:absolute-datetime #inst "2015-06-01T00:00:00.000000000-00:00" :day]]
+                [:<
+                 !day.timestamp
+                 [:absolute-datetime #inst "2015-06-03T00:00:00.000000000-00:00" :day]]]}))
   (data/dataset sad-toucan-incidents
-    (data/$ids incidents
-      (wrap-value-literals
-        {:source-table (data/id :incidents)
-         :filter       [:and
-                        [:> [:datetime-field [:field-id $timestamp] :day] "2015-06-01"]
-                        [:< [:datetime-field [:field-id $timestamp] :day] "2015-06-03"]]}))))
+    (wrap-value-literals
+      (data/mbql-query incidents
+        {:filter [:and
+                  [:> !day.timestamp "2015-06-01"]
+                  [:< !day.timestamp "2015-06-03"]]}))))
 
 ;; string filters like `starts-with` should not parse datetime strings for obvious reasons
 (expect
-  (data/$ids checkins
-    {:source-table (data/id :checkins)
-     :filter        [:starts-with
-                     [:datetime-field [:field-id $date] :month]
-                     [:value "2018-10-01" {:base_type     :type/Date
-                                           :special_type  nil
-                                           :database_type "DATE"
-                                           :unit          :month}]]})
-  (data/$ids checkins
-    (wrap-value-literals
-      {:source-table (data/id :checkins)
-       :filter       [:starts-with [:datetime-field [:field-id $date] :month] "2018-10-01"]})))
+  (data/mbql-query checkins
+    {:filter [:starts-with
+              !month.date
+              [:value "2018-10-01" {:base_type     :type/Date
+                                    :special_type  nil
+                                    :database_type "DATE"
+                                    :unit          :month}]]})
+  (wrap-value-literals
+    (data/mbql-query checkins
+      {:filter [:starts-with !month.date "2018-10-01"]})))
 
 ;; does wrapping value literals work recursively on source queries as well?
 (expect
-  (data/$ids checkins
-    {:source-query {:source-table (data/id :checkins)
+  (data/mbql-query checkins
+    {:source-query {:source-table $$checkins
                     :filter       [:>
-                                   [:field-id $date]
+                                   $date
                                    [:absolute-datetime #inst "2014-01-01T00:00:00.000000000-00:00" :default]]}})
-  (data/$ids checkins
-    (wrap-value-literals
-      {:source-query {:source-table (data/id :checkins)
-                      :filter       [:> [:field-id $date] "2014-01-01"]}})))
+  (wrap-value-literals
+    (data/mbql-query checkins
+      {:source-query {:source-table $$checkins
+                      :filter       [:> $date "2014-01-01"]}})))
 
 ;; Make sure we apply the transformation to predicates in all parts of the query, not only `:filter`
 (expect
   (data/dataset sad-toucan-incidents
-    (data/$ids incidents
-      {:source-table (data/id :incidents)
-       :aggregation [[:share
-                      [:>
-                       [:datetime-field [:field-id $timestamp] :day]
-                       [:absolute-datetime  (du/->Timestamp "2015-06-01" "UTC") :day]]]]}))
+    (data/mbql-query incidents
+      {:aggregation [[:share
+                      [:> !day.timestamp [:absolute-datetime (du/->Timestamp "2015-06-01" "UTC") :day]]]]}))
 
   (data/dataset sad-toucan-incidents
-    (data/$ids incidents
-      (wrap-value-literals
-        {:source-table (data/id :incidents)
-         :aggregation  [[:share [:> [:datetime-field [:field-id $timestamp] :day] "2015-06-01"]]]}))))
+    (wrap-value-literals
+      (data/mbql-query incidents
+        {:aggregation [[:share [:> !day.timestamp "2015-06-01"]]]}))))

--- a/test/metabase/query_processor/test_util.clj
+++ b/test/metabase/query_processor/test_util.clj
@@ -1,48 +1,73 @@
 (ns metabase.query-processor.test-util
   "Utilities for writing Query Processor tests that test internal workings of the QP rather than end-to-end results,
-  e.g. middleware tests."
-  (:require [metabase.models
-             [database :refer [Database]]
-             [field :refer [Field]]
-             [table :refer [Table]]]
+  e.g. middleware tests.
+
+  The various QP Store functions & macros in this namespace are primarily meant to help write QP Middleware tests, so
+  you can test a given piece of middleware without having to worry about putting things in the QP Store
+  yourself (since this is usually done by other middleware in the first place)."
+  (:require [metabase.mbql.util :as mbql.u]
+            [metabase.query-processor :as qp]
             [metabase.query-processor.store :as qp.store]
             [metabase.test.data :as data]
             [metabase.util.schema :as su]
-            [schema.core :as s]
-            [toucan.db :as db]))
-
-(s/defn ^:private everything-store-database []
-  (or (:database @@#'qp.store/*store*)
-      (db/select-one (into [Database] qp.store/database-columns-to-fetch), :id (data/id))))
+            [schema.core :as s]))
 
 (s/defn ^:private everything-store-table [table-id :- (s/maybe su/IntGreaterThanZero)]
   (or (get-in @@#'qp.store/*store* [:tables table-id])
-      (db/select-one (into [Table] qp.store/table-columns-to-fetch), :id table-id)))
+      (do
+        (qp.store/fetch-and-store-tables! [table-id])
+        (qp.store/table table-id))))
 
 (s/defn ^:private everything-store-field [field-id :- (s/maybe su/IntGreaterThanZero)]
   (or (get-in @@#'qp.store/*store* [:fields field-id])
-      (db/select-one (into [Field] qp.store/field-columns-to-fetch), :id field-id)))
+      (do
+        (qp.store/fetch-and-store-fields! [field-id])
+        (qp.store/field field-id))))
 
 (defn do-with-everything-store
   "Impl for `with-everything-store`."
   [f]
-  (with-redefs [qp.store/database everything-store-database
-                qp.store/table    everything-store-table
-                qp.store/field    everything-store-field]
+  (with-redefs [qp.store/table everything-store-table
+                qp.store/field everything-store-field]
     (qp.store/with-store
+      (qp.store/fetch-and-store-database! (data/id))
       (f))))
 
 (defmacro with-everything-store
-  "When testing a specific piece of middleware, you often need to load things into the QP store, but doing so can be
-  tedious. This macro swaps out the normal QP store backend with one that fetches Tables and Fields from the DB
+  "When testing a specific piece of middleware, you often need to load things into the QP Store, but doing so can be
+  tedious. This macro swaps out the normal QP Store backend with one that fetches Tables and Fields from the DB
   on-demand, making tests a lot nicer to write.
 
-  You still need to store the Database yourself, because the getter function takes no args; we don't know which DB
-  you'd want to fetch."
+  When fetching the database, this assumes you're using the 'current' database bound to `(data/db)`, so be sure to use
+  `data/with-db` if needed."
   [& body]
   `(do-with-everything-store (fn [] ~@body)))
 
-(defn store-contents []
+(defn store-referenced-database!
+  "Store the Database for a `query` in the QP Store."
+  [{:keys [database]}]
+  (qp.store/fetch-and-store-database! database))
+
+(defn store-referenced-tables!
+  "Store any Tables referenced in `query` in the QP Store."
+  [query]
+  (when-let [table-ids (seq
+                        (flatten
+                         (mbql.u/match query
+                           (m :guard (every-pred map? (comp integer? :source-table)))
+                           (cons (:source-table m)  (recur (dissoc m :source-table))))))]
+    (qp.store/fetch-and-store-tables! table-ids)))
+
+(defn store-referenced-fields!
+  "Store any Fields referenced (by ID) in `query` in the QP Store."
+  [query]
+  (when-let [field-ids (seq (mbql.u/match query [:field-id id] id))]
+    (qp.store/fetch-and-store-fields! field-ids)))
+
+
+(defn store-contents
+  "Fetch the names of all the objects currently in the QP Store."
+  []
   (let [store @@#'qp.store/*store*]
     (-> store
         (update :database :name)
@@ -51,3 +76,16 @@
                           (set
                            (for [[_ {table-id :table_id, field-name :name}] fields]
                              [(get-in store [:tables table-id :name]) field-name])))))))
+
+(defn card-with-source-metadata-for-query
+  "Given an MBQL `query`, return the relevant keys for creating a Card with that query and matching `:result_metadata`.
+
+    (tt/with-temp Card [card (qp.test-util/card-with-source-metadata-for-query
+                              (data/mbql-query venues {:aggregation [[:count]]}))]
+      ...)"
+  [query]
+  (let [results  (qp/process-query query)
+        metadata (or (get-in results [:data :results_metadata :columns])
+                     (throw (ex-info "Query failure" results)))]
+    {:dataset_query   query
+     :result_metadata metadata}))

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -370,3 +370,12 @@
   [results]
   (or (some-> (data results) :cols vec)
       (throw (ex-info "Query does not have any :cols in results." results))))
+
+(defn tz-shifted-driver-bug?
+  "Returns true if `driver` is affected by the bug originally observed in
+  Oracle (https://github.com/metabase/metabase/issues/5789) but later found in Redshift and Snowflake. The timezone is
+  applied correctly, but the date operations that we use aren't using that timezone. This function is used to
+  differentiate Oracle from the other report-timezone databases until that bug can get fixed. Redshift and Snowflake
+  also have this issue."
+  [driver]
+  (contains? #{:snowflake :oracle :redshift} driver))

--- a/test/metabase/query_processor_test/breakout_test.clj
+++ b/test/metabase/query_processor_test/breakout_test.clj
@@ -3,14 +3,18 @@
   (:require [cheshire.core :as json]
             [metabase
              [query-processor :as qp]
-             [query-processor-test :refer :all]
+             [query-processor-test :as qp.test]
              [util :as u]]
+            [metabase.mbql.schema :as mbql.s]
             [metabase.models
              [card :refer [Card]]
              [dimension :refer [Dimension]]
              [field :refer [Field]]
              [field-values :refer [FieldValues]]]
-            [metabase.query-processor.middleware.add-dimension-projections :as add-dim-projections]
+            [metabase.query-processor.middleware
+             [add-dimension-projections :as add-dim-projections]
+             [add-source-metadata :as add-source-metadata]]
+            [metabase.query-processor.test-util :as qp.test-util]
             [metabase.test
              [data :as data]
              [util :as tu]]
@@ -20,76 +24,76 @@
             [toucan.util.test :as tt]))
 
 ;;; single column
-(qp-expect-with-all-drivers
+(qp.test/qp-expect-with-all-drivers
   {:rows        [[1 31] [2 70] [3 75] [4 77] [5 69] [6 70] [7 76] [8 81] [9 68] [10 78] [11 74] [12 59] [13 76] [14 62] [15 34]]
    :columns     [(data/format-name "user_id")
                  "count"]
-   :cols        [(breakout-col (checkins-col :user_id))
-                 (aggregate-col :count)]
+   :cols        [(qp.test/breakout-col (qp.test/checkins-col :user_id))
+                 (qp.test/aggregate-col :count)]
    :native_form true}
   (->> (data/run-mbql-query checkins
          {:aggregation [[:count]]
           :breakout    [$user_id]
           :order-by    [[:asc $user_id]]})
-       booleanize-native-form
-       (format-rows-by [int int])
+       qp.test/booleanize-native-form
+       (qp.test/format-rows-by [int int])
        tu/round-fingerprint-cols))
 
 ;;; BREAKOUT w/o AGGREGATION
 ;; This should act as a "distinct values" query and return ordered results
-(qp-expect-with-all-drivers
-  {:cols        [(breakout-col (checkins-col :user_id))]
+(qp.test/qp-expect-with-all-drivers
+  {:cols        [(qp.test/breakout-col (qp.test/checkins-col :user_id))]
    :columns     [(data/format-name "user_id")]
    :rows        [[1] [2] [3] [4] [5] [6] [7] [8] [9] [10]]
    :native_form true}
   (->> (data/run-mbql-query checkins
          {:breakout [$user_id]
           :limit    10})
-       booleanize-native-form
-       (format-rows-by [int])
+       qp.test/booleanize-native-form
+       (qp.test/format-rows-by [int])
        tu/round-fingerprint-cols))
 
 
 ;;; "BREAKOUT" - MULTIPLE COLUMNS W/ IMPLICT "ORDER_BY"
 ;; Fields should be implicitly ordered :ASC for all the fields in `breakout` that are not specified in `order-by`
-(qp-expect-with-all-drivers
+(qp.test/qp-expect-with-all-drivers
   {:rows        [[1 1 1] [1 5 1] [1 7 1] [1 10 1] [1 13 1] [1 16 1] [1 26 1] [1 31 1] [1 35 1] [1 36 1]]
    :columns     [(data/format-name "user_id")
                  (data/format-name "venue_id")
                  "count"]
-   :cols        [(breakout-col (checkins-col :user_id))
-                 (breakout-col (checkins-col :venue_id))
-                 (aggregate-col :count)]
+   :cols        [(qp.test/breakout-col (qp.test/checkins-col :user_id))
+                 (qp.test/breakout-col (qp.test/checkins-col :venue_id))
+                 (qp.test/aggregate-col :count)]
    :native_form true}
   (->> (data/run-mbql-query checkins
          {:aggregation [[:count]]
           :breakout    [$user_id $venue_id]
           :limit       10})
-       booleanize-native-form
-       (format-rows-by [int int int])
+       qp.test/booleanize-native-form
+       (qp.test/format-rows-by [int int int])
        tu/round-fingerprint-cols))
 
 ;;; "BREAKOUT" - MULTIPLE COLUMNS W/ EXPLICIT "ORDER_BY"
 ;; `breakout` should not implicitly order by any fields specified in `order-by`
-(qp-expect-with-all-drivers
+(qp.test/qp-expect-with-all-drivers
   {:rows        [[15 2 1] [15 3 1] [15 7 1] [15 14 1] [15 16 1] [15 18 1] [15 22 1] [15 23 2] [15 24 1] [15 27 1]]
    :columns     [(data/format-name "user_id")
                  (data/format-name "venue_id")
                  "count"]
-   :cols        [(breakout-col (checkins-col :user_id))
-                 (breakout-col (checkins-col :venue_id))
-                 (aggregate-col :count)]
+   :cols        [(qp.test/breakout-col (qp.test/checkins-col :user_id))
+                 (qp.test/breakout-col (qp.test/checkins-col :venue_id))
+                 (qp.test/aggregate-col :count)]
    :native_form true}
   (->> (data/run-mbql-query checkins
          {:aggregation [[:count]]
           :breakout    [$user_id $venue_id]
           :order-by    [[:desc $user_id]]
           :limit       10})
-       booleanize-native-form
-       (format-rows-by [int int int])
+       qp.test/booleanize-native-form
+       (qp.test/format-rows-by [int int int])
        tu/round-fingerprint-cols))
 
-(qp-expect-with-all-drivers
+(qp.test/qp-expect-with-all-drivers
   {:rows        [[2 8 "Artisan"]
                  [3 2 "Asian"]
                  [4 2 "BBQ"]
@@ -98,9 +102,9 @@
    :columns     [(data/format-name "category_id")
                  "count"
                  "Foo"]
-   :cols        [(assoc (breakout-col (venues-col :category_id))
+   :cols        [(assoc (qp.test/breakout-col (qp.test/venues-col :category_id))
                    :remapped_to "Foo")
-                 (aggregate-col :count)
+                 (qp.test/aggregate-col :count)
                  (#'add-dim-projections/create-remapped-col "Foo" (data/format-name "category_id"))]
    :native_form true}
   (data/with-data
@@ -116,11 +120,11 @@
            {:aggregation [[:count]]
             :breakout    [$category_id]
             :limit       5})
-         booleanize-native-form
-         (format-rows-by [int int str])
+         qp.test/booleanize-native-form
+         (qp.test/format-rows-by [int int str])
          tu/round-fingerprint-cols)))
 
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :foreign-keys)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :foreign-keys)
   [["Wine Bar" "Thai" "Thai" "Thai" "Thai" "Steakhouse" "Steakhouse" "Steakhouse" "Steakhouse" "Southern"]
    ["American" "American" "American" "American" "American" "American" "American" "American" "Artisan" "Artisan"]]
   (data/with-data
@@ -132,79 +136,87 @@
     [(->> (data/run-mbql-query venues
             {:order-by [[:desc $category_id]]
              :limit    10})
-           rows
+           qp.test/rows
            (map last))
      (->> (data/run-mbql-query venues
             {:order-by [[:asc $category_id]]
              :limit    10})
-           rows
+           qp.test/rows
            (map last))]))
 
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :binning)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :binning)
   [[10.0 1] [32.0 4] [34.0 57] [36.0 29] [40.0 9]]
-  (format-rows-by [(partial u/round-to-decimals 1) int]
-    (rows (data/run-mbql-query venues
-            {:aggregation [[:count]]
-             :breakout    [[:binning-strategy $latitude :num-bins 20]]}))))
+  (qp.test/format-rows-by [(partial u/round-to-decimals 1) int]
+    (qp.test/rows
+      (data/run-mbql-query venues
+        {:aggregation [[:count]]
+         :breakout    [[:binning-strategy $latitude :num-bins 20]]}))))
 
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :binning)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :binning)
   [[0.0 1] [20.0 90] [40.0 9]]
-  (format-rows-by [(partial u/round-to-decimals 1) int]
-    (rows (data/run-mbql-query venues
-            {:aggregation [[:count]]
-             :breakout    [[:binning-strategy $latitude :num-bins 3]]}))))
+  (qp.test/format-rows-by [(partial u/round-to-decimals 1) int]
+    (qp.test/rows
+      (data/run-mbql-query venues
+        {:aggregation [[:count]]
+         :breakout    [[:binning-strategy $latitude :num-bins 3]]}))))
 
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :binning)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :binning)
   [[10.0 -170.0 1] [32.0 -120.0 4] [34.0 -120.0 57] [36.0 -125.0 29] [40.0 -75.0 9]]
-  (format-rows-by [(partial u/round-to-decimals 1) (partial u/round-to-decimals 1) int]
-    (rows (data/run-mbql-query venues
-            {:aggregation [[:count]]
-             :breakout    [[:binning-strategy $latitude :num-bins 20]
-                           [:binning-strategy $longitude :num-bins 20]]}))))
+  (qp.test/format-rows-by [(partial u/round-to-decimals 1) (partial u/round-to-decimals 1) int]
+    (qp.test/rows
+      (data/run-mbql-query venues
+        {:aggregation [[:count]]
+         :breakout    [[:binning-strategy $latitude :num-bins 20]
+                       [:binning-strategy $longitude :num-bins 20]]}))))
 
 ;; Currently defaults to 8 bins when the number of bins isn't
 ;; specified
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :binning)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :binning)
   [[10.0 1] [30.0 90] [40.0 9]]
-  (format-rows-by [(partial u/round-to-decimals 1) int]
-    (rows (data/run-mbql-query venues
-            {:aggregation [[:count]]
-             :breakout    [[:binning-strategy $latitude :default]]}))))
+  (qp.test/format-rows-by [(partial u/round-to-decimals 1) int]
+    (qp.test/rows
+      (data/run-mbql-query venues
+        {:aggregation [[:count]]
+         :breakout    [[:binning-strategy $latitude :default]]}))))
 
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :binning)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :binning)
   [[10.0 1] [30.0 61] [35.0 29] [40.0 9]]
   (tu/with-temporary-setting-values [breakout-bin-width 5.0]
-    (format-rows-by [(partial u/round-to-decimals 1) int]
-      (rows (data/run-mbql-query venues
-              {:aggregation [[:count]]
-               :breakout    [[:binning-strategy $latitude :default]]})))))
+    (qp.test/format-rows-by [(partial u/round-to-decimals 1) int]
+      (qp.test/rows
+        (data/run-mbql-query venues
+          {:aggregation [[:count]]
+           :breakout    [[:binning-strategy $latitude :default]]})))))
 
 ;; Testing bin-width
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :binning)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :binning)
   [[10.0 1] [33.0 4] [34.0 57] [37.0 29] [40.0 9]]
-  (format-rows-by [(partial u/round-to-decimals 1) int]
-    (rows (data/run-mbql-query venues
-            {:aggregation [[:count]]
-             :breakout    [[:binning-strategy $latitude :bin-width 1]]}))))
+  (qp.test/format-rows-by [(partial u/round-to-decimals 1) int]
+    (qp.test/rows
+      (data/run-mbql-query venues
+        {:aggregation [[:count]]
+         :breakout    [[:binning-strategy $latitude :bin-width 1]]}))))
 
 ;; Testing bin-width using a float
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :binning)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :binning)
   [[10.0 1] [32.5 61] [37.5 29] [40.0 9]]
-  (format-rows-by [(partial u/round-to-decimals 1) int]
-    (rows (data/run-mbql-query venues
-            {:aggregation [[:count]]
-             :breakout    [[:binning-strategy $latitude :bin-width 2.5]]}))))
+  (qp.test/format-rows-by [(partial u/round-to-decimals 1) int]
+    (qp.test/rows
+      (data/run-mbql-query venues
+        {:aggregation [[:count]]
+         :breakout    [[:binning-strategy $latitude :bin-width 2.5]]}))))
 
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :binning)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :binning)
   [[33.0 4] [34.0 57]]
   (tu/with-temporary-setting-values [breakout-bin-width 1.0]
-    (format-rows-by [(partial u/round-to-decimals 1) int]
-      (rows (data/run-mbql-query venues
-              {:aggregation [[:count]]
-               :filter      [:and
-                             [:< $latitude 35]
-                             [:> $latitude 20]]
-               :breakout    [[:binning-strategy $latitude :default]]})))))
+    (qp.test/format-rows-by [(partial u/round-to-decimals 1) int]
+      (qp.test/rows
+        (data/run-mbql-query venues
+          {:aggregation [[:count]]
+           :filter      [:and
+                         [:< $latitude 35]
+                         [:> $latitude 20]]
+           :breakout    [[:binning-strategy $latitude :default]]})))))
 
 (defn- round-binning-decimals [result]
   (let [round-to-decimal #(u/round-to-decimals 4 %)]
@@ -215,8 +227,8 @@
         (update-in [:binning_info :max_value] round-to-decimal))))
 
 ;;Validate binning info is returned with the binning-strategy
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :binning)
-  (assoc (breakout-col (venues-col :latitude))
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :binning)
+  (assoc (qp.test/breakout-col (qp.test/venues-col :latitude))
     :binning_info {:min_value 10.0, :max_value 50.0, :num_bins 4, :bin_width 10.0, :binning_strategy :bin-width})
   (-> (data/run-mbql-query venues
         {:aggregation [[:count]]
@@ -225,8 +237,8 @@
       (get-in [:data :cols])
       first))
 
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :binning)
-  (assoc (breakout-col (venues-col :latitude))
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :binning)
+  (assoc (qp.test/breakout-col (qp.test/venues-col :latitude))
     :binning_info {:min_value 7.5, :max_value 45.0, :num_bins 5, :bin_width 7.5, :binning_strategy :num-bins})
   (-> (data/run-mbql-query venues
         {:aggregation [[:count]]
@@ -236,9 +248,9 @@
       first))
 
 ;;Validate binning info is returned with the binning-strategy
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :binning)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :binning)
   {:status :failed
-   :class  Exception
+   :class  clojure.lang.ExceptionInfo
    :error  "Unable to bin Field without a min/max value"}
   (tu/with-temp-vals-in-db Field (data/id :venues :latitude) {:fingerprint {:type {:type/Number {:min nil, :max nil}}}}
     (-> (tu.log/suppress-output
@@ -247,47 +259,42 @@
              :breakout    [[:binning-strategy $latitude :default]]}))
         (select-keys [:status :class :error]))))
 
-(defn- field->result-metadata [field]
-  (select-keys field [:name :display_name :description :base_type :special_type :unit :fingerprint]))
-
 (defn- nested-venues-query [card-or-card-id]
-  {:database metabase.models.database/virtual-id
+  {:database mbql.s/saved-questions-virtual-database-id
    :type     :query
    :query    {:source-table (str "card__" (u/get-id card-or-card-id))
               :aggregation  [:count]
               :breakout     [[:binning-strategy [:field-literal (data/format-name :latitude) :type/Float] :num-bins 20]]}})
 
 ;; Binning should be allowed on nested queries that have result metadata
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :binning :nested-queries)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :binning :nested-queries)
   [[10.0 1] [32.0 4] [34.0 57] [36.0 29] [40.0 9]]
-  (tt/with-temp Card [card {:dataset_query   {:database (data/id)
-                                              :type     :query
-                                              :query    {:source-query {:source-table (data/id :venues)}}}
-                            :result_metadata (mapv field->result-metadata (db/select Field :table_id (data/id :venues)))}]
+  (tt/with-temp Card [card (qp.test-util/card-with-source-metadata-for-query
+                            (data/mbql-query nil
+                              {:source-query {:source-table $$venues}}))]
     (->> (nested-venues-query card)
          qp/process-query
-         rows
-         (format-rows-by [(partial u/round-to-decimals 1) int]))))
+         qp.test/rows
+         (qp.test/format-rows-by [(partial u/round-to-decimals 1) int]))))
 
 ;; Binning is not supported when there is no fingerprint to determine boundaries
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :binning :nested-queries)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :binning :nested-queries)
   Exception
   (tu.log/suppress-output
-    (tt/with-temp Card [card {:dataset_query {:database (data/id)
-                                              :type     :query
-                                              :query    {:source-query {:source-table (data/id :venues)}}}}]
-      (-> (nested-venues-query card)
-          qp/process-query
-          rows))))
+    ;; Unfortunately our new `add-source-metadata` middleware is just too good at what it does and will pull in
+    ;; metadata from the source query, so disable that for now so we can make sure the `update-binning-strategy`
+    ;; middleware is doing the right thing
+    (with-redefs [add-source-metadata/mbql-source-query->metadata (constantly nil)]
+      (tt/with-temp Card [card {:dataset_query (data/mbql-query venues)}]
+        (-> (nested-venues-query card)
+            qp/process-query
+            qp.test/rows)))))
 
 ;; if we include a Field in both breakout and fields, does the query still work? (Normalization should be taking care
 ;; of this) (#8760)
-(expect-with-non-timeseries-dbs
+(qp.test/expect-with-non-timeseries-dbs
   :completed
-  (-> (qp/process-query
-        {:database (data/id)
-         :type     :query
-         :query    {:source-table (data/id :venues)
-                    :breakout     [[:field-id (data/id :venues :price)]]
-                    :fields       [["field_id" (data/id :venues :price)]]}})
-      :status))
+  (:status
+   (data/run-mbql-query venues
+     {:breakout [[:field-id %price]]
+      :fields   [["field_id" %price]]})))

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -37,15 +37,6 @@
     (long x)
     x))
 
-(defn tz-shifted-engine-bug?
-  "Returns true if `engine` is affected by the bug originally observed in
-  Oracle (https://github.com/metabase/metabase/issues/5789) but later found in Redshift and Snowflake. The timezone is
-  applied correctly, but the date operations that we use aren't using that timezone. This function is used to
-  differentiate Oracle from the other report-timezone databases until that bug can get fixed. Redshift and Snowflake
-  also have this issue."
-  [engine]
-  (contains? #{:snowflake :oracle :redshift} engine))
-
 (defn- sad-toucan-incidents-with-bucketing
   "Returns 10 sad toucan incidents grouped by `UNIT`"
   ([unit]
@@ -131,7 +122,7 @@
     (sad-toucan-result (source-date-formatter utc-tz) result-date-formatter-without-tz)
 
     ;; There's a bug here where we are reading in the UTC time as pacific, so we're 7 hours off
-    (tz-shifted-engine-bug? driver/*driver*)
+    (qp.test/tz-shifted-driver-bug? driver/*driver*)
     (sad-toucan-result (source-date-formatter pacific-tz) (result-date-formatter pacific-tz))
 
     ;; When the reporting timezone is applied, the same datetime value is returned, but set in the pacific timezone
@@ -151,7 +142,7 @@
     (= :sqlite driver/*driver*)
     (sad-toucan-result (source-date-formatter utc-tz) result-date-formatter-without-tz)
 
-    (tz-shifted-engine-bug? driver/*driver*)
+    (qp.test/tz-shifted-driver-bug? driver/*driver*)
     (sad-toucan-result (source-date-formatter eastern-tz) (result-date-formatter eastern-tz))
 
     ;; The time instant is the same as UTC (or pacific) but should be offset by the eastern timezone
@@ -175,7 +166,7 @@
     (= :sqlite driver/*driver*)
     (sad-toucan-result (source-date-formatter utc-tz) result-date-formatter-without-tz)
 
-    (tz-shifted-engine-bug? driver/*driver*)
+    (qp.test/tz-shifted-driver-bug? driver/*driver*)
     (sad-toucan-result (source-date-formatter eastern-tz) (result-date-formatter eastern-tz))
 
     ;; The JVM timezone should have no impact on a database that uses a report timezone
@@ -200,7 +191,7 @@
     (= :sqlite driver/*driver*)
     (sad-toucan-result (source-date-formatter utc-tz) result-date-formatter-without-tz)
 
-    (tz-shifted-engine-bug? driver/*driver*)
+    (qp.test/tz-shifted-driver-bug? driver/*driver*)
     (sad-toucan-result (source-date-formatter pacific-tz) (result-date-formatter pacific-tz))
 
     (supports-report-timezone? driver/*driver*)
@@ -264,7 +255,7 @@
     (results-by-hour (source-date-formatter utc-tz)
                      result-date-formatter-without-tz)
 
-    (tz-shifted-engine-bug? driver/*driver*)
+    (qp.test/tz-shifted-driver-bug? driver/*driver*)
     (results-by-hour (source-date-formatter pacific-tz) (result-date-formatter pacific-tz))
 
     (supports-report-timezone? driver/*driver*)
@@ -286,7 +277,7 @@
 ;; first three results of the pacific results to the last three of the
 ;; UTC results (i.e. pacific is 7 hours back of UTC at that time)
 (qp.test/expect-with-non-timeseries-dbs
-  (if (and (not (tz-shifted-engine-bug? driver/*driver*))
+  (if (and (not (qp.test/tz-shifted-driver-bug? driver/*driver*))
            (supports-report-timezone? driver/*driver*))
     [[0 8] [1 9] [2 7] [3 10] [4 10] [5 9] [6 6] [7 5] [8 7] [9 7]]
     [[0 13] [1 8] [2 4] [3 7] [4 5] [5 13] [6 10] [7 8] [8 9] [9 7]])
@@ -390,7 +381,7 @@
                     date-formatter-without-time
                     [6 10 4 9 9 8 8 9 7 9])
 
-    (tz-shifted-engine-bug? driver/*driver*)
+    (qp.test/tz-shifted-driver-bug? driver/*driver*)
     (results-by-day (tformat/with-zone date-formatter-without-time pacific-tz)
                     (result-date-formatter pacific-tz)
                     [6 10 4 9 9 8 8 9 7 9])
@@ -423,7 +414,7 @@
                     date-formatter-without-time
                     [6 10 4 9 9 8 8 9 7 9])
 
-    (tz-shifted-engine-bug? driver/*driver*)
+    (qp.test/tz-shifted-driver-bug? driver/*driver*)
     (results-by-day (tformat/with-zone date-formatter-without-time eastern-tz)
                     (result-date-formatter eastern-tz)
                     [6 10 4 9 9 8 8 9 7 9])
@@ -456,7 +447,7 @@
                     date-formatter-without-time
                     [6 10 4 9 9 8 8 9 7 9])
 
-    (tz-shifted-engine-bug? driver/*driver*)
+    (qp.test/tz-shifted-driver-bug? driver/*driver*)
     (results-by-day (tformat/with-zone date-formatter-without-time pacific-tz)
                     (result-date-formatter pacific-tz)
                     [6 10 4 9 9 8 8 9 7 9])
@@ -481,7 +472,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (qp.test/expect-with-non-timeseries-dbs
-  (if (and (not (tz-shifted-engine-bug? driver/*driver*))
+  (if (and (not (qp.test/tz-shifted-driver-bug? driver/*driver*))
            (supports-report-timezone? driver/*driver*))
     [[1 29] [2 36] [3 33] [4 29] [5 13] [6 38] [7 22]]
     [[1 28] [2 38] [3 29] [4 27] [5 24] [6 30] [7 24]])
@@ -498,7 +489,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (qp.test/expect-with-non-timeseries-dbs
-  (if (and (not (tz-shifted-engine-bug? driver/*driver*))
+  (if (and (not (qp.test/tz-shifted-driver-bug? driver/*driver*))
            (supports-report-timezone? driver/*driver*))
     [[1 8] [2 9] [3 9] [4 4] [5 11] [6 8] [7 6] [8 10] [9 6] [10 10]]
     [[1 6] [2 10] [3 4] [4 9] [5  9] [6 8] [7 8] [8  9] [9 7] [10  9]])
@@ -515,7 +506,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (qp.test/expect-with-non-timeseries-dbs
-  (if (and (not (tz-shifted-engine-bug? driver/*driver*))
+  (if (and (not (qp.test/tz-shifted-driver-bug? driver/*driver*))
            (supports-report-timezone? driver/*driver*))
     [[152 8] [153 9] [154 9] [155 4] [156 11] [157 8] [158 6] [159 10] [160 6] [161 10]]
     [[152 6] [153 10] [154 4] [155 9] [156  9] [157  8] [158 8] [159  9] [160 7] [161  9]])
@@ -585,7 +576,7 @@
                      date-formatter-without-time
                      [46 47 40 60 7])
 
-    (tz-shifted-engine-bug? driver/*driver*)
+    (qp.test/tz-shifted-driver-bug? driver/*driver*)
     (results-by-week (tformat/with-zone date-formatter-without-time pacific-tz)
                      (result-date-formatter pacific-tz)
                      [46 47 40 60 7])
@@ -617,7 +608,7 @@
                      date-formatter-without-time
                      [46 47 40 60 7])
 
-    (tz-shifted-engine-bug? driver/*driver*)
+    (qp.test/tz-shifted-driver-bug? driver/*driver*)
     (results-by-week (tformat/with-zone date-formatter-without-time eastern-tz)
                      (result-date-formatter eastern-tz)
                      [46 47 40 60 7])
@@ -646,7 +637,7 @@
                      date-formatter-without-time
                      [46 47 40 60 7])
 
-    (tz-shifted-engine-bug? driver/*driver*)
+    (qp.test/tz-shifted-driver-bug? driver/*driver*)
     (results-by-week (tformat/with-zone date-formatter-without-time pacific-tz)
                      (result-date-formatter pacific-tz)
                      [46 47 40 60 7])

--- a/test/metabase/query_processor_test/explicit_joins_test.clj
+++ b/test/metabase/query_processor_test/explicit_joins_test.clj
@@ -3,11 +3,15 @@
             [metabase
              [driver :as driver]
              [query-processor :as qp]
-             [query-processor-test :as qp.test]]
+             [query-processor-test :as qp.test]
+             [util :as u]]
+            [metabase.models.card :refer [Card]]
+            [metabase.query-processor.test-util :as qp.test-util]
             [metabase.test.data :as data]
             [metabase.test.data
              [datasets :as datasets]
-             [interface :as tx]]))
+             [interface :as tx]]
+            [toucan.util.test :as tt]))
 
 (defn- native-form [query]
   (:query (qp/query->native query)))
@@ -27,17 +31,17 @@
   (native-form
    (data/mbql-query venues
      {:joins [{:source-table $$categories
-               :condition    [:= [:field-id $category_id] 1]}]})))
+               :condition    [:= $category_id 1]}]})))
 
 (defn- query-with-strategy [strategy]
   (data/dataset bird-flocks
     (data/mbql-query bird
-      {:fields   [[:field-id $name] [:joined-field "f" [:field-id $flock.name]]]
+      {:fields   [$name &f.flock.name]
        :joins    [{:source-table $$flock
-                   :condition    [:= [:field-id $flock_id] [:joined-field "f" [:field-id $flock.id]]]
+                   :condition    [:= $flock_id &f.flock.id]
                    :strategy     strategy
                    :alias        "f"}]
-       :order-by [[:asc [:field-id $name]]]})))
+       :order-by [[:asc $name]]})))
 
 ;; Can we supply a custom alias? Can we do a left outer join ??
 (datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :left-join)
@@ -152,16 +156,15 @@
              [13 "Paul Pelican"     2   2   "SoMa Squadron"]
              [4  "Peter Pelican"    2   2   "SoMa Squadron"]
              [1  "Russell Crow"     4   4   "Mission Street Murder"]]}
-  (qp.test/format-rows-by [int str #(some-> % int) #(some-> % int) #(some-> % str)]
+  (qp.test/format-rows-by [int str #(some-> % int) #(some-> % int) identity]
     (qp.test/rows+column-names
-      (qp/process-query
-        (data/dataset bird-flocks
-          (data/mbql-query bird
-            {:joins    [{:source-table $$flock
-                         :condition    [:= [:field-id $flock_id] [:joined-field "f" [:field-id $flock.id]]]
-                         :alias        "f"
-                         :fields       :all}]
-             :order-by [[:asc [:field-id $name]]]}))))))
+      (data/dataset bird-flocks
+        (data/run-mbql-query bird
+          {:joins    [{:source-table $$flock
+                       :condition    [:= $flock_id &f.flock.id]
+                       :alias        "f"
+                       :fields       :all}]
+           :order-by [[:asc [:field-id $name]]]})))))
 
 ;; Can we include no Fields (with `:none`)
 (datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :left-join)
@@ -186,14 +189,13 @@
              [1  "Russell Crow"     4  ]]}
   (qp.test/format-rows-by [#(some-> % int) str #(some-> % int)]
     (qp.test/rows+column-names
-      (qp/process-query
-        (data/dataset bird-flocks
-          (data/mbql-query bird
-            {:joins    [{:source-table $$flock
-                         :condition    [:= [:field-id $flock_id] [:joined-field "f" [:field-id $flock.id]]]
-                         :alias        "f"
-                         :fields       :none}]
-             :order-by [[:asc [:field-id $name]]]}))))))
+      (data/dataset bird-flocks
+        (data/run-mbql-query bird
+          {:joins    [{:source-table $$flock
+                       :condition    [:= $flock_id &f.flock.id]
+                       :alias        "f"
+                       :fields       :none}]
+           :order-by [[:asc [:field-id $name]]]})))))
 
 ;;Can we include a list of specific Fields?
 (datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :left-join)
@@ -216,42 +218,227 @@
              [13 "Paul Pelican"    "SoMa Squadron"]
              [4  "Peter Pelican"   "SoMa Squadron"]
              [1  "Russell Crow"    "Mission Street Murder"]]}
-  (qp.test/format-rows-by [#(some-> % int) str #(some-> % str)]
+  (qp.test/format-rows-by [#(some-> % int) str identity]
     (qp.test/rows+column-names
-      (qp/process-query
-        (data/dataset bird-flocks
-          (data/mbql-query bird
-            {:fields   [$id $name]
-             :joins    [{:source-table $$flock
-                         :condition    [:= [:field-id $flock_id] [:joined-field "f" [:field-id $flock.id]]]
-                         :alias        "f"
-                         :fields       [[:joined-field "f" $flock.name]]}]
-             :order-by [[:asc [:field-id $name]]]}))))))
+      (data/dataset bird-flocks
+        (data/run-mbql-query bird
+          {:fields   [$id $name]
+           :joins    [{:source-table $$flock
+                       :condition    [:= $flock_id &f.flock.id]
+                       :alias        "f"
+                       :fields       [&f.flock.name]}]
+           :order-by [[:asc [:field-id $name]]]})))))
 
-;; TODO Can we join on bucketed datetimes?
+;; Do Joins with `:fields``:all` work if the joined table includes Fields that come back wrapped in `:datetime-field`
+;; forms?
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :left-join)
+  {:columns
+   (mapv data/format-name ["id" "name" "last_login" "id_2" "date" "user_id" "venue_id"])
 
-;; TODO Can we join against a source nested MBQL query?
+   :rows
+   ;; not sure why only Oracle seems to do this
+   (let [tz (if (= driver/*driver* :oracle) "07:00:00.000Z"  "00:00:00.000Z")]
+     [[1 "Plato Yeshua"        "2014-04-01T08:30:00.000Z" 1 (str "2014-04-07T" tz) 5 12]
+      [2 "Felipinho Asklepios" "2014-12-05T15:15:00.000Z" 2 (str "2014-09-18T" tz) 1 31]
+      [3 "Kaneonuskatew Eiran" "2014-11-06T16:15:00.000Z" 3 (str "2014-09-15T" tz) 8 56]])}
+  (qp.test/format-rows-by [int identity identity int identity int int]
+    (qp.test/rows+column-names
+      (data/run-mbql-query users
+        {:source-table $$users
+         :joins        [{:source-table $$checkins
+                         :alias        "c"
+                         :fields       "all"
+                         :condition    [:= $id &c.checkins.id]}]
+         :order-by     [["asc" ["joined-field" "c" $checkins.id]]]
+         :limit        3}))))
+
+;; Can we run a query that for whatever reason ends up with a `SELECT *` for the source query
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :left-join)
+  {:columns [(data/format-name "id") "sum"]
+   :rows    [[1 5] [2 1] [3 8]]}
+  (qp.test/format-rows-by [int int]
+    (qp.test/rows+column-names
+      (data/run-mbql-query checkins
+        {:source-query {:source-table $$checkins
+                        :aggregation  [[:sum $user_id->users.id]]
+                        :breakout     [$id]}
+         :joins        [{:alias        "u"
+                         :source-table $$users
+                         :condition    [:= *checkins.id &u.users.id]}]
+         :order-by     [[:asc [:field-literal (data/format-name "id") :type/Integer]]]
+         :limit        3}))))
+
+;; Can we join against a source nested MBQL query?
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :left-join)
+  [[29 "20th Century Cafe" 12  37.775 -122.423 2]
+   [ 8 "25°"               11 34.1015 -118.342 2]
+   [93 "33 Taps"            7 34.1018 -118.326 2]]
+  (qp.test/formatted-venues-rows
+   (qp.test/rows
+     (data/run-mbql-query venues
+       {:source-table $$venues
+        :joins        [{:alias        "cat"
+                        :source-query {:source-table $$categories}
+                        :condition    [:= $category_id &cat.*categories.id]}]
+        :order-by     [[:asc $name]]
+        :limit        3}))))
+
+;; Can we join against a `card__id` source query and use `:fields` `:all`?
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :left-join)
+  {:rows
+   [[29 "20th Century Cafe" 12 37.775  -122.423 2 12 "Café"]
+    [8  "25°"               11 34.1015 -118.342 2 11 "Burger"]
+    [93 "33 Taps"           7  34.1018 -118.326 2  7 "Bar"]]
+
+   :columns
+   (mapv data/format-name ["id" "name" "category_id" "latitude" "longitude" "price" "id_2" "name_2"])}
+  (tt/with-temp Card [{card-id :id} (qp.test-util/card-with-source-metadata-for-query (data/mbql-query categories))]
+    (qp.test/format-rows-by [int identity int (partial u/round-to-decimals 4) (partial u/round-to-decimals 4) int
+                             int identity]
+      (qp.test/rows+column-names
+        (data/run-mbql-query venues
+          {:joins    [{:alias        "cat"
+                       :source-table (str "card__" card-id)
+                       :fields       :all
+                       :condition    [:= $category_id &cat.*categories.id]}]
+           :order-by [[:asc $name]]
+           :limit    3})))))
+
+;; Can we join on a Field literal for a source query?
+;;
+;; Also: if you join against an *explicit* source query, do all columns for both queries come back? (Only applies if
+;; you include `:source-metadata`)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :left-join)
+  {:rows
+   [["2013-01-01T00:00:00.000Z"  8 "2013-01-01T00:00:00.000Z"  8]
+    ["2013-02-01T00:00:00.000Z" 11 "2013-02-01T00:00:00.000Z" 11]
+    ["2013-03-01T00:00:00.000Z" 21 "2013-03-01T00:00:00.000Z" 21]
+    ["2013-04-01T00:00:00.000Z" 26 "2013-04-01T00:00:00.000Z" 26]
+    ["2013-05-01T00:00:00.000Z" 23 "2013-05-01T00:00:00.000Z" 23]
+    ["2013-06-01T00:00:00.000Z" 26 "2013-06-01T00:00:00.000Z" 26]
+    ["2013-07-01T00:00:00.000Z" 20 "2013-07-01T00:00:00.000Z" 20]
+    ["2013-08-01T00:00:00.000Z" 22 "2013-08-01T00:00:00.000Z" 22]
+    ["2013-09-01T00:00:00.000Z" 13 "2013-09-01T00:00:00.000Z" 13]
+    ["2013-10-01T00:00:00.000Z" 26 "2013-10-01T00:00:00.000Z" 26]]
+   :columns [(data/format-name "date") "count" (data/format-name "date_2") "count_2"]}
+  (qp.test/format-rows-by [identity int identity int]
+    (qp.test/rows+column-names
+      (tt/with-temp Card [{card-id :id} (qp.test-util/card-with-source-metadata-for-query
+                                         (data/mbql-query checkins
+                                           {:aggregation [[:count]]
+                                            :breakout    [!month.date]}))]
+        (data/run-mbql-query checkins
+          {:source-query {:source-table $$checkins
+                          :aggregation  [[:count]]
+                          :breakout     [!month.date]}
+           :joins
+           [{:fields       :all
+             :alias        "checkins_2"
+             :source-table (str "card__" card-id)
+             :condition    [:= !month.*date &checkins_2.*date]}]
+           :order-by     [[:asc !month.*date]]
+           :limit        10})))))
+
+;; Can we aggregate on the results of a JOIN?
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :left-join)
+  ;; for whatever reason H2 gives slightly different answers :unamused:
+  {:rows    (let [driver-avg #(if (= metabase.driver/*driver* :h2) %1 %2)]
+              [["2014-01-01T00:00:00.000Z" 77]
+               ["2014-02-01T00:00:00.000Z" 81]
+               ["2014-04-01T00:00:00.000Z" (driver-avg 50 49)]
+               ["2014-07-01T00:00:00.000Z" (driver-avg 69 68)]
+               ["2014-08-01T00:00:00.000Z" 64]
+               ["2014-10-01T00:00:00.000Z" (driver-avg 66 65)]
+               ["2014-11-01T00:00:00.000Z" (driver-avg 75 74)]
+               ["2014-12-01T00:00:00.000Z" 70]])
+   :columns [(data/format-name "last_login") "avg"]}
+  (qp.test/format-rows-by [identity int]
+    (qp.test/rows+column-names
+      (tt/with-temp Card [{card-id :id} (qp.test-util/card-with-source-metadata-for-query
+                                         (data/mbql-query checkins
+                                           {:aggregation [[:count]]
+                                            :breakout    [$user_id]}))]
+        (data/run-mbql-query users
+          {:joins       [{:fields       :all
+                          :alias        "checkins_by_user"
+                          :source-table (str "card__" card-id)
+                          :condition    [:= $id &checkins_by_user.*checkins.user_id]}]
+           :aggregation [[:avg &checkins_by_user.*count/Float]]
+           :breakout    [!month.last_login]})))))
+
+;; NEW! Can we still get all of our columns, even if we *DON'T* specify the metadata?
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :left-join)
+  ;; datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :left-join)
+  {:rows    [["2013-01-01T00:00:00.000Z"  8 "2013-01-01T00:00:00.000Z"  8]
+             ["2013-02-01T00:00:00.000Z" 11 "2013-02-01T00:00:00.000Z" 11]
+             ["2013-03-01T00:00:00.000Z" 21 "2013-03-01T00:00:00.000Z" 21]]
+   :columns [(data/format-name "date") "count" (data/format-name "date_2") "count_2"]}
+  (tt/with-temp Card [{card-id               :id
+                       {source-query :query} :dataset_query
+                       source-metadata       :result_metadata} (qp.test-util/card-with-source-metadata-for-query
+                       (data/mbql-query checkins
+                         {:aggregation [[:count]]
+                          :breakout    [!month.date]}))]
+    (qp.test/rows+column-names
+      (qp.test/format-rows-by [identity int identity int]
+        (data/run-mbql-query checkins
+          {:source-query source-query
+           :joins        [{:source-table (str "card__" card-id)
+                           :alias        "checkins_by_month"
+                           :fields       :all
+                           :condition    [:= *checkins.date &checkins_by_month.*checkins.date]}]
+           :order-by     [[:asc *checkins.date]]
+           :limit        3})))))
+
+;; Should be able to use a joined field in a `:time-interval` clause
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :left-join)
+  {:rows    []
+   :columns (mapv data/format-name ["id" "name" "category_id" "latitude" "longitude" "price"])}
+  (qp.test/rows+column-names
+    (data/run-mbql-query venues
+      {:joins    [{:source-table $$checkins
+                   :alias        "c"
+                   :strategy     :right-join
+                   :condition    [:= $id &c.checkins.venue_id]}]
+       :filter   [:time-interval &c.checkins.date -30 :day]
+       :order-by [[:asc &c.checkins.id]]
+       :limit    10})))
+
+;; Do we gracefully handle situtations where joins would produce multiple columns with the same name?
+;;
+;; (Multiple columns named `id` in the example below)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :left-join)
+  {:rows
+   ;; again, not sure why Oracle is the only driver giving us wrong answers here
+   (let [tz (if (= driver/*driver* :oracle) "07:00:00.000Z"  "00:00:00.000Z")]
+     [[1 (str "2014-04-07T" tz) 5 12 5 "Brite Spot Family Restaurant" 20 34.078 -118.261 2]
+      [2 (str "2014-09-18T" tz) 1 31 1 "Red Medicine"                  4 10.065 -165.374 3]])
+   :columns (mapv data/format-name
+                  ["id" "date" "user_id" "venue_id" "id_2" "name" "category_id" "latitude" "longitude" "price"])}
+  (qp.test/rows+column-names
+    (qp.test/format-rows-by [int str int int int str int (partial u/round-to-decimals 3) (partial u/round-to-decimals 3) int]
+      (data/run-mbql-query checkins
+        {:source-query {:source-table $$checkins
+                        :joins
+                        [{:fields       :all
+                          :alias        "u"
+                          :source-table $$users
+                          :condition    [:= $user_id &u.users.id]}]}
+         :joins        [{:fields       :all
+                         :alias        "v"
+                         :source-table $$venues
+                         :condition    [:= *user_id &v.venues.id]}]
+         :order-by     [[:asc $id]]
+         :limit        2}))))
+
+
 
 ;; TODO Can we join against a source nested native query?
 
-;; TODO Can we include a list of specific Field for the source nested query?
-
 ;; TODO Do joins inside nested queries work?
+
+;; TODO Do multiple joins work, and return columns in the correct order?
 
 ;; TODO Can we join the same table twice with different conditions?
 
 ;; TODO Can we join the same table twice with the same condition?
-
-;; TODO - Can we run a wacko query that does duplicate joins against the same table?
-(defn- x []
-  (qp/process-query
-    (data/mbql-query checkins
-      {:source-query {:source-table $$checkins
-                      :aggregation  [[:sum $user_id->users.id]]
-                      :breakout     [[:field-id $id]]}
-       :joins        [{:alias        "u"
-                       :source-table $$users
-                       :condition    [:=
-                                      [:field-literal "ID" :type/BigInteger]
-                                      [:joined-field "u" $users.id]]}]
-       :limit        10})))

--- a/test/metabase/query_processor_test/failure_test.clj
+++ b/test/metabase/query_processor_test/failure_test.clj
@@ -1,10 +1,10 @@
 (ns metabase.query-processor-test.failure-test
   "Tests for how the query processor as a whole handles failures."
-  (:require [expectations :refer [expect]]
-            [medley.core :as m]
-            [metabase.query-processor :as qp]
+  (:require [metabase.query-processor :as qp]
             [metabase.query-processor.interface :as qp.i]
-            [metabase.test.data :as data]
+            [metabase.test
+             [data :as data]
+             [util :as tu]]
             [metabase.util.schema :as su]
             [schema.core :as s]))
 
@@ -29,44 +29,34 @@
                 "LIMIT 1048576")
    :params nil})
 
-(def ^:private ^{:arglists '([stacktrace])} valid-stacktrace?
-  (complement (partial s/check [su/NonBlankString])))
-
 ;; running a bad query via `process-query` should return stacktrace, query, preprocessed query, and native query
-(expect
-  {:status       :failed
-   :class        Exception
-   :error        true
-   :stacktrace   true
+(tu/expect-schema
+  {:status       (s/eq :failed)
+   :class        (s/eq Exception)
+   :error        s/Str
+   :stacktrace   [su/NonBlankString]
    ;; `:database` is removed by the catch-exceptions middleware for historical reasons
-   :query        (dissoc (bad-query) :database)
-   :preprocessed (bad-query:preprocessed)
-   :native       bad-query:native}
-  (-> (qp/process-query (bad-query))
-      (update :error (every-pred string? seq))
-      (update :stacktrace valid-stacktrace?)
-      ;; don't care about query hash + type
-      (m/dissoc-in [:query :info])
-      (m/dissoc-in [:preprocessed :info])))
+   :query        (s/eq (dissoc (bad-query) :database))
+   :preprocessed (s/eq (bad-query:preprocessed))
+   :native       (s/eq bad-query:native)
+   :cause        {:class (s/eq org.h2.jdbc.JdbcSQLException)
+                  :error #"Cannot parse \"TIMESTAMP\" constant \"1\"; SQL statement:.*"
+                  :cause {:class (s/eq java.lang.IllegalArgumentException)
+                          :error (s/eq "1")}}}
+  (qp/process-query (bad-query)))
 
 ;; running via `process-query-and-save-execution!` should return similar info and a bunch of other nonsense too
-(expect
-  {:database_id  (data/id)
-   :started_at   true
-   :json_query   (assoc-in (bad-query) [:middleware :userland-query?] true)
-   :native       bad-query:native
-   :status       :failed
-   :stacktrace   true
-   :context      :question
-   :error        true
-   :row_count    0
-   :running_time true
-   :preprocessed (assoc-in (bad-query:preprocessed) [:middleware :userland-query?] true)
-   :data         {:rows [], :cols [], :columns []}}
-  (-> (qp/process-query-and-save-execution! (bad-query) {:context :question})
-      (update :error (every-pred string? seq))
-      (update :started_at (partial instance? java.util.Date))
-      (update :stacktrace valid-stacktrace?)
-      (update :running_time (complement neg?))
-      (m/dissoc-in [:query :info])
-      (m/dissoc-in [:preprocessed :info])))
+(tu/expect-schema
+  {:database_id  (s/eq (data/id))
+   :started_at   java.util.Date
+   :json_query   (s/eq (assoc-in (bad-query) [:middleware :userland-query?] true))
+   :native       (s/eq bad-query:native)
+   :status       (s/eq :failed)
+   :stacktrace   [su/NonBlankString]
+   :context      (s/eq :question)
+   :error        su/NonBlankString
+   :row_count    (s/eq 0)
+   :running_time (s/constrained s/Int (complement neg?))
+   :preprocessed (s/eq (assoc-in (bad-query:preprocessed) [:middleware :userland-query?] true))
+   :data         (s/eq {:rows [], :cols [], :columns []})}
+  (qp/process-query-and-save-execution! (bad-query) {:context :question}))

--- a/test/metabase/query_processor_test/implicit_joins_test.clj
+++ b/test/metabase/query_processor_test/implicit_joins_test.clj
@@ -1,6 +1,8 @@
 (ns metabase.query-processor-test.implicit-joins-test
   "Test for JOIN behavior."
-  (:require [metabase.query-processor-test :as qp.test]
+  (:require [metabase
+             [driver :as driver]
+             [query-processor-test :as qp.test]]
             [metabase.test.data :as data]
             [metabase.test.data.datasets :as datasets]))
 
@@ -96,7 +98,7 @@
 ;; Check that trying to use a Foreign Key fails for Mongo and other DBs
 (datasets/expect-with-drivers (qp.test/non-timeseries-drivers-without-feature :foreign-keys)
   {:status :failed
-   :error  "foreign-keys is not supported by this driver."}
+   :error  (format "%s driver does not support foreign keys." driver/*driver*)}
   (select-keys
    (data/dataset tupac-sightings
      (data/run-mbql-query sightings

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -12,7 +12,6 @@
             [metabase.models
              [card :as card :refer [Card]]
              [collection :as collection :refer [Collection]]
-             [database :as database :refer [Database]]
              [field :refer [Field]]
              [permissions :as perms]
              [permissions-group :as group]
@@ -22,9 +21,8 @@
              [data :as data]
              [util :as tu]]
             [metabase.test.data
-             [dataset-definitions :as defs]
              [datasets :as datasets]
-             [users :refer [create-users-if-needed! user->client]]]
+             [users :refer [user->client]]]
             [metabase.util.honeysql-extensions :as hx]
             [toucan.db :as db]
             [toucan.util.test :as tt]))

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -607,19 +607,6 @@
 
 ;; try this in an end-to-end fashion using the API and make sure we can save a Card if we have appropriate read
 ;; permissions for the source query
-(defn- do-with-temp-copy-of-test-db
-  "Run `f` with a temporary Database that copies the details from the standard test database. `f` is invoked as `(f
-  db)`."
-  [f]
-  (data/with-db (data/get-or-create-database! defs/test-data)
-    (create-users-if-needed!)
-    (tt/with-temp Database [db {:details (:details (data/db)), :engine "h2"}]
-      (f db))))
-
-(defmacro ^:private with-temp-copy-of-test-db {:style/indent 1} [[db-binding] & body]
-  `(do-with-temp-copy-of-test-db (fn [~(or db-binding '_)]
-                                   ~@body)))
-
 (defn- save-card-via-API-with-native-source-query!
   "Attempt to save a Card that uses a native source query and belongs to a Collection with `collection-id` via the API
   using Rasta. Use this to test how the API endpoint behaves based on certain permissions grants for the `All Users`
@@ -642,12 +629,12 @@
 (expect
   :ok
   (tu/with-non-admin-groups-no-root-collection-perms
-    (with-temp-copy-of-test-db [db]
+    (data/with-temp-copy-of-test-db
       (tt/with-temp* [Collection [source-card-collection]
                       Collection [dest-card-collection]]
         (perms/grant-collection-read-permissions!      (group/all-users) source-card-collection)
         (perms/grant-collection-readwrite-permissions! (group/all-users) dest-card-collection)
-        (save-card-via-API-with-native-source-query! 200 db source-card-collection dest-card-collection)
+        (save-card-via-API-with-native-source-query! 200 (data/db) source-card-collection dest-card-collection)
         :ok))))
 
 ;; however, if we do *not* have read permissions for the source Card's collection we shouldn't be allowed to save the
@@ -657,20 +644,20 @@
 (expect
   "You don't have permissions to do that."
   (tu/with-non-admin-groups-no-root-collection-perms
-    (with-temp-copy-of-test-db [db]
+    (data/with-temp-copy-of-test-db
       (tt/with-temp Collection [dest-card-collection]
         (perms/grant-collection-readwrite-permissions! (group/all-users) dest-card-collection)
-        (save-card-via-API-with-native-source-query! 403 db nil dest-card-collection)))))
+        (save-card-via-API-with-native-source-query! 403 (data/db) nil dest-card-collection)))))
 
 ;; Card in a different Collection for which we do not have perms
 (expect
   "You don't have permissions to do that."
   (tu/with-non-admin-groups-no-root-collection-perms
-    (with-temp-copy-of-test-db [db]
+    (data/with-temp-copy-of-test-db
       (tt/with-temp* [Collection [source-card-collection]
                       Collection [dest-card-collection]]
         (perms/grant-collection-readwrite-permissions! (group/all-users) dest-card-collection)
-        (save-card-via-API-with-native-source-query! 403 db source-card-collection dest-card-collection)))))
+        (save-card-via-API-with-native-source-query! 403 (data/db) source-card-collection dest-card-collection)))))
 
 ;; similarly, if we don't have *write* perms for the dest collection it should also fail
 
@@ -678,20 +665,20 @@
 (expect
   "You don't have permissions to do that."
   (tu/with-non-admin-groups-no-root-collection-perms
-    (with-temp-copy-of-test-db [db]
+    (data/with-temp-copy-of-test-db
       (tt/with-temp Collection [source-card-collection]
         (perms/grant-collection-read-permissions! (group/all-users) source-card-collection)
-        (save-card-via-API-with-native-source-query! 403 db source-card-collection nil)))))
+        (save-card-via-API-with-native-source-query! 403 (data/db) source-card-collection nil)))))
 
 ;; Try to save in a different Collection for which we do not have perms
 (expect
   "You don't have permissions to do that."
   (tu/with-non-admin-groups-no-root-collection-perms
-    (with-temp-copy-of-test-db [db]
+    (data/with-temp-copy-of-test-db
       (tt/with-temp* [Collection [source-card-collection]
                       Collection [dest-card-collection]]
         (perms/grant-collection-read-permissions! (group/all-users) source-card-collection)
-        (save-card-via-API-with-native-source-query! 403 db source-card-collection dest-card-collection)))))
+        (save-card-via-API-with-native-source-query! 403 (data/db) source-card-collection dest-card-collection)))))
 
 ;; make sure that if we refer to a Field that is actually inside the source query, the QP is smart enough to figure
 ;; out what you were referring to and behave appropriately

--- a/test/metabase/query_processor_test/time_field_test.clj
+++ b/test/metabase/query_processor_test/time_field_test.clj
@@ -12,8 +12,8 @@
      (data/with-db (data/get-or-create-database! defs/test-data-with-time)
        (data/run-mbql-query users
          ~(merge
-           {:fields   `[~'$id ~'$name ~'$last_login_time]
-            :order-by `[[:asc ~'$id]]}
+           '{:fields   [$id $name $last_login_time]
+             :order-by [[:asc $id]]}
            additional-clauses)))))
 
 ;; Basic between query on a time field

--- a/test/metabase/query_processor_test/unix_timestamp_test.clj
+++ b/test/metabase/query_processor_test/unix_timestamp_test.clj
@@ -2,8 +2,7 @@
   "Tests for UNIX timestamp support."
   (:require [metabase
              [driver :as driver]
-             [query-processor-test :refer :all]]
-            [metabase.query-processor-test.date-bucketing-test :as dbt]
+             [query-processor-test :as qp.test :refer :all]]
             [metabase.test
              [data :as data]
              [util :as tu]]))
@@ -37,7 +36,7 @@
      ["2015-06-09"  7]
      ["2015-06-10"  9]]
 
-    (dbt/tz-shifted-engine-bug? driver/*driver*)
+    (qp.test/tz-shifted-driver-bug? driver/*driver*)
     [["2015-06-01T00:00:00.000-07:00" 6]
      ["2015-06-02T00:00:00.000-07:00" 10]
      ["2015-06-03T00:00:00.000-07:00" 4]

--- a/test/metabase/sync/analyze/query_results_test.clj
+++ b/test/metabase/sync/analyze/query_results_test.clj
@@ -1,18 +1,17 @@
 (ns metabase.sync.analyze.query-results-test
   (:require [clojure.string :as str]
-            [expectations :refer :all]
+            [expectations :refer [expect]]
             [metabase
              [query-processor :as qp]
              [util :as u]]
-            [metabase.models
-             [card :refer [Card]]
-             [database :as database]]
+            [metabase.mbql.schema :as mbql.s]
+            [metabase.models.card :refer [Card]]
             [metabase.sync.analyze.fingerprint.fingerprinters :as fprint]
-            [metabase.sync.analyze.query-results :as qr :refer :all]
+            [metabase.sync.analyze.query-results :as qr]
             [metabase.test
              [data :as data]
              [util :as tu]]
-            [metabase.test.mock.util :as mutil]
+            [metabase.test.mock.util :as mock.u]
             [toucan.util.test :as tt]))
 
 (defn- column->name-keyword [field-or-column-metadata]
@@ -36,45 +35,44 @@
       (throw (ex-info "Query Failed" results)))
     (->> results
          :data
-         results->column-metadata
+         qr/results->column-metadata
          :metadata
          (tu/round-all-decimals 2))))
 
 (defn- query-for-card [card]
-  {:database database/virtual-id
+  {:database mbql.s/saved-questions-virtual-database-id
    :type     :query
    :query    {:source-table (str "card__" (u/get-id card))}})
 
 (def ^:private venue-name->special-types
-  {:id          :type/PK,
-   :name        :type/Name,
-   :price       :type/Category,
-   :category_id :type/FK,
-   :latitude    :type/Latitude,
+  {:id          :type/PK
+   :name        :type/Name
+   :price       :type/Category
+   :category_id :type/FK
+   :latitude    :type/Latitude
    :longitude   :type/Longitude})
 
 ;; Getting the result metadata for a card backed by an MBQL query should use the fingerprints from the related fields
 (expect
-  mutil/venue-fingerprints
-  (tt/with-temp Card [card {:dataset_query {:database (data/id)
-                                            :type     :query
-                                            :query    {:source-table (data/id :venues)}}}]
-    (tu/throw-if-called fprint/with-global-fingerprinter ; check for a "proper" fingerprinter, fallthrough for PKs is fune.
+  mock.u/venue-fingerprints
+  (tu/throw-if-called fprint/with-global-fingerprinter
+    (tt/with-temp Card [card {:dataset_query (data/mbql-query venues)}]
+      ;; check for a "proper" fingerprinter, fallthrough for PKs is fine.
       (name->fingerprints
        (query->result-metadata (query-for-card card))))))
 
 ;; Getting the result metadata for a card backed by an MBQL query should just infer the types of all the fields
 (expect
   venue-name->special-types
-  (tt/with-temp Card [card {:dataset_query {:database (data/id)
-                                            :type     :query
-                                            :query    {:source-table (data/id :venues)}}}]
+  (tt/with-temp Card [card {:dataset_query (data/mbql-query venues)}]
     (name->special-type (query->result-metadata (query-for-card card)))))
 
 ;; Native queries don't know what the associated Fields are for the results, we need to compute the fingerprints, but
 ;; they should sill be the same except for some of the optimizations we do when we have all the information.
 (expect
-  (update mutil/venue-fingerprints :category_id assoc :type {:type/Number {:min 2.0, :max 74.0, :avg 29.98, :q1 7.0, :q3 49.0 :sd 23.06}})
+  (assoc-in mock.u/venue-fingerprints
+            [:category_id :type]
+            {:type/Number {:min 2.0, :max 74.0, :avg 29.98, :q1 7.0, :q3 49.0 :sd 23.06}})
   (tt/with-temp Card [card {:dataset_query {:database (data/id)
                                             :type     :native
                                             :native   {:query "select * from venues"}}}]
@@ -95,17 +93,15 @@
 
 ;; Limiting to just 1 column on an MBQL query should still get the result metadata from the Field
 (expect
-  (select-keys mutil/venue-fingerprints [:longitude])
-  (tt/with-temp Card [card {:dataset_query {:database (data/id)
-                                            :type     :query
-                                            :query    {:source-table (data/id :venues)}}}]
+  (select-keys mock.u/venue-fingerprints [:longitude])
+  (tt/with-temp Card [card {:dataset_query (data/mbql-query venues)}]
     (tu/throw-if-called fprint/fingerprinter
       (name->fingerprints
        (query->result-metadata (assoc-in (query-for-card card) [:query :fields] [[:field-id (data/id :venues :longitude)]]))))))
 
 ;; Similar query as above, just native so that we need to calculate the fingerprint
 (expect
-  (select-keys mutil/venue-fingerprints [:longitude])
+  (select-keys mock.u/venue-fingerprints [:longitude])
   (tt/with-temp Card [card {:dataset_query {:database (data/id)
                                             :type     :native
                                             :native   {:query "select longitude from venues"}}}]

--- a/test/metabase/sync/field_values_test.clj
+++ b/test/metabase/sync/field_values_test.clj
@@ -1,8 +1,7 @@
 (ns metabase.sync.field-values-test
   "Tests around the way Metabase syncs FieldValues, and sets the values of `field.has_field_values`."
-  (:require [expectations :refer :all]
+  (:require [expectations :refer [expect]]
             [metabase.models
-             [database :refer [Database]]
              [field :refer [Field]]
              [field-values :as field-values :refer [FieldValues]]
              [table :refer [Table]]]
@@ -32,7 +31,7 @@
    2 (do (db/delete! FieldValues :field_id (data/id :venues :price))
          (venues-price-field-values))
    ;; 3. After the delete, a field values should be created, the rest updated
-   3 (sync-database!' "update-field-values" (Database (data/id)))
+   3 (sync-database!' "update-field-values" (data/db))
    ;; 4. Now re-sync the table and make sure they're back
    4 (do (sync/sync-table! (Table (data/id :venues)))
          (venues-price-field-values))})
@@ -50,7 +49,7 @@
            :values [1 2 3])
          (venues-price-field-values))
    ;; 3. Now re-sync the table and validate the field values updated
-   3 (sync-database!' "update-field-values" (Database (data/id)))
+   3 (sync-database!' "update-field-values" (data/db))
    ;; 4. Make sure the value is back
    4 (venues-price-field-values)})
 

--- a/test/metabase/sync/sync_metadata/fields_test.clj
+++ b/test/metabase/sync/sync_metadata/fields_test.clj
@@ -8,7 +8,6 @@
              [sync :as sync]
              [util :as u]]
             [metabase.models
-             [database :refer [Database]]
              [field :refer [Field]]
              [table :refer [Table]]]
             [metabase.sync.sync-metadata.fields.sync-instances :as sync-fields.sync-instances]
@@ -165,12 +164,12 @@
                                                          :id field-id)
                                                        (update :fk_target_field_id #(db/exists? Field :id %)))))
         {before-step-info :step-info,
-         before-task-history :task-history} (sut/sync-database! "sync-fks" (Database (data/id)))
+         before-task-history :task-history} (sut/sync-database! "sync-fks" (data/db))
         before-special-type-exists? (get-special-type-and-fk-exists?)
         _ (db/update! Field field-id, :special_type nil, :fk_target_field_id nil)
         after-special-type-exists? (get-special-type-and-fk-exists?)
         {after-step-info :step-info,
-         after-task-history :task-history} (sut/sync-database! "sync-fks" (Database (data/id)))]
+         after-task-history :task-history} (sut/sync-database! "sync-fks" (data/db))]
     [
      (sut/only-step-keys before-step-info)
      (:task_details before-task-history)

--- a/test/metabase/sync/sync_metadata/fields_test.clj
+++ b/test/metabase/sync/sync_metadata/fields_test.clj
@@ -8,7 +8,6 @@
              [sync :as sync]
              [util :as u]]
             [metabase.models
-             [database :refer [Database]]
              [field :refer [Field]]
              [table :refer [Table]]]
             [metabase.sync.sync-metadata.fields.sync-instances :as sync-fields.sync-instances]
@@ -19,8 +18,7 @@
             [metabase.test.data.one-off-dbs :as one-off-dbs]
             [toucan
              [db :as db]
-             [hydrate :refer [hydrate]]]
-            [toucan.util.test :as tt]))
+             [hydrate :refer [hydrate]]]))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                         Dropping & Undropping Columns                                          |

--- a/test/metabase/sync/sync_metadata/fields_test.clj
+++ b/test/metabase/sync/sync_metadata/fields_test.clj
@@ -8,17 +8,19 @@
              [sync :as sync]
              [util :as u]]
             [metabase.models
+             [database :refer [Database]]
              [field :refer [Field]]
              [table :refer [Table]]]
             [metabase.sync.sync-metadata.fields.sync-instances :as sync-fields.sync-instances]
-            [metabase.sync.util-test :as sut]
+            [metabase.sync.util-test :as sync.util-test]
             [metabase.test
              [data :as data]
              [util :as tu]]
             [metabase.test.data.one-off-dbs :as one-off-dbs]
             [toucan
              [db :as db]
-             [hydrate :refer [hydrate]]]))
+             [hydrate :refer [hydrate]]]
+            [toucan.util.test :as tt]))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                         Dropping & Undropping Columns                                          |
@@ -118,69 +120,72 @@
   (sync/sync-table! (Table (data/id :venues))))
 
 ;; Test PK Syncing
-(expect [:type/PK
-         nil
-         :type/PK
-         :type/Latitude
-         :type/PK]
-  (let [get-special-type (fn [] (db/select-one-field :special_type Field, :id (data/id :venues :id)))]
-    [;; Special type should be :id to begin with
-     (get-special-type)
-     ;; Clear out the special type
-     (do (db/update! Field (data/id :venues :id), :special_type nil)
-         (get-special-type))
-     ;; Calling sync-table! should set the special type again
-     (do (force-sync-table! (data/id :venues))
-         (get-special-type))
-     ;; sync-table! should *not* change the special type of fields that are marked with a different type
-     (do (db/update! Field (data/id :venues :id), :special_type :type/Latitude)
-         (get-special-type))
-     ;; Make sure that sync-table runs set-table-pks-if-needed!
-     (do (db/update! Field (data/id :venues :id), :special_type nil)
-         (force-sync-table! (Table (data/id :venues)))
-         (get-special-type))]))
+(expect
+  [:type/PK
+   nil
+   :type/PK
+   :type/Latitude
+   :type/PK]
+  (data/with-temp-copy-of-test-db
+    (let [get-special-type (fn [] (db/select-one-field :special_type Field, :id (data/id :venues :id)))]
+      [ ;; Special type should be :id to begin with
+       (get-special-type)
+       ;; Clear out the special type
+       (do (db/update! Field (data/id :venues :id), :special_type nil)
+           (get-special-type))
+       ;; Calling sync-table! should set the special type again
+       (do (force-sync-table! (data/id :venues))
+           (get-special-type))
+       ;; sync-table! should *not* change the special type of fields that are marked with a different type
+       (do (db/update! Field (data/id :venues :id), :special_type :type/Latitude)
+           (get-special-type))
+       ;; Make sure that sync-table runs set-table-pks-if-needed!
+       (do (db/update! Field (data/id :venues :id), :special_type nil)
+           (force-sync-table! (Table (data/id :venues)))
+           (get-special-type))])))
 
 
 ;; Check that Foreign Key relationships were created on sync as we expect
-(expect (data/id :venues :id)
+(expect
+  (data/id :venues :id)
   (db/select-one-field :fk_target_field_id Field, :id (data/id :checkins :venue_id)))
 
-(expect (data/id :users :id)
+(expect
+  (data/id :users :id)
   (db/select-one-field :fk_target_field_id Field, :id (data/id :checkins :user_id)))
 
-(expect (data/id :categories :id)
+(expect
+  (data/id :categories :id)
   (db/select-one-field :fk_target_field_id Field, :id (data/id :venues :category_id)))
 
 ;; Check that sync-table! causes FKs to be set like we'd expect
-(expect (concat
-         (repeat 2 {:total-fks 3, :updated-fks 0, :total-failed 0})
-         [{:special_type :type/FK, :fk_target_field_id true}
-          {:special_type nil,      :fk_target_field_id false}]
-         (repeat 2 {:total-fks 3, :updated-fks 1, :total-failed 0})
-         [{:special_type :type/FK, :fk_target_field_id true}])
-  (let [field-id (data/id :checkins :user_id)
-        get-special-type-and-fk-exists? (fn []
-                                          (into {} (-> (db/select-one [Field :special_type :fk_target_field_id],
-                                                         :id field-id)
-                                                       (update :fk_target_field_id #(db/exists? Field :id %)))))
-        {before-step-info :step-info,
-         before-task-history :task-history} (sut/sync-database! "sync-fks" (data/db))
-        before-special-type-exists? (get-special-type-and-fk-exists?)
-        _ (db/update! Field field-id, :special_type nil, :fk_target_field_id nil)
-        after-special-type-exists? (get-special-type-and-fk-exists?)
-        {after-step-info :step-info,
-         after-task-history :task-history} (sut/sync-database! "sync-fks" (data/db))]
-    [
-     (sut/only-step-keys before-step-info)
-     (:task_details before-task-history)
-     ;; FK should exist to start with
-     before-special-type-exists?
-     ;; Clear out FK / special_type
-     after-special-type-exists?
-     ;; Run sync-table and they should be set again
-     (sut/only-step-keys after-step-info)
-     (:task_details after-task-history)
-     (get-special-type-and-fk-exists?)]))
+(expect
+  {:before
+   {:step-info         {:total-fks 3, :updated-fks 0, :total-failed 0}
+    :task-details      {:total-fks 3, :updated-fks 0, :total-failed 0}
+    :special-type      :type/FK
+    :fk-target-exists? true}
+
+   :after
+   {:step-info         {:total-fks 3, :updated-fks 1, :total-failed 0}
+    :task-details      {:total-fks 3, :updated-fks 1, :total-failed 0}
+    :special-type      :type/FK
+    :fk-target-exists? true}}
+  (data/with-temp-copy-of-test-db
+    (let [state (fn []
+                  (let [{:keys                  [step-info]
+                         {:keys [task_details]} :task-history}    (sync.util-test/sync-database! "sync-fks" (data/db))
+                        {:keys [special_type fk_target_field_id]} (db/select-one [Field :special_type :fk_target_field_id]
+                                                                    :id (data/id :checkins :user_id))]
+                    {:step-info         (sync.util-test/only-step-keys step-info)
+                     :task-details      task_details
+                     :special-type      special_type
+                     :fk-target-exists? (db/exists? Field :id fk_target_field_id)}))]
+      (array-map
+       :before (state)
+       :after  (do (db/update! Field (data/id :checkins :user_id), :special_type nil, :fk_target_field_id nil)
+                   (state))))))
+
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                     tests related to sync's Field hashes                                       |

--- a/test/metabase/test/data/datasets.clj
+++ b/test/metabase/test/data/datasets.clj
@@ -82,7 +82,7 @@
      (defn ~(vary-meta (symbol (str "expect-with-drivers-" (hash &form)))
                        assoc :expectation true)
        []
-       (doexpect-with-drivers (get-drivers-or-fail (fn [] ~drivers)) get-e# get-a# '~expected '~actual))))
+       (doexpect-with-drivers (get-drivers-or-fail (^:once fn* [] ~drivers)) get-e# get-a# '~expected '~actual))))
 
 (defmacro expect-with-all-drivers
   "Generate unit tests for all drivers specified in env var `DRIVERS`. `*driver*` is bound to the current driver inside

--- a/test/metabase/test/data/env.clj
+++ b/test/metabase/test/data/env.clj
@@ -9,7 +9,7 @@
 
     # just test against :h2 (default)
     DRIVERS=h2"
-  (:require [clojure.string :as s]
+  (:require [clojure.string :as str]
             [clojure.tools.logging :as log]
             [colorize.core :as color]
             [environ.core :refer [env]]
@@ -22,8 +22,8 @@
     (println
      (u/format-color 'red
          "The env var ENGINES is no longer supported. Please specify drivers to run tests against with DRIVERS instead.")))
-  (when-let [env-drivers (some-> (env :drivers) s/lower-case)]
-    (set (for [engine (s/split env-drivers #",")
+  (when-let [env-drivers (some-> (env :drivers) str/lower-case)]
+    (set (for [engine (str/split env-drivers #",")
                :when engine]
            (keyword engine)))))
 

--- a/test/metabase/test/data/mbql_query_impl.clj
+++ b/test/metabase/test/data/mbql_query_impl.clj
@@ -1,0 +1,165 @@
+(ns metabase.test.data.mbql-query-impl
+  "Internal implementation of `data/$ids` and `data/mbql-query` and related macros."
+  (:require [clojure
+             [string :as str]
+             [walk :as walk]]
+            [metabase.models.field :refer [Field]]
+            [toucan.db :as db]))
+
+(defn- field-id-call
+  "Replace a token string like `field` or `table.field` with a call to `data/id`."
+  [source-table-symb token-str]
+  (let [parts (str/split token-str #"\.")]
+    (cons
+     'metabase.test.data/id
+     (if (= (count parts) 1)
+       [(keyword source-table-symb) (keyword (first parts))]
+       (map keyword parts)))))
+
+
+(defn- clause-type-and-args
+  "Given a token string, return the matching Fieldclause "
+  [token-str]
+  (if-let [[_ source-token-str dest-token-str] (re-matches #"(^.*)->(.*$)" token-str)]
+    [:fk-> source-token-str dest-token-str]
+    [:field-id token-str]))
+
+
+(defmulti ^:private mbql-field
+  "Convert `token-str` to MBQL and `data/id` calls using `strategy` for producing the result.
+
+  *  `:wrap`    = wrap the clause in `:field-id` or `:fk->`
+  *  `:raw`     = return raw Integer Field ID
+  *  `:literal` = wrap the clause in `:field-literal`"
+  {:arglists '([strategy clause-type source-table-symb & tokens])}
+  (fn [strategy clause-type & _] [strategy clause-type]))
+
+(defmethod mbql-field [:wrap :field-id]
+  [_ _ source-table-symb token-str]
+  [:field-id (field-id-call source-table-symb token-str)])
+
+(defmethod mbql-field [:wrap :fk->]
+  [_ _ source-table-symb source-token-str dest-token-str]
+  [:fk->
+   [:field-id (field-id-call source-table-symb source-token-str)]
+   [:field-id (field-id-call source-table-symb dest-token-str)]])
+
+(defmethod mbql-field [:raw :field-id]
+  [_ _ source-table-symb token-str]
+  (field-id-call source-table-symb token-str))
+
+(defmethod mbql-field [:raw :fk->]
+  [_ _ source-table-symb source-token-str dest-token-str]
+  (throw (ex-info "Error: It doesn't make sense to have an 'raw' fk-> form. (Don't know which ID to use.)"
+           {:source-table-symb     source-table-symb
+            :source-token-str source-token-str
+            :dest-token-str   dest-token-str})))
+
+(defn field-name [field-id]
+  (db/select-one-field :name Field :id field-id))
+
+(defn field-base-type [field-id]
+  (db/select-one-field :base_type Field :id field-id))
+
+(defn- field-literal [source-table-symb token-str]
+  (if (str/includes? token-str "/")
+    (let [[field-name field-type] (str/split token-str #"/")]
+      [:field-literal field-name (keyword "type" field-type)])
+    [:field-literal
+     (list `field-name      (field-id-call source-table-symb token-str))
+     (list `field-base-type (field-id-call source-table-symb token-str))]))
+
+(defmethod mbql-field [:literal :field-id]
+  [_ _ source-table-symb token-str]
+  (field-literal source-table-symb token-str))
+
+(defmethod mbql-field [:literal :fk->]
+  [_ _ source-table-symb source-token-str dest-token-str]
+  [:fk->
+   (field-literal source-table-symb source-token-str)
+   (field-literal source-table-symb dest-token-str)])
+
+
+(defn- mbql-field-with-strategy [strategy source-table-symb token-str]
+  (let [[clause-type & args] (clause-type-and-args token-str)]
+    (apply mbql-field strategy clause-type source-table-symb args)))
+
+(defn- token->sigil [token]
+  (when-let [[_ sigil] (re-matches #"^([$%*!&]{1,2}).*[\w/]$" (str token))]
+    sigil))
+
+(defmulti ^:private parse-token-by-sigil
+  {:arglists '([source-table-symb token])}
+  (fn [_ token]
+    (when (symbol? token)
+      (token->sigil token))))
+
+(defmethod parse-token-by-sigil :default [_ token] token)
+
+;; $ = wrapped Field ID
+(defmethod parse-token-by-sigil "$"
+  [source-table-symb token]
+  (mbql-field-with-strategy :wrap source-table-symb (.substring (str token) 1)))
+
+;; % = raw Field ID
+(defmethod parse-token-by-sigil "%"
+  [source-table-symb token]
+  (mbql-field-with-strategy :raw source-table-symb (.substring (str token) 1)))
+
+;; * = Field Literal
+(defmethod parse-token-by-sigil "*"
+  [source-table-symb token]
+  (mbql-field-with-strategy :literal source-table-symb (.substring (str token) 1)))
+
+;; & = Field qualified by JOIN ALIAS
+(defmethod parse-token-by-sigil "&"
+  [source-table-symb token]
+  (if-let [[_ alias-name token] (re-matches #"^&([^.]+)\.(.+$)" (str token))]
+    [:joined-field alias-name (parse-token-by-sigil source-table-symb (if (token->sigil token)
+                                                                        (symbol token)
+                                                                        (symbol (str \$ token))))]
+    (throw (ex-info "Error parsing token starting with '&'"
+             {:token token}))))
+
+;; `!unit.<field> = datetime field
+(defmethod parse-token-by-sigil "!"
+  [source-table-symb token]
+  (if-let [[_ unit token] (re-matches #"^!([^.]+)\.(.+$)" (str token))]
+    [:datetime-field
+     (parse-token-by-sigil source-table-symb (if (token->sigil token)
+                                               (symbol token)
+                                               (symbol (str \$ token))))
+     (keyword unit)]
+    (throw (ex-info "Error parsing token starting with '!!'"
+             {:token token}))))
+
+;; $$ = table ID.
+(defmethod parse-token-by-sigil "$$"
+  [_ token]
+  (list 'metabase.test.data/id (keyword (.substring (str token) 2))))
+
+
+(defn parse-tokens
+  "Internal impl fn of `$ids` and `mbql-query` macros. Walk `body` and replace `$field` (and related) tokens with calls
+  to `id`.
+
+  Only Symbols that end with an alphanumeric character will parsed -- this way we don't accidentally try to parse
+  something like a function call or dynamic variable."
+  [source-table-symb-or-nil body]
+  (walk/postwalk (partial parse-token-by-sigil source-table-symb-or-nil) body))
+
+
+(defn wrap-inner-query
+  "Internal impl fn of `data/mbql-query` macro."
+  [inner-query]
+  {:database (list 'metabase.test.data/id)
+   :type     :query
+   :query    inner-query})
+
+(defn maybe-add-source-table
+  "Internal impl fn of `data/mbql-query` macro. Add `:source-table` to `inner-query` unless it already has a
+  `:source-table` or `:source-query` key."
+  [inner-query table]
+  (if (some (partial contains? inner-query) #{:source-table :source-query})
+    inner-query
+    (assoc inner-query :source-table (list 'metabase.test.data/id (keyword table)))))

--- a/test/metabase/test/data/sql_jdbc/execute.clj
+++ b/test/metabase/test/data/sql_jdbc/execute.clj
@@ -1,6 +1,6 @@
 (ns metabase.test.data.sql-jdbc.execute
   (:require [clojure.java.jdbc :as jdbc]
-            [clojure.string :as s]
+            [clojure.string :as str]
             [metabase.driver :as driver]
             [metabase.test.data.interface :as tx]
             [metabase.test.data.sql-jdbc.spec :as spec])
@@ -15,12 +15,12 @@
 
 (defn default-execute-sql! [driver context dbdef sql & {:keys [execute!]
                                                         :or   {execute! jdbc-execute!}}]
-  (let [sql (some-> sql s/trim)]
+  (let [sql (some-> sql str/trim)]
     (when (and (seq sql)
                ;; make sure SQL isn't just semicolons
-               (not (s/blank? (s/replace sql #";" ""))))
+               (not (str/blank? (str/replace sql #";" ""))))
       ;; Remove excess semicolons, otherwise snippy DBs like Oracle will barf
-      (let [sql (s/replace sql #";+" ";")]
+      (let [sql (str/replace sql #";+" ";")]
         (try
           (execute! (spec/dbdef->spec driver context dbdef) sql)
           (catch SQLException e
@@ -42,9 +42,9 @@
   ampersand (`⅋`) is understood as an \"escaped\" semicolon in the resulting SQL statement."
   [driver context dbdef sql  & {:keys [execute!] :or {execute! default-execute-sql!}}]
   (when sql
-    (doseq [statement (map s/trim (s/split sql #";+"))]
+    (doseq [statement (map str/trim (str/split sql #";+"))]
       (when (seq statement)
-        (execute! driver context dbdef (s/replace statement #"⅋" ";"))))))
+        (execute! driver context dbdef (str/replace statement #"⅋" ";"))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -50,10 +50,10 @@
     (nil? (s/check schema actual)))
   (expected-message [_ _ _ _]
     (str "Result did not match schema:\n"
-         (u/pprint-to-str (s/explain schema))))
+         (u/pprint-to-str 'green (s/explain schema))))
   (actual-message [_ actual _ _]
     (str "Was:\n"
-         (u/pprint-to-str actual)))
+         (u/pprint-to-str 'red actual)))
   (message [_ actual _ _]
     (u/pprint-to-str (s/check schema actual))))
 

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -210,7 +210,7 @@
   (u/snake-keys {:num-cans 2, :lisp-case? {:nested-maps? true}}))
 
 
-;; `xor`
+;; `xor` & `xor-pred`
 (expect false (u/xor false false))
 (expect true  (u/xor false true))
 (expect true  (u/xor true  false))
@@ -225,3 +225,12 @@
 (expect false (u/xor false true  true))
 (expect false (u/xor true  false true))
 (expect false (u/xor true  true  true))
+
+(expect false  (boolean ((u/xor-pred :a :b :c) {})))
+(expect true   (boolean ((u/xor-pred :a :b :c) {:a 1})))
+(expect true   (boolean ((u/xor-pred :a :b :c) {:b 1})))
+(expect true   (boolean ((u/xor-pred :a :b :c) {:c 1})))
+(expect false  (boolean ((u/xor-pred :a :b :c) {:a 1, :b 1})))
+(expect false  (boolean ((u/xor-pred :a :b :c) {:a 1, :c 1})))
+(expect false  (boolean ((u/xor-pred :a :b :c) {:b 1, :c 1})))
+(expect false  (boolean ((u/xor-pred :a :b :c) {:a 1, :b 1, :c 1})))

--- a/test_resources/log4j.properties
+++ b/test_resources/log4j.properties
@@ -17,7 +17,7 @@ log4j.appender.file.layout.ConversionPattern=%d [%t] %-5p%c - %m%n
 # customizations to logging by package
 log4j.logger.metabase=ERROR
 log4j.logger.metabase.driver=INFO
-log4j.logger.metabase.plugins=DEBUG
+log4j.logger.metabase.plugins=INFO
 log4j.logger.metabase.test-setup=INFO
 log4j.logger.metabase.test.data.datasets=INFO
 log4j.logger.metabase.test.data=INFO


### PR DESCRIPTION
Many days of hammering away at the joins code and fixing edge cases from the `notebook-mode` branch. Backporting now so I can run tests against all drivers & make sure lint errors/etc. are 💯 

slash so @sbelak can start using the new stuff without having to merge in `notebook-mode`

Other cool improvements:

##### Massive improvements to `data/$ids` and `data/mbql-query` macros

I tweaked these macros to make them behave the same way in all situations and to add some new options to save me from getting Emacs pinky. Here's an example with (almost) everything you can do:

```clj
(data/mbql-query venues
  {:fields [$id
            $checkins.id
            $category_id->categories.name
            *name
            *count/Integer
            !month.checkins.date]
   :joins  [{:source-table $$categories
             :fk-field-id  %category_id
             :alias        "cat"
             :condition    [:= $category_id &cat.categories.id]}]})
```

It expands to:

```clj
{:database (data/id),
 :type :query,
 :query
 {:fields
  [[:field-id (data/id :venues :id)]
   [:field-id (data/id :checkins :id)]
   [:fk-> [:field-id (data/id :venues :category_id)] [:field-id (data/id :categories :name)]]
   [:field-literal (mbql-query-impl/field-name (data/id :venues :name)) (mbql-query-impl/field-base-type (data/id :venues :name))]
   [:field-literal "count" :type/Integer]
   [:datetime-field [:field-id (data/id :checkins :date)] :month]],
  :joins
  [{:source-table (data/id :categories),
    :fk-field-id (data/id :venues :category_id),
    :alias "cat",
    :condition [:= [:field-id (data/id :venues :category_id)] [:joined-field "cat" [:field-id (data/id :categories :id)]]]}],
  :source-table (data/id :venues)}}
```

So, quite a bit less typing. The TL;DR is that the macro looks for symbols starting with special sigils and rewrites those as appropriate MBQL Field clauses. The old version of the macro supported `$field`, `$$table`, and `$fk-source->fk-dest` forms, but the new version supports all of that as well as several new ones, and any combination thereof.

*  `$`  = wrapped Field ID
*  `$$` = table ID
*  `%`  = raw Field ID
*  `*`  = field-literal for Field in app DB; `*field/type` for others
*  `&`  = wrap in `joined-field`
*  `!`  = wrap in `:datetime-field`

This does make writing tests 100% easier, especially for tests that run against multiple drivers