### PR TITLE
update d3 choropleth scale to match legend

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -244,12 +244,13 @@ export default class ChoroplethMap extends Component {
       });
 
     const valuesMap = {};
-    const domain = [];
     for (const row of rows) {
-      valuesMap[getRowKey(row)] =
-        (valuesMap[getRowKey(row)] || 0) + getRowValue(row);
-      domain.push(getRowValue(row));
+      const key = getRowKey(row);
+      const value = getRowValue(row);
+      valuesMap[key] = (valuesMap[key] || 0) + value;
     }
+    const domainSet = new Set(Object.values(valuesMap));
+    const domain = Array.from(domainSet);
 
     const _heatMapColors = settings["map.colors"] || HEAT_MAP_COLORS;
     const heatMapColors =

--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -258,10 +258,11 @@ export default class ChoroplethMap extends Component {
         : _heatMapColors;
 
     const groups = ss.ckmeans(domain, heatMapColors.length);
+    const groupBoundaries = groups.slice(1).map(cluster => cluster[0]);
 
     const colorScale = d3.scale
-      .quantile()
-      .domain(groups.map(cluster => cluster[0]))
+      .threshold()
+      .domain(groupBoundaries)
       .range(heatMapColors);
 
     const legendColors = heatMapColors;


### PR DESCRIPTION
Resolves #7486

Values were incorrectly colored on the map.

I'm guessing this bug was caused by changing the binning code and updating the legend without the corresponding color scale. I haven't done the git spelunking to confirm that theory though.

# Before
<img width="670" alt="Screen Shot 2019-06-05 at 3 11 28 PM" src="https://user-images.githubusercontent.com/691495/58983178-38de7480-87a4-11e9-8250-07fa9f42b30f.png">

# After
<img width="670" alt="Screen Shot 2019-06-05 at 3 06 17 PM" src="https://user-images.githubusercontent.com/691495/58983201-4693fa00-87a4-11e9-8649-4e6ba35fd55b.png">
