### PR TITLE
Only use formatStringFallback if there's no special type on the column

### DIFF
--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -630,7 +630,11 @@ export function formatValueRaw(value: Value, options: FormattingOptions = {}) {
   ) {
     return formatDateTime(value, options);
   } else if (typeof value === "string") {
-    return formatStringFallback(value, options);
+    if (column && column.special_type != null) {
+      return value;
+    } else {
+      return formatStringFallback(value, options);
+    }
   } else if (typeof value === "number" && isCoordinate(column)) {
     const range = rangeForValue(value, options.column);
     if (range && !options.noRange) {

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -157,6 +157,15 @@ describe("formatting", () => {
         ),
       ).toEqual(true);
     });
+    it("should not add mailto prefix if there's a different special type", () => {
+      expect(
+        formatValue("foobar@example.com", {
+          jsx: true,
+          rich: true,
+          column: { special_type: "type/PK" },
+        }),
+      ).toEqual("foobar@example.com");
+    });
   });
 
   describe("formatUrl", () => {


### PR DESCRIPTION
Resolves #7775

I just used @tlrobinson's suggested solution from the issue: https://github.com/metabase/metabase/issues/7775#issuecomment-393991854