### PR TITLE
Fix multiseries chart without data in the first series

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -128,16 +128,19 @@ export const GRAPH_DATA_SETTINGS = {
     section: t`Data`,
     title: t`X-axis`,
     widget: "fields",
-    isValid: ([{ card, data }], vizSettings) =>
-      columnsAreValid(
-        card.visualization_settings["graph.dimensions"],
-        data,
-        vizSettings["graph._dimension_filter"],
-      ) &&
-      columnsAreValid(
-        card.visualization_settings["graph.metrics"],
-        data,
-        vizSettings["graph._metric_filter"],
+    isValid: (series, vizSettings) =>
+      series.some(
+        ({ card, data }) =>
+          columnsAreValid(
+            card.visualization_settings["graph.dimensions"],
+            data,
+            vizSettings["graph._dimension_filter"],
+          ) &&
+          columnsAreValid(
+            card.visualization_settings["graph.metrics"],
+            data,
+            vizSettings["graph._metric_filter"],
+          ),
       ),
     getDefault: (series, vizSettings) => getDefaultColumns(series).dimensions,
     persistDefault: true,
@@ -167,16 +170,19 @@ export const GRAPH_DATA_SETTINGS = {
     section: t`Data`,
     title: t`Y-axis`,
     widget: "fields",
-    isValid: ([{ card, data }], vizSettings) =>
-      columnsAreValid(
-        card.visualization_settings["graph.dimensions"],
-        data,
-        vizSettings["graph._dimension_filter"],
-      ) &&
-      columnsAreValid(
-        card.visualization_settings["graph.metrics"],
-        data,
-        vizSettings["graph._metric_filter"],
+    isValid: (series, vizSettings) =>
+      series.some(
+        ({ card, data }) =>
+          columnsAreValid(
+            card.visualization_settings["graph.dimensions"],
+            data,
+            vizSettings["graph._dimension_filter"],
+          ) &&
+          columnsAreValid(
+            card.visualization_settings["graph.metrics"],
+            data,
+            vizSettings["graph._metric_filter"],
+          ),
       ),
     getDefault: (series, vizSettings) => getDefaultColumns(series).metrics,
     persistDefault: true,

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -215,11 +215,13 @@ export const GRAPH_BUBBLE_SETTINGS = {
     section: t`Data`,
     title: t`Bubble size`,
     widget: "field",
-    isValid: ([{ card, data }], vizSettings) =>
-      columnsAreValid(
-        [card.visualization_settings["scatter.bubble"]],
-        data,
-        isNumeric,
+    isValid: (series, vizSettings) =>
+      series.some(({ card, data }) =>
+        columnsAreValid(
+          [card.visualization_settings["scatter.bubble"]],
+          data,
+          isNumeric,
+        ),
       ),
     getDefault: series => getDefaultColumns(series).bubble,
     getProps: ([{ card, data }], vizSettings, onChange) => {


### PR DESCRIPTION
Resovles #9893

The core problem was that when a series is empty, the column types are returned as `type/*`. If the _first_ series had no rows returned, the saved metrics and dimensions would be invalid. This would lead to the confusing error message "What fields do you want to use for the X and Y axes?"

Why just the first series? When checking for validity we destructured the first series, but ignored any others.

The fix I made here was to change the two relevant `isValid` functions to check if **any** series is valid.

old:
```js
isValid: ([{ card, data }], vizSettings) => stuff
```

new:
```js
isValid: (series, vizSettings) => series.some(({ card, data }) => stuff
```

Is this the right change? It definitely seems wrong to only look a the first series to check validity, but without seeing this bug, I would have guessed the right answer is to use `every` here rather than `some`.

As an alternative, is it possible to have results with no rows still return the type of the columns? That would let us use `every` every even when results have no rows.

If we _do_ want to keep this change, should I update the other settings defs beyond, `graph.metrics` and `graph.dimensions`? There are a handful of others that similarly destructure the first series.