### PR TITLE
Pie chart bug with one zero value row

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
@@ -240,26 +240,23 @@ export default class PieChart extends Component {
       .partition(d => d.percentage > sliceThreshold)
       .value();
 
-    let otherSlice;
-    if (others.length > 1) {
-      let otherTotal = others.reduce((acc, o) => acc + o.value, 0);
-      if (otherTotal > 0) {
-        otherSlice = {
-          key: "Other",
-          value: otherTotal,
-          percentage: otherTotal / total,
-          color: colors["text-light"],
-        };
-        slices.push(otherSlice);
+    const otherTotal = others.reduce((acc, o) => acc + o.value, 0);
+    // Multiple others get squashed together under the key "Other"
+    let otherSlice =
+      others.length === 1
+        ? others[0]
+        : {
+            key: "Other",
+            value: otherTotal,
+            percentage: otherTotal / total,
+            color: colors["text-light"],
+          };
+    if (otherSlice.value > 0) {
+      // increase "other" slice so it's barely visible
+      if (otherSlice.percentage < OTHER_SLICE_MIN_PERCENTAGE) {
+        otherSlice.value = total * OTHER_SLICE_MIN_PERCENTAGE;
       }
-    } else {
-      slices.push(...others);
-    }
-
-    // increase "other" slice so it's barely visible
-    // $FlowFixMe
-    if (otherSlice && otherSlice.percentage < OTHER_SLICE_MIN_PERCENTAGE) {
-      otherSlice.value = total * OTHER_SLICE_MIN_PERCENTAGE;
+      slices.push(otherSlice);
     }
 
     let legendTitles = slices.map(slice => [


### PR DESCRIPTION
Resolves #7784

This bug occurred when a single row with a value of zero was charted. Two rows that were both zero worked correctly. 

The issue was that the check for `otherTotal > 0` only happened when there were multiple other rows but not just a single other row. The fix was to rework the logic so that check happens regardless of how many `others` rows there are.

I felt it wasn't worth the trouble to test this, but maybe that's a sign that some of the logic here should be extracted from render? 