### PR TITLE
Pass through column settings as formatting options

### DIFF
--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -597,6 +597,7 @@ export function formatValueRaw(value: Value, options: FormattingOptions = {}) {
     jsx: false,
     remap: true,
     ...options,
+    ...(column || {}).settings,
   };
 
   if (options.remap && column) {

--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -597,7 +597,6 @@ export function formatValueRaw(value: Value, options: FormattingOptions = {}) {
     jsx: false,
     remap: true,
     ...options,
-    ...(column || {}).settings,
   };
 
   if (options.remap && column) {

--- a/frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx
@@ -109,6 +109,7 @@ export class ObjectDetail extends Component {
       } else {
         cellValue = formatValue(value, {
           column: column,
+          ...column.settings
           jsx: true,
           rich: true,
         });

--- a/frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx
@@ -109,7 +109,7 @@ export class ObjectDetail extends Component {
       } else {
         cellValue = formatValue(value, {
           column: column,
-          ...column.settings
+          ...column.settings,
           jsx: true,
           rich: true,
         });


### PR DESCRIPTION
Resolves #10099 

This passes through column formatting options, so that they show up in the detail view as they do in the table view. 