### PR TITLE
Unified Dockerfile [WIP]

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,5 @@ target/*
 
 .dockerignore
 Dockerfile
+
+!target/uberjar/metabase.jar

--- a/bin/start
+++ b/bin/start
@@ -117,7 +117,6 @@ fi
 JAVA_OPTS="$JAVA_OPTS -XX:+IgnoreUnrecognizedVMOptions" # Don't barf if we see an option we don't understand (e.g. Java 9 option on Java 7/8)
 JAVA_OPTS="$JAVA_OPTS -Djava.awt.headless=true"         # don't try to start AWT. Not sure this does anything but better safe than wasting memory
 JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8"            # Use UTF-8
-JAVA_OPTS="$JAVA_OPTS --add-modules=java.xml.bind"      # Enable access to java.xml.bind module (Java 9)
 
 echo "Using these JAVA_OPTS: ${JAVA_OPTS}"
 


### PR DESCRIPTION
This attempts to combine `./bin/docker/Dockerfile` and `./Dockerfile` by adding a `BUILD_TYPE` build argument, which defaults to `docker` to do a full build within the Dockerfile, but can also be set to `external` to copy an already built jar from `./target/uberjar/metabase.jar` instead.

Currently it requires Docker ["BuildKit"](https://docs.docker.com/develop/develop-images/build_enhancements/) support, which allows it to only build the stages required for the final target stage. I'm not sure if it's possible to enable that on DockerHub's automated builds though, so this might not be useful for us yet.

Use this to do a full build inside Docker:

```
DOCKER_BUILDKIT=1 docker build .
```

or like this to use an externally built jar:

```
./bin/build
DOCKER_BUILDKIT=1 docker build --build-arg BUILD_TYPE=external .
```

TODO:
* [ ] consolidate `./bin/start` and `./bin/docker/run_metabase.sh`
* [ ] update `./bin/docker/build_image.sh` to use `./Dockerfile` with `BUILD_TYPE=external`