### PR TITLE
default date picker to have today selected

### DIFF
--- a/frontend/src/metabase/parameters/components/widgets/DateSingleWidget.jsx
+++ b/frontend/src/metabase/parameters/components/widgets/DateSingleWidget.jsx
@@ -7,7 +7,7 @@ const DateSingleWidget = ({ value, setValue, onClose }) => (
   <div className="p1">
     <Calendar
       initial={value ? moment(value) : null}
-      selected={value ? moment(value) : null}
+      selected={value ? moment(value) : moment()}
       selectedEnd={value ? moment(value) : null}
       onChange={value => {
         setValue(value);

--- a/frontend/src/metabase/parameters/components/widgets/DateSingleWidget.jsx
+++ b/frontend/src/metabase/parameters/components/widgets/DateSingleWidget.jsx
@@ -3,19 +3,22 @@ import React from "react";
 import Calendar from "metabase/components/Calendar.jsx";
 import moment from "moment";
 
-const DateSingleWidget = ({ value, setValue, onClose }) => (
-  <div className="p1">
-    <Calendar
-      initial={value ? moment(value) : null}
-      selected={value ? moment(value) : moment()}
-      selectedEnd={value ? moment(value) : null}
-      onChange={value => {
-        setValue(value);
-        onClose();
-      }}
-    />
-  </div>
-);
+const DateSingleWidget = ({ value, setValue, onClose }) => {
+  value = value ? moment(value) : moment();
+  return (
+    <div className="p1">
+      <Calendar
+        initial={value}
+        selected={value}
+        selectedEnd={value}
+        onChange={value => {
+          setValue(value);
+          onClose();
+        }}
+      />
+    </div>
+  );
+};
 
 DateSingleWidget.format = value =>
   value ? moment(value).format("MMMM D, YYYY") : "";


### PR DESCRIPTION
Resolves #10115 

The discrepancy between the parameter UI in the native query editor and the query builder UI was whether today was selected. I added `moment()` as a default value for the date picker.