### PR TITLE
Fix creating DB on setup

### DIFF
--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -62,7 +62,10 @@
     (public-settings/anon-tracking-enabled (or (nil? allow_tracking)
                                                allow_tracking))
     ;; setup database (if needed)
-    (when (some-> engine driver/available?)
+    (when engine
+      (when-not (driver/available? engine)
+        (throw (ex-info (str (tru "Cannot create Database: cannot find driver {0}." engine))
+                 {:engine engine})))
       (let [db (db/insert! Database
                  (merge
                   {:name         name

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -71,15 +71,30 @@
   hierarchy
   (make-hierarchy))
 
-(defn registered?
+(defn- registered?
   "Is `driver` a valid registered driver?"
   [driver]
-  (isa? hierarchy driver ::driver))
+  (isa? hierarchy (keyword driver) ::driver))
 
-(defn abstract?
-  "Is `driver` an abstract \"base class\"?"
+(defn- concrete?
+  "Is `driver` registered, and non-abstract?"
   [driver]
-  (not (isa? hierarchy driver ::concrete)))
+  (isa? hierarchy (keyword driver) ::concrete))
+
+(defn- abstract?
+  "Is `driver` an abstract \"base class\"? i.e. a driver that you cannot use directly when adding a Database, such as
+  `:sql` or `:sql-jdbc`."
+  [driver]
+  (not (concrete? driver)))
+
+(defn available?
+  "Is this driver available for use? (i.e. should we show it as an option when adding a new database?) This is `true`
+  for all registered, non-abstract drivers and false everything else.
+
+  Note that an available driver is not necessarily initialized yet; for example lazy-loaded drivers are *registered*
+  when Metabase starts up (meaning this will return `true` for them) and only initialized when first needed."
+  [driver]
+  ((every-pred registered? concrete?) driver))
 
 (s/defn ^:private driver->expected-namespace [driver :- s/Keyword]
   (symbol
@@ -107,7 +122,7 @@
           (catch Throwable _
             (throw (Exception. (str (tru "Could not find {0} driver." driver))))))))))
 
-(defn- load-driver-namespace-if-needed
+(defn- load-driver-namespace-if-needed!
   "Load the expected namespace for a `driver` if it has not already been registed. This only works for core Metabase
   drivers, whose namespaces follow an expected pattern; drivers provided by 3rd-party plugins are expected to register
   themselves in their plugin initialization code.
@@ -147,7 +162,7 @@
   [driver :- (s/cond-pre s/Str s/Keyword)]
   (classloader/the-classloader)
   (let [driver (keyword driver)]
-    (load-driver-namespace-if-needed driver)
+    (load-driver-namespace-if-needed! driver)
     driver))
 
 (defn- check-abstractness-hasnt-changed
@@ -162,8 +177,8 @@
   "Add a new parent to `driver`."
   [driver new-parent]
   (when-not *compile-files*
-    (load-driver-namespace-if-needed driver)
-    (load-driver-namespace-if-needed new-parent)
+    (load-driver-namespace-if-needed! driver)
+    (load-driver-namespace-if-needed! new-parent)
     (alter-var-root #'hierarchy derive driver new-parent)))
 
 (defn register!
@@ -202,7 +217,7 @@
         (derive! ::concrete))
       (doseq [parent (u/one-or-many parent)
               :when  parent]
-        (load-driver-namespace-if-needed parent)
+        (load-driver-namespace-if-needed! parent)
         (derive! parent)))
     ;; ok, log our great success
     (log/info
@@ -329,26 +344,6 @@
   )
 
 (defmethod initialize! :default [_]) ; no-op
-
-
-(defmulti ^:deprecated available?
-  "Is this driver available for use? (i.e. should we show it as an option when adding a new database?) This is `true` by
-  default for all non-abstract driver types and false for abstract ones; some drivers might want to override this to
-  return false even if the driver isn't abstract -- for example, the Oracle driver might return false if the JDBC
-  driver it depends on is not available.
-
-  This method is also used in tests to determine whether the standard set of Query Processor tests should
-  automatically against it; for one-off test drivers to test specific functionality, you should return `false`.
-
-  DEPRECATED -- drivers that require external dependencies are now shipping as plugins; they can declare dependencies
-  on external classes, and we can skip loading them entirely if the dependencies are not available. Please do not
-  implement this method; it will most likely be removed before version 1.0 ships."
-  {:arglists '([driver])}
-  dispatch-on-uninitialized-driver
-  :hierarchy #'hierarchy)
-
-(defmethod available? ::driver [driver]
-  (isa? hierarchy driver ::concrete))
 
 
 (defmulti display-name

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -82,7 +82,7 @@
           :when   (not (#{:common :util :query-processor :google}
                         driver))]
     (try
-      (#'driver/load-driver-namespace-if-needed driver)
+      (#'driver/load-driver-namespace-if-needed! driver)
       (catch Throwable e
         (log/error e (trs "Error loading namespace"))))))
 

--- a/src/metabase/plugins/lazy_loaded_driver.clj
+++ b/src/metabase/plugins/lazy_loaded_driver.clj
@@ -83,7 +83,6 @@
     ;; ok, now add implementations for the so-called "non-trivial" driver multimethods
     (doseq [[^MultiFn multifn, f]
             {driver/initialize!           (make-initialize! driver add-to-classpath! init-steps)
-             driver/available?            (constantly (not abstract))
              driver/display-name          (when display-name (constantly display-name))
              driver/connection-properties (constantly connection-props)}]
       (when f

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -431,7 +431,7 @@
 
 ;; make sure that GET /api/database/include_cards=true removes Cards that belong to a driver that doesn't support
 ;; nested queries
-(driver/register! ::no-nested-query-support :parent :h2)
+(driver/register! ::no-nested-query-support :parent :h2, :abstract? true)
 
 (defmethod driver/supports? [::no-nested-query-support :nested-queries] [_ _] false)
 

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -297,10 +297,11 @@
   {:permissions-error? (s/eq true)
    :message            (s/eq "You do not have permissions to run this query.")
    s/Any               s/Any}
-  (data/with-temp-copy-of-db
-    ;; Give All Users permissions to see the `venues` Table, but not ad-hoc native perms
-    (perms/revoke-permissions! (group/all-users) (data/id))
-    (perms/grant-permissions! (group/all-users) (data/id) "PUBLIC" (data/id :venues))
-    ((test-users/user->client :rasta) :post "dataset/native"
-     (data/mbql-query venues
-       {:fields [$id $name]}))))
+  (tu.log/suppress-output
+    (data/with-temp-copy-of-db
+      ;; Give All Users permissions to see the `venues` Table, but not ad-hoc native perms
+      (perms/revoke-permissions! (group/all-users) (data/id))
+      (perms/grant-permissions! (group/all-users) (data/id) "PUBLIC" (data/id :venues))
+      ((test-users/user->client :rasta) :post "dataset/native"
+       (data/mbql-query venues
+         {:fields [$id $name]})))))

--- a/test/metabase/api/setup_test.clj
+++ b/test/metabase/api/setup_test.clj
@@ -5,7 +5,9 @@
              [http-client :as http]
              [public-settings :as public-settings]
              [setup :as setup]]
-            [metabase.models.user :refer [User]]
+            [metabase.models
+             [database :refer [Database]]
+             [user :refer [User]]]
             [metabase.test.data.users :as test-users]
             [metabase.test.util :as tu]
             [toucan.db :as db]))
@@ -37,32 +39,69 @@
         (db/delete! User :email email)))))
 
 
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                                  POST /setup                                                   |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+;; Check that we can Create a Database when we set up MB (#10135)
+(expect
+  {:db-exists? true, :user-exists? true})
+(defn- x []
+  (let [token      (setup/create-token!)
+        db-name    (tu/random-name)
+        user-email (tu/random-email)]
+    (try
+      (http/client :post 200 "setup"
+                   {:token    token
+                    :prefs    {:site_name "Test", :allow_tracking "true"},
+                    :database {:engine  "h2"
+                               :name    db-name
+                               :details {:db  "file:/home/hansen/Downloads/Metabase/longnames.db",
+                                         :ssl true}},
+                    :user     {:first_name (tu/random-name)
+                               :last_name  (tu/random-name)
+                               :email      user-email
+                               :password   "Testtest1"
+                               :site_name  "Test"}})
+      {:db-exists?   (db/exists? Database :name db-name)
+       :user-exists? (db/exists? User :email user-email)}
+      (finally
+        (db/delete! Database :name db-name)
+        (db/delete! User :email user-email)))))
+
 ;; Test input validations
-(expect {:errors {:token "Token does not match the setup token."}}
+(expect
+  {:errors {:token "Token does not match the setup token."}}
   (http/client :post 400 "setup" {}))
 
-(expect {:errors {:token "Token does not match the setup token."}}
+(expect
+  {:errors {:token "Token does not match the setup token."}}
   (http/client :post 400 "setup" {:token "foobar"}))
 
-(expect {:errors {:site_name "value must be a non-blank string."}}
+(expect
+  {:errors {:site_name "value must be a non-blank string."}}
   (http/client :post 400 "setup" {:token (setup/token-value)}))
 
-(expect {:errors {:first_name "value must be a non-blank string."}}
+(expect
+  {:errors {:first_name "value must be a non-blank string."}}
   (http/client :post 400 "setup" {:token (setup/token-value)
                                   :prefs {:site_name "awesomesauce"}}))
 
-(expect {:errors {:last_name "value must be a non-blank string."}}
+(expect
+  {:errors {:last_name "value must be a non-blank string."}}
   (http/client :post 400 "setup" {:token (setup/token-value)
                                   :prefs {:site_name "awesomesauce"}
                                   :user {:first_name "anything"}}))
 
-(expect {:errors {:email "value must be a valid email address."}}
+(expect
+  {:errors {:email "value must be a valid email address."}}
   (http/client :post 400 "setup" {:token (setup/token-value)
                                   :prefs {:site_name "awesomesauce"}
                                   :user {:first_name "anything"
                                          :last_name "anything"}}))
 
-(expect {:errors {:password "Insufficient password strength"}}
+(expect
+  {:errors {:password "Insufficient password strength"}}
   (http/client :post 400 "setup" {:token (setup/token-value)
                                   :prefs {:site_name "awesomesauce"}
                                   :user {:first_name "anything"
@@ -70,7 +109,8 @@
                                          :email "anything@metabase.com"}}))
 
 ;; valid email + complex password
-(expect {:errors {:email "value must be a valid email address."}}
+(expect
+  {:errors {:email "value must be a valid email address."}}
   (http/client :post 400 "setup" {:token (setup/token-value)
                                   :prefs {:site_name "awesomesauce"}
                                   :user {:token "anything"
@@ -79,7 +119,8 @@
                                          :email "anything"
                                          :password "anything"}}))
 
-(expect {:errors {:password "Insufficient password strength"}}
+(expect
+  {:errors {:password "Insufficient password strength"}}
   (http/client :post 400 "setup" {:token (setup/token-value)
                                   :prefs {:site_name "awesomesauce"}
                                   :user {:token "anything"
@@ -89,12 +130,18 @@
                                          :password "anything"}}))
 
 
-;; ## POST /api/setup/validate
-(expect {:errors {:token "Token does not match the setup token."}}
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                            POST /api/setup/validate                                            |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(expect
+  {:errors {:token "Token does not match the setup token."}}
   (http/client :post 400 "setup/validate" {}))
 
-(expect {:errors {:token "Token does not match the setup token."}}
+(expect
+  {:errors {:token "Token does not match the setup token."}}
   (http/client :post 400 "setup/validate" {:token "foobar"}))
 
-(expect {:errors {:engine "value must be a valid database engine."}}
+(expect
+  {:errors {:engine "value must be a valid database engine."}}
   (http/client :post 400 "setup/validate" {:token (setup/token-value)}))

--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -3,7 +3,7 @@
             [metabase.driver :as driver]
             [metabase.plugins.classloader :as classloader]))
 
-(driver/register! ::test-driver)
+(driver/register! ::test-driver, :abstract? true)
 
 (defmethod driver/supports? [::test-driver :foreign-keys] [_ _] true)
 
@@ -32,5 +32,10 @@
     (.getContextClassLoader (Thread/currentThread))))
 
 ;; `driver/available?` should work for if `driver` is a string -- see #10135
-(expect (driver/available? ::test-driver))
-(expect (driver/available? "metabase.driver-test/test-driver"))
+(expect
+  (with-redefs [driver/concrete? (constantly true)]
+    (driver/available? ::test-driver)))
+
+(expect
+  (with-redefs [driver/concrete? (constantly true)]
+    (driver/available? "metabase.driver-test/test-driver")))

--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -5,8 +5,6 @@
 
 (driver/register! ::test-driver)
 
-(defmethod driver/available? ::test-driver [_] false)
-
 (defmethod driver/supports? [::test-driver :foreign-keys] [_ _] true)
 
 ;; driver-supports?
@@ -32,3 +30,7 @@
     (.setContextClassLoader (Thread/currentThread) (ClassLoader/getSystemClassLoader))
     (driver/the-driver :h2)
     (.getContextClassLoader (Thread/currentThread))))
+
+;; `driver/available?` should work for if `driver` is a string -- see #10135
+(expect (driver/available? ::test-driver))
+(expect (driver/available? "metabase.driver-test/test-driver"))

--- a/test/metabase/query_processor/middleware/add_settings_test.clj
+++ b/test/metabase/query_processor/middleware/add_settings_test.clj
@@ -4,7 +4,7 @@
             [metabase.models.setting :as setting]
             [metabase.query-processor.middleware.add-settings :as add-settings]))
 
-(driver/register! ::test-driver)
+(driver/register! ::test-driver, :abstract? true)
 
 (defmethod driver/supports? [::test-driver :set-timezone] [_ _] true)
 

--- a/test/metabase/query_processor/middleware/add_settings_test.clj
+++ b/test/metabase/query_processor/middleware/add_settings_test.clj
@@ -6,8 +6,6 @@
 
 (driver/register! ::test-driver)
 
-(defmethod driver/available? ::test-driver [_] false)
-
 (defmethod driver/supports? [::test-driver :set-timezone] [_ _] true)
 
 (expect

--- a/test/metabase/query_processor_test/failure_test.clj
+++ b/test/metabase/query_processor_test/failure_test.clj
@@ -5,6 +5,7 @@
             [metabase.test
              [data :as data]
              [util :as tu]]
+            [metabase.test.util.log :as tu.log]
             [metabase.util.schema :as su]
             [schema.core :as s]))
 
@@ -43,7 +44,8 @@
                   :error #"Cannot parse \"TIMESTAMP\" constant \"1\"; SQL statement:.*"
                   :cause {:class (s/eq java.lang.IllegalArgumentException)
                           :error (s/eq "1")}}}
-  (qp/process-query (bad-query)))
+  (tu.log/suppress-output
+    (qp/process-query (bad-query))))
 
 ;; running via `process-query-and-save-execution!` should return similar info and a bunch of other nonsense too
 (tu/expect-schema

--- a/test/metabase/sync/util_test.clj
+++ b/test/metabase/sync/util_test.clj
@@ -25,8 +25,6 @@
 
 (driver/register! ::concurrent-sync-test)
 
-(defmethod driver/available? ::concurrent-sync-test [_] false)
-
 (defmethod driver/describe-database ::concurrent-sync-test [& _]
   (swap! calls-to-describe-database inc)
   (Thread/sleep 1000)

--- a/test/metabase/sync/util_test.clj
+++ b/test/metabase/sync/util_test.clj
@@ -23,7 +23,7 @@
 
 (defonce ^:private calls-to-describe-database (atom 0))
 
-(driver/register! ::concurrent-sync-test)
+(driver/register! ::concurrent-sync-test, :abstract? true)
 
 (defmethod driver/describe-database ::concurrent-sync-test [& _]
   (swap! calls-to-describe-database inc)

--- a/test/metabase/sync_database_test.clj
+++ b/test/metabase/sync_database_test.clj
@@ -49,7 +49,7 @@
                         :database-type "VARCHAR"
                         :base-type     :type/Text}}}})
 
