### PR TITLE
Better documentation about HTTPS

### DIFF
--- a/docs/operations-guide/start.md
+++ b/docs/operations-guide/start.md
@@ -280,15 +280,17 @@ By default, Metabase will be listening on `localhost`.  In some production envir
 
 ### Using HTTPS with Metabase
 
-If you have an ssl certificate and would prefer to have Metabase run over HTTPS directly using its webserver you can do so by using the following environment variables:
+If you have an SSL certificate and would prefer to have Metabase run over HTTPS directly using its webserver you can do so by using the following environment variables:
 
     export MB_JETTY_SSL="true"
-    export MB_JETTY_SSL_Port="8443"
-    export MB_JETTY_SSL_Keystore="path/to/keystore.jks"
-    export MB_JETTY_SSL_Keystore_Password="storepass"
+    export MB_JETTY_SSL_PORT="8443"
+    export MB_JETTY_SSL_KEYSTORE="path/to/keystore.jks" # replace these values with your own
+    export MB_JETTY_SSL_KEYSTORE_PASSWORD="storepass"
     java -jar metabase.jar
+    
+Be sure to replace `MB_JETTY_SSL_KEYSTORE` and `MB_JETTY_SSL_KEYSTORE_PASSWORD` with the correct path and password, respectively, to your [Java KeyStore](https://www.digitalocean.com/community/tutorials/java-keytool-essentials-working-with-java-keystores). With the above settings applied you will be running Metabase on port 8443 over HTTPS using the supplied certificate.
 
-With the above settings applied you will be running Metabase on port 8443 over HTTPS using the supplied certificate.  #secured
+No idea how to generate a Java KeyStore yourself? This is sort of an advanced topic, but if you're feeling froggy you can read more about how to configure SSL in Jetty [here](https://www.eclipse.org/jetty/documentation/current/configuring-ssl.html). Otherwise, you'll probably find it easiest to handle SSL termination outside of Metabase, for example by the Elastic Load Balancer if deploying via Elastic Beanstalk.
 
 
 # Changing Metabase password complexity


### PR DESCRIPTION
I think some people literally thought you set the env vars as follows:

```
export MB_JETTY_SSL_Keystore="path/to/keystore.jks"
export MB_JETTY_SSL_Keystore_Password="storepass"
```

and it would work. I've added a note to tell people to replace that, and if they have no idea what a Java KeyStore is, some links to get them started, and a note that if they don't know what it is they might have an easier time letting something like an ELB handle their SSL termination.