### PR TITLE
Use SQL Server Docker image for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
   default:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:lein-2.8.1-node-browsers
+      - image: circleci/clojure:lein-2.9.1-node-browsers
 
   build:
     working_directory: /home/circleci/metabase/metabase/
@@ -18,12 +18,12 @@ executors:
   java-11:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:openjdk-11-lein-2.8.1
+      - image: circleci/clojure:openjdk-11-lein-2.9.1
 
   postgres-9-6:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:lein-2.8.1-node-browsers
+      - image: circleci/clojure:lein-2.9.1
         environment:
           MB_DB_TYPE: postgres
           MB_DB_PORT: 5432
@@ -44,7 +44,7 @@ executors:
         default: ""
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:lein-2.8.1-node-browsers
+      - image: circleci/clojure:lein-2.9.1
         environment:
           MB_DB_TYPE: mysql
           MB_DB_HOST: localhost
@@ -58,17 +58,16 @@ executors:
   mongo:
      working_directory: /home/circleci/metabase/metabase/
      docker:
-       - image: circleci/clojure:lein-2.8.1-node-browsers
+       - image: circleci/clojure:lein-2.9.1
        - image: circleci/mongo:3.4
 
   presto:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:lein-2.8.1-node-browsers
+      - image: circleci/clojure:lein-2.9.1
         environment:
           MB_PRESTO_TEST_HOST: localhost
           MB_PRESTO_TEST_PORT: 8080
-
       - image: metabase/presto-mb-ci
         environment:
           JAVA_TOOL_OPTIONS: "-Xmx2g"
@@ -76,14 +75,27 @@ executors:
   sparksql:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:lein-2.8.1-node-browsers
+      - image: circleci/clojure:lein-2.9.1
       - image: metabase/spark:2.1.1
 
   vertica:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:lein-2.8.1-node-browsers
+      - image: circleci/clojure:lein-2.9.1
       - image: sumitchawla/vertica
+
+  sqlserver:
+    working_directory: /home/circleci/metabase/metabase/
+    docker:
+      - image: circleci/clojure:lein-2.9.1
+        environment:
+          MB_SQLSERVER_TEST_HOST: localhost
+          MB_SQLSERVER_TEST_PASSWORD: 'P@ssw0rd'
+          MB_SQLSERVER_TEST_USER: SA
+      - image: mcr.microsoft.com/mssql/server:2017-latest
+        environment:
+          ACCEPT_EULA: Y
+          SA_PASSWORD: 'P@ssw0rd'
 
 
 
@@ -573,6 +585,7 @@ workflows:
           name: be-tests-sqlserver
           requires:
             - be-tests
+          e: sqlserver
           driver: sqlserver
 
       - test-driver:

--- a/project.clj
+++ b/project.clj
@@ -99,7 +99,7 @@
                  com.sun.jdmk/jmxtools
                  com.sun.jmx/jmxri]]
    [medley "1.2.0"]                                                   ; lightweight lib of useful functions
-   [metabase/mbql "1.0.1"]                                            ; MBQL language schema & util fns
+   [metabase/mbql "1.0.2"]                                            ; MBQL language schema & util fns
    [metabase/throttle "1.0.1"]                                        ; Tools for throttling access to API endpoints and other code pathways
    [javax.xml.bind/jaxb-api "2.4.0-b180830.0359"]                     ; add the `javax.xml.bind` classes which we're still using but were removed in Java 11
    [net.sf.cssbox/cssbox "4.12" :exclusions [org.slf4j/slf4j-api]]    ; HTML / CSS rendering


### PR DESCRIPTION
We live in a crazy alternate universe where M$ has made SQL Server Linux Docker images available so we might as well start using those for CI instead of relying on the instance we have living in RDS.

This will let us run tests locally much faster and much more easily and let us run tests against community PRs for SQL Server stuff as well.

Resolves #9976