### PR TITLE
Disable draggable action buttons on cards when editing dashboard

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -239,7 +239,7 @@ const ChartSettingsButton = ({ series, onReplaceAllVisualizationSettings }) => (
     triggerElement={
       <Icon name="gear" size={HEADER_ICON_SIZE} style={HEADER_ACTION_STYLE} />
     }
-    triggerClasses="text-light text-medium-hover cursor-pointer flex align-center flex-no-shrink mr1"
+    triggerClasses="text-light text-medium-hover cursor-pointer flex align-center flex-no-shrink mr1 drag-disabled"
   >
     <ChartSettingsWithState
       series={series}
@@ -251,7 +251,7 @@ const ChartSettingsButton = ({ series, onReplaceAllVisualizationSettings }) => (
 
 const RemoveButton = ({ onRemove }) => (
   <a
-    className="text-light text-medium-hover "
+    className="text-light text-medium-hover drag-disabled"
     data-metabase-event="Dashboard;Remove Card Modal"
     onClick={onRemove}
     style={HEADER_ACTION_STYLE}
@@ -263,7 +263,7 @@ const RemoveButton = ({ onRemove }) => (
 const AddSeriesButton = ({ series, onAddSeries }) => (
   <a
     data-metabase-event={"Dashboard;Edit Series Modal;open"}
-    className="text-light text-medium-hover cursor-pointer h3 flex-no-shrink relative mr1"
+    className="text-light text-medium-hover cursor-pointer h3 flex-no-shrink relative mr1 drag-disabled"
     onClick={onAddSeries}
     style={HEADER_ACTION_STYLE}
   >

--- a/frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx
@@ -147,8 +147,7 @@ export default class DashCardCardParameterMapper extends Component {
 
     return (
       <div
-        className="mx1 flex flex-column align-center"
-        onMouseDown={e => e.stopPropagation()}
+        className="mx1 flex flex-column align-center drag-disabled"
       >
         {dashcard.series && dashcard.series.length > 0 && (
           <div

--- a/frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx
@@ -146,9 +146,7 @@ export default class DashCardCardParameterMapper extends Component {
     }
 
     return (
-      <div
-        className="mx1 flex flex-column align-center drag-disabled"
-      >
+      <div className="mx1 flex flex-column align-center drag-disabled">
         {dashcard.series && dashcard.series.length > 0 && (
           <div
             className="h5 mb1 text-bold"

--- a/frontend/src/metabase/visualizations/visualizations/Text.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text.jsx
@@ -211,10 +211,13 @@ const TextActionButtons = ({
       >
         <a
           data-metabase-event={"Dashboard;Text;edit"}
-          className={cx(" cursor-pointer h3 flex-no-shrink relative mr1", {
-            "text-light text-medium-hover": isShowingRenderedOutput,
-            "text-brand": !isShowingRenderedOutput,
-          })}
+          className={cx(
+            "cursor-pointer h3 flex-no-shrink relative mr1 drag-disabled",
+            {
+              "text-light text-medium-hover": isShowingRenderedOutput,
+              "text-brand": !isShowingRenderedOutput,
+            },
+          )}
           onClick={onEdit}
           style={HEADER_ACTION_STYLE}
         >
@@ -231,10 +234,13 @@ const TextActionButtons = ({
 
         <a
           data-metabase-event={"Dashboard;Text;preview"}
-          className={cx(" cursor-pointer h3 flex-no-shrink relative mr1", {
-            "text-light text-medium-hover": !isShowingRenderedOutput,
-            "text-brand": isShowingRenderedOutput,
-          })}
+          className={cx(
+            "cursor-pointer h3 flex-no-shrink relative mr1 drag-disabled",
+            {
+              "text-light text-medium-hover": !isShowingRenderedOutput,
+              "text-brand": isShowingRenderedOutput,
+            },
+          )}
           onClick={onPreview}
           style={HEADER_ACTION_STYLE}
         >


### PR DESCRIPTION
This should fix #2187, #3313, #5301, #7246 + many forum posts.
EDIT: And also prevent draggable filter mappings (#5365, #7068).

This uses the `DraggableCore`s `cancel` parameter, which is used for the lower-right corner resizable handler of cards (`.react-resizable-handle`) and textarea on Text Box cards (`.drag-disabled`).
I've tried to look for tests, which does some drag events, but can't find any in the source, so no tests :cry:

I have not been able to reproduce the issue, but it seems like it's hitting a lot of people.
Tried with Chrome+Opera+Brave+Firefox+IE+Edge on Windows 10+2012 (and several Linux) using touchpad+trackpoint+touchscreen+mouse.