### PR TITLE
Fix centering issue with hacky spacer

### DIFF
--- a/frontend/src/metabase/visualizations/components/ScalarValue.jsx
+++ b/frontend/src/metabase/visualizations/components/ScalarValue.jsx
@@ -27,35 +27,40 @@ const ScalarValue = ({ value, isFullscreen, isDashboard }) => (
   <h1 className="ScalarValue cursor-pointer text-brand-hover">{value}</h1>
 );
 
-export const ScalarTitle = ({ title, description, onClick }) => (
-  <div className="flex align-center full justify-center px2">
-    {/*
+export const ScalarTitle = ({ title, description, onClick }) => {
+  const iconWidth = "24px";
+  return (
+    <div className="flex align-center full justify-center px2">
+      {/*
       This is a hacky spacer so that the h3 is centered correctly.
       It needs match the width of the tooltip icon on the other side.
      */}
-    {description && description.length > 0 && <div style={{ width: "24px" }} />}
-    <h3
-      onClick={onClick}
-      className={cx(
-        "Scalar-title overflow-hidden fullscreen-normal-text fullscreen-night-text text-brand-hover",
-        {
-          "cursor-pointer": !!onClick,
-        },
+      {description && description.length > 0 && (
+        <div style={{ width: iconWidth }} />
       )}
-    >
-      <Ellipsified tooltip={title}>{title}</Ellipsified>
-    </h3>
-    {description && description.length > 0 && (
-      <div
-        className="hover-child cursor-pointer ml1 text-brand-hover"
-        style={{ marginTop: 5 }}
+      <h3
+        onClick={onClick}
+        className={cx(
+          "Scalar-title overflow-hidden fullscreen-normal-text fullscreen-night-text text-brand-hover",
+          {
+            "cursor-pointer": !!onClick,
+          },
+        )}
       >
-        <Tooltip tooltip={description} maxWidth={"22em"}>
-          <Icon name="infooutlined" />
-        </Tooltip>
-      </div>
-    )}
-  </div>
-);
+        <Ellipsified tooltip={title}>{title}</Ellipsified>
+      </h3>
+      {description && description.length > 0 && (
+        <div
+          className="hover-child cursor-pointer pl1 text-brand-hover"
+          style={{ marginTop: 5, width: iconWidth }}
+        >
+          <Tooltip tooltip={description} maxWidth={"22em"}>
+            <Icon name="infooutlined" />
+          </Tooltip>
+        </div>
+      )}
+    </div>
+  );
+};
 
 export default ScalarValue;

--- a/frontend/src/metabase/visualizations/components/ScalarValue.jsx
+++ b/frontend/src/metabase/visualizations/components/ScalarValue.jsx
@@ -29,6 +29,11 @@ const ScalarValue = ({ value, isFullscreen, isDashboard }) => (
 
 export const ScalarTitle = ({ title, description, onClick }) => (
   <div className="flex align-center full justify-center px2">
+    {/*
+      This is a hacky spacer so that the h3 is centered correctly.
+      It needs match the width of the tooltip icon on the other side.
+     */}
+    {description && description.length > 0 && <div style={{ width: "24px" }} />}
     <h3
       onClick={onClick}
       className={cx(

--- a/frontend/src/metabase/visualizations/components/ScalarValue.jsx
+++ b/frontend/src/metabase/visualizations/components/ScalarValue.jsx
@@ -27,40 +27,39 @@ const ScalarValue = ({ value, isFullscreen, isDashboard }) => (
   <h1 className="ScalarValue cursor-pointer text-brand-hover">{value}</h1>
 );
 
-export const ScalarTitle = ({ title, description, onClick }) => {
-  const iconWidth = "24px";
-  return (
-    <div className="flex align-center full justify-center px2">
-      {/*
+const ICON_WIDTH = 24;
+
+export const ScalarTitle = ({ title, description, onClick }) => (
+  <div className="flex align-center full justify-center px2">
+    {/*
       This is a hacky spacer so that the h3 is centered correctly.
       It needs match the width of the tooltip icon on the other side.
      */}
-      {description && description.length > 0 && (
-        <div style={{ width: iconWidth }} />
+    {description && description.length > 0 && (
+      <div style={{ width: ICON_WIDTH }} />
+    )}
+    <h3
+      onClick={onClick}
+      className={cx(
+        "Scalar-title overflow-hidden fullscreen-normal-text fullscreen-night-text text-brand-hover",
+        {
+          "cursor-pointer": !!onClick,
+        },
       )}
-      <h3
-        onClick={onClick}
-        className={cx(
-          "Scalar-title overflow-hidden fullscreen-normal-text fullscreen-night-text text-brand-hover",
-          {
-            "cursor-pointer": !!onClick,
-          },
-        )}
+    >
+      <Ellipsified tooltip={title}>{title}</Ellipsified>
+    </h3>
+    {description && description.length > 0 && (
+      <div
+        className="hover-child cursor-pointer pl1 text-brand-hover"
+        style={{ marginTop: 5, width: ICON_WIDTH }}
       >
-        <Ellipsified tooltip={title}>{title}</Ellipsified>
-      </h3>
-      {description && description.length > 0 && (
-        <div
-          className="hover-child cursor-pointer pl1 text-brand-hover"
-          style={{ marginTop: 5, width: iconWidth }}
-        >
-          <Tooltip tooltip={description} maxWidth={"22em"}>
-            <Icon name="infooutlined" />
-          </Tooltip>
-        </div>
-      )}
-    </div>
-  );
-};
+        <Tooltip tooltip={description} maxWidth={"22em"}>
+          <Icon name="infooutlined" />
+        </Tooltip>
+      </div>
+    )}
+  </div>
+);
 
 export default ScalarValue;


### PR DESCRIPTION
Resolves #9870 

# Before

![before](https://user-images.githubusercontent.com/691495/59231367-67968980-8bae-11e9-9e1b-6eb61c1b3e16.gif)

# After

![after](https://user-images.githubusercontent.com/691495/59231369-69f8e380-8bae-11e9-8027-75b8010e4514.gif)

# Any better options?

I think this looks better, but I don't really like the solution. It's simple and only a line of code, but adding a spacer that needs to match the width of the tooltip icon feels awkward to me.

I also considered absolutely positioning the icon, but that required a bunch more pixel tweaking than this. Are there any clever flexbox based solutions that I'm missing?