### PR TITLE
Add info about deploying metabase on D2C

### DIFF
--- a/docs/operations-guide/running-metabase-on-d2c.md
+++ b/docs/operations-guide/running-metabase-on-d2c.md
@@ -1,0 +1,28 @@
+# Deploying Metabase on D2C.io
+
+## Supported cloud providers
+
+- AWS
+- GCP
+- Digital Ocean
+- Vultr
+- UpCloud
+
+## Supported operation systems and other requirements for connecting own servers:
+
+- OS: Ubuntu server 16.04/18.04; Debian 8/9
+- We strongly recommend to use a kernel with version >= 4.0 for better Docker performance using OverlayFS, otherwise the storage driver - will be "devicemapper"
+- Free disk space: 5 Gb
+- Opened incoming SSH port
+- For the Weave network to work, you must open ports 6783, 6784 (TCP/UDP)
+- For better performance, we recommend ensuring that VXLAN tunneling is allowed
+
+## Deploy
+
+Single click deployment:
+
+[![Deploy](https://raw.githubusercontent.com/mastappl/images/master/deployTo.png)](https://panel.d2c.io/?import=https://github.com/d2cio/metabase-postgres-stack/archive/master.zip/)
+
+### Demo
+
+![How to deploy a stack](https://raw.githubusercontent.com/mastappl/images/master/metabase.gif)

--- a/docs/operations-guide/start.md
+++ b/docs/operations-guide/start.md
@@ -46,6 +46,9 @@ Community support only at this time, but learn how to deploy Metabase as a servi
 #### [Running on Kubernetes](running-metabase-on-kubernetes.md)
 Community Helm chart for running Metabase on Kubernetes
 
+#### [Running on D2C](running-metabase-on-d2c.md)
+Community support for running Metabase on D2C
+
 # Upgrading Metabase
 
 Before you attempt to upgrade Metabase, you should make a backup of the application database just in case. While it is unlikely you will need to roll back, it will do wonders for your peace of mind.


### PR DESCRIPTION
D2C is a private virtual PaaS. 
We've prepared a stack which allows users to deploy Metabase to linked cloud providers or own server with a single click.
The stack page is here - https://d2c.io/stackhub/metabase