### PR TITLE
Fix issue with adding/subtracting partial months

### DIFF
--- a/frontend/test/metabase/visualizations/lib/apply_axis.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/apply_axis.unit.spec.js
@@ -1,0 +1,42 @@
+import { stretchTimeseriesDomain } from "metabase/visualizations/lib/apply_axis";
+import moment from "moment";
+
+describe("visualization.lib.apply_axis", () => {
+  describe("stretchTimeseriesDomain", () => {
+    it("should extend a partial month", () => {
+      const domain = ["2020-04-01", "2020-06-01"].map(s => moment.utc(s));
+      const dataInterval = { interval: "month", count: 1 };
+
+      const newDomain = stretchTimeseriesDomain(domain, dataInterval);
+
+      expect(newDomain.map(d => d.toISOString())).toEqual([
+        "2020-03-09T00:00:00.000Z",
+        "2020-06-24T00:00:00.000Z",
+      ]);
+    });
+
+    it("should extend a partial week", () => {
+      const domain = ["2020-04-01", "2020-04-15"].map(s => moment.utc(s));
+      const dataInterval = { interval: "week", count: 1 };
+
+      const newDomain = stretchTimeseriesDomain(domain, dataInterval);
+
+      expect(newDomain.map(d => d.toISOString())).toEqual([
+        "2020-03-27T00:00:00.000Z",
+        "2020-04-20T00:00:00.000Z",
+      ]);
+    });
+
+    it("should extend a partial day", () => {
+      const domain = ["2020-04-01", "2020-04-05"].map(s => moment.utc(s));
+      const dataInterval = { interval: "day", count: 1 };
+
+      const newDomain = stretchTimeseriesDomain(domain, dataInterval);
+
+      expect(newDomain.map(d => d.toISOString())).toEqual([
+        "2020-03-31T06:00:00.000Z",
+        "2020-04-05T18:00:00.000Z",
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
Resolves #9005, Resolves #7935

We stretch our x axes by 0.75 units to give a bit of margin. This wasn't working with some date units because moment rounds when adding or subtracting months. Adding a full month instead of 0.75 months would cause unnecessary ticks to appear.

# Before

<img width="852" alt="Screen Shot 2019-05-31 at 3 41 54 PM" src="https://user-images.githubusercontent.com/691495/58735102-681d6c00-83c7-11e9-8597-00c22c1aa872.png">

# After

<img width="852" alt="Screen Shot 2019-05-31 at 3 41 00 PM" src="https://user-images.githubusercontent.com/691495/58735107-6bb0f300-83c7-11e9-95f6-a3c9a44fe13b.png">
