### PR TITLE
Use Clojure 1.10.1 :racing_car:

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -32,7 +32,7 @@
   ;; !!                                   AND ADD A COMMENT EXPLAINING THEIR PURPOSE                                  !!
   ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   :dependencies
-  [[org.clojure/clojure "1.10.0"]
+  [[org.clojure/clojure "1.10.1"]
    [org.clojure/core.async "0.4.490"
     :exclusions [org.clojure/tools.reader]]
    [org.clojure/core.match "0.3.0"]                                   ; optimized pattern matching library for Clojure


### PR DESCRIPTION
Clojure 1.10.1 is out that includes a fix for a "drastic performance regression" caused by changes to the JVM in certain builds. See https://clojure.org/news/2019/06/06/clojure1-10-1