### PR TITLE
Change "back to last run" button text

### DIFF
--- a/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
@@ -73,7 +73,7 @@ export default class VisualizationResult extends Component {
                   className="Button"
                   onClick={() => window.history.back()}
                 >
-                  {t`Back to last run`}
+                  {t`Back to previous results`}
                 </button>
               </div>
             }


### PR DESCRIPTION
This was just bugging me because "last run" doesn't sound natural.

# Before
![Screen Shot 2019-06-12 at 4 50 32 PM](https://user-images.githubusercontent.com/2223916/59394297-f7b20b80-8d33-11e9-8168-4baed623ef93.png)
# After
![Screen Shot 2019-06-12 at 5 01 37 PM](https://user-images.githubusercontent.com/2223916/59394300-faacfc00-8d33-11e9-9d98-ff5787d0a88f.png)
