### PR TITLE
Add special case for timeseries with one x value

### DIFF
--- a/frontend/src/metabase/visualizations/lib/timeseries.js
+++ b/frontend/src/metabase/visualizations/lib/timeseries.js
@@ -196,6 +196,10 @@ function computeTimeseriesDataInvervalIndex(xValues, unit) {
   if (unit && INTERVAL_INDEX_BY_UNIT[unit] != undefined) {
     return INTERVAL_INDEX_BY_UNIT[unit];
   }
+  // Always use 'day' when there's just one value.
+  if (xValues.length === 1) {
+    return TIMESERIES_INTERVALS.findIndex(ti => ti.interval === "day");
+  }
   // Keep track of the value seen for each level of granularity,
   // if any don't match then we know the data is *at least* that granular.
   const values = [];

--- a/frontend/test/metabase/visualizations/lib/timeseries.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/timeseries.unit.spec.js
@@ -132,6 +132,7 @@ describe("visualization.lib.timeseries", () => {
         10,
         [["2015-01-01T00:00:00.000Z"], ["2025-01-01T00:00:00.000Z"]],
       ],
+      ["day", 1, [["2019-01-01T00:00:00.000Z"]]],
     ];
 
     TEST_CASES.map(([expectedInterval, expectedCount, data]) => {


### PR DESCRIPTION
I toyed with the idea of still using `TIMESERIES_INTERVALS` and showing the right "resolution" for a single timestamp. After thinking more about it, I'm not sure it makes sense so I just added a special case to always pick "day" when there's just one timestamp.