### PR TITLE
Reorganize `pulse.render` code

### DIFF
--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -11,6 +11,7 @@
              [public-settings :as public-settings]
              [util :as u]]
             [metabase.pulse.render :as render]
+            [metabase.pulse.render.style :as render.style]
             [metabase.util
              [date :as du]
              [export :as export]
@@ -195,8 +196,8 @@
 (defn- pulse-context [pulse]
   (merge {:emailType    "pulse"
           :pulseName    (:name pulse)
-          :sectionStyle (render/style (render/section-style))
-          :colorGrey4   render/color-gray-4
+          :sectionStyle (render.style/style (render.style/section-style))
+          :colorGrey4   render.style/color-gray-4
           :logoFooter   true}
          (random-quote-context)))
 
@@ -284,8 +285,8 @@
      (merge {:questionURL (url/card-url card-id)
              :questionName card-name
              :emailType    "alert"
-             :sectionStyle (render/section-style)
-             :colorGrey4   render/color-gray-4
+             :sectionStyle (render.style/section-style)
+             :colorGrey4   render.style/color-gray-4
              :logoFooter   true}
             (random-quote-context)
             (when alert-condition-map

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -1,106 +1,18 @@
 (ns metabase.pulse.render
   (:require [clojure.tools.logging :as log]
-            [metabase.mbql.util :as mbql.u]
+            [hiccup.core :refer [h]]
             [metabase.pulse.render
-             [color :as color]
+             [body :as body]
              [common :as common]
-             [datetime :as datetime]
              [image-bundle :as image-bundle]
              [png :as png]
-             [style :as style]
-             [table :as table]]
-            [metabase.util :as u]
+             [style :as style]]
             [metabase.util
-             [date :as du]
              [i18n :refer [trs tru]]
-             [ui-logic :as ui-logic]
              [urls :as urls]]
-            [schema.core :as s])
-  (:import [java.awt BasicStroke Color RenderingHints]
-           java.awt.image.BufferedImage
-           java.io.ByteArrayOutputStream
-           java.util.Date
-           javax.imageio.ImageIO))
+            [schema.core :as s]))
 
 (def ^:private ^:const card-width 400)
