### PR TITLE
Use classloader/require everywhere; un-HACK driver test HACKs

### DIFF
--- a/lein-plugins/include-drivers/project.clj
+++ b/lein-plugins/include-drivers/project.clj
@@ -1,4 +1,5 @@
-(defproject metabase/lein-include-drivers "1.0.7"
+(defproject metabase/lein-include-drivers "1.0.8"
   :min-lein-version "2.5.0"
   :eval-in-leiningen true
-  :deploy-repositories [["clojars" {:sign-releases false}]])
+  :deploy-repositories [["clojars" {:sign-releases false}]]
+  :dependencies [[colorize "0.1.1" :exclusions [org.clojure/clojure]]])

--- a/modules/drivers/bigquery/src/metabase/driver/bigquery.clj
+++ b/modules/drivers/bigquery/src/metabase/driver/bigquery.clj
@@ -10,7 +10,6 @@
              [core :as hsql]
              [helpers :as h]]
             [metabase
-             [config :as config]
              [driver :as driver]
              [util :as u]]
             [metabase.driver
@@ -467,14 +466,7 @@
 
 (defmethod driver/supports? [:bigquery :expressions] [_ _] false)
 
-;; Don't enable foreign keys when testing because BigQuery *doesn't* have a notion of foreign keys. Joins are still
-;; allowed, which puts us in a weird position, however; people can manually specifiy "foreign key" relationships in
-;; admin and everything should work correctly. Since we can't infer any "FK" relationships during sync our normal FK
-;; tests are not appropriate for BigQuery, so they're disabled for the time being.
-;;
-;; TODO - either write BigQuery-speciifc tests for FK functionality or add additional code to manually set up these FK
-;; relationships for FK tables
-(defmethod driver/supports? [:bigquery :foreign-keys] [_ _] (not config/is-test?))
+(defmethod driver/supports? [:bigquery :foreign-keys] [_ _] true)
 
 ;; BigQuery doesn't return a timezone with it's time strings as it's always UTC, JodaTime parsing also defaults to UTC
 (defmethod driver.common/current-db-time-date-formatters :bigquery [_]

--- a/modules/drivers/bigquery/test/metabase/test/data/bigquery.clj
+++ b/modules/drivers/bigquery/test/metabase/test/data/bigquery.clj
@@ -4,6 +4,10 @@
              [format :as tformat]]
             [clojure.string :as str]
             [medley.core :as m]
+            [metabase
+             [config :as config]
+             [driver :as driver]
+             [util :as u]]
             [metabase.driver
              [bigquery :as bigquery]
              [google :as google]]
@@ -11,7 +15,6 @@
              [datasets :as datasets]
              [interface :as tx]
              [sql :as sql.tx]]
-            [metabase.util :as u]
             [metabase.util
              [date :as du]
              [schema :as su]]
@@ -23,6 +26,16 @@
            java.sql.Time))
 
 (sql.tx/add-test-extensions! :bigquery)
+
+;; Don't enable foreign keys when testing because BigQuery *doesn't* have a notion of foreign keys. Joins are still
+;; allowed, which puts us in a weird position, however; people can manually specifiy "foreign key" relationships in
+;; admin and everything should work correctly. Since we can't infer any "FK" relationships during sync our normal FK
+;; tests are not appropriate for BigQuery, so they're disabled for the time being.
+;;
+;; TODO - either write BigQuery-speciifc tests for FK functionality or add additional code to manually set up these FK
+;; relationships for FK tables
+(defmethod driver/supports? [:bigquery :foreign-keys] [_ _] (not config/is-test?))
+
 
 ;;; ----------------------------------------------- Connection Details -----------------------------------------------
 

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -13,6 +13,7 @@
              [schema :as mbql.s]
              [util :as mbql.u]]
             [metabase.models.field :refer [Field]]
+            [metabase.plugins.classloader :as classloader]
             [metabase.query-processor
              [interface :as i]
              [store :as qp.store]]
