### PR TITLE
Add :include-all-drivers to :ring profile; fix lein-include-drivers middleware

### DIFF
--- a/lein-plugins/include-drivers/project.clj
+++ b/lein-plugins/include-drivers/project.clj
@@ -1,4 +1,4 @@
-(defproject metabase/lein-include-drivers "1.0.5"
+(defproject metabase/lein-include-drivers "1.0.6"
   :min-lein-version "2.5.0"
   :eval-in-leiningen true
   :deploy-repositories [["clojars" {:sign-releases false}]])

--- a/lein-plugins/include-drivers/src/leiningen/include_drivers.clj
+++ b/lein-plugins/include-drivers/src/leiningen/include_drivers.clj
@@ -19,7 +19,7 @@
   (let [drivers
         (cond
           (= include-drivers :all)
-          (.list (java.io.File. "modules/drivers"))
+          (.list (File. "modules/drivers"))
 
           (coll? include-drivers)
           include-drivers
@@ -29,25 +29,49 @@
     (concat drivers
             (set (mapcat driver-parents drivers)))))
 
+(defn- plugins-file-exists? [filename-pattern]
+  (some
+   (fn [filename]
+     (re-matches filename-pattern filename))
+   (.list (File. "plugins"))))
+
+(defn- driver-dependencies-satisfied?
+  "If `project` specifies a list of dependency filenames like
+
+    {:include-drivers-dependencies [#\"^ojdbc[78]\\.jar$\"]}
+
+  Make sure a file matching that name pattern exists in the `/plugins` directory."
+  {:arglists '([project])}
+  [{:keys [include-drivers-dependencies]}]
+  (every? plugins-file-exists? include-drivers-dependencies))
+
 (defn- test-drivers-source-paths [test-drivers]
   (vec
    (for [driver test-drivers
          :let   [source-path (format "modules/drivers/%s/src" driver)]
-         :when  (file-exists? source-path)]
+         :when  (and (file-exists? source-path)
+                     (driver-dependencies-satisfied? driver))]
      source-path)))
 
 (defn- test-drivers-test-paths [test-drivers]
   (vec
    (for [driver test-drivers
          :let   [test-path (format "modules/drivers/%s/test" driver)]
-         :when  (file-exists? test-path)]
+         :when  (and (file-exists? test-path)
+                     (driver-dependencies-satisfied? driver))]
      test-path)))
 
 (defn- test-drivers-projects [test-drivers]
   (for [driver test-drivers
         :let   [project-file (format "modules/drivers/%s/project.clj" driver)]
-        :when  (file-exists? project-file)]
-    (p/read project-file)))
+        :when  (file-exists? project-file)
+        :let   [project (p/read project-file)]
+        :when  (or (driver-dependencies-satisfied? project)
+                   (println
+                    (format "Not including %s because not all dependencies matching %s found in /plugins"
+                            driver
+                            (:include-drivers-dependencies project))))]
+    project))
 
 (defn- test-drivers-dependencies [test-projects]
   (vec

--- a/modules/drivers/oracle/project.clj
+++ b/modules/drivers/oracle/project.clj
@@ -1,6 +1,8 @@
 (defproject metabase/oracle-driver "1.0.0"
   :min-lein-version "2.5.0"
 
+  :include-drivers-dependencies [#"^ojdbc[78]\.jar$"]
+
   :profiles
   {:provided
    {:dependencies [[metabase-core "1.0.0-SNAPSHOT"]]}

--- a/modules/drivers/vertica/project.clj
+++ b/modules/drivers/vertica/project.clj
@@ -1,6 +1,8 @@
 (defproject metabase/vertica-driver "1.0.0-SNAPSHOT"
   :min-lein-version "2.5.0"
 
+  :include-drivers-dependencies [#"^vertica-jdbc-.*\.jar$"]
+
   :profiles
   {:provided
    {:dependencies [[metabase-core "1.0.0-SNAPSHOT"]]}

--- a/project.clj
+++ b/project.clj
@@ -179,6 +179,7 @@
    ;; start the dev HTTP server with 'lein ring server'
    :ring
    [:exclude-tests
+    :include-all-drivers
     {:dependencies
      ;; used internally by lein ring to track namespace changes. Newer version contains fix by yours truly with 1000x faster launch time
      [[ns-tracker "0.4.0"]]
@@ -195,7 +196,7 @@
 
    :with-include-drivers-middleware
    {:plugins
-    [[metabase/lein-include-drivers "1.0.5"]]
+    [[metabase/lein-include-drivers "1.0.6"]]
 
     :middleware
     [leiningen.include-drivers/middleware]}


### PR DESCRIPTION
*  Tweak our `lein-include-drivers` middleware so it does the right thing for Oracle and Vertica if their dependencies aren't present
*  Tweak `lein ring server` so it includes driver source so you can work on drivers without having to run the server from the REPL or build them first