### PR TITLE
Fix edit segments and metrics

### DIFF
--- a/src/metabase/api/metric.clj
+++ b/src/metabase/api/metric.clj
@@ -77,7 +77,7 @@
         new-def    (->> clean-body :definition (normalize/normalize-fragment []))
         new-body   (merge
                      (dissoc clean-body :revision_message)
-                     {:definition new-def})
+                     (when new-def {:definition new-def}))
         changes    (when-not (= new-body existing)
                      new-body)
         archive?   (:archived changes)]

--- a/src/metabase/api/metric.clj
+++ b/src/metabase/api/metric.clj
@@ -8,6 +8,7 @@
              [related :as related]
              [util :as u]]
             [metabase.api.common :as api]
+            [metabase.mbql.normalize :as normalize]
             [metabase.models
              [interface :as mi]
              [metric :as metric :refer [Metric]]
@@ -69,13 +70,17 @@
   "Check whether current user has write permissions, then update Metric with values in `body`. Publishes appropriate
   event and returns updated/hydrated Metric."
   [id {:keys [revision_message archived], :as body}]
-  (let [existing (api/write-check Metric id)
-        [changes] (data/diff
-                   (u/select-keys-when body
+  (let [existing   (api/write-check Metric id)
+        clean-body (u/select-keys-when body
                      :present #{:description :caveats :how_is_this_calculated :points_of_interest}
                      :non-nil #{:archived :definition :name :show_in_getting_started})
-                   existing)
-        archive? (:archived changes)]
+        new-def    (->> clean-body :definition (normalize/normalize-fragment []))
+        new-body   (merge
+                     (dissoc clean-body :revision_message)
+                     {:definition new-def})
+        changes    (when-not (= new-body existing)
+                     new-body)
+        archive?   (:archived changes)]
     (when changes
       (db/update! Metric id changes))
     (u/prog1 (hydrated-metric id)

--- a/src/metabase/api/segment.clj
+++ b/src/metabase/api/segment.clj
@@ -1,7 +1,6 @@
 (ns metabase.api.segment
   "/api/segment endpoints."
-  (:require [clojure.data :as data]
-            [clojure.tools.logging :as log]
+  (:require [clojure.tools.logging :as log]
             [compojure.core :refer [DELETE GET POST PUT]]
             [metabase
              [events :as events]
@@ -65,7 +64,7 @@
         clean-body (u/select-keys-when body
                      :present #{:description :caveats :points_of_interest}
                      :non-nil #{:archived :definition :name :show_in_getting_started})
-        norm-body  (->> clean-body (normalize/normalize-fragment [:definition]) )
+        norm-body  (->> clean-body (normalize/normalize-fragment [:definition]))
         changes    (when-not (= norm-body existing)
                      norm-body)
         archive?   (:archived changes)]

--- a/src/metabase/api/segment.clj
+++ b/src/metabase/api/segment.clj
@@ -8,6 +8,7 @@
              [related :as related]
              [util :as u]]
             [metabase.api.common :as api]
+            [metabase.mbql.normalize :as normalize]
             [metabase.models
              [interface :as mi]
              [revision :as revision]
@@ -66,7 +67,11 @@
                      :present #{:description :caveats :points_of_interest}
                      :non-nil #{:archived :definition :name :show_in_getting_started})
                    existing)
-        archive?  (:archived changes)]
+        archive?  (:archived changes)
+        new-def   (->> body (normalize/normalize-fragment [:definition :filter] ) :definition)
+        changes   (if (= new-def (:definition existing))
+                    (dissoc changes :definition)
+                    (assoc changes :definition new-def))]
     (when changes
       (db/update! Segment id changes))
     (u/prog1 (hydrated-segment id)

--- a/src/metabase/api/segment.clj
+++ b/src/metabase/api/segment.clj
@@ -67,7 +67,7 @@
         new-def    (->> clean-body :definition (normalize/normalize-fragment []))
         new-body   (merge
                      (dissoc clean-body :revision_message)
-                     {:definition new-def})
+                     (when new-def {:definition new-def}))
         changes    (when-not (= new-body existing)
                      new-body)
         archive?   (:archived changes)]

--- a/src/metabase/api/segment.clj
+++ b/src/metabase/api/segment.clj
@@ -64,9 +64,12 @@
         clean-body (u/select-keys-when body
                      :present #{:description :caveats :points_of_interest}
                      :non-nil #{:archived :definition :name :show_in_getting_started})
-        norm-body  (->> clean-body (normalize/normalize-fragment [:definition]))
-        changes    (when-not (= norm-body existing)
-                     norm-body)
+        new-def    (->> clean-body :definition (normalize/normalize-fragment []))
+        new-body   (merge
+                     (dissoc clean-body :revision_message)
+                     {:definition new-def})
+        changes    (when-not (= new-body existing)
+                     new-body)
         archive?   (:archived changes)]
     (when changes
       (db/update! Segment id changes))

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -81,7 +81,7 @@
   :in  (comp json-in maybe-normalize)
   :out (comp (catch-normalization-exceptions maybe-normalize) json-out-with-keywordization))
 
-;; `metric-segment-definition` is, predicatbly, for Metric/Segment `:definition`s, which are just the inner MBQL query
+;; `metric-segment-definition` is, predictably, for Metric/Segment `:definition`s, which are just the inner MBQL query
 (defn- normalize-metric-segment-definition [definition]
   (when definition
     (normalize/normalize-fragment [:query] definition)))

--- a/test/metabase/api/metric_test.clj
+++ b/test/metabase/api/metric_test.clj
@@ -139,7 +139,7 @@
           :creator_id (user->id :rasta)
           :creator    (user-details (fetch-user :rasta))
           :definition {:database 2
-                       :query    {:filter ["not" "the toucans you're looking for"]}}})
+                       :query    {:filter ["not" ["=" "field" "the toucans you're looking for"]]}}})
   (tt/with-temp* [Database [{database-id :id}]
                   Table    [{table-id :id} {:db_id database-id}]
                   Metric   [{:keys [id]} {:table_id table-id}]]
@@ -155,7 +155,7 @@
        :table_id                456
        :revision_message        "I got me some revisions"
        :definition              {:database 2
-                                 :query    {:filter ["not" "the toucans you're looking for"]}}}))))
+                                 :query    {:filter ["not" ["=" "field" "the toucans you're looking for"]]}}}))))
 
 ;; Can we archive a Metric with the PUT endpoint?
 


### PR DESCRIPTION
https://github.com/metabase/metabase/issues/9783

Currently, we are using the results of non-normalized diff to determine which parts of a segment sent from the FE we should update.  This result in inconsistent results. 

This PR first normalizes the `:definition` of a new segment from FE, compares to (already-normalized) existing segment in db, and if it has changed, update with new value in db.

Above also applies to metrics

TODO:
- [x] tests
- [x] update docstrings in changed fns
- [x] apply fix to metrics