### PR TITLE
Fix segment/metric form to only ask for desc of changes for existing records

### DIFF
--- a/frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx
@@ -6,7 +6,6 @@ import FormInput from "../components/FormInput.jsx";
 import FormTextArea from "../components/FormTextArea.jsx";
 import FieldSet from "metabase/components/FieldSet.jsx";
 import PartialQueryBuilder from "../components/PartialQueryBuilder.jsx";
-import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper.jsx";
 import { t } from "ttag";
 import { formatValue } from "metabase/lib/formatting";
 
@@ -99,101 +98,95 @@ export default class MetricForm extends Component {
     const isNewRecord = id.value === "";
 
     return (
-      <LoadingAndErrorWrapper loading={!table && !table.aggregation_options}>
-        {() => (
-          <form className="full" onSubmit={handleSubmit}>
-            <div className="wrapper py4">
-              <FormLabel
-                title={
-                  isNewRecord ? t`Create Your Metric` : t`Edit Your Metric`
+      <form className="full" onSubmit={handleSubmit}>
+        <div className="wrapper py4">
+          <FormLabel
+            title={isNewRecord ? t`Create Your Metric` : t`Edit Your Metric`}
+            description={
+              isNewRecord
+                ? t`You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating "Average Price" for an Orders table.`
+                : t`Make changes to your metric and leave an explanatory note.`
+            }
+          >
+            {metadata && table && (
+              <PartialQueryBuilder
+                features={{
+                  filter: true,
+                  aggregation: true,
+                }}
+                metadata={
+                  metadata.tables &&
+                  metadata.tables[table.id].fields &&
+                  Object.assign(new Metadata(), metadata, {
+                    tables: {
+                      ...metadata.tables,
+                      [table.id]: Object.assign(
+                        new Table(),
+                        metadata.tables[table.id],
+                        {
+                          aggregation_options: (
+                            table.aggregation_options || []
+                          ).filter(a => a.short !== "rows"),
+                          metrics: [],
+                        },
+                      ),
+                    },
+                  })
                 }
-                description={
-                  isNewRecord
-                    ? t`You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating "Average Price" for an Orders table.`
-                    : t`Make changes to your metric and leave an explanatory note.`
+                tableMetadata={table}
+                previewSummary={
+                  previewSummary == null
+                    ? ""
+                    : t`Result: ` + formatValue(previewSummary)
                 }
-              >
-                <PartialQueryBuilder
-                  features={{
-                    filter: true,
-                    aggregation: true,
-                  }}
-                  metadata={
-                    metadata &&
-                    table &&
-                    metadata.tables &&
-                    metadata.tables[table.id].fields &&
-                    Object.assign(new Metadata(), metadata, {
-                      tables: {
-                        ...metadata.tables,
-                        [table.id]: Object.assign(
-                          new Table(),
-                          metadata.tables[table.id],
-                          {
-                            aggregation_options: (
-                              table.aggregation_options || []
-                            ).filter(a => a.short !== "rows"),
-                            metrics: [],
-                          },
-                        ),
-                      },
-                    })
-                  }
-                  tableMetadata={table}
-                  previewSummary={
-                    previewSummary == null
-                      ? ""
-                      : t`Result: ` + formatValue(previewSummary)
-                  }
-                  updatePreviewSummary={this.updatePreviewSummary.bind(this)}
-                  {...definition}
-                />
-              </FormLabel>
-              <div style={{ maxWidth: "575px" }}>
+                updatePreviewSummary={this.updatePreviewSummary.bind(this)}
+                {...definition}
+              />
+            )}
+          </FormLabel>
+          <div style={{ maxWidth: "575px" }}>
+            <FormLabel
+              title={t`Name Your Metric`}
+              description={t`Give your metric a name to help others find it.`}
+            >
+              <FormInput
+                field={name}
+                placeholder={t`Something descriptive but not too long`}
+              />
+            </FormLabel>
+            <FormLabel
+              title={t`Describe Your Metric`}
+              description={t`Give your metric a description to help others understand what it's about.`}
+            >
+              <FormTextArea
+                field={description}
+                placeholder={t`This is a good place to be more specific about less obvious metric rules`}
+              />
+            </FormLabel>
+            {!isNewRecord && (
+              <FieldSet legend={t`Reason For Changes`}>
                 <FormLabel
-                  title={t`Name Your Metric`}
-                  description={t`Give your metric a name to help others find it.`}
-                >
-                  <FormInput
-                    field={name}
-                    placeholder={t`Something descriptive but not too long`}
-                  />
-                </FormLabel>
-                <FormLabel
-                  title={t`Describe Your Metric`}
-                  description={t`Give your metric a description to help others understand what it's about.`}
+                  description={t`Leave a note to explain what changes you made and why they were required.`}
                 >
                   <FormTextArea
-                    field={description}
-                    placeholder={t`This is a good place to be more specific about less obvious metric rules`}
+                    field={revision_message}
+                    placeholder={t`This will show up in the revision history for this metric to help everyone remember why things changed`}
                   />
                 </FormLabel>
-                {!isNewRecord && (
-                  <FieldSet legend={t`Reason For Changes`}>
-                    <FormLabel
-                      description={t`Leave a note to explain what changes you made and why they were required.`}
-                    >
-                      <FormTextArea
-                        field={revision_message}
-                        placeholder={t`This will show up in the revision history for this metric to help everyone remember why things changed`}
-                      />
-                    </FormLabel>
-                    <div className="flex align-center">
-                      {this.renderActionButtons()}
-                    </div>
-                  </FieldSet>
-                )}
-              </div>
-            </div>
-
-            {isNewRecord && (
-              <div className="border-top py4">
-                <div className="wrapper">{this.renderActionButtons()}</div>
-              </div>
+                <div className="flex align-center">
+                  {this.renderActionButtons()}
+                </div>
+              </FieldSet>
             )}
-          </form>
+          </div>
+        </div>
+
+        {isNewRecord && (
+          <div className="border-top py4">
+            <div className="wrapper">{this.renderActionButtons()}</div>
+          </div>
         )}
-      </LoadingAndErrorWrapper>
+      </form>
     );
   }
 }

--- a/frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx
@@ -90,12 +90,13 @@ export default class MetricForm extends Component {
   render() {
     const {
       fields: { id, name, description, definition, revision_message },
-      metric,
       metadata,
       table,
       handleSubmit,
       previewSummary,
     } = this.props;
+
+    const isNewRecord = id.value === "";
 
     return (
       <LoadingAndErrorWrapper loading={!table && !table.aggregation_options}>
@@ -104,14 +105,12 @@ export default class MetricForm extends Component {
             <div className="wrapper py4">
               <FormLabel
                 title={
-                  metric && metric.id != null
-                    ? t`Edit Your Metric`
-                    : t`Create Your Metric`
+                  isNewRecord ? t`Create Your Metric` : t`Edit Your Metric`
                 }
                 description={
-                  metric && metric.id != null
-                    ? t`Make changes to your metric and leave an explanatory note.`
-                    : t`You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating "Average Price" for an Orders table.`
+                  isNewRecord
+                    ? t`You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating "Average Price" for an Orders table.`
+                    : t`Make changes to your metric and leave an explanatory note.`
                 }
               >
                 <PartialQueryBuilder
@@ -169,7 +168,7 @@ export default class MetricForm extends Component {
                     placeholder={t`This is a good place to be more specific about less obvious metric rules`}
                   />
                 </FormLabel>
-                {id.value != null && (
+                {!isNewRecord && (
                   <FieldSet legend={t`Reason For Changes`}>
                     <FormLabel
                       description={t`Leave a note to explain what changes you made and why they were required.`}
@@ -187,7 +186,7 @@ export default class MetricForm extends Component {
               </div>
             </div>
 
-            {id.value == null && (
+            {isNewRecord && (
               <div className="border-top py4">
                 <div className="wrapper">{this.renderActionButtons()}</div>
               </div>

--- a/frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx
@@ -92,12 +92,13 @@ export default class SegmentForm extends Component {
   render() {
     const {
       fields: { id, name, description, definition, revision_message },
-      segment,
       metadata,
       table,
       handleSubmit,
       previewSummary,
     } = this.props;
+
+    const isNewRecord = id.value === "";
 
     return (
       <LoadingAndErrorWrapper loading={!table}>
@@ -106,16 +107,14 @@ export default class SegmentForm extends Component {
             <div className="wrapper py4">
               <FormLabel
                 title={
-                  segment && segment.id != null
-                    ? t`Edit Your Segment`
-                    : t`Create Your Segment`
+                  isNewRecord ? t`Create Your Segment` : t`Edit Your Segment`
                 }
                 description={
-                  segment && segment.id != null
-                    ? t`Make changes to your segment and leave an explanatory note.`
-                    : t`Select and add filters to create your new segment for the ${
+                  isNewRecord
+                    ? t`Select and add filters to create your new segment for the ${
                         table.display_name
                       } table`
+                    : t`Make changes to your segment and leave an explanatory note.`
                 }
               >
                 <PartialQueryBuilder
@@ -169,7 +168,7 @@ export default class SegmentForm extends Component {
                     placeholder={t`This is a good place to be more specific about less obvious segment rules`}
                   />
                 </FormLabel>
-                {id.value != null && (
+                {!isNewRecord && (
                   <FieldSet legend={t`Reason For Changes`}>
                     <FormLabel
                       description={t`Leave a note to explain what changes you made and why they were required.`}
@@ -187,7 +186,7 @@ export default class SegmentForm extends Component {
               </div>
             </div>
 
-            {id.value == null && (
+            {isNewRecord && (
               <div className="border-top py4">
                 <div className="wrapper">{this.renderActionButtons()}</div>
               </div>

--- a/frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx
@@ -6,7 +6,6 @@ import FormInput from "../components/FormInput.jsx";
 import FormTextArea from "../components/FormTextArea.jsx";
 import FieldSet from "metabase/components/FieldSet.jsx";
 import PartialQueryBuilder from "../components/PartialQueryBuilder.jsx";
-import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper.jsx";
 import { t } from "ttag";
 import { formatValue } from "metabase/lib/formatting";
 
@@ -101,99 +100,93 @@ export default class SegmentForm extends Component {
     const isNewRecord = id.value === "";
 
     return (
-      <LoadingAndErrorWrapper loading={!table}>
-        {() => (
-          <form className="full" onSubmit={handleSubmit}>
-            <div className="wrapper py4">
-              <FormLabel
-                title={
-                  isNewRecord ? t`Create Your Segment` : t`Edit Your Segment`
+      <form className="full" onSubmit={handleSubmit}>
+        <div className="wrapper py4">
+          <FormLabel
+            title={isNewRecord ? t`Create Your Segment` : t`Edit Your Segment`}
+            description={
+              isNewRecord
+                ? t`Select and add filters to create your new segment for the ${
+                    table.display_name
+                  } table`
+                : t`Make changes to your segment and leave an explanatory note.`
+            }
+          >
+            {metadata && table && (
+              <PartialQueryBuilder
+                features={{
+                  filter: true,
+                }}
+                metadata={
+                  metadata.tables &&
+                  metadata.tables[table.id].fields &&
+                  Object.assign(new Metadata(), metadata, {
+                    tables: {
+                      ...metadata.tables,
+                      [table.id]: Object.assign(
+                        new Table(),
+                        metadata.tables[table.id],
+                        {
+                          segments: [],
+                        },
+                      ),
+                    },
+                  })
                 }
-                description={
-                  isNewRecord
-                    ? t`Select and add filters to create your new segment for the ${
-                        table.display_name
-                      } table`
-                    : t`Make changes to your segment and leave an explanatory note.`
+                tableMetadata={table}
+                previewSummary={
+                  previewSummary == null
+                    ? ""
+                    : formatValue(previewSummary) + " rows"
                 }
-              >
-                <PartialQueryBuilder
-                  features={{
-                    filter: true,
-                  }}
-                  metadata={
-                    metadata &&
-                    table &&
-                    metadata.tables &&
-                    metadata.tables[table.id].fields &&
-                    Object.assign(new Metadata(), metadata, {
-                      tables: {
-                        ...metadata.tables,
-                        [table.id]: Object.assign(
-                          new Table(),
-                          metadata.tables[table.id],
-                          {
-                            segments: [],
-                          },
-                        ),
-                      },
-                    })
-                  }
-                  tableMetadata={table}
-                  previewSummary={
-                    previewSummary == null
-                      ? ""
-                      : formatValue(previewSummary) + " rows"
-                  }
-                  updatePreviewSummary={this.updatePreviewSummary.bind(this)}
-                  {...definition}
-                />
-              </FormLabel>
-              <div style={{ maxWidth: "575px" }}>
+                updatePreviewSummary={this.updatePreviewSummary.bind(this)}
+                {...definition}
+              />
+            )}
+          </FormLabel>
+          <div style={{ maxWidth: "575px" }}>
+            <FormLabel
+              title={t`Name Your Segment`}
+              description={t`Give your segment a name to help others find it.`}
+            >
+              <FormInput
+                field={name}
+                placeholder={t`Something descriptive but not too long`}
+              />
+            </FormLabel>
+            <FormLabel
+              title={t`Describe Your Segment`}
+              description={t`Give your segment a description to help others understand what it's about.`}
+            >
+              <FormTextArea
+                field={description}
+                placeholder={t`This is a good place to be more specific about less obvious segment rules`}
+              />
+            </FormLabel>
+            {!isNewRecord && (
+              <FieldSet legend={t`Reason For Changes`}>
                 <FormLabel
-                  title={t`Name Your Segment`}
-                  description={t`Give your segment a name to help others find it.`}
-                >
-                  <FormInput
-                    field={name}
-                    placeholder={t`Something descriptive but not too long`}
-                  />
-                </FormLabel>
-                <FormLabel
-                  title={t`Describe Your Segment`}
-                  description={t`Give your segment a description to help others understand what it's about.`}
+                  description={t`Leave a note to explain what changes you made and why they were required.`}
                 >
                   <FormTextArea
-                    field={description}
-                    placeholder={t`This is a good place to be more specific about less obvious segment rules`}
+                    field={revision_message}
+                    placeholder={t`This will show up in the revision history for this segment to help everyone remember why things changed`}
                   />
                 </FormLabel>
-                {!isNewRecord && (
-                  <FieldSet legend={t`Reason For Changes`}>
-                    <FormLabel
-                      description={t`Leave a note to explain what changes you made and why they were required.`}
-                    >
-                      <FormTextArea
-                        field={revision_message}
-                        placeholder={t`This will show up in the revision history for this segment to help everyone remember why things changed`}
-                      />
-                    </FormLabel>
-                    <div className="flex align-center">
-                      {this.renderActionButtons()}
-                    </div>
-                  </FieldSet>
-                )}
-              </div>
-            </div>
-
-            {isNewRecord && (
-              <div className="border-top py4">
-                <div className="wrapper">{this.renderActionButtons()}</div>
-              </div>
+                <div className="flex align-center">
+                  {this.renderActionButtons()}
+                </div>
+              </FieldSet>
             )}
-          </form>
+          </div>
+        </div>
+
+        {isNewRecord && (
+          <div className="border-top py4">
+            <div className="wrapper">{this.renderActionButtons()}</div>
+          </div>
         )}
-      </LoadingAndErrorWrapper>
+      </form>
     );
   }
 }

--- a/frontend/test/metabase/admin/datamodel/MetricForm.unit.spec.js
+++ b/frontend/test/metabase/admin/datamodel/MetricForm.unit.spec.js
@@ -1,0 +1,36 @@
+import React from "react";
+import { render, cleanup } from "@testing-library/react";
+import "jest-dom/extend-expect";
+
+import { getStore } from "metabase/store";
+import normalReducers from "metabase/reducers-main";
+
+import MetricForm from "metabase/admin/datamodel/containers/MetricForm";
+
+function renderForm(props) {
+  const store = getStore(normalReducers);
+  return render(
+    <MetricForm store={store} table={{ aggregation_options: [] }} {...props} />,
+  );
+}
+
+describe("MetricForm", () => {
+  afterEach(cleanup);
+
+  it("should render creation UI", () => {
+    const { getByText, queryByText } = renderForm();
+    getByText("Create Your Metric");
+    getByText(/^You can create saved metrics/);
+    expect(queryByText("Reason For Changes")).toBe(null);
+    getByText("Save changes");
+  });
+
+  it("should render UI for existing metrics", () => {
+    const metric = { id: 123 };
+    const { getByText } = renderForm({ metric });
+    getByText("Edit Your Metric");
+    getByText(/^Make changes to your metric/);
+    getByText("Reason For Changes");
+    getByText("Save changes");
+  });
+});

--- a/frontend/test/metabase/admin/datamodel/SegmentForm.unit.spec.js
+++ b/frontend/test/metabase/admin/datamodel/SegmentForm.unit.spec.js
@@ -1,0 +1,40 @@
+import React from "react";
+import { render, cleanup } from "@testing-library/react";
+import "jest-dom/extend-expect";
+
+import { getStore } from "metabase/store";
+import normalReducers from "metabase/reducers-main";
+
+import SegmentForm from "metabase/admin/datamodel/containers/SegmentForm";
+
+function renderForm(props) {
+  const store = getStore(normalReducers);
+  return render(
+    <SegmentForm
+      store={store}
+      table={{ aggregation_options: [] }}
+      {...props}
+    />,
+  );
+}
+
+describe("SegmentForm", () => {
+  afterEach(cleanup);
+
+  it("should render creation UI", () => {
+    const { getByText, queryByText } = renderForm();
+    getByText("Create Your Segment");
+    getByText(/^Select and add filters to create your new segment/);
+    expect(queryByText("Reason For Changes")).toBe(null);
+    getByText("Save changes");
+  });
+
+  it("should render UI for existing segments", () => {
+    const segment = { id: 123 };
+    const { getByText } = renderForm({ segment });
+    getByText("Edit Your Segment");
+    getByText(/^Make changes to your segment/);
+    getByText("Reason For Changes");
+    getByText("Save changes");
+  });
+});


### PR DESCRIPTION
Resolves #10209

We had the logic in place to toggle the UI, but the definition of new record was broken since it appears that `id.value` is `""` for new records.

~I'm planning to take this as an opportunity to try out `react-testing-library`, but haven't added them here yet.~
I added some basic tests using `react-testing-library`.