### PR TITLE
Fix 'additional fields' functionality

### DIFF
--- a/frontend/src/metabase/lib/dataset.js
+++ b/frontend/src/metabase/lib/dataset.js
@@ -11,6 +11,8 @@ import type {
 import type { Card } from "metabase/meta/types/Card";
 import type { Field as FieldReference } from "metabase/meta/types/Query";
 
+import Dimension from "metabase-lib/lib/Dimension";
+
 type ColumnSetting = {
   name: ColumnName,
   fieldRef?: FieldReference,
@@ -94,15 +96,21 @@ export function findColumnForColumnSetting(
   }
 }
 
+function normalizeFieldRef(fieldRef: ?FieldReference): ?FieldReference {
+  const dimension = Dimension.parseMBQL(fieldRef);
+  return dimension && dimension.mbql();
+}
+
 export function findColumnIndexForColumnSetting(
   columns: Column[],
   columnSetting: ColumnSetting,
 ): number {
-  const { fieldRef } = columnSetting;
+  // NOTE: need to normalize field refs because they may be old style [fk->, 1, 2]
+  const fieldRef = normalizeFieldRef(columnSetting.fieldRef);
   // first try to find by fieldRef
   if (fieldRef != null) {
     const index = _.findIndex(columns, col =>
-      _.isEqual(fieldRef, fieldRefForColumn(col)),
+      _.isEqual(fieldRef, normalizeFieldRef(fieldRefForColumn(col))),
     );
     if (index >= 0) {
       return index;

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
@@ -102,13 +102,15 @@ export default class ChartSettingOrderedColumns extends Component {
 
   render() {
     const { value, question, columns } = this.props;
+    const query = question.query();
 
     let additionalFieldOptions = { count: 0 };
-    if (columns && question && question.query() instanceof StructuredQuery) {
+    if (columns && question && query instanceof StructuredQuery) {
       const fieldRefs = columns.map(column => fieldRefForColumn(column));
-      additionalFieldOptions = question.query().fieldsOptions(dimension => {
-        const mbql = dimension.mbql();
-        return !_.find(fieldRefs, fieldRef => _.isEqual(fieldRef, mbql));
+      additionalFieldOptions = query.fieldsOptions(dimension => {
+        return !_.find(fieldRefs, fieldRef =>
+          dimension.isSameBaseDimension(fieldRef),
+        );
       });
     }
 

--- a/frontend/test/metabase/lib/dataset.unit.spec.js
+++ b/frontend/test/metabase/lib/dataset.unit.spec.js
@@ -1,4 +1,4 @@
-import { fieldRefForColumn } from "metabase/lib/dataset";
+import { fieldRefForColumn, findColumnForColumnSetting } from "metabase/lib/dataset";
 
 const FIELD_COLUMN = { id: 1 };
 const FK_COLUMN = { id: 1, fk_field_id: 2 };
@@ -11,6 +11,8 @@ describe("metabase/util/dataset", () => {
       expect(fieldRefForColumn(FIELD_COLUMN)).toEqual(["field-id", 1]);
     });
     it('should return `["fk->", 2, 1]` for a fk column', () => {
+      // NOTE: this is incorrect, it should be returning normalized MBQL like
+      // ["fk->", ["field-id", 2], ["field-id", 1]]
       expect(fieldRefForColumn(FK_COLUMN)).toEqual(["fk->", 2, 1]);
     });
     it('should return `["expression", 2, 1]` for a fk column', () => {
@@ -47,5 +49,25 @@ describe("metabase/util/dataset", () => {
         3,
       ]);
     });
+  })
+
+  describe("findColumnForColumnSetting", () => {
+    const columns = [
+      { name: "bar", id: 42 },
+      { name: "foo", id: 1, fk_field_id: 2 },
+      { name: "baz", id: 43 }
+    ]
+    it("should find column with name", () => {
+      const column = findColumnForColumnSetting(columns, { name: "foo" })
+      expect(column).toBe(columns[1])
+    })
+    it("should find column with normalized fieldRef", () => {
+      const column = findColumnForColumnSetting(columns, { fieldRef: ["fk->", ["field-id", 2], ["field-id", 1]] })
+      expect(column).toBe(columns[1])
+    })
+    it("should find column with non-normalized fieldRef", () => {
+      const column = findColumnForColumnSetting(columns, { fieldRef: ["fk->", 2, 1] })
+      expect(column).toBe(columns[1])
+    })
   });
 });


### PR DESCRIPTION
Resolves #9144

I'm not exactly sure how this broke, but the underlying problem is `fieldRefForColumn` [and similar functions](https://github.com/metabase/metabase/issues/8859) return non-normalized MBQL like `["fk->", 1, 2]` but should be returning `["fk->", ["field-id", 1], ["field-id", 2]]`.

Until we have some way to migrate/normalize `visualization_settings` we'll have to just make sure to normalize `fieldRef` in functions like `findColumnIndexForColumnSetting`.