### PR TITLE
Fall back to the first section if currentSection's widgets aren't set

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -158,7 +158,8 @@ class ChartSettings extends Component {
       };
       widgets = [widget];
     } else {
-      widgets = sections[currentSection];
+      // if there are no named tabs, get widgets from the first one
+      widgets = sections[currentSection] || Object.values(sections)[0];
     }
 
     const extraWidgetProps = {


### PR DESCRIPTION
Resolves #9346, Resolves #10118 (which is a dupe I created)

The edit settings button was telling the setting modal to open to the Data tab, but that tab didn't exist.