-(def ^:private ^:const rows-limit 20)
-(def ^:private ^:const cols-limit 10)
-(def ^:private ^:const sparkline-dot-radius 6)
-(def ^:private ^:const sparkline-thickness 3)
-(def ^:private ^:const sparkline-pad 8)
-
-;; NOTE: hiccup does not escape content by default so be sure to use "h" to escape any user-controlled content :-/
-
-;;; --------------------------------------------------- Helper Fns ---------------------------------------------------
-
-(defn- graphing-columns [card {:keys [cols] :as data}]
-  [(or (ui-logic/x-axis-rowfn card data)
-       first)
-   (or (ui-logic/y-axis-rowfn card data)
-       second)])
-
-(defn- number-field?
-  [field]
-  (or (isa? (:base_type field)    :type/Number)
-      (isa? (:special_type field) :type/Number)))
-
-(defn detect-pulse-card-type
-  "Determine the pulse (visualization) type of a CARD, e.g. `:scalar` or `:bar`."
-  [card data]
-  (let [col-count                 (-> data :cols count)
-        row-count                 (-> data :rows count)
-        [col-1-rowfn col-2-rowfn] (graphing-columns card data)
-        col-1                     (col-1-rowfn (:cols data))
-        col-2                     (col-2-rowfn (:cols data))
-        aggregation               (-> card :dataset_query :query :aggregation first)]
-    (cond
-      (or (zero? row-count)
-          ;; Many aggregations result in [[nil]] if there are no rows to aggregate after filters
-          (= [[nil]] (-> data :rows)))                             :empty
-      (contains? #{:pin_map :state :country} (:display card))      nil
-      (and (= col-count 1)
-           (= row-count 1))                                        :scalar
-      (and (= col-count 2)
-           (> row-count 1)
-           (mbql.u/datetime-field? col-1)
-           (number-field? col-2))                                  :sparkline
-      (and (= col-count 2)
-           (number-field? col-2))                                  :bar
-      :else                                                        :table)))
-
-(defn- show-in-table? [{:keys [special_type visibility_type] :as column}]
-  (and (not (isa? special_type :type/Description))
-       (not (contains? #{:details-only :retired :sensitive} visibility_type))))
-
-(defn include-csv-attachment?
-  "Returns true if this card and resultset should include a CSV attachment"
-  [card {:keys [cols rows] :as result-data}]
-  (or (:include_csv card)
-      (and (not (:include_xls card))
-           (= :table (detect-pulse-card-type card result-data))
-           (or
-            ;; If some columns are not shown, include an attachment
-            (some (complement show-in-table?) cols)
-            ;; If there are too many rows or columns, include an attachment
-            (< cols-limit (count cols))
-            (< rows-limit (count rows))))))
-
-(defn count-displayed-columns
-  "Return a count of the number of columns to be included in a table display"
-  [cols]
-  (count (filter show-in-table? cols)))
-
-
-;;; --------------------------------------------------- Formatting ---------------------------------------------------
-
-(defn- format-cell
-  [timezone value col]
-  (cond
-    (mbql.u/datetime-field? col)                             (datetime/format-timestamp timezone value col)
-    (and (number? value) (not (mbql.u/datetime-field? col))) (common/format-number value)
-    :else                                                    (str value)))
-
-;;; --------------------------------------------------- Rendering ----------------------------------------------------
 
 (def ^:dynamic *include-buttons*
   "Should the rendered pulse include buttons? (default: `false`)"
@@ -109,278 +21,6 @@
 (def ^:dynamic *include-title*
   "Should the rendered pulse include a title? (default: `false`)"
   false)
-
-(def ^:dynamic *render-img-fn*
-  "The function that should be used for rendering image bytes. Defaults to `render-img-data-uri`."
-  image-bundle/render-img-data-uri)
-
-(defn- card-href
-  [card]
-  (h (urls/card-url (:id card))))
-
-
-
-(defn- create-remapping-lookup
-  "Creates a map with from column names to a column index. This is used to figure out what a given column name or value
-  should be replaced with"
-  [cols]
-  (into {}
-        (for [[col-idx {:keys [remapped_from]}] (map vector (range) cols)
-              :when remapped_from]
-          [remapped_from col-idx])))
-
-(defn- query-results->header-row
-  "Returns a row structure with header info from `cols`. These values are strings that are ready to be rendered as HTML"
-  [remapping-lookup cols include-bar?]
-  {:row (for [maybe-remapped-col cols
-              :when (show-in-table? maybe-remapped-col)
-              :let [{:keys [base_type special_type] :as col} (if (:remapped_to maybe-remapped-col)
-                                                               (nth cols (get remapping-lookup (:name maybe-remapped-col)))
-                                                               maybe-remapped-col)
-                    column-name (name (or (:display_name col) (:name col)))]
-              ;; If this column is remapped from another, it's already
-              ;; in the output and should be skipped
-              :when (not (:remapped_from maybe-remapped-col))]
-          (if (or (isa? base_type :type/Number)
-                  (isa? special_type :type/Number))
-            (common/->NumericWrapper column-name)
-            column-name))
-   :bar-width (when include-bar? 99)})
-
-(defn- query-results->row-seq
-  "Returns a seq of stringified formatted rows that can be rendered into HTML"
-  [timezone remapping-lookup cols rows bar-column max-value]
-  (for [row rows]
-    {:bar-width (when-let [bar-value (and bar-column (bar-column row))]
-                  ;; cast to double to avoid "Non-terminating decimal expansion" errors
-                  (float (* 100 (/ (double bar-value) max-value))))
-     :row (for [[maybe-remapped-col maybe-remapped-row-cell] (map vector cols row)
-                :when (and (not (:remapped_from maybe-remapped-col))
-                           (show-in-table? maybe-remapped-col))
-                :let [[col row-cell] (if (:remapped_to maybe-remapped-col)
-                                       [(nth cols (get remapping-lookup (:name maybe-remapped-col)))
-                                        (nth row (get remapping-lookup (:name maybe-remapped-col)))]
-                                       [maybe-remapped-col maybe-remapped-row-cell])]]
-            (format-cell timezone row-cell col))}))
-
-(defn- prep-for-html-rendering
-  "Convert the query results (`cols` and `rows`) into a formatted seq of rows (list of strings) that can be rendered as
-  HTML"
-  [timezone cols rows bar-column max-value column-limit]
-  (let [remapping-lookup (create-remapping-lookup cols)
-        limited-cols (take column-limit cols)]
-    (cons
-     (query-results->header-row remapping-lookup limited-cols bar-column)
-     (query-results->row-seq timezone remapping-lookup limited-cols (take rows-limit rows) bar-column max-value))))
-
-(defn- strong-limit-text [number]
-  [:strong {:style (style/style {:color style/color-gray-3})} (h (common/format-number number))])
-
-(defn- render-truncation-warning
-  [col-limit col-count row-limit row-count]
-  (let [over-row-limit (> row-count row-limit)
-        over-col-limit (> col-count col-limit)]
-    (when (or over-row-limit over-col-limit)
-      [:div {:style (style/style {:padding-top :16px})}
-       (cond
-
-         (and over-row-limit over-col-limit)
-         [:div {:style (style/style {:color          style/color-gray-2
-                                     :padding-bottom :10px})}
-          "Showing " (strong-limit-text row-limit)
-          " of "     (strong-limit-text row-count)
-          " rows and " (strong-limit-text col-limit)
-          " of "     (strong-limit-text col-count)
-          " columns."]
-
-         over-row-limit
-         [:div {:style (style/style {:color          style/color-gray-2
-                                     :padding-bottom :10px})}
-          "Showing " (strong-limit-text row-limit)
-          " of "     (strong-limit-text row-count)
-          " rows."]
-
-         over-col-limit
-         [:div {:style (style/style {:color          style/color-gray-2
-                                     :padding-bottom :10px})}
-          "Showing " (strong-limit-text col-limit)
-          " of "     (strong-limit-text col-count)
-          " columns."])])))
-
-(defn- attached-results-text
-  "Returns hiccup structures to indicate truncated results are available as an attachment"
-  [render-type cols cols-limit rows rows-limit]
-  (when (and (not= :inline render-type)
-             (or (< cols-limit (count-displayed-columns cols))
-                 (< rows-limit (count rows))))
-    [:div {:style (style/style {:color         style/color-gray-2
-                                :margin-bottom :16px})}
-     "More results have been included as a file attachment"]))
-
-(s/defn ^:private render:table :- common/RenderedPulseCard
-  [render-type timezone card {:keys [cols rows] :as data}]
-  (let [table-body [:div
-                    (table/render-table (color/make-color-selector data (:visualization_settings card))
-                                  (mapv :name (:cols data))
-                                  (prep-for-html-rendering timezone cols rows nil nil cols-limit))
-                    (render-truncation-warning cols-limit (count-displayed-columns cols) rows-limit (count rows))]]
-    {:attachments nil
-     :content     (if-let [results-attached (attached-results-text render-type cols cols-limit rows rows-limit)]
-                    (list results-attached table-body)
-                    (list table-body))}))
-
-(defn- non-nil-rows
-  "Remove any rows that have a nil value for the `x-axis-fn` OR `y-axis-fn`"
-  [x-axis-fn y-axis-fn rows]
-  (filter (every-pred x-axis-fn y-axis-fn) rows))
-
-(s/defn ^:private render:bar :- common/RenderedPulseCard
-  [timezone card {:keys [cols] :as data}]
-  (let [[x-axis-rowfn y-axis-rowfn] (graphing-columns card data)
-        rows (non-nil-rows x-axis-rowfn y-axis-rowfn (:rows data))
-        max-value (apply max (map y-axis-rowfn rows))]
-    {:attachments nil
-     :content     [:div
-                   (table/render-table (color/make-color-selector data (:visualization_settings card))
-                                 (mapv :name cols)
-                                 (prep-for-html-rendering timezone cols rows y-axis-rowfn max-value 2))
-                   (render-truncation-warning 2 (count-displayed-columns cols) rows-limit (count rows))]}))
-
-(s/defn ^:private render:scalar :- common/RenderedPulseCard
-  [timezone card {:keys [cols rows]}]
-  {:attachments nil
-   :content     [:div {:style (style/style (style/scalar-style))}
-                 (h (format-cell timezone (ffirst rows) (first cols)))]})
-
-(defn- render-sparkline-to-png
-  "Takes two arrays of numbers between 0 and 1 and plots them as a sparkline"
-  [xs ys width height]
-  (let [os    (ByteArrayOutputStream.)
-        image (BufferedImage. (+ width (* 2 sparkline-pad)) (+ height (* 2 sparkline-pad)) BufferedImage/TYPE_INT_ARGB)
-        xt    (map #(+ sparkline-pad (* width %)) xs)
-        yt    (map #(+ sparkline-pad (- height (* height %))) ys)]
-    (doto (.createGraphics image)
-      (.setRenderingHints (RenderingHints. RenderingHints/KEY_ANTIALIASING RenderingHints/VALUE_ANTIALIAS_ON))
-      (.setColor (Color. 211 227 241))
-      (.setStroke (BasicStroke. sparkline-thickness BasicStroke/CAP_ROUND BasicStroke/JOIN_ROUND))
-      (.drawPolyline (int-array (count xt) xt)
-                     (int-array (count yt) yt)
-                     (count xt))
-      (.setColor (Color. 45 134 212))
-      (.fillOval (- (last xt) sparkline-dot-radius)
-                 (- (last yt) sparkline-dot-radius)
-                 (* 2 sparkline-dot-radius)
-                 (* 2 sparkline-dot-radius))
-      (.setColor Color/white)
-      (.setStroke (BasicStroke. 2))
-      (.drawOval (- (last xt) sparkline-dot-radius)
-                 (- (last yt) sparkline-dot-radius)
-                 (* 2 sparkline-dot-radius)
-                 (* 2 sparkline-dot-radius)))
-    (when-not (ImageIO/write image "png" os)                    ; returns `true` if successful -- see JavaDoc
-      (let [^String msg (str (tru "No appropriate image writer found!"))]
-        (throw (Exception. msg))))
-    (.toByteArray os)))
-
-(s/defn ^:private render:sparkline :- common/RenderedPulseCard
-  [render-type timezone card {:keys [rows cols] :as data}]
-  (let [[x-axis-rowfn y-axis-rowfn] (graphing-columns card data)
-        ft-row                      (if (mbql.u/datetime-field? (x-axis-rowfn cols))
-                                      #(.getTime ^Date (du/->Timestamp % timezone))
-                                      identity)
-        rows                        (non-nil-rows x-axis-rowfn y-axis-rowfn
-                                                  (if (> (ft-row (x-axis-rowfn (first rows)))
-                                                         (ft-row (x-axis-rowfn (last rows))))
-                                                    (reverse rows)
-                                                    rows))
-        xs                          (map (comp ft-row x-axis-rowfn) rows)
-        xmin                        (apply min xs)
-        xmax                        (apply max xs)
-        xrange                      (- xmax xmin)
-        xs'                         (map #(/ (double (- % xmin)) xrange) xs)
-        ys                          (map y-axis-rowfn rows)
-        ymin                        (apply min ys)
-        ymax                        (apply max ys)
-        yrange                      (max 1 (- ymax ymin))                    ; `(max 1 ...)` so we don't divide by zero
-        ys'                         (map #(/ (double (- % ymin)) yrange) ys) ; cast to double to avoid "Non-terminating decimal expansion" errors
-        rows'                       (reverse (take-last 2 rows))
-        values                      (map (comp common/format-number y-axis-rowfn) rows')
-        labels                      (datetime/format-timestamp-pair timezone (map x-axis-rowfn rows') (x-axis-rowfn cols))
-        image-bundle                (image-bundle/make-image-bundle render-type (render-sparkline-to-png xs' ys' 524 130))]
-
-    {:attachments (when image-bundle
-                    (image-bundle/image-bundle->attachment image-bundle))
-     :content     [:div
-                   [:img {:style (style/style {:display :block
-                                               :width   :100%})
-                          :src   (:image-src image-bundle)}]
-                   [:table
-                    [:tr
-                     [:td {:style (style/style {:color         style/color-brand
-                                                :font-size     :24px
-                                                :font-weight   700
-                                                :padding-right :16px})}
-                      (first values)]
-                     [:td {:style (style/style {:color       style/color-gray-3
-                                                :font-size   :24px
-                                                :font-weight 700})}
-                      (second values)]]
-                    [:tr
-                     [:td {:style (style/style {:color         style/color-brand
-                                                :font-size     :16px
-                                                :font-weight   700
-                                                :padding-right :16px})}
-                      (first labels)]
-                     [:td {:style (style/style {:color     style/color-gray-3
-                                                :font-size :16px})}
-                      (second labels)]]]]}))
-
-(s/defn ^:private render:empty :- common/RenderedPulseCard
-  [render-type _ _]
-  (let [image-bundle (image-bundle/no-results-image-bundle render-type)]
-    {:attachments (image-bundle/image-bundle->attachment image-bundle)
-     :content     [:div {:style (style/style {:text-align :center})}
-                   [:img {:style (style/style {:width :104px})
-                          :src   (:image-src image-bundle)}]
-                   [:div {:style (style/style
-                                  (style/font-style)
-                                  {:margin-top :8px
-                                   :color      style/color-gray-4})}
-                    "No results"]]}))
-
-(s/defn ^:private render:attached :- common/RenderedPulseCard
-  [render-type _ _]
-  (let [image-bundle (image-bundle/attached-image-bundle render-type)]
-    {:attachments (image-bundle/image-bundle->attachment image-bundle)
-     :content     [:div {:style (style/style {:text-align :center})}
-                   [:img {:style (style/style {:width :30px})
-                          :src   (:image-src image-bundle)}]
-                   [:div {:style (style/style
-                                  (style/font-style)
-                                  {:margin-top :8px
-                                   :color      style/color-gray-4})}
-                    "This question has been included as a file attachment"]]}))
-
-(s/defn ^:private render:unknown :- common/RenderedPulseCard
-  [_ _]
-  {:attachments nil
-   :content     [:div {:style (style/style
-                               (style/font-style)
-                               {:color       style/color-gold
-                                :font-weight 700})}
-                 "We were unable to display this card."
-                 [:br]
-                 "Please view this card in Metabase."]})
-
-(s/defn ^:private render:error :- common/RenderedPulseCard
-  [_ _]
-  {:attachments nil
-   :content     [:div {:style (style/style
-                               (style/font-style)
-                               {:color       style/color-error
-                                :font-weight 700
-                                :padding     :16px})}
-                 "An error occurred while displaying this card."]})
 
 (s/defn ^:private make-title-if-needed :- (s/maybe common/RenderedPulseCard)
   [render-type card]
@@ -415,22 +55,18 @@
     (when error
       (let [^String msg (str (tru "Card has errors: {0}" error))]
         (throw (ex-info msg results))))
-    (case (detect-pulse-card-type card data)
-      :empty     (render:empty     render-type card data)
-      :scalar    (render:scalar    timezone card data)
-      :sparkline (render:sparkline render-type timezone card data)
-      :bar       (render:bar       timezone card data)
-      :table     (render:table     render-type timezone card data)
-      (if (is-attached? card)
-        (render:attached render-type card data)
-        (render:unknown card data)))
+    (let [render-type (or (body/detect-pulse-card-type card data)
+                          (when (is-attached? card)
+                            :attached)
+                          :unknown)]
+      (body/render render-type timezone card data))
     (catch Throwable e
-      (log/error (trs "Pulse card render error")
-                 (class e)
-                 (.getMessage e)
-                 "\n"
-                 (u/pprint-to-str (u/filtered-stacktrace e)))
-      (render:error card data))))
+      (log/error e (trs "Pulse card render error"))
+      (body/render :error timezone card e))))
+
+(defn- card-href
+  [card]
+  (h (urls/card-url (:id card))))
 
 (s/defn ^:private render-pulse-card :- common/RenderedPulseCard
   "Render a single `card` for a `Pulse` to Hiccup HTML. `result` is the QP results."
@@ -461,11 +97,12 @@
   (let [{:keys [attachments content]} (binding [*include-title* true]
                                         (render-pulse-card :attachment timezone card result))]
     {:attachments attachments
-     :content     [:div {:style (style/style (merge {:margin-top       :10px
-                                               :margin-bottom    :20px}
+     :content     [:div {:style (style/style (merge
+                                              {:margin-top    :10px
+                                               :margin-bottom :20px}
                                               ;; Don't include the border on cards rendered with a table as the table
                                               ;; will be to larger and overrun the border
-                                              (when-not (= :table (detect-pulse-card-type card data))
+                                              (when-not (= :table (body/detect-pulse-card-type card data))
                                                 {:border           "1px solid #dddddd"
                                                  :border-radius    :2px
                                                  :background-color :white

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -156,6 +156,7 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defmulti render
+  "Render a Pulse as `chart-type` (e.g. `:bar`, `:scalar`, etc.) and `render-type` (either `:inline` or `:attachment`)."
   {:arglists '([chart-type render-type timezone card data])}
   (fn [chart-type _ _ _ _] chart-type))
 

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -1,0 +1,376 @@
+(ns metabase.pulse.render.body
+  (:require [hiccup.core :refer [h]]
+            [metabase.mbql.util :as mbql.u]
+            [metabase.pulse.render
+             [color :as color]
+             [common :as common]
+             [datetime :as datetime]
+             [image-bundle :as image-bundle]
+             [style :as style]
+             [table :as table]]
+            [metabase.util
+             [date :as du]
+             [i18n :refer [tru]]
+             [ui-logic :as ui-logic]]
+            [schema.core :as s])
+  (:import [java.awt BasicStroke Color RenderingHints]
+           java.awt.image.BufferedImage
+           java.io.ByteArrayOutputStream
+           java.util.Date
+           javax.imageio.ImageIO))
+
+(def ^:private ^:const rows-limit 20)
+(def ^:private ^:const cols-limit 10)
+(def ^:private ^:const sparkline-dot-radius 6)
+(def ^:private ^:const sparkline-thickness 3)
+(def ^:private ^:const sparkline-pad 8)
+
+;; NOTE: hiccup does not escape content by default so be sure to use "h" to escape any user-controlled content :-/
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                                   Helper Fns                                                   |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defn- graphing-columns [card {:keys [cols] :as data}]
+  [(or (ui-logic/x-axis-rowfn card data)
+       first)
+   (or (ui-logic/y-axis-rowfn card data)
+       second)])
+
+(defn- number-field?
+  [field]
+  (or (isa? (:base_type field)    :type/Number)
+      (isa? (:special_type field) :type/Number)))
+
+(defn detect-pulse-card-type
+  "Determine the pulse (visualization) type of a `card`, e.g. `:scalar` or `:bar`."
+  [card data]
+  (let [col-count                 (-> data :cols count)
+        row-count                 (-> data :rows count)
+        [col-1-rowfn col-2-rowfn] (graphing-columns card data)
+        col-1                     (col-1-rowfn (:cols data))
+        col-2                     (col-2-rowfn (:cols data))
+        aggregation               (-> card :dataset_query :query :aggregation first)]
+    (cond
+      (or (zero? row-count)
+          ;; Many aggregations result in [[nil]] if there are no rows to aggregate after filters
+          (= [[nil]] (-> data :rows)))                             :empty
+      (contains? #{:pin_map :state :country} (:display card))      nil
+      (and (= col-count 1)
+           (= row-count 1))                                        :scalar
+      (and (= col-count 2)
+           (> row-count 1)
+           (mbql.u/datetime-field? col-1)
+           (number-field? col-2))                                  :sparkline
+      (and (= col-count 2)
+           (number-field? col-2))                                  :bar
+      :else                                                        :table)))
+
+(defn- show-in-table? [{:keys [special_type visibility_type] :as column}]
+  (and (not (isa? special_type :type/Description))
+       (not (contains? #{:details-only :retired :sensitive} visibility_type))))
+
+(defn include-csv-attachment?
+  "Returns true if this card and resultset should include a CSV attachment"
+  [card {:keys [cols rows] :as result-data}]
+  (or (:include_csv card)
+      (and (not (:include_xls card))
+           (= :table (detect-pulse-card-type card result-data))
+           (or
+            ;; If some columns are not shown, include an attachment
+            (some (complement show-in-table?) cols)
+            ;; If there are too many rows or columns, include an attachment
+            (< cols-limit (count cols))
+            (< rows-limit (count rows))))))
+
+(defn count-displayed-columns
+  "Return a count of the number of columns to be included in a table display"
+  [cols]
+  (count (filter show-in-table? cols)))
+
+
+;;; --------------------------------------------------- Formatting ---------------------------------------------------
+
+(defn- format-cell
+  [timezone value col]
+  (cond
+    (mbql.u/datetime-field? col)                             (datetime/format-timestamp timezone value col)
+    (and (number? value) (not (mbql.u/datetime-field? col))) (common/format-number value)
+    :else                                                    (str value)))
+
+;;; --------------------------------------------------- Rendering ----------------------------------------------------
+
+(def ^:dynamic *render-img-fn*
+  "The function that should be used for rendering image bytes. Defaults to `render-img-data-uri`."
+  image-bundle/render-img-data-uri)
+
+(defn- create-remapping-lookup
+  "Creates a map with from column names to a column index. This is used to figure out what a given column name or value
+  should be replaced with"
+  [cols]
+  (into {}
+        (for [[col-idx {:keys [remapped_from]}] (map vector (range) cols)
+              :when remapped_from]
+          [remapped_from col-idx])))
+
+(defn- query-results->header-row
+  "Returns a row structure with header info from `cols`. These values are strings that are ready to be rendered as HTML"
+  [remapping-lookup cols include-bar?]
+  {:row (for [maybe-remapped-col cols
+              :when (show-in-table? maybe-remapped-col)
+              :let [{:keys [base_type special_type] :as col} (if (:remapped_to maybe-remapped-col)
+                                                               (nth cols (get remapping-lookup (:name maybe-remapped-col)))
+                                                               maybe-remapped-col)
+                    column-name (name (or (:display_name col) (:name col)))]
+              ;; If this column is remapped from another, it's already
+              ;; in the output and should be skipped
+              :when (not (:remapped_from maybe-remapped-col))]
+          (if (or (isa? base_type :type/Number)
+                  (isa? special_type :type/Number))
+            (common/->NumericWrapper column-name)
+            column-name))
+   :bar-width (when include-bar? 99)})
+
+(defn- query-results->row-seq
+  "Returns a seq of stringified formatted rows that can be rendered into HTML"
+  [timezone remapping-lookup cols rows bar-column max-value]
+  (for [row rows]
+    {:bar-width (when-let [bar-value (and bar-column (bar-column row))]
+                  ;; cast to double to avoid "Non-terminating decimal expansion" errors
+                  (float (* 100 (/ (double bar-value) max-value))))
+     :row (for [[maybe-remapped-col maybe-remapped-row-cell] (map vector cols row)
+                :when (and (not (:remapped_from maybe-remapped-col))
+                           (show-in-table? maybe-remapped-col))
+                :let [[col row-cell] (if (:remapped_to maybe-remapped-col)
+                                       [(nth cols (get remapping-lookup (:name maybe-remapped-col)))
+                                        (nth row (get remapping-lookup (:name maybe-remapped-col)))]
+                                       [maybe-remapped-col maybe-remapped-row-cell])]]
+            (format-cell timezone row-cell col))}))
+
+(defn- prep-for-html-rendering
+  "Convert the query results (`cols` and `rows`) into a formatted seq of rows (list of strings) that can be rendered as
+  HTML"
+  [timezone cols rows bar-column max-value column-limit]
+  (let [remapping-lookup (create-remapping-lookup cols)
+        limited-cols (take column-limit cols)]
+    (cons
+     (query-results->header-row remapping-lookup limited-cols bar-column)
+     (query-results->row-seq timezone remapping-lookup limited-cols (take rows-limit rows) bar-column max-value))))
+
+(defn- strong-limit-text [number]
+  [:strong {:style (style/style {:color style/color-gray-3})} (h (common/format-number number))])
+
+(defn- render-truncation-warning
+  [col-limit col-count row-limit row-count]
+  (let [over-row-limit (> row-count row-limit)
+        over-col-limit (> col-count col-limit)]
+    (when (or over-row-limit over-col-limit)
+      [:div {:style (style/style {:padding-top :16px})}
+       (cond
+
+         (and over-row-limit over-col-limit)
+         [:div {:style (style/style {:color          style/color-gray-2
+                                     :padding-bottom :10px})}
+          "Showing " (strong-limit-text row-limit)
+          " of "     (strong-limit-text row-count)
+          " rows and " (strong-limit-text col-limit)
+          " of "     (strong-limit-text col-count)
+          " columns."]
+
+         over-row-limit
+         [:div {:style (style/style {:color          style/color-gray-2
+                                     :padding-bottom :10px})}
+          "Showing " (strong-limit-text row-limit)
+          " of "     (strong-limit-text row-count)
+          " rows."]
+
+         over-col-limit
+         [:div {:style (style/style {:color          style/color-gray-2
+                                     :padding-bottom :10px})}
+          "Showing " (strong-limit-text col-limit)
+          " of "     (strong-limit-text col-count)
+          " columns."])])))
+
+(defn- attached-results-text
+  "Returns hiccup structures to indicate truncated results are available as an attachment"
+  [render-type cols cols-limit rows rows-limit]
+  (when (and (not= :inline render-type)
+             (or (< cols-limit (count-displayed-columns cols))
+                 (< rows-limit (count rows))))
+    [:div {:style (style/style {:color         style/color-gray-2
+                                :margin-bottom :16px})}
+     "More results have been included as a file attachment"]))
+
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                                     render                                                     |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defmulti render
+  {:arglists '([render-type timezone card data])}
+  (fn [render-type _ _ _] render-type))
+
+(s/defmethod render :table :- common/RenderedPulseCard
+  [render-type timezone card {:keys [cols rows] :as data}]
+  (let [table-body [:div
+                    (table/render-table (color/make-color-selector data (:visualization_settings card))
+                                        (mapv :name (:cols data))
+                                        (prep-for-html-rendering timezone cols rows nil nil cols-limit))
+                    (render-truncation-warning cols-limit (count-displayed-columns cols) rows-limit (count rows))]]
+    {:attachments nil
+     :content     (if-let [results-attached (attached-results-text render-type cols cols-limit rows rows-limit)]
+                    (list results-attached table-body)
+                    (list table-body))}))
+
+(defn- non-nil-rows
+  "Remove any rows that have a nil value for the `x-axis-fn` OR `y-axis-fn`"
+  [x-axis-fn y-axis-fn rows]
+  (filter (every-pred x-axis-fn y-axis-fn) rows))
+
+(s/defmethod render :bar :- common/RenderedPulseCard
+  [_ timezone card {:keys [cols] :as data}]
+  (let [[x-axis-rowfn y-axis-rowfn] (graphing-columns card data)
+        rows (non-nil-rows x-axis-rowfn y-axis-rowfn (:rows data))
+        max-value (apply max (map y-axis-rowfn rows))]
+    {:attachments nil
+     :content     [:div
+                   (table/render-table (color/make-color-selector data (:visualization_settings card))
+                                 (mapv :name cols)
+                                 (prep-for-html-rendering timezone cols rows y-axis-rowfn max-value 2))
+                   (render-truncation-warning 2 (count-displayed-columns cols) rows-limit (count rows))]}))
+
+(s/defmethod render :scalar :- common/RenderedPulseCard
+  [_ timezone card {:keys [cols rows]}]
+  {:attachments nil
+   :content     [:div {:style (style/style (style/scalar-style))}
+                 (h (format-cell timezone (ffirst rows) (first cols)))]})
+
+(defn- render-sparkline-to-png
+  "Takes two arrays of numbers between 0 and 1 and plots them as a sparkline"
+  [xs ys width height]
+  (let [os    (ByteArrayOutputStream.)
+        image (BufferedImage. (+ width (* 2 sparkline-pad)) (+ height (* 2 sparkline-pad)) BufferedImage/TYPE_INT_ARGB)
+        xt    (map #(+ sparkline-pad (* width %)) xs)
+        yt    (map #(+ sparkline-pad (- height (* height %))) ys)]
+    (doto (.createGraphics image)
+      (.setRenderingHints (RenderingHints. RenderingHints/KEY_ANTIALIASING RenderingHints/VALUE_ANTIALIAS_ON))
+      (.setColor (Color. 211 227 241))
+      (.setStroke (BasicStroke. sparkline-thickness BasicStroke/CAP_ROUND BasicStroke/JOIN_ROUND))
+      (.drawPolyline (int-array (count xt) xt)
+                     (int-array (count yt) yt)
+                     (count xt))
+      (.setColor (Color. 45 134 212))
+      (.fillOval (- (last xt) sparkline-dot-radius)
+                 (- (last yt) sparkline-dot-radius)
+                 (* 2 sparkline-dot-radius)
+                 (* 2 sparkline-dot-radius))
+      (.setColor Color/white)
+      (.setStroke (BasicStroke. 2))
+      (.drawOval (- (last xt) sparkline-dot-radius)
+                 (- (last yt) sparkline-dot-radius)
+                 (* 2 sparkline-dot-radius)
+                 (* 2 sparkline-dot-radius)))
+    (when-not (ImageIO/write image "png" os)                    ; returns `true` if successful -- see JavaDoc
+      (let [^String msg (str (tru "No appropriate image writer found!"))]
+        (throw (Exception. msg))))
+    (.toByteArray os)))
+
+(s/defmethod render :sparkline :- common/RenderedPulseCard
+  [render-type timezone card {:keys [rows cols] :as data}]
+  (let [[x-axis-rowfn y-axis-rowfn] (graphing-columns card data)
+        ft-row                      (if (mbql.u/datetime-field? (x-axis-rowfn cols))
+                                      #(.getTime ^Date (du/->Timestamp % timezone))
+                                      identity)
+        rows                        (non-nil-rows x-axis-rowfn y-axis-rowfn
+                                                  (if (> (ft-row (x-axis-rowfn (first rows)))
+                                                         (ft-row (x-axis-rowfn (last rows))))
+                                                    (reverse rows)
+                                                    rows))
+        xs                          (map (comp ft-row x-axis-rowfn) rows)
+        xmin                        (apply min xs)
+        xmax                        (apply max xs)
+        xrange                      (- xmax xmin)
+        xs'                         (map #(/ (double (- % xmin)) xrange) xs)
+        ys                          (map y-axis-rowfn rows)
+        ymin                        (apply min ys)
+        ymax                        (apply max ys)
+        yrange                      (max 1 (- ymax ymin))                    ; `(max 1 ...)` so we don't divide by zero
+        ys'                         (map #(/ (double (- % ymin)) yrange) ys) ; cast to double to avoid "Non-terminating decimal expansion" errors
+        rows'                       (reverse (take-last 2 rows))
+        values                      (map (comp common/format-number y-axis-rowfn) rows')
+        labels                      (datetime/format-timestamp-pair timezone (map x-axis-rowfn rows') (x-axis-rowfn cols))
+        image-bundle                (image-bundle/make-image-bundle render-type (render-sparkline-to-png xs' ys' 524 130))]
+
+    {:attachments (when image-bundle
+                    (image-bundle/image-bundle->attachment image-bundle))
+     :content     [:div
+                   [:img {:style (style/style {:display :block
+                                               :width   :100%})
+                          :src   (:image-src image-bundle)}]
+                   [:table
+                    [:tr
+                     [:td {:style (style/style {:color         style/color-brand
+                                                :font-size     :24px
+                                                :font-weight   700
+                                                :padding-right :16px})}
+                      (first values)]
+                     [:td {:style (style/style {:color       style/color-gray-3
+                                                :font-size   :24px
+                                                :font-weight 700})}
+                      (second values)]]
+                    [:tr
+                     [:td {:style (style/style {:color         style/color-brand
+                                                :font-size     :16px
+                                                :font-weight   700
+                                                :padding-right :16px})}
+                      (first labels)]
+                     [:td {:style (style/style {:color     style/color-gray-3
+                                                :font-size :16px})}
+                      (second labels)]]]]}))
+
+(s/defmethod render :empty :- common/RenderedPulseCard
+  [render-type _ _ _]
+  (let [image-bundle (image-bundle/no-results-image-bundle render-type)]
+    {:attachments (image-bundle/image-bundle->attachment image-bundle)
+     :content     [:div {:style (style/style {:text-align :center})}
+                   [:img {:style (style/style {:width :104px})
+                          :src   (:image-src image-bundle)}]
+                   [:div {:style (style/style
+                                  (style/font-style)
+                                  {:margin-top :8px
+                                   :color      style/color-gray-4})}
+                    "No results"]]}))
+
+(s/defmethod render :attached :- common/RenderedPulseCard
+  [render-type _ _ _]
+  (let [image-bundle (image-bundle/attached-image-bundle render-type)]
+    {:attachments (image-bundle/image-bundle->attachment image-bundle)
+     :content     [:div {:style (style/style {:text-align :center})}
+                   [:img {:style (style/style {:width :30px})
+                          :src   (:image-src image-bundle)}]
+                   [:div {:style (style/style
+                                  (style/font-style)
+                                  {:margin-top :8px
+                                   :color      style/color-gray-4})}
+                    "This question has been included as a file attachment"]]}))
+
+(s/defmethod render :unknown :- common/RenderedPulseCard
+  [_ _ _ _]
+  {:attachments nil
+   :content     [:div {:style (style/style
+                               (style/font-style)
+                               {:color       style/color-gold
+                                :font-weight 700})}
+                 "We were unable to display this card."
+                 [:br]
+                 "Please view this card in Metabase."]})
+
+(s/defmethod render :error :- common/RenderedPulseCard
+  [_ _ _ _]
+  {:attachments nil
+   :content     [:div {:style (style/style
+                               (style/font-style)
+                               {:color       style/color-error
+                                :font-weight 700
+                                :padding     :16px})}
+                 "An error occurred while displaying this card."]})

--- a/src/metabase/pulse/render/color.clj
+++ b/src/metabase/pulse/render/color.clj
@@ -1,4 +1,4 @@
-(ns metabase.pulse.color
+(ns metabase.pulse.render.color
   "Namespaces that uses the Nashorn javascript engine to invoke some shared javascript code that we use to determine
   the background color of pulse table cells"
   (:require [cheshire.core :as json]
@@ -56,5 +56,5 @@
 (defn get-background-color
   "Get the correct color for a cell in a pulse table. This is intended to be invoked on each cell of every row in the
   table. See `make-color-selector` for more info."
-  [^JSObject color-selector cell-value column-name row-index]
+  [^JSObject color-selector, cell-value column-name row-index]
   (.call color-selector color-selector (object-array [cell-value row-index column-name])))

--- a/src/metabase/pulse/render/common.clj
+++ b/src/metabase/pulse/render/common.clj
@@ -1,8 +1,20 @@
 (ns metabase.pulse.render.common
-  (:require [schema.core :as s])
+  (:require [schema.core :as s]
+            [clojure.pprint :refer [cl-format]])
   (:import java.net.URL))
 
 (def RenderedPulseCard
   "Schema used for functions that operate on pulse card contents and their attachments"
   {:attachments (s/maybe {s/Str URL})
    :content     [s/Any]})
+
+(defrecord NumericWrapper [num-str]
+  hutil/ToString
+  (to-str [_] num-str)
+
+  Object
+  (toString [_] num-str))
+
+(defn format-number
+  [n]
+  (NumericWrapper. (cl-format nil (if (integer? n) "~:d" "~,2f") n)))

--- a/src/metabase/pulse/render/common.clj
+++ b/src/metabase/pulse/render/common.clj
@@ -1,6 +1,8 @@
 (ns metabase.pulse.render.common
-  (:require [schema.core :as s]
-            [clojure.pprint :refer [cl-format]])
+  (:require [clojure.pprint :refer [cl-format]]
+            [hiccup.util :as hutil]
+            [metabase.util.ui-logic :as ui-logic]
+            [schema.core :as s])
   (:import java.net.URL))
 
 (def RenderedPulseCard
@@ -18,3 +20,14 @@
 (defn format-number
   [n]
   (NumericWrapper. (cl-format nil (if (integer? n) "~:d" "~,2f") n)))
+
+(defn graphing-column-row-fns [card {:keys [cols] :as data}]
+  [(or (ui-logic/x-axis-rowfn card data)
+       first)
+   (or (ui-logic/y-axis-rowfn card data)
+       second)])
+
+(defn non-nil-rows
+  "Remove any rows that have a nil value for the `x-axis-fn` OR `y-axis-fn`"
+  [x-axis-fn y-axis-fn rows]
+  (filter (every-pred x-axis-fn y-axis-fn) rows))

--- a/src/metabase/pulse/render/common.clj
+++ b/src/metabase/pulse/render/common.clj
@@ -1,0 +1,8 @@
+(ns metabase.pulse.render.common
+  (:require [schema.core :as s])
+  (:import java.net.URL))
+
+(def RenderedPulseCard
+  "Schema used for functions that operate on pulse card contents and their attachments"
+  {:attachments (s/maybe {s/Str URL})
+   :content     [s/Any]})

--- a/src/metabase/pulse/render/common.clj
+++ b/src/metabase/pulse/render/common.clj
@@ -17,11 +17,16 @@
   Object
   (toString [_] num-str))
 
-(defn format-number
-  [n]
+(s/defn format-number :- NumericWrapper
+  "Format a number `n` and return it as a NumericWrapper; this type is used to do special formatting in other
+  `pulse.render` namespaces."
+  [n :- s/Num]
   (NumericWrapper. (cl-format nil (if (integer? n) "~:d" "~,2f") n)))
 
-(defn graphing-column-row-fns [card {:keys [cols] :as data}]
+(defn graphing-column-row-fns
+  "Return a pair of `[get-x-axis get-y-axis]` functions that can be used to get the x-axis and y-axis values in a row,
+  or columns, respectively."
+  [card {:keys [cols] :as data}]
   [(or (ui-logic/x-axis-rowfn card data)
        first)
    (or (ui-logic/y-axis-rowfn card data)

--- a/src/metabase/pulse/render/datetime.clj
+++ b/src/metabase/pulse/render/datetime.clj
@@ -1,0 +1,114 @@
+(ns metabase.pulse.render.datetime
+  "Logic for rendering datetimes inside Pulses."
+  (:require [clj-time
+             [core :as t]
+             [format :as f]]
+            [metabase.util
+             [date :as du]
+             [i18n :refer [tru]]
+             [schema :as su]]
+            [schema.core :as s])
+  (:import [org.joda.time DateTime DateTimeZone]))
+
+(defn- reformat-timestamp [timezone old-format-timestamp new-format-string]
+  (f/unparse (f/with-zone (f/formatter new-format-string)
+               (DateTimeZone/forTimeZone timezone))
+             (du/str->date-time old-format-timestamp timezone)))
+
+(defn format-timestamp
+  "Formats timestamps with human friendly absolute dates based on the column :unit"
+  [timezone timestamp col]
+  (case (:unit col)
+    :hour          (reformat-timestamp timezone timestamp "h a - MMM YYYY")
+    :week          (str "Week " (reformat-timestamp timezone timestamp "w - YYYY"))
+    :month         (reformat-timestamp timezone timestamp "MMMM YYYY")
+    :quarter       (let [timestamp-obj (du/str->date-time timestamp timezone)]
+                     (str "Q"
+                          (inc (int (/ (t/month timestamp-obj)
+                                       3)))
+                          " - "
+                          (t/year timestamp-obj)))
+
+    ;; TODO: probably shouldn't even be showing sparkline for x-of-y groupings?
+    (:year :hour-of-day :day-of-week :week-of-year :month-of-year)
+    (str timestamp)
+
+    (reformat-timestamp timezone timestamp "MMM d, YYYY")))
+
+
+(def ^:private year  (comp t/year  t/now))
+(def ^:private month (comp t/month t/now))
+(def ^:private day   (comp t/day   t/now))
+
+(def ^:private RenderableInterval
+  {:interval-start     org.joda.time.DateMidnight
+   :interval           org.joda.time.base.BaseSingleFieldPeriod
+   :this-interval-name su/NonBlankString
+   :last-interval-name su/NonBlankString})
+
+(defmulti ^:private renderable-interval
+  {:arglists '([unit])}
+  identity)
+
+(defmethod renderable-interval :default [_] nil)
+
+(defmethod renderable-interval :day [_]
+  {:interval-start     (t/date-midnight (year) (month) (day))
+   :interval           (t/days 1)
+   :this-interval-name (tru "Today")
+   :last-interval-name (tru "Yesterday")})
+
+(defn- start-of-this-week []
+  (-> (org.joda.time.LocalDate.) .weekOfWeekyear .roundFloorCopy .toDateTimeAtStartOfDay))
+
+(defmethod renderable-interval :week [_]
+  (start-of-this-week)
+  (t/weeks 1)
+  (tru "This week")
+  (tru "Last week"))
+
+(defmethod renderable-interval :month [_]
+  (t/date-midnight (year) (month))
+  (t/months 1)
+  (tru "This month")
+  (tru "Last month"))
+
+(defn- start-of-this-quarter []
+  (t/date-midnight (year) (inc (* 3 (Math/floor (/ (dec (month))
+                                                   3))))))
+
+(defmethod renderable-interval :quarter [_]
+  (start-of-this-quarter)
+  (t/months 3)
+  (tru "This quarter")
+  (tru "Last quarter"))
+
+(defmethod renderable-interval :year [_]
+  (t/date-midnight (year))
+  (t/years 1)
+  (tru "This year")
+  (tru "Last year"))
+
+(s/defn ^:private date->interval-name :- (s/maybe su/NonBlankString)
+  [date :- DateTime, unit :- s/Keyword]
+  (when-let [{:keys [interval-start interval this-interval-name last-interval-name]} (renderable-interval unit)]
+    (condp t/within? date
+      (t/interval interval-start (t/plus interval-start interval))
+      this-interval-name
+
+      (t/interval (t/minus interval-start interval) interval-start)
+      last-interval-name)))
+
+(defn format-timestamp-relative
+  "Formats timestamps with relative names (today, yesterday, this *, last *) based on column :unit, if possible,
+  otherwie returns nil"
+  [timezone timestamp {:keys [unit]}]
+  (date->interval-name (du/str->date-time timestamp timezone) unit))
+
+(defn format-timestamp-pair
+  "Formats a pair of timestamps, using relative formatting for the first timestamps if possible and 'Previous :unit' for
+  the second, otherwise absolute timestamps for both"
+  [timezone [a b] col]
+  (if-let [a' (format-timestamp-relative timezone a col)]
+    [a' (str "Previous " (-> col :unit name))]
+    [(format-timestamp timezone a col) (format-timestamp timezone b col)]))

--- a/src/metabase/pulse/render/datetime.clj
+++ b/src/metabase/pulse/render/datetime.clj
@@ -8,8 +8,8 @@
              [i18n :refer [tru]]
              [schema :as su]]
             [schema.core :as s])
-  (:import [org.joda.time DateTime DateTimeZone]
-           org.joda.time.DateMidnight
+  (:import metabase.util.i18n.UserLocalizedString
+           [org.joda.time DateMidnight DateTime DateTimeZone]
            org.joda.time.base.BaseSingleFieldPeriod))
 
 (defn- reformat-timestamp [timezone old-format-timestamp new-format-string]
@@ -45,8 +45,8 @@
 (def ^:private RenderableInterval
   {:interval-start     DateMidnight
    :interval           BaseSingleFieldPeriod
-   :this-interval-name su/NonBlankString
-   :last-interval-name su/NonBlankString})
+   :this-interval-name UserLocalizedString
+   :last-interval-name UserLocalizedString})
 
 (defmulti ^:private renderable-interval
   {:arglists '([unit])}
@@ -105,9 +105,11 @@
         this-interval-name
 
         (t/interval (t/minus interval-start interval) interval-start)
-        last-interval-name))))
+        last-interval-name
 
-(defn format-timestamp-relative
+        nil))))
+
+(s/defn format-timestamp-relative :- (s/maybe su/NonBlankString)
   "Formats timestamps with relative names (today, yesterday, this *, last *) based on column :unit, if possible,
   otherwie returns nil"
   [timezone timestamp {:keys [unit]}]

--- a/src/metabase/pulse/render/image_bundle.clj
+++ b/src/metabase/pulse/render/image_bundle.clj
@@ -5,7 +5,8 @@
   (:require [clojure.java.io :as io])
   (:import java.net.URL
            java.util.Arrays
-           org.apache.commons.io.IOUtils))
+           org.apache.commons.io.IOUtils
+           org.fit.cssbox.misc.Base64Coder))
 
 (defn- hash-bytes
   "Generate a hash to be used in a Content-ID"
@@ -47,7 +48,7 @@
     [render-type (class url-or-bytes)]))
 
 (defmethod make-image-bundle [:attachment java.net.URL]
-  [render-type ^java.net.URL url]
+  [render-type, ^java.net.URL url]
   (let [content-id (mb-hash-str (hash-image-url url))]
     {:content-id  content-id
      :image-url   url
@@ -64,12 +65,12 @@
      :render-type render-type}))
 
 (defmethod make-image-bundle [:inline java.net.URL]
-  [render-type ^java.net.URL url]
+  [render-type, ^java.net.URL url]
   {:image-src   (-> url io/input-stream IOUtils/toByteArray render-img-data-uri)
    :image-url   url
    :render-type render-type})
 
-(defmethod make-image-bundle [:inline (class (byte-array 0))]
+(defmethod make-image-bundle [:inline (Class/forName "[B")]
   [render-type image-bytes]
   {:image-src   (render-img-data-uri image-bytes)
    :render-type render-type})
@@ -93,17 +94,17 @@
 (defn external-link-image-bundle [render-type]
   (case render-type
     :attachment @external-link-image
-    :inline (make-image-bundle render-type external-link-url)))
+    :inline     (make-image-bundle render-type external-link-url)))
 
 (defn no-results-image-bundle [render-type]
   (case render-type
     :attachment @no-results-image
-    :inline (make-image-bundle render-type no-results-url)))
+    :inline     (make-image-bundle render-type no-results-url)))
 
 (defn attached-image-bundle [render-type]
   (case render-type
     :attachment @attached-image
-    :inline (make-image-bundle render-type attached-url)))
+    :inline     (make-image-bundle render-type attached-url)))
 
 (defn image-bundle->attachment [{:keys [render-type content-id image-url]}]
   (case render-type

--- a/src/metabase/pulse/render/image_bundle.clj
+++ b/src/metabase/pulse/render/image_bundle.clj
@@ -1,0 +1,111 @@
+(ns metabase.pulse.render.image-bundle
+  "Logic related to creating image bundles, and some predefined ones. An image bundle contains the data needed to
+  either encode the image inline in a URL (when `render-type` is `:inline`), or create the hashes/references needed
+  for an attached image (`render-type` of `:attachment`)"
+  (:require [clojure.java.io :as io])
+  (:import java.net.URL
+           java.util.Arrays
+           org.apache.commons.io.IOUtils))
+
+(defn- hash-bytes
+  "Generate a hash to be used in a Content-ID"
+  [^bytes img-bytes]
+  (Math/abs ^Integer (Arrays/hashCode img-bytes)))
+
+(defn- hash-image-url
+  "Generate a hash to be used in a Content-ID"
+  [^java.net.URL url]
+  (-> url io/input-stream IOUtils/toByteArray hash-bytes))
+
+(defn- content-id-reference [content-id]
+  (str "cid:" content-id))
+
+(defn- mb-hash-str [image-hash]
+  (str image-hash "@metabase"))
+
+(defn- write-byte-array-to-temp-file
+  [^bytes img-bytes]
+  (let [f (doto (java.io.File/createTempFile "metabase_pulse_image_" ".png")
+            .deleteOnExit)]
+    (with-open [fos (java.io.FileOutputStream. f)]
+      (.write fos img-bytes))
+    f))
+
+(defn- byte-array->url [^bytes img-bytes]
+  (-> img-bytes write-byte-array-to-temp-file io/as-url))
+
+(defn render-img-data-uri
+  "Takes a PNG byte array and returns a Base64 encoded URI"
+  [img-bytes]
+  (str "data:image/png;base64," (String. (Base64Coder/encode img-bytes))))
+
+(defmulti make-image-bundle
+  "Create an image bundle. An image bundle contains the data needed to either encode the image inline (when
+  `render-type` is `:inline`), or create the hashes/references needed for an attached image (`render-type` of
+  `:attachment`)"
+  (fn [render-type url-or-bytes]
+    [render-type (class url-or-bytes)]))
+
+(defmethod make-image-bundle [:attachment java.net.URL]
+  [render-type ^java.net.URL url]
+  (let [content-id (mb-hash-str (hash-image-url url))]
+    {:content-id  content-id
+     :image-url   url
+     :image-src   (content-id-reference content-id)
+     :render-type render-type}))
+
+(defmethod make-image-bundle [:attachment (class (byte-array 0))]
+  [render-type image-bytes]
+  (let [image-url (byte-array->url image-bytes)
+        content-id (mb-hash-str (hash-bytes image-bytes))]
+    {:content-id  content-id
+     :image-url   image-url
+     :image-src   (content-id-reference content-id)
+     :render-type render-type}))
+
+(defmethod make-image-bundle [:inline java.net.URL]
+  [render-type ^java.net.URL url]
+  {:image-src   (-> url io/input-stream IOUtils/toByteArray render-img-data-uri)
+   :image-url   url
+   :render-type render-type})
+
+(defmethod make-image-bundle [:inline (class (byte-array 0))]
+  [render-type image-bytes]
+  {:image-src   (render-img-data-uri image-bytes)
+   :render-type render-type})
+
+(def ^:private external-link-url (io/resource "frontend_client/app/assets/img/external_link.png"))
+(def ^:private no-results-url    (io/resource "frontend_client/app/assets/img/pulse_no_results@2x.png"))
+(def ^:private attached-url      (io/resource "frontend_client/app/assets/img/attachment@2x.png"))
+
+(def ^:private external-link-image
+  (delay
+   (make-image-bundle :attachment external-link-url)))
+
+(def ^:private no-results-image
+  (delay
+   (make-image-bundle :attachment no-results-url)))
+
+(def ^:private attached-image
+  (delay
+    (make-image-bundle :attachment attached-url)))
+
+(defn external-link-image-bundle [render-type]
+  (case render-type
+    :attachment @external-link-image
+    :inline (make-image-bundle render-type external-link-url)))
+
+(defn no-results-image-bundle [render-type]
+  (case render-type
+    :attachment @no-results-image
+    :inline (make-image-bundle render-type no-results-url)))
+
+(defn attached-image-bundle [render-type]
+  (case render-type
+    :attachment @attached-image
+    :inline (make-image-bundle render-type attached-url)))
+
+(defn image-bundle->attachment [{:keys [render-type content-id image-url]}]
+  (case render-type
+    :attachment {content-id image-url}
+    :inline     nil))

--- a/src/metabase/pulse/render/image_bundle.clj
+++ b/src/metabase/pulse/render/image_bundle.clj
@@ -91,22 +91,30 @@
   (delay
     (make-image-bundle :attachment attached-url)))
 
-(defn external-link-image-bundle [render-type]
+(defn external-link-image-bundle
+  "Image bundle for an external link icon."
+  [render-type]
   (case render-type
     :attachment @external-link-image
     :inline     (make-image-bundle render-type external-link-url)))
 
-(defn no-results-image-bundle [render-type]
+(defn no-results-image-bundle
+  "Image bundle for the 'No results' image."
+  [render-type]
   (case render-type
     :attachment @no-results-image
     :inline     (make-image-bundle render-type no-results-url)))
 
-(defn attached-image-bundle [render-type]
+(defn attached-image-bundle
+  "Image bundle for paperclip 'attachment' image."
+  [render-type]
   (case render-type
     :attachment @attached-image
     :inline     (make-image-bundle render-type attached-url)))
 
-(defn image-bundle->attachment [{:keys [render-type content-id image-url]}]
+(defn image-bundle->attachment
+  "Convert an image bundle into an email attachment."
+  [{:keys [render-type content-id image-url]}]
   (case render-type
     :attachment {content-id image-url}
     :inline     nil))

--- a/src/metabase/pulse/render/png.clj
+++ b/src/metabase/pulse/render/png.clj
@@ -1,0 +1,79 @@
+(ns metabase.pulse.render.png
+  "Logic for rendering HTML to a PNG.
+
+  Ported by @tlrobinson from
+  https://github.com/radkovo/CSSBox/blob/cssbox-4.10/src/main/java/org/fit/cssbox/demo/ImageRenderer.java with
+  subsequent code simplification and cleanup by @camsaul
+
+  CSSBox JavaDoc is here: http://cssbox.sourceforge.net/api/index.html"
+  (:require [clojure.tools.logging :as log]
+            [hiccup.core :refer [html]]
+            [metabase.pulse.render
+             [common :as common]
+             [style :as style]]
+            [schema.core :as s])
+  (:import cz.vutbr.web.css.MediaSpec
+           java.awt.Dimension
+           java.awt.image.BufferedImage
+           [java.io ByteArrayInputStream ByteArrayOutputStream]
+           java.nio.charset.StandardCharsets
+           javax.imageio.ImageIO
+           [org.fit.cssbox.css CSSNorm DOMAnalyzer DOMAnalyzer$Origin]
+           [org.fit.cssbox.io DefaultDOMSource StreamDocumentSource]
+           org.fit.cssbox.layout.BrowserCanvas
+           org.w3c.dom.Document))
+
+(defn- write-image!
+  [^BufferedImage image, ^String format-name, ^ByteArrayOutputStream output-stream]
+  (try
+    (ImageIO/write image format-name output-stream)
+    (catch javax.imageio.IIOException iioex
+      (log/error iioex "Error writing image to output stream")
+      (throw iioex))))
+
+(defn- dom-analyzer
+  ^DOMAnalyzer [^Document doc, ^StreamDocumentSource doc-source, ^Dimension window-size]
+  (doto (DOMAnalyzer. doc (.getURL doc-source))
+    (.setMediaSpec (doto (MediaSpec. "screen")
+                     (.setDimensions       (.width window-size) (.height window-size))
+                     (.setDeviceDimensions (.width window-size) (.height window-size))))
+    .attributesToStyles
+    (.addStyleSheet nil (CSSNorm/stdStyleSheet)   DOMAnalyzer$Origin/AGENT)
+    (.addStyleSheet nil (CSSNorm/userStyleSheet)  DOMAnalyzer$Origin/AGENT)
+    (.addStyleSheet nil (CSSNorm/formsStyleSheet) DOMAnalyzer$Origin/AGENT)
+    .getStyleSheets))
+
+(defn- content-canvas
+  ^BrowserCanvas [^Document doc, ^StreamDocumentSource doc-source, width]
+  (let [window-size (Dimension. width 1)
+        da          (dom-analyzer doc doc-source window-size)
+        canvas      (doto (BrowserCanvas. (.getRoot da) da (.getURL doc-source))
+                      (.setAutoMediaUpdate false)
+                      (.setAutoSizeUpdate true))]
+    (doto (.getConfig canvas)
+      (.setClipViewport false)
+      (.setLoadImages true)
+      (.setLoadBackgroundImages true))
+    (doto canvas
+      (.createLayout window-size))))
+
+(defn- render-to-png!
+  [^String html, ^ByteArrayOutputStream os, width]
+  (with-open [is (ByteArrayInputStream. (.getBytes html StandardCharsets/UTF_8))]
+    (let [doc-source     (StreamDocumentSource. is nil "text/html; charset=utf-8")
+          doc            (.parse (DefaultDOMSource. doc-source))
+          content-canvas (content-canvas doc doc-source width)]
+      (write-image! (.getImage content-canvas) "png" os))))
+
+(s/defn render-html-to-png :- bytes
+  "Render the Hiccup HTML `content` of a Pulse to a PNG image, returning a byte array."
+  [{:keys [content]} :- common/RenderedPulseCard
+   width]
+  (let [html (html [:html [:body {:style (style/style
+                                          {:margin           0
+                                           :padding          0
+                                           :background-color :white})}
+                           content]])]
+    (with-open [os (ByteArrayOutputStream.)]
+      (render-to-png! html os width)
+      (.toByteArray os))))

--- a/src/metabase/pulse/render/sparkline.clj
+++ b/src/metabase/pulse/render/sparkline.clj
@@ -1,0 +1,93 @@
+(ns metabase.pulse.render.sparkline
+  (:require [metabase.mbql.util :as mbql.u]
+            [metabase.pulse.render
+             [common :as common]
+             [image-bundle :as image-bundle]]
+            [metabase.util
+             [date :as du]
+             [i18n :refer [tru]]])
+  (:import [java.awt BasicStroke Color RenderingHints]
+           java.awt.image.BufferedImage
+           java.io.ByteArrayOutputStream
+           java.util.Date
+           javax.imageio.ImageIO))
+
+(def ^:private ^:const dot-radius 6)
+(def ^:private ^:const thickness  3)
+(def ^:private ^:const pad        8)
+(def ^:private ^:const width      524)
+(def ^:private ^:const height     524)
+
+(defn- render-sparkline-to-png
+  "Takes two arrays of numbers between 0 and 1 and plots them as a sparkline"
+  [xs ys]
+  (with-open [os (ByteArrayOutputStream.)]
+    (let [image (BufferedImage. (+ width (* 2 pad)) (+ height (* 2 pad)) BufferedImage/TYPE_INT_ARGB)
+          xt    (map #(+ pad (* width %)) xs)
+          yt    (map #(+ pad (- height (* height %))) ys)]
+      (doto (.createGraphics image)
+        (.setRenderingHints (RenderingHints. RenderingHints/KEY_ANTIALIASING RenderingHints/VALUE_ANTIALIAS_ON))
+        (.setColor (Color. 211 227 241))
+        (.setStroke (BasicStroke. thickness BasicStroke/CAP_ROUND BasicStroke/JOIN_ROUND))
+        (.drawPolyline (int-array (count xt) xt)
+                       (int-array (count yt) yt)
+                       (count xt))
+        (.setColor (Color. 45 134 212))
+        (.fillOval (- (last xt) dot-radius)
+                   (- (last yt) dot-radius)
+                   (* 2 dot-radius)
+                   (* 2 dot-radius))
+        (.setColor Color/white)
+        (.setStroke (BasicStroke. 2))
+        (.drawOval (- (last xt) dot-radius)
+                   (- (last yt) dot-radius)
+                   (* 2 dot-radius)
+                   (* 2 dot-radius)))
+      ;; returns `true` if successful -- see JavaDoc
+      (when-not (ImageIO/write image "png" os)
+        (throw (Exception. (str (tru "No appropriate image writer found!")))))
+      (.toByteArray os))))
+
+(defn- format-val-fn [timezone cols x-axis-rowfn]
+  (if (mbql.u/datetime-field? (x-axis-rowfn cols))
+    #(.getTime ^Date (du/->Timestamp % timezone))
+    identity))
+
+(defn sparkline-image-bundle
+  "Render a sparkline chart to an image bundle."
+  [render-type timezone card {:keys [rows cols] :as data}]
+  ;; `x-axis-rowfn` and `y-axis-rowfn` are functions that get whatever is at the corresponding index
+  (let [[x-axis-rowfn
+         y-axis-rowfn] (common/graphing-column-row-fns card data)
+        format-val     (format-val-fn timezone cols x-axis-rowfn)
+        x-axis-values  (let [x-axis-values (map (comp format-val x-axis-rowfn) rows)
+                             xmin          (apply min x-axis-values)
+                             xmax          (apply max x-axis-values)
+                             xrange        (- xmax xmin)]
+                         (for [v x-axis-values]
+                           (/ (double (- v xmin))
+                              xrange)))
+        ;; `(max 1 ...)` so we don't divide by zero
+        ;; cast to double to avoid "Non-terminating decimal expansion" errors
+        y-axis-values  (let [y-axis-values (map y-axis-rowfn rows)
+                             ymin          (apply min y-axis-values)
+                             ymax          (apply max y-axis-values)
+                             yrange        (max 1 (- ymax ymin))]
+                         (for [v y-axis-values]
+                           (/ (double (- v ymin)) yrange)))]
+    (image-bundle/make-image-bundle render-type (render-sparkline-to-png x-axis-values y-axis-values))))
+
+
+(defn sparkline-rows
+  "Get sorted rows from query results, with nils removed, appropriate for rendering as a sparkline."
+  [timezone card {:keys [rows cols], :as data}]
+  (let [[x-axis-rowfn
+         y-axis-rowfn] (common/graphing-column-row-fns card data)
+        format-val     (format-val-fn timezone cols x-axis-rowfn)]
+    (common/non-nil-rows
+     x-axis-rowfn
+     y-axis-rowfn
+     (if (> (format-val (x-axis-rowfn (first rows)))
+            (format-val (x-axis-rowfn (last rows))))
+       (reverse rows)
+       rows))))

--- a/src/metabase/pulse/render/style.clj
+++ b/src/metabase/pulse/render/style.clj
@@ -1,0 +1,50 @@
+(ns metabase.pulse.render.style
+  "CSS styles and related helper code for Pulse rendering."
+  (:require [clojure.string :as str]))
+
+(defn style
+  "Compile one or more CSS style maps into a string.
+
+     (style {:font-weight 400, :color \"white\"}) -> \"font-weight: 400; color: white;\""
+  [& style-maps]
+  (str/join " " (for [[k v] (into {} style-maps)
+                      :let  [v (if (keyword? v) (name v) v)]]
+                  (str (name k) ": " v ";"))))
+
+(def ^:const color-brand      "rgb(45,134,212)")
+(def ^:const color-purple     "rgb(135,93,175)")
+(def ^:const color-gold       "#F9D45C")
+(def ^:const color-error      "#EF8C8C")
+(def ^:const color-gray-1     "rgb(248,248,248)")
+(def ^:const color-gray-2     "rgb(189,193,191)")
+(def ^:const color-gray-3     "rgb(124,131,129)")
+(def ^:const color-gray-4 "A ~25% Gray color." "rgb(57,67,64)")
+(def ^:const color-dark-gray  "#616D75")
+(def ^:const color-row-border "#EDF0F1")
+
+
+(defn- primary-color []
+  color-brand)
+
+(defn font-style []
+  {:font-family "Lato, \"Helvetica Neue\", Helvetica, Arial, sans-serif"})
+
+(defn section-style
+  "CSS style for a Pulse section."
+  []
+  (font-style))
+
+(defn header-style []
+  (merge
+   (font-style)
+   {:font-size       :16px
+    :font-weight     700
+    :color           color-gray-4
+    :text-decoration :none}))
+
+(defn scalar-style []
+  (merge
+   (font-style)
+   {:font-size   :24px
+    :font-weight 700
+    :color       (primary-color)}))

--- a/src/metabase/pulse/render/style.clj
+++ b/src/metabase/pulse/render/style.clj
@@ -2,6 +2,9 @@
   "CSS styles and related helper code for Pulse rendering."
   (:require [clojure.string :as str]))
 
+;; TODO - we should move other CSS definitions from `metabase.pulse.render` namespaces into this one, so they're all
+;; in one place.
+
 (defn style
   "Compile one or more CSS style maps into a string.
 
@@ -11,22 +14,49 @@
                       :let  [v (if (keyword? v) (name v) v)]]
                   (str (name k) ": " v ";"))))
 
-(def ^:const color-brand      "rgb(45,134,212)")
-(def ^:const color-purple     "rgb(135,93,175)")
-(def ^:const color-gold       "#F9D45C")
-(def ^:const color-error      "#EF8C8C")
-(def ^:const color-gray-1     "rgb(248,248,248)")
-(def ^:const color-gray-2     "rgb(189,193,191)")
-(def ^:const color-gray-3     "rgb(124,131,129)")
-(def ^:const color-gray-4 "A ~25% Gray color." "rgb(57,67,64)")
-(def ^:const color-dark-gray  "#616D75")
-(def ^:const color-row-border "#EDF0F1")
+(def ^:const color-brand
+  "Classic Metabase blue."
+  "#2D86D4")
+
+(def ^:const color-purple
+  "Used as background color for cells in bar chart tables."
+  "#875DAF")
+
+(def ^:const color-gold
+  "Used as color for 'We were unable to display this Pulse' messages."
+  "#F9D45C")
+
+(def ^:const color-error
+  "Color for error messages."
+  "#EF8C8C")
+
+(def ^:const color-gray-1
+  "~97% gray."
+  "#F8F8F8")
+
+(def ^:const color-gray-2
+  "~75% gray."
+  "#BDC1BF")
+
+(def ^:const color-gray-3
+  "~50% gray."
+  "#7C8381")
+
+(def ^:const color-gray-4
+  "~25% gray."
+  "#394340")
+
+(def ^:const color-row-border
+  "Used as color for the bottom border of table headers for charts with `:table` vizualization."
+  "#EDF0F1")
 
 
 (defn- primary-color []
   color-brand)
 
-(defn font-style []
+(defn font-style
+  "Font family to use in rendered Pulses."
+  []
   {:font-family "Lato, \"Helvetica Neue\", Helvetica, Arial, sans-serif"})
 
 (defn section-style
@@ -34,7 +64,9 @@
   []
   (font-style))
 
-(defn header-style []
+(defn header-style
+  "Style for a header of a pulse section."
+  []
   (merge
    (font-style)
    {:font-size       :16px
@@ -42,7 +74,9 @@
     :color           color-gray-4
     :text-decoration :none}))
 
-(defn scalar-style []
+(defn scalar-style
+  "Style for a scalar display-type 'chart' in a Pulse."
+  []
   (merge
    (font-style)
    {:font-size   :24px

--- a/src/metabase/util/date.clj
+++ b/src/metabase/util/date.clj
@@ -447,9 +447,10 @@
 (defn str->date-time
   "Like clj-time.format/parse but uses an ordered list of parsers to be faster. Returns the parsed date, or `nil` if it
   was unable to be parsed."
-  (^org.joda.time.DateTime [^String date-str]
+  (^DateTime [^String date-str]
    (str->date-time date-str nil))
-  ([^String date-str ^TimeZone tz]
+
+  (^DateTime [^String date-str, ^TimeZone tz]
    (str->date-time-with-formatters ordered-date-parsers date-str tz)))
 
 (def ^:private ordered-time-parsers

--- a/src/metabase/util/i18n.clj
+++ b/src/metabase/util/i18n.clj
@@ -95,7 +95,7 @@
                      (str node)
                      node)) x))
 
-(defn ex-info
+(defn ^:deprecated ex-info
   "Just like `clojure.core/ex-info` but it is i18n-aware. It will call `str` on `msg` and walk `ex-data` converting any
   `SystemLocalizedString` and `UserLocalizedString`s to a regular string"
   ([msg ex-data-map]

--- a/test/metabase/email_test.clj
+++ b/test/metabase/email_test.clj
@@ -128,16 +128,16 @@
                 @inbox)))
 
 (defn email-to
-  "Creates a default email map for `USER-KWD` via `user/fetch-user`, as would be returned by `with-fake-inbox`"
+  "Creates a default email map for `user-kwd` via `user/fetch-user`, as would be returned by `with-fake-inbox`"
   [user-kwd & [email-map]]
   (let [{:keys [email]} (user/fetch-user user-kwd)]
-    {email [(merge {:from "notifications@metabase.com",
+    {email [(merge {:from (email/email-from-address)
                     :to #{email}}
                     email-map)]}))
 
 ;; simple test of email sending capabilities
 (expect
-  [{:from    "notifications@metabase.com"
+  [{:from    (email/email-from-address)
     :to      ["test@test.com"]
     :subject "101 Reasons to use Metabase"
     :body    [{:type    "text/html; charset=utf-8"

--- a/test/metabase/pulse/render/color_test.clj
+++ b/test/metabase/pulse/render/color_test.clj
@@ -1,6 +1,6 @@
-(ns metabase.pulse.color-test
-  (:require [expectations :refer :all]
-            [metabase.pulse.color :as color :refer :all]))
+(ns metabase.pulse.render.color-test
+  (:require [expectations :refer [expect]]
+            [metabase.pulse.render.color :as color]))
 
 (def ^:private red "#ff0000")
 (def ^:private green "#00ff00")
@@ -30,19 +30,19 @@
 (expect
   [red green red green]
   (with-test-js-engine test-script
-    (let [color-selector (make-color-selector {:cols [{:name "test"}]
+    (let [color-selector (color/make-color-selector {:cols [{:name "test"}]
                                                :rows [[1] [2] [3] [4]]}
                                               {"even" red, "odd" green})]
       (for [row-index (range 0 4)]
-        (get-background-color color-selector "any value" "any column" row-index)))))
+        (color/get-background-color color-selector "any value" "any column" row-index)))))
 
 ;; Same test as above, but make sure we convert any keywords as keywords don't get converted to strings automatically
 ;; when passed to a nashorn function
 (expect
   [red green red green]
   (with-test-js-engine test-script
-    (let [color-selector (make-color-selector {:cols [{:name "test"}]
+    (let [color-selector (color/make-color-selector {:cols [{:name "test"}]
                                                :rows [[1] [2] [3] [4]]}
                                               {:even red, :odd  green})]
       (for [row-index (range 0 4)]
-        (get-background-color color-selector "any value" "any column" row-index)))))
+        (color/get-background-color color-selector "any value" "any column" row-index)))))

--- a/test/metabase/pulse/render/table_test.clj
+++ b/test/metabase/pulse/render/table_test.clj
@@ -1,0 +1,69 @@
+(ns metabase.pulse.render.table-test
+  (:require [expectations :refer [expect]]
+            [metabase.pulse.render
+             [color :as color]
+             [table :as table]
+             [test-util :as render.tu]]
+            [metabase.test.util :as tu]))
+
+(defn- query-results->header+rows
+  "Makes pulse header and data rows with no bar-width. Including bar-width just adds extra HTML that will be ignored."
+  [{:keys [cols rows]}]
+  (for [row-values (cons (map :name cols) rows)]
+    {:row row-values
+     :bar-width nil}))
+
+(defn- postwalk-collect
+  "Invoke `collect-fn` on each node satisfying `pred`. If `collect-fn` returns a value, accumulate that and return the
+  results."
+  [pred collect-fn form]
+  (let [results (atom [])]
+    (tu/postwalk-pred pred
+                      (fn [node]
+                        (when-let [result (collect-fn node)]
+                          (swap! results conj result))
+                        node)
+                      form)
+    @results))
+
+(defn- find-table-body
+  "Given the hiccup data structure, find the table body and return it"
+  [results]
+  (postwalk-collect (every-pred vector? #(= :tbody (first %)))
+                    ;; The Hiccup form is [:tbody (...rows...)], so grab the second item
+                    second
+                    results))
+
+(defn- style-map->background-color
+  "Finds the background color in the style string of a Hiccup style map"
+  [{:keys [style]}]
+  (let [[_ color-str] (re-find #".*background-color: ([^;]*);" style)]
+    color-str))
+
+(defn- cell-value->background-color
+  "Returns a map of cell values to background colors of the pulse table found in the hiccup `results` data
+  structure. This only includes the data cell values, not the header values."
+  [results]
+  (into {} (postwalk-collect (every-pred vector? #(= :td (first %)))
+                             (fn [[_ style-map cell-value]]
+                               [cell-value (style-map->background-color style-map)])
+                             results)))
+
+;; Smoke test for background color selection. Background color decided by some shared javascript code. It's being
+;; invoked and included in the cell color of the pulse table. This is somewhat fragile code as the only way to find
+;; that style information is to crawl the clojure-ized HTML datastructure and pick apart the style string associated
+;; with the cell value. The script right now is hard coded to always return #ff0000. Once the real script is in place,
+;; we should find some similar basic values that can rely on. The goal isn't to test out the javascript choosing in
+;; the color (that should be done in javascript) but to verify that the pieces are all connecting correctly
+(expect
+  {"1" "",                     "2" "",                     "3" "rgba(0, 255, 0, 0.75)"
+   "4" "",                     "5" "",                     "6" "rgba(0, 128, 128, 0.75)"
+   "7" "rgba(255, 0, 0, 0.65)" "8" "rgba(255, 0, 0, 0.2)"  "9" "rgba(0, 0, 255, 0.75)"}
+  (let [query-results {:cols [{:name "a"} {:name "b"} {:name "c"}]
+                       :rows [[1 2 3]
+                              [4 5 6]
+                              [7 8 9]]}]
+    (-> (color/make-color-selector query-results (:visualization_settings render.tu/test-card))
+        (#'table/render-table ["a" "b" "c"] (query-results->header+rows query-results))
+        find-table-body
+        cell-value->background-color)))

--- a/test/metabase/pulse/render/test_util.clj
+++ b/test/metabase/pulse/render/test_util.clj
@@ -1,0 +1,17 @@
+(ns metabase.pulse.render.test-util)
+
+(def test-card
+  {:visualization_settings
+   {"table.column_formatting" [{:columns       ["a"]
+                                :type          :single
+                                :operator      ">"
+                                :value         5
+                                :color         "#ff0000"
+                                :highlight_row true}
+                               {:columns       ["c"]
+                                :type          "range"
+                                :min_type      "custom"
+                                :min_value     3
+                                :max_type      "custom"
+                                :max_value     9
+                                :colors        ["#00ff00" "#0000ff"]}]}})

--- a/test/metabase/pulse_test.clj
+++ b/test/metabase/pulse_test.clj
@@ -14,7 +14,7 @@
              [pulse-card :refer [PulseCard]]
              [pulse-channel :refer [PulseChannel]]
              [pulse-channel-recipient :refer [PulseChannelRecipient]]]
-            [metabase.pulse.render :as render]
+            [metabase.pulse.render.body :as render.body]
             [metabase.query-processor.middleware.constraints :as constraints]
             [metabase.test
              [data :as data]
@@ -518,13 +518,13 @@
    [nil] ;; -> attached-results-text should return nil since it's a slack message
    ]
   (slack-test-setup
-   (with-redefs [render/attached-results-text (wrap-function (var-get #'render/attached-results-text))]
+   (with-redefs [render.body/attached-results-text (wrap-function (var-get #'render.body/attached-results-text))]
      (let [[pulse-results] (pulse/send-pulse! (pulse.model/retrieve-pulse pulse-id))]
        ;; If we don't force the thunk, the rendering code will never execute and attached-results-text won't be called
        (force-bytes-thunk pulse-results)
        [(thunk->boolean pulse-results)
-        (count (input (var-get #'render/attached-results-text)))
-        (output (var-get #'render/attached-results-text))]))))
+        (count (input (var-get #'render.body/attached-results-text)))
+        (output (var-get #'render.body/attached-results-text))]))))
 
 (defn- produces-bytes? [{:keys [attachment-bytes-thunk]}]
   (< 0 (alength (attachment-bytes-thunk))))


### PR DESCRIPTION
Break up massive `metabase.pulse.render` namespace into a few smaller chunks that are easier to wrap one's head around.