-(driver/register! ::sync-test)
+(driver/register! ::sync-test, :abstract? true)
 
 (defmethod driver/describe-database ::sync-test [& _]
   {:tables (set (for [table (vals sync-test-tables)]

--- a/test/metabase/sync_database_test.clj
+++ b/test/metabase/sync_database_test.clj
@@ -51,8 +51,6 @@
 
 (driver/register! ::sync-test)
 
-(defmethod driver/available? ::sync-test [_] false)
-
 (defmethod driver/describe-database ::sync-test [& _]
   {:tables (set (for [table (vals sync-test-tables)]
                   (dissoc table :fields)))})

--- a/test/metabase/test/mock/moviedb.clj
+++ b/test/metabase/test/mock/moviedb.clj
@@ -71,8 +71,6 @@
 
 (driver/register! ::moviedb)
 
-(defmethod driver/available? ::moviedb [_] false)
-
 (defmethod driver/describe-database ::moviedb [_ {:keys [exclude-tables]}]
   (let [tables (for [table (vals moviedb-tables)
                      :when (not (contains? exclude-tables (:name table)))]

--- a/test/metabase/test/mock/moviedb.clj
+++ b/test/metabase/test/mock/moviedb.clj
@@ -69,7 +69,7 @@
                :base-type :type/Text}}}})
 
 
-(driver/register! ::moviedb)
+(driver/register! ::moviedb, :abstract? true)
 
 (defmethod driver/describe-database ::moviedb [_ {:keys [exclude-tables]}]
   (let [tables (for [table (vals moviedb-tables)

--- a/test/metabase/test/mock/toucanery.clj
+++ b/test/metabase/test/mock/toucanery.clj
@@ -52,8 +52,6 @@
 
 (driver/register! ::toucanery)
 
-(defmethod driver/available? ::toucanery [_] false)
-
 (defmethod driver/describe-database ::toucanery [_ {:keys [exclude-tables]}]
   (let [tables (for [table (vals toucanery-tables)
                      :when (not (contains? exclude-tables (:name table)))]

--- a/test/metabase/test/mock/toucanery.clj
+++ b/test/metabase/test/mock/toucanery.clj
@@ -50,7 +50,7 @@
                               :database-type "VARCHAR"
                               :base-type     :type/Text}}}})
 
-(driver/register! ::toucanery)
+(driver/register! ::toucanery, :abstract? true)
 
 (defmethod driver/describe-database ::toucanery [_ {:keys [exclude-tables]}]
   (let [tables (for [table (vals toucanery-tables)


### PR DESCRIPTION
We didn't have a test to make sure `POST /api/setup` actually created the DB, and the endpoint failed silently if it could not find the driver with which to create the DB. There was a bug in our `driver/available?` implementations that did not work as expected if `driver` name was a string instead of keyword (it is supposed to work with either). 

* `POST /api/setup` should throw Exception if driver is unavailable rather than failing silently.
* Added tests for `POST /api/setup`
* `driver/available?` should properly handle string driver names. Added tests
* Refactored to make `driver/available?` a simple function that checks whether driver is regsitered and concrete instead of a multimethod because drivers are not supposed to implement that method anymore anyway (it has been marked as deprecated for a few months now)
*  Made a few functions in `metabase.driver` private to reduce the surface area of its interface

Fixes #10135