### PR TITLE
Add tests to `computeTimeseriesTicksInterval`

### DIFF
--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -102,7 +102,6 @@ export function applyChartTimeseriesXAxis(
 
   // compute the data interval
   const dataInterval = xInterval;
-  let tickInterval = dataInterval;
 
   if (chart.settings["graph.x_axis.labels_enabled"]) {
     chart.xAxisLabel(
@@ -120,24 +119,6 @@ export function applyChartTimeseriesXAxis(
       dimensionColumn = { ...dimensionColumn, unit: dataInterval.interval };
     }
 
-    // special handling for weeks
-    // TODO: are there any other cases where we should do this?
-    if (dataInterval.interval === "week") {
-      // if tick interval is compressed then show months instead of weeks because they're nicer formatted
-      const newTickInterval = computeTimeseriesTicksInterval(
-        xDomain,
-        tickInterval,
-        chart.width(),
-      );
-      if (
-        newTickInterval.interval !== tickInterval.interval ||
-        newTickInterval.count !== tickInterval.count
-      ) {
-        (dimensionColumn = { ...dimensionColumn, unit: "month" }),
-          (tickInterval = { interval: "month", count: 1 });
-      }
-    }
-
     chart.xAxis().tickFormat(timestamp => {
       // timestamp is a plain Date object which discards the timezone,
       // so add it back in so it's formatted correctly
@@ -152,9 +133,9 @@ export function applyChartTimeseriesXAxis(
     });
 
     // Compute a sane interval to display based on the data granularity, domain, and chart width
-    tickInterval = computeTimeseriesTicksInterval(
+    const tickInterval = computeTimeseriesTicksInterval(
       xDomain,
-      tickInterval,
+      xInterval,
       chart.width(),
     );
     chart.xAxis().ticks(tickInterval.rangeFn, tickInterval.count);

--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -129,7 +129,7 @@ export function applyChartTimeseriesXAxis(
       });
     });
 
-    // Compute a sane interval to display based on the data granularity, domain, and chart width
+    // Update the xInterval to take into account chart width
     const tickInterval = computeTimeseriesTicksInterval(
       xDomain,
       xInterval,

--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -100,9 +100,6 @@ export function applyChartTimeseriesXAxis(
   const dataOffset =
     parseTimestamp(firstSeries.data.rows[0][0]).utcOffset() / 60;
 
-  // compute the data interval
-  const dataInterval = xInterval;
-
   if (chart.settings["graph.x_axis.labels_enabled"]) {
     chart.xAxisLabel(
       chart.settings["graph.x_axis.title_text"] ||
@@ -116,7 +113,7 @@ export function applyChartTimeseriesXAxis(
     );
 
     if (dimensionColumn.unit == null) {
-      dimensionColumn = { ...dimensionColumn, unit: dataInterval.interval };
+      dimensionColumn = { ...dimensionColumn, unit: xInterval.interval };
     }
 
     chart.xAxis().tickFormat(timestamp => {
@@ -144,15 +141,15 @@ export function applyChartTimeseriesXAxis(
   }
 
   // pad the domain slightly to prevent clipping
-  xDomain = stretchTimeseriesDomain(xDomain, dataInterval);
+  xDomain = stretchTimeseriesDomain(xDomain, xInterval);
 
   // set the x scale
-  chart.x(d3.time.scale.utc().domain(xDomain)); //.nice(d3.time[dataInterval.interval]));
+  chart.x(d3.time.scale.utc().domain(xDomain));
 
   // set the x units (used to compute bar size)
   chart.xUnits((start, stop) =>
     Math.ceil(
-      1 + moment(stop).diff(start, dataInterval.interval) / dataInterval.count,
+      1 + moment(stop).diff(start, xInterval.interval) / xInterval.count,
     ),
   );
 }

--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -116,7 +116,7 @@ export function applyChartTimeseriesXAxis(
       dimensionColumn = { ...dimensionColumn, unit: xInterval.interval };
     }
 
-    chart.xAxis().tickFormat(timestamp => {
+    const tickFormat = timestamp => {
       // timestamp is a plain Date object which discards the timezone,
       // so add it back in so it's formatted correctly
       const timestampFixed = moment(timestamp)
@@ -127,13 +127,16 @@ export function applyChartTimeseriesXAxis(
         type: "axis",
         compact: chart.settings["graph.x_axis.axis_enabled"] === "compact",
       });
-    });
+    };
+
+    chart.xAxis().tickFormat(tickFormat);
 
     // Compute tick interval, which maybe drops xInterval ticks on narrow charts
     const tickInterval = computeTimeseriesTicksInterval(
       xDomain,
       xInterval,
       chart.width(),
+      tickFormat,
     );
     chart.xAxis().ticks(tickInterval.rangeFn, tickInterval.count);
   } else {

--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -129,7 +129,7 @@ export function applyChartTimeseriesXAxis(
       });
     });
 
-    // Update the xInterval to take into account chart width
+    // Compute tick interval, which maybe drops xInterval ticks on narrow charts
     const tickInterval = computeTimeseriesTicksInterval(
       xDomain,
       xInterval,

--- a/frontend/src/metabase/visualizations/lib/timeseries.js
+++ b/frontend/src/metabase/visualizations/lib/timeseries.js
@@ -281,9 +281,17 @@ function timeseriesTicksInterval(
 /// isn't smart enough to actually estimate how much space each tick will take. Instead the estimated with is
 /// hardcoded below.
 /// TODO - it would be nice to rework this a bit so we
-function maxTicksForChartWidth(chartWidth) {
-  const MIN_PIXELS_PER_TICK = 160;
-  return Math.floor(chartWidth / MIN_PIXELS_PER_TICK); // round down so we don't end up with too many ticks
+function maxTicksForChartWidth(chartWidth, tickFormat) {
+  const PIXELS_PER_CHARACTER = 8;
+  // if there isn't enough buffer, the labels are hidden in LineAreaBarPostRender
+  const TICK_BUFFER_PIXELS = 25;
+
+  // day of week and month names vary in length, but it's slow to check all of them
+  // as an approximation we just use a specific date which was long in my locale
+  const formattedValue = tickFormat(new Date(2019, 8, 4));
+  const pixelsPerTick =
+    formattedValue.length * PIXELS_PER_CHARACTER + TICK_BUFFER_PIXELS;
+  return Math.floor(chartWidth / pixelsPerTick); // round down so we don't end up with too many ticks
 }
 
 /// return the range, in milliseconds, of the xDomain. ("Range" in this sense refers to the total "width"" of the
@@ -296,10 +304,15 @@ function timeRangeMilliseconds(xDomain) {
 
 /// return the appropriate entry in TIMESERIES_INTERVALS for a given chart with domain, interval, and width.
 /// The entry is used to calculate how often a tick should be displayed for this chart (e.g. one tick every 5 minutes)
-export function computeTimeseriesTicksInterval(xDomain, xInterval, chartWidth) {
+export function computeTimeseriesTicksInterval(
+  xDomain,
+  xInterval,
+  chartWidth,
+  tickFormat,
+) {
   return timeseriesTicksInterval(
     xInterval,
     timeRangeMilliseconds(xDomain),
-    maxTicksForChartWidth(chartWidth),
+    maxTicksForChartWidth(chartWidth, tickFormat),
   );
 }

--- a/frontend/test/metabase/visualizations/lib/apply_axis.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/apply_axis.unit.spec.js
@@ -8,9 +8,9 @@ describe("visualization.lib.apply_axis", () => {
   describe("stretchTimeseriesDomain", () => {
     it("should extend a partial month", () => {
       const domain = ["2020-04-01", "2020-06-01"].map(s => moment.utc(s));
-      const dataInterval = { interval: "month", count: 1 };
+      const xInterval = { interval: "month", count: 1 };
 
-      const newDomain = stretchTimeseriesDomain(domain, dataInterval);
+      const newDomain = stretchTimeseriesDomain(domain, xInterval);
 
       expect(newDomain.map(d => d.toISOString())).toEqual([
         "2020-03-09T00:00:00.000Z",
@@ -20,9 +20,9 @@ describe("visualization.lib.apply_axis", () => {
 
     it("should extend a partial week", () => {
       const domain = ["2020-04-01", "2020-04-15"].map(s => moment.utc(s));
-      const dataInterval = { interval: "week", count: 1 };
+      const xInterval = { interval: "week", count: 1 };
 
-      const newDomain = stretchTimeseriesDomain(domain, dataInterval);
+      const newDomain = stretchTimeseriesDomain(domain, xInterval);
 
       expect(newDomain.map(d => d.toISOString())).toEqual([
         "2020-03-27T00:00:00.000Z",
@@ -32,9 +32,9 @@ describe("visualization.lib.apply_axis", () => {
 
     it("should extend a partial day", () => {
       const domain = ["2020-04-01", "2020-04-05"].map(s => moment.utc(s));
-      const dataInterval = { interval: "day", count: 1 };
+      const xInterval = { interval: "day", count: 1 };
 
-      const newDomain = stretchTimeseriesDomain(domain, dataInterval);
+      const newDomain = stretchTimeseriesDomain(domain, xInterval);
 
       expect(newDomain.map(d => d.toISOString())).toEqual([
         "2020-03-31T06:00:00.000Z",

--- a/frontend/test/metabase/visualizations/lib/timeseries.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/timeseries.unit.spec.js
@@ -175,6 +175,15 @@ describe("visualization.lib.timeseries", () => {
         },
         { expectedInterval: "year", expectedCount: 1 },
       ],
+      // shouldn't move to a more granular interval than what was passed
+      [
+        {
+          xDomain: [new Date("2020-01-01"), new Date("2021-01-01")],
+          xInterval: { interval: "month", count: 3 },
+          chartWidth: 1920,
+        },
+        { expectedInterval: "month", expectedCount: 3 },
+      ],
     ];
 
     TEST_CASES.map(

--- a/frontend/test/metabase/visualizations/lib/timeseries.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/timeseries.unit.spec.js
@@ -1,6 +1,7 @@
 import {
   dimensionIsTimeseries,
   computeTimeseriesDataInverval,
+  computeTimeseriesTicksInterval,
 } from "metabase/visualizations/lib/timeseries";
 
 import { TYPE } from "metabase/lib/types";
@@ -143,5 +144,54 @@ describe("visualization.lib.timeseries", () => {
         expect(count).toBe(expectedCount);
       });
     });
+  });
+
+  describe("computeTimeseriesTicksInterval", () => {
+    const TEST_CASES = [
+      // on a wide chart, 12 month ticks shouldn't be changed
+      [
+        {
+          xDomain: [new Date("2020-01-01"), new Date("2021-01-01")],
+          xInterval: { interval: "month", count: 1 },
+          chartWidth: 1920,
+        },
+        { expectedInterval: "month", expectedCount: 1 },
+      ],
+      // it should be bump to quarters on a narrower chart
+      [
+        {
+          xDomain: [new Date("2020-01-01"), new Date("2021-01-01")],
+          xInterval: { interval: "month", count: 1 },
+          chartWidth: 800,
+        },
+        { expectedInterval: "month", expectedCount: 3 },
+      ],
+      // even narrower and we should show yearly ticks
+      [
+        {
+          xDomain: [new Date("2020-01-01"), new Date("2021-01-01")],
+          xInterval: { interval: "month", count: 1 },
+          chartWidth: 500,
+        },
+        { expectedInterval: "year", expectedCount: 1 },
+      ],
+    ];
+
+    TEST_CASES.map(
+      ([
+        { xDomain, xInterval, chartWidth },
+        { expectedInterval, expectedCount },
+      ]) => {
+        it("should return " + expectedCount + " " + expectedInterval, () => {
+          const { interval, count } = computeTimeseriesTicksInterval(
+            xDomain,
+            xInterval,
+            chartWidth,
+          );
+          expect(interval).toBe(expectedInterval);
+          expect(count).toBe(expectedCount);
+        });
+      },
+    );
   });
 });

--- a/frontend/test/metabase/visualizations/lib/timeseries.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/timeseries.unit.spec.js
@@ -147,6 +147,8 @@ describe("visualization.lib.timeseries", () => {
   });
 
   describe("computeTimeseriesTicksInterval", () => {
+    // computeTimeseriesTicksInterval just uses tickFormat to measure the character length of the current formatting style
+    const fakeTickFormat = () => "2020-01-01";
     const TEST_CASES = [
       // on a wide chart, 12 month ticks shouldn't be changed
       [
@@ -154,6 +156,7 @@ describe("visualization.lib.timeseries", () => {
           xDomain: [new Date("2020-01-01"), new Date("2021-01-01")],
           xInterval: { interval: "month", count: 1 },
           chartWidth: 1920,
+          tickFormat: fakeTickFormat,
         },
         { expectedInterval: "month", expectedCount: 1 },
       ],
@@ -163,6 +166,7 @@ describe("visualization.lib.timeseries", () => {
           xDomain: [new Date("2020-01-01"), new Date("2021-01-01")],
           xInterval: { interval: "month", count: 1 },
           chartWidth: 800,
+          tickFormat: fakeTickFormat,
         },
         { expectedInterval: "month", expectedCount: 3 },
       ],
@@ -172,6 +176,7 @@ describe("visualization.lib.timeseries", () => {
           xDomain: [new Date("2020-01-01"), new Date("2021-01-01")],
           xInterval: { interval: "month", count: 1 },
           chartWidth: 500,
+          tickFormat: fakeTickFormat,
         },
         { expectedInterval: "year", expectedCount: 1 },
       ],
@@ -181,14 +186,27 @@ describe("visualization.lib.timeseries", () => {
           xDomain: [new Date("2020-01-01"), new Date("2021-01-01")],
           xInterval: { interval: "month", count: 3 },
           chartWidth: 1920,
+          tickFormat: fakeTickFormat,
         },
         { expectedInterval: "month", expectedCount: 3 },
+      ],
+      // Long date formats should update the interval to have fewer ticks
+      [
+        {
+          xDomain: [new Date("2020-01-01"), new Date("2021-01-01")],
+          xInterval: { interval: "month", count: 1 },
+          chartWidth: 1920,
+          tickFormat: () =>
+            // thankfully no date format is actually this long
+            "The eigth day of July in the year of our Lord 2019",
+        },
+        { expectedInterval: "year", expectedCount: 1 },
       ],
     ];
 
     TEST_CASES.map(
       ([
-        { xDomain, xInterval, chartWidth },
+        { xDomain, xInterval, chartWidth, tickFormat },
         { expectedInterval, expectedCount },
       ]) => {
         it("should return " + expectedCount + " " + expectedInterval, () => {
@@ -196,6 +214,7 @@ describe("visualization.lib.timeseries", () => {
             xDomain,
             xInterval,
             chartWidth,
+            tickFormat,
           );
           expect(interval).toBe(expectedInterval);
           expect(count).toBe(expectedCount);


### PR DESCRIPTION
This PR merges two small changes to how we compute the ticks interval for timeseries axes.
1. Remove a special case around weeks
2. Add some tests

## Removing the weeks case
I removed code in `applyChartTimeseriesXAxis` that would force the interval to months if it was changing and the data interval was weeks. I'm pretty sure this wasn't doing anything since `tickInterval` was overwritten shortly after.

The only possible effect I could see is that `dimensionColumn`'s unit was updated. However, I didn't see any update to the formatting resulting from that. I'd love some extra eyes on it to see if I missed anything.

If it turns out that we do need a special case like this, I think it would better fit inside `computeTimeseriesTicksInterval` itself, so I can add it back there.

## Adding tests

I might end up revisiting the behavior here, but I wanted to get some tests around the current functionality before I start mucking with it. I added a few simple tests speccing out how `computeTimeseriesTicksInterval` updated the granularity based on chart width.

As an example of what I might update: #10280
