### PR TITLE
Use topological sorting for source query cycle detection

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -120,7 +120,8 @@
    [org.eclipse.jetty/jetty-server "9.4.15.v20190215"]                ; We require JDK 8 which allows us to run Jetty 9.4, ring-jetty-adapter runs on 1.7 which forces an older version
    [ring/ring-json "0.4.0"]                                           ; Ring middleware for reading/writing JSON automatically
    [stencil "0.5.0"]                                                  ; Mustache templates for Clojure
-   [toucan "1.11.0" :exclusions [org.clojure/java.jdbc honeysql]]]    ; Model layer, hydration, and DB utilities
+   [toucan "1.11.0" :exclusions [org.clojure/java.jdbc honeysql]]     ; Model layer, hydration, and DB utilities
+   [weavejester/dependency "0.2.1"]]                                  ; Dependency graphs and topological sorting
 
   :main ^:skip-aot metabase.core
 

--- a/test/metabase/query_processor/middleware/fetch_source_query_test.clj
+++ b/test/metabase/query_processor/middleware/fetch_source_query_test.clj
@@ -246,25 +246,12 @@
 ;;   C
 ;;
 (expect
-  (tt/with-temp* [Card [{card-1-id :id} {:dataset_query {:database (data/id)
-                                                         :type     :query
-                                                         :query    {:source-table (data/id :venues)}}
-                                         :name "foo"
-                                         :display :table
-                                         :visualization_settings {}
-                                         :creator_id 1}]
-                  Card [{card-2-id :id} {:dataset_query {:database (data/id)
-                                                         :type     :query
-                                                         :query    {:source-table (str "card__" card-1-id)}}
-                                         :name "foo"
-                                         :display :table
-                                         :visualization_settings {}
-                                         :creator_id 1}]]
-    (some?
-     (resolve-card-id-source-tables
-      {:database (data/id)
-       :type     :query
-       :query    {:source-table (str "card__" card-1-id)
-                  :joins        [{:alias "c"
-                                  :source-table (str "card__" card-2-id)
-                                  :condition [:= [:field-literal "ID" :type/Number] [:joined-field "c" [:field-id (data/id :venues :id)]]]}]}}))))
+  (tt/with-temp* [Card [{card-1-id :id} {:dataset_query (data/mbql-query venues)}]
+                  Card [{card-2-id :id} {:dataset_query (data/mbql-query nil
+                                                          {:source-table (str "card__" card-1-id)})}]]
+    (resolve-card-id-source-tables
+     (data/mbql-query nil
+       {:source-table (str "card__" card-1-id)
+        :joins        [{:alias        "c"
+                        :source-table (str "card__" card-2-id)
+                        :condition    [:= *ID/Number &c.venues.id]}]}))))

--- a/test/metabase/query_processor/middleware/fetch_source_query_test.clj
+++ b/test/metabase/query_processor/middleware/fetch_source_query_test.clj
@@ -237,7 +237,14 @@
         (or save-error
             (resolve-card-id-source-tables (circular-source-query card-1-id)))))))
 
-;; Alow complex dependency topologies
+;; Alow complex dependency topologies such as:
+;;
+;;   A
+;:   | \
+;;   B  |
+;;   | /
+;;   C
+;;
 (expect
   (tt/with-temp* [Card [{card-1-id :id} {:dataset_query {:database (data/id)
                                                          :type     :query


### PR DESCRIPTION
Fixes a bug in our current implementation which would trip on valid dependency graphs with the following topology:
```
A
|  \
B  |
|  /
C
```
I've came across this in the wild when doing self-joins.

`weavejester/dependency` will be needed anyway for ETL, so no harm there.