### PR TITLE
More improvements to QP debugging tools

### DIFF
--- a/src/metabase/query_processor/middleware/add_settings.clj
+++ b/src/metabase/query_processor/middleware/add_settings.clj
@@ -1,11 +1,12 @@
 (ns metabase.query-processor.middleware.add-settings
   "Middleware for adding a `:settings` map to a query before it is processed."
-  (:require [medley.core :as m]
+  (:require [metabase.driver :as driver]
             [metabase.driver.util :as driver.u]))
 
-(defn- add-settings* [{:keys [driver] :as query}]
-  (let [settings {:report-timezone (driver.u/report-timezone-if-supported driver)}]
-    (assoc query :settings (m/filter-vals (complement nil?) settings))))
+(defn- add-settings* [query]
+  (if-let [report-timezone (driver.u/report-timezone-if-supported driver/*driver*)]
+    (assoc-in query [:settings :report-timezone] report-timezone)
+    query))
 
 (defn add-settings
   "Adds the `:settings` map to the query which can contain any fixed properties that would be useful at execution time.

--- a/test/metabase/query_processor/middleware/add_settings_test.clj
+++ b/test/metabase/query_processor/middleware/add_settings_test.clj
@@ -1,26 +1,41 @@
 (ns metabase.query-processor.middleware.add-settings-test
   (:require [expectations :refer [expect]]
             [metabase.driver :as driver]
-            [metabase.models.setting :as setting]
-            [metabase.query-processor.middleware.add-settings :as add-settings]))
+            [metabase.query-processor.middleware.add-settings :as add-settings]
+            [metabase.test.util :as tu]))
 
-(driver/register! ::test-driver, :abstract? true)
+(driver/register! ::timezone-driver, :abstract? true)
 
-(defmethod driver/supports? [::test-driver :set-timezone] [_ _] true)
+(defmethod driver/supports? [::timezone-driver :set-timezone] [_ _] true)
 
+(driver/register! ::no-timezone-driver, :abstract? true)
+
+(defmethod driver/supports? [::timezone-driver :set-timezone] [_ _] false)
+
+(defn- add-settings [driver query]
+  (driver/with-driver driver
+    ((add-settings/add-settings identity) query)))
+
+;; no `report-timezone` set = query should not be changed
 (expect
-  [{:settings {}}
-   {:settings {}}
-   {:settings {:report-timezone "US/Mountain"}}]
-  (let [original-tz (setting/get :report-timezone)
-        response1   ((add-settings/add-settings identity) {:driver ::test-driver})]
-    ;; make sure that if the timezone is an empty string we skip it in settings
-    (setting/set! :report-timezone "")
-    (let [response2 ((add-settings/add-settings identity) {:driver ::test-driver})]
-      ;; if the timezone is something valid it should show up in the query settings
-      (setting/set! :report-timezone "US/Mountain")
-      (let [response3 ((add-settings/add-settings identity) {:driver ::test-driver})]
-        (setting/set! :report-timezone original-tz)
-        [(dissoc response1 :driver)
-         (dissoc response2 :driver)
-         (dissoc response3 :driver)]))))
+  {}
+  (tu/with-temporary-setting-values [report-timezone nil]
+    (add-settings ::timezone-driver {})))
+
+;; `report-timezone` is an empty string = query should not be changed
+(expect
+  {}
+  (tu/with-temporary-setting-values [report-timezone ""]
+    (add-settings ::timezone-driver {})))
+
+;; if the timezone is something valid it should show up in the query settings
+(expect
+  {:settings {:report-timezone "US/Mountain"}}
+  (tu/with-temporary-setting-values [report-timezone "US/Mountain"]
+    (add-settings ::timezone-driver {})))
+
+;; if the driver doesn't support `:set-timezone`, query should be unchanged, even if `report-timezone` is valid
+(expect
+  {}
+  (tu/with-temporary-setting-values [report-timezone "US/Mountain"]
+    (add-settings ::no-timezone-driver {})))

--- a/test/metabase/query_processor/middleware/add_settings_test.clj
+++ b/test/metabase/query_processor/middleware/add_settings_test.clj
@@ -10,7 +10,7 @@
 
 (driver/register! ::no-timezone-driver, :abstract? true)
 
-(defmethod driver/supports? [::timezone-driver :set-timezone] [_ _] false)
+(defmethod driver/supports? [::no-timezone-driver :set-timezone] [_ _] false)
 
 (defn- add-settings [driver query]
   (driver/with-driver driver

--- a/test/metabase/query_processor_test/failure_test.clj
+++ b/test/metabase/query_processor_test/failure_test.clj
@@ -21,8 +21,7 @@
    :query    {:source-table (data/id :venues)
               :fields       [[:datetime-field [:field-id (data/id :venues :id)] :month]]
               :limit        qp.i/absolute-max-results}
-   :driver   :h2
-   :settings {}})
+   :driver   :h2})
 
 (def ^:private bad-query:native
   {:query  (str "SELECT parsedatetime(formatdatetime(\"PUBLIC\".\"VENUES\".\"ID\", 'yyyyMM'), 'yyyyMM') AS \"ID\" "


### PR DESCRIPTION
More tweaks to my QP debugging tools that wraps each piece of QP middleware with special "debugging" middleware that logs any changes to query and results (or thrown exceptions) made by the middleware, validates all changes against schemas, etc.

These tweaks prevent Exceptions from being logged more than once, removes "false-alarm" logging for changes that happen at the async->sync transitions, and filter out irrelevant frames from logged exception stacktraces to produce more readable output.