### PR TITLE
sort idfields in datamodel

### DIFF
--- a/frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx
@@ -207,6 +207,19 @@ export class SpecialTypeAndTargetPicker extends Component {
     const includeSchema =
       _.uniq(idfields.map(idField => idField.table.schema)).length > 1;
 
+    idfields.sort((...fields) => {
+      const [f1, f2] = fields.map(f =>
+        f.displayName({ includeTable: true, includeSchema }),
+      );
+      if (f1 < f2) {
+        return -1;
+      }
+      if (f1 > f2) {
+        return 1;
+      }
+      return 0;
+    });
+
     return (
       <div>
         <Select

--- a/frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx
@@ -185,7 +185,7 @@ export class SpecialTypeAndTargetPicker extends Component {
   };
 
   render() {
-    const { field, idfields, className, selectSeparator } = this.props;
+    const { field, className, selectSeparator } = this.props;
 
     let specialTypes = MetabaseCore.field_special_types.slice(0);
     specialTypes.push({
@@ -202,23 +202,16 @@ export class SpecialTypeAndTargetPicker extends Component {
 
     const showCurrencyTypeSelect = isCurrency(field);
 
+    let { idfields } = this.props;
+
     // If all FK target fields are in the same schema (like `PUBLIC` for sample dataset)
     // or if there are no schemas at all, omit the schema name
     const includeSchema =
       _.uniq(idfields.map(idField => idField.table.schema)).length > 1;
 
-    idfields.sort((...fields) => {
-      const [f1, f2] = fields.map(f =>
-        f.displayName({ includeTable: true, includeSchema }),
-      );
-      if (f1 < f2) {
-        return -1;
-      }
-      if (f1 > f2) {
-        return 1;
-      }
-      return 0;
-    });
+    idfields = _.sortBy(idfields, field =>
+      field.displayName({ includeTable: true, includeSchema }),
+    );
 
     return (
       <div>


### PR DESCRIPTION
Resolves #10080 

To avoid any potential perf issues, It feels like this should live in a memoized selector rather than render. The downside to that is it would move some view-concerns into the selector (the options to `displayName` and it would require duplicating the `includeSchema` logic. 🤷‍♂ sorting should be fast though.