### PR TITLE
fix bug where bubble size couldn't be in column index 0

### DIFF
--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
@@ -321,7 +321,9 @@ function transformSingleSeries(s, series, seriesIndex) {
     settings["scatter.bubble"] &&
     _.findIndex(cols, col => col.name === settings["scatter.bubble"]);
   const extraColumnIndexes =
-    bubbleColumnIndex && bubbleColumnIndex >= 0 ? [bubbleColumnIndex] : [];
+    bubbleColumnIndex != null && bubbleColumnIndex >= 0
+      ? [bubbleColumnIndex]
+      : [];
 
   if (dimensions.length > 1) {
     const [dimensionColumnIndex, seriesColumnIndex] = dimensionColumnIndexes;


### PR DESCRIPTION
Resolves #8109

This bug was due to zero being falsey. This caused `extraColumnIndexes` to be set as `[]` whenever `bubbleColumnIndex` was zero. Despite that being a valid index.

 I updated the check to look at whether it's null or undefined.