### PR TITLE
Native query endpoint; cleanup of metabase.test.data :shower:

### DIFF
--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -12,6 +12,7 @@
              [card :refer [Card]]
              [database :as database :refer [Database]]
              [query :as query]]
+            [metabase.query-processor :as qp]
             [metabase.query-processor
              [async :as qp.async]
              [util :as qputil]]
@@ -21,8 +22,7 @@
              [export :as ex]
              [i18n :refer [trs tru]]
              [schema :as su]]
-            [schema.core :as s]
-            [metabase.query-processor :as qp])
+            [schema.core :as s])
   (:import clojure.core.async.impl.channels.ManyToManyChannel))
 
 ;;; -------------------------------------------- Running a Query Normally --------------------------------------------

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -21,7 +21,8 @@
              [export :as ex]
              [i18n :refer [trs tru]]
              [schema :as su]]
-            [schema.core :as s])
+            [schema.core :as s]
+            [metabase.query-processor :as qp])
   (:import clojure.core.async.impl.channels.ManyToManyChannel))
 
 ;;; -------------------------------------------- Running a Query Normally --------------------------------------------
@@ -168,6 +169,11 @@
                    [query
                     (assoc query :constraints constraints/default-query-constraints)])
              0)})
+
+(api/defendpoint POST "/native"
+  "Fetch a native version of an MBQL query."
+  [:as {query :body}]
+  (qp/query->native query))
 
 
 (api/define-routes)

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -368,8 +368,10 @@
 
 
 (defmulti can-connect?
-  "Check whether we can connect to a `Database` with DETAILS-MAP and perform a simple query. For example, a SQL
-  database might try running a query like `SELECT 1;`. This function should return `true` or `false`."
+  "Check whether we can connect to a `Database` with `details-map` and perform a simple query. For example, a SQL
+  database might try running a query like `SELECT 1;`. This function should return truthy if a connection to the DB
+  can be made successfully, otherwise it should return falsey or throw an appropriate Exception. Exceptions if a
+  connection cannot be made."
   {:arglists '([driver details])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -215,7 +215,8 @@
         (fn [qp]
           (fn [query]
             (let [results-promise (promise)
-                  results         (qp (assoc query :results-promise results-promise))]
+                  results         (binding [async-wait/*disable-async-wait* true]
+                                    (qp (assoc query :results-promise results-promise)))]
               (if (realized? results-promise)
                 @results-promise
                 ;; if the results promise was never delivered, it means we never made it all the way to the
@@ -244,6 +245,7 @@
   simliar functionality for queries that are actually executed.)"
   {:style/indent 0}
   [query]
+  (perms/check-current-user-has-adhoc-native-query-perms query)
   (let [results (preprocess query)]
     (or (get results :native)
         (throw (ex-info (str (tru "No native form returned."))

--- a/src/metabase/query_processor/middleware/mbql_to_native.clj
+++ b/src/metabase/query_processor/middleware/mbql_to_native.clj
@@ -9,14 +9,16 @@
             [metabase.util.i18n :refer [tru]]))
 
 (defn- query->native-form
-  "Return a `:native` query form for QUERY, converting it from MBQL if needed."
+  "Return a `:native` query form for `query`, converting it from MBQL if needed."
   [{query-type :type, :as query}]
   (u/prog1 (if-not (= :query query-type)
              (:native query)
-             (try (driver/mbql->native (:driver query) query)
-                  (catch Throwable e
-                    (log/error (tru "Error transforming MBQL query to native:") "\n" (u/pprint-to-str query))
-                    (throw e))))
+             (try
+               (driver/mbql->native (:driver query) query)
+               (catch Throwable e
+                 (when-not i/*disable-qp-logging*
+                   (log/error (tru "Error transforming MBQL query to native:") "\n" (u/pprint-to-str query)))
+                 (throw e))))
     (when-not i/*disable-qp-logging*
       (log/debug (u/format-color 'green "NATIVE FORM: %s\n%s\n" (u/emoji "😳") (u/pprint-to-str <>))))))
 

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -19,11 +19,17 @@
                               (throw (Exception. (str (tru "Card {0} does not exist." card-id))))))
     (throw (Exception. (str (tru "You do not have permissions to view Card {0}." card-id))))))
 
+(defn- perms-exception [required-perms]
+  (ex-info (str (tru "You do not have permissions to run this query."))
+    {:required-permissions required-perms
+     :actual-permissions   @*current-user-permissions-set*
+     :permissions-error?   true}))
+
 (s/defn ^:private check-ad-hoc-query-perms
   [outer-query]
-  (when-not (perms/set-has-full-permissions-for-set? @*current-user-permissions-set*
-              (query-perms/perms-set outer-query, :throw-exceptions? true, :already-preprocessed? true))
-    (throw (Exception. (str (tru "You do not have permissions to run this query."))))))
+  (let [required-perms (query-perms/perms-set outer-query, :throw-exceptions? true, :already-preprocessed? true)]
+    (when-not (perms/set-has-full-permissions-for-set? @*current-user-permissions-set* required-perms)
+      (throw (perms-exception required-perms)))))
 
 (s/defn ^:private check-query-permissions*
   "Check that User with `user-id` has permissions to run `query`, or throw an exception."
@@ -41,3 +47,17 @@
   'publishing' a Card)."
   [qp]
   (comp qp check-query-permissions*))
+
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                            Non-middleware util fns                                             |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defn check-current-user-has-adhoc-native-query-perms
+  "Check that the current user (if bound) has adhoc native query permissions to run `query`, or throw an
+  Exception. (This is used by `qp/query->native` to check perms before converting an MBQL query to native.)"
+  [{database-id :database, :as query}]
+  (when *current-user-id*
+    (let [required-perms (perms/adhoc-native-query-path database-id)]
+      (when-not (perms/set-has-full-permissions? @*current-user-permissions-set* required-perms)
+        (throw (perms-exception required-perms))))))

--- a/src/metabase/query_processor/store.clj
+++ b/src/metabase/query_processor/store.clj
@@ -147,7 +147,10 @@
       (throw (ex-info (str (tru "Attempting to fetch second Database. Queries can only reference one Database."))
                {:existing-id existing-db-id, :attempted-to-fetch database-id})))
     ;; if there's no DB, fetch + save
-    (store-database! (db/select-one (into [Database] database-columns-to-fetch) :id database-id))))
+    (store-database!
+     (or (db/select-one (into [Database] database-columns-to-fetch) :id database-id)
+         (throw (ex-info (str (tru "Database {0} does not exist." (str database-id)))
+                  {:database database-id}))))))
 
 (def ^:private IDs
   (s/maybe

--- a/test/expectation_options.clj
+++ b/test/expectation_options.clj
@@ -191,7 +191,7 @@
       ;; Uncomment `check-test-data-unchanged` when you want to debug situations where tests are being bad citizens
       ;; and leaving the metadata about the test data in a different state than it started out with. This is not
       ;; enabled by default because it adds ~5ms to each test which adds up when we have ~4000 tests (as of May 2019)
-      #_check-test-data-unchanged ; NOCOMMIT
+      #_check-test-data-unchanged
       log-slow-tests
       enforce-timeout
       check-table-cleanup))

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -564,7 +564,7 @@
     :table_id   (data/id :venues)
     :name       "PRICE"
     :dimensions []}]
-  (data/with-data
+  (data/with-temp-objects
     (data/create-venue-category-remapping "Foo")
     (category-id-special-type
      :type/Category
@@ -583,7 +583,7 @@
     :table_id   (data/id :venues)
     :name       "PRICE"
     :dimensions []}]
-  (data/with-data
+  (data/with-temp-objects
     (data/create-venue-category-remapping "Foo")
     (category-id-special-type
      :type/Enum
@@ -602,7 +602,7 @@
     :table_id   (data/id :venues)
     :name       "PRICE"
     :dimensions []}]
-  (data/with-data
+  (data/with-temp-objects
     (data/create-venue-category-fk-remapping "Foo")
     (category-id-special-type
      :type/Category

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -74,17 +74,17 @@
   #{{:name "number-of-cans", :base_type :type/Boolean, :special_type :type/Category}
     {:name "id",             :base_type :type/Integer, :special_type :type/PK}
     {:name "thing",          :base_type :type/Text,    :special_type :type/Category}}
-  (data/with-db-for-dataset [db tiny-int-ones]
-    (db->fields db)))
+  (data/dataset tiny-int-ones
+    (db->fields (data/db))))
 
 ;; if someone says specifies `tinyInt1isBit=false`, it should come back as a number instead
 (expect-with-driver :mysql
   #{{:name "number-of-cans", :base_type :type/Integer, :special_type :type/Quantity}
     {:name "id",             :base_type :type/Integer, :special_type :type/PK}
     {:name "thing",          :base_type :type/Text,    :special_type :type/Category}}
-  (data/with-db-for-dataset [db tiny-int-ones]
+  (data/dataset tiny-int-ones
     (tt/with-temp Database [db {:engine "mysql"
-                                :details (assoc (:details db)
+                                :details (assoc (:details (data/db))
                                            :additional-options "tinyInt1isBit=false")}]
       (sync/sync-database! db)
       (db->fields db))))

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -64,12 +64,10 @@
 ;; Verify that we identify JSON columns and mark metadata properly during sync
 (datasets/expect-with-driver :postgres
   :type/SerializedJSON
-  (data/with-db-for-dataset
-    [_
-     (tx/dataset-definition "Postgres with a JSON Field"
-       ["venues"
-        [{:field-name "address", :base-type {:native "json"}}]
-        [[(hsql/raw "to_json('{\"street\": \"431 Natoma\", \"city\": \"San Francisco\", \"state\": \"CA\", \"zip\": 94103}'::text)")]]])]
+  (data/dataset (tx/dataset-definition "Postgres with a JSON Field"
+                  ["venues"
+                   [{:field-name "address", :base-type {:native "json"}}]
+                   [[(hsql/raw "to_json('{\"street\": \"431 Natoma\", \"city\": \"San Francisco\", \"state\": \"CA\", \"zip\": 94103}'::text)")]]])
     (db/select-one-field :special_type Field, :id (data/id :venues :address))))
 
 

--- a/test/metabase/pulse_test.clj
+++ b/test/metabase/pulse_test.clj
@@ -19,9 +19,7 @@
             [metabase.test
              [data :as data]
              [util :as tu]]
-            [metabase.test.data
-             [dataset-definitions :as defs]
-             [users :as users]]
+            [metabase.test.data.users :as users]
             [schema.core :as s]
             [toucan.db :as db]
             [toucan.util.test :as tt]))
@@ -50,9 +48,8 @@
 
 (defn- pulse-test-fixture
   [f]
-  (data/with-db (data/get-or-create-database! defs/test-data)
-    (tu/with-temporary-setting-values [site-url "https://metabase.com/testmb"]
-      (f))))
+  (tu/with-temporary-setting-values [site-url "https://metabase.com/testmb"]
+    (f)))
 
 (defmacro ^:private slack-test-setup
   "Macro that ensures test-data is present and disables sending of all notifications"

--- a/test/metabase/query_processor/middleware/catch_exceptions_test.clj
+++ b/test/metabase/query_processor/middleware/catch_exceptions_test.clj
@@ -1,6 +1,14 @@
 (ns metabase.query-processor.middleware.catch-exceptions-test
   (:require [expectations :refer [expect]]
-            [metabase.query-processor.middleware.catch-exceptions :as catch-exceptions]))
+            [metabase.models
+             [permissions :as perms]
+             [permissions-group :as group]]
+            [metabase.query-processor.middleware.catch-exceptions :as catch-exceptions]
+            [metabase.test
+             [data :as data]
+             [util :as tu]]
+            [metabase.test.data.users :as test-users]
+            [schema.core :as s]))
 
 (defn- catch-exceptions
   ([qp]
@@ -42,3 +50,30 @@
        (fn [_ _ raise _]
          (raise (Exception. "Something went wrong"))))
       (update :stacktrace boolean)))
+
+;; If someone doesn't have native query execution permissions, they shouldn't see the native version of the query in
+;; the error response
+(tu/expect-schema
+  {:native       (s/eq nil)
+   :preprocessed (s/pred map?)
+   s/Any         s/Any}
+  (data/with-temp-copy-of-test-db
+    (perms/revoke-permissions! (group/all-users) (data/id))
+    (perms/grant-permissions! (group/all-users) (data/id) "PUBLIC" (data/id :venues))
+    (test-users/with-test-user :rasta
+      (data/run-mbql-query venues {:fields [!month.id]}))))
+
+;; They should see it if they have ad-hoc native query perms
+(tu/expect-schema
+  {:native
+   (s/eq {:query  (str "SELECT parsedatetime(formatdatetime(\"PUBLIC\".\"VENUES\".\"ID\", 'yyyyMM'), 'yyyyMM') "
+                       "AS \"ID\" FROM \"PUBLIC\".\"VENUES\" LIMIT 1048576")
+          :params nil})
+   :preprocessed (s/pred map?)
+   s/Any         s/Any}
+  (data/with-temp-copy-of-test-db
+    (perms/revoke-permissions! (group/all-users) (data/id))
+    (perms/grant-permissions! (group/all-users) (data/id) "PUBLIC" (data/id :venues))
+    (perms/grant-native-readwrite-permissions! (group/all-users) (data/id))
+    (test-users/with-test-user :rasta
+      (data/run-mbql-query venues {:fields [!month.id]}))))

--- a/test/metabase/query_processor/middleware/catch_exceptions_test.clj
+++ b/test/metabase/query_processor/middleware/catch_exceptions_test.clj
@@ -57,7 +57,7 @@
   {:native       (s/eq nil)
    :preprocessed (s/pred map?)
    s/Any         s/Any}
-  (data/with-temp-copy-of-test-db
+  (data/with-temp-copy-of-db
     (perms/revoke-permissions! (group/all-users) (data/id))
     (perms/grant-permissions! (group/all-users) (data/id) "PUBLIC" (data/id :venues))
     (test-users/with-test-user :rasta
@@ -71,7 +71,7 @@
           :params nil})
    :preprocessed (s/pred map?)
    s/Any         s/Any}
-  (data/with-temp-copy-of-test-db
+  (data/with-temp-copy-of-db
     (perms/revoke-permissions! (group/all-users) (data/id))
     (perms/grant-permissions! (group/all-users) (data/id) "PUBLIC" (data/id :venues))
     (perms/grant-native-readwrite-permissions! (group/all-users) (data/id))

--- a/test/metabase/query_processor/middleware/format_rows_test.clj
+++ b/test/metabase/query_processor/middleware/format_rows_test.clj
@@ -3,19 +3,18 @@
             [expectations :refer :all]
             [metabase
              [driver :as driver]
-             [query-processor-test :as qpt]]
+             [query-processor-test :as qp.test]]
             [metabase.query-processor.middleware.format-rows :as format-rows]
             [metabase.test
              [data :as data]
-             [util :as tu]]
-            [metabase.test.data.dataset-definitions :as defs]))
+             [util :as tu]]))
 
 (def ^:private dbs-exempt-from-format-rows-tests
   "DBs to skip the tests below for. TODO - why are so many databases not running these tests? Most of these should be
   able to pass with a few tweaks."
   #{:oracle :mongo :redshift :presto :sparksql :snowflake})
 
-(qpt/expect-with-non-timeseries-dbs-except dbs-exempt-from-format-rows-tests
+(qp.test/expect-with-non-timeseries-dbs-except dbs-exempt-from-format-rows-tests
   (if (= :sqlite driver/*driver*)
     [[1 "Plato Yeshua"        "2014-04-01 00:00:00" "08:30:00"]
      [2 "Felipinho Asklepios" "2014-12-05 00:00:00" "15:15:00"]
@@ -28,13 +27,13 @@
      [3 "Kaneonuskatew Eiran" "2014-11-06T00:00:00.000Z" "16:15:00.000Z"]
      [4 "Simcha Yan"          "2014-01-01T00:00:00.000Z" "08:30:00.000Z"]
      [5 "Quentin Sören"       "2014-10-03T00:00:00.000Z" "17:30:00.000Z"]])
-  (->> (data/with-db (data/get-or-create-database! defs/test-data-with-time)
-         (data/run-mbql-query users
-           {:order-by [[:asc $id]]
-            :limit    5}))
-       qpt/rows))
+  (qp.test/rows
+    (data/dataset test-data-with-time
+      (data/run-mbql-query users
+        {:order-by [[:asc $id]]
+         :limit    5}))))
 
-(qpt/expect-with-non-timeseries-dbs-except dbs-exempt-from-format-rows-tests
+(qp.test/expect-with-non-timeseries-dbs-except dbs-exempt-from-format-rows-tests
   (cond
     (= :sqlite driver/*driver*)
     [[1 "Plato Yeshua"        "2014-04-01 00:00:00" "08:30:00"]
@@ -43,7 +42,7 @@
      [4 "Simcha Yan"          "2014-01-01 00:00:00" "08:30:00"]
      [5 "Quentin Sören"       "2014-10-03 00:00:00" "17:30:00"]]
 
-    (qpt/supports-report-timezone? driver/*driver*)
+    (qp.test/supports-report-timezone? driver/*driver*)
     [[1 "Plato Yeshua"        "2014-04-01T00:00:00.000-07:00" "00:30:00.000-08:00"]
      [2 "Felipinho Asklepios" "2014-12-05T00:00:00.000-08:00" "07:15:00.000-08:00"]
      [3 "Kaneonuskatew Eiran" "2014-11-06T00:00:00.000-08:00" "08:15:00.000-08:00"]
@@ -56,13 +55,12 @@
      [3 "Kaneonuskatew Eiran" "2014-11-06T00:00:00.000Z" "16:15:00.000Z"]
      [4 "Simcha Yan"          "2014-01-01T00:00:00.000Z" "08:30:00.000Z"]
      [5 "Quentin Sören"       "2014-10-03T00:00:00.000Z" "17:30:00.000Z"]])
-  (data/with-db (data/get-or-create-database! defs/test-data-with-time)
+  (data/dataset test-data-with-time
     (tu/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
-      (mapv vec
-            (qpt/rows
-              (data/run-mbql-query users
-                {:order-by [[:asc $id]]
-                 :limit    5}))))))
+      (qp.test/rows
+        (data/run-mbql-query users
+          {:order-by [[:asc $id]]
+           :limit    5})))))
 
 
 (expect

--- a/test/metabase/query_processor/middleware/parameters/sql_test.clj
+++ b/test/metabase/query_processor/middleware/parameters/sql_test.clj
@@ -364,13 +364,14 @@
                                 :timezone "UTC"
                                 :name     "mock_db"
                                 :id       1}
-    ~@body))
+     ~@body))
 
 (defn- expand* [query]
-  (with-h2-db-timezone
-    (-> (sql/expand (assoc (normalize/normalize query) :driver :h2))
-        :native
-        (select-keys [:query :params :template-tags]))))
+  (-> (with-h2-db-timezone
+        (driver/with-driver :h2
+          (sql/expand (normalize/normalize query))))
+      :native
+      (select-keys [:query :params :template-tags])))
 
 ;; unspecified optional param
 (expect

--- a/test/metabase/query_processor/middleware/permissions_test.clj
+++ b/test/metabase/query_processor/middleware/permissions_test.clj
@@ -125,14 +125,17 @@
 ;; Make sure it works end-to-end: make sure bound `*current-user-id*` and `*current-user-permissions-set*` are used to
 ;; permissions check queries
 (tu/expect-schema
- {:status    (s/eq :failed)
-  :class     (s/eq Exception)
-  :error    (s/eq "You do not have permissions to run this query.")
-  s/Keyword s/Any}
- (binding [api/*current-user-id*              (users/user->id :rasta)
-           api/*current-user-permissions-set* (delay #{})]
+  {:status   (s/eq :failed)
+   :class    (s/eq clojure.lang.ExceptionInfo)
+   :error    (s/eq "You do not have permissions to run this query.")
+   :ex-data  (s/eq {:required-permissions #{(perms/object-path (data/id) "PUBLIC" (data/id :venues))}
+                    :actual-permissions   #{}
+                    :permissions-error?   true})
+   s/Keyword s/Any}
+  (binding [api/*current-user-id*              (users/user->id :rasta)
+            api/*current-user-permissions-set* (delay #{})]
    (qp/process-query
-    {:database (data/id)
-     :type     :query
-     :query    {:source-table (data/id :venues)
-                :limit        1}})))
+     {:database (data/id)
+      :type     :query
+      :query    {:source-table (data/id :venues)
+                 :limit        1}})))

--- a/test/metabase/query_processor_test/breakout_test.clj
+++ b/test/metabase/query_processor_test/breakout_test.clj
@@ -107,7 +107,7 @@
                  (qp.test/aggregate-col :count)
                  (#'add-dim-projections/create-remapped-col "Foo" (data/format-name "category_id"))]
    :native_form true}
-  (data/with-data
+  (data/with-temp-objects
     (fn []
       (let [venue-names (data/dataset-field-values "categories" "name")]
         [(db/insert! Dimension {:field_id (data/id :venues :category_id)
@@ -127,7 +127,7 @@
 (datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :foreign-keys)
   [["Wine Bar" "Thai" "Thai" "Thai" "Thai" "Steakhouse" "Steakhouse" "Steakhouse" "Steakhouse" "Southern"]
    ["American" "American" "American" "American" "American" "American" "American" "American" "Artisan" "Artisan"]]
-  (data/with-data
+  (data/with-temp-objects
     (fn []
       [(db/insert! Dimension {:field_id                (data/id :venues :category_id)
                               :name                    "Foo"

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -627,7 +627,7 @@
 (expect
   :ok
   (tu/with-non-admin-groups-no-root-collection-perms
-    (data/with-temp-copy-of-test-db
+    (data/with-temp-copy-of-db
       (tt/with-temp* [Collection [source-card-collection]
                       Collection [dest-card-collection]]
         (perms/grant-collection-read-permissions!      (group/all-users) source-card-collection)
@@ -642,7 +642,7 @@
 (expect
   "You don't have permissions to do that."
   (tu/with-non-admin-groups-no-root-collection-perms
-    (data/with-temp-copy-of-test-db
+    (data/with-temp-copy-of-db
       (tt/with-temp Collection [dest-card-collection]
         (perms/grant-collection-readwrite-permissions! (group/all-users) dest-card-collection)
         (save-card-via-API-with-native-source-query! 403 (data/db) nil dest-card-collection)))))
@@ -651,7 +651,7 @@
 (expect
   "You don't have permissions to do that."
   (tu/with-non-admin-groups-no-root-collection-perms
-    (data/with-temp-copy-of-test-db
+    (data/with-temp-copy-of-db
       (tt/with-temp* [Collection [source-card-collection]
                       Collection [dest-card-collection]]
         (perms/grant-collection-readwrite-permissions! (group/all-users) dest-card-collection)
@@ -663,7 +663,7 @@
 (expect
   "You don't have permissions to do that."
   (tu/with-non-admin-groups-no-root-collection-perms
-    (data/with-temp-copy-of-test-db
+    (data/with-temp-copy-of-db
       (tt/with-temp Collection [source-card-collection]
         (perms/grant-collection-read-permissions! (group/all-users) source-card-collection)
         (save-card-via-API-with-native-source-query! 403 (data/db) source-card-collection nil)))))
@@ -672,7 +672,7 @@
 (expect
   "You don't have permissions to do that."
   (tu/with-non-admin-groups-no-root-collection-perms
-    (data/with-temp-copy-of-test-db
+    (data/with-temp-copy-of-db
       (tt/with-temp* [Collection [source-card-collection]
                       Collection [dest-card-collection]]
         (perms/grant-collection-read-permissions! (group/all-users) source-card-collection)

--- a/test/metabase/query_processor_test/query_to_native_test.clj
+++ b/test/metabase/query_processor_test/query_to_native_test.clj
@@ -1,0 +1,95 @@
+(ns metabase.query-processor-test.query-to-native-test
+  "Tests around the `query->native` function."
+  (:require [expectations :refer [expect]]
+            [metabase.api.common :as api]
+            [metabase.models.permissions :as perms]
+            [metabase.query-processor :as qp]
+            [metabase.query-processor.middleware.async-wait :as async-wait]
+            [metabase.test
+             [data :as data]
+             [util :as tu]]
+            [schema.core :as s]))
+
+;; Can we convert an MBQL query to a native query?
+(expect
+  {:query (str "SELECT \"PUBLIC\".\"VENUES\".\"ID\" AS \"ID\","
+               " \"PUBLIC\".\"VENUES\".\"NAME\" AS \"NAME\","
+               " \"PUBLIC\".\"VENUES\".\"CATEGORY_ID\" AS \"CATEGORY_ID\","
+               " \"PUBLIC\".\"VENUES\".\"LATITUDE\" AS \"LATITUDE\","
+               " \"PUBLIC\".\"VENUES\".\"LONGITUDE\" AS \"LONGITUDE\","
+               " \"PUBLIC\".\"VENUES\".\"PRICE\" AS \"PRICE\" "
+               "FROM \"PUBLIC\".\"VENUES\" "
+               "LIMIT 1048576")
+   :params nil}
+  (qp/query->native (data/mbql-query venues)))
+
+;; If query is already native, `query->native` should still do stuff like parsing parameters
+(expect
+  {:query         "SELECT * FROM VENUES WHERE price = 3;"
+   :template-tags {"price"
+                   {:name         "price"
+                    :display-name "Price"
+                    :type         :number
+                    :required     false}}
+   :params        []}
+  (qp/query->native
+    {:database   (data/id)
+     :type       :native
+     :native     {:query         "SELECT * FROM VENUES [[WHERE price = {{price}}]];"
+                  :template-tags {"price" {:name "price", :display-name "Price", :type :number, :required false}}}
+     :parameters [{:type "category", :target [:variable [:template-tag "price"]], :value "3"}]}))
+
+;; `query->native` should not be subject to async waiting
+(expect
+  (tu/throw-if-called async-wait/run-in-thread-pool
+    (qp/query->native (data/mbql-query venues))))
+
+
+;; If user permissions are bound, we should do permissions checking when you call `query->native`; you should need
+;; native query execution permissions for the DB in question plus the perms needed for the original query in order to
+;; use `query->native`
+(defn- query->native-with-user-perms
+  [{database-id :database, {source-table-id :source-table} :query, :as query} {:keys [object-perms? native-perms?]}]
+  (try
+    (binding [api/*current-user-id*              Integer/MAX_VALUE
+              api/*current-user-permissions-set* (delay (cond-> #{}
+                                                          object-perms? (conj (perms/object-path database-id "PUBLIC" source-table-id))
+                                                          native-perms? (conj (perms/adhoc-native-query-path database-id))))]
+      (qp/query->native query))
+    (catch clojure.lang.ExceptionInfo e
+      (ex-data e))))
+
+(expect
+  (query->native-with-user-perms
+   (data/mbql-query venues)
+   {:object-perms? true, :native-perms? true}))
+
+;; If you don't have MBQL permissions for the original query it should throw an error
+(tu/expect-schema
+  {:status (s/eq :failed)
+   :error  (s/eq "You do not have permissions to run this query.")
+   s/Any   s/Any}
+  (query->native-with-user-perms
+   (data/mbql-query venues)
+   {:object-perms? false, :native-perms? true}))
+
+;; If you don't have have native query execution permissions for the DB it should throw an error
+;;
+;; query->native throws an Exception that doesn't get wrapped the normal way; it *does* include a message, but our
+;; helper function doesn't show it
+(expect
+  {:required-permissions (perms/adhoc-native-query-path (data/id))
+   :actual-permissions   #{(perms/object-path (data/id) "PUBLIC" (data/id :venues))}
+   :permissions-error?   true}
+  (query->native-with-user-perms
+   (data/mbql-query venues)
+   {:object-perms? true, :native-perms? false}))
+
+;; If the query is bad in some way it should return a relevant error (?)
+(tu/expect-schema
+  {:status (s/eq :failed)
+   :error  (s/eq (format "Database %d does not exist." Integer/MAX_VALUE))
+   s/Any   s/Any}
+  (query->native-with-user-perms
+   {:database Integer/MAX_VALUE, :type :query, :query {:source-table Integer/MAX_VALUE}}
+   {:object-perms? true, :native-perms? true}))

--- a/test/metabase/query_processor_test/time_field_test.clj
+++ b/test/metabase/query_processor_test/time_field_test.clj
@@ -4,12 +4,11 @@
              [query-processor-test :as qpt]]
             [metabase.test
              [data :as data]
-             [util :as tu]]
-            [metabase.test.data.dataset-definitions :as defs]))
+             [util :as tu]]))
 
 (defmacro ^:private time-query [additional-clauses]
   `(qpt/rows
-     (data/with-db (data/get-or-create-database! defs/test-data-with-time)
+     (data/dataset ~'test-data-with-time
        (data/run-mbql-query users
          ~(merge
            '{:fields   [$id $name $last_login_time]

--- a/test/metabase/query_processor_test/timezones_test.clj
+++ b/test/metabase/query_processor_test/timezones_test.clj
@@ -10,19 +10,15 @@
              [data :as data]
              [util :as tu]]
             [metabase.test.data
-             [dataset-definitions :as defs]
              [datasets :refer [expect-with-drivers]]
              [sql :as sql.tx]]
             [toucan.db :as db]))
 
-(defn- call-with-timezones-db [f]
-  (data/with-db (data/get-or-create-database! defs/test-data-with-timezones)
-    (f)))
-
 (defmacro ^:private with-tz-db
   "Calls `with-db` on the `test-data-with-timezones` dataset and ensures the timestamps are fixed up on MySQL"
   [& body]
-  `(call-with-timezones-db (fn [] ~@body)))
+  `(data/dataset ~'test-data-with-timezones
+     (fn [] ~@body)))
 
 (def ^:private default-utc-results
   #{[6 "Shad Ferdynand" "2014-08-02T12:30:00.000Z"]})

--- a/test/metabase/sync/sync_metadata/comments_test.clj
+++ b/test/metabase/sync/sync_metadata/comments_test.clj
@@ -31,8 +31,8 @@
   #{{:name (data/format-name "id"), :description nil}
     {:name (data/format-name "with_comment"), :description "comment"}
     {:name (data/format-name "no_comment"), :description nil}}
-  (data/with-db-for-dataset [db basic-field-comments]
-    (db->fields db)))
+  (data/dataset basic-field-comments
+    (db->fields (data/db))))
 
 ;; test changing the description in metabase db so we can check it is not overwritten by comment in source db when resyncing
 (tx/defdataset ^:private update-desc
@@ -43,12 +43,13 @@
 (datasets/expect-with-drivers #{:h2 :postgres}
   #{{:name (data/format-name "id"), :description nil}
     {:name (data/format-name "updated_desc"), :description "updated description"}}
-  (data/with-db-for-dataset [db update-desc]
-    ;; change the description in metabase while the source table comment remains the same
-    (db/update-where! Field {:id (data/id "update_desc" "updated_desc")}, :description "updated description")
-    ;; now sync the DB again, this should NOT overwrite the manually updated description
-    (sync/sync-table! (Table (data/id "update_desc")))
-    (db->fields db)))
+  (data/dataset update-desc
+    (data/with-temp-copy-of-db
+      ;; change the description in metabase while the source table comment remains the same
+      (db/update-where! Field {:id (data/id "update_desc" "updated_desc")}, :description "updated description")
+      ;; now sync the DB again, this should NOT overwrite the manually updated description
+      (sync/sync-table! (Table (data/id "update_desc")))
+      (db->fields (data/db)))))
 
 ;; test adding a comment to the source data that was initially empty, so we can check that the resync picks it up
 (tx/defdataset ^:private comment-after-sync
@@ -59,11 +60,11 @@
 (datasets/expect-with-drivers #{:h2 :postgres}
   #{{:name (data/format-name "id"), :description nil}
     {:name (data/format-name "comment_after_sync"), :description "added comment"}}
-  (data/with-db-for-dataset [db comment-after-sync]
+  (data/dataset comment-after-sync
     ;; modify the source DB to add the comment and resync. The easiest way to do this is just destroy the entire DB
     ;; and re-create a modified version. As such, let the SQL JDBC driver know the DB is being "modified" so it can
     ;; destroy its current connection pool
-    (driver/notify-database-updated driver/*driver* db)
+    (driver/notify-database-updated driver/*driver* (data/db))
     (let [modified-dbdef (update
                           comment-after-sync
                           :table-definitions
@@ -75,7 +76,7 @@
                                 [(assoc fielddef :field-comment "added comment")]))]))]
       (tx/create-db! driver/*driver* modified-dbdef))
     (sync/sync-table! (Table (data/id "comment_after_sync")))
-    (db->fields db)))
+    (db->fields (data/db))))
 
 
 ;; Tests for table comments: ------------------
@@ -93,25 +94,27 @@
 ;; test basic comments on table
 (datasets/expect-with-drivers #{:h2 :postgres}
   #{{:name (data/format-name "table_with_comment"), :description "table comment"}}
-  (data/with-db-for-dataset [db (basic-table "table_with_comment" "table comment")]
-    (db->tables db)))
+  (data/dataset (basic-table "table_with_comment" "table comment")
+    (db->tables (data/db))))
 
-;; test changing the description in metabase on table to check it is not overwritten by comment in source db when resyncing
+;; test changing the description in metabase on table to check it is not overwritten by comment in source db when
+;; resyncing
 (datasets/expect-with-drivers #{:h2 :postgres}
   #{{:name (data/format-name "table_with_updated_desc"), :description "updated table description"}}
-  (data/with-db-for-dataset [db (basic-table "table_with_updated_desc" "table comment")]
-    ;; change the description in metabase while the source table comment remains the same
-    (db/update-where! Table {:id (data/id "table_with_updated_desc")}, :description "updated table description")
-    ;; now sync the DB again, this should NOT overwrite the manually updated description
-    (sync-tables/sync-tables! db)
-    (db->tables db)))
+  (data/dataset (basic-table "table_with_updated_desc" "table comment")
+    (data/with-temp-copy-of-db
+      ;; change the description in metabase while the source table comment remains the same
+      (db/update-where! Table {:id (data/id "table_with_updated_desc")}, :description "updated table description")
+      ;; now sync the DB again, this should NOT overwrite the manually updated description
+      (sync-tables/sync-tables! (data/db))
+      (db->tables (data/db)))))
 
 ;; test adding a comment to the source table that was initially empty, so we can check that the resync picks it up
 (datasets/expect-with-drivers #{:h2 :postgres}
   #{{:name (data/format-name "table_with_comment_after_sync"), :description "added comment"}}
-  (data/with-db-for-dataset [db (basic-table "table_with_comment_after_sync" nil)]
+  (data/dataset (basic-table "table_with_comment_after_sync" nil)
     ;; modify the source DB to add the comment and resync
-    (driver/notify-database-updated driver/*driver* db)
+    (driver/notify-database-updated driver/*driver* (data/db))
     (tx/create-db! driver/*driver* (basic-table "table_with_comment_after_sync" "added comment"))
-    (sync-tables/sync-tables! db)
-    (db->tables db)))
+    (sync-tables/sync-tables! (data/db))
+    (db->tables (data/db))))

--- a/test/metabase/sync/sync_metadata/fields_test.clj
+++ b/test/metabase/sync/sync_metadata/fields_test.clj
@@ -124,7 +124,7 @@
    :type/PK
    :type/Latitude
    :type/PK]
-  (data/with-temp-copy-of-test-db
+  (data/with-temp-copy-of-db
     (let [get-special-type (fn [] (db/select-one-field :special_type Field, :id (data/id :venues :id)))]
       [ ;; Special type should be :id to begin with
        (get-special-type)
@@ -169,7 +169,7 @@
     :task-details      {:total-fks 3, :updated-fks 1, :total-failed 0}
     :special-type      :type/FK
     :fk-target-exists? true}}
-  (data/with-temp-copy-of-test-db
+  (data/with-temp-copy-of-db
     (let [state (fn []
                   (let [{:keys                  [step-info]
                          {:keys [task_details]} :task-history}    (sync.util-test/sync-database! "sync-fks" (data/db))

--- a/test/metabase/task/send_pulses_test.clj
+++ b/test/metabase/task/send_pulses_test.clj
@@ -12,9 +12,7 @@
              [pulse-channel-recipient :refer [PulseChannelRecipient]]]
             [metabase.task.send-pulses :refer :all]
             [metabase.test.data :as data]
-            [metabase.test.data
-             [dataset-definitions :as defs]
-             [users :as users]]
+            [metabase.test.data.users :as users]
             [toucan.util.test :as tt]))
 
 (tt/expect-with-temp [Card                 [{card-id :id}  (assoc (checkins-query {:breakout [["datetime-field" (data/id :checkins :date) "hour"]]})
@@ -35,14 +33,13 @@
                              :body    {"My Question Name" true}})
    :exceptions []}
   (et/with-fake-inbox
-    (data/with-db (data/get-or-create-database! defs/test-data)
-      (let [exceptions (atom [])
-            on-error   (fn [_ exception]
-                         (swap! exceptions conj exception))]
-        (et/with-expected-messages 1
-          (#'metabase.task.send-pulses/send-pulses! 0 "fri" :first :first on-error))
-        {:emails     (et/regex-email-bodies #"My Question Name")
-         :exceptions @exceptions}))))
+    (let [exceptions (atom [])
+          on-error   (fn [_ exception]
+                       (swap! exceptions conj exception))]
+      (et/with-expected-messages 1
+        (#'metabase.task.send-pulses/send-pulses! 0 "fri" :first :first on-error))
+      {:emails     (et/regex-email-bodies #"My Question Name")
+       :exceptions @exceptions})))
 
 ;; Test that when we attempt to send a pulse that is archived, it just skips the pulse and sends nothing. Previously
 ;; this failed schema validation (see issue #8581)
@@ -65,21 +62,20 @@
                   PulseChannelRecipient [_               {:user_id          (users/user->id :rasta)
                                                           :pulse_channel_id pc-id}]]
     (et/with-fake-inbox
-      (data/with-db (data/get-or-create-database! defs/test-data)
-        (let [exceptions (atom [])
-              on-error   (fn [_ exception]
-                           (swap! exceptions conj exception))]
-          (et/with-expected-messages 1
-            ;; Send the pulse, though it's not going to send anything. Typically we'd block waiting for the message to
-            ;; arrive, but there should be no message
-            (#'metabase.task.send-pulses/send-pulses! 0 "fri" :first :first on-error)
-            ;; This sends a test message. If we see our test message that means we didn't send a pulse message (which
-            ;; is what we want)
-            (email/send-message!
-              :subject      "Test"
-              :recipients   ["rasta@metabase.com"]
-              :message-type :html
-              :message      "Test Message"))
-          {:emails     (et/regex-email-bodies #"Test Message")
-           ;; There shouldn't be any failures, just skipping over the archived pulse
-           :exceptions @exceptions})))))
+      (let [exceptions (atom [])
+            on-error   (fn [_ exception]
+                         (swap! exceptions conj exception))]
+        (et/with-expected-messages 1
+          ;; Send the pulse, though it's not going to send anything. Typically we'd block waiting for the message to
+          ;; arrive, but there should be no message
+          (#'metabase.task.send-pulses/send-pulses! 0 "fri" :first :first on-error)
+          ;; This sends a test message. If we see our test message that means we didn't send a pulse message (which
+          ;; is what we want)
+          (email/send-message!
+            :subject      "Test"
+            :recipients   ["rasta@metabase.com"]
+            :message-type :html
+            :message      "Test Message"))
+        {:emails     (et/regex-email-bodies #"Test Message")
+         ;; There shouldn't be any failures, just skipping over the archived pulse
+         :exceptions @exceptions}))))

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -34,62 +34,36 @@
 
      (There are several variations of this macro; see documentation below for more details.)"
   (:require [cheshire.core :as json]
-            [clojure.tools.logging :as log]
             [medley.core :as m]
             [metabase
-             [driver :as driver]
              [query-processor :as qp]
-             [sync :as sync]
              [util :as u]]
             [metabase.driver.util :as driver.u]
             [metabase.models
-             [database :refer [Database]]
              [dimension :refer [Dimension]]
-             [field :as field :refer [Field]]
-             [field-values :refer [FieldValues]]
-             [table :refer [Table]]]
+             [field-values :refer [FieldValues]]]
             [metabase.test.data
              [dataset-definitions :as defs]
+             [impl :as impl]
              [interface :as tx]
              [mbql-query-impl :as mbql-query-impl]]
-            [metabase.test.util.timezone :as tu.tz]
-            [schema.core :as s]
             [toucan.db :as db]))
-
-(declare get-or-create-database!)
-
 
 ;;; ------------------------------------------ Dataset-Independent Data Fns ------------------------------------------
 
 ;; These functions offer a generic way to get bits of info like Table + Field IDs from any of our many driver/dataset
 ;; combos.
 
-(defn get-or-create-test-data-db!
-  "Get or create the Test Data database for `driver`, which defaults to `driver/*driver*`, or `:h2` if that is unbound."
-  ([]       (get-or-create-test-data-db! (tx/driver)))
-  ([driver] (get-or-create-database! driver defs/test-data)))
-
-(def ^:dynamic ^:private *get-db*
-  "Implementation of `db` function that should return the current working test database when called, always with no
-  arguments. By default, this is `get-or-create-test-data-db!` for the current driver/`*driver*`, which does exactly what it
-  suggests."
-  get-or-create-test-data-db!)
-
 (defn db
   "Return the current database.
    Relies on the dynamic variable `*get-db*`, which can be rebound with `with-db`."
   []
-  (*get-db*))
-
-(defn do-with-db [db f]
-  (binding [*get-db* (constantly db)]
-    (f)))
+  (impl/*get-db*))
 
 (defmacro with-db
   "Run body with `db` as the current database. Calls to `db` and `id` use this value."
   [db & body]
-  `(do-with-db ~db (fn [] ~@body)))
-
+  `(impl/do-with-db ~db (fn [] ~@body)))
 
 (defmacro $ids
   "Convert symbols like `$field` to `id` fn calls. Input is split into separate args by splitting the token on `.`.
@@ -197,7 +171,6 @@
   `(qp/process-query
      (mbql-query ~table ~(or query {}))))
 
-
 (defn format-name
   "Format a SQL schema, table, or field identifier in the correct way for the current database by calling the driver's
   implementation of `format-name`. (Most databases use the default implementation of `identity`; H2 uses
@@ -205,51 +178,65 @@
   [nm]
   (tx/format-name (tx/driver) (name nm)))
 
-(defn- get-table-id-or-explode [db-id table-name]
-  {:pre [(integer? db-id) ((some-fn keyword? string?) table-name)]}
-  (let [table-name        (format-name table-name)
-        table-id-for-name (partial db/select-one-id Table, :db_id db-id, :name)]
-    (or (table-id-for-name table-name)
-        (table-id-for-name (let [db-name (db/select-one-field :name Database :id db-id)]
-                             (tx/db-qualified-table-name db-name table-name)))
-        (throw (Exception. (format "No Table '%s' found for Database %d.\nFound: %s" table-name db-id
-                                   (u/pprint-to-str (db/select-id->field :name Table, :db_id db-id, :active true))))))))
-
-(defn table-name
-  "Return the correct (database specific) table name for `table-name`. For most databases `table-name` is just
-  returned. For others (like Oracle), the real name is prefixed by the dataset and might be different"
-  [db-id table-name]
-  (db/select-one-field :name Table :id (get-table-id-or-explode db-id table-name)))
-
-(defn- get-field-id-or-explode [table-id field-name & {:keys [parent-id]}]
-  (let [field-name (format-name field-name)]
-    (or (db/select-one-id Field, :active true, :table_id table-id, :name field-name, :parent_id parent-id)
-        (throw (Exception. (format "Couldn't find Field %s for Table %d.\nFound: %s"
-                                   (str \' field-name \' (when parent-id
-                                                           (format " (parent: %d)" parent-id)))
-                                   table-id
-                                   (u/pprint-to-str (db/select-id->field :name Field, :active true, :table_id table-id))))))))
-
 (defn id
   "Get the ID of the current database or one of its Tables or Fields. Relies on the dynamic variable `*get-db*`, which
   can be rebound with `with-db`."
   ([]
-   {:post [(integer? %)]}
-   (:id (db)))
+   (u/get-id (db)))
 
   ([table-name]
-   ;; Ensure the database has been created
-   (db)
-   (get-table-id-or-explode (id) table-name))
+   (impl/the-table-id (id) (format-name table-name)))
 
   ([table-name field-name & nested-field-names]
-   ;; Ensure the database has been created
-   (db)
-   (let [table-id (id table-name)]
-     (loop [parent-id (get-field-id-or-explode table-id field-name), [nested-field-name & more] nested-field-names]
-       (if-not nested-field-name
-         parent-id
-         (recur (get-field-id-or-explode table-id nested-field-name, :parent-id parent-id) more))))))
+   (apply impl/the-field-id (id table-name) (map format-name (cons field-name nested-field-names)))))
+
+(defmacro dataset
+  "Load and sync a temporary Database defined by `dataset`, make it the current DB (for `metabase.test.data` functions
+  like `id` and `db`), and execute `body`.
+
+  `dataset` can be one of the following:
+
+  *  A symbol...
+     *  ...naming a dataset definition in either the current namespace, or in `metabase.test.data.dataset-definitions`.
+
+        (data/dataset sad-toucan-incidents ...)
+
+     *  ...qualified by a namespace, naming a dataset definition in that namespace.
+
+        (data/dataset my-namespace/my-dataset-def ...)
+
+     *  ...naming a local binding.
+
+       (let [my-dataset-def (get-dataset-definition)]
+         (data/dataset my-dataset-def ...)
+
+  *  An inline dataset definition:
+
+     (data/dataset (get-dataset-definition) ...)"
+  {:style/indent 1}
+  [dataset & body]
+  `(impl/do-with-dataset ~(if (and (symbol? dataset)
+                                   (not (get &env dataset)))
+                            `(impl/resolve-dataset-definition '~(ns-name *ns*) '~dataset)
+                            dataset)
+     (fn [] ~@body)))
+
+(defmacro with-temp-copy-of-db
+  "Run `body` with the current DB (i.e., the one that powers `data/db` and `data/id`) bound to a temporary copy of the
+  current DB. Tables and Fields are copied as well."
+  {:style/indent 0}
+  [& body]
+  `(impl/do-with-temp-copy-of-db (fn [] ~@body)))
+
+(defmacro with-temp-objects
+  "Calls `data-load-fn` to create a sequence of Toucan objects, then runs `body`; finally, deletes the objects."
+  [data-load-fn & body]
+  `(impl/do-with-temp-objects ~data-load-fn (fn [] ~@body)))
+
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                          Rarely-Used Helper Functions                                          |
+;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defn fks-supported?
   "Does the current engine support foreign keys?"
@@ -270,191 +257,7 @@
   (tx/expected-base-type->actual (tx/driver) base-type))
 
 
-;; ## Loading / Deleting Test Datasets
-
-(defn- add-extra-metadata!
-  "Add extra metadata like Field base-type, etc."
-  [{:keys [table-definitions], :as database-definition} db]
-  {:pre [(seq table-definitions)]}
-  (doseq [{:keys [table-name], :as table-definition} table-definitions]
-    (let [table (delay (or (tx/metabase-instance table-definition db)
-                           (throw (Exception. (format "Table '%s' not loaded from definiton:\n%s\nFound:\n%s"
-                                                      table-name
-                                                      (u/pprint-to-str (dissoc table-definition :rows))
-                                                      (u/pprint-to-str (db/select [Table :schema :name], :db_id (:id db))))))))]
-      (doseq [{:keys [field-name visibility-type special-type], :as field-definition} (:field-definitions table-definition)]
-        (let [field (delay (or (tx/metabase-instance field-definition @table)
-                               (throw (Exception. (format "Field '%s' not loaded from definition:\n"
-                                                          field-name
-                                                          (u/pprint-to-str field-definition))))))]
-          (when visibility-type
-            (log/debug (format "SET VISIBILITY TYPE %s.%s -> %s" table-name field-name visibility-type))
-            (db/update! Field (:id @field) :visibility_type (name visibility-type)))
-          (when special-type
-            (log/debug (format "SET SPECIAL TYPE %s.%s -> %s" table-name field-name special-type))
-            (db/update! Field (:id @field) :special_type (u/keyword->qualified-name special-type))))))))
-
-(defn- create-database! [driver {:keys [database-name], :as database-definition}]
-  {:pre [(seq database-name)]}
-  ;; Create the database and load its data
-  ;; ALWAYS CREATE DATABASE AND LOAD DATA AS UTC! Unless you like broken tests
-  (tu.tz/with-jvm-tz "UTC"
-    (tx/create-db! driver database-definition))
-  ;; Add DB object to Metabase DB
-  (let [db (db/insert! Database
-             :name    database-name
-             :engine  (name driver)
-             :details (tx/dbdef->connection-details driver :db database-definition))]
-    ;; sync newly added DB
-    (sync/sync-database! db)
-    ;; add extra metadata for fields
-    (try
-      (add-extra-metadata! database-definition db)
-      (catch Throwable e
-        (println "Error adding extra metadata:" e)))
-    ;; make sure we're returing an up-to-date copy of the DB
-    (Database (u/get-id db))))
-
-
-(defonce ^:private ^{:arglists '([driver]), :doc "We'll have a very bad time if any sort of test runs that calls
-  `data/db` for the first time calls it multiple times in parallel -- for example my Oracle test that runs 30 sync
-  calls at the same time to make sure nothing explodes and cursors aren't leaked. To make sure this doesn't happen
-  we'll keep a map of driver->lock and only allow a given driver to create one Database at a time. Because each DB has
-  its own lock we can still create different DBs for different drivers at the same time."}
-  driver->create-database-lock
-  (let [locks (atom {})]
-    (fn [driver]
-      (let [driver (driver/the-driver driver)]
-        (or
-         (@locks driver)
-         (do
-           (swap! locks update driver #(or % (Object.)))
-           (@locks driver)))))))
-
-(defmulti get-or-create-database!
-  "Create DBMS database associated with `database-definition`, create corresponding Metabase Databases/Tables/Fields,
-  and sync the Database. `driver` is a keyword name of a driver that implements test extension methods (as defined in
-  the `metabase.test.data.interface` namespace); `driver` defaults to `driver/*driver*` if bound, or `:h2` if not.
-  `database-definition` is anything that implements the `tx/get-database-definition` method."
-  {:arglists '([database-definition] [driver database-definition])}
-  (fn
-    ([_]
-     (tx/dispatch-on-driver-with-test-extensions (tx/driver)))
-    ([driver _]
-     (tx/dispatch-on-driver-with-test-extensions driver)))
-  :hierarchy #'driver/hierarchy)
-
-(defmethod get-or-create-database! :default
-  ([dbdef]
-   (get-or-create-database! (tx/driver) dbdef))
-
-  ([driver dbdef]
-   (let [dbdef (tx/get-dataset-definition dbdef)]
-     (or
-      (tx/metabase-instance dbdef driver)
-      (locking (driver->create-database-lock driver)
-        (or
-         (tx/metabase-instance dbdef driver)
-         (create-database! driver dbdef)))))))
-
-
-(s/defn do-with-db-for-dataset
-  "Execute `f` with `dbdef` loaded as the current dataset. `f` takes a single argument, the DatabaseInstance that was
-  loaded and synced from `dbdef`."
-  [dataset-definition, f :- (s/pred fn?)]
-  (let [dbdef (tx/get-dataset-definition dataset-definition)]
-    (binding [db/*disable-db-logging* true]
-      (let [db (get-or-create-database! (tx/driver) dbdef)]
-        (assert db)
-        (assert (db/exists? Database :id (u/get-id db)))
-        (with-db db
-          (f db))))))
-
-
-(defmacro with-db-for-dataset
-  "Load and sync `database-definition` with `driver` and execute `body` with the newly created Database bound to
-  `db-binding`, and make it the current database for `metabase.test.data` functions like `id`.
-
-     (with-db-for-dataset [db tupac-sightings]
-       (driver/process-quiery {:database (:id db)
-                               :type     :query
-                               :query    {:source-table (:id &events)
-                                          :aggregation  [\"count\"]
-                                          :filter       [\"<\" (:id &events.timestamp) \"1765-01-01\"]}}))
-
-  A given Database is only created once per run of the test suite, and is automatically destroyed at the conclusion
-  of the suite."
-  [[db-binding dataset-def] & body]
-  `(do-with-db-for-dataset ~dataset-def
-     (fn [~db-binding]
-       ~@body)))
-
-(defn resolve-dbdef [namespace-symb symb]
-  @(or (ns-resolve namespace-symb symb)
-       (ns-resolve 'metabase.test.data.dataset-definitions symb)
-       (throw (Exception. (format "Dataset definition not found: '%s/%s' or 'metabase.test.data.dataset-definitions/%s'"
-                                  namespace-symb symb symb)))))
-
-(defmacro dataset
-  "Load and sync a temporary Database defined by `dataset`, make it the current DB (for `metabase.test.data` functions
-  like `id` and `db`), and execute `body`.
-
-  Like `with-db-for-dataset`, but takes an unquoted symbol naming a DatabaseDefinition rather than the dbef itself.
-  `dataset` is optionally namespace-qualified; if not, `metabase.test.data.dataset-definitions` is assumed.
-
-     (dataset sad-toucan-incidents
-       ...)"
-  {:style/indent 1}
-  [dataset & body]
-  `(with-db-for-dataset [~'_ (resolve-dbdef '~(ns-name *ns*) '~dataset)]
-     ~@body))
-
-(defn- copy-db-tables-and-fields! [old-db-id new-db-id]
-  (doseq [{old-table-id :id, :as table} (db/select Table :db_id old-db-id {:order-by [[:id :asc]]})]
-    (let [{new-table-id :id} (db/insert! Table (-> table (dissoc :id) (assoc :db_id new-db-id)))]
-      (doseq [field (db/select Field :table_id old-table-id {:order-by [[:id :asc]]})]
-        (db/insert! Field (-> field (dissoc :id) (assoc :table_id new-table-id)))))))
-
-(defn do-with-temp-copy-of-test-db
-  "Run `f` with a temporary Database that copies the details from the standard test database, and syncs it."
-  [f]
-  (let [{:keys [engine], original-name :name, :as original-db} (select-keys (db) [:details :engine :name])
-        copy-name                                              (format "%s___COPY" original-name)]
-    (try
-      (let [{new-db-id :id, :as new-db} (db/insert! Database (assoc original-db :name copy-name))]
-        (copy-db-tables-and-fields! (id) new-db-id)
-        (with-db new-db
-          (f)))
-      (finally (db/delete! Database :engine (name engine), :name copy-name)))))
-
-(defmacro with-temp-copy-of-test-db
-  "Run `body` with the current DB (i.e., the one that powers `data/db` and `data/id`) bound to a temporary copy of the
-  current DB. Tables and Fields are copied as well."
-  {:style/indent 0}
-  [& body]
-  `(do-with-temp-copy-of-test-db (fn [] ~@body)))
-
-
-(defn- delete-model-instance!
-  "Allows deleting a row by the model instance toucan returns when it's inserted"
-  [{:keys [id] :as instance}]
-  (db/delete! (-> instance name symbol) :id id))
-
-(defn call-with-data
-  "Takes a thunk `data-load-fn` that returns a seq of Toucan model instances that will be deleted after `body-fn`
-  finishes"
-  [data-load-fn body-fn]
-  (let [result-instances (data-load-fn)]
-    (try
-      (body-fn)
-      (finally
-        (doseq [instance result-instances]
-          (delete-model-instance! instance))))))
-
-(defmacro with-data
-  "Calls `data-load-fn` to create a sequence of Toucan objects, then runs `body`; finally, deletes the objects."
-  [data-load-fn & body]
-  `(call-with-data ~data-load-fn (fn [] ~@body)))
+;; The functions below are used so infrequently they hardly belong in this namespace.
 
 (defn dataset-field-values
   "Get all the values for a field in a `dataset-definition`.

--- a/test/metabase/test/data/dataset_definitions.clj
+++ b/test/metabase/test/data/dataset_definitions.clj
@@ -1,5 +1,5 @@
 (ns metabase.test.data.dataset-definitions
-  "Definitions of various datasets for use in tests with `data/dataset` or `data/with-db-for-dataset`."
+  "Definitions of various datasets for use in tests with `data/dataset` and the like."
   (:require [medley.core :as m]
             [metabase.test.data.interface :as tx])
   (:import java.sql.Time

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -1,0 +1,253 @@
+(ns metabase.test.data.impl
+  "Internal implementation of various helper functions in `metabase.test.data`."
+  (:require [clojure.tools.logging :as log]
+            [metabase
+             [driver :as driver]
+             [sync :as sync]
+             [util :as u]]
+            [metabase.models
+             [database :refer [Database]]
+             [field :as field :refer [Field]]
+             [table :refer [Table]]]
+            [metabase.plugins.classloader :as classloader]
+            [metabase.test.data
+             [dataset-definitions :as defs]
+             [interface :as tx]]
+            [metabase.test.util.timezone :as tu.tz]
+            [toucan.db :as db]))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                          get-or-create-database!; db                                           |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+
+(defonce ^:private ^{:arglists '([driver]), :doc "We'll have a very bad time if any sort of test runs that calls
+  `data/db` for the first time calls it multiple times in parallel -- for example my Oracle test that runs 30 sync
+  calls at the same time to make sure nothing explodes and cursors aren't leaked. To make sure this doesn't happen
+  we'll keep a map of driver->lock and only allow a given driver to create one Database at a time. Because each DB has
+  its own lock we can still create different DBs for different drivers at the same time."}
+  driver->create-database-lock
+  (let [locks (atom {})]
+    (fn [driver]
+      (let [driver (driver/the-driver driver)]
+        (or
+         (@locks driver)
+         (do
+           (swap! locks update driver #(or % (Object.)))
+           (@locks driver)))))))
+
+(defmulti get-or-create-database!
+  "Create DBMS database associated with `database-definition`, create corresponding Metabase Databases/Tables/Fields,
+  and sync the Database. `driver` is a keyword name of a driver that implements test extension methods (as defined in
+  the `metabase.test.data.interface` namespace); `driver` defaults to `driver/*driver*` if bound, or `:h2` if not.
+  `database-definition` is anything that implements the `tx/get-database-definition` method."
+  {:arglists '([driver database-definition])}
+  tx/dispatch-on-driver-with-test-extensions
+  :hierarchy #'driver/hierarchy)
+
+
+(defn- add-extra-metadata!
+  "Add extra metadata like Field base-type, etc."
+  [{:keys [table-definitions], :as database-definition} db]
+  {:pre [(seq table-definitions)]}
+  (doseq [{:keys [table-name], :as table-definition} table-definitions]
+    (let [table (delay (or (tx/metabase-instance table-definition db)
+                           (throw (Exception. (format "Table '%s' not loaded from definiton:\n%s\nFound:\n%s"
+                                                      table-name
+                                                      (u/pprint-to-str (dissoc table-definition :rows))
+                                                      (u/pprint-to-str (db/select [Table :schema :name], :db_id (:id db))))))))]
+      (doseq [{:keys [field-name visibility-type special-type], :as field-definition} (:field-definitions table-definition)]
+        (let [field (delay (or (tx/metabase-instance field-definition @table)
+                               (throw (Exception. (format "Field '%s' not loaded from definition:\n"
+                                                          field-name
+                                                          (u/pprint-to-str field-definition))))))]
+          (when visibility-type
+            (log/debug (format "SET VISIBILITY TYPE %s.%s -> %s" table-name field-name visibility-type))
+            (db/update! Field (:id @field) :visibility_type (name visibility-type)))
+          (when special-type
+            (log/debug (format "SET SPECIAL TYPE %s.%s -> %s" table-name field-name special-type))
+            (db/update! Field (:id @field) :special_type (u/keyword->qualified-name special-type))))))))
+
+(defn- create-database! [driver {:keys [database-name], :as database-definition}]
+  {:pre [(seq database-name)]}
+  ;; Create the database and load its data
+  ;; ALWAYS CREATE DATABASE AND LOAD DATA AS UTC! Unless you like broken tests
+  (tu.tz/with-jvm-tz "UTC"
+    (tx/create-db! driver database-definition))
+  ;; Add DB object to Metabase DB
+  (let [db (db/insert! Database
+             :name    database-name
+             :engine  (name driver)
+             :details (tx/dbdef->connection-details driver :db database-definition))]
+    ;; sync newly added DB
+    (sync/sync-database! db)
+    ;; add extra metadata for fields
+    (try
+      (add-extra-metadata! database-definition db)
+      (catch Throwable e
+        (println "Error adding extra metadata:" e)))
+    ;; make sure we're returing an up-to-date copy of the DB
+    (Database (u/get-id db))))
+
+
+(defmethod get-or-create-database! :default [driver dbdef]
+  (let [dbdef (tx/get-dataset-definition dbdef)]
+    (or
+     (tx/metabase-instance dbdef driver)
+     (locking (driver->create-database-lock driver)
+       (or
+        (tx/metabase-instance dbdef driver)
+        (create-database! driver dbdef))))))
+
+(defn- get-or-create-test-data-db!
+  "Get or create the Test Data database for `driver`, which defaults to `driver/*driver*`, or `:h2` if that is unbound."
+  ([]       (get-or-create-test-data-db! (tx/driver)))
+  ([driver] (get-or-create-database! driver defs/test-data)))
+
+(def ^:dynamic *get-db*
+  "Implementation of `db` function that should return the current working test database when called, always with no
+  arguments. By default, this is `get-or-create-test-data-db!` for the current driver/`*driver*`, which does exactly what it
+  suggests."
+  get-or-create-test-data-db!)
+
+(defn do-with-db
+  "Internal impl of `data/with-db`."
+  [db f]
+  (binding [*get-db* (constantly db)]
+    (f)))
+
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                                       id                                                       |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defn the-table-id
+  "Internal impl of `(data/id table)."
+  [db-id table-name]
+  {:pre [(integer? db-id) ((some-fn keyword? string?) table-name)]}
+  (let [table-id-for-name (partial db/select-one-id Table, :db_id db-id, :name)]
+    (or (table-id-for-name table-name)
+        (table-id-for-name (let [db-name (db/select-one-field :name Database :id db-id)]
+                             (tx/db-qualified-table-name db-name table-name)))
+        (throw (Exception. (format "No Table '%s' found for Database %d.\nFound: %s" table-name db-id
+                                   (u/pprint-to-str (db/select-id->field :name Table, :db_id db-id, :active true))))))))
+
+(defn- the-field-id* [table-id field-name & {:keys [parent-id]}]
+  {:pre [((some-fn keyword? string?) field-name)]}
+  (or (db/select-one-id Field, :active true, :table_id table-id, :name field-name, :parent_id parent-id)
+      (throw (Exception.
+              (format "Couldn't find Field %s for Table %d.\nFound: %s"
+                      (str \' field-name \' (when parent-id
+                                              (format " (parent: %d)" parent-id)))
+                      table-id
+                      (u/pprint-to-str (db/select-id->field :name Field, :active true, :table_id table-id)))))))
+
+(defn the-field-id
+  "Internal impl of `(data/id table field)`."
+  [table-id field-name & nested-field-names]
+  {:pre [(integer? table-id)]}
+  (loop [parent-id (the-field-id* table-id field-name), [nested-field-name & more] nested-field-names]
+    (if-not nested-field-name
+      parent-id
+      (recur (the-field-id* table-id nested-field-name, :parent-id parent-id) more))))
+
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                              with-temp-copy-of-db                                              |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defn- copy-table-fields! [old-table-id new-table-id]
+  (db/insert-many! Field
+    (for [field (db/select Field :table_id old-table-id {:order-by [[:id :asc]]})]
+      (-> field (dissoc :id :fk_target_field_id) (assoc :table_id new-table-id)))))
+
+(defn- copy-db-tables! [old-db-id new-db-id]
+  (let [old-tables    (db/select Table :db_id old-db-id {:order-by [[:id :asc]]})
+        new-table-ids (db/insert-many! Table
+                        (for [table old-tables]
+                          (-> table (dissoc :id) (assoc :db_id new-db-id))))]
+    (doseq [[old-table-id new-table-id] (zipmap (map :id old-tables) new-table-ids)]
+      (copy-table-fields! old-table-id new-table-id))))
+
+(defn- copy-db-fks! [old-db-id new-db-id]
+  (doseq [{:keys [source-field source-table target-field target-table]}
+          (db/query {:select    [[:source-field.name :source-field]
+                                 [:source-table.name :source-table]
+                                 [:target-field.name   :target-field]
+                                 [:target-table.name   :target-table]]
+                     :from      [[Field :source-field]]
+                     :left-join [[Table :source-table] [:= :source-field.table_id :source-table.id]
+                                 [Field :target-field] [:= :source-field.fk_target_field_id :target-field.id]
+                                 [Table :target-table] [:= :target-field.table_id :target-table.id]]
+                     :where     [:and
+                                 [:= :source-table.db_id old-db-id]
+                                 [:= :target-table.db_id old-db-id]
+                                 [:not= :source-field.fk_target_field_id nil]]})]
+    (db/update! Field (the-field-id (the-table-id new-db-id source-table) source-field)
+      :fk_target_field_id (the-field-id (the-table-id new-db-id target-table) target-field))))
+
+(defn- copy-db-tables-and-fields! [old-db-id new-db-id]
+  (copy-db-tables! old-db-id new-db-id)
+  (copy-db-fks! old-db-id new-db-id))
+
+(defn do-with-temp-copy-of-db
+  "Internal impl of `data/with-temp-copy-of-db`. Run `f` with a temporary Database that copies the details from the
+  standard test database, and syncs it."
+  [f]
+  (let [{old-db-id :id, :as old-db}                            (*get-db*)
+        {:keys [engine], original-name :name, :as original-db} (select-keys old-db [:details :engine :name])
+        copy-name                                              (format "%s___COPY" original-name)]
+    (try
+      (let [{new-db-id :id, :as new-db} (db/insert! Database (assoc original-db :name copy-name))]
+        (copy-db-tables-and-fields! old-db-id new-db-id)
+        (do-with-db new-db f))
+      (finally (db/delete! Database :engine (name engine), :name copy-name)))))
+
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                                    dataset                                                     |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defn resolve-dataset-definition
+  "Impl for `data/dataset` macro. Resolve a dataset definition (e.g. `test-data` or `sad-toucan-incidents` in a
+  namespace."
+  [namespace-symb symb]
+  @(or (ns-resolve namespace-symb symb)
+       (do
+         (classloader/the-classloader)
+         (require 'metabase.test.data.dataset-definitions)
+         (ns-resolve 'metabase.test.data.dataset-definitions symb))
+       (throw (Exception. (format "Dataset definition not found: '%s/%s' or 'metabase.test.data.dataset-definitions/%s'"
+                                  namespace-symb symb symb)))))
+
+(defn do-with-dataset
+  "Impl for `data/dataset` macro."
+  {:style/indent 1}
+  [dataset-definition f]
+  (let [dbdef (tx/get-dataset-definition dataset-definition)]
+    (binding [db/*disable-db-logging* true]
+      (let [db (get-or-create-database! (tx/driver) dbdef)]
+        (assert db)
+        (assert (db/exists? Database :id (u/get-id db)))
+        (do-with-db db f)))))
+
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                               with-temp-objects                                                |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defn- delete-model-instance!
+  "Allows deleting a row by the model instance toucan returns when it's inserted"
+  [{:keys [id] :as instance}]
+  (db/delete! (-> instance name symbol) :id id))
+
+(defn do-with-temp-objects
+  "Internal impl of `data/with-data`. Takes a thunk `data-load-fn` that returns a seq of Toucan model instances that
+  will be deleted after `body-fn` finishes"
+  [data-load-fn body-fn]
+  (let [result-instances (data-load-fn)]
+    (try
+      (body-fn)
+      (finally
+        (doseq [instance result-instances]
+          (delete-model-instance! instance))))))

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -34,7 +34,6 @@
              [user :refer [User]]]
             [metabase.plugins.classloader :as classloader]
             [metabase.test.data :as data]
-            [metabase.test.data.dataset-definitions :as defs]
             [metabase.util.date :as du]
             [schema.core :as s]
             [toucan.db :as db]

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -596,38 +596,38 @@
 
   `f` should return a future that can be canceled."
   [f]
-  (data/with-db (data/get-or-create-database! defs/test-data)
-    (let [called-cancel? (promise)
-          called-query?  (promise)
-          pause-query    (promise)
-          query-thunk    (fn []
-                           (data/run-mbql-query checkins
-                             {:aggregation [[:count]]}))
-          ;; When the query is ran via the datasets endpoint, it will run in a future. That future can be canceled,
-          ;; which should cause an interrupt
-          query-future   (f query-thunk called-query? called-cancel? pause-query)]
-      ;; The cancelled-query? and called-cancel? timeouts are very high and are really just intended to
-      ;; prevent the test from hanging indefinitely. It shouldn't be hit unless something is really wrong
-      (when (= ::query-never-called (deref called-query? 10000 ::query-never-called))
-        (throw (TimeoutException. "query should have been called by now.")))
-      ;; At this point in time, the query is blocked, waiting for `pause-query` do be delivered. Cancel still should
-      ;; not have been called yet.
-      (assert (not (realized? called-cancel?)) "cancel still should not have been called yet.")
-      ;; If we cancel the future, it should throw an InterruptedException, which should call the cancel
-      ;; method on the prepared statement
-      (future-cancel query-future)
-      (when (= ::cancel-never-called (deref called-cancel? 10000 ::cancel-never-called))
-        (throw (TimeoutException. "cancel should have been called by now.")))
-      ;; This releases the fake query function so it finishes
-      (deliver pause-query true)
-      ::success)))
+  (let [called-cancel? (promise)
+        called-query?  (promise)
+        pause-query    (promise)
+        query-thunk    (fn []
+                         (data/run-mbql-query checkins
+                           {:aggregation [[:count]]}))
+        ;; When the query is ran via the datasets endpoint, it will run in a future. That future can be canceled,
+        ;; which should cause an interrupt
+        query-future   (f query-thunk called-query? called-cancel? pause-query)]
+    ;; The cancelled-query? and called-cancel? timeouts are very high and are really just intended to
+    ;; prevent the test from hanging indefinitely. It shouldn't be hit unless something is really wrong
+    (when (= ::query-never-called (deref called-query? 10000 ::query-never-called))
+      (throw (TimeoutException. "query should have been called by now.")))
+    ;; At this point in time, the query is blocked, waiting for `pause-query` do be delivered. Cancel still should
+    ;; not have been called yet.
+    (assert (not (realized? called-cancel?)) "cancel still should not have been called yet.")
+    ;; If we cancel the future, it should throw an InterruptedException, which should call the cancel
+    ;; method on the prepared statement
+    (future-cancel query-future)
+    (when (= ::cancel-never-called (deref called-cancel? 10000 ::cancel-never-called))
+      (throw (TimeoutException. "cancel should have been called by now.")))
+    ;; This releases the fake query function so it finishes
+    (deliver pause-query true)
+    ::success))
 
 (defmacro throw-if-called
   "Redefines `fn-var` with a function that throws an exception if it's called"
   {:style/indent 1}
-  [fn-var & body]
-  `(with-redefs [~fn-var (fn [& args#]
-                           (throw (RuntimeException. "Should not be called!")))]
+  [fn-symb & body]
+  {:pre [(symbol? fn-symb)]}
+  `(with-redefs [~fn-symb (fn [& ~'_]
+                            (throw (RuntimeException. ~(format "%s should not be called!" fn-symb))))]
      ~@body))
 
 

--- a/test/metabase/timeseries_query_processor_test/util.clj
+++ b/test/metabase/timeseries_query_processor_test/util.clj
@@ -13,18 +13,10 @@
   "The normal test-data DB definition as a flattened, single-table DB definition."
   (tx/flattened-dataset-definition defs/test-data "checkins"))
 
-;; force loading of the flattened db definitions for the DBs that need it
-(defn- load-event-based-db-data!
-  {:expectations-options :before-run}
-  []
-  (doseq [driver event-based-dbs]
-    (datasets/with-driver-when-testing driver
-      (data/do-with-db-for-dataset flattened-db-def (constantly nil)))))
-
 (defn do-with-flattened-dbdef
   "Execute `f` with a flattened version of the test data DB as the current DB def."
   [f]
-  (data/do-with-db-for-dataset flattened-db-def (fn [_] (f))))
+  (data/dataset flattened-db-def (f)))
 
 (defmacro with-flattened-dbdef
   "Execute `body` using the flattened test data DB definition."


### PR DESCRIPTION
*  New `POST /api/dataset/native` endpoint to convert an MBQL query to native
*  cleaned up `metabase.test.data` namespace and moved complicated macro implementations into new `metabase.test.data.impl` namespace so we don't have to look at them when referring to one of the most commonly used namespaces. Consolidated a handful of macros that all did variations of the same things into a smaller set to reduce the cognitive load required to read & write MB tests