### PR TITLE
Parse timezone for times

### DIFF
--- a/frontend/src/metabase/lib/time.js
+++ b/frontend/src/metabase/lib/time.js
@@ -58,7 +58,7 @@ export function parseTime(value) {
   if (moment.isMoment(value)) {
     return value;
   } else if (typeof value === "string") {
-    return moment(value, [
+    return moment.parseZone(value, [
       "HH:mm:SS.sssZZ",
       "HH:mm:SS.sss",
       "HH:mm:SS.sss",

--- a/frontend/test/metabase/lib/time.unit.spec.js
+++ b/frontend/test/metabase/lib/time.unit.spec.js
@@ -1,4 +1,4 @@
-import { parseTimestamp } from "metabase/lib/time";
+import { parseTime, parseTimestamp } from "metabase/lib/time";
 import moment from "moment";
 
 describe("time", () => {
@@ -39,6 +39,22 @@ describe("time", () => {
           expect(result.unix()).toEqual(expectedMoment.unix());
         },
       );
+    });
+  });
+
+  describe("parseTime", () => {
+    it("parse timezones", () => {
+      const result = parseTime("01:02:03.456+07:00");
+
+      expect(moment.isMoment(result)).toBe(true);
+      expect(result.format("h:mm A")).toBe("1:02 AM");
+    });
+
+    it("parse time without seconds", () => {
+      const result = parseTime("01:02");
+
+      expect(moment.isMoment(result)).toBe(true);
+      expect(result.format("h:mm A")).toBe("1:02 AM");
     });
   });
 });


### PR DESCRIPTION
Given this data and a Metabase report timezone of UTC, we were incorrectly presenting the time, but not the timestamp. The fix was to parse the timezone.

```
 transaction_date |  transaction_datetime  | transaction_time 
------------------+------------------------+------------------
 2018-12-03       | 2018-12-03 08:04:07-05 | 13:04:07+00
```

# Before

![image](https://user-images.githubusercontent.com/691495/59388895-fafcc580-8d3a-11e9-81c1-70d5a33857b2.png)

# After

![image](https://user-images.githubusercontent.com/691495/59388849-dc96ca00-8d3a-11e9-8691-5c3f992bafcd.png)
