### PR TITLE
Re-enable formatting unit tests

### DIFF
--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -19,8 +19,7 @@ describe("formatting", () => {
       expect(formatNumber(-10)).toEqual("-10");
       expect(formatNumber(-99999999)).toEqual("-99,999,999");
     });
-    // FIXME: failing on CI
-    xit("should format to 2 significant digits", () => {
+    it("should format to 2 significant digits", () => {
       expect(formatNumber(1 / 3)).toEqual("0.33");
       expect(formatNumber(-1 / 3)).toEqual("-0.33");
       expect(formatNumber(0.0001 / 3)).toEqual("0.000033");
@@ -60,8 +59,7 @@ describe("formatting", () => {
         expect(formatNumber(-0.22, options)).toEqual("-22%");
       });
     });
-    // FIXME: failing on CI
-    xit("should format to correct number of decimal places", () => {
+    it("should format to correct number of decimal places", () => {
       expect(formatNumber(0.1)).toEqual("0.1");
       expect(formatNumber(0.11)).toEqual("0.11");
       expect(formatNumber(0.111)).toEqual("0.11");


### PR DESCRIPTION
They pass locally, but I guess `// FIXME: failing on CI` implies they always worked there? While I'm in here, I figured if I can get them working again.