### PR TITLE
Fix include-drivers middleware :wrench:

### DIFF
--- a/lein-plugins/include-drivers/project.clj
+++ b/lein-plugins/include-drivers/project.clj
@@ -1,4 +1,4 @@
-(defproject metabase/lein-include-drivers "1.0.6"
+(defproject metabase/lein-include-drivers "1.0.7"
   :min-lein-version "2.5.0"
   :eval-in-leiningen true
   :deploy-repositories [["clojars" {:sign-releases false}]])

--- a/project.clj
+++ b/project.clj
@@ -196,7 +196,7 @@
 
    :with-include-drivers-middleware
    {:plugins
-    [[metabase/lein-include-drivers "1.0.6"]]
+    [[metabase/lein-include-drivers "1.0.7"]]
 
     :middleware
     [leiningen.include-drivers/middleware]}


### PR DESCRIPTION
Tweak the middleware that powers `lein ring server` to fix behavior when Oracle/Vertica driver deps aren't present