@@ -38,8 +39,8 @@
 ;; These are loaded here and not in the `:require` above because they tend to get automatically removed by
 ;; `cljr-clean-ns` and also cause Eastwood to complain about unused namespaces
 (when-not *compile-files*
-  (require 'monger.joda-time
-           'monger.json))
+  (classloader/require 'monger.joda-time
+                       'monger.json))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                     Schema                                                     |

--- a/modules/drivers/oracle/src/metabase/driver/oracle.clj
+++ b/modules/drivers/oracle/src/metabase/driver/oracle.clj
@@ -1,12 +1,8 @@
 (ns metabase.driver.oracle
-  (:require [clojure
-             [set :as set]
-             [string :as str]]
-            [clojure.java.jdbc :as jdbc]
+  (:require [clojure.java.jdbc :as jdbc]
+            [clojure.string :as str]
             [honeysql.core :as hsql]
-            [metabase
-             [config :as config]
-             [driver :as driver]]
+            [metabase.driver :as driver]
             [metabase.driver.common :as driver.common]
             [metabase.driver.sql
              [query-processor :as sql.qp]
@@ -248,8 +244,7 @@
   (apply driver.common/current-db-time args))
 
 (defmethod sql-jdbc.sync/excluded-schemas :oracle [_]
-  (set/union
-   #{"ANONYMOUS"
+  #{"ANONYMOUS"
      ;; TODO - are there othere APEX tables we want to skip? Maybe we should make this a pattern instead? (#"^APEX_")
      "APEX_040200"
      "APPQOSSYS"
@@ -274,12 +269,7 @@
      "SYSTEM"
      "WMSYS"
      "XDB"
-     "XS$NULL"}
-   (when config/is-test?
-     ;; DIRTY HACK (!) This is similar hack we do for Redshift, see the explanation there we just want to ignore all
-     ;; the test "session schemas" that don't match the current test
-     (require 'metabase.test.data.oracle)
-     ((resolve 'metabase.test.data.oracle/non-session-schemas)))))
+     "XS$NULL"})
 
 (defmethod sql-jdbc.execute/set-timezone-sql :oracle [_]
   "ALTER session SET time_zone = %s")

--- a/modules/drivers/oracle/test/metabase/test/data/oracle.clj
+++ b/modules/drivers/oracle/test/metabase/test/data/oracle.clj
@@ -109,9 +109,9 @@
   (set (map :username (jdbc/query (dbspec) ["SELECT username FROM dba_users WHERE username <> ?" session-schema]))))
 
 (let [orig (get-method sql-jdbc.sync/excluded-schemas :oracle)]
-  (defmethod sql-jdbc.sync/excluded-schemas :oracle [_]
+  (defmethod sql-jdbc.sync/excluded-schemas :oracle [driver]
     (set/union
-     (orig)
+     (orig driver)
      (when config/is-test?
        ;; This is similar hack we do for Redshift, see the explanation there we just want to ignore all the test
        ;; "session schemas" that don't match the current test

--- a/modules/drivers/oracle/test/metabase/test/data/oracle.clj
+++ b/modules/drivers/oracle/test/metabase/test/data/oracle.clj
@@ -1,14 +1,19 @@
 (ns metabase.test.data.oracle
   (:require [clojure.java.jdbc :as jdbc]
-            [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+            [clojure.set :as set]
+            [metabase
+             [config :as config]
+             [util :as u]]
+            [metabase.driver.sql-jdbc
+             [connection :as sql-jdbc.conn]
+             [sync :as sql-jdbc.sync]]
             [metabase.test.data
              [interface :as tx]
              [sql :as sql.tx]
              [sql-jdbc :as sql-jdbc.tx]]
             [metabase.test.data.sql-jdbc
              [execute :as execute]
-             [load-data :as load-data]]
-            [metabase.util :as u]))
+             [load-data :as load-data]]))
 
 (sql-jdbc.tx/add-test-extensions! :oracle)
 
@@ -102,6 +107,17 @@
   be ignored). (This is used as part of the implementation of `excluded-schemas` for the Oracle driver during tests.)"
   []
   (set (map :username (jdbc/query (dbspec) ["SELECT username FROM dba_users WHERE username <> ?" session-schema]))))
+
+(def ^:private excluded-schemas
+  (sql-jdbc.sync/excluded-schemas :oracle))
+
+(defmethod sql-jdbc.sync/excluded-schemas :oracle [_]
+  (set/union
+   excluded-schemas
+   (when config/is-test?
+     ;; This is similar hack we do for Redshift, see the explanation there we just want to ignore all the test
+     ;; "session schemas" that don't match the current test
+     (non-session-schemas))))
 
 
 ;;; Clear out the sesion schema before and after tests run

--- a/modules/drivers/presto/src/metabase/driver/presto.clj
+++ b/modules/drivers/presto/src/metabase/driver/presto.clj
@@ -13,7 +13,6 @@
              [core :as hsql]
              [helpers :as h]]
             [metabase
-             [config :as config]
              [driver :as driver]
              [util :as u]]
             [metabase.driver.common :as driver.common]
@@ -363,5 +362,4 @@
 (defmethod driver/supports? [:presto :expression-aggregations]         [_ _] true)
 (defmethod driver/supports? [:presto :binning]                         [_ _] true)
 
-;; during unit tests don't treat presto as having FK support
-(defmethod driver/supports? [:presto :foreign-keys] [_ _] (not config/is-test?))
+(defmethod driver/supports? [:presto :foreign-keys] [_ _] true)

--- a/modules/drivers/presto/test/metabase/test/data/presto.clj
+++ b/modules/drivers/presto/test/metabase/test/data/presto.clj
@@ -4,6 +4,9 @@
             [honeysql
              [core :as hsql]
              [helpers :as h]]
+            [metabase
+             [config :as config]
+             [driver :as driver]]
             [metabase.driver.presto :as presto]
             [metabase.driver.sql.util :as sql.u]
             [metabase.driver.sql.util.unprepare :as unprepare]
@@ -13,6 +16,9 @@
   (:import java.util.Date))
 
 (sql.tx/add-test-extensions! :presto)
+
+;; during unit tests don't treat presto as having FK support
+(defmethod driver/supports? [:presto :foreign-keys] [_ _] (not config/is-test?))
 
 ;;; IDriverTestExtensions implementation
 

--- a/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
+++ b/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
@@ -6,9 +6,7 @@
             [honeysql
              [core :as hsql]
              [helpers :as h]]
-            [metabase
-             [config :as config]
-             [driver :as driver]]
+            [metabase.driver :as driver]
             [metabase.driver.hive-like :as hive-like]
             [metabase.driver.sql
              [query-processor :as sql.qp]
@@ -142,7 +140,6 @@
 (defmethod driver/supports? [:sparksql :nested-queries]                  [_ _] true)
 (defmethod driver/supports? [:sparksql :standard-deviation-aggregations] [_ _] true)
 
-;; during unit tests don't treat Spark SQL as having FK support
-(defmethod driver/supports? [:sparksql :foreign-keys] [_ _] (not config/is-test?))
+(defmethod driver/supports? [:sparksql :foreign-keys] [_ _] true)
 
 (defmethod sql.qp/quote-style :sparksql [_] :mysql)

--- a/modules/drivers/sparksql/test/metabase/test/data/sparksql.clj
+++ b/modules/drivers/sparksql/test/metabase/test/data/sparksql.clj
@@ -3,9 +3,11 @@
             [clojure.string :as str]
             [honeysql
              [core :as hsql]
-             [format :as hformat]
-             [helpers :as h]]
-            [metabase.driver.hive-like :as hive-like]
+             [format :as hformat]]
+            [metabase
+             [config :as config]
+             [driver :as driver]
+             [util :as u]]
             [metabase.driver.sql
              [query-processor :as sql.qp]
              [util :as sql.u]]
@@ -14,15 +16,15 @@
              [interface :as tx]
              [sql :as sql.tx]
              [sql-jdbc :as sql-jdbc.tx]]
-            [metabase.test.data.sql.ddl :as ddl]
             [metabase.test.data.sql-jdbc
              [execute :as execute]
-             [load-data :as load-data]
-             [spec :as spec]]
-            [metabase.util :as u]
-            [metabase.util.honeysql-extensions :as hx]))
+             [load-data :as load-data]]
+            [metabase.test.data.sql.ddl :as ddl]))
 
 (sql-jdbc.tx/add-test-extensions! :sparksql)
+
+;; during unit tests don't treat Spark SQL as having FK support
+(defmethod driver/supports? [:sparksql :foreign-keys] [_ _] (not config/is-test?))
 
 (defmethod sql.tx/field-base-type->sql-type [:sparksql :type/BigInteger] [_ _] "BIGINT")
 (defmethod sql.tx/field-base-type->sql-type [:sparksql :type/Boolean]    [_ _] "BOOLEAN")

--- a/project.clj
+++ b/project.clj
@@ -196,7 +196,7 @@
 
    :with-include-drivers-middleware
    {:plugins
-    [[metabase/lein-include-drivers "1.0.7"]]
+    [[metabase/lein-include-drivers "1.0.8"]]
 
     :middleware
     [leiningen.include-drivers/middleware]}

--- a/src/metabase/api/email.clj
+++ b/src/metabase/api/email.clj
@@ -75,6 +75,8 @@
   (let [email-settings (select-keys settings (keys mb-to-smtp-settings))
         smtp-settings  (-> (set/rename-keys email-settings mb-to-smtp-settings)
                            (assoc :port (some-> (:email-smtp-port settings) Integer/parseInt)))
+        ;; TODO - this is :thumbs_down`, we should just use `with-redefs` for `email/test-smtp-connection` where
+        ;; needed in the tests. FIXME!
         response       (if-not config/is-test?
                          ;; in normal conditions, validate connection
                          (email/test-smtp-connection smtp-settings)

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -20,6 +20,7 @@
              [config :as config]
              [db :as mdb]
              [util :as u]]
+            [metabase.plugins.classloader :as classloader]
             [metabase.util.date :as du]))
 
 (defn ^:command migrate
@@ -32,7 +33,7 @@
   ([]
    (load-from-h2 nil))
   ([h2-connection-string]
-   (require 'metabase.cmd.load-from-h2)
+   (classloader/require 'metabase.cmd.load-from-h2)
    (binding [mdb/*disable-data-migrations* true]
      ((resolve 'metabase.cmd.load-from-h2/load-from-h2!) h2-connection-string))))
 
@@ -40,20 +41,20 @@
   "Start Metabase the usual way and exit. Useful for profiling Metabase launch time."
   []
   ;; override env var that would normally make Jetty block forever
-  (require 'environ.core 'metabase.core)
+  (classloader/require 'environ.core 'metabase.core)
   (alter-var-root #'environ.core/env assoc :mb-jetty-join "false")
   (du/profile "start-normally" ((resolve 'metabase.core/start-normally))))
 
 (defn ^:command reset-password
   "Reset the password for a user with `email-address`."
   [email-address]
-  (require 'metabase.cmd.reset-password)
+  (classloader/require 'metabase.cmd.reset-password)
   ((resolve 'metabase.cmd.reset-password/reset-password!) email-address))
 
 (defn ^:command refresh-integration-test-db-metadata
   "Re-sync the frontend integration test DB's metadata for the Sample Dataset."
   []
-  (require 'metabase.cmd.refresh-integration-test-db-metadata)
+  (classloader/require 'metabase.cmd.refresh-integration-test-db-metadata)
   ((resolve 'metabase.cmd.refresh-integration-test-db-metadata/refresh-integration-test-db-metadata)))
 
 (defn ^:command help
@@ -89,14 +90,14 @@
   "Generate a markdown file containing documentation for all API endpoints. This is written to a file called
   `docs/api-documentation.md`."
   []
-  (require 'metabase.cmd.endpoint-dox)
+  (classloader/require 'metabase.cmd.endpoint-dox)
   ((resolve 'metabase.cmd.endpoint-dox/generate-dox!)))
 
 (defn ^:command driver-methods
   "Print a list of all multimethods a available for a driver to implement. A useful reference when implementing a new
   driver."
   []
-  (require 'metabase.cmd.driver-methods)
+  (classloader/require 'metabase.cmd.driver-methods)
   ((resolve 'metabase.cmd.driver-methods/print-available-multimethods)))
 
 

--- a/src/metabase/cmd/driver_methods.clj
+++ b/src/metabase/cmd/driver_methods.clj
@@ -2,6 +2,7 @@
   (:require [clojure.java.classpath :as classpath]
             [clojure.string :as str]
             [clojure.tools.namespace.find :as ns-find]
+            [metabase.plugins.classloader :as classloader]
             [metabase.util :as u]))
 
 (defn- driver-ns-symbs []
@@ -11,7 +12,7 @@
          :when   (and (or (starts-with? "metabase.driver")
                           (starts-with? "metabase.test.data"))
                       (do
-                        (u/ignore-exceptions (require ns-symb))
+                        (u/ignore-exceptions (classloader/require ns-symb))
                         (find-ns ns-symb)))]
      ns-symb)))
 

--- a/src/metabase/cmd/endpoint_dox.clj
+++ b/src/metabase/cmd/endpoint_dox.clj
@@ -4,7 +4,8 @@
             [clojure.string :as str]
             [metabase
              [config :as config]
-             [util :as u]]))
+             [util :as u]]
+            [metabase.plugins.classloader :as classloader]))
 
 (defn- dox
   "Generate a Markdown string containing documentation for all Metabase API endpoints."
@@ -14,7 +15,7 @@
        "\n\n"
        (str/join "\n\n\n" (for [ns-symb     @u/metabase-namespace-symbols
                                 :when       (.startsWith (name ns-symb) "metabase.api.")
-                                [symb varr] (do (require ns-symb)
+                                [symb varr] (do (classloader/require ns-symb)
                                                 (sort (ns-interns ns-symb)))
                                 :when       (:is-endpoint? (meta varr))]
                             (:doc (meta varr))))))

--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -3,7 +3,8 @@
              [io :as io]
              [shell :as shell]]
             [clojure.string :as str]
-            [environ.core :as environ])
+            [environ.core :as environ]
+            [metabase.plugins.classloader :as classloader])
   (:import clojure.lang.Keyword))
 
 (def ^Boolean is-windows?
@@ -106,7 +107,7 @@
 ;; If for some wacky reason the test namespaces are getting loaded (e.g. when running via
 ;; `lein ring` or `lein ring sever`, DO NOT RUN THE EXPECTATIONS TESTS AT SHUTDOWN! THIS WILL NUKE YOUR APPLICATION DB
 (try
-  (require 'expectations)
+  (classloader/require 'expectations)
   ((resolve 'expectations/disable-run-on-shutdown))
   ;; This will fail if the test dependencies aren't present (e.g. in a JAR situation) which is totally fine
   (catch Throwable _))

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -19,6 +19,7 @@
             [metabase.models
              [setting :as setting]
              [user :refer [User]]]
+            [metabase.plugins.classloader :as classloader]
             [metabase.util.i18n :refer [set-locale trs]]
             [toucan.db :as db]))
 
@@ -127,7 +128,7 @@
       (System/exit 1))))
 
 (defn- run-cmd [cmd args]
-  (require 'metabase.cmd)
+  (classloader/require 'metabase.cmd)
   ((resolve 'metabase.cmd/run-cmd) cmd args))
 
 

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -401,7 +401,6 @@
   ([driver :- s/Keyword, details :- su/Map]
    (log/info (u/format-color 'cyan (trs "Verifying {0} Database Connection ..." (name driver))))
    (assert (binding [*allow-potentailly-unsafe-connections* true]
-
              (classloader/require 'metabase.driver.util)
              ((resolve 'metabase.driver.util/can-connect-with-details?) driver details :throw-exceptions))
      (trs "Unable to connect to Metabase {0} DB." (name driver)))

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -13,6 +13,7 @@
             [metabase.db
              [connection-pool :as connection-pool]
              [spec :as dbspec]]
+            [metabase.plugins.classloader :as classloader]
             [metabase.util
              [date :as du]
              [i18n :refer [trs]]
@@ -400,7 +401,8 @@
   ([driver :- s/Keyword, details :- su/Map]
    (log/info (u/format-color 'cyan (trs "Verifying {0} Database Connection ..." (name driver))))
    (assert (binding [*allow-potentailly-unsafe-connections* true]
-             (require 'metabase.driver.util)
+
+             (classloader/require 'metabase.driver.util)
              ((resolve 'metabase.driver.util/can-connect-with-details?) driver details :throw-exceptions))
      (trs "Unable to connect to Metabase {0} DB." (name driver)))
    (log/info (trs "Verify Database Connection ... ") (u/emoji "✅"))))
@@ -455,7 +457,7 @@
   "Do any custom code-based migrations now that the db structure is up to date."
   []
   (when-not *disable-data-migrations*
-    (require 'metabase.db.migrations)
+    (classloader/require 'metabase.db.migrations)
     ((resolve 'metabase.db.migrations/run-all!))))
 
 

--- a/src/metabase/events.clj
+++ b/src/metabase/events.clj
@@ -14,8 +14,8 @@
             [metabase
              [config :as config]
              [util :as u]]
+            [metabase.plugins.classloader :as classloader]
             [metabase.util.i18n :refer [trs]]))
-
 
 ;;; --------------------------------------------------- LIFECYCLE ----------------------------------------------------
 
@@ -30,7 +30,7 @@
   (when-not config/is-test?
     (doseq [ns-symb @u/metabase-namespace-symbols
             :when   (.startsWith (name ns-symb) "metabase.events.")]
-      (require ns-symb)
+      (classloader/require ns-symb)
       ;; look for `events-init` function in the namespace and call it if it exists
       (when-let [init-fn (ns-resolve ns-symb 'events-init)]
         (log/info (trs "Starting events listener:") (u/format-color 'blue ns-symb) (u/emoji "👂"))

--- a/src/metabase/handler.clj
+++ b/src/metabase/handler.clj
@@ -11,6 +11,7 @@
              [misc :as mw.misc]
              [security :as mw.security]
              [session :as mw.session]]
+            [metabase.plugins.classloader :as classloader]
             [ring.middleware
              [cookies :refer [wrap-cookies]]
              [keyword-params :refer [wrap-keyword-params]]
@@ -18,7 +19,7 @@
 
 ;; required here because this namespace is not actually used anywhere but we need it to be loaded because it adds
 ;; impls for handling `core.async` channels as web server responses
-(require 'metabase.async.api-response)
+(classloader/require 'metabase.async.api-response)
 
 (def app
   "The primary entry point to the Ring HTTP server."

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -26,12 +26,7 @@
   [database]
   (try
     ;; this is done this way to avoid circular dependencies
-    ;;
-    ;; TODO - I really need to audit all the places we call `require` and make sure they call `the-classloader` first,
-    ;; to make sure the classes get loaded into the right classloader. Actually maybe we should consider adding an
-    ;; injection into each `ns` to remove the mapping for `clojure.core/require` so you have to use the right one
-    (classloader/the-classloader)
-    (require 'metabase.task.sync-databases)
+    (classloader/require 'metabase.task.sync-databases)
     ((resolve 'metabase.task.sync-databases/schedule-tasks-for-db!) database)
     (catch Throwable e
       (log/error e (trs "Error scheduling tasks for DB")))))
@@ -44,7 +39,7 @@
   [database]
   (try
     (classloader/the-classloader)
-    (require 'metabase.task.sync-databases)
+    (classloader/require 'metabase.task.sync-databases)
     ((resolve 'metabase.task.sync-databases/unschedule-tasks-for-db!) database)
     (catch Throwable e
       (log/error e (trs "Error unscheduling tasks for DB.")))))
@@ -53,7 +48,7 @@
   [database]
   (try
     (classloader/the-classloader)
-    (require 'metabase.query-processor.middleware.async-wait)
+    (classloader/require 'metabase.query-processor.middleware.async-wait)
     ((resolve 'metabase.query-processor.middleware.async-wait/destroy-thread-pool!) database)
     (catch Throwable e
       (log/error e (trs "Error destroying thread pool for DB.")))))

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -1,5 +1,6 @@
 (ns metabase.models.field-values
   (:require [clojure.tools.logging :as log]
+            [metabase.plugins.classloader :as classloader]
             [metabase.util :as u]
             [metabase.util
              [i18n :refer [trs]]
@@ -74,7 +75,7 @@
   "Fetch a sequence of distinct values for `field` that are below the `total-max-length` threshold. If the values are
   past the threshold, this returns `nil`."
   [field]
-  (require 'metabase.db.metadata-queries)
+  (classloader/require 'metabase.db.metadata-queries)
   (let [values ((resolve 'metabase.db.metadata-queries/field-distinct-values) field)]
     (when (values-less-than-total-max-length? values)
       values)))

--- a/src/metabase/plugins/init_steps.clj
+++ b/src/metabase/plugins/init_steps.clj
@@ -19,12 +19,7 @@
 
 (defmethod do-init-step! :load-namespace [{nmspace :namespace}]
   (log/debug (u/format-color 'blue (trs "Loading plugin namespace {0}..." nmspace)))
-  ;; done for side-effects to ensure context classloader is the right one
-  (classloader/the-classloader)
-  ;; as elsewhere make sure Clojure is using our context classloader (which should normally be true anyway) because
-  ;; that's the one that will have access to the JARs we've added to the classpath at runtime
-  (binding [*use-context-classloader* true]
-    (require (symbol nmspace))))
+  (classloader/require (symbol nmspace)))
 
 (defmethod do-init-step! :register-jdbc-driver [{class-name :class}]
   (jdbc-proxy/create-and-register-proxy-driver! class-name))

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -9,6 +9,7 @@
             [metabase.models
              [common :as common]
              [setting :as setting :refer [defsetting]]]
+            [metabase.plugins.classloader :as classloader]
             [metabase.public-settings.metastore :as metastore]
             [metabase.util
              [i18n :refer [available-locales-with-names set-locale trs tru]]
@@ -201,7 +202,7 @@
    :anon_tracking_enabled (anon-tracking-enabled)
    :custom_geojson        (setting/get :custom-geojson)
    :custom_formatting     (setting/get :custom-formatting)
-   :email_configured      (do (require 'metabase.email)
+   :email_configured      (do (classloader/require 'metabase.email)
                               ((resolve 'metabase.email/email-configured?)))
    :embedding             (enable-embedding)
    :enable_query_caching  (enable-query-caching)
@@ -212,7 +213,7 @@
    :google_auth_client_id (setting/get :google-auth-client-id)
    :has_sample_dataset    (db/exists? 'Database, :is_sample true)
    :hide_embed_branding   (metastore/hide-embed-branding?)
-   :ldap_configured       (do (require 'metabase.integrations.ldap)
+   :ldap_configured       (do (classloader/require 'metabase.integrations.ldap)
                               ((resolve 'metabase.integrations.ldap/ldap-configured?)))
    :available_locales     (available-locales-with-names)
    :map_tile_server_url   (map-tile-server-url)
@@ -222,7 +223,7 @@
    :public_sharing        (enable-public-sharing)
    :report_timezone       (setting/get :report-timezone)
    :setup_token           (do
-                            (require 'metabase.setup)
+                            (classloader/require 'metabase.setup)
                             ((resolve 'metabase.setup/token-value)))
    :site_name             (site-name)
    :site_url              (site-url)

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -44,12 +44,13 @@
   ;; to no longer satisfy the protocol
   ([backend-ns-symb]
    (get-backend-instance-in-namespace backend-ns-symb :allow-reload))
+
   ([backend-ns-symb allow-reload?]
    (let [varr (ns-resolve backend-ns-symb 'instance)]
      (cond
        (not varr)             (throw (Exception. (str "No var named 'instance' found in namespace " backend-ns-symb)))
        (valid-backend? @varr) @varr
-       allow-reload?          (do (require backend-ns-symb :reload)
+       allow-reload?          (do (classloader/require backend-ns-symb :reload)
                                   (get-backend-instance-in-namespace backend-ns-symb false))
        :else                  (throw (Exception. (format "%s/instance doesn't satisfy IQueryProcessorCacheBackend"
                                                          backend-ns-symb)))))))
@@ -63,9 +64,8 @@
    (resolve-backend (config/config-kw :mb-qp-cache-backend)))
 
   ([backend]
-   (classloader/the-classloader)
    (let [backend-ns-symb (symbol (str "metabase.query-processor.middleware.cache-backend." (munge (name backend))))]
-     (require backend-ns-symb)
+     (classloader/require backend-ns-symb)
      (log/info (trs "Using query processor cache backend: {0}" (u/format-color 'blue backend)) (u/emoji "💾"))
      (get-backend-instance-in-namespace backend-ns-symb))))
 

--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -61,14 +61,11 @@
 (defn- find-and-load-task-namespaces!
   "Search Classpath for namespaces that start with `metabase.tasks.`, then `require` them so initialization can happen."
   []
-  ;; make sure current thread is using canonical MB classloader
-  (classloader/the-classloader)
-  ;; first, load all the task namespaces
   (doseq [ns-symb @u/metabase-namespace-symbols
           :when   (.startsWith (name ns-symb) "metabase.task.")]
     (try
       (log/debug (trs "Loading tasks namespace:") (u/format-color 'blue ns-symb))
-      (require ns-symb)
+      (classloader/require ns-symb)
       (catch Throwable e
         (log/error e (trs "Error loading tasks namespace {0}" ns-symb))))))
 

--- a/test/metabase/cmd/load_from_h2_test.clj
+++ b/test/metabase/cmd/load_from_h2_test.clj
@@ -5,6 +5,7 @@
              [db :as mdb]
              [util :as u]]
             [metabase.cmd.load-from-h2 :as load-from-h2]
+            [metabase.plugins.classloader :as classloader]
             [toucan
              [db :as db]
              [models :as models]]))
@@ -43,7 +44,7 @@
              :when    (or (re-find #"^metabase\.models\." (name ns))
                           (= (name ns) "metabase.db.migrations"))
              :when    (not (re-find #"test" (name ns)))
-             [_ varr] (do (require ns)
+             [_ varr] (do (classloader/require ns)
                           (ns-interns ns))
              :let     [{model-name :name, :as model} (var-get varr)]
              :when    (and (models/model? model)

--- a/test/metabase/middleware/json_test.clj
+++ b/test/metabase/middleware/json_test.clj
@@ -1,10 +1,11 @@
 (ns metabase.middleware.json-test
   (:require [cheshire.core :as json]
-            [expectations :refer [expect]]))
+            [expectations :refer [expect]]
+            [metabase.plugins.classloader :as classloader]))
 
 ;;; JSON encoding tests
 ;; Required here so so custom Cheshire encoders are loaded
-(require 'metabase.middleware.json)
+(classloader/require 'metabase.middleware.json)
 
 ;; Check that we encode byte arrays as the hex values of their first four bytes
 (expect

--- a/test/metabase/query_processor_test/timezones_test.clj
+++ b/test/metabase/query_processor_test/timezones_test.clj
@@ -18,7 +18,7 @@
   "Calls `with-db` on the `test-data-with-timezones` dataset and ensures the timestamps are fixed up on MySQL"
   [& body]
   `(data/dataset ~'test-data-with-timezones
-     (fn [] ~@body)))
+     ~@body))
 
 (def ^:private default-utc-results
   #{[6 "Shad Ferdynand" "2014-08-02T12:30:00.000Z"]})

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -214,8 +214,7 @@
   [namespace-symb symb]
   @(or (ns-resolve namespace-symb symb)
        (do
-         (classloader/the-classloader)
-         (require 'metabase.test.data.dataset-definitions)
+         (classloader/require 'metabase.test.data.dataset-definitions)
          (ns-resolve 'metabase.test.data.dataset-definitions symb))
        (throw (Exception. (format "Dataset definition not found: '%s/%s' or 'metabase.test.data.dataset-definitions/%s'"
                                   namespace-symb symb symb)))))

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -2,6 +2,7 @@
   "Internal implementation of various helper functions in `metabase.test.data`."
   (:require [clojure.tools.logging :as log]
             [metabase
+             [config :as config]
              [driver :as driver]
              [sync :as sync]
              [util :as u]]
@@ -68,26 +69,36 @@
             (log/debug (format "SET SPECIAL TYPE %s.%s -> %s" table-name field-name special-type))
             (db/update! Field (:id @field) :special_type (u/keyword->qualified-name special-type))))))))
 
