### PR TITLE
Fix numeric category error with Postgres

### DIFF
--- a/src/metabase/query_processor/middleware/parameters/mbql.clj
+++ b/src/metabase/query_processor/middleware/parameters/mbql.clj
@@ -17,9 +17,9 @@
   convert the parameters to integers or floating-point numbers."
   [param-type param-value, field-id :- su/IntGreaterThanZero]
   (cond
-    ;; for `id` type params look up the base-type of the Field and see if it's a number or not. If it *is* a number
-    ;; then recursively call this function and parse the param value as a number as appropriate.
-    (and (= param-type :id)
+    ;; for `id` or `category` type params look up the base-type of the Field and see if it's a number or not.
+    ;; If it *is* a number then recursively call this function and parse the param value as a number as appropriate.
+    (and (or (= param-type :id) (= param-type :category))
          (isa? (db/select-one-field :base_type Field :id field-id) :type/Number))
     (recur :number param-value field-id)
 

--- a/src/metabase/query_processor/middleware/parameters/mbql.clj
+++ b/src/metabase/query_processor/middleware/parameters/mbql.clj
@@ -19,7 +19,7 @@
   (cond
     ;; for `id` or `category` type params look up the base-type of the Field and see if it's a number or not.
     ;; If it *is* a number then recursively call this function and parse the param value as a number as appropriate.
-    (and (or (= param-type :id) (= param-type :category))
+    (and (#{:id :category} param-type)
          (isa? (db/select-one-field :base_type Field :id field-id) :type/Number))
     (recur :number param-value field-id)
 

--- a/test/metabase/query_processor/middleware/parameters/mbql_test.clj
+++ b/test/metabase/query_processor/middleware/parameters/mbql_test.clj
@@ -189,6 +189,19 @@
                          :target [:dimension $id]
                          :value  "100"}]})))))
 
+;; check that Categories work correctly (passed in as strings, as the frontend is wont to do; should get converted)
+(datasets/expect-with-drivers params-test-drivers
+  [[6]]
+  (qp.test/format-rows-by [int]
+    (qp.test/rows
+      (qp/process-query
+        (data/query venues
+          {:query      {:aggregation [[:count]]}
+           :parameters [{:name   "price"
+                         :type   :category
+                         :target $price
+                         :value  "4"}]})))))
+
 ;; test that we can inject a basic `WHERE id = 9` type param (`id` type)
 (datasets/expect-with-drivers params-test-drivers
   [[9 "Nils Gotam"]]


### PR DESCRIPTION
 #2981 ensured that numeric IDs that are passed in as strings by the front-end are converted to numbers. This needs to be done for numeric categories as well, as postgres will not do an implicit cast and fail to run the query otherwise.

AFAIK, there is no open issue for this bug, there are a few comments though, referenced by @flamber [here](https://github.com/metabase/metabase/issues/7891#issuecomment-497898971): 
 - https://github.com/metabase/metabase/issues/5632#issuecomment-489165061 @pelletencate
 - https://github.com/metabase/metabase/issues/2854#issuecomment-409295946 @thomashs