### PR TITLE
Only show funnel legend header if there are action buttons but no title

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
@@ -40,7 +40,7 @@ export default class Funnel extends Component {
     height: 4,
   };
 
-  static isSensible(cols, rows) {
+  static isSensible({ cols, rows }) {
     return cols.length === 2;
   }
 
@@ -166,12 +166,15 @@ export default class Funnel extends Component {
               actionButtons={actionButtons}
             />
           )}
-          <LegendHeader
-            className="flex-no-shrink"
-            series={series._raw || series}
-            actionButtons={!hasTitle && actionButtons}
-            onChangeCardAndRun={onChangeCardAndRun}
-          />
+          {!hasTitle &&
+          actionButtons && ( // always show action buttons if we have them
+              <LegendHeader
+                className="flex-no-shrink"
+                series={series._raw || series}
+                actionButtons={actionButtons}
+                onChangeCardAndRun={onChangeCardAndRun}
+              />
+            )}
           <FunnelNormal {...this.props} className="flex-full" />
         </div>
       );


### PR DESCRIPTION
Resolves #9486 

I don't really know what the action buttons are, so I just copied the logic from LineAreaBar as @flamber  [suggested](https://github.com/metabase/metabase/issues/9486#issuecomment-467106473). Do we expect to have those for funnels when a title isn't set? 

@flamber pointed out the change to `isSensible` resolves #4890.