### PR TITLE
Show stacked charts and stacking options with just one series

### DIFF
--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -132,10 +132,8 @@ export const isOrdinal = settings =>
 export const isHistogramBar = ({ settings, chartType }) =>
   isHistogram(settings) && chartType === "bar";
 
-export const isStacked = (settings, datas) =>
-  settings["stackable.stack_type"] && datas.length > 1;
+export const isStacked = (settings, datas) => settings["stackable.stack_type"];
 export const isNormalized = (settings, datas) =>
-  isStacked(settings, datas) &&
   settings["stackable.stack_type"] === "normalized";
 
 // find the first nonempty single series

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -273,9 +273,6 @@ export const STACKABLE_SETTINGS = {
         ? "stacked"
         : null,
     getHidden: (series, settings) => {
-      if (series.length < 2) {
-        return true;
-      }
       const displays = series.map(single => settings.series(single).display);
       return !_.any(displays, display => STACKABLE_DISPLAY_TYPES.has(display));
     },

--- a/frontend/test/metabase/visualizations/components/LineAreaBarRenderer-bar.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/LineAreaBarRenderer-bar.unit.spec.js
@@ -27,7 +27,7 @@ const DEFAULT_COLUMN_SETTINGS = {
   date_style: "MMMM D, YYYY",
 };
 
-function MainSeries(chartType, settings = {}) {
+function MainSeries(chartType, settings = {}, value = 1) {
   return {
     card: {
       display: chartType,
@@ -41,7 +41,7 @@ function MainSeries(chartType, settings = {}) {
         StringColumn({ display_name: "Category", source: "breakout" }),
         NumberColumn({ display_name: "Sum", source: "aggregation" }),
       ],
-      rows: [["A", 1]],
+      rows: [["A", value]],
     },
   };
 }
@@ -156,6 +156,23 @@ describe("LineAreaBarRenderer-bar", () => {
     expect(getDataKeyValues(calls[1][0])).toEqual([
       { key: "Category", value: "A" },
       { key: "% Count", value: "67%" },
+    ]);
+  });
+
+  it(`should render an bar normalized chart with just one series`, () => {
+    const onHoverChange = jest.fn();
+    renderLineAreaBar(
+      element,
+      [MainSeries("bar", { "stackable.stack_type": "normalized" }, 3)],
+      { onHoverChange },
+    );
+
+    dispatchUIEvent(qsa(".bar, .dot")[0], "mousemove");
+
+    const { calls } = onHoverChange.mock;
+    expect(getDataKeyValues(calls[0][0])).toEqual([
+      { key: "Category", value: "A" },
+      { key: "% Sum", value: "100%" },
     ]);
   });
 


### PR DESCRIPTION
Resolves #9362 

**I'm not convinced this is a good change. Is the fix worse than the initial bug?**

The issue was due to a chart getting set up on data with multiple series, but later the data updates and only one series is present. I updated the behavior to keep stacking settings (including normalization) even if only one series is present.

With that change, there was a new weird scenario: the stacking settings still depend on having multiple series. While your chart will now maintain its stacking settings, there'd be no way to remove them. To prevent this, I updated the `getHidden` behavior on that setting to display if any series are stackable.

The result is that you can now turn on stacking even if you just have one series to begin with. Is that ok? I feel it might be a bit confusing.

One compromise I tried out but decided against is to have the setting's display logic rely on either having multiple series _or_ currently having stacking turned on. There, you'd be able to keep stacking even if data reduced to a single series and you'd be able to remove stacking whenever it's on. The downside of this approach is that when you removed stacking the settings would disappear.