### PR TITLE
Use feature name on ChoroplethMap hover

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -162,7 +162,7 @@ export default class ChoroplethMap extends Component {
       projection = null;
     }
 
-    // const nameProperty = details.region_name;
+    const nameProperty = details.region_name;
     const keyProperty = details.region_key;
 
     if (!geoJson) {
@@ -191,7 +191,7 @@ export default class ChoroplethMap extends Component {
       getCanonicalRowKey(row[dimensionIndex], settings["map.region"]);
     const getRowValue = row => row[metricIndex] || 0;
 
-    // const getFeatureName = feature => String(feature.properties[nameProperty]);
+    const getFeatureName = feature => String(feature.properties[nameProperty]);
     const getFeatureKey = feature =>
       String(feature.properties[keyProperty]).toLowerCase();
 
@@ -202,12 +202,13 @@ export default class ChoroplethMap extends Component {
 
     const rowByFeatureKey = new Map(rows.map(row => [getRowKey(row), row]));
 
-    const getFeatureClickObject = row => ({
+    const getFeatureClickObject = (row, feature) => ({
       value: row[metricIndex],
       column: cols[metricIndex],
       dimensions: [
         {
-          value: row[dimensionIndex],
+          value:
+            feature != null ? getFeatureName(feature) : row[dimensionIndex],
           column: cols[dimensionIndex],
         },
       ],
@@ -234,7 +235,7 @@ export default class ChoroplethMap extends Component {
         const row = hover && rowByFeatureKey.get(getFeatureKey(hover.feature));
         if (row && onHoverChange) {
           onHoverChange({
-            ...getFeatureClickObject(row),
+            ...getFeatureClickObject(row, hover.feature),
             event: hover.event,
           });
         } else if (onHoverChange) {


### PR DESCRIPTION
After experiencing the same issue as https://github.com/metabase/metabase/issues/8986 I took a look at the ChoroplethMap file and found some leftover code to get the feature name and decided to try to fix this issue!

(only added the feature name to the `onHover` and not to the `onClick` in order to still be able to click through and filter by the id)

Hope it's up to par, cheers!

<img width="972" alt="metabase-map-issue" src="https://user-images.githubusercontent.com/198782/58638385-97ab7600-82ec-11e9-8232-e40cd2a42ac4.png">


###### Before submitting the PR, please make sure you do the following
- [ ] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.
### Tests
-  [x] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [ ] If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`

-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
