### PR TITLE
Better ag display names (etc.)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,23 @@ version: 2.1
 ########################################################################################################################
 
 executors:
-  default:
+  basic:
+    working_directory: /home/circleci/metabase/metabase/
+    docker:
+      - image: alpine/git
+
+  clojure:
+    working_directory: /home/circleci/metabase/metabase/
+    docker:
+      - image: circleci/clojure:lein-2.9.1
+
+  node:
+    working_directory: /home/circleci/metabase/metabase/
+    docker:
+      # - image: circleci/node:7-browsers
+      - image: circleci/clojure:lein-2.9.1-node-browsers
+
+  clojure-and-node:
     working_directory: /home/circleci/metabase/metabase/
     docker:
       - image: circleci/clojure:lein-2.9.1-node-browsers
@@ -149,7 +165,7 @@ jobs:
 ########################################################################################################################
 
   checkout:
-    executor: default
+    executor: basic
     steps:
       - restore_cache:
           keys:
@@ -177,7 +193,7 @@ jobs:
             - metabase/metabase
 
   yaml-linter:
-    executor: default
+    executor: node
     steps:
       - attach-workspace
       - run:
@@ -195,7 +211,7 @@ jobs:
 ########################################################################################################################
 
   be-deps:
-    executor: default
+    executor: clojure
     steps:
       - attach-workspace
       - restore-be-deps-cache
@@ -209,7 +225,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: default
+        default: clojure
       lein-command:
         type: string
     executor: << parameters.e >>
@@ -221,7 +237,7 @@ jobs:
           no_output_timeout: 5m
 
   be-linter-reflection-warnings:
-    executor: default
+    executor: clojure
     steps:
       - attach-workspace
       - restore-be-deps-cache
@@ -234,7 +250,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: default
+        default: clojure
       driver:
         type: string
       timeout:
@@ -327,7 +343,7 @@ jobs:
 ########################################################################################################################
 
   fe-deps:
-    executor: default
+    executor: node
     steps:
       - attach-workspace
       - restore-fe-deps-cache
@@ -350,49 +366,49 @@ jobs:
             - /home/circleci/yarn.lock.checksum
 
   fe-linter-eslint:
-    executor: default
+    executor: node
     steps:
       - run-yarn-command:
           command-name: Run ESLint linter
           command: lint-eslint
 
   fe-linter-prettier:
-    executor: default
+    executor: node
     steps:
       - run-yarn-command:
           command-name: Run Prettier formatting linter
           command: lint-prettier
 
   fe-linter-flow:
-    executor: default
+    executor: node
     steps:
       - run-yarn-command:
           command-name: Run Flow type checker
           command: flow
 
   fe-tests-karma:
-    executor: default
+    executor: node
     steps:
       - run-yarn-command:
           command-name: Run frontend tests (karma)
           command: run test-karma
 
   fe-tests-unit:
-    executor: default
+    executor: node
     steps:
       - run-yarn-command:
           command-name: Run frontend unit tests
           command: run test-unit
 
   fe-tests-integration:
-    executor: default
+    executor: node
     steps:
       - run-yarn-command:
           command-name: Run frontend integration tests
           command: run test-integration
 
   build-uberjar:
-    executor: default
+    executor: clojure-and-node
     steps:
       - attach-workspace
       - restore-be-deps-cache
@@ -412,7 +428,7 @@ jobs:
             - /home/circleci/metabase/metabase/target/uberjar/metabase.jar
 
   fe-tests-e2e:
-    executor: default
+    executor: clojure-and-node
     steps:
       - run-yarn-command:
           command-name: Run frontend e2e tests
@@ -431,7 +447,7 @@ jobs:
 ########################################################################################################################
 
   deploy-master:
-    executor: default
+    executor: basic
     steps:
       - attach-workspace
       - run: ./bin/deploy-webhook $DEPLOY_WEBHOOK

--- a/frontend/src/metabase/meta/types/Dataset.js
+++ b/frontend/src/metabase/meta/types/Dataset.js
@@ -33,7 +33,6 @@ export type Row = Value[];
 
 export type DatasetData = {
   cols: Column[],
-  columns: ColumnName[],
   rows: Row[],
   rows_truncated?: number,
 };

