### PR TITLE
round very small values to zero on the y axis

### DIFF
--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -317,6 +317,17 @@ export function applyChartOrdinalXAxis(
   chart.x(d3.scale.ordinal().domain(xValues)).xUnits(dc.units.ordinal);
 }
 
+// Sometimes tick marks are placed *just* off from zero.
+// We still want to format these as "0" rather than "0.0000000000000018".
+// But! We need to allow for real non-zero ticks at very small values,
+// so we scale a tolerance to the extent of the yAxis.
+// The tolerance is arbitrarily set to one millionth of the yExtent.
+const TOLERANCE_TO_Y_EXTENT = 1e6;
+export function maybeRoundValueToZero(value, [yMin, yMax]) {
+  const tolerance = Math.abs(yMax - yMin) / TOLERANCE_TO_Y_EXTENT;
+  return Math.abs(value) < tolerance ? 0 : value;
+}
+
 export function applyChartYAxis(chart, series, yExtent, axisName) {
   let axis;
   if (axisName !== "right") {
@@ -359,10 +370,7 @@ export function applyChartYAxis(chart, series, yExtent, axisName) {
     } else {
       const metricColumn = series[0].data.cols[1];
       axis.axis().tickFormat(value => {
-        if (Math.abs(value) < Number.EPSILON) {
-          // snap very small values to zero
-          value = 0;
-        }
+        value = maybeRoundValueToZero(value, yExtent);
         return formatValue(value, chart.settings.column(metricColumn));
       });
     }

--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -358,11 +358,13 @@ export function applyChartYAxis(chart, series, yExtent, axisName) {
       axis.axis().tickFormat(value => Math.round(value * 100) + "%");
     } else {
       const metricColumn = series[0].data.cols[1];
-      axis
-        .axis()
-        .tickFormat(value =>
-          formatValue(value, chart.settings.column(metricColumn)),
-        );
+      axis.axis().tickFormat(value => {
+        if (Math.abs(value) < Number.EPSILON) {
+          // snap very small values to zero
+          value = 0;
+        }
+        return formatValue(value, chart.settings.column(metricColumn));
+      });
     }
     chart.renderHorizontalGridLines(true);
     adjustYAxisTicksIfNeeded(axis.axis(), chart.height());

--- a/frontend/test/metabase/visualizations/lib/apply_axis.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/apply_axis.unit.spec.js
@@ -1,4 +1,7 @@
-import { stretchTimeseriesDomain } from "metabase/visualizations/lib/apply_axis";
+import {
+  maybeRoundValueToZero,
+  stretchTimeseriesDomain,
+} from "metabase/visualizations/lib/apply_axis";
 import moment from "moment";
 
 describe("visualization.lib.apply_axis", () => {
@@ -37,6 +40,26 @@ describe("visualization.lib.apply_axis", () => {
         "2020-03-31T06:00:00.000Z",
         "2020-04-05T18:00:00.000Z",
       ]);
+    });
+  });
+
+  describe("maybeRoundValueToZero", () => {
+    it("shouldn't change big values", () => {
+      const value = maybeRoundValueToZero(0.2, [-1, 1]);
+
+      expect(value).toBe(0.2);
+    });
+
+    it("should snap small values to zero", () => {
+      const value = maybeRoundValueToZero(0.0000000000018, [-1, 1]);
+
+      expect(value).toBe(0);
+    });
+
+    it("shouldn't snap small values to zero if the yExtent is small", () => {
+      const value = maybeRoundValueToZero(0.0000000000018, [-1e-20, 1e-20]);
+
+      expect(value).toBe(0.0000000000018);
     });
   });
 });


### PR DESCRIPTION
Resolves #9986 

This PR fixes the issue by checking if a number is _very_ close to zero and if so replacing it with zero. I used [`Number.EPSILON`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/EPSILON) as the cutoff.

Is there ever a time when we want to show values between `Number.EPSILON` and zero? If not, I'll just move this logic to `formatValue` where it could catch more cases and be tested more easily.

# Before

<img width="570" alt="Screen Shot 2019-06-13 at 11 17 18 AM" src="https://user-images.githubusercontent.com/691495/59445028-e49f4a00-8dcc-11e9-9bd1-e75c5712f6f7.png">


# After

<img width="570" alt="Screen Shot 2019-06-13 at 11 12 01 AM" src="https://user-images.githubusercontent.com/691495/59445031-e701a400-8dcc-11e9-8604-b0d910290825.png">
