### PR TITLE
Bump ring-gzip-middleware dep version; remove customizations

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -47,7 +47,7 @@
    [amalloy/ring-buffer "1.2.2"
     :exclusions [org.clojure/clojure
                  org.clojure/clojurescript]]                          ; fixed length queue implementation, used in log buffering
-   [amalloy/ring-gzip-middleware "0.1.3"]                             ; Ring middleware to GZIP responses if client can handle it
+   [amalloy/ring-gzip-middleware "0.1.4"]                             ; Ring middleware to GZIP responses if client can handle it
    [aleph "0.4.6" :exclusions [org.clojure/tools.logging]]            ; Async HTTP library; WebSockets
    [bigml/histogram "4.1.3"]                                          ; Histogram data structure
    [buddy/buddy-core "1.5.0"                                          ; various cryptograhpic functions

--- a/src/metabase/handler.clj
+++ b/src/metabase/handler.clj
@@ -14,6 +14,7 @@
             [metabase.plugins.classloader :as classloader]
             [ring.middleware
              [cookies :refer [wrap-cookies]]
+             [gzip :refer [wrap-gzip]]
              [keyword-params :refer [wrap-keyword-params]]
              [params :refer [wrap-params]]]))
 
@@ -43,10 +44,9 @@
    mw.session/wrap-session-id              ; looks for a Metabase Session ID and assoc as :metabase-session-id
    mw.auth/wrap-api-key                    ; looks for a Metabase API Key on the request and assocs as :metabase-api-key
    mw.misc/maybe-set-site-url              ; set the value of `site-url` if it hasn't been set yet
-   ;; Disabled for now because some things like CSV download buttons don't work with this on.
    mw.misc/bind-user-locale                ; Binds *locale* for i18n
    wrap-cookies                            ; Parses cookies in the request map and assocs as :cookies
    mw.misc/add-content-type                ; Adds a Content-Type header for any response that doesn't already have one
    mw.misc/disable-streaming-buffering     ; Add header to streaming (async) responses so ngnix doesn't buffer keepalive bytes
-   mw.misc/wrap-gzip))                     ; GZIP response if client can handle it
+   wrap-gzip))                             ; GZIP response if client can handle it
 ;; ▲▲▲ PRE-PROCESSING ▲▲▲ happens from BOTTOM-TO-TOP


### PR DESCRIPTION
When we moved to an async webserver in 0.32.0 I had to replace some of the Ring middleware we used with custom versions that worked with 3-arity async ring handlers. I finally got around to opening PRs to merge my customizations back into the original libs. 

PR https://github.com/clj-commons/ring-gzip-middleware/pull/10 was to merge my changes to make `ring-gzip-middleware` async compatible upstream which was released yesterday in version `0.1.4`. So we can bump our dep version and remove my tweaks from Metabase itself