### PR TITLE
Update CODEOWNERS to be a little less aggressive

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,7 @@
 
 *.clj @camsaul
-*.js @tlrobinson
-*.jsx @tlrobinson
 *.css @kdoh
-/frontend/ @tlrobinson @kdoh
+/frontend/src @tlrobinson @kdoh
 /frontend/src/metabase/components/ @kdoh
 /frontend/src/metabase/admin/datamodel/ @tlrobinson @paulrosenzweig
 /frontend/src/metabase/entities/ @tlrobinson @paulrosenzweig


### PR DESCRIPTION
I think we can exclude automatic review requests on things like tests, so I'm removing the `*.js` and `*.jsx` and switching `/frontend` to `/frontend/src`