### PR TITLE
Measure timeseries axis labels' character length to adjust tick interval

### DIFF
--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -116,7 +116,7 @@ export function applyChartTimeseriesXAxis(
       dimensionColumn = { ...dimensionColumn, unit: xInterval.interval };
     }
 
-    chart.xAxis().tickFormat(timestamp => {
+    const tickFormat = timestamp => {
       // timestamp is a plain Date object which discards the timezone,
       // so add it back in so it's formatted correctly
       const timestampFixed = moment(timestamp)
@@ -127,13 +127,16 @@ export function applyChartTimeseriesXAxis(
         type: "axis",
         compact: chart.settings["graph.x_axis.axis_enabled"] === "compact",
       });
-    });
+    };
+
+    chart.xAxis().tickFormat(tickFormat);
 
     // Compute tick interval, which maybe drops xInterval ticks on narrow charts
     const tickInterval = computeTimeseriesTicksInterval(
       xDomain,
       xInterval,
       chart.width(),
+      tickFormat,
     );
     chart.xAxis().ticks(tickInterval.rangeFn, tickInterval.count);
   } else {

--- a/frontend/src/metabase/visualizations/lib/timeseries.js
+++ b/frontend/src/metabase/visualizations/lib/timeseries.js
@@ -281,9 +281,17 @@ function timeseriesTicksInterval(
 /// isn't smart enough to actually estimate how much space each tick will take. Instead the estimated with is
 /// hardcoded below.
 /// TODO - it would be nice to rework this a bit so we
-function maxTicksForChartWidth(chartWidth) {
-  const MIN_PIXELS_PER_TICK = 160;
-  return Math.floor(chartWidth / MIN_PIXELS_PER_TICK); // round down so we don't end up with too many ticks
+function maxTicksForChartWidth(chartWidth, tickFormat) {
+  const PIXELS_PER_CHARACTER = 8;
+  // if there isn't enough buffer, the labels are hidden in LineAreaBarPostRender
+  const TICK_BUFFER_PIXELS = 25;
+
+  // day of week and month names vary in length, but it's slow to check all of them
+  // as an approximation we just use a specific date which was long in my locale
+  const formattedValue = tickFormat(new Date(2019, 8, 4));
+  const pixelsPerTick =
+    formattedValue.length * PIXELS_PER_CHARACTER + TICK_BUFFER_PIXELS;
+  return Math.floor(chartWidth / pixelsPerTick); // round down so we don't end up with too many ticks
 }
 
 /// return the range, in milliseconds, of the xDomain. ("Range" in this sense refers to the total "width"" of the
@@ -296,10 +304,15 @@ function timeRangeMilliseconds(xDomain) {
 
 /// return the appropriate entry in TIMESERIES_INTERVALS for a given chart with domain, interval, and width.
 /// The entry is used to calculate how often a tick should be displayed for this chart (e.g. one tick every 5 minutes)
-export function computeTimeseriesTicksInterval(xDomain, xInterval, chartWidth) {
+export function computeTimeseriesTicksInterval(
+  xDomain,
+  xInterval,
+  chartWidth,
+  tickFormat,
+) {
   return timeseriesTicksInterval(
     xInterval,
     timeRangeMilliseconds(xDomain),
-    maxTicksForChartWidth(chartWidth),
+    maxTicksForChartWidth(chartWidth, tickFormat),
   );
 }

--- a/frontend/test/metabase/visualizations/lib/timeseries.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/timeseries.unit.spec.js
@@ -147,6 +147,8 @@ describe("visualization.lib.timeseries", () => {
   });
 
   describe("computeTimeseriesTicksInterval", () => {
+    // computeTimeseriesTicksInterval just uses tickFormat to measure the character length of the current formatting style
+    const fakeTickFormat = () => "2020-01-01";
     const TEST_CASES = [
       // on a wide chart, 12 month ticks shouldn't be changed
       [
@@ -154,6 +156,7 @@ describe("visualization.lib.timeseries", () => {
           xDomain: [new Date("2020-01-01"), new Date("2021-01-01")],
           xInterval: { interval: "month", count: 1 },
           chartWidth: 1920,
+          tickFormat: fakeTickFormat,
         },
         { expectedInterval: "month", expectedCount: 1 },
       ],
@@ -163,6 +166,7 @@ describe("visualization.lib.timeseries", () => {
           xDomain: [new Date("2020-01-01"), new Date("2021-01-01")],
           xInterval: { interval: "month", count: 1 },
           chartWidth: 800,
+          tickFormat: fakeTickFormat,
         },
         { expectedInterval: "month", expectedCount: 3 },
       ],
@@ -172,6 +176,7 @@ describe("visualization.lib.timeseries", () => {
           xDomain: [new Date("2020-01-01"), new Date("2021-01-01")],
           xInterval: { interval: "month", count: 1 },
           chartWidth: 500,
+          tickFormat: fakeTickFormat,
         },
         { expectedInterval: "year", expectedCount: 1 },
       ],
@@ -181,14 +186,27 @@ describe("visualization.lib.timeseries", () => {
           xDomain: [new Date("2020-01-01"), new Date("2021-01-01")],
           xInterval: { interval: "month", count: 3 },
           chartWidth: 1920,
+          tickFormat: fakeTickFormat,
         },
         { expectedInterval: "month", expectedCount: 3 },
+      ],
+      // Long date formats should update the interval to have fewer ticks
+      [
+        {
+          xDomain: [new Date("2020-01-01"), new Date("2021-01-01")],
+          xInterval: { interval: "month", count: 1 },
+          chartWidth: 1920,
+          tickFormat: () =>
+            // thankfully no date format is actually this long
+            "The eigth day of July in the year of our Lord 2019",
+        },
+        { expectedInterval: "year", expectedCount: 1 },
       ],
     ];
 
     TEST_CASES.map(
       ([
-        { xDomain, xInterval, chartWidth },
+        { xDomain, xInterval, chartWidth, tickFormat },
         { expectedInterval, expectedCount },
       ]) => {
         it("should return " + expectedCount + " " + expectedInterval, () => {
@@ -196,6 +214,7 @@ describe("visualization.lib.timeseries", () => {
             xDomain,
             xInterval,
             chartWidth,
+            tickFormat,
           );
           expect(interval).toBe(expectedInterval);
           expect(count).toBe(expectedCount);


### PR DESCRIPTION
Resolves #10280 

Currently, we assume every timeseries axis label takes up 160px. This PR refines that estimate by looking at the character length given the current formatting of a sample date. This lets us more tightly pack labels together because often the labels are much less than 160px. It also means that the tick count adjusts as you change label formatting ("2019/7/8" vs "Monday, July 8 2019")