### PR TITLE
allow LoadingAndErrorWrapper to be empty

### DIFF
--- a/frontend/src/metabase/components/LoadingAndErrorWrapper.jsx
+++ b/frontend/src/metabase/components/LoadingAndErrorWrapper.jsx
@@ -109,7 +109,12 @@ export default class LoadingAndErrorWrapper extends Component {
     );
 
     if (noWrapper && !error && !loading) {
-      return React.Children.only(this.getChildren());
+      const children = this.getChildren();
+      // special case for loading wrapper with null/undefined child
+      if (children == null) {
+        return null;
+      }
+      return React.Children.only(children);
     }
     return (
       <div className={this.props.className} style={this.props.style}>

--- a/frontend/test/metabase/components/LoadingAndErrorWrapper.unit.spec.js
+++ b/frontend/test/metabase/components/LoadingAndErrorWrapper.unit.spec.js
@@ -22,6 +22,10 @@ describe("LoadingAndErrorWrapper", () => {
       expect(wrapper.find(Child).length).toEqual(1);
     });
 
+    it("shouldn't fail if loaded with null children and no wrapper", () => {
+      mount(<LoadingAndErrorWrapper loading={false} noWrapper />);
+    });
+
     it("should display a given scene during loading", () => {
       const Scene = () => <div>Fun load animation</div>;
 


### PR DESCRIPTION
Resolves #10212 

I think this was caused by my change a while back to have entity loaders always set `noWrapper` to true for `LoadingAndErrorWrapper`. When the loader doesn't wrap its contents, it passes the children through `React.Children.only`, which errors on null/undefined. Code that previously worked by returning `null` when no databases were available was now erroring and continuing to show the loading spinner. This PR allows `LoadingAndErrorWrapper` with `noWrapper=true` to have no children.

