### PR TITLE
Fix file path in generate-sample-dataset

### DIFF
--- a/lein-commands/sample-dataset/metabase/sample_dataset/generate.clj
+++ b/lein-commands/sample-dataset/metabase/sample_dataset/generate.clj
@@ -51,7 +51,7 @@
 
 (defn- load-addresses! []
   (println "Loading addresses...")
-  (reset! addresses (edn/read-string (slurp "sample_dataset/metabase/sample_dataset/addresses.edn")))
+  (reset! addresses (edn/read-string (slurp "lein-commands/sample-dataset/metabase/sample_dataset/addresses.edn")))
   :ok)
 
 (defn- next-address []


### PR DESCRIPTION

###### Before submitting the PR, please make sure you do the following
### Tests
-  [x] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [x] If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`

-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).


This PR is to fix an issue with the generate-sample-dataset command.

```
Syntax error (FileNotFoundException) compiling at (/private/var/folders/tk/my_07lss1nx2hkwlp069xfbr0000gn/T/form-init4399207532267591130.clj:1:125).
sample_dataset/metabase/sample_dataset/addresses.edn (No such file or directory)
```