### PR TITLE
Fix misaligned tooltips in Firefox

### DIFF
--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -524,7 +524,7 @@ function getCharts(
         // shift bar/line and dots
         .selectAll(".stack, .dc-tooltip")
         .each(function() {
-          this.style.transform = `translate(${spacing / 2}px, 0)`;
+          this.setAttribute("transform", `translate(${spacing / 2}, 0)`);
         });
     });
   }


### PR DESCRIPTION
Resolves #10184 

I'm still not quite sure what the issue is in Firefox, but the new code works in Firefox, Chrome, and Safari.