### PR TITLE
Fix internal version numbers for Redshift driver

### DIFF
--- a/modules/drivers/redshift/project.clj
+++ b/modules/drivers/redshift/project.clj
@@ -1,4 +1,4 @@
-(defproject metabase/redshift-driver "1.0.0-SNAPSHOT-1.2.18.1036"
+(defproject metabase/redshift-driver "1.0.0-SNAPSHOT-1.2.27.1051"
   :min-lein-version "2.5.0"
 
   :repositories

--- a/modules/drivers/redshift/resources/metabase-plugin.yaml
+++ b/modules/drivers/redshift/resources/metabase-plugin.yaml
@@ -1,6 +1,6 @@
 info:
   name: Metabase Redshift Driver
-  version: 1.0.0-SNAPSHOT-1.2.18.1036
+  version: 1.0.0-SNAPSHOT-1.2.27.1051
   description: Allows Metabase to connect to Redshift databases.
 driver:
   name: redshift


### PR DESCRIPTION
Driver version is currently only used internally (subject to change in the future)

Update internal versions to fix confusion WRT what JDBC driver version we're using.

Resolves #9981