### PR TITLE
Use adoptopenjdk/openjdk11:alpine-jre as new Docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN keytool -noprompt -import -trustcacerts -alias aws-rds \
 # # STAGE 2: runner
 # ###################
 
-FROM openjdk:8-jre-alpine as runner
+FROM adoptopenjdk/openjdk11:alpine-jre as runner
 
 WORKDIR /app
 

--- a/bin/docker/Dockerfile
+++ b/bin/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-alpine
+FROM adoptopenjdk/openjdk11:alpine-jre
 
 ENV FC_LANG en-US
 ENV LC_CTYPE en_US.UTF-8


### PR DESCRIPTION
As discussed last week.

*  Most of the community is switching over to AdoptOpenJDK stuff these days as official support from Oracle is limited
*  We've fully supported Java 11 for a while, test against it, and most of us use it locally for development
*  AdoptOpenJDK is committed to shipping Java 11 as an LTS release so we can continue using it as a base image for a while
*  Java 11 should have some nice performance improvements and better memory usage
*  Most importantly, Java 11 better respects ulimits when running in containerized environments when automatically determining heap memory limits and the like, which should make running in constrained environments (especially Heroku hobby dynos) less of a delicate balancing act