--- a/frontend/src/metabase/visualizations/components/ColumnSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ColumnSettings.jsx
@@ -46,7 +46,6 @@ const ColumnSettings = ({
     column = { ...column, unit: "default" };
   }
 
-  // $FlowFixMe
   const settingsDefs = getSettingDefintionsForColumn(series, column);
 
   const computedSettings = getComputedSettings(

--- a/frontend/src/metabase/visualizations/visualizations/Table.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.jsx
@@ -336,7 +336,7 @@ export default class Table extends Component {
         ),
       });
     } else {
-      const { cols, rows, columns } = data;
+      const { cols, rows } = data;
       const columnSettings = settings["table.columns"];
       const columnIndexes = columnSettings
         .filter(columnSetting => columnSetting.enabled)
@@ -348,7 +348,6 @@ export default class Table extends Component {
       this.setState({
         data: {
           cols: columnIndexes.map(i => cols[i]),
-          columns: columnIndexes.map(i => columns[i]),
           rows: rows.map(row => columnIndexes.map(i => row[i])),
         },
       });

--- a/modules/drivers/bigquery/src/metabase/driver/bigquery.clj
+++ b/modules/drivers/bigquery/src/metabase/driver/bigquery.clj
@@ -237,7 +237,7 @@
      (let [^TableSchema schema (.getSchema response)
            parsers             (doall
                                 (for [^TableFieldSchema field (.getFields schema)
-                                      :let [parser-fn (type->parser (.getType field))]]
+                                      :let                    [parser-fn (type->parser (.getType field))]]
                                   (parser-fn *bigquery-timezone*)))
            columns             (for [column (table-schema->metabase-field-info schema)]
                                  (-> column

--- a/modules/drivers/bigquery/test/metabase/driver/bigquery_test.clj
+++ b/modules/drivers/bigquery/test/metabase/driver/bigquery_test.clj
@@ -5,7 +5,7 @@
             [metabase
              [driver :as driver]
              [query-processor :as qp]
-             [query-processor-test :as qptest]
+             [query-processor-test :as qp.test]
              [util :as u]]
             [metabase.db.metadata-queries :as metadata-queries]
             [metabase.driver.bigquery :as bigquery]
@@ -53,26 +53,24 @@
 ;; make sure that BigQuery native queries maintain the column ordering specified in the SQL -- post-processing
 ;; ordering shouldn't apply (Issue #2821)
 (expect-with-driver :bigquery
-  {:columns ["venue_id" "user_id" "checkins_id"],
-   :cols    [{:name "venue_id",    :display_name "venue_id",    :source :native, :base_type :type/Integer}
-             {:name "user_id",     :display_name "user_id",     :source :native, :base_type :type/Integer}
-             {:name "checkins_id", :display_name "checkins_id", :source :native, :base_type :type/Integer}]}
-
-  (select-keys (:data (qp/process-query
-                        {:native   {:query (str "SELECT `test_data.checkins`.`venue_id` AS `venue_id`, "
-                                                "       `test_data.checkins`.`user_id` AS `user_id`, "
-                                                "       `test_data.checkins`.`id` AS `checkins_id` "
-                                                "FROM `test_data.checkins` "
-                                                "LIMIT 2")}
-                         :type     :native
-                         :database (data/id)}))
-               [:cols :columns]))
+  [{:name "venue_id", :display_name "venue_id", :source :native, :base_type :type/Integer}
+   {:name "user_id", :display_name "user_id", :source :native, :base_type :type/Integer}
+   {:name "checkins_id", :display_name "checkins_id", :source :native, :base_type :type/Integer}]
+  (qp.test/cols
+    (qp/process-query
+      {:native   {:query (str "SELECT `test_data.checkins`.`venue_id` AS `venue_id`, "
+                              "       `test_data.checkins`.`user_id` AS `user_id`, "
+                              "       `test_data.checkins`.`id` AS `checkins_id` "
+                              "FROM `test_data.checkins` "
+                              "LIMIT 2")}
+       :type     :native
+       :database (data/id)})))
 
 ;; make sure that the bigquery driver can handle named columns with characters that aren't allowed in BQ itself
 (expect-with-driver :bigquery
   {:rows    [[113]]
    :columns ["User_ID_Plus_Venue_ID"]}
-  (qptest/rows+column-names
+  (qp.test/rows+column-names
     (qp/process-query {:database (data/id)
                        :type     "query"
                        :query    {:source-table (data/id :checkins)
@@ -128,7 +126,7 @@
 
 (expect-with-driver :bigquery
   {:rows [[7929 7929]], :columns ["sum" "sum_2"]}
-  (qptest/rows+column-names
+  (qp.test/rows+column-names
     (qp/process-query {:database (data/id)
                        :type     "query"
                        :query    {:source-table (data/id :checkins)
@@ -137,7 +135,7 @@
 
 (expect-with-driver :bigquery
   {:rows [[7929 7929 7929]], :columns ["sum" "sum_2" "sum_3"]}
-  (qptest/rows+column-names
+  (qp.test/rows+column-names
     (qp/process-query {:database (data/id)
                        :type     "query"
                        :query    {:source-table (data/id :checkins)

--- a/modules/drivers/druid/test/metabase/driver/druid_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid_test.clj
@@ -6,7 +6,7 @@
             [metabase
              [driver :as driver]
              [query-processor :as qp]
-             [query-processor-test :refer [rows rows+column-names]]
+             [query-processor-test :as qp.test]
              [util :as u]]
             [metabase.db.metadata-queries :as metadata-queries]
             [metabase.driver
@@ -19,7 +19,7 @@
             [metabase.test
              [data :as data]
              [util :as tu]]
-            [metabase.test.data.datasets :as datasets :refer [expect-with-driver]]
+            [metabase.test.data.datasets :as datasets]
             [metabase.test.util
              [log :as tu.log]
              [timezone :as tu.tz]]
@@ -96,11 +96,10 @@
   {:base_type :type/Text})
 
 ;; test druid native queries
-(expect-with-driver :druid
+(datasets/expect-with-driver :druid
   {:row_count 2
    :status    :completed
-   :data      {:columns     ["timestamp" "id" "user_name" "venue_price" "venue_name" "count"]
-               :rows        [["2013-01-03T08:00:00.000Z" "931" "Simcha Yan" "1" "Kinaree Thai Bistro"       1]
+   :data      {:rows        [["2013-01-03T08:00:00.000Z" "931" "Simcha Yan" "1" "Kinaree Thai Bistro"       1]
                              ["2013-01-10T08:00:00.000Z" "285" "Kfir Caj"   "2" "Ruen Pair Thai Restaurant" 1]]
                :cols        (mapv #(merge col-defaults %)
                                   [{:name "timestamp",   :source :native, :display_name "timestamp"}
@@ -126,7 +125,7 @@
      :aggregations [{:type :count
                      :name :count}]}))
 
-(expect-with-driver :druid
+(datasets/expect-with-driver :druid
   :completed
   (:status (process-native-query native-query-2)))
 
@@ -142,12 +141,12 @@
                          ~@body))))
 
 (defmacro ^:private druid-query-returning-rows {:style/indent 0} [& body]
-  `(rows (druid-query ~@body)))
+  `(qp.test/rows (druid-query ~@body)))
 
 ;; Count the number of events in the given week. Metabase uses Sunday as the start of the week, Druid by default will
 ;; use Monday.All of the below events should happen in one week. Using Druid's default grouping, 3 of the events would
 ;; have counted for the previous week
-(expect-with-driver :druid
+(datasets/expect-with-driver :druid
   [["2015-10-04" 9]]
   (druid-query-returning-rows
     {:filter      [:between [:datetime-field $timestamp :day] "2015-10-04" "2015-10-10"]
@@ -155,7 +154,7 @@
      :breakout    [[:datetime-field $timestamp :week]]}))
 
 ;; sum, *
-(expect-with-driver :druid
+(datasets/expect-with-driver :druid
   [["1" 110688.0]
    ["2" 616708.0]
    ["3" 179661.0]
@@ -165,7 +164,7 @@
      :breakout    [$venue_price]}))
 
 ;; min, +
-(expect-with-driver :druid
+(datasets/expect-with-driver :druid
   [["1"  4.0]
    ["2"  3.0]
    ["3"  8.0]
@@ -175,7 +174,7 @@
      :breakout    [$venue_price]}))
 
 ;; max, /
-(expect-with-driver :druid
+(datasets/expect-with-driver :druid
   [["1" 1000.0]
    ["2"  499.5]
    ["3"  332.0]
@@ -185,7 +184,7 @@
      :breakout    [$venue_price]}))
 
 ;; avg, -
-(expect-with-driver :druid
+(datasets/expect-with-driver :druid
   [["1" 500.85067873303166]
    ["2" 1002.7772357723577]
    ["3" 1562.2695652173913]
@@ -195,25 +194,25 @@
      :breakout    [$venue_price]}))
 
 ;; share
-(expect-with-driver :druid
+(datasets/expect-with-driver :druid
   [[0.951]]
   (druid-query-returning-rows
    {:aggregation [[:share [:< $venue_price 4]]]}))
 
 ;; count-where
-(expect-with-driver :druid
+(datasets/expect-with-driver :druid
   [[951]]
   (druid-query-returning-rows
    {:aggregation [[:count-where [:< $venue_price 4]]]}))
 
 ;; sum-where
-(expect-with-driver :druid
+(datasets/expect-with-driver :druid
   [[1796.0]]
   (druid-query-returning-rows
    {:aggregation [[:sum-where $venue_price [:< $venue_price 4]]]}))
 
 ;; post-aggregation math w/ 2 args: count + sum
-(expect-with-driver :druid
+(datasets/expect-with-driver :druid
   [["1"  442.0]
    ["2" 1845.0]
    ["3"  460.0]
@@ -223,7 +222,7 @@
      :breakout    [$venue_price]}))
 
 ;; post-aggregation math w/ 3 args: count + sum + count
-(expect-with-driver :druid
+(datasets/expect-with-driver :druid
   [["1"  663.0]
    ["2" 2460.0]
    ["3"  575.0]
@@ -236,7 +235,7 @@
      :breakout    [$venue_price]}))
 
 ;; post-aggregation math w/ a constant: count * 10
-(expect-with-driver :druid
+(datasets/expect-with-driver :druid
   [["1" 2210.0]
    ["2" 6150.0]
    ["3" 1150.0]
@@ -246,7 +245,7 @@
      :breakout    [$venue_price]}))
 
 ;; nested post-aggregation math: count + (count * sum)
-(expect-with-driver :druid
+(datasets/expect-with-driver :druid
   [["1"  49062.0]
    ["2" 757065.0]
    ["3"  39790.0]
@@ -258,7 +257,7 @@
      :breakout    [$venue_price]}))
 
 ;; post-aggregation math w/ avg: count + avg
-(expect-with-driver :druid
+(datasets/expect-with-driver :druid
   [["1"  721.8506787330316]
    ["2" 1116.388617886179]
    ["3"  635.7565217391304]
@@ -268,7 +267,7 @@
      :breakout    [$venue_price]}))
 
 ;; post aggregation math + math inside aggregations: max(venue_price) + min(venue_price - id)
-(expect-with-driver :druid
+(datasets/expect-with-driver :druid
   [["1" -998.0]
    ["2" -995.0]
    ["3" -990.0]
@@ -280,7 +279,7 @@
      :breakout    [$venue_price]}))
 
 ;; aggregation w/o field
-(expect-with-driver :druid
+(datasets/expect-with-driver :druid
   [["1" 222.0]
    ["2" 616.0]
    ["3" 116.0]
@@ -290,7 +289,7 @@
      :breakout    [$venue_price]}))
 
 ;; aggregation with math inside the aggregation :scream_cat:
-(expect-with-driver :druid
+(datasets/expect-with-driver :druid
   [["1"  442.0]
    ["2" 1845.0]
    ["3"  460.0]
@@ -300,59 +299,58 @@
      :breakout    [$venue_price]}))
 
 ;; check that we can name an expression aggregation w/ aggregation at top-level
-(expect-with-driver :druid
-  {:rows    [["1"  442.0]
-             ["2" 1845.0]
-             ["3"  460.0]
-             ["4"  245.0]]
-   :columns ["venue_price"
-             "New Price"]}
-  (rows+column-names
+(datasets/expect-with-driver :druid
+  [["1"  442.0]
+   ["2" 1845.0]
+   ["3"  460.0]
+   ["4"  245.0]]
+  (qp.test/rows
     (druid-query
       {:aggregation [[:named [:sum [:+ $venue_price 1]] "New Price"]]
        :breakout    [$venue_price]})))
 
 ;; check that we can name an expression aggregation w/ expression at top-level
-(expect-with-driver :druid
+(datasets/expect-with-driver :druid
   {:rows    [["1"  180.0]
              ["2" 1189.0]
              ["3"  304.0]
              ["4"  155.0]]
    :columns ["venue_price" "Sum-41"]}
-  (rows+column-names
+  (qp.test/rows+column-names
     (druid-query
       {:aggregation [[:named [:- [:sum $venue_price] 41] "Sum-41"]]
        :breakout    [$venue_price]})))
 
 ;; check that we can handle METRICS (ick) inside expression aggregation clauses
-(expect-with-driver :druid
+(datasets/expect-with-driver :druid
   [["2" 1231.0]
    ["3"  346.0]
    ["4" 197.0]]
   (tqpt/with-flattened-dbdef
     (tt/with-temp Metric [metric {:definition {:aggregation [:sum [:field-id (data/id :checkins :venue_price)]]
                                                :filter      [:> [:field-id (data/id :checkins :venue_price)] 1]}}]
-      (rows (qp/process-query
-              {:database (data/id)
-               :type     :query
-               :query    {:source-table (data/id :checkins)
-                          :aggregation  [:+ [:metric (u/get-id metric)] 1]
-                          :breakout     [[:field-id (data/id :checkins :venue_price)]]}})))))
+      (qp.test/rows
+        (qp/process-query
+          {:database (data/id)
+           :type     :query
+           :query    {:source-table (data/id :checkins)
+                      :aggregation  [:+ [:metric (u/get-id metric)] 1]
+                      :breakout     [[:field-id (data/id :checkins :venue_price)]]}})))))
 
 (expect
   #"com.jcraft.jsch.JSchException:"
   (try
-    (let [engine :druid
-          details    {:ssl            false
-                      :password       "changeme"
-                      :tunnel-host    "localhost"
-                      :tunnel-pass    "BOGUS-BOGUS"
-                      :port           5432
-                      :dbname         "test"
-                      :host           "http://localhost"
-                      :tunnel-enabled true
-                      :tunnel-port    22
-                      :tunnel-user    "bogus"}]
+    (let [engine  :druid
+          details {:ssl            false
+                   :password       "changeme"
+                   :tunnel-host    "localhost"
+                   :tunnel-pass    "BOGUS-BOGUS"
+                   :port           5432
+                   :dbname         "test"
+                   :host           "http://localhost"
+                   :tunnel-enabled true
+                   :tunnel-port    22
+                   :tunnel-user    "bogus"}]
       (tu.log/suppress-output
         (driver.u/can-connect-with-details? engine details :throw-exceptions)))
        (catch Exception e
@@ -389,44 +387,33 @@
 ;; Make sure Druid cols + columns come back in the same order and that that order is the expected MBQL columns order
 ;; (#9294)
 (datasets/expect-with-driver :druid
-  {:columns ["id"
-             "timestamp"
-             "count"
-             "user_last_login"
-             "user_name"
-             "venue_category_name"
-             "venue_latitude"
-             "venue_longitude"
-             "venue_name"
-             "venue_price"]
-   :cols    ["id"
-             "timestamp"
-             "count"
-             "user_last_login"
-             "user_name"
-             "venue_category_name"
-             "venue_latitude"
-             "venue_longitude"
-             "venue_name"
-             "venue_price"]
-   :rows    [["931"
-              "2013-01-03T08:00:00.000Z"
-              1
-              "2014-01-01T08:30:00.000Z"
-              "Simcha Yan"
-              "Thai"
-              "34.094"
-              "-118.344"
-              "Kinaree Thai Bistro"
-              "1"]]}
+  {:cols ["id"
+          "timestamp"
+          "count"
+          "user_last_login"
+          "user_name"
+          "venue_category_name"
+          "venue_latitude"
+          "venue_longitude"
+          "venue_name"
+          "venue_price"]
+   :rows [["931"
+           "2013-01-03T08:00:00.000Z"
+           1
+           "2014-01-01T08:30:00.000Z"
+           "Simcha Yan"
+           "Thai"
+           "34.094"
+           "-118.344"
+           "Kinaree Thai Bistro"
+           "1"]]}
   (tqpt/with-flattened-dbdef
     (let [results (qp/process-query
                     {:database (data/id)
                      :type     :query
-                     :query    {:source-table  (data/id :checkins)
-                                :limit         1}})]
+                     :query    {:source-table (data/id :checkins)
+                                :limit        1}})]
       (assert (= (:status results) :completed)
         (u/pprint-to-str 'red results))
-      {:columns (-> results :data :columns)
-       :cols    (->> results :data :cols (map :name))
-       :rows    (-> results :data :rows)})))
+      {:cols (->> results :data :cols (map :name))
+       :rows (-> results :data :rows)})))

--- a/modules/drivers/googleanalytics/test/metabase/driver/googleanalytics_test.clj
+++ b/modules/drivers/googleanalytics/test/metabase/driver/googleanalytics_test.clj
@@ -264,8 +264,7 @@
 (expect
   {:row_count 1
    :status    :completed
-   :data      {:columns     [:ga:eventLabel :ga:totalEvents]
-               :rows        [["Toucan Sighting" 1000]]
+   :data      {:rows        [["Toucan Sighting" 1000]]
                :native_form expected-ga-query
                :cols        [{:description     "This is ga:eventLabel"
                               :special_type    nil

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -79,7 +79,6 @@
   {:status    :completed
    :row_count 1
    :data      {:rows        [[1]]
-               :columns     ["count"]
                :cols        [{:name "count", :display_name "count", :base_type :type/Integer, :source :native}]
                :native_form {:collection "venues"
                              :query      native-query}}}
@@ -284,10 +283,9 @@
 ;; and #8894)
 (datasets/expect-with-driver :mongo
   ;; if the column does not come back in the results for a given document we should fill in the missing values with nils
-  {:columns ["_id" "name" "parent_id"]
-   :rows    [[1 "African"  nil]
-             [2 "American" nil]
-             [3 "Artisan"  nil]]}
+  {:rows [[1 "African"  nil]
+          [2 "American" nil]
+          [3 "Artisan"  nil]]}
   ;; add a temporary Field that doesn't actually exist to test data categories
   (tt/with-temp Field [_ {:name "parent_id", :table_id (data/id :categories)}]
     ;; ok, now run a basic MBQL query against categories Table. When implicit Field IDs get added the `parent_id`

--- a/project.clj
+++ b/project.clj
@@ -33,7 +33,7 @@
   ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   :dependencies
   [[org.clojure/clojure "1.10.1"]
-   [org.clojure/core.async "0.4.490"
+   [org.clojure/core.async "0.4.500"
     :exclusions [org.clojure/tools.reader]]
    [org.clojure/core.match "0.3.0"]                                   ; optimized pattern matching library for Clojure
    [org.clojure/core.memoize "0.7.1"]                                 ; needed by core.match; has useful FIFO, LRU, etc. caching mechanisms
@@ -152,7 +152,7 @@
   {:dev
    {:dependencies
     [[clj-http-fake "1.0.3" :exclusions [slingshot]]                  ; Library to mock clj-http responses
-     [expectations "2.2.0-beta2"]                                     ; unit tests
+     [expectations "2.1.10"]                                          ; unit tests
      [ring/ring-mock "0.3.2"]]
 
     :plugins

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -61,6 +61,7 @@
 
 ;;; ----------------------------------------------- Filtered Fetch Fns -----------------------------------------------
 
+;; TODO - rewrite the functions below as multimethod & impls
 (defn- cards:all
   "Return all `Cards`."
   []

--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -251,6 +251,7 @@
   "Check that embedding is enabled, that `object` exists, and embedding for `object` is enabled."
   ([entity id]
    (check-embedding-enabled-for-object (db/select-one [entity :enable_embedding] :id id)))
+
   ([object]
    (api/check-embedding-enabled)
    (api/check-404 object)

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -71,7 +71,7 @@
     (ex-info "An error occurred while running the query." {:status-code 400})
     (u/select-nested-keys
      results
-     [[:data :columns :cols :rows :rows_truncated :insights] [:json_query :parameters] :error :status])))
+     [[:data :cols :rows :rows_truncated :insights] [:json_query :parameters] :error :status])))
 
 (defn run-query-for-card-with-id-async
   "Run the query belonging to Card with `card-id` with `parameters` and other query options (e.g. `:constraints`).

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -568,11 +568,13 @@
         :quoting             (quote-style driver)
         :allow-dashed-names? true))
     (catch Throwable e
-      (log/error (u/format-color 'red
-                     (str (tru "Invalid HoneySQL form:")
-                          "\n"
-                          (u/pprint-to-str honeysql-form))))
-      (throw e))))
+      (try
+        (log/error (u/format-color 'red
+                       (str (tru "Invalid HoneySQL form:")
+                            "\n"
+                            (u/pprint-to-str honeysql-form))))
+        (finally
+          (throw e))))))
 
 (defn- add-default-select
   "Add `SELECT *` to `honeysql-form` if no `:select` clause is present."

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -175,11 +175,13 @@
       (try
         (jdbc/query conn (into [stmt] params) opts)
         (catch InterruptedException e
-          (log/warn (tru "Client closed connection, canceling query"))
-          ;; This is what does the real work of canceling the query. We aren't checking the result of
-          ;; `query-future` but this will cause an exception to be thrown, saying the query has been cancelled.
-          (.cancel stmt)
-          (throw e))))))
+          (try
+            (log/warn (tru "Client closed connection, canceling query"))
+            ;; This is what does the real work of canceling the query. We aren't checking the result of
+            ;; `query-future` but this will cause an exception to be thrown, saying the query has been cancelled.
+            (.cancel stmt)
+            (finally
+              (throw e))))))))
 
 (defn- run-query
   "Run the query itself."

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -2,7 +2,9 @@
   "Preprocessor that does simple transformations to all incoming queries, simplifing the driver-specific
   implementations."
   (:require [medley.core :as m]
-            [metabase.driver :as driver]
+            [metabase
+             [config :as config]
+             [driver :as driver]]
             [metabase.driver.util :as driver.u]
             [metabase.mbql.schema :as mbql.s]
             [metabase.query-processor.debug :as debug]
@@ -277,19 +279,23 @@
     {:status (s/enum :completed :failed :canceled), s/Any s/Any})
    "Valid query response (core.async channel or map with :status)"))
 
-(def ^:dynamic *debug*
-  "Bind this to `true` to print debugging messages when processing the query."
-  false)
+;; QP debugging is only enabled in dev mode
+(when config/is-dev?
+  (def ^:dynamic *debug*
+    "Bind this to `true` to print debugging messages when processing the query."
+    false))
 
-(s/defn process-query :- QueryResponse
+(def ^{:style/indent 0, :arglists '([query])} process-query
   "Process an MBQL query. This is the main entrypoint to the magical realm of the Query Processor. Returns a
   core.async channel if option `:async?` is true; otherwise returns results in the usual format. For async queries, if
   the core.async channel is closed, the query will be canceled."
-  {:style/indent 0}
-  [query]
-  ((if *debug*
-     debugging-pipeline
-     default-pipeline) query))
+  (if config/is-dev?
+    (s/fn :- QueryResponse
+      [query]
+      ((if *debug*
+         debugging-pipeline
+         default-pipeline) query))
+    default-pipeline))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/query_processor/middleware/add_dimension_projections.clj
+++ b/src/metabase/query_processor/middleware/add_dimension_projections.clj
@@ -212,8 +212,6 @@
         ;; Get the entires we're going to add to `:cols` for each of the remapped values we add
         internal-only-cols (map :new-column internal-only-dims)]
     (-> results
-        ;; add the names of each newly added column to the end of `:columns`
-        (update :columns concat (map :to internal-only-dims))
         ;; add remapping info `:remapped_from` and `:remapped_to` to each existing `:col`
         (update :cols add-remapping-info remapping-dimensions internal-only-cols)
         ;; now add the entries for each newly added column to the end of `:cols`

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -31,30 +31,30 @@
    ;; various other stuff from the original Field can and should be included such as `:settings`
    s/Any                          s/Any})
 
+(defmulti column-info
+  "Determine the `:cols` info that should be returned in the query results, which is a sequence of maps containing
+  information about the columns in the results. Dispatches on query type."
+  {:arglists '([query results])}
+  (fn [query _]
+    (:type query)))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                      Adding :cols info for native queries                                      |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(defn- native-cols
-  "Infer the types of columns by looking at the first value for each in the results, which will be added to the results
-  as `:cols`. This is used for native queries, which don't have the type information from the original `Field` objects
-  used in the query."
-  [{:keys [columns rows]}]
-  (vec (for [i    (range (count columns))
-             :let [col (nth columns i)]]
-         {:name         (name col)
-          :display_name (u/keyword->qualified-name col)
-          :base_type    (or (driver.common/values->base-type (for [row rows]
-                                                               (nth row i)))
-                            :type/*)
-          :source       :native})))
-
-(defn- add-native-column-info
-  [{:keys [columns], :as results}]
-  (assoc results
-    :columns (mapv name columns)
-    :cols    (native-cols results)))
+(defmethod column-info :native
+  [_ {:keys [columns rows]}]
+  ;; Infer the types of columns by looking at the first value for each in the results. Native queries don't have the
+  ;; type information from the original `Field` objects used in the query.
+  (vec
+   (for [i    (range (count columns))
+         :let [col (nth columns i)]]
+     {:name         (name col)
+      :display_name (u/keyword->qualified-name col)
+      :base_type    (or (driver.common/values->base-type (for [row rows]
+                                                           (nth row i)))
+                        :type/*)
+      :source       :native})))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -131,21 +131,19 @@
    :/ "div"
    :* "mul"})
 
-(declare aggregation-name)
-
 (defn- expression-ag-arg->name
   "Generate an appropriate name for an `arg` in an expression aggregation."
-  [arg]
+  [recursive-name-fn arg]
   (mbql.u/match-one arg
     ;; if the arg itself is a nested expression, recursively find a name for it, and wrap in parens
     [(_ :guard #{:+ :- :/ :*}) & _]
-    (str "(" (aggregation-name &match) ")")
+    (str "(" (recursive-name-fn &match) ")")
 
     ;; if the arg is another aggregation, recurse to get its name. (Only aggregations, nested expressions, or numbers
     ;; are allowed as args to expression aggregations; thus anything that's an MBQL clause, but not a nested
     ;; expression, is a ag clause.)
     [(_ :guard keyword?) & _]
-    (aggregation-name &match)
+    (recursive-name-fn &match)
 
     ;; otherwise for things like numbers just use that directly
     _ &match))
@@ -153,13 +151,16 @@
 (s/defn aggregation-name :- su/NonBlankString
   "Return an appropriate field *and* display name for an `:aggregation` subclause (an aggregation or
   expression). Takes an options map as schema won't support passing keypairs directly as a varargs. `{:top-level?
-  true}` will cause a name to be generated that will appear in the results, other names with a leading __ will be
-  trimmed on some backends."
-  [ag-clause :- mbql.s/Aggregation & [{:keys [top-level?]}]]
+  true}` will cause a name to be generated that will appear in the results, other names with a leading `__` will be
+  trimmed on some backends.
+
+  These names are also used directly in queries, e.g. in the equivalent of a SQL `AS` clause."
+  [ag-clause :- mbql.s/Aggregation & [{:keys [top-level? recursive-name-fn], :or {recursive-name-fn aggregation-name}}]]
   (when-not driver/*driver*
     (throw (Exception. (str (tru "*driver* is unbound.")))))
   (mbql.u/match-one ag-clause
-    ;; if a custom name was provided use it
+    ;; if a custom name was provided use it. Some drivers have limits on column names, so call
+    ;; `format-custom-field-name` so they can modify it as needed.
     [:named _ ag-name]
     (driver/format-custom-field-name driver/*driver* ag-name)
 
@@ -170,23 +171,76 @@
            (str (arithmetic-op->text operator)
                 "__"))
          (str/join (str " " (name operator) " ")
-                   (map expression-ag-arg->name args)))
+                   (map (partial expression-ag-arg->name recursive-name-fn) args)))
 
-    ;; for unnamed normal aggregations, the column alias is always the same as the ag type except for `:distinct` which
-    ;; is called `:count` (WHY?)
-    [:distinct _]
+    ;; for historic reasons a distinct count clause is still named "count". Don't change this or you might break FE
+    ;; stuff that keys off of aggregation names.
+    ;;
+    ;; `cum-count` and `cum-sum` get the same names as the non-cumulative versions, due to limitations (they are
+    ;; written out of the query before we ever see them). For other code that makes use of this function give them
+    ;; the correct names to expect.
+    [(_ :guard #{:distinct :cum-count}) _]
     "count"
 
-    ;; for any other aggregation just use the name of the clause e.g. `sum`
+    [:sum-sum _]
+    "sum"
+
+    ;; for any other aggregation just use the name of the clause e.g. `sum`.
     [clause-name & _]
     (name clause-name)))
 
-(defn- ag->name-info [ag]
-  (let [ag-name (aggregation-name ag)]
-    {:name         ag-name
-     :display_name ag-name}))
+(declare aggregation-display-name)
 
-(s/defn ^:private col-info-for-aggregation-clause
+(s/defn ^:private aggregation-arg-display-name :- su/NonBlankString
+  "Name to use for an aggregation clause argument such as a Field when constructing the complete aggregation name."
+  [ag-arg :- Object]
+  (or (when (mbql.preds/Field? ag-arg)
+        (when-let [info (col-info-for-field-clause {} ag-arg)]
+          (some info [:display_name :name])))
+      (aggregation-display-name ag-arg)))
+
+(s/defn aggregation-display-name :- su/NonBlankString
+  "Return an appropriate user-facing display name for an aggregation clause."
+  [ag-clause]
+  (mbql.u/match-one ag-clause
+    ;; if a custom name was provided use it
+    [:named _ ag-name]
+    ag-name
+
+    [(operator :guard #{:+ :- :/ :*}) & args]
+    (str/join (format " %s " (name operator))
+              (map (partial expression-ag-arg->name aggregation-arg-display-name) args))
+
+    [:count]
+    (str (tru "count"))
+
+    [:distinct    arg]   (str (tru "distinct count of {0}"     (aggregation-arg-display-name arg)))
+    [:count       arg]   (str (tru "count of {0}"              (aggregation-arg-display-name arg)))
+    [:avg         arg]   (str (tru "average of {0}"            (aggregation-arg-display-name arg)))
+    ;; cum-count and cum-sum get names for count and sum, respectively (see explanation in `aggregation-name`)
+    [:cum-count   arg]   (str (tru "count of {0}"              (aggregation-arg-display-name arg)))
+    [:cum-sum     arg]   (str (tru "sum of {0}"                (aggregation-arg-display-name arg)))
+    [:stddev      arg]   (str (tru "standard deviation of {0}" (aggregation-arg-display-name arg)))
+    [:sum         arg]   (str (tru "sum of {0}"                (aggregation-arg-display-name arg)))
+    [:min         arg]   (str (tru "minimum value of {0}"      (aggregation-arg-display-name arg)))
+    [:max         arg]   (str (tru "maximum value of {0}"      (aggregation-arg-display-name arg)))
+
+    ;; until we have a way to generate good names for filters we'll just have to say 'matching condition' for now
+    [:sum-where   arg _] (str (tru "sum of {0} matching condition" (aggregation-arg-display-name arg)))
+    [:share       _]     (str (tru "share of rows matching condition"))
+    [:count-where _]     (str (tru "count of rows matching condition"))
+
+    (_ :guard mbql.preds/Field?)
+    (:display_name (col-info-for-field-clause nil ag-clause))
+
+    _
+    (aggregation-name ag-clause {:recursive-name-fn aggregation-arg-display-name})))
+
+(defn- ag->name-info [ag]
+  {:name         (aggregation-name ag)
+   :display_name (aggregation-display-name ag)})
+
+(s/defn col-info-for-aggregation-clause
   "Return appropriate column metadata for an `:aggregation` clause."
   ; `clause` is normally an aggregation clause but this function can call itself recursively; see comments by the
   ; `match` pattern for field clauses below
@@ -294,7 +348,7 @@
 (defn- cols-for-source-query
   [{:keys [source-metadata], {native-source-query :native, :as source-query} :source-query} results]
   (if native-source-query
-    (maybe-merge-source-metadata source-metadata (native-cols results))
+    (maybe-merge-source-metadata source-metadata (column-info {:type :native} results))
     (mbql-cols source-query results)))
 
 (defn ^:private mbql-cols
@@ -311,10 +365,10 @@
       :else
       cols)))
 
-(defn- add-mbql-column-info [{inner-query :query, :as query} results]
-  (let [cols (mbql-cols inner-query results)]
-    (check-correct-number-of-columns-returned cols results)
-    (assoc results :cols cols)))
+(defmethod column-info :query
+  [{inner-query :query, :as query} results]
+  (u/prog1 (mbql-cols inner-query results)
+    (check-correct-number-of-columns-returned <> results)))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -336,24 +390,27 @@
 ;;; |                                           add-column-info middleware                                           |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
+(defn- merge-cols-returned-by-driver
+  "If the driver returned a `:cols` map with its results, which is completely optional, merge our `:cols` derived
+  from logic above with theirs. We'll prefer the values in theirs to ours. This is important for wacky drivers
+  like GA that use things like native metrics, which we have no information about.
+
+  It's the responsibility of the driver to make sure the `:cols` are returned in the correct number and order."
+  [cols cols-returned-by-driver]
+  (if (seq cols-returned-by-driver)
+    (map merge cols cols-returned-by-driver)
+    cols))
+
 (s/defn ^:private add-column-info* :- {:cols ColsWithUniqueNames, s/Keyword s/Any}
-  [{query-type :type, :as query} {cols-returned-by-driver :cols, :as results}]
-  (->
-   ;; add `:cols` info to the query, using the appropriate function based on query type
-   (if-not (= query-type :query)
-     (add-native-column-info results)
-     (add-mbql-column-info query results))
-   ;; If the driver returned a `:cols` map with its results, which is completely optional, merge our `:cols` derived
-   ;; from logic above with theirs. We'll prefer the values in theirs to ours. This is important for wacky drivers
-   ;; like GA that use things like native metrics, which we have no information about.
-   ;;
-   ;; It's the responsibility of the driver to make sure the `:cols` are returned in the correct number and order.
-   (update :cols (if (seq cols-returned-by-driver)
-                   #(map merge % cols-returned-by-driver)
-                   identity))
-   ;; Finally, make sure the `:name` of each map in `:cols` is unique, since the FE uses it as a key for stuff like
-   ;; column settings
-   (update :cols deduplicate-cols-names)))
+  [query {cols-returned-by-driver :cols, :as results}]
+  ;; merge in `:cols` if returned by the driver, then make sure the `:name` of each map in `:cols` is unique, since
+  ;; the FE uses it as a key for stuff like column settings
+  (let [cols (deduplicate-cols-names
+              (merge-cols-returned-by-driver (column-info query results) cols-returned-by-driver))]
+    (-> results
+        (assoc :cols cols)
+        ;; remove `:columns` which we no longer need
+        (dissoc :columns))))
 
 (defn add-column-info
   "Middleware for adding type information about the columns in the query results (the `:cols` key)."
@@ -385,7 +442,6 @@
                  (nil? columns)))
     (let [sorted-columns (expected-column-sort-order query results)]
       (assoc results
-        ;; TODO - we don't really use `columns` any more and can remove this at some point
         :columns (map u/keyword->qualified-name sorted-columns)
         :rows    (for [row rows]
                    (for [col sorted-columns]

--- a/src/metabase/query_processor/middleware/dev.clj
+++ b/src/metabase/query_processor/middleware/dev.clj
@@ -9,14 +9,16 @@
 
 (def QPResultsFormat
   "Schema for the expected format of results returned by a query processor."
-  {:columns               [(s/cond-pre s/Keyword s/Str)]
-   ;; This is optional because QPs don't neccesarily have to add it themselves; annotate will take care of that
-   ;; If QPs do add it, those will be merged in with what annotate adds
-   ;;
-   ;; A more complete schema is used to check this in `annotate`
-   (s/optional-key :cols) [{s/Keyword s/Any}]
-   :rows                  s/Any
-   s/Keyword              s/Any})
+  (s/constrained
+   { ;; This is optional because QPs don't neccesarily have to add it themselves; annotate will take care of that
+    ;; If QPs do add it, those will be merged in with what annotate adds
+    ;;
+    ;; A more complete schema is used to check this in `annotate`
+    (s/optional-key :cols) [{s/Keyword s/Any}]
+    :rows                  s/Any
+    s/Keyword              s/Any}
+   (complement :columns)
+   "QP results should no longer include :columns."))
 
 (def ^{:arglists '([results])} validate-results
   "Validate that the RESULTS of executing a query match the `QPResultsFormat` schema. Throws an `Exception` if they are

--- a/src/metabase/query_processor/middleware/process_userland_query.clj
+++ b/src/metabase/query_processor/middleware/process_userland_query.clj
@@ -64,9 +64,8 @@
    {:status    :failed
     :error     message
     :row_count 0
-    :data      {:rows    []
-                :cols    []
-                :columns []}}
+    :data      {:rows []
+                :cols []}}
    ;; include stacktrace and preprocessed/native stages of the query if available in the response which should
    ;; make debugging queries a bit easier
    (-> (select-keys result [:stacktrace :preprocessed :native])

--- a/test/expectation_options.clj
+++ b/test/expectation_options.clj
@@ -62,7 +62,7 @@
 
 ;;; ------------------------------------------------- log-slow-tests -------------------------------------------------
 
-(def ^:private slow-test-threshold-ms 2000)
+(def ^:private slow-test-threshold-ms 5000)
 
 (defn- log-slow-tests
   "Log a message about any test that takes longer than `slow-test-threshold-ms` to run. Ideally we'd keep all our tests

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.api.dashboard-test
   "Tests for /api/dashboard endpoints."
-  (:require [expectations :refer :all]
+  (:require [clojure.walk :as walk]
+            [expectations :refer :all]
             [medley.core :as m]
             [metabase
              [http-client :as http]
@@ -987,11 +988,23 @@
 ;;; |                                Tests for including query average duration info                                 |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
+(defn- vectorize-byte-arrays
+  "Walk form X and convert any byte arrays in the results to standard Clojure vectors. This is useful when writing
+  tests that return byte arrays (such as things that work with query hashes),since identical arrays are not considered
+  equal."
+  {:style/indent 0}
+  [x]
+  (walk/postwalk (fn [form]
+                   (if (instance? (Class/forName "[B") form)
+                     (vec form)
+                     form))
+                 x))
+
 (expect
   [[-109 -42 53 92 -31 19 -111 13 -11 -111 127 -110 -12 53 -42 -3 -58 -61 60 97 123 -65 -117 -110 -27 -2 -99 102 -59 -29 49 27]
    [43 -96 52 23 -69 81 -59 15 -74 -59 -83 -9 -110 40 1 -64 -117 -44 -67 79 -123 -9 -107 20 113 -59 -93 25 60 124 -110 -30]]
-  (tu/vectorize-byte-arrays
-    (#'dashboard-api/dashcard->query-hashes {:card {:dataset_query {:database 1}}})))
+  (vectorize-byte-arrays
+   (#'dashboard-api/dashcard->query-hashes {:card {:dataset_query {:database 1}}})))
 
 (expect
   [[89 -75 -86 117 -35 -13 -69 -36 -17 84 37 86 -121 -59 -3 1 37 -117 -86 -42 -127 -42 -74 101 83 72 10 44 75 -126 43 66]
@@ -1000,7 +1013,7 @@
    [116 69 -44 77 100 8 -40 -67 25 -4 27 -21 111 98 -45 85 83 -27 -39 8 63 -25 -88 74 32 -10 -2 35 102 -72 -104 111]
    [-84 -2 87 22 -4 105 68 48 -113 93 -29 52 3 102 123 -70 -123 36 31 76 -16 87 70 116 -93 109 -88 108 125 -36 -43 73]
    [90 127 103 -71 -76 -36 41 -107 -7 -13 -83 -87 28 86 -94 110 74 -86 110 -54 -128 124 102 -73 -127 88 77 -36 62 5 -84 -100]]
-  (tu/vectorize-byte-arrays
+  (vectorize-byte-arrays
     (#'dashboard-api/dashcard->query-hashes {:card   {:dataset_query {:database 2}}
                                              :series [{:dataset_query {:database 3}}
                                                       {:dataset_query {:database 4}}]})))
@@ -1014,7 +1027,7 @@
    [116 69 -44 77 100 8 -40 -67 25 -4 27 -21 111 98 -45 85 83 -27 -39 8 63 -25 -88 74 32 -10 -2 35 102 -72 -104 111]
    [-84 -2 87 22 -4 105 68 48 -113 93 -29 52 3 102 123 -70 -123 36 31 76 -16 87 70 116 -93 109 -88 108 125 -36 -43 73]
    [90 127 103 -71 -76 -36 41 -107 -7 -13 -83 -87 28 86 -94 110 74 -86 110 -54 -128 124 102 -73 -127 88 77 -36 62 5 -84 -100]]
-  (tu/vectorize-byte-arrays (#'dashboard-api/dashcards->query-hashes [{:card   {:dataset_query {:database 1}}}
+  (vectorize-byte-arrays (#'dashboard-api/dashcards->query-hashes [{:card   {:dataset_query {:database 1}}}
                                                                       {:card   {:dataset_query {:database 2}}
                                                                        :series [{:dataset_query {:database 3}}
                                                                                 {:dataset_query {:database 4}}]}])))

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -5,7 +5,7 @@
              [generate :as generate]]
             [clojure.data.csv :as csv]
             [dk.ative.docjure.spreadsheet :as spreadsheet]
-            [expectations :refer :all]
+            [expectations :refer [expect]]
             [medley.core :as m]
             [metabase.mbql.schema :as mbql.s]
             [metabase.models
@@ -56,7 +56,6 @@
 (expect
   {:api-response
    {:data                   {:rows        [[1000]]
-                             :columns     ["count"]
                              :cols        [{:base_type    "type/Integer"
                                             :special_type "type/Number"
                                             :name         "count"
@@ -104,7 +103,6 @@
 (expect
   {:api-response
    {:data         {:rows    []
-                   :columns []
                    :cols    []}
     :row_count    0
     :status       "failed"

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -7,7 +7,7 @@
             [clojure.string :as str]
             [crypto.random :as crypto-random]
             [dk.ative.docjure.spreadsheet :as spreadsheet]
-            [expectations :refer :all]
+            [expectations :refer [expect]]
             [metabase
              [http-client :as http]
              [util :as u]]
@@ -70,8 +70,7 @@
 
 (defn successful-query-results
   ([]
-   {:data       {:columns  ["count"]
-                 :cols     [{:base_type    "type/Integer"
+   {:data       {:cols     [{:base_type    "type/Integer"
                              :special_type "type/Number"
                              :name         "count"
                              :display_name "count"

--- a/test/metabase/api/field_test.clj
+++ b/test/metabase/api/field_test.clj
@@ -2,7 +2,7 @@
   "Tests for `/api/field` endpoints."
   (:require [expectations :refer :all]
             [metabase
-             [query-processor-test :as qpt]
+             [query-processor-test :as qp.test]
              [util :as u]]
             [metabase.api.field :as field-api]
             [metabase.driver.util :as driver.u]
@@ -15,7 +15,7 @@
              [util :as tu]]
             [metabase.test.data.users :refer [user->client]]
             [metabase.test.util.log :as tu.log]
-            [metabase.timeseries-query-processor-test.util :as tqpt]
+            [metabase.timeseries-query-processor-test.util :as tqp.test]
             [ring.util.codec :as codec]
             [toucan
              [db :as db]
@@ -570,14 +570,14 @@
 
 
 ;; make sure `search-values` works on with our various drivers
-(qpt/expect-with-non-timeseries-dbs
+(qp.test/expect-with-non-timeseries-dbs
   [[1 "Red Medicine"]]
-  (qpt/format-rows-by [int str]
+  (qp.test/format-rows-by [int str]
     (field-api/search-values (Field (data/id :venues :id))
                              (Field (data/id :venues :name))
                              "Red")))
 
-(tqpt/expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [["139" "Red Medicine"]
    ["375" "Red Medicine"]
    ["72"  "Red Medicine"]]
@@ -586,7 +586,7 @@
                            "Red"))
 
 ;; make sure it also works if you use the same Field twice
-(qpt/expect-with-non-timeseries-dbs
+(qp.test/expect-with-non-timeseries-dbs
   [["Red Medicine" "Red Medicine"]]
   (field-api/search-values (Field (data/id :venues :name))
                            (Field (data/id :venues :name))
@@ -595,7 +595,7 @@
 ;; disabled for now because for some reason Druid itself is failing to run this query with an “Invalid type marker
 ;; byte 0x3c” error message. The query itself is fine so I suspect this might be an issue with Druid itself. Either
 ;; way, I can find very little information about it online. Try reenabling this test next time we upgrade Druid.
-#_(tqpt/expect-with-timeseries-dbs
+#_(tqp.test/expect-with-timeseries-dbs
   [["Red Medicine" "Red Medicine"]]
   (field-api/search-values (Field (data/id :checkins :venue_name))
                            (Field (data/id :checkins :venue_name))

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -220,10 +220,16 @@
     (tt/with-temp Card [{uuid :public_uuid} (card-with-date-field-filter)]
       ;; make sure the URL doesn't include /api/ at the beginning like it normally would
       (binding [http/*url-prefix* (str/replace http/*url-prefix* #"/api/$" "/")]
-        (http/client :get 200 (str "public/question/" uuid ".csv")
-                     :parameters (json/encode [{:type   :date/quarter-year
-                                                :target [:dimension [:template-tag :date]]
-                                                :value  "Q1-2014"}]))))))
+        (try
+          (http/client :get 200 (str "public/question/" uuid ".csv")
+                       :parameters (json/encode [{:type   :date/quarter-year
+                                                  :target [:dimension [:template-tag :date]]
+                                                  :value  "Q1-2014"}]))
+          ;; this test is failing a lot recently with ConnectExceptions. This is here to debug it
+          (catch java.net.ConnectException e
+            (println "Connection to " http/*url-prefix* "public/question/" uuid ".csv refused.")
+            (println (.getMessage e))
+            (throw e)))))))
 
 ;; make sure we include all the relevant fields like `:insights`
 (defn- card-with-trendline []
@@ -235,7 +241,7 @@
                               :aggregation  [[:count]]}}))
 
 (expect
-  #{:cols :rows :insights :columns}
+  #{:cols :rows :insights}
   (tu/with-temporary-setting-values [enable-public-sharing true]
     (tt/with-temp Card [{uuid :public_uuid} (card-with-trendline)]
       (-> (http/client :get 200 (str "public/card/" uuid "/query"))

--- a/test/metabase/driver/sql_jdbc/native_test.clj
+++ b/test/metabase/driver/sql_jdbc/native_test.clj
@@ -16,7 +16,6 @@
    :row_count 2
    :data      {:rows        [[100]
                              [99]]
-               :columns     ["ID"]
                :cols        [{:name "ID", :display_name "ID", :base_type :type/Integer, :source :native}]
                :native_form {:query "SELECT ID FROM VENUES ORDER BY ID DESC LIMIT 2", :params []}}}
   (-> (qp/process-query {:native   {:query "SELECT ID FROM VENUES ORDER BY ID DESC LIMIT 2"}
@@ -31,7 +30,6 @@
    :row_count 2
    :data      {:rows        [[100 "Mohawk Bend" 46]
                              [99 "Golden Road Brewing" 10]]
-               :columns     ["ID" "NAME" "CATEGORY_ID"]
                :cols        [{:name "ID",          :display_name "ID",          :source :native, :base_type :type/Integer}
                              {:name "NAME",        :display_name "NAME",        :source :native, :base_type :type/Text}
                              {:name "CATEGORY_ID", :display_name "CATEGORY_ID", :source :native, :base_type :type/Integer}]

--- a/test/metabase/models/query/permissions_test.clj
+++ b/test/metabase/models/query/permissions_test.clj
@@ -260,15 +260,25 @@
     (perms/object-path (data/id) "PUBLIC" (data/id :users))}
   (tt/with-temp Card [{card-id :id} (qp.test-util/card-with-source-metadata-for-query
                                      (data/mbql-query checkins
-                                       {:aggregation [[:sum $id]]
-                                        :breakout    [$user_id]}))]
+                                                      {:aggregation [[:sum $id]]
+                                                       :breakout    [$user_id]}))]
     (query-perms/perms-set
      (data/mbql-query users
-       {:joins [{:fields       :all
-                 :alias        "__alias__"
-                 :source-table (str "card__" card-id)
-                 :condition    [:=
-                                $id
-                                ["joined-field" "__alias__" ["field-literal" "USER_ID" "type/Integer"]]]}]
-        :limit 10})
+                      {:joins [{:fields       :all
+                                :alias        "__alias__"
+                                :source-table (str "card__" card-id)
+                                :condition    [:=
+                                               $id
+                                               ["joined-field" "__alias__" ["field-literal" "USER_ID" "type/Integer"]]]}]
+                       :limit 10})
      :throw-exceptions? true)))
+
+(expect
+  #{(perms/object-path (data/id) "PUBLIC" (data/id :checkins))
+    (perms/object-path (data/id) "PUBLIC" (data/id :users))}
+  (query-perms/perms-set
+   (data/mbql-query users
+     {:joins [{:alias        "c"
+               :source-table $$checkins
+               :condition    [:= $id &c.*USER_ID/Integer]}]})
+   :throw-exceptions? true))

--- a/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
+++ b/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
@@ -121,7 +121,6 @@
              [3 "The Apple Pan"                11 2 "Bar"]
              [4 "Wurstküche"                   29 2 "Baz"]
              [5 "Brite Spot Family Restaurant" 20 2 "Qux"]]
-   :columns ["ID" "NAME" "CATEGORY_ID" "PRICE" "Foo"]
    :cols    [example-result-cols-id
              example-result-cols-name
              (assoc example-result-cols-category-id
@@ -143,7 +142,6 @@
                 [3 "The Apple Pan"                11 2]
                 [4 "Wurstküche"                   29 2]
                 [5 "Brite Spot Family Restaurant" 20 2]]
-      :columns ["ID" "NAME" "CATEGORY_ID" "PRICE"]
       :cols    [example-result-cols-id
                 example-result-cols-name
                 example-result-cols-category-id
@@ -166,7 +164,6 @@
 
 (expect
   {:rows    []
-   :columns ["ID" "NAME" "CATEGORY_ID" "PRICE" "CATEGORY"]
    :cols    [example-result-cols-id
              example-result-cols-name
              (assoc example-result-cols-category-id
@@ -178,7 +175,6 @@
   (#'add-dim-projections/remap-results
    [{:name "My Venue Category", :field_id 11, :human_readable_field_id 27}]
    {:rows    []
-    :columns ["ID" "NAME" "CATEGORY_ID" "PRICE" "CATEGORY"]
     :cols    [example-result-cols-id
               example-result-cols-name
               example-result-cols-category-id

--- a/test/metabase/query_processor/middleware/add_source_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/add_source_metadata_test.clj
@@ -83,7 +83,7 @@
      :source-metadata (concat
                        (venues-source-metadata :price)
                        [{:name         "avg"
-                         :display_name "avg"
+                         :display_name "average of ID"
                          :base_type    :type/BigInteger
                          :special_type :type/PK}])})
   (add-source-metadata

--- a/test/metabase/query_processor/middleware/async_wait_test.clj
+++ b/test/metabase/query_processor/middleware/async_wait_test.clj
@@ -6,7 +6,8 @@
             [metabase.test.util.async :as tu.async]
             [metabase.util :as u]
             [toucan.util.test :as tt])
-  (:import java.util.concurrent.Executors))
+  (:import java.util.concurrent.Executors
+           org.apache.commons.lang3.concurrent.BasicThreadFactory$Builder))
 
 (def ^:private ^:dynamic *dynamic-var* false)
 
@@ -41,7 +42,10 @@
 ;; binding should not be persisted between executions -- should be reset when we reuse a thread
 (expect
   false
-  (let [thread-pool (Executors/newSingleThreadExecutor)]
+  (let [thread-pool (Executors/newSingleThreadExecutor
+                     (.build
+                      (doto (BasicThreadFactory$Builder.)
+                        (.daemon true))))]
     (with-redefs [async-wait/db-thread-pool (constantly thread-pool)]
       (tt/with-temp Database [{db-id :id}]
         (binding [*dynamic-var* true]

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -8,11 +8,13 @@
              [driver :as driver]
              [util :as u]]
             [metabase.driver.util :as driver.u]
+            [metabase.models.field :refer [Field]]
             [metabase.test.data :as data]
             [metabase.test.data
              [datasets :as datasets]
              [env :as tx.env]
-             [interface :as tx]]))
+             [interface :as tx]]
+            [toucan.db :as db]))
 
 ;;; ---------------------------------------------- Helper Fns + Macros -----------------------------------------------
 
@@ -40,6 +42,7 @@
   [feature]
   (set/difference non-timeseries-drivers (non-timeseries-drivers-with-feature feature)))
 
+;; TODO - should be renamed to `expect-with-non-timeseries-drivers`
 (defmacro expect-with-non-timeseries-dbs
   {:style/indent 0}
   [expected actual]
@@ -54,7 +57,11 @@
      ~expected
      ~actual))
 
-(defmacro qp-expect-with-all-drivers
+(defmacro ^:deprecated qp-expect-with-all-drivers
+  "Wraps `expected` form in the 'wrapped' query results (includes `:status` and `:row_count`.)
+
+  DEPRECATED -- If you don't care about `:status` and `:row_count` (you usually don't) use `qp.test/rows` or
+  `qp.test/rows-and-columns` instead."
   {:style/indent 0}
   [data query-form & post-process-fns]
   `(expect-with-non-timeseries-dbs
@@ -64,29 +71,8 @@
      (-> ~query-form
          ~@post-process-fns)))
 
-;; TODO - this is only used in a single place, consider removing it
-(defmacro qp-expect-with-drivers
-  {:style/indent 1}
-  [drivers data query-form]
-  `(datasets/expect-with-drivers ~drivers
-     {:status    :completed
-      :row_count ~(count (:rows data))
-      :data      ~data}
-     ~query-form))
-
-
-(defn ->columns
-  "Generate the vector that should go in the `columns` part of a QP result; done by calling `format-name` against each
-  column name."
-  [& names]
-  (mapv (partial data/format-name)
-        names))
-
-
 ;; Predefinied Column Fns: These are meant for inclusion in the expected output of the QP tests, to save us from
 ;; writing the same results several times
-
-;; #### categories
 
 (defn- col-defaults []
   {:description     nil
@@ -95,239 +81,134 @@
    :parent_id       nil
    :source          :fields})
 
-(defn- target-field [field]
-  (when (data/fks-supported?)
-    (dissoc field :target :schema_name :fk_field_id :remapped_from :remapped_to :fingerprint)))
+(defn col
+  "Get a Field as it would appear in the Query Processor results in `:cols`.
 
-(defn categories-col
-  "Return column information for the `categories` column named by keyword COL."
-  [col]
+    (qp.test/col :venues :id)"
+  [table-kw field-kw]
   (merge
    (col-defaults)
-   {:table_id (data/id :categories)
-    :id       (data/id :categories col)}
-   (case col
-     :id   {:special_type :type/PK
-            :base_type    (data/id-field-type)
-            :name         (data/format-name "id")
-            :display_name "ID"}
-     :name {:special_type :type/Name
-            :base_type    (data/expected-base-type->actual :type/Text)
-            :name         (data/format-name "name")
-            :display_name "Name"
-            :fingerprint  {:global {:distinct-count 75
-                                    :nil%           0.0}
-                           :type   {:type/Text {:percent-json   0.0
-                                                :percent-url    0.0
-                                                :percent-email  0.0
-                                                :average-length 8.33}}}})))
+   (db/select-one [Field :id :table_id :special_type :base_type :name :display_name :fingerprint]
+     :id (data/id table-kw field-kw))
+   (when (= field-kw :last_login)
+     {:unit :default})))
 
-;; #### users
-(defn users-col
-  "Return column information for the `users` column named by keyword COL."
-  [col]
-  (merge
-   (col-defaults)
-   {:table_id (data/id :users)
-    :id       (data/id :users col)}
-   (case col
-     :id         {:special_type :type/PK
-                  :base_type    (data/id-field-type)
-                  :name         (data/format-name "id")
-                  :display_name "ID"
-                  :fingerprint  nil}
-     :name       {:special_type :type/Name
-                  :base_type    (data/expected-base-type->actual :type/Text)
-                  :name         (data/format-name "name")
-                  :display_name "Name"
-                  :fingerprint  {:global {:distinct-count 15
-                                          :nil%           0.0}
-                                 :type   {:type/Text {:percent-json   0.0
-                                                      :percent-url    0.0
-                                                      :percent-email  0.0
-                                                      :average-length 13.27}}}}
-     :last_login {:special_type nil
-                  :base_type    (data/expected-base-type->actual :type/DateTime)
-                  :name         (data/format-name "last_login")
-                  :display_name "Last Login"
-                  :unit         :default
-                  :fingerprint  {:global {:distinct-count 15
-                                          :nil%           0.0}
-                                 :type   {:type/DateTime {:earliest "2014-01-01T08:30:00.000Z"
-                                                          :latest   "2014-12-05T15:15:00.000Z"}}}})))
+(defn- expected-column-names
+  "Get a sequence of keyword names of Fields belonging to a Table in the order they'd normally appear in QP results."
+  [table-kw]
+  (case table-kw
+    :categories [:id :name]
+    :checkins   [:id :date :user_id :venue_id]
+    :users      [:id :name :last_login]
+    :venues     [:id :name :category_id :latitude :longitude :price]
+    (throw (IllegalArgumentException. (format "Sorry, we don't know the default columns for Table %s." table-kw)))))
 
-;; #### venues
-(defn venues-columns
-  "Names of all columns for the `venues` table."
-  []
-  (->columns "id" "name" "category_id" "latitude" "longitude" "price"))
+(defn expected-cols
+  "Get a sequence of Fields belonging to a Table as they would appear in the Query Processor results in `:cols`. The
+  second arg, `cols`, is optional; if not supplied, this function will return all columns for that Table in the
+  default order.
 
-(defn venues-col
-  "Return column information for the `venues` column named by keyword COL."
-  [col]
-  (merge
-   (col-defaults)
-   {:table_id (data/id :venues)
-    :id       (data/id :venues col)}
-   (case col
-     :id          {:special_type :type/PK
-                   :base_type    (data/id-field-type)
-                   :name         (data/format-name "id")
-                   :display_name "ID"
-                   :fingerprint  nil}
-     :category_id {:special_type (if (data/fks-supported?)
-                                   :type/FK
-                                   :type/Category)
-                   :base_type    (data/expected-base-type->actual :type/Integer)
-                   :name         (data/format-name "category_id")
-                   :display_name "Category ID"
-                   :fingerprint  (if (data/fks-supported?)
-                                   {:global {:distinct-count 28
-                                             :nil%           0.0}}
-                                   {:global {:distinct-count 28
-                                             :nil%           0.0},
-                                    :type {:type/Number {:min 2.0, :max 74.0, :avg 29.98, :q1 7.0, :q3 49.0 :sd 23.06}}})}
-     :price       {:special_type :type/Category
-                   :base_type    (data/expected-base-type->actual :type/Integer)
-                   :name         (data/format-name "price")
-                   :display_name "Price"
-                   :fingerprint  {:global {:distinct-count 4
-                                           :nil%           0.0},
-                                  :type {:type/Number {:min 1.0, :max 4.0, :avg 2.03, :q1 1.0, :q3 2.0 :sd 0.77}}}}
-     :longitude   {:special_type :type/Longitude
-                   :base_type    (data/expected-base-type->actual :type/Float)
-                   :name         (data/format-name "longitude")
-                   :fingerprint  {:global {:distinct-count 84
-                                           :nil%           0.0},
-                                  :type {:type/Number {:min -165.37, :max -73.95, :avg -116.0 :q1 -122.0, :q3 -118.0 :sd 14.16}}}
-                   :display_name "Longitude"}
-     :latitude    {:special_type :type/Latitude
-                   :base_type    (data/expected-base-type->actual :type/Float)
-                   :name         (data/format-name "latitude")
-                   :display_name "Latitude"
-                   :fingerprint  {:global {:distinct-count 94
-                                           :nil%           0.0},
-                                  :type {:type/Number {:min 10.06, :max 40.78, :avg 35.51, :q1 34.0, :q3 38.0 :sd 3.43}}}}
-     :name        {:special_type :type/Name
-                   :base_type    (data/expected-base-type->actual :type/Text)
-                   :name         (data/format-name "name")
-                   :display_name "Name"
-                   :fingerprint  {:global {:distinct-count 100
-                                           :nil%           0.0},
-                                  :type {:type/Text {:percent-json 0.0, :percent-url 0.0, :percent-email 0.0, :average-length 15.63}}}})))
+    ;; all columns in default order
+    (qp.test/cols :users)
 
-(defn venues-cols
-  "`cols` information for all the columns in `venues`."
-  []
-  (mapv venues-col [:id :name :category_id :latitude :longitude :price]))
+    ;; users.id, users.name, and users.last_login
+    (qp.test/cols :users [:id :name :last_login])"
+  ([table-kw]
+   (expected-cols table-kw (expected-column-names table-kw)))
 
-;; #### checkins
-(defn checkins-col
-  "Return column information for the `checkins` column named by keyword COL."
-  [col]
-  (merge
-   (col-defaults)
-   {:table_id (data/id :checkins)
-    :id       (data/id :checkins col)}
-   (case col
-     :id       {:special_type :type/PK
-                :base_type    (data/id-field-type)
-                :name         (data/format-name "id")
-                :display_name "ID"}
-     :venue_id {:special_type (when (data/fks-supported?)
-                                :type/FK)
-                :base_type    (data/expected-base-type->actual :type/Integer)
-                :name         (data/format-name "venue_id")
-                :display_name "Venue ID"
-                :fingerprint  (if (data/fks-supported?)
-                                {:global {:distinct-count 100
-                                          :nil%           0.0}}
-                                {:global {:distinct-count 100
-                                          :nil%           0.0},
-                                 :type {:type/Number {:min 1.0, :max 100.0, :avg 51.97, :q1 28.0, :q3 76.0 :sd 28.51}}})}
-     :user_id  {:special_type (if (data/fks-supported?)
-                                :type/FK
-                                :type/Category)
-                :base_type    (data/expected-base-type->actual :type/Integer)
-                :name         (data/format-name "user_id")
-                :display_name "User ID"
-                :fingerprint  (if (data/fks-supported?)
-                                {:global {:distinct-count 15
-                                          :nil%           0.0}}
-                                {:global {:distinct-count 15
-                                          :nil%           0.0},
-                                 :type {:type/Number {:min 1.0, :max 15.0, :avg 7.93 :q1 4.0, :q3 11.0 :sd 3.99}}})})))
-
-
-;;; #### aggregate columns
+  ([table-kw cols]
+   (mapv (partial col table-kw) cols)))
 
 (defn aggregate-col
   "Return the column information we'd expect for an aggregate column. For all columns besides `:count`, you'll need to
   pass the `Field` in question as well.
 
     (aggregate-col :count)
-    (aggregate-col :avg (venues-col :id))"
-  {:arglists '([ag-type] [ag-type field])}
-  [& args]
-  (apply tx/aggregate-column-info (tx/driver) args))
+    (aggregate-col :avg (col :venues :id))
+    (aggregate-col :avg :venues :id)"
+  ([ag-type]
+   (tx/aggregate-column-info (tx/driver) ag-type))
 
-(defn breakout-col [col]
-  (assoc col :source :breakout))
+  ([ag-type field]
+   (tx/aggregate-column-info (tx/driver) ag-type field))
 
-;; TODO - maybe this needs a new name now that it also removes the results_metadata
-(defn booleanize-native-form
+  ([ag-type table-kw field-kw]
+   (tx/aggregate-column-info (tx/driver) ag-type (col table-kw field-kw))))
+
+(defn breakout-col
+  ([col]
+   (assoc col :source :breakout))
+
+  ([table-kw field-kw]
+   (breakout-col (col table-kw field-kw))))
+
+(defn ^:deprecated booleanize-native-form
   "Convert `:native_form` attribute to a boolean to make test results comparisons easier. Remove `data.results_metadata`
-  as well since it just takes a lot of space and the checksum can vary based on whether encryption is enabled."
+  as well since it just takes a lot of space and the checksum can vary based on whether encryption is enabled.
+
+  DEPRECATED: Just use `qp.test/rows` or `qp.test/row-and-cols` instead."
   [m]
   (-> m
       (update-in [:data :native_form] boolean)
       (m/dissoc-in [:data :results_metadata])
       (m/dissoc-in [:data :insights])))
 
+(defn- default-format-rows-by-fns [table-kw]
+  (case table-kw
+    :categories [int identity]
+    :checkins   [int identity int int]
+    :users      [int identity identity]
+    :venues     [int identity int (partial u/round-to-decimals 4) (partial u/round-to-decimals 4) int]
+    (throw (IllegalArgumentException. (format "Sorry, we don't have default format-rows-by fns for Table %s." table-kw)))))
+
 (defn format-rows-by
-  "Format the values in result ROWS with the fns at the corresponding indecies in FORMAT-FNS. ROWS can be a sequence
-  or any of the common map formats we expect in QP tests.
+  "Format the values in result `rows` with the fns at the corresponding indecies in `format-fns`. `rows` can be a
+  sequence or any of the common map formats we expect in QP tests.
 
     (format-rows-by [int str double] [[1 1 1]]) -> [[1 \"1\" 1.0]]
 
-  By default, does't call fns on `nil` values; pass a truthy value as optional param FORMAT-NIL-VALUES? to override
+  `format-fns` can be a sequence of functions, or may be the name of one of the 'big four' test data Tables to use
+  their defaults:
+
+    (format-rows-by :venue (data/run-mbql-query :venues))
+
+  By default, does't call fns on `nil` values; pass a truthy value as optional param `format-nil-values`? to override
   this behavior."
   {:style/indent 1}
-  ([format-fns rows]
-   (format-rows-by format-fns false rows))
+  ([format-fns response]
+   (format-rows-by format-fns false response))
 
   ([format-fns format-nil-values? response]
    (when (= (:status response) :failed)
      (println "Error running query:" (u/pprint-to-str 'red response))
      (throw (ex-info (:error response) response)))
 
-   (-> response
-       ((fn format-rows [rows]
-          (cond
-            (:data rows)
-            (update rows :data format-rows)
+   (let [format-fns (if (keyword? format-fns)
+                      (default-format-rows-by-fns format-fns)
+                      format-fns)]
+     (-> response
+         ((fn format-rows [rows]
+            (cond
+              (:data rows)
+              (update rows :data format-rows)
 
-            (:rows rows)
-            (update rows :rows format-rows)
+              (:rows rows)
+              (update rows :rows format-rows)
 
-            (sequential? rows)
-            (vec
-             (for [row rows]
-               (vec
-                (for [[f v] (partition 2 (interleave format-fns row))]
-                  (when (or v format-nil-values?)
-                    (try
-                      (f v)
-                      (catch Throwable e
-                        (printf "(%s %s) failed: %s" f v (.getMessage e))
-                        (throw e))))))))
+              (sequential? rows)
+              (vec
+               (for [row rows]
+                 (vec
+                  (for [[f v] (partition 2 (interleave format-fns row))]
+                    (when (or v format-nil-values?)
+                      (try
+                        (f v)
+                        (catch Throwable e
+                          (printf "(%s %s) failed: %s" f v (.getMessage e))
+                          (throw e))))))))
 
-            :else
-            (throw (ex-info "Unexpected response: rows are not sequential!" {:response response}))))))))
-
-(def ^{:arglists '([results])} formatted-venues-rows
-  "Helper function to format the rows in `results` when running a 'raw data' query against the Venues test table."
-  (partial format-rows-by [int str int (partial u/round-to-decimals 4) (partial u/round-to-decimals 4) int]))
+              :else
+              (throw (ex-info "Unexpected response: rows are not sequential!" {:response response})))))))))
 
 (defn data
   "Return the result `data` from a successful query run, or throw an Exception if processing failed."
@@ -346,12 +227,14 @@
   (or (some-> (data results) :rows vec)
       (throw (ex-info "Query does not have any :rows in results." results))))
 
-(defn rows+column-names
-  "Return the result rows and column names from query `results`, or throw an Exception if they're missing."
-  {:style/indent 0}
-  [results]
-  {:rows    (rows results)
-   :columns (get-in results [:data :columns])})
+(defn formatted-rows
+  "Combines `rows` and `format-rows-by`."
+  {:style/indent 1}
+  ([format-fns response]
+   (format-rows-by format-fns (rows response)))
+
+  ([format-fns format-nil-values? response]
+   (format-rows-by format-fns format-nil-values? (rows response))))
 
 (defn first-row
   "Return the first row in the `results` of a query, or throw an Exception if they're missing."
@@ -370,6 +253,20 @@
   [results]
   (or (some-> (data results) :cols vec)
       (throw (ex-info "Query does not have any :cols in results." results))))
+
+(defn rows-and-cols
+  "Return both `:rows` and `:cols` from the results. Equivalent to
+
+    {:rows (rows results), :cols (cols results)}"
+  {:style/indent 0}
+  [results]
+  {:rows (rows results), :cols (cols results)})
+
+(defn rows+column-names
+  "Return the result rows and column names from query `results`, or throw an Exception if they're missing."
+  {:style/indent 0}
+  [results]
+  {:rows (rows results), :columns (map :name (cols results))})
 
 (defn tz-shifted-driver-bug?
   "Returns true if `driver` is affected by the bug originally observed in

--- a/test/metabase/query_processor_test/aggregation_test.clj
+++ b/test/metabase/query_processor_test/aggregation_test.clj
@@ -2,7 +2,7 @@
   "Tests for MBQL aggregations."
   (:require [expectations :refer [expect]]
             [metabase
-             [query-processor-test :as qp.test :refer :all]
+             [query-processor-test :as qp.test]
              [util :as u]]
             [metabase.models.field :refer [Field]]
             [metabase.test
@@ -10,94 +10,73 @@
              [util :as tu]]
             [metabase.test.data.datasets :as datasets]))
 
-;;; ---------------------------------------------- "COUNT" AGGREGATION -----------------------------------------------
-
-(qp-expect-with-all-drivers
-  {:rows        [[100]]
-   :columns     ["count"]
-   :cols        [(aggregate-col :count)]
-   :native_form true}
-  (->> (data/run-mbql-query venues
-         {:aggregation [[:count]]})
-       booleanize-native-form
-       (format-rows-by [int])))
+;; count aggregation
+(qp.test/expect-with-non-timeseries-dbs
+  {:rows [[100]]
+   :cols [(qp.test/aggregate-col :count)]}
+  (qp.test/format-rows-by [int]
+    (qp.test/rows-and-cols
+      (data/run-mbql-query venues
+        {:aggregation [[:count]]}))))
 
 
-;;; ----------------------------------------------- "SUM" AGGREGATION ------------------------------------------------
-(qp-expect-with-all-drivers
-  {:rows        [[203]]
-   :columns     ["sum"]
-   :cols        [(aggregate-col :sum (venues-col :price))]
-   :native_form true}
-  (->> (data/run-mbql-query venues
-         {:aggregation [[:sum $price]]})
-       booleanize-native-form
-       (format-rows-by [int])))
+;; sum aggregation
+(qp.test/expect-with-non-timeseries-dbs
+  {:rows [[203]]
+   :cols [(qp.test/aggregate-col :sum :venues :price)]}
+  (qp.test/format-rows-by [int]
+    (qp.test/rows-and-cols
+     (data/run-mbql-query venues
+       {:aggregation [[:sum $price]]}))))
 
 
-;;; ----------------------------------------------- "AVG" AGGREGATION ------------------------------------------------
-(qp-expect-with-all-drivers
-  {:rows        [[35.5059]]
-   :columns     ["avg"]
-   :cols        [(aggregate-col :avg (venues-col :latitude))]
-   :native_form true}
-  (->> (data/run-mbql-query venues
-         {:aggregation [[:avg $latitude]]})
-       booleanize-native-form
-       (format-rows-by [(partial u/round-to-decimals 4)])))
+;; avg aggregation
+(qp.test/expect-with-non-timeseries-dbs
+  {:rows [[35.5059]]
+   :cols [(qp.test/aggregate-col :avg  :venues :latitude)]}
+  (qp.test/rows-and-cols
+    (qp.test/format-rows-by [(partial u/round-to-decimals 4)]
+      (data/run-mbql-query venues
+        {:aggregation [[:avg $latitude]]}))))
 
 
-;;; ------------------------------------------ "DISTINCT COUNT" AGGREGATION ------------------------------------------
-(qp-expect-with-all-drivers
-  {:rows        [[15]]
-   :columns     ["count"]
-   :cols        [(aggregate-col :count (Field (data/id :checkins :user_id)))]
-   :native_form true}
-  (->> (data/run-mbql-query checkins
-         {:aggregation [[:distinct $user_id]]})
-       booleanize-native-form
-       (format-rows-by [int])))
+;; distinct count aggregation
+(qp.test/expect-with-non-timeseries-dbs
+  {:rows [[15]]
+   :cols [(qp.test/aggregate-col :distinct :checkins :user_id)]}
+  (qp.test/rows-and-cols
+    (qp.test/format-rows-by [int]
+      (data/run-mbql-query checkins
+        {:aggregation [[:distinct $user_id]]}))))
 
-
-;;; ------------------------------------------------- NO AGGREGATION -------------------------------------------------
 ;; Test that no aggregation (formerly known as a 'rows' aggregation in MBQL '95) just returns rows as-is.
-(qp-expect-with-all-drivers
-  {:rows        [[ 1 "Red Medicine"                  4 10.0646 -165.374 3]
-                 [ 2 "Stout Burgers & Beers"        11 34.0996 -118.329 2]
-                 [ 3 "The Apple Pan"                11 34.0406 -118.428 2]
-                 [ 4 "Wurstküche"                   29 33.9997 -118.465 2]
-                 [ 5 "Brite Spot Family Restaurant" 20 34.0778 -118.261 2]
-                 [ 6 "The 101 Coffee Shop"          20 34.1054 -118.324 2]
-                 [ 7 "Don Day Korean Restaurant"    44 34.0689 -118.305 2]
-                 [ 8 "25°"                          11 34.1015 -118.342 2]
-                 [ 9 "Krua Siri"                    71 34.1018 -118.301 1]
-                 [10 "Fred 62"                      20 34.1046 -118.292 2]]
-   :columns     (venues-columns)
-   :cols        (venues-cols)
-   :native_form true}
-    (-> (data/run-mbql-query venues
-          {:limit    10
-           :order-by [[:asc $id]]})
-        booleanize-native-form
-        formatted-venues-rows
-        tu/round-fingerprint-cols))
+(qp.test/expect-with-non-timeseries-dbs
+  [[ 1 "Red Medicine"                  4 10.0646 -165.374 3]
+   [ 2 "Stout Burgers & Beers"        11 34.0996 -118.329 2]
+   [ 3 "The Apple Pan"                11 34.0406 -118.428 2]
+   [ 4 "Wurstküche"                   29 33.9997 -118.465 2]
+   [ 5 "Brite Spot Family Restaurant" 20 34.0778 -118.261 2]
+   [ 6 "The 101 Coffee Shop"          20 34.1054 -118.324 2]
+   [ 7 "Don Day Korean Restaurant"    44 34.0689 -118.305 2]
+   [ 8 "25°"                          11 34.1015 -118.342 2]
+   [ 9 "Krua Siri"                    71 34.1018 -118.301 1]
+   [10 "Fred 62"                      20 34.1046 -118.292 2]]
+  (qp.test/formatted-rows :venues
+    (data/run-mbql-query venues
+      {:limit    10
+       :order-by [[:asc $id]]})))
 
 
-;;; ----------------------------------------------- STDDEV AGGREGATION -----------------------------------------------
-
-(qp-expect-with-drivers (non-timeseries-drivers-with-feature :standard-deviation-aggregations)
-  {:columns     ["stddev"]
-   :cols        [(aggregate-col :stddev (venues-col :latitude))]
-   :rows        [[3.4]]
-   :native_form true}
-  (-> (data/run-mbql-query venues
-        {:aggregation [[:stddev $latitude]]})
-      booleanize-native-form
-      (update-in [:data :rows] (fn [[[v]]]
-                                 [[(u/round-to-decimals 1 v)]]))))
+;; standard deviation aggregations
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :standard-deviation-aggregations)
+  {:cols [(qp.test/aggregate-col :stddev :venues :latitude)]
+   :rows [[3.4]]}
+  (qp.test/rows-and-cols
+    (qp.test/format-rows-by [(partial u/round-to-decimals 1)]
+      (data/run-mbql-query venues {:aggregation [[:stddev $latitude]]}))))
 
 ;; Make sure standard deviation fails for the Mongo driver since its not supported
-(datasets/expect-with-drivers (non-timeseries-drivers-without-feature :standard-deviation-aggregations)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-without-feature :standard-deviation-aggregations)
   {:status :failed
    :error  "standard-deviation-aggregations is not supported by this driver."}
   (select-keys (data/run-mbql-query venues
@@ -109,33 +88,33 @@
 ;;; |                                                   MIN & MAX                                                    |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(expect-with-non-timeseries-dbs
+(qp.test/expect-with-non-timeseries-dbs
   [1]
-  (first-row
-    (format-rows-by [int]
+  (qp.test/first-row
+    (qp.test/format-rows-by [int]
       (data/run-mbql-query venues
         {:aggregation [[:min $price]]}))))
 
-(expect-with-non-timeseries-dbs
+(qp.test/expect-with-non-timeseries-dbs
   [4]
-  (first-row
-    (format-rows-by [int]
+  (qp.test/first-row
+    (qp.test/format-rows-by [int]
       (data/run-mbql-query venues
         {:aggregation [[:max $price]]}))))
 
-(expect-with-non-timeseries-dbs
+(qp.test/expect-with-non-timeseries-dbs
   [[1 34.0071] [2 33.7701] [3 10.0646] [4 33.983]]
-  (format-rows-by [int (partial u/round-to-decimals 4)]
-    (rows (data/run-mbql-query venues
-            {:aggregation [[:min $latitude]]
-             :breakout    [$price]}))))
+  (qp.test/formatted-rows [int (partial u/round-to-decimals 4)]
+    (data/run-mbql-query venues
+      {:aggregation [[:min $latitude]]
+       :breakout    [$price]})))
 
-(expect-with-non-timeseries-dbs
+(qp.test/expect-with-non-timeseries-dbs
   [[1 37.8078] [2 40.7794] [3 40.7262] [4 40.7677]]
-  (format-rows-by [int (partial u/round-to-decimals 4)]
-    (rows (data/run-mbql-query venues
-            {:aggregation [[:max $latitude]]
-             :breakout    [$price]}))))
+  (qp.test/formatted-rows [int (partial u/round-to-decimals 4)]
+    (data/run-mbql-query venues
+      {:aggregation [[:max $latitude]]
+       :breakout    [$price]})))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -143,193 +122,165 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 ;; can we run a simple query with *two* aggregations?
-(expect-with-non-timeseries-dbs
+(qp.test/expect-with-non-timeseries-dbs
   [[100 203]]
-  (format-rows-by [int int]
-    (rows (data/run-mbql-query venues
-            {:aggregation [[:count] [:sum $price]]}))))
+  (qp.test/formatted-rows [int int]
+    (data/run-mbql-query venues
+      {:aggregation [[:count] [:sum $price]]})))
 
 ;; how about with *three* aggregations?
-(expect-with-non-timeseries-dbs
+(qp.test/expect-with-non-timeseries-dbs
   [[2 100 203]]
-  (format-rows-by [int int int]
-    (rows (data/run-mbql-query venues
-            {:aggregation [[:avg $price] [:count] [:sum $price]]}))))
+  (qp.test/formatted-rows [int int int]
+    (data/run-mbql-query venues
+      {:aggregation [[:avg $price] [:count] [:sum $price]]})))
 
 ;; make sure that multiple aggregations of the same type have the correct metadata (#4003)
 ;;
 ;; TODO - this isn't tested against Mongo because those driver doesn't currently work correctly with multiple columns
 ;; with the same name. It seems like it would be pretty easy to take the stuff we have for BigQuery and generalize it
 ;; so we can use it with Mongo
-(datasets/expect-with-drivers (disj non-timeseries-drivers :mongo)
-  [(aggregate-col :count)
-   (assoc (aggregate-col :count) :name "count_2")]
-  (-> (data/run-mbql-query venues
-        {:aggregation [[:count] [:count]]})
-      :data :cols))
+(datasets/expect-with-drivers (disj qp.test/non-timeseries-drivers :mongo)
+  [(qp.test/aggregate-col :count)
+   (assoc (qp.test/aggregate-col :count) :name "count_2")]
+  (qp.test/cols
+    (data/run-mbql-query venues
+      {:aggregation [[:count] [:count]]})))
 
 
 ;;; ------------------------------------------------- CUMULATIVE SUM -------------------------------------------------
 
 ;;; cum_sum w/o breakout should be treated the same as sum
-(qp-expect-with-all-drivers
-  {:rows        [[120]]
-   :columns     ["sum"]
-   :cols        [(aggregate-col :sum (users-col :id))]
-   :native_form true}
-  (->> (data/run-mbql-query users
-         {:aggregation [[:cum-sum $id]]})
-       booleanize-native-form
-       (format-rows-by [int])))
+(qp.test/expect-with-non-timeseries-dbs
+  {:rows [[120]]
+   :cols [(qp.test/aggregate-col :sum :users :id)]}
+  (qp.test/rows-and-cols
+    (qp.test/format-rows-by [int]
+      (data/run-mbql-query users
+        {:aggregation [[:cum-sum $id]]}))))
 
 
 ;;; Simple cumulative sum where breakout field is same as cum_sum field
-(qp-expect-with-all-drivers
-  {:rows        [[ 1   1]
-                 [ 2   3]
-                 [ 3   6]
-                 [ 4  10]
-                 [ 5  15]
-                 [ 6  21]
-                 [ 7  28]
-                 [ 8  36]
-                 [ 9  45]
-                 [10  55]
-                 [11  66]
-                 [12  78]
-                 [13  91]
-                 [14 105]
-                 [15 120]]
-   :columns     [(data/format-name "id")
-                 "sum"]
-   :cols        [(breakout-col (users-col :id))
-                 (aggregate-col :sum (users-col :id))]
-   :native_form true}
-  (->> (data/run-mbql-query users
-         {:aggregation [[:cum-sum $id]]
-          :breakout [$id]})
-       booleanize-native-form
-       (format-rows-by [int int])))
+(qp.test/expect-with-non-timeseries-dbs
+  {:rows [[ 1   1]
+          [ 2   3]
+          [ 3   6]
+          [ 4  10]
+          [ 5  15]
+          [ 6  21]
+          [ 7  28]
+          [ 8  36]
+          [ 9  45]
+          [10  55]
+          [11  66]
+          [12  78]
+          [13  91]
+          [14 105]
+          [15 120]]
+   :cols [(qp.test/breakout-col :users :id)
+          (qp.test/aggregate-col :sum :users :id)]}
+  (qp.test/rows-and-cols
+    (qp.test/format-rows-by [int int]
+      (data/run-mbql-query users
+        {:aggregation [[:cum-sum $id]]
+         :breakout    [$id]}))))
 
 
 ;;; Cumulative sum w/ a different breakout field
-(qp-expect-with-all-drivers
-  {:rows        [["Broen Olujimi"        14]
-                 ["Conchúr Tihomir"      21]
-                 ["Dwight Gresham"       34]
-                 ["Felipinho Asklepios"  36]
-                 ["Frans Hevel"          46]
-                 ["Kaneonuskatew Eiran"  49]
-                 ["Kfir Caj"             61]
-                 ["Nils Gotam"           70]
-                 ["Plato Yeshua"         71]
-                 ["Quentin Sören"        76]
-                 ["Rüstem Hebel"         91]
-                 ["Shad Ferdynand"       97]
-                 ["Simcha Yan"          101]
-                 ["Spiros Teofil"       112]
-                 ["Szymon Theutrich"    120]]
-   :columns     [(data/format-name "name")
-                 "sum"]
-   :cols        [(breakout-col (users-col :name))
-                 (aggregate-col :sum (users-col :id))]
-   :native_form true}
-  (->> (data/run-mbql-query users
-         {:aggregation [[:cum-sum $id]]
-          :breakout    [$name]})
-       booleanize-native-form
-       (format-rows-by [str int])
-       tu/round-fingerprint-cols))
+(qp.test/expect-with-non-timeseries-dbs
+  {:rows [["Broen Olujimi"        14]
+          ["Conchúr Tihomir"      21]
+          ["Dwight Gresham"       34]
+          ["Felipinho Asklepios"  36]
+          ["Frans Hevel"          46]
+          ["Kaneonuskatew Eiran"  49]
+          ["Kfir Caj"             61]
+          ["Nils Gotam"           70]
+          ["Plato Yeshua"         71]
+          ["Quentin Sören"        76]
+          ["Rüstem Hebel"         91]
+          ["Shad Ferdynand"       97]
+          ["Simcha Yan"          101]
+          ["Spiros Teofil"       112]
+          ["Szymon Theutrich"    120]]
+   :cols [(qp.test/breakout-col :users :name)
+          (qp.test/aggregate-col :sum :users :id)]}
+  (qp.test/rows-and-cols
+    (qp.test/format-rows-by [str int]
+      (data/run-mbql-query users
+        {:aggregation [[:cum-sum $id]]
+         :breakout    [$name]}))))
 
 
 ;;; Cumulative sum w/ a different breakout field that requires grouping
-(qp-expect-with-all-drivers
-  {:columns     [(data/format-name "price")
-                 "sum"]
-   :cols        [(breakout-col (venues-col :price))
-                 (aggregate-col :sum (venues-col :id))]
-   :rows        [[1 1211]
-                 [2 4066]
-                 [3 4681]
-                 [4 5050]]
-   :native_form true}
-  (->> (data/run-mbql-query venues
-         {:aggregation [[:cum-sum $id]]
-          :breakout    [$price]})
-       booleanize-native-form
-       (format-rows-by [int int])
-       tu/round-fingerprint-cols))
+(qp.test/expect-with-non-timeseries-dbs
+  {:cols [(qp.test/breakout-col :venues :price)
+          (qp.test/aggregate-col :sum :venues :id)]
+   :rows [[1 1211]
+          [2 4066]
+          [3 4681]
+          [4 5050]]}
+  (qp.test/rows-and-cols
+   (qp.test/format-rows-by [int int]
+     (data/run-mbql-query venues
+       {:aggregation [[:cum-sum $id]]
+        :breakout    [$price]}))))
 
 
 ;;; ------------------------------------------------ CUMULATIVE COUNT ------------------------------------------------
 
-(defn- cumulative-count-col [col-fn col-name]
-  (assoc (aggregate-col :count (col-fn col-name))
-    :base_type    :type/Integer
-    :special_type :type/Number))
-
 ;;; cum_count w/o breakout should be treated the same as count
-(qp-expect-with-all-drivers
-  {:rows        [[15]]
-   :columns     ["count"]
-   :cols        [(cumulative-count-col users-col :id)]
-   :native_form true}
-  (->> (data/run-mbql-query users
-         {:aggregation [[:cum-count $id]]})
-       booleanize-native-form
-       (format-rows-by [int])))
+(qp.test/expect-with-non-timeseries-dbs
+  {:rows [[15]]
+   :cols [(qp.test/aggregate-col :cum-count :users :id)]}
+  (qp.test/rows-and-cols
+    (qp.test/format-rows-by [int]
+      (data/run-mbql-query users
+        {:aggregation [[:cum-count $id]]}))))
 
 ;;; Cumulative count w/ a different breakout field
-(qp-expect-with-all-drivers
-  {:rows        [["Broen Olujimi"        1]
-                 ["Conchúr Tihomir"      2]
-                 ["Dwight Gresham"       3]
-                 ["Felipinho Asklepios"  4]
-                 ["Frans Hevel"          5]
-                 ["Kaneonuskatew Eiran"  6]
-                 ["Kfir Caj"             7]
-                 ["Nils Gotam"           8]
-                 ["Plato Yeshua"         9]
-                 ["Quentin Sören"       10]
-                 ["Rüstem Hebel"        11]
-                 ["Shad Ferdynand"      12]
-                 ["Simcha Yan"          13]
-                 ["Spiros Teofil"       14]
-                 ["Szymon Theutrich"    15]]
-   :columns     [(data/format-name "name")
-                 "count"]
-   :cols        [(breakout-col (users-col :name))
-                 (cumulative-count-col users-col :id)]
-   :native_form true}
-  (->> (data/run-mbql-query users
-         {:aggregation [[:cum-count $id]]
-          :breakout    [$name]})
-       booleanize-native-form
-       (format-rows-by [str int])
-       tu/round-fingerprint-cols))
+(qp.test/expect-with-non-timeseries-dbs
+  {:rows [["Broen Olujimi"        1]
+          ["Conchúr Tihomir"      2]
+          ["Dwight Gresham"       3]
+          ["Felipinho Asklepios"  4]
+          ["Frans Hevel"          5]
+          ["Kaneonuskatew Eiran"  6]
+          ["Kfir Caj"             7]
+          ["Nils Gotam"           8]
+          ["Plato Yeshua"         9]
+          ["Quentin Sören"       10]
+          ["Rüstem Hebel"        11]
+          ["Shad Ferdynand"      12]
+          ["Simcha Yan"          13]
+          ["Spiros Teofil"       14]
+          ["Szymon Theutrich"    15]]
+   :cols [(qp.test/breakout-col :users :name)
+          (qp.test/aggregate-col :cum-count :users :id)]}
+  (qp.test/rows-and-cols
+    (qp.test/format-rows-by [str int]
+      (data/run-mbql-query users
+        {:aggregation [[:cum-count $id]]
+         :breakout    [$name]}))))
 
 
 ;; Cumulative count w/ a different breakout field that requires grouping
-(qp-expect-with-all-drivers
-  {:columns     [(data/format-name "price")
-                 "count"]
-   :cols        [(breakout-col (venues-col :price))
-                 (cumulative-count-col venues-col :id)]
+(qp.test/expect-with-non-timeseries-dbs
+  {:cols        [(qp.test/breakout-col :venues :price)
+                 (qp.test/aggregate-col :cum-count :venues :id)]
    :rows        [[1 22]
                  [2 81]
                  [3 94]
-                 [4 100]]
-   :native_form true}
-  (->> (data/run-mbql-query venues
-         {:aggregation [[:cum-count $id]]
-          :breakout    [$price]})
-       booleanize-native-form
-       (format-rows-by [int int])
-       tu/round-fingerprint-cols))
+                 [4 100]]}
+  (qp.test/rows-and-cols
+    (qp.test/format-rows-by [int int]
+      (data/run-mbql-query venues
+        {:aggregation [[:cum-count $id]]
+         :breakout    [$price]}))))
 
 ;; Does Field.settings show up for aggregate Fields?
 (expect
-  (assoc (aggregate-col :sum (Field (data/id :venues :price)))
+  (assoc (qp.test/aggregate-col :sum :venues :price)
     :settings {:is_priceless false})
   (tu/with-temp-vals-in-db Field (data/id :venues :price) {:settings {:is_priceless false}}
     (let [results (data/run-mbql-query venues

--- a/test/metabase/query_processor_test/breakout_test.clj
+++ b/test/metabase/query_processor_test/breakout_test.clj
@@ -24,89 +24,70 @@
             [toucan.util.test :as tt]))
 
 ;;; single column
-(qp.test/qp-expect-with-all-drivers
-  {:rows        [[1 31] [2 70] [3 75] [4 77] [5 69] [6 70] [7 76] [8 81] [9 68] [10 78] [11 74] [12 59] [13 76] [14 62] [15 34]]
-   :columns     [(data/format-name "user_id")
-                 "count"]
-   :cols        [(qp.test/breakout-col (qp.test/checkins-col :user_id))
-                 (qp.test/aggregate-col :count)]
-   :native_form true}
-  (->> (data/run-mbql-query checkins
-         {:aggregation [[:count]]
-          :breakout    [$user_id]
-          :order-by    [[:asc $user_id]]})
-       qp.test/booleanize-native-form
-       (qp.test/format-rows-by [int int])
-       tu/round-fingerprint-cols))
+(qp.test/expect-with-non-timeseries-dbs
+  {:rows [[1 31] [2 70] [3 75] [4 77] [5 69] [6 70] [7 76] [8 81] [9 68] [10 78] [11 74] [12 59] [13 76] [14 62] [15 34]]
+   :cols [(qp.test/breakout-col :checkins :user_id)
+          (qp.test/aggregate-col :count)]}
+  (qp.test/rows-and-cols
+   (qp.test/format-rows-by [int int]
+     (data/run-mbql-query checkins
+       {:aggregation [[:count]]
+        :breakout    [$user_id]
+        :order-by    [[:asc $user_id]]}))))
 
 ;;; BREAKOUT w/o AGGREGATION
 ;; This should act as a "distinct values" query and return ordered results
-(qp.test/qp-expect-with-all-drivers
-  {:cols        [(qp.test/breakout-col (qp.test/checkins-col :user_id))]
-   :columns     [(data/format-name "user_id")]
-   :rows        [[1] [2] [3] [4] [5] [6] [7] [8] [9] [10]]
-   :native_form true}
-  (->> (data/run-mbql-query checkins
-         {:breakout [$user_id]
-          :limit    10})
-       qp.test/booleanize-native-form
-       (qp.test/format-rows-by [int])
-       tu/round-fingerprint-cols))
+(qp.test/expect-with-non-timeseries-dbs
+  {:cols [(qp.test/breakout-col :checkins :user_id)]
+   :rows [[1] [2] [3] [4] [5] [6] [7] [8] [9] [10]]}
+  (qp.test/rows-and-cols
+   (qp.test/format-rows-by [int]
+     (data/run-mbql-query checkins
+       {:breakout [$user_id]
+        :limit    10}))))
 
 
 ;;; "BREAKOUT" - MULTIPLE COLUMNS W/ IMPLICT "ORDER_BY"
 ;; Fields should be implicitly ordered :ASC for all the fields in `breakout` that are not specified in `order-by`
-(qp.test/qp-expect-with-all-drivers
-  {:rows        [[1 1 1] [1 5 1] [1 7 1] [1 10 1] [1 13 1] [1 16 1] [1 26 1] [1 31 1] [1 35 1] [1 36 1]]
-   :columns     [(data/format-name "user_id")
-                 (data/format-name "venue_id")
-                 "count"]
-   :cols        [(qp.test/breakout-col (qp.test/checkins-col :user_id))
-                 (qp.test/breakout-col (qp.test/checkins-col :venue_id))
-                 (qp.test/aggregate-col :count)]
-   :native_form true}
-  (->> (data/run-mbql-query checkins
-         {:aggregation [[:count]]
-          :breakout    [$user_id $venue_id]
-          :limit       10})
-       qp.test/booleanize-native-form
-       (qp.test/format-rows-by [int int int])
-       tu/round-fingerprint-cols))
+(qp.test/expect-with-non-timeseries-dbs
+  {:rows [[1 1 1] [1 5 1] [1 7 1] [1 10 1] [1 13 1] [1 16 1] [1 26 1] [1 31 1] [1 35 1] [1 36 1]]
+   :cols [(qp.test/breakout-col :checkins :user_id)
+          (qp.test/breakout-col :checkins :venue_id)
+          (qp.test/aggregate-col :count)]}
+  (qp.test/rows-and-cols
+   (qp.test/format-rows-by [int int int]
+     (data/run-mbql-query checkins
+       {:aggregation [[:count]]
+        :breakout    [$user_id $venue_id]
+        :limit       10}))))
 
 ;;; "BREAKOUT" - MULTIPLE COLUMNS W/ EXPLICIT "ORDER_BY"
 ;; `breakout` should not implicitly order by any fields specified in `order-by`
-(qp.test/qp-expect-with-all-drivers
-  {:rows        [[15 2 1] [15 3 1] [15 7 1] [15 14 1] [15 16 1] [15 18 1] [15 22 1] [15 23 2] [15 24 1] [15 27 1]]
-   :columns     [(data/format-name "user_id")
-                 (data/format-name "venue_id")
-                 "count"]
-   :cols        [(qp.test/breakout-col (qp.test/checkins-col :user_id))
-                 (qp.test/breakout-col (qp.test/checkins-col :venue_id))
-                 (qp.test/aggregate-col :count)]
-   :native_form true}
-  (->> (data/run-mbql-query checkins
-         {:aggregation [[:count]]
-          :breakout    [$user_id $venue_id]
-          :order-by    [[:desc $user_id]]
-          :limit       10})
-       qp.test/booleanize-native-form
-       (qp.test/format-rows-by [int int int])
-       tu/round-fingerprint-cols))
+(qp.test/expect-with-non-timeseries-dbs
+  {:rows [[15 2 1] [15 3 1] [15 7 1] [15 14 1] [15 16 1] [15 18 1] [15 22 1] [15 23 2] [15 24 1] [15 27 1]]
+   :cols [(qp.test/breakout-col :checkins :user_id)
+          (qp.test/breakout-col :checkins :venue_id)
+          (qp.test/aggregate-col :count)]}
+  (qp.test/rows-and-cols
+    (qp.test/format-rows-by [int int int]
+      (data/run-mbql-query checkins
+        {:aggregation [[:count]]
+         :breakout    [$user_id $venue_id]
+         :order-by    [[:desc $user_id]]
+         :limit       10}))))
 
-(qp.test/qp-expect-with-all-drivers
-  {:rows        [[2 8 "Artisan"]
-                 [3 2 "Asian"]
-                 [4 2 "BBQ"]
-                 [5 7 "Bakery"]
-                 [6 2 "Bar"]]
-   :columns     [(data/format-name "category_id")
-                 "count"
-                 "Foo"]
-   :cols        [(assoc (qp.test/breakout-col (qp.test/venues-col :category_id))
-                   :remapped_to "Foo")
-                 (qp.test/aggregate-col :count)
-                 (#'add-dim-projections/create-remapped-col "Foo" (data/format-name "category_id"))]
-   :native_form true}
+;; TODO - I have no idea what exactly these tests are testing??? This and the one below. Someone please determine and
+;; then write a description.
+(qp.test/expect-with-non-timeseries-dbs
+  {:rows [[2 8 "Artisan"]
+          [3 2 "Asian"]
+          [4 2 "BBQ"]
+          [5 7 "Bakery"]
+          [6 2 "Bar"]]
+   :cols [(assoc (qp.test/breakout-col :venues :category_id)
+            :remapped_to "Foo")
+          (qp.test/aggregate-col :count)
+          (#'add-dim-projections/create-remapped-col "Foo" (data/format-name "category_id"))]}
   (data/with-temp-objects
     (fn []
       (let [venue-names (data/dataset-field-values "categories" "name")]
@@ -116,107 +97,104 @@
          (db/insert! FieldValues {:field_id              (data/id :venues :category_id)
                                   :values                (json/generate-string (range 0 (count venue-names)))
                                   :human_readable_values (json/generate-string venue-names)})]))
-    (->> (data/run-mbql-query venues
-           {:aggregation [[:count]]
-            :breakout    [$category_id]
-            :limit       5})
-         qp.test/booleanize-native-form
-         (qp.test/format-rows-by [int int str])
-         tu/round-fingerprint-cols)))
+    (qp.test/rows-and-cols
+      (qp.test/format-rows-by [int int str]
+        (data/run-mbql-query venues
+          {:aggregation [[:count]]
+           :breakout    [$category_id]
+           :limit       5})))))
 
 (datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :foreign-keys)
-  [["Wine Bar" "Thai" "Thai" "Thai" "Thai" "Steakhouse" "Steakhouse" "Steakhouse" "Steakhouse" "Southern"]
-   ["American" "American" "American" "American" "American" "American" "American" "American" "Artisan" "Artisan"]]
+  {:descending-categories
+   ["Wine Bar" "Thai" "Thai" "Thai" "Thai" "Steakhouse" "Steakhouse" "Steakhouse" "Steakhouse" "Southern"]
+
+   :ascending-categories
+   ["American" "American" "American" "American" "American" "American" "American" "American" "Artisan" "Artisan"]}
   (data/with-temp-objects
     (fn []
       [(db/insert! Dimension {:field_id                (data/id :venues :category_id)
                               :name                    "Foo"
                               :type                    :external
                               :human_readable_field_id (data/id :categories :name)})])
-    [(->> (data/run-mbql-query venues
+    {:descending-categories
+     (->> (data/run-mbql-query venues
             {:order-by [[:desc $category_id]]
              :limit    10})
-           qp.test/rows
-           (map last))
+          qp.test/rows
+          (map last))
+
+     :ascending-categories
      (->> (data/run-mbql-query venues
             {:order-by [[:asc $category_id]]
              :limit    10})
-           qp.test/rows
-           (map last))]))
+          qp.test/rows
+          (map last))}))
 
 (datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :binning)
   [[10.0 1] [32.0 4] [34.0 57] [36.0 29] [40.0 9]]
-  (qp.test/format-rows-by [(partial u/round-to-decimals 1) int]
-    (qp.test/rows
-      (data/run-mbql-query venues
-        {:aggregation [[:count]]
-         :breakout    [[:binning-strategy $latitude :num-bins 20]]}))))
+  (qp.test/formatted-rows [(partial u/round-to-decimals 1) int]
+    (data/run-mbql-query venues
+      {:aggregation [[:count]]
+       :breakout    [[:binning-strategy $latitude :num-bins 20]]})))
 
 (datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :binning)
   [[0.0 1] [20.0 90] [40.0 9]]
-  (qp.test/format-rows-by [(partial u/round-to-decimals 1) int]
-    (qp.test/rows
-      (data/run-mbql-query venues
-        {:aggregation [[:count]]
-         :breakout    [[:binning-strategy $latitude :num-bins 3]]}))))
+  (qp.test/formatted-rows [(partial u/round-to-decimals 1) int]
+    (data/run-mbql-query venues
+      {:aggregation [[:count]]
+       :breakout    [[:binning-strategy $latitude :num-bins 3]]})))
 
 (datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :binning)
   [[10.0 -170.0 1] [32.0 -120.0 4] [34.0 -120.0 57] [36.0 -125.0 29] [40.0 -75.0 9]]
-  (qp.test/format-rows-by [(partial u/round-to-decimals 1) (partial u/round-to-decimals 1) int]
-    (qp.test/rows
-      (data/run-mbql-query venues
-        {:aggregation [[:count]]
-         :breakout    [[:binning-strategy $latitude :num-bins 20]
-                       [:binning-strategy $longitude :num-bins 20]]}))))
+  (qp.test/formatted-rows [(partial u/round-to-decimals 1) (partial u/round-to-decimals 1) int]
+    (data/run-mbql-query venues
+      {:aggregation [[:count]]
+       :breakout    [[:binning-strategy $latitude :num-bins 20]
+                     [:binning-strategy $longitude :num-bins 20]]})))
 
 ;; Currently defaults to 8 bins when the number of bins isn't
 ;; specified
 (datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :binning)
   [[10.0 1] [30.0 90] [40.0 9]]
-  (qp.test/format-rows-by [(partial u/round-to-decimals 1) int]
-    (qp.test/rows
-      (data/run-mbql-query venues
-        {:aggregation [[:count]]
-         :breakout    [[:binning-strategy $latitude :default]]}))))
+  (qp.test/formatted-rows [(partial u/round-to-decimals 1) int]
+    (data/run-mbql-query venues
+      {:aggregation [[:count]]
+       :breakout    [[:binning-strategy $latitude :default]]})))
 
 (datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :binning)
   [[10.0 1] [30.0 61] [35.0 29] [40.0 9]]
   (tu/with-temporary-setting-values [breakout-bin-width 5.0]
-    (qp.test/format-rows-by [(partial u/round-to-decimals 1) int]
-      (qp.test/rows
-        (data/run-mbql-query venues
-          {:aggregation [[:count]]
-           :breakout    [[:binning-strategy $latitude :default]]})))))
+    (qp.test/formatted-rows [(partial u/round-to-decimals 1) int]
+      (data/run-mbql-query venues
+        {:aggregation [[:count]]
+         :breakout    [[:binning-strategy $latitude :default]]}))))
 
 ;; Testing bin-width
 (datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :binning)
   [[10.0 1] [33.0 4] [34.0 57] [37.0 29] [40.0 9]]
-  (qp.test/format-rows-by [(partial u/round-to-decimals 1) int]
-    (qp.test/rows
-      (data/run-mbql-query venues
-        {:aggregation [[:count]]
-         :breakout    [[:binning-strategy $latitude :bin-width 1]]}))))
+  (qp.test/formatted-rows [(partial u/round-to-decimals 1) int]
+    (data/run-mbql-query venues
+      {:aggregation [[:count]]
+       :breakout    [[:binning-strategy $latitude :bin-width 1]]})))
 
 ;; Testing bin-width using a float
 (datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :binning)
   [[10.0 1] [32.5 61] [37.5 29] [40.0 9]]
-  (qp.test/format-rows-by [(partial u/round-to-decimals 1) int]
-    (qp.test/rows
-      (data/run-mbql-query venues
-        {:aggregation [[:count]]
-         :breakout    [[:binning-strategy $latitude :bin-width 2.5]]}))))
+  (qp.test/formatted-rows [(partial u/round-to-decimals 1) int]
+    (data/run-mbql-query venues
+      {:aggregation [[:count]]
+       :breakout    [[:binning-strategy $latitude :bin-width 2.5]]})))
 
 (datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :binning)
   [[33.0 4] [34.0 57]]
   (tu/with-temporary-setting-values [breakout-bin-width 1.0]
-    (qp.test/format-rows-by [(partial u/round-to-decimals 1) int]
-      (qp.test/rows
-        (data/run-mbql-query venues
-          {:aggregation [[:count]]
-           :filter      [:and
-                         [:< $latitude 35]
-                         [:> $latitude 20]]
-           :breakout    [[:binning-strategy $latitude :default]]})))))
+    (qp.test/formatted-rows [(partial u/round-to-decimals 1) int]
+      (data/run-mbql-query venues
+        {:aggregation [[:count]]
+         :filter      [:and
+                       [:< $latitude 35]
+                       [:> $latitude 20]]
+         :breakout    [[:binning-strategy $latitude :default]]}))))
 
 (defn- round-binning-decimals [result]
   (let [round-to-decimal #(u/round-to-decimals 4 %)]
@@ -228,23 +206,21 @@
 
 ;;Validate binning info is returned with the binning-strategy
 (datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :binning)
-  (assoc (qp.test/breakout-col (qp.test/venues-col :latitude))
+  (assoc (qp.test/breakout-col :venues :latitude)
     :binning_info {:min_value 10.0, :max_value 50.0, :num_bins 4, :bin_width 10.0, :binning_strategy :bin-width})
   (-> (data/run-mbql-query venues
         {:aggregation [[:count]]
          :breakout    [[:binning-strategy $latitude :default]]})
-      tu/round-fingerprint-cols
-      (get-in [:data :cols])
+      qp.test/cols
       first))
 
 (datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :binning)
-  (assoc (qp.test/breakout-col (qp.test/venues-col :latitude))
+  (assoc (qp.test/breakout-col :venues :latitude)
     :binning_info {:min_value 7.5, :max_value 45.0, :num_bins 5, :bin_width 7.5, :binning_strategy :num-bins})
   (-> (data/run-mbql-query venues
         {:aggregation [[:count]]
          :breakout    [[:binning-strategy $latitude :num-bins 5]]})
-      tu/round-fingerprint-cols
-      (get-in [:data :cols])
+      qp.test/cols
       first))
 
 ;;Validate binning info is returned with the binning-strategy
@@ -272,10 +248,9 @@
   (tt/with-temp Card [card (qp.test-util/card-with-source-metadata-for-query
                             (data/mbql-query nil
                               {:source-query {:source-table $$venues}}))]
-    (->> (nested-venues-query card)
-         qp/process-query
-         qp.test/rows
-         (qp.test/format-rows-by [(partial u/round-to-decimals 1) int]))))
+    (qp.test/formatted-rows [(partial u/round-to-decimals 1) int]
+      (qp/process-query
+        (nested-venues-query card)))))
 
 ;; Binning is not supported when there is no fingerprint to determine boundaries
 (datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :binning :nested-queries)
@@ -286,9 +261,9 @@
     ;; middleware is doing the right thing
     (with-redefs [add-source-metadata/mbql-source-query->metadata (constantly nil)]
       (tt/with-temp Card [card {:dataset_query (data/mbql-query venues)}]
-        (-> (nested-venues-query card)
-            qp/process-query
-            qp.test/rows)))))
+        (qp.test/rows
+          (qp/process-query
+            (nested-venues-query card)))))))
 
 ;; if we include a Field in both breakout and fields, does the query still work? (Normalization should be taking care
 ;; of this) (#8760)
@@ -296,5 +271,5 @@
   :completed
   (:status
    (data/run-mbql-query venues
-     {:breakout [[:field-id %price]]
-      :fields   [["field_id" %price]]})))
+     {:breakout [$price]
+      :fields   [$price]})))

--- a/test/metabase/query_processor_test/explicit_joins_test.clj
+++ b/test/metabase/query_processor_test/explicit_joins_test.clj
@@ -273,7 +273,7 @@
   [[29 "20th Century Cafe" 12  37.775 -122.423 2]
    [ 8 "25°"               11 34.1015 -118.342 2]
    [93 "33 Taps"            7 34.1018 -118.326 2]]
-  (qp.test/formatted-venues-rows
+  (qp.test/format-rows-by :venues
    (qp.test/rows
      (data/run-mbql-query venues
        {:source-table $$venues

--- a/test/metabase/query_processor_test/expression_aggregations_test.clj
+++ b/test/metabase/query_processor_test/expression_aggregations_test.clj
@@ -2,8 +2,7 @@
   "Tests for expression aggregations and for named aggregations."
   (:require [metabase
              [driver :as driver]
-             [query-processor :as qp]
-             [query-processor-test :refer :all]
+             [query-processor-test :as qp.test]
              [util :as u]]
             [metabase.models.metric :refer [Metric]]
             [metabase.test.data :as data]
@@ -11,40 +10,43 @@
             [toucan.util.test :as tt]))
 
 ;; sum, *
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :expression-aggregations)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :expression-aggregations)
   [[1 1211]
    [2 5710]
    [3 1845]
    [4 1476]]
-  (format-rows-by [int int]
-    (rows (data/run-mbql-query venues
-            {:aggregation [[:sum [:* $id $price]]]
-             :breakout    [$price]}))))
+  (qp.test/format-rows-by [int int]
+    (qp.test/rows
+      (data/run-mbql-query venues
+        {:aggregation [[:sum [:* $id $price]]]
+         :breakout    [$price]}))))
 
 ;; min, +
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :expression-aggregations)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :expression-aggregations)
   [[1 10]
    [2  4]
    [3  4]
    [4 20]]
-  (format-rows-by [int int]
-    (rows (data/run-mbql-query venues
-            {:aggregation [[:min [:+ $id $price]]]
-             :breakout    [$price]}))))
+  (qp.test/format-rows-by [int int]
+    (qp.test/rows
+      (data/run-mbql-query venues
+        {:aggregation [[:min [:+ $id $price]]]
+         :breakout    [$price]}))))
 
 ;; max, /
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :expression-aggregations)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :expression-aggregations)
   [[1 94]
    [2 50]
    [3 26]
    [4 20]]
-  (format-rows-by [int int]
-    (rows (data/run-mbql-query venues
-            {:aggregation [[:max [:/ $id $price]]]
-             :breakout    [$price]}))))
+  (qp.test/format-rows-by [int int]
+    (qp.test/rows
+      (data/run-mbql-query venues
+        {:aggregation [[:max [:/ $id $price]]]
+         :breakout    [$price]}))))
 
 ;; avg, -
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :expression-aggregations)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :expression-aggregations)
   (if (= driver/*driver* :h2)
     [[1  55]
      [2  97]
@@ -54,61 +56,66 @@
      [2  96]
      [3 141]
      [4 246]])
-  (format-rows-by [int int]
-    (rows (data/run-mbql-query venues
-            {:aggregation [[:avg [:* $id $price]]]
-             :breakout    [$price]}))))
+  (qp.test/format-rows-by [int int]
+    (qp.test/rows
+      (data/run-mbql-query venues
+        {:aggregation [[:avg [:* $id $price]]]
+         :breakout    [$price]}))))
 
 ;; post-aggregation math w/ 2 args: count + sum
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :expression-aggregations)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :expression-aggregations)
   [[1  44]
    [2 177]
    [3  52]
    [4  30]]
-  (format-rows-by [int int]
-    (rows (data/run-mbql-query venues
-            {:aggregation [[:+
-                            [:count $id]
-                            [:sum $price]]]
-             :breakout    [$price]}))))
+  (qp.test/format-rows-by [int int]
+    (qp.test/rows
+      (data/run-mbql-query venues
+        {:aggregation [[:+
+                        [:count $id]
+                        [:sum $price]]]
+         :breakout    [$price]}))))
 
 ;; post-aggregation math w/ 3 args: count + sum + count
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :expression-aggregations)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :expression-aggregations)
   [[1  66]
    [2 236]
    [3  65]
    [4  36]]
-  (format-rows-by [int int]
-    (rows (data/run-mbql-query venues
-            {:aggregation [[:+ [:count $id] [:sum $price] [:count $price]]]
-             :breakout    [$price]}))))
+  (qp.test/format-rows-by [int int]
+    (qp.test/rows
+      (data/run-mbql-query venues
+        {:aggregation [[:+ [:count $id] [:sum $price] [:count $price]]]
+         :breakout    [$price]}))))
 
 ;; post-aggregation math w/ a constant: count * 10
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :expression-aggregations)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :expression-aggregations)
   [[1 220]
    [2 590]
    [3 130]
    [4  60]]
-  (format-rows-by [int int]
-    (rows (data/run-mbql-query venues
-            {:aggregation [[:* [:count $id] 10]]
-             :breakout    [$price]}))))
+  (qp.test/format-rows-by [int int]
+    (qp.test/rows
+      (data/run-mbql-query venues
+        {:aggregation [[:* [:count $id] 10]]
+         :breakout    [$price]}))))
 
 ;; nested post-aggregation math: count + (count * sum)
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :expression-aggregations)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :expression-aggregations)
   [[1  506]
    [2 7021]
    [3  520]
    [4  150]]
-  (format-rows-by [int int]
-    (rows (data/run-mbql-query venues
-            {:aggregation [[:+
-                            [:count $id]
-                            [:* [:count $id] [:sum $price]]]]
-             :breakout    [$price]}))))
+  (qp.test/format-rows-by [int int]
+    (qp.test/rows
+      (data/run-mbql-query venues
+        {:aggregation [[:+
+                        [:count $id]
+                        [:* [:count $id] [:sum $price]]]]
+         :breakout    [$price]}))))
 
 ;; post-aggregation math w/ avg: count + avg
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :expression-aggregations)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :expression-aggregations)
   (if (= driver/*driver* :h2)
     [[1  77]
      [2 107]
@@ -118,94 +125,103 @@
      [2 107]
      [3  60]
      [4  67]])
-  (format-rows-by [int int]
-    (rows (data/run-mbql-query venues
-            {:aggregation [[:+ [:count $id] [:avg $id]]]
-             :breakout    [$price]}))))
+  (qp.test/format-rows-by [int int]
+    (qp.test/rows
+      (data/run-mbql-query venues
+        {:aggregation [[:+ [:count $id] [:avg $id]]]
+         :breakout    [$price]}))))
 
 ;; post aggregation math + math inside aggregations: max(venue_price) + min(venue_price - id)
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :expression-aggregations)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :expression-aggregations)
   [[1 -92]
    [2 -96]
    [3 -74]
    [4 -73]]
-  (format-rows-by [int int]
-    (rows (data/run-mbql-query venues
-            {:aggregation [[:+ [:max $price] [:min [:- $price $id]]]]
-             :breakout    [$price]}))))
+  (qp.test/format-rows-by [int int]
+    (qp.test/rows
+      (data/run-mbql-query venues
+        {:aggregation [[:+ [:max $price] [:min [:- $price $id]]]]
+         :breakout    [$price]}))))
 
 ;; aggregation w/o field
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :expression-aggregations)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :expression-aggregations)
   [[1 23]
    [2 60]
    [3 14]
    [4  7]]
-  (format-rows-by [int int]
-    (rows (data/run-mbql-query venues
-            {:aggregation [[:+ 1 [:count]]]
-             :breakout    [$price]}))))
+  (qp.test/format-rows-by [int int]
+    (qp.test/rows
+      (data/run-mbql-query venues
+        {:aggregation [[:+ 1 [:count]]]
+         :breakout    [$price]}))))
 
 ;; Sorting by an un-named aggregate expression
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :expression-aggregations)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :expression-aggregations)
   [[1 2] [2 2] [12 2] [4 4] [7 4] [10 4] [11 4] [8 8]]
-  (format-rows-by [int int]
-    (rows (data/run-mbql-query users
-            {:aggregation [[:* [:count] 2]]
-             :breakout    [[:datetime-field $last_login :month-of-year]]
-             :order-by    [[:asc [:aggregation 0]]]}))))
+  (qp.test/format-rows-by [int int]
+    (qp.test/rows
+      (data/run-mbql-query users
+        {:aggregation [[:* [:count] 2]]
+         :breakout    [[:datetime-field $last_login :month-of-year]]
+         :order-by    [[:asc [:aggregation 0]]]}))))
 
 ;; aggregation with math inside the aggregation :scream_cat:
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :expression-aggregations)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :expression-aggregations)
   [[1  44]
    [2 177]
    [3  52]
    [4  30]]
-  (format-rows-by [int int]
-    (rows (data/run-mbql-query venues
-            {:aggregation [[:sum [:+ $price 1]]]
-             :breakout    [$price]}))))
+  (qp.test/format-rows-by [int int]
+    (qp.test/rows
+      (data/run-mbql-query venues
+        {:aggregation [[:sum [:+ $price 1]]]
+         :breakout    [$price]}))))
 
 ;; check that we can name an expression aggregation w/ aggregation at top-level
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :expression-aggregations)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :expression-aggregations)
   {:rows    [[1  44]
              [2 177]
              [3  52]
              [4  30]]
    :columns [(data/format-name "price")
-             (driver/format-custom-field-name driver/*driver* "New Price")]} ; Redshift annoyingly always lowercases column aliases
-    (format-rows-by [int int]
-      (rows+column-names (data/run-mbql-query venues
-                           {:aggregation [[:named [:sum [:+ $price 1]] "New Price"]]
-                            :breakout    [$price]}))))
+             ;; Redshift annoyingly always lowercases column aliases
+             (driver/format-custom-field-name driver/*driver* "New Price")]}
+  (qp.test/format-rows-by [int int]
+    (qp.test/rows+column-names
+      (data/run-mbql-query venues
+        {:aggregation [[:named [:sum [:+ $price 1]] "New Price"]]
+         :breakout    [$price]}))))
 
 ;; check that we can name an expression aggregation w/ expression at top-level
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :expression-aggregations)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :expression-aggregations)
   {:rows    [[1 -19]
              [2  77]
              [3  -2]
              [4 -17]]
    :columns [(data/format-name "price")
              (driver/format-custom-field-name driver/*driver* "Sum-41")]}
-  (format-rows-by [int int]
-    (rows+column-names (data/run-mbql-query venues
-                         {:aggregation [[:named [:- [:sum $price] 41] "Sum-41"]]
-                          :breakout    [$price]}))))
+  (qp.test/format-rows-by [int int]
+    (qp.test/rows+column-names
+      (data/run-mbql-query venues
+        {:aggregation [[:named [:- [:sum $price] 41] "Sum-41"]]
+         :breakout    [$price]}))))
 
 ;; check that we can handle METRICS (ick) inside expression aggregation clauses
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :expression-aggregations)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :expression-aggregations)
   [[2 119]
    [3  40]
    [4  25]]
   (tt/with-temp Metric [metric {:table_id   (data/id :venues)
                                 :definition {:aggregation [:sum [:field-id (data/id :venues :price)]]
                                              :filter      [:> [:field-id (data/id :venues :price)] 1]}}]
-    (format-rows-by [int int]
-      (rows (data/run-mbql-query venues
-              {:aggregation [:+ [:metric (u/get-id metric)] 1]
-               :breakout    [[:field-id $price]]})))))
+    (qp.test/format-rows-by [int int]
+      (qp.test/rows
+        (data/run-mbql-query venues
+          {:aggregation [:+ [:metric (u/get-id metric)] 1]
+           :breakout    [[:field-id $price]]})))))
 
 ;; check that we can handle METRICS (ick) inside a NAMED clause
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :expression-aggregations)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :expression-aggregations)
   {:rows    [[2 118]
              [3  39]
              [4  24]]
@@ -214,48 +230,43 @@
   (tt/with-temp Metric [metric {:table_id   (data/id :venues)
                                 :definition {:aggregation [:sum [:field-id (data/id :venues :price)]]
                                              :filter      [:> [:field-id (data/id :venues :price)] 1]}}]
-    (format-rows-by [int int]
-      (rows+column-names (data/run-mbql-query venues
-                           {:aggregation  [[:named [:metric (u/get-id metric)] "My Cool Metric"]]
-                            :breakout     [[:field-id $price]]})))))
+    (qp.test/format-rows-by [int int]
+      (qp.test/rows+column-names
+        (data/run-mbql-query venues
+          {:aggregation [[:named [:metric (u/get-id metric)] "My Cool Metric"]]
+           :breakout    [[:field-id $price]]})))))
 
 ;; check that METRICS (ick) with a nested aggregation still work inside a NAMED clause
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :expression-aggregations)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :expression-aggregations)
   {:rows    [[2 118]
              [3  39]
              [4  24]]
    :columns [(data/format-name "price")
              (driver/format-custom-field-name driver/*driver* "My Cool Metric")]}
-  (tt/with-temp Metric [metric {:table_id   (data/id :venues)
-                                :definition {:aggregation [[:sum [:field-id (data/id :venues :price)]]]
-                                             :filter      [:> [:field-id (data/id :venues :price)] 1]}}]
-    (format-rows-by [int int]
-      (rows+column-names (qp/process-query
-                           {:database (data/id)
-                            :type     :query
-                            :query    {:source-table (data/id :venues)
-                                       :aggregation  [[:named [:metric (u/get-id metric)] "My Cool Metric"]]
-                                       :breakout     [[:field-id (data/id :venues :price)]]}})))))
+  (tt/with-temp Metric [metric (data/$ids venues
+                                 {:table_id   $$venues
+                                  :definition {:aggregation [[:sum $price]]
+                                               :filter      [:> $price 1]}})]
+    (qp.test/format-rows-by [int int]
+      (qp.test/rows+column-names
+        (data/run-mbql-query venues
+          {:aggregation [[:named [:metric (u/get-id metric)] "My Cool Metric"]]
+           :breakout    [[:field-id $price]]})))))
 
 ;; check that named aggregations come back with the correct column metadata (#4002)
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :expression-aggregations)
-  (let [col-name (driver/format-custom-field-name driver/*driver* "Count of Things")]
-    (assoc (aggregate-col :count)
-      :name         col-name
-      :display_name col-name))
-  (-> (qp/process-query
-        {:database (data/id)
-         :type     :query
-         :query    {:source-table (data/id :venues)
-                    :aggregation  [[:named ["COUNT"] "Count of Things"]]}})
-      :data :cols first))
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :expression-aggregations)
+  (assoc (qp.test/aggregate-col :count)
+    :name         (driver/format-custom-field-name driver/*driver* "Count of Things")
+    :display_name "Count of Things")
+  (-> (data/run-mbql-query venues
+        {:aggregation [[:named ["COUNT"] "Count of Things"]]})
+      qp.test/cols
+      first))
 
 ;; check that we can use cumlative count in expression aggregations
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :expression-aggregations)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :expression-aggregations)
   [[1000]]
-  (format-rows-by [int]
-    (rows (qp/process-query
-            {:database (data/id)
-             :type     :query
-             :query    {:source-table (data/id :venues)
-                        :aggregation  [["*" ["cum_count"] 10]]}}))))
+  (qp.test/format-rows-by [int]
+    (qp.test/rows
+      (data/run-mbql-query venues
+        {:aggregation [["*" ["cum_count"] 10]]}))))

--- a/test/metabase/query_processor_test/failure_test.clj
+++ b/test/metabase/query_processor_test/failure_test.clj
@@ -60,6 +60,7 @@
    :row_count    (s/eq 0)
    :running_time (s/constrained s/Int (complement neg?))
    :preprocessed (s/eq (assoc-in (bad-query:preprocessed) [:middleware :userland-query?] true))
-   :data         (s/eq {:rows [], :cols [], :columns []})}
+   :data         {:rows (s/eq [])
+                  :cols (s/eq [])}}
   (tu.log/suppress-output
     (qp/process-query-and-save-execution! (bad-query) {:context :question})))

--- a/test/metabase/query_processor_test/fields_test.clj
+++ b/test/metabase/query_processor_test/fields_test.clj
@@ -5,24 +5,22 @@
 
 ;; Test that we can restrict the Fields that get returned to the ones specified, and that results come back in the
 ;; order of the IDs in the `fields` clause
-(qp.test/qp-expect-with-all-drivers
-  {:rows        [["Red Medicine"                  1]
-                 ["Stout Burgers & Beers"         2]
-                 ["The Apple Pan"                 3]
-                 ["Wurstküche"                    4]
-                 ["Brite Spot Family Restaurant"  5]
-                 ["The 101 Coffee Shop"           6]
-                 ["Don Day Korean Restaurant"     7]
-                 ["25°"                           8]
-                 ["Krua Siri"                     9]
-                 ["Fred 62"                      10]]
-   :columns     (qp.test/->columns "name" "id")
-   :cols        [(qp.test/venues-col :name)
-                 (qp.test/venues-col :id)]
-   :native_form true}
-  (->> (data/run-mbql-query venues
-         {:fields   [$name $id]
-          :limit    10
-          :order-by [[:asc $id]]})
-       qp.test/booleanize-native-form
-       (qp.test/format-rows-by [str int])))
+(qp.test/expect-with-non-timeseries-dbs
+  {:rows [["Red Medicine"                  1]
+          ["Stout Burgers & Beers"         2]
+          ["The Apple Pan"                 3]
+          ["Wurstküche"                    4]
+          ["Brite Spot Family Restaurant"  5]
+          ["The 101 Coffee Shop"           6]
+          ["Don Day Korean Restaurant"     7]
+          ["25°"                           8]
+          ["Krua Siri"                     9]
+          ["Fred 62"                      10]]
+   :cols [(qp.test/col :venues :name)
+          (qp.test/col :venues :id)]}
+  (qp.test/format-rows-by [str int]
+    (qp.test/rows-and-cols
+      (data/run-mbql-query venues
+        {:fields   [$name $id]
+         :limit    10
+         :order-by [[:asc $id]]}))))

--- a/test/metabase/query_processor_test/nested_field_test.clj
+++ b/test/metabase/query_processor_test/nested_field_test.clj
@@ -1,12 +1,12 @@
 (ns metabase.query-processor-test.nested-field-test
   "Tests for nested field access."
-  (:require [metabase.query-processor-test :refer :all]
+  (:require [metabase.query-processor-test :as qp.test]
             [metabase.test.data :as data]
             [metabase.test.data.datasets :as datasets]))
 
 ;;; Nested Field in FILTER
 ;; Get the first 10 tips where tip.venue.name == "Kyle's Low-Carb Grill"
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :nested-fields)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :nested-fields)
   [[8   "Kyle's Low-Carb Grill"]
    [67  "Kyle's Low-Carb Grill"]
    [80  "Kyle's Low-Carb Grill"]
@@ -16,16 +16,18 @@
    [417 "Kyle's Low-Carb Grill"]
    [426 "Kyle's Low-Carb Grill"]
    [470 "Kyle's Low-Carb Grill"]]
-  (->> (data/dataset geographical-tips
-         (data/run-mbql-query tips
-           {:filter   [:= $tips.venue.name "Kyle's Low-Carb Grill"]
-            :order-by [[:asc $id]]
-            :limit    10}))
-       rows (mapv (fn [[id _ _ _ {venue-name :name}]] [id venue-name]))))
+  (mapv
+   (fn [[id _ _ _ {venue-name :name}]] [id venue-name])
+   (qp.test/rows
+     (data/dataset geographical-tips
+       (data/run-mbql-query tips
+         {:filter   [:= $tips.venue.name "Kyle's Low-Carb Grill"]
+          :order-by [[:asc $id]]
+          :limit    10})))))
 
 ;;; Nested Field in ORDER
 ;; Let's get all the tips Kyle posted on Twitter sorted by tip.venue.name
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :nested-fields)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :nested-fields)
   [[446
     {:mentions ["@cams_mexican_gastro_pub"], :tags ["#mexican" "#gastro" "#pub"], :service "twitter", :username "kyle"}
     "Cam's Mexican Gastro Pub is a historical and underappreciated place to conduct a business meeting with friends."
@@ -54,69 +56,69 @@
      :medium "http://cloudfront.net/cedd4221-dbdb-46c3-95a9-935cce6b3fe5/med.jpg",
      :small  "http://cloudfront.net/cedd4221-dbdb-46c3-95a9-935cce6b3fe5/small.jpg"}
     {:phone "415-901-6541", :name "Pacific Heights Free-Range Eatery", :categories ["Free-Range" "Eatery"], :id "88b361c8-ce69-4b2e-b0f2-9deedd574af6"}]]
-  (rows (data/dataset geographical-tips
-          (data/run-mbql-query tips
-            {:filter   [:and
-                        [:= $tips.source.service "twitter"]
-                        [:= $tips.source.username "kyle"]]
-             :order-by [[:asc $tips.venue.name]]}))))
+  (qp.test/rows
+    (data/dataset geographical-tips
+      (data/run-mbql-query tips
+        {:filter   [:and
+                    [:= $tips.source.service "twitter"]
+                    [:= $tips.source.username "kyle"]]
+         :order-by [[:asc $tips.venue.name]]}))))
 
 ;; Nested Field in AGGREGATION
 ;; Let's see how many *distinct* venue names are mentioned
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :nested-fields)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :nested-fields)
   [99]
-  (first-row (data/dataset geographical-tips
-               (data/run-mbql-query tips
-                 {:aggregation [[:distinct $tips.venue.name]]}))))
+  (qp.test/first-row
+    (data/dataset geographical-tips
+      (data/run-mbql-query tips
+        {:aggregation [[:distinct $tips.venue.name]]}))))
 
 ;; Now let's just get the regular count
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :nested-fields)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :nested-fields)
   [500]
-  (first-row (data/dataset geographical-tips
-               (data/run-mbql-query tips
-                 {:aggregation [[:count $tips.venue.name]]}))))
+  (qp.test/first-row
+    (data/dataset geographical-tips
+      (data/run-mbql-query tips
+        {:aggregation [[:count $tips.venue.name]]}))))
 
 ;;; Nested Field in BREAKOUT
 ;; Let's see how many tips we have by source.service
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :nested-fields)
-  {:rows        [["facebook"   107]
-                 ["flare"      105]
-                 ["foursquare" 100]
-                 ["twitter"     98]
-                 ["yelp"        90]]
-   :columns     ["source.service" "count"]
-   :native_form true}
-  (->> (data/dataset geographical-tips
-         (data/run-mbql-query tips
-           {:aggregation [[:count]]
-            :breakout    [$tips.source.service]}))
-       booleanize-native-form
-       :data (#(dissoc % :cols)) (format-rows-by [str int])))
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :nested-fields)
+  [["facebook"   107]
+   ["flare"      105]
+   ["foursquare" 100]
+   ["twitter"     98]
+   ["yelp"        90]]
+  (qp.test/rows
+    (qp.test/format-rows-by [str int]
+      (data/dataset geographical-tips
+        (data/run-mbql-query tips
+          {:aggregation [[:count]]
+           :breakout    [$tips.source.service]})))))
 
 ;;; Nested Field in FIELDS
 ;; Return the first 10 tips with just tip.venue.name
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :nested-fields)
-  {:columns ["venue.name"]
-   :rows    [["Lucky's Gluten-Free Café"]
-             ["Joe's Homestyle Eatery"]
-             ["Lower Pac Heights Cage-Free Coffee House"]
-             ["Oakland European Liquor Store"]
-             ["Tenderloin Gormet Restaurant"]
-             ["Marina Modern Sushi"]
-             ["Sunset Homestyle Grill"]
-             ["Kyle's Low-Carb Grill"]
-             ["Mission Homestyle Churros"]
-             ["Sameer's Pizza Liquor Store"]]}
-  (select-keys (:data (data/dataset geographical-tips
-                        (data/run-mbql-query tips
-                          {:fields   [$tips.venue.name]
-                           :order-by [[:asc $id]]
-                           :limit    10})))
-               [:columns :rows]))
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :nested-fields)
+  [["Lucky's Gluten-Free Café"]
+   ["Joe's Homestyle Eatery"]
+   ["Lower Pac Heights Cage-Free Coffee House"]
+   ["Oakland European Liquor Store"]
+   ["Tenderloin Gormet Restaurant"]
+   ["Marina Modern Sushi"]
+   ["Sunset Homestyle Grill"]
+   ["Kyle's Low-Carb Grill"]
+   ["Mission Homestyle Churros"]
+   ["Sameer's Pizza Liquor Store"]]
+  (qp.test/rows
+    (data/dataset geographical-tips
+      (data/run-mbql-query tips
+        {:fields   [$tips.venue.name]
+         :order-by [[:asc $id]]
+         :limit    10}))))
 
 
 ;;; Nested Field w/ ordering by aggregation
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :nested-fields)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :nested-fields)
   [["jane"           4]
    ["kyle"           5]
    ["tupac"          5]
@@ -131,9 +133,10 @@
    ["cam_saul"      10]
    ["rasta_toucan"  13]
    [nil            400]]
-  (->> (data/dataset geographical-tips
-         (data/run-mbql-query tips
-           {:aggregation [[:count]]
-            :breakout    [$tips.source.mayor]
-            :order-by    [[:asc [:aggregation 0]]]}))
-       rows (format-rows-by [identity int])))
+  (qp.test/format-rows-by [identity int]
+    (qp.test/rows
+      (data/dataset geographical-tips
+        (data/run-mbql-query tips
+          {:aggregation [[:count]]
+           :breakout    [$tips.source.mayor]
+           :order-by    [[:asc [:aggregation 0]]]})))))

--- a/test/metabase/query_processor_test/order_by_test.clj
+++ b/test/metabase/query_processor_test/order_by_test.clj
@@ -3,14 +3,11 @@
   (:require [clojure.math.numeric-tower :as math]
             [metabase
              [driver :as driver]
-             [query-processor-test :refer :all]]
-            [metabase.models.field :refer [Field]]
-            [metabase.test
-             [data :as data]
-             [util :as tu]]
+             [query-processor-test :as qp.test]]
+            [metabase.test.data :as data]
             [metabase.test.data.datasets :as datasets]))
 
-(expect-with-non-timeseries-dbs
+(qp.test/expect-with-non-timeseries-dbs
   [[1 12 375]
    [1  9 139]
    [1  1  72]
@@ -21,115 +18,94 @@
    [2  9 833]
    [2  8 380]
    [2  5 719]]
-  (->> (data/run-mbql-query checkins
-         {:fields   [$venue_id $user_id $id]
-          :order-by [[:asc $venue_id]
-                     [:desc $user_id]
-                     [:asc $id]]
-          :limit    10})
-       rows (format-rows-by [int int int])))
+  (qp.test/format-rows-by [int int int]
+    (qp.test/rows
+      (data/run-mbql-query checkins
+        {:fields   [$venue_id $user_id $id]
+         :order-by [[:asc $venue_id]
+                    [:desc $user_id]
+                    [:asc $id]]
+         :limit    10}))))
 
 
 ;;; ------------------------------------------- order-by aggregate fields --------------------------------------------
 
 ;;; order-by aggregate ["count"]
-(qp-expect-with-all-drivers
-  {:columns     [(data/format-name "price")
-                 "count"]
-   :rows        [[4  6]
-                 [3 13]
-                 [1 22]
-                 [2 59]]
-   :cols        [(breakout-col (venues-col :price))
-                 (aggregate-col :count)]
-   :native_form true}
-  (->> (data/run-mbql-query venues
-         {:aggregation [[:count]]
-          :breakout    [$price]
-          :order-by    [[:asc [:aggregation 0]]]})
-       booleanize-native-form
-       (format-rows-by [int int])
-       tu/round-fingerprint-cols))
+(qp.test/expect-with-non-timeseries-dbs
+  {:rows [[4  6]
+          [3 13]
+          [1 22]
+          [2 59]]
+   :cols [(qp.test/breakout-col :venues :price)
+          (qp.test/aggregate-col :count)]}
+  (qp.test/rows-and-cols
+    (qp.test/format-rows-by [int int]
+      (data/run-mbql-query venues
+        {:aggregation [[:count]]
+         :breakout    [$price]
+         :order-by    [[:asc [:aggregation 0]]]}))))
 
 
 ;;; order-by aggregate ["sum" field-id]
-(qp-expect-with-all-drivers
-  {:columns     [(data/format-name "price")
-                 "sum"]
-   :rows        [[2 2855]
-                 [1 1211]
-                 [3  615]
-                 [4  369]]
-   :cols        [(breakout-col (venues-col :price))
-                 (aggregate-col :sum (venues-col :id))]
-   :native_form true}
-  (->> (data/run-mbql-query venues
-         {:aggregation [[:sum $id]]
-          :breakout    [$price]
-          :order-by    [[:desc [:aggregation 0]]]})
-       booleanize-native-form
-       (format-rows-by [int int])
-       tu/round-fingerprint-cols))
+(qp.test/expect-with-non-timeseries-dbs
+  {:rows [[2 2855]
+          [1 1211]
+          [3  615]
+          [4  369]]
+   :cols [(qp.test/breakout-col :venues :price)
+          (qp.test/aggregate-col :sum :venues :id)]}
+  (qp.test/rows-and-cols
+    (qp.test/format-rows-by [int int]
+      (data/run-mbql-query venues
+        {:aggregation [[:sum $id]]
+         :breakout    [$price]
+         :order-by    [[:desc [:aggregation 0]]]}))))
 
 
 ;;; order-by aggregate ["distinct" field-id]
-(qp-expect-with-all-drivers
-  {:columns     [(data/format-name "price")
-                 "count"]
-   :rows        [[4  6]
-                 [3 13]
-                 [1 22]
-                 [2 59]]
-   :cols        [(breakout-col (venues-col :price))
-                 (aggregate-col :count (Field (data/id :venues :id)))]
-   :native_form true}
-  (->> (data/run-mbql-query venues
-         {:aggregation [[:distinct $id]]
-          :breakout    [$price]
-          :order-by    [[:asc [:aggregation 0]]]})
-       booleanize-native-form
-       (format-rows-by [int int])
-       tu/round-fingerprint-cols))
+(qp.test/expect-with-non-timeseries-dbs
+  {:rows [[4  6]
+          [3 13]
+          [1 22]
+          [2 59]]
+   :cols [(qp.test/breakout-col :venues :price)
+          (qp.test/aggregate-col :distinct :venues :id)]}
+  (qp.test/rows-and-cols
+    (qp.test/format-rows-by [int int]
+      (data/run-mbql-query venues
+        {:aggregation [[:distinct $id]]
+         :breakout    [$price]
+         :order-by    [[:asc [:aggregation 0]]]}))))
 
 
 ;;; order-by aggregate ["avg" field-id]
-(expect-with-non-timeseries-dbs
-  {:columns     [(data/format-name "price")
-                 "avg"]
-   :rows        [[3 22]
-                 [2 28]
-                 [1 32]
-                 [4 53]]
-   :cols        [(breakout-col (venues-col :price))
-                 (aggregate-col :avg (venues-col :category_id))]
-   :native_form true}
-  (->> (data/run-mbql-query venues
-         {:aggregation [[:avg $category_id]]
-          :breakout    [$price]
-          :order-by    [[:asc [:aggregation 0]]]})
-       booleanize-native-form
-       data
-       (format-rows-by [int int])
-       tu/round-fingerprint-cols))
+(qp.test/expect-with-non-timeseries-dbs
+  {:rows [[3 22]
+          [2 28]
+          [1 32]
+          [4 53]]
+   :cols [(qp.test/breakout-col :venues :price)
+          (qp.test/aggregate-col :avg :venues :category_id)]}
+  (qp.test/rows-and-cols
+    (qp.test/format-rows-by [int int]
+      (data/run-mbql-query venues
+        {:aggregation [[:avg $category_id]]
+         :breakout    [$price]
+         :order-by    [[:asc [:aggregation 0]]]}))))
 
 ;;; ### order-by aggregate ["stddev" field-id]
 ;; SQRT calculations are always NOT EXACT (normal behavior) so round everything to the nearest int.
 ;; Databases might use different versions of SQRT implementations
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :standard-deviation-aggregations)
-  {:columns     [(data/format-name "price")
-                 "stddev"]
-   :rows        [[3 (if (= :mysql driver/*driver*) 25 26)]
-                 [1 24]
-                 [2 21]
-                 [4 (if (= :mysql driver/*driver*) 14 15)]]
-   :cols        [(breakout-col (venues-col :price))
-                 (aggregate-col :stddev (venues-col :category_id))]
-   :native_form true}
-  (->> (data/run-mbql-query venues
-         {:aggregation [[:stddev $category_id]]
-          :breakout    [$price]
-          :order-by    [[:desc [:aggregation 0]]]})
-       booleanize-native-form
-       data
-       (format-rows-by [int (comp int math/round)])
-       tu/round-fingerprint-cols))
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :standard-deviation-aggregations)
+  {:rows [[3 (if (= :mysql driver/*driver*) 25 26)]
+          [1 24]
+          [2 21]
+          [4 (if (= :mysql driver/*driver*) 14 15)]]
+   :cols [(qp.test/breakout-col :venues :price)
+          (qp.test/aggregate-col :stddev (qp.test/col :venues :category_id))]}
+  (qp.test/rows-and-cols
+    (qp.test/format-rows-by [int (comp int math/round)]
+      (data/run-mbql-query venues
+        {:aggregation [[:stddev $category_id]]
+         :breakout    [$price]
+         :order-by    [[:desc [:aggregation 0]]]}))))

--- a/test/metabase/query_processor_test/remapping_test.clj
+++ b/test/metabase/query_processor_test/remapping_test.clj
@@ -2,117 +2,93 @@
   "Tests for the remapping results"
   (:require [metabase
              [query-processor :as qp]
-             [query-processor-test :as qp.test :refer :all]]
+             [query-processor-test :as qp.test]]
             [metabase.models
              [dimension :refer [Dimension]]
              [field :refer [Field]]]
             [metabase.query-processor.middleware.add-dimension-projections :as add-dimension-projections]
-            [metabase.test
-             [data :as data]
-             [util :as tu]]
+            [metabase.test.data :as data]
             [metabase.test.data.datasets :as datasets]
             [toucan.db :as db]))
 
-(qp-expect-with-all-drivers
-  {:rows        [["20th Century Cafe"               12 "Café"]
-                 ["25°"                             11 "Burger"]
-                 ["33 Taps"                          7 "Bar"]
-                 ["800 Degrees Neapolitan Pizzeria" 58 "Pizza"]]
-   :columns     [(data/format-name "name")
-                 (data/format-name "category_id")
-                 "Foo"]
-   :cols        [(venues-col :name)
-                 (assoc (venues-col :category_id) :remapped_to "Foo")
-                 (#'add-dimension-projections/create-remapped-col "Foo" (data/format-name "category_id"))]
-   :native_form true}
+(qp.test/expect-with-non-timeseries-dbs
+ {:rows [["20th Century Cafe"               12 "Café"]
+         ["25°"                             11 "Burger"]
+         ["33 Taps"                          7 "Bar"]
+         ["800 Degrees Neapolitan Pizzeria" 58 "Pizza"]]
+  :cols [(qp.test/col :venues :name)
+         (assoc (qp.test/col :venues :category_id) :remapped_to "Foo")
+         (#'add-dimension-projections/create-remapped-col "Foo" (data/format-name "category_id"))]}
   (data/with-temp-objects
     (data/create-venue-category-remapping "Foo")
-    (->> (data/run-mbql-query venues
-           {:fields   [$name $category_id]
-            :order-by [[:asc $name]]
-            :limit    4})
-         qp.test/booleanize-native-form
-         (qp.test/format-rows-by [str int str])
-         tu/round-fingerprint-cols)))
+    (qp.test/rows-and-cols
+      (qp.test/format-rows-by [str int str]
+        (data/run-mbql-query venues
+          {:fields   [$name $category_id]
+           :order-by [[:asc $name]]
+           :limit    4})))))
 
 (defn- select-columns
   "Focuses the given resultset to columns that return true when passed to `columns-pred`. Typically this would be done
   as part of the query, however there's a bug currently preventing that from working when remapped. This allows the
   data compared to be smaller and avoid that bug."
+  {:style/indent 1}
   [columns-pred results]
-  (let [col-indexes (remove nil? (map-indexed (fn [idx col]
-                                                (when (columns-pred col)
-                                                  idx))
-                                              (get-in results [:data :columns])))]
-    (-> results
-        (update-in [:data :columns]
-                   (fn [rows]
-                     (filterv columns-pred rows)))
-        (update-in [:data :cols]
-                   (fn [rows]
-                     (filterv #(columns-pred (:name %)) rows)))
-        (update-in [:data :rows]
-                   (fn [rows]
-                     (map #(mapv % col-indexes) rows))))))
+  (let [results-data (qp.test/data results)
+        col-indexes  (keep-indexed (fn [idx col]
+                                     (when (columns-pred (:name col))
+                                       idx))
+                                   (:cols results-data))]
+    {:rows (for [row (:rows results-data)]
+             (mapv (vec row) col-indexes))
+     :cols (for [col   (:cols results-data)
+                 :when (columns-pred (:name col))]
+             col)}))
 
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :foreign-keys)
-  {:rows        [["20th Century Cafe"               2 "Café"]
-                 ["25°"                             2 "Burger"]
-                 ["33 Taps"                         2 "Bar"]
-                 ["800 Degrees Neapolitan Pizzeria" 2 "Pizza"]]
-   :columns     [(:name (venues-col :name))
-                 (:name (venues-col :price))
-                 (data/format-name "name_2")]
-   :cols        [(venues-col :name)
-                 (venues-col :price)
-                 (assoc (categories-col :name)
-                   :fk_field_id   (data/id :venues :category_id)
-                   :display_name  "Foo"
-                   :name          (data/format-name "name_2")
-                   :remapped_from (data/format-name "category_id"))]
-   :native_form true}
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :foreign-keys)
+  {:rows [["20th Century Cafe"               2 "Café"]
+          ["25°"                             2 "Burger"]
+          ["33 Taps"                         2 "Bar"]
+          ["800 Degrees Neapolitan Pizzeria" 2 "Pizza"]]
+   :cols [(qp.test/col :venues :name)
+          (qp.test/col :venues :price)
+          (assoc (qp.test/col :categories :name)
+            :fk_field_id   (data/id :venues :category_id)
+            :display_name  "Foo"
+            :name          (data/format-name "name_2")
+            :remapped_from (data/format-name "category_id"))]}
   (data/with-temp-objects
     (data/create-venue-category-fk-remapping "Foo")
-    (->> (data/run-mbql-query venues
-           {:order-by [[:asc $name]]
-            :limit    4})
-         qp.test/booleanize-native-form
-         (qp.test/format-rows-by [int str int double double int str])
-         (select-columns (set (map data/format-name ["name" "price" "name_2"])))
-         tu/round-fingerprint-cols
-         data)))
+    (select-columns (set (map data/format-name ["name" "price" "name_2"]))
+      (qp.test/format-rows-by [int str int double double int str]
+        (data/run-mbql-query venues
+          {:order-by [[:asc $name]]
+           :limit    4})))))
 
 ;; Check that we can have remappings when we include a `:fields` clause that restricts the query fields returned
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :foreign-keys)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :foreign-keys)
   {:rows        [["20th Century Cafe"               2 "Café"]
                  ["25°"                             2 "Burger"]
                  ["33 Taps"                         2 "Bar"]
                  ["800 Degrees Neapolitan Pizzeria" 2 "Pizza"]]
-   :columns     [(:name (venues-col :name))
-                 (:name (venues-col :price))
-                 (data/format-name "name_2")]
-   :cols        [(venues-col :name)
-                 (venues-col :price)
-                 (assoc (categories-col :name)
+   :cols        [(qp.test/col :venues :name)
+                 (qp.test/col :venues :price)
+                 (assoc (qp.test/col :categories :name)
                    :fk_field_id   (data/id :venues :category_id)
                    :display_name  "Foo"
                    :name          (data/format-name "name_2")
-                   :remapped_from (data/format-name "category_id"))]
-   :native_form true}
+                   :remapped_from (data/format-name "category_id"))]}
   (data/with-temp-objects
     (data/create-venue-category-fk-remapping "Foo")
-    (->> (data/run-mbql-query venues
-           {:fields   [$name $price $category_id]
-            :order-by [[:asc $name]]
-            :limit    4})
-         qp.test/booleanize-native-form
-         (qp.test/format-rows-by [str int str str])
-         (select-columns (set (map data/format-name ["name" "price" "name_2"])))
-         tu/round-fingerprint-cols
-         :data)))
+    (select-columns (set (map data/format-name ["name" "price" "name_2"]))
+      (qp.test/format-rows-by [str int str str]
+        (data/run-mbql-query venues
+          {:fields   [$name $price $category_id]
+           :order-by [[:asc $name]]
+           :limit    4})))))
 
 ;; Test that we can remap inside an MBQL nested query
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :foreign-keys :nested-queries)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :foreign-keys :nested-queries)
   ["Kinaree Thai Bistro" "Ruen Pair Thai Restaurant" "Yamashiro Hollywood" "Spitz Eagle Rock" "The Gumbo Pot"]
   (data/with-temp-objects
     (fn []
@@ -123,12 +99,12 @@
     (->> (data/run-mbql-query checkins
            {:order-by [[:asc $date]]
             :limit    5})
-         rows
+         qp.test/rows
          (map last))))
 
 ;; Test a remapping with conflicting names, in the case below there are two name fields, one from Venues and the other
 ;; from Categories
-(datasets/expect-with-drivers (non-timeseries-drivers-with-feature :foreign-keys :nested-queries)
+(datasets/expect-with-drivers (qp.test/non-timeseries-drivers-with-feature :foreign-keys :nested-queries)
   ["20th Century Cafe" "25°" "33 Taps" "800 Degrees Neapolitan Pizzeria"]
   (data/with-temp-objects
     (data/create-venue-category-fk-remapping "Foo")
@@ -138,7 +114,7 @@
             :query {:source-table (data/id :venues)
                     :order-by [[(data/id :venues :name) :ascending]]
                     :limit 4}})
-         rows
+         qp.test/rows
          (map second))))
 
 ;; Test out a self referencing column. This has a users table like the one that is in `test-data`, but also includes a
@@ -147,7 +123,7 @@
 ;;
 ;; Having a self-referencing FK is currently broken with the Redshift and Oracle backends. The issue related to fix
 ;; this is https://github.com/metabase/metabase/issues/8510
-(datasets/expect-with-drivers (disj (non-timeseries-drivers-with-feature :foreign-keys) :redshift :oracle :vertica)
+(datasets/expect-with-drivers (disj (qp.test/non-timeseries-drivers-with-feature :foreign-keys) :redshift :oracle :vertica)
   ["Dwight Gresham" "Shad Ferdynand" "Kfir Caj" "Plato Yeshua"]
   (data/dataset test-data-self-referencing-user
     (data/with-temp-objects
@@ -163,5 +139,5 @@
       (->> (data/run-mbql-query users
              {:order-by [[:asc $name]]
               :limit    4})
-           rows
+           qp.test/rows
            (map last)))))

--- a/test/metabase/timeseries_query_processor_test.clj
+++ b/test/metabase/timeseries_query_processor_test.clj
@@ -2,22 +2,15 @@
   "Query processor tests for DBs that are event-based, like Druid.
   There architecture is different enough that we can't test them along with our 'normal' DBs in `query-procesor-test`."
   (:require [metabase
-             [query-processor-test :refer [first-row format-rows-by rows]]
+             [query-processor-test :as qp.test :refer [rows]]
              [util :as u]]
             [metabase.test.data :as data]
-            [metabase.timeseries-query-processor-test.util :refer :all]))
-
-(defn data [results]
-  (when-let [data (or (:data results)
-                      (println (u/pprint-to-str results)))] ; DEBUG
-    (-> data
-        (select-keys [:columns :rows])
-        (update :rows vec))))
+            [metabase.timeseries-query-processor-test.util :as tqp.test]))
 
 ;;; # Tests
 
 ;;; "bare rows" query, limit
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
  {:columns ["id"
             "timestamp"
              "count"
@@ -30,11 +23,12 @@
              "venue_price"]
    :rows [["931", "2013-01-03T08:00:00.000Z", 1, "2014-01-01T08:30:00.000Z", "Simcha Yan", "Thai", "34.094",  "-118.344", "Kinaree Thai Bistro",       "1"]
           ["285", "2013-01-10T08:00:00.000Z", 1, "2014-07-03T01:30:00.000Z", "Kfir Caj",   "Thai", "34.1021", "-118.306", "Ruen Pair Thai Restaurant", "2"]]}
-  (data (data/run-mbql-query checkins
-          {:limit 2})))
+ (qp.test/rows+column-names
+  (data/run-mbql-query checkins
+    {:limit 2})))
 
 ;;; "bare rows" query, limit, order-by timestamp desc
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["id"
              "timestamp"
              "count"
@@ -47,12 +41,13 @@
              "venue_price"]
    :rows    [["693", "2015-12-29T08:00:00.000Z", 1, "2014-07-03T19:30:00.000Z", "Frans Hevel", "Mexican", "34.0489", "-118.238", "Señor Fish",       "2"]
              ["570", "2015-12-26T08:00:00.000Z", 1, "2014-07-03T01:30:00.000Z", "Kfir Caj",    "Chinese", "37.7949", "-122.406", "Empress of China", "3"]]}
-  (data (data/run-mbql-query checkins
-          {:order-by [[:desc $timestamp]]
-           :limit    2})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:order-by [[:desc $timestamp]]
+      :limit    2})))
 
 ;;; "bare rows" query, limit, order-by timestamp asc
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["id"
              "timestamp"
              "count"
@@ -65,89 +60,96 @@
              "venue_price"]
    :rows    [["931", "2013-01-03T08:00:00.000Z", 1, "2014-01-01T08:30:00.000Z", "Simcha Yan", "Thai", "34.094",  "-118.344", "Kinaree Thai Bistro",       "1"]
              ["285", "2013-01-10T08:00:00.000Z", 1, "2014-07-03T01:30:00.000Z", "Kfir Caj",   "Thai", "34.1021", "-118.306", "Ruen Pair Thai Restaurant", "2"]]}
-  (data (data/run-mbql-query checkins
-          {:order-by [[:asc $timestamp]]
-           :limit    2})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:order-by [[:asc $timestamp]]
+      :limit    2})))
 
 
 
 ;;; fields clause
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["venue_name" "venue_category_name" "timestamp"],
    :rows    [["Kinaree Thai Bistro"       "Thai" "2013-01-03T08:00:00.000Z"]
              ["Ruen Pair Thai Restaurant" "Thai" "2013-01-10T08:00:00.000Z"]]}
-  (data (data/run-mbql-query checkins
-          {:fields [$venue_name $venue_category_name $timestamp]
-           :limit  2})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:fields [$venue_name $venue_category_name $timestamp]
+      :limit  2})))
 
 ;;; fields clause, order by timestamp asc
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["venue_name" "venue_category_name" "timestamp"],
    :rows    [["Kinaree Thai Bistro"       "Thai" "2013-01-03T08:00:00.000Z"]
              ["Ruen Pair Thai Restaurant" "Thai" "2013-01-10T08:00:00.000Z"]]}
-  (data (data/run-mbql-query checkins
-          {:fields   [$venue_name $venue_category_name $timestamp]
-           :order-by [[:asc $timestamp]]
-           :limit    2})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:fields   [$venue_name $venue_category_name $timestamp]
+      :order-by [[:asc $timestamp]]
+      :limit    2})))
 
 ;;; fields clause, order by timestamp desc
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["venue_name" "venue_category_name" "timestamp"],
    :rows    [["Señor Fish"       "Mexican" "2015-12-29T08:00:00.000Z"]
              ["Empress of China" "Chinese" "2015-12-26T08:00:00.000Z"]]}
-  (data (data/run-mbql-query checkins
-          {:fields   [$venue_name $venue_category_name $timestamp]
-           :order-by [[:desc $timestamp]]
-           :limit    2})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:fields   [$venue_name $venue_category_name $timestamp]
+      :order-by [[:desc $timestamp]]
+      :limit    2})))
 
 
 
 ;;; count
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [1000]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:count]]})))
 
 ;;; count(field)
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [1000]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:count $user_name]]})))
 
 ;;; avg
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["avg"]
    :rows    [[1.992]]}
-  (data (data/run-mbql-query checkins
-          {:aggregation [[:avg $venue_price]]})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:aggregation [[:avg $venue_price]]})))
 
 ;;; sum
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["sum"]
    :rows    [[1992.0]]}
-  (data (data/run-mbql-query checkins
-          {:aggregation [[:sum $venue_price]]})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:aggregation [[:sum $venue_price]]})))
 
 ;;; avg
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["avg"]
    :rows    [[1.992]]}
   (->> (data/run-mbql-query checkins
          {:aggregation [[:avg $venue_price]]})
-       (format-rows-by [(partial u/round-to-decimals 3)])
-       data))
+       (qp.test/format-rows-by [(partial u/round-to-decimals 3)])
+       qp.test/rows+column-names))
 
 ;;; distinct count
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [[4]]
   (->> (data/run-mbql-query checkins
          {:aggregation [[:distinct $venue_price]]})
-       rows (format-rows-by [int])))
+       qp.test/rows
+       (qp.test/format-rows-by [int])))
 
 ;;; 1 breakout (distinct values)
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["user_name"]
    :rows    [["Broen Olujimi"]
              ["Conchúr Tihomir"]
@@ -164,11 +166,12 @@
              ["Simcha Yan"]
              ["Spiros Teofil"]
              ["Szymon Theutrich"]]}
-  (data (data/run-mbql-query checkins
-          {:breakout [$user_name]})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:breakout [$user_name]})))
 
 ;;; 2 breakouts
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["user_name" "venue_category_name"]
    :rows    [["Broen Olujimi" "American"]
              ["Broen Olujimi" "Artisan"]
@@ -180,12 +183,13 @@
              ["Broen Olujimi" "Caribbean"]
              ["Broen Olujimi" "Deli"]
              ["Broen Olujimi" "Dim Sum"]]}
-  (data (data/run-mbql-query checkins
-          {:breakout [$user_name $venue_category_name]
-           :limit    10})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:breakout [$user_name $venue_category_name]
+      :limit    10})))
 
 ;;; 1 breakout w/ explicit order by
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["user_name"]
    :rows    [["Szymon Theutrich"]
              ["Spiros Teofil"]
@@ -197,13 +201,14 @@
              ["Nils Gotam"]
              ["Kfir Caj"]
              ["Kaneonuskatew Eiran"]]}
-  (data (data/run-mbql-query checkins
-          {:breakout [$user_name]
-           :order-by [[:desc $user_name]]
-           :limit    10})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:breakout [$user_name]
+      :order-by [[:desc $user_name]]
+      :limit    10})))
 
 ;;; 2 breakouts w/ explicit order by
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["user_name" "venue_category_name"]
    :rows    [["Broen Olujimi"       "American"]
              ["Conchúr Tihomir"     "American"]
@@ -215,13 +220,14 @@
              ["Nils Gotam"          "American"]
              ["Plato Yeshua"        "American"]
              ["Quentin Sören"       "American"]]}
-  (data (data/run-mbql-query checkins
-          {:breakout [$user_name $venue_category_name]
-           :order-by [[:asc $venue_category_name]]
-           :limit    10})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:breakout [$user_name $venue_category_name]
+      :order-by [[:asc $venue_category_name]]
+      :limit    10})))
 
 ;;; count w/ 1 breakout
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["user_name" "count"]
    :rows    [["Broen Olujimi"       62]
              ["Conchúr Tihomir"     76]
@@ -238,12 +244,13 @@
              ["Simcha Yan"          77]
              ["Spiros Teofil"       74]
              ["Szymon Theutrich"    81]]}
-  (data (data/run-mbql-query checkins
-          {:aggregation [[:count]]
-           :breakout    [$user_name]})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:aggregation [[:count]]
+      :breakout    [$user_name]})))
 
 ;;; count w/ 2 breakouts
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["user_name" "venue_category_name" "count"]
    :rows    [["Broen Olujimi" "American"  8]
              ["Broen Olujimi" "Artisan"   1]
@@ -255,78 +262,81 @@
              ["Broen Olujimi" "Caribbean" 1]
              ["Broen Olujimi" "Deli"      2]
              ["Broen Olujimi" "Dim Sum"   2]]}
-  (data (data/run-mbql-query checkins
-          {:aggregation [[:count]]
-           :breakout    [$user_name $venue_category_name]
-           :limit       10})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:aggregation [[:count]]
+      :breakout    [$user_name $venue_category_name]
+      :limit       10})))
 
 ;;; filter >
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [49]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:count]]
        :filter      [:> $venue_price 3]})))
 
 ;;; filter <
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [836]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:count]]
        :filter      [:< $venue_price 3]})))
 
 ;;; filter >=
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [164]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:count]]
        :filter      [:>= $venue_price 3]})))
 
 ;;; filter <=
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [951]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:count]]
        :filter      [:<= $venue_price 3]})))
 
 ;;; filter =
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["user_name" "venue_name" "venue_category_name" "timestamp"]
    :rows    [["Plato Yeshua" "Fred 62"        "Diner"    "2013-03-12T07:00:00.000Z"]
              ["Plato Yeshua" "Dimples"        "Karaoke"  "2013-04-11T07:00:00.000Z"]
              ["Plato Yeshua" "Baby Blues BBQ" "BBQ"      "2013-06-03T07:00:00.000Z"]
              ["Plato Yeshua" "The Daily Pint" "Bar"      "2013-07-25T07:00:00.000Z"]
              ["Plato Yeshua" "Marlowe"        "American" "2013-09-10T07:00:00.000Z"]]}
-  (data (data/run-mbql-query checkins
-          {:fields [$user_name $venue_name $venue_category_name $timestamp]
-           :filter [:= $user_name "Plato Yeshua"]
-           :limit  5})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:fields [$user_name $venue_name $venue_category_name $timestamp]
+      :filter [:= $user_name "Plato Yeshua"]
+      :limit  5})))
 
 ;;; filter !=
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [969]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:count]]
        :filter      [:!= $user_name "Plato Yeshua"]})))
 
 ;;; filter AND
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["user_name" "venue_name" "timestamp"]
    :rows    [["Plato Yeshua" "The Daily Pint" "2013-07-25T07:00:00.000Z"]]}
-  (data (data/run-mbql-query checkins
-          {:fields [$user_name $venue_name $timestamp]
-           :filter [:and
-                    [:= $venue_category_name "Bar"]
-                    [:= $user_name "Plato Yeshua"]]})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:fields [$user_name $venue_name $timestamp]
+      :filter [:and
+               [:= $venue_category_name "Bar"]
+               [:= $user_name "Plato Yeshua"]]})))
 
 ;;; filter OR
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [199]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:count]]
        :filter      [:or
@@ -334,61 +344,65 @@
                      [:= $venue_category_name "American"]]})))
 
 ;;; filter BETWEEN (inclusive)
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [951]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:count]]
        :filter      [:between $venue_price 1 3]})))
 
 ;;; filter INSIDE
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["venue_name"]
    :rows    [["Red Medicine"]]}
-  (data (data/run-mbql-query checkins
-          {:breakout [$venue_name]
-           :filter   [:inside $venue_latitude $venue_longitude 10.0649 -165.379 10.0641 -165.371]})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:breakout [$venue_name]
+      :filter   [:inside $venue_latitude $venue_longitude 10.0649 -165.379 10.0641 -165.371]})))
 
 ;;; filter IS_NULL
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [0]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:count]]
        :filter      [:is-null $venue_category_name]})))
 
 ;;; filter NOT_NULL
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [1000]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:count]]
        :filter      [:not-null $venue_category_name]})))
 
 ;;; filter STARTS_WITH
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["venue_category_name"]
    :rows    [["Mediterannian"] ["Mexican"]]}
-  (data (data/run-mbql-query checkins
-          {:breakout [$venue_category_name]
-           :filter   [:starts-with $venue_category_name "Me"]})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:breakout [$venue_category_name]
+      :filter   [:starts-with $venue_category_name "Me"]})))
 
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["venue_category_name"]
    :rows    []}
-  (data (data/run-mbql-query checkins
-          {:breakout [$venue_category_name]
-           :filter   [:starts-with $venue_category_name "ME"]})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:breakout [$venue_category_name]
+      :filter   [:starts-with $venue_category_name "ME"]})))
 
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["venue_category_name"]
    :rows    [["Mediterannian"] ["Mexican"]]}
-  (data (data/run-mbql-query checkins
-          {:breakout [$venue_category_name]
-           :filter   [:starts-with $venue_category_name "ME" {:case-sensitive false}]})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:breakout [$venue_category_name]
+      :filter   [:starts-with $venue_category_name "ME" {:case-sensitive false}]})))
 
 ;;; filter ENDS_WITH
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["venue_category_name"]
    :rows    [["American"]
              ["Artisan"]
@@ -398,18 +412,20 @@
              ["Korean"]
              ["Mediterannian"]
              ["Mexican"]]}
-  (data (data/run-mbql-query checkins
-          {:breakout [$venue_category_name]
-           :filter   [:ends-with $venue_category_name "an"]})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:breakout [$venue_category_name]
+      :filter   [:ends-with $venue_category_name "an"]})))
 
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["venue_category_name"]
    :rows    []}
-  (data (data/run-mbql-query checkins
-          {:breakout [$venue_category_name]
-           :filter   [:ends-with $venue_category_name "AN"]})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:breakout [$venue_category_name]
+      :filter   [:ends-with $venue_category_name "AN"]})))
 
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["venue_category_name"]
    :rows    [["American"]
              ["Artisan"]
@@ -419,12 +435,13 @@
              ["Korean"]
              ["Mediterannian"]
              ["Mexican"]]}
-  (data (data/run-mbql-query checkins
-          {:breakout [$venue_category_name]
-           :filter   [:ends-with $venue_category_name "AN" {:case-sensitive false}]})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:breakout [$venue_category_name]
+      :filter   [:ends-with $venue_category_name "AN" {:case-sensitive false}]})))
 
 ;;; filter CONTAINS
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["venue_category_name"]
    :rows    [["American"]
              ["Bakery"]
@@ -434,18 +451,20 @@
              ["German"]
              ["Mediterannian"]
              ["Southern"]]}
-  (data (data/run-mbql-query checkins
-          {:breakout [$venue_category_name]
-           :filter   [:contains $venue_category_name "er"]})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:breakout [$venue_category_name]
+      :filter   [:contains $venue_category_name "er"]})))
 
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["venue_category_name"]
    :rows    []}
-  (data (data/run-mbql-query checkins
-          {:breakout [$venue_category_name]
-           :filter   [:contains $venue_category_name "eR"]})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:breakout [$venue_category_name]
+      :filter   [:contains $venue_category_name "eR"]})))
 
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["venue_category_name"]
    :rows    [["American"]
              ["Bakery"]
@@ -455,12 +474,13 @@
              ["German"]
              ["Mediterannian"]
              ["Southern"]]}
-  (data (data/run-mbql-query checkins
-          {:breakout [$venue_category_name]
-           :filter   [:contains $venue_category_name "eR" {:case-sensitive false}]})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:breakout [$venue_category_name]
+      :filter   [:contains $venue_category_name "eR" {:case-sensitive false}]})))
 
 ;;; order by aggregate field (?)
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["user_name" "venue_category_name" "count"]
    :rows    [["Szymon Theutrich"    "Bar"      13]
              ["Dwight Gresham"      "Mexican"  12]
@@ -472,165 +492,178 @@
              ["Spiros Teofil"       "Bar"      10]
              ["Dwight Gresham"      "Bar"       9]
              ["Frans Hevel"         "Japanese"  9]]}
-  (data (data/run-mbql-query checkins
-          {:aggregation [[:count]]
-           :breakout    [$user_name $venue_category_name]
-           :order-by    [[:desc [:aggregation 0]]]
-           :limit       10})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:aggregation [[:count]]
+      :breakout    [$user_name $venue_category_name]
+      :order-by    [[:desc [:aggregation 0]]]
+      :limit       10})))
 
 ;;; date bucketing - default (day)
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["timestamp" "count"]
    :rows    [["2013-01-03+00:00" 1]
              ["2013-01-10+00:00" 1]
              ["2013-01-19+00:00" 1]
              ["2013-01-22+00:00" 1]
              ["2013-01-23+00:00" 1]]}
-  (data (data/run-mbql-query checkins
-          {:aggregation [[:count]]
-           :breakout    [$timestamp]
-           :limit       5})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:aggregation [[:count]]
+      :breakout    [$timestamp]
+      :limit       5})))
 
 ;;; date bucketing - minute
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["timestamp" "count"]
    :rows    [["2013-01-03T08:00:00+00:00" 1]
              ["2013-01-10T08:00:00+00:00" 1]
              ["2013-01-19T08:00:00+00:00" 1]
              ["2013-01-22T08:00:00+00:00" 1]
              ["2013-01-23T08:00:00+00:00" 1]]}
-  (data (data/run-mbql-query checkins
-          {:aggregation [[:count]]
-           :breakout    [[:datetime-field $timestamp :minute]]
-           :limit       5})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:aggregation [[:count]]
+      :breakout    [[:datetime-field $timestamp :minute]]
+      :limit       5})))
 
 ;;; date bucketing - minute-of-hour
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["timestamp" "count"]
    :rows    [[0 1000]]}
-  (data (data/run-mbql-query checkins
-          {:aggregation [[:count]]
-           :breakout    [[:datetime-field $timestamp :minute-of-hour]]
-           :limit       5})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:aggregation [[:count]]
+      :breakout    [[:datetime-field $timestamp :minute-of-hour]]
+      :limit       5})))
 
 ;;; date bucketing - hour
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["timestamp" "count"]
    :rows    [["2013-01-03T08:00:00+00:00" 1]
              ["2013-01-10T08:00:00+00:00" 1]
              ["2013-01-19T08:00:00+00:00" 1]
              ["2013-01-22T08:00:00+00:00" 1]
              ["2013-01-23T08:00:00+00:00" 1]]}
-  (data (data/run-mbql-query checkins
-          {:aggregation [[:count]]
-           :breakout    [[:datetime-field $timestamp :hour]]
-           :limit       5})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:aggregation [[:count]]
+      :breakout    [[:datetime-field $timestamp :hour]]
+      :limit       5})))
 
 ;;; date bucketing - hour-of-day
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["timestamp" "count"]
    :rows    [[7 719]
              [8 281]]}
-  (data (data/run-mbql-query checkins
-          {:aggregation [[:count]]
-           :breakout    [[:datetime-field $timestamp :hour-of-day]]
-           :limit       5})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:aggregation [[:count]]
+      :breakout    [[:datetime-field $timestamp :hour-of-day]]
+      :limit       5})))
 
 ;;; date bucketing - week
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["timestamp" "count"]
    :rows    [["2012-12-30" 1]
              ["2013-01-06" 1]
              ["2013-01-13" 1]
              ["2013-01-20" 4]
              ["2013-01-27" 1]]}
-  (data (data/run-mbql-query checkins
-          {:aggregation [[:count]]
-           :breakout    [[:datetime-field $timestamp :week]]
-           :limit       5})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:aggregation [[:count]]
+      :breakout    [[:datetime-field $timestamp :week]]
+      :limit       5})))
 
 ;;; date bucketing - day
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["timestamp" "count"]
    :rows    [["2013-01-03+00:00" 1]
              ["2013-01-10+00:00" 1]
              ["2013-01-19+00:00" 1]
              ["2013-01-22+00:00" 1]
              ["2013-01-23+00:00" 1]]}
-  (data (data/run-mbql-query checkins
-          {:aggregation [[:count]]
-           :breakout    [[:datetime-field $timestamp :day]]
-           :limit       5})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:aggregation [[:count]]
+      :breakout    [[:datetime-field $timestamp :day]]
+      :limit       5})))
 
 ;;; date bucketing - day-of-week
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["timestamp" "count"]
    :rows    [[1 135]
              [2 143]
              [3 153]
              [4 136]
              [5 139]]}
-  (data (data/run-mbql-query checkins
-          {:aggregation [[:count]]
-           :breakout    [[:datetime-field $timestamp :day-of-week]]
-           :limit       5})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:aggregation [[:count]]
+      :breakout    [[:datetime-field $timestamp :day-of-week]]
+      :limit       5})))
 
 ;;; date bucketing - day-of-month
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["timestamp" "count"]
    :rows    [[1 36]
              [2 36]
              [3 42]
              [4 35]
              [5 43]]}
-  (data (data/run-mbql-query checkins
-          {:aggregation [[:count]]
-           :breakout    [[:datetime-field $timestamp :day-of-month]]
-           :limit       5})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:aggregation [[:count]]
+      :breakout    [[:datetime-field $timestamp :day-of-month]]
+      :limit       5})))
 
 ;;; date bucketing - day-of-year
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["timestamp" "count"]
    :rows    [[3 2]
              [4 6]
              [5 1]
              [6 1]
              [7 2]]}
-  (data (data/run-mbql-query checkins
-          {:aggregation [[:count]]
-           :breakout    [[:datetime-field $timestamp :day-of-year]]
-           :limit       5})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:aggregation [[:count]]
+      :breakout    [[:datetime-field $timestamp :day-of-year]]
+      :limit       5})))
 
 ;;; date bucketing - week-of-year
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["timestamp" "count"]
    :rows    [[1 10]
              [2  7]
              [3  8]
              [4 10]
              [5  4]]}
-  (data (data/run-mbql-query checkins
-          {:aggregation [[:count]]
-           :breakout    [[:datetime-field $timestamp :week-of-year]]
-           :limit       5})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:aggregation [[:count]]
+      :breakout    [[:datetime-field $timestamp :week-of-year]]
+      :limit       5})))
 
 ;;; date bucketing - month
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["timestamp" "count"]
    :rows    [["2013-01-01"  8]
              ["2013-02-01" 11]
              ["2013-03-01" 21]
              ["2013-04-01" 26]
              ["2013-05-01" 23]]}
-  (data (data/run-mbql-query checkins
-          {:aggregation [[:count]]
-           :breakout    [[:datetime-field $timestamp :month]]
-           :limit       5})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:aggregation [[:count]]
+      :breakout    [[:datetime-field $timestamp :month]]
+      :limit       5})))
 
 ;; This test is similar to the above query but doesn't use a limit clause which causes the query to be a grouped
 ;; timeseries query rather than a topN query. The dates below are formatted incorrectly due to
 ;; https://github.com/metabase/metabase/issues/5969.
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["timestamp" "count"]
    :rows    [["2013-01-01" 8]
              ["2013-02-01" 11]
@@ -640,179 +673,183 @@
   (-> (data/run-mbql-query checkins
         {:aggregation [[:count]]
          :breakout    [[:datetime-field $timestamp :month]]})
-      data
+      qp.test/rows+column-names
       (update :rows #(take 5 %))))
 
 ;;; date bucketing - month-of-year
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["timestamp" "count"]
    :rows    [[1  38]
              [2  70]
              [3  92]
              [4  89]
              [5 111]]}
-  (data (data/run-mbql-query checkins
-          {:aggregation [[:count]]
-           :breakout    [[:datetime-field $timestamp :month-of-year]]
-           :limit       5})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:aggregation [[:count]]
+      :breakout    [[:datetime-field $timestamp :month-of-year]]
+      :limit       5})))
 
 ;;; date bucketing - quarter
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["timestamp" "count"]
    :rows    [["2013-01-01" 40]
              ["2013-04-01" 75]
              ["2013-07-01" 55]
              ["2013-10-01" 65]
              ["2014-01-01" 107]]}
-  (data (data/run-mbql-query checkins
-          {:aggregation [[:count]]
-           :breakout    [[:datetime-field $timestamp :quarter]]
-           :limit       5})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:aggregation [[:count]]
+      :breakout    [[:datetime-field $timestamp :quarter]]
+      :limit       5})))
 
 ;;; date bucketing - quarter-of-year
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["timestamp" "count"]
    :rows    [[1 200]
              [2 284]
              [3 278]
              [4 238]]}
-  (data (data/run-mbql-query checkins
-          {:aggregation [[:count]]
-           :breakout    [[:datetime-field $timestamp :quarter-of-year]]
-           :limit       5})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:aggregation [[:count]]
+      :breakout    [[:datetime-field $timestamp :quarter-of-year]]
+      :limit       5})))
 
 ;;; date bucketing - year
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   {:columns ["timestamp" "count"]
    :rows    [[2013 235]
              [2014 498]
              [2015 267]]}
-  (data (data/run-mbql-query checkins
-          {:aggregation [[:count]]
-           :breakout    [[:datetime-field $timestamp :year]]
-           :limit       5})))
+  (qp.test/rows+column-names
+   (data/run-mbql-query checkins
+     {:aggregation [[:count]]
+      :breakout    [[:datetime-field $timestamp :year]]
+      :limit       5})))
 
 
 
 ;;; `not` filter -- Test that we can negate the various other filter clauses
 
 ;;; =
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [999]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:count]]
        :filter      [:not [:= $id 1]]})))
 
 ;;; !=
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [1]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:count]]
        :filter      [:not [:!= $id 1]]})))
 ;;; <
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [961]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:count]]
        :filter      [:not [:< $id 40]]})))
 
 ;;; >
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [40]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:count]]
        :filter      [:not [:> $id 40]]})))
 
 ;;; <=
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [960]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:count]]
        :filter      [:not [:<= $id 40]]})))
 
 ;;; >=
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [39]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:count]]
        :filter      [:not [:>= $id 40]]})))
 
 ;;; is-null
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [1000]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:count]]
        :filter      [:not [:is-null $id]]})))
 
 ;;; between
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [989]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:count]]
        :filter      [:not [:between $id 30 40]]})))
 
 ;;; inside
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [377]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:count]]
        :filter      [:not [:inside $venue_latitude $venue_longitude 40 -120 30 -110]]})))
 
 ;;; starts-with
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [795]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:count]]
        :filter      [:not [:starts-with $venue_name "T"]]})))
 
 ;;; contains
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [971]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:count]]
        :filter      [:not [:contains $venue_name "BBQ"]]})))
 
 ;;; ends-with
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [884]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:count]]
        :filter      [:not [:ends-with $venue_name "a"]]})))
 
 ;;; and
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [975]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:count]]
        :filter      [:not [:and
                            [:> $id 32]
                            [:contains $venue_name "BBQ"]]]})))
 ;;; or
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [28]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:count]]
        :filter      [:not [:or [:> $id 32]
                            [:contains $venue_name "BBQ"]]]})))
 
 ;;; nested and/or
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [969]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:count]]
        :filter      [:not [:or [:and
@@ -821,17 +858,17 @@
                            [:contains $venue_name "BBQ"]]]})))
 
 ;;; nested not
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [29]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:count]]
        :filter      [:not [:not [:contains $venue_name "BBQ"]]]})))
 
 ;;; not nested inside and/or
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [4]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:count]]
        :filter      [:and
@@ -839,9 +876,9 @@
                      [:contains $venue_name "BBQ"]]})))
 
 ;;; time-interval
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [1000]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:count]]
        ;; test data is all in the past so nothing happened today <3
@@ -852,59 +889,59 @@
 ;;; MIN & MAX
 
 ;; tests for dimension columns
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [4.0]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:max $venue_price]]})))
 
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [1.0]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:min $venue_price]]})))
 
 ;; tests for metric columns
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [1.0]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:max $count]]})))
 
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [1.0]
-  (first-row
+  (qp.test/first-row
     (data/run-mbql-query checkins
       {:aggregation [[:min $count]]})))
 
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   ;; some sort of weird quirk w/ druid where all columns in breakout get converted to strings
   [["1" 34.0071] ["2" 33.7701] ["3" 10.0646] ["4" 33.983]]
   (rows (data/run-mbql-query checkins
           {:aggregation [[:min $venue_latitude]]
            :breakout    [$venue_price]})))
 
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [["1" 37.8078] ["2" 40.7794] ["3" 40.7262] ["4" 40.7677]]
   (rows (data/run-mbql-query checkins
           {:aggregation [[:max $venue_latitude]]
            :breakout    [$venue_price]})))
 
 ;; Do we properly handle queries that have more than one of the same aggregation? (#4166)
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [[35643 1992]]
-  (format-rows-by [int int]
+  (qp.test/format-rows-by [int int]
     (rows
       (data/run-mbql-query checkins
         {:aggregation [[:sum $venue_latitude] [:sum $venue_price]]}))))
 
 ;; Make sure sorting by aggregations works correctly for Timeseries queries (#9185)
-(expect-with-timeseries-dbs
+(tqp.test/expect-with-timeseries-dbs
   [["Steakhouse" 3.6]
    ["Chinese"    3.0]
    ["Wine Bar"   3.0]
    ["Japanese"   2.7]]
-  (format-rows-by [str (partial u/round-to-decimals 1)]
+  (qp.test/format-rows-by [str (partial u/round-to-decimals 1)]
     (rows
       (data/run-mbql-query checkins
         {:aggregation  [[:avg $venue_price]]


### PR DESCRIPTION
While I was working on this I took the time to fix some issues where too many tangentially-related tests needed to change when changing something like this. Tests that are testing something like filtering shouldn't need be updated when I change the display names in the results. So I spent a while reworking our tests and consolidating maybe 20 or so test helper functions & macros into maybe 5 or so and simplifying the tests a lot.

I removed the unused `:columns` in the results as well while I was at it