### PR TITLE
GA driver doesn't support basic aggregations; add missing declaration

### DIFF
--- a/modules/drivers/googleanalytics/src/metabase/driver/googleanalytics.clj
+++ b/modules/drivers/googleanalytics/src/metabase/driver/googleanalytics.clj
@@ -15,6 +15,9 @@
 
 (driver/register! :googleanalytics, :parent :google)
 
+(defmethod driver/supports? [:googleanalytics :basic-aggregations] [_ _] false)
+
+
 ;;; ----------------------------------------------------- Client -----------------------------------------------------
 
 (defn- ^Analytics credential->client [^GoogleCredential credential]


### PR DESCRIPTION
Oversight on my part. GA is doesn't support basic aggregations so it shouldn't be in the driver features lists