### PR TITLE
Fix regression against syncing SparkSQL string type

### DIFF
--- a/modules/drivers/sparksql/src/metabase/driver/hive_like.clj
+++ b/modules/drivers/sparksql/src/metabase/driver/hive_like.clj
@@ -23,25 +23,26 @@
 
 (defmethod sql-jdbc.sync/database-type->base-type :hive-like [_ database-type]
   (condp re-matches (name database-type)
-    #"boolean"               :type/Boolean
-    #"tinyint"               :type/Integer
-    #"smallint"              :type/Integer
-    #"int"                   :type/Integer
-    #"bigint"                :type/BigInteger
-    #"float"                 :type/Float
-    #"double"                :type/Float
-    #"double precision"      :type/Double
-    #"decimal.*"             :type/Decimal
-    #"char.*"                :type/Text
-    #"varchar.*"             :type/Text
-    #"binary*"               :type/*
-    #"date"                  :type/Date
-    #"time"                  :type/Time
-    #"timestamp"             :type/DateTime
-    #"interval"              :type/*
-    #"array.*"               :type/Array
-    #"map"                   :type/Dictionary
-    #".*"                    :type/*))
+    #"boolean"          :type/Boolean
+    #"tinyint"          :type/Integer
+    #"smallint"         :type/Integer
+    #"int"              :type/Integer
+    #"bigint"           :type/BigInteger
+    #"float"            :type/Float
+    #"double"           :type/Float
+    #"double precision" :type/Double
+    #"decimal.*"        :type/Decimal
+    #"char.*"           :type/Text
+    #"varchar.*"        :type/Text
+    #"string.*"         :type/Text
+    #"binary*"          :type/*
+    #"date"             :type/Date
+    #"time"             :type/Time
+    #"timestamp"        :type/DateTime
+    #"interval"         :type/*
+    #"array.*"          :type/Array
+    #"map"              :type/Dictionary
+    #".*"               :type/*))
 
 (defmethod sql.qp/current-datetime-fn :hive-like [_] :%now)
 

--- a/modules/drivers/sparksql/test/metabase/driver/hive_like_test.clj
+++ b/modules/drivers/sparksql/test/metabase/driver/hive_like_test.clj
@@ -1,0 +1,10 @@
+(ns metabase.driver.hive-like-test
+  (:require [expectations :refer [expect]]
+            [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]))
+
+;; make sure the various types we use for running tests are actually mapped to the correct DB type
+(expect :type/Text     (sql-jdbc.sync/database-type->base-type :hive-like :string))
+(expect :type/Integer  (sql-jdbc.sync/database-type->base-type :hive-like :int))
+(expect :type/Date     (sql-jdbc.sync/database-type->base-type :hive-like :date))
+(expect :type/DateTime (sql-jdbc.sync/database-type->base-type :hive-like :timestamp))
+(expect :type/Float    (sql-jdbc.sync/database-type->base-type :hive-like :double))

--- a/modules/drivers/sparksql/test/metabase/driver/sparksql_test.clj
+++ b/modules/drivers/sparksql/test/metabase/driver/sparksql_test.clj
@@ -1,5 +1,5 @@
 (ns metabase.driver.sparksql-test
-  (:require [expectations :refer :all]
+  (:require [expectations :refer [expect]]
             [metabase.driver.sql.query-processor :as sql.qp]))
 
 ;; Make sure our custom implementation of `apply-page` works the way we'd expect


### PR DESCRIPTION
#10207 left out the `string` type which caused lots of our tests to break.