+(def ^:private create-database-timeout
+  "Max amount of time to wait for driver text extensions to create a DB and load test data."
+  (* 4 60 1000)) ; 4 minutes
+
 (defn- create-database! [driver {:keys [database-name], :as database-definition}]
   {:pre [(seq database-name)]}
-  ;; Create the database and load its data
-  ;; ALWAYS CREATE DATABASE AND LOAD DATA AS UTC! Unless you like broken tests
-  (tu.tz/with-jvm-tz "UTC"
-    (tx/create-db! driver database-definition))
-  ;; Add DB object to Metabase DB
-  (let [db (db/insert! Database
-             :name    database-name
-             :engine  (name driver)
-             :details (tx/dbdef->connection-details driver :db database-definition))]
-    ;; sync newly added DB
-    (sync/sync-database! db)
-    ;; add extra metadata for fields
-    (try
-      (add-extra-metadata! database-definition db)
-      (catch Throwable e
-        (println "Error adding extra metadata:" e)))
-    ;; make sure we're returing an up-to-date copy of the DB
-    (Database (u/get-id db))))
+  (try
+    ;; Create the database and load its data
+    ;; ALWAYS CREATE DATABASE AND LOAD DATA AS UTC! Unless you like broken tests
+    (u/with-timeout create-database-timeout
+      (tu.tz/with-jvm-tz "UTC"
+        (tx/create-db! driver database-definition)))
+    ;; Add DB object to Metabase DB
+    (let [db (db/insert! Database
+               :name    database-name
+               :engine  (name driver)
+               :details (tx/dbdef->connection-details driver :db database-definition))]
+      ;; sync newly added DB
+      (sync/sync-database! db)
+      ;; add extra metadata for fields
+      (try
+        (add-extra-metadata! database-definition db)
+        (catch Throwable e
+          (println "Error adding extra metadata:" e)))
+      ;; make sure we're returing an up-to-date copy of the DB
+      (Database (u/get-id db)))
+    (catch Throwable e
+      (log/error e (format "Failed to create %s '%s' test database" driver database-name))
+      (when config/is-test?
+        (System/exit -1)))))
 
 
 (defmethod get-or-create-database! :default [driver dbdef]

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -149,7 +149,7 @@
 
 
 (defn- user-id [username]
-  (require 'metabase.test.data.users)
+  (classloader/require 'metabase.test.data.users)
   ((resolve 'metabase.test.data.users/user->id) username))
 
 (defn- rasta-id [] (user-id :rasta))

--- a/test/metabase/test_setup.clj
+++ b/test/metabase/test_setup.clj
@@ -4,6 +4,7 @@
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [metabase
+             [config :as config]
              [db :as mdb]
              [handler :as handler]
              [plugins :as plugins]
@@ -78,11 +79,37 @@
     (u/deref-with-timeout start-web-server! 10000)
     nil))
 
+(defn- shutdown-threads!
+  "Attempt to shut down any non-daemon threads that are still alive for whatever reason. For some reason lately (6/2019)
+  tests have been hanging on shutdown on occasion -- I think they might be core.async threads. (?)
+
+  Once we resolve the issues and figure out which ones are hanging we can remove this. Logged info below may help
+  debug the issues."
+  []
+  (doseq [[^Thread thread, stacktrace] (Thread/getAllStackTraces)
+          :when                        (and (.isAlive thread)
+                                            (not (.isDaemon thread))
+                                            (not= (.getName thread) "main"))]
+    (println
+     "attempting to shut down thread:"
+     (u/pprint-to-str 'blue
+       {:name        (.getName thread)
+        :state       (.name (.getState thread))
+        :alive?      (.isAlive thread)
+        :interrupted (.isInterrupted thread)
+        :frames      (take 5 stacktrace)}))
+    (try
+      (.interrupt thread)
+      (catch Throwable e
+        (log/error e "Failed to make Thread a daemon thread")))))
+
 (defn test-teardown
   {:expectations-options :after-run}
   []
   (log/info "Shutting down Metabase unit test runner")
-  (server/stop-web-server!))
+  (server/stop-web-server!)
+  (when config/is-test?
+    (shutdown-threads!)))
 
 (defn call-with-test-scaffolding
   "Runs `test-startup` and ensures `test-teardown` is always called. This function is useful for running a test (or test


### PR DESCRIPTION
*  Add a new `classloader/require` function that will load namespaces with our canonical classloader which is a nicer experience that having to remember to make sure it's being used by the current thread by calling `(classloader/the-classloader)` and binding `*use-context-classloader*`. This should make sure we don't run into any weird class not found errors if something was loaded into the wrong classloader

*  Move some test-specific driver code (like the Oracle code that tweaks the list of schemas to ignore) into driver test extension namespaces rather than the drivers themselves which was never really where they belonged in the first place. Will facilitate moving driver features lists to YAML down the road