### PR TITLE
Add regexpEscape to replace deprecated RegExp.excape

### DIFF
--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx
@@ -6,6 +6,8 @@ import { t, ngettext, msgid } from "ttag";
 import _ from "underscore";
 import cx from "classnames";
 
+import { regexpEscape } from "metabase/lib/string";
+
 export default class MetadataSchemaList extends Component {
   constructor(props, context) {
     super(props, context);
@@ -22,7 +24,7 @@ export default class MetadataSchemaList extends Component {
     this.setState({
       searchText: event.target.value,
       searchRegex: event.target.value
-        ? new RegExp(RegExp.escape(event.target.value), "i")
+        ? new RegExp(regexpEscape(event.target.value), "i")
         : null,
     });
   }

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx
@@ -8,6 +8,8 @@ import { t, ngettext, msgid } from "ttag";
 import _ from "underscore";
 import cx from "classnames";
 
+import { regexpEscape } from "metabase/lib/string";
+
 export default class MetadataTableList extends Component {
   constructor(props, context) {
     super(props, context);
@@ -30,7 +32,7 @@ export default class MetadataTableList extends Component {
     this.setState({
       searchText: event.target.value,
       searchRegex: event.target.value
-        ? new RegExp(RegExp.escape(event.target.value), "i")
+        ? new RegExp(regexpEscape(event.target.value), "i")
         : null,
     });
   }

--- a/frontend/src/metabase/lib/string.js
+++ b/frontend/src/metabase/lib/string.js
@@ -3,13 +3,15 @@ import _ from "underscore";
 // Creates a regex that will find an order dependent, case insensitive substring. All whitespace will be rendered as ".*" in the regex, to create a fuzzy search.
 export function createMultiwordSearchRegex(input) {
   if (input) {
-    return new RegExp(
-      _.map(input.split(/\s+/), word => {
-        return RegExp.escape(word);
-      }).join(".*"),
-      "i",
-    );
+    return new RegExp(_.map(input.split(/\s+/), regexpEscape).join(".*"), "i");
   }
+}
+
+// prefix special characters with "\" for creating a regex
+export function regexpEscape(s) {
+  const regexpSpecialChars = /[\^\$\\\.\*\+\?\(\)\[\]\{\}\|]/g;
+  // "$&" in the replacement string is replaced with the matched string
+  return s.replace(regexpSpecialChars, "\\$&");
 }
 
 export const countLines = str => str.split(/\n/g).length;

--- a/frontend/test/metabase/lib/string.unit.spec.js
+++ b/frontend/test/metabase/lib/string.unit.spec.js
@@ -1,0 +1,17 @@
+import { regexpEscape } from "metabase/lib/string";
+
+describe("regexpEscape", () => {
+  const testCases = [
+    ["nothing special here", "nothing special here"],
+    ["somewhat ./\\ special", "somewhat \\./\\\\ special"],
+    [
+      "extra special ^$\\.*+?()[]{}|",
+      "extra special \\^\\$\\\\\\.\\*\\+\\?\\(\\)\\[\\]\\{\\}\\|",
+    ],
+  ];
+  for (const [raw, escaped] of testCases) {
+    it(`should escape "${raw}" to "${escaped}"`, () => {
+      expect(regexpEscape(raw)).toEqual(escaped);
+    });
+  }
+});


### PR DESCRIPTION
Resolves #10272 

This broke when I upgraded our polyfills in #10211. It turns out `RegExp.escape` is no longer being considered as part of the spec, so it was dropped.

There are (of course) npm packages that do the same thing, but I just added function to our code base and added some basic tests. IMO it's too small to justify a dependency, but I'm happy to use a package if others disagree.