### PR TITLE
LineAreaBar optimizations

### DIFF
--- a/frontend/src/metabase/css/core/flex.css
+++ b/frontend/src/metabase/css/core/flex.css
@@ -35,6 +35,10 @@
   flex-basis: auto;
 }
 
+.flex-basis-zero {
+  flex-basis: 0;
+}
+
 .shrink-below-content-size {
   /* W3C spec says:
      * By default, flex items won’t shrink below their minimum content size (the length of the longest word or

--- a/frontend/src/metabase/visualizations/components/LeafletChoropleth.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletChoropleth.jsx
@@ -100,8 +100,10 @@ const LeafletChoropleth = ({
       map.fitBounds(minimalBounds);
       // map.fitBounds(geoFeatureGroup.getBounds());
 
-      return () => {
-        map.remove();
+      return {
+        deregister: () => {
+          map.remove();
+        },
       };
     }}
   />

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
@@ -282,7 +282,7 @@ export default class LineAreaBarChart extends Component {
           {...this.props}
           series={series}
           settings={settings}
-          className="renderer flex-full"
+          className="renderer flex-full flex-basis-zero"
           maxSeries={MAX_SERIES}
           renderer={this.constructor.renderer}
         />

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -11,6 +11,8 @@ import { lighten } from "metabase/lib/colors";
 import {
   computeSplit,
   computeMaxDecimalsForValues,
+  getAvailableCanvasWidth,
+  getAvailableCanvasHeight,
   getFriendlyName,
   getXValues,
   colorShades,
@@ -775,7 +777,7 @@ type DeregisterFunction = () => void;
 export default function lineAreaBar(
   element: Element,
   props: LineAreaBarProps,
-): DeregisterFunction {
+): { deregister: DeregisterFunction, resize: Function } {
   const { onRender, isScalarSeries, settings, series } = props;
 
   const warnings = {};
@@ -883,10 +885,19 @@ export default function lineAreaBar(
     });
   }
 
-  // return an unregister function
-  return () => {
+  const deregister = () => {
     dc.chartRegistry.deregister(parent);
   };
+  const resize = () => {
+    parent.width(getAvailableCanvasWidth(element));
+    parent.height(getAvailableCanvasHeight(element));
+    // I think this is always defined, but the dc.js examples check before calling
+    if (parent.rescale) {
+      parent.rescale();
+    }
+    parent.redraw();
+  };
+  return { deregister, resize };
 }
 
 export const lineRenderer = (element, props) =>

--- a/frontend/src/metabase/visualizations/lib/RowRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/RowRenderer.js
@@ -13,7 +13,7 @@ import { checkXAxisLabelOverlap } from "./LineAreaBarPostRender";
 export default function rowRenderer(
   element,
   { settings, series, onHoverChange, onVisualizationClick, height },
-): DeregisterFunction {
+): { deregister: DeregisterFunction } {
   const { cols } = series[0].data;
 
   if (series.length > 1) {
@@ -173,7 +173,9 @@ export default function rowRenderer(
     chart.selectAll(".axis").remove();
   }
 
-  return () => {
-    dc.chartRegistry.deregister(chart);
+  return {
+    deregister: () => {
+      dc.chartRegistry.deregister(chart);
+    },
   };
 }

--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -102,13 +102,20 @@ function moment_fast_toString() {
   return this._i;
 }
 
+const parseTimestampCache = new Map();
+
 export function HACK_parseTimestamp(value, unit, warn) {
   if (value == null) {
     warn(NULL_DIMENSION_WARNING);
     return null;
   } else {
+    const cacheKey = value + unit;
+    if (parseTimestampCache.has(cacheKey)) {
+      return parseTimestampCache.get(cacheKey);
+    }
     const m = parseTimestamp(value, unit);
     m.toString = moment_fast_toString;
+    parseTimestampCache.set(cacheKey, m);
     return m;
   }
 }


### PR DESCRIPTION
This PR has two separate optimizations. Both of them are pretty small wins, but hopefully they have some impact.

# 1. Don't rerender unless the series changed

If the only update was a resize, we take a streamlined path to update the chart. Instead of calling `render` we call `rescale` and `redraw` after updating the width and height. Unlike `render`, `redraw` updates the chart rather than drawing it all from scratch. Unfortunately, it's still very slow on large datasets.

## What about avoiding rerendering when the series _did_ change?

I started down this path, but it looked like it was going to be pretty complicated to get right.

The rendering code creates nested charts, updates chart settings, adds event handlers, etc. Many of these actions are non-idempotent, and it would take some care to tease out what needs to be updated with a new series.

If `redraw` were _much_ faster than `render`, I think it would be worth it. To start, just using `redraw` to resize felt like a better ROI. If we wanted to expand this, I think the next step would be to use `redraw` when there's new data, but still do a full `render` if the settings or card displays change.

# 2. Cache timestamp parsing

Outside of rendering itself, I was only able to find one place that accounted for meaningful slowness in my example chart: `getDatas`. Most of that time was spent parsing timestamps.

We still need to parse these, but I figured that time is wasted on rerender. I added a cache to avoid duplicate parsing. 

However, my example was pretty pathological for date parsing with >1600 dates. I expect most charts won't benefit as much if at all. Also, the first render still has to pay the full cost of parsing all those dates:

<img width="217" src="https://user-images.githubusercontent.com/691495/60747907-b093f080-9f56-11e9-8d60-87dc9c2842f3.png">

The cache is implemented as a Map, and values are never deleted. It seems like it'd be hard to grow this to a problematic size since the keys and values are both pretty small. That said, it's definitely a possibility, If we're concerned about the leak I can replace with a LRU cache that will just hold a few thousand values.
