### PR TITLE
show x axis with just one label

### DIFF
--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -308,7 +308,7 @@ function onRenderHideDisabledAxis(chart) {
 }
 
 function onRenderHideBadAxis(chart) {
-  if (chart.selectAll(".axis.x .tick")[0].length === 1) {
+  if (chart.selectAll(".axis.x .tick")[0].length === 0) {
     chart.selectAll(".axis.x").remove();
   }
 }


### PR DESCRIPTION
Resolves #8540

Given that we explicitly [set tick count to zero](https://github.com/metabase/metabase/blob/fix-8540/frontend/src/metabase/visualizations/lib/apply_axis.js#L369) when there's no axis, I'm not sure what this line was meant to fix. Is there some case when we don't want to show a single tick's label?