### PR TITLE
Fix broken tooltips

### DIFF
--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -549,16 +549,10 @@ function isDefaultLinkProtocol(protocol) {
 
 export function formatUrl(
   value: Value,
-  {
-    jsx,
-    rich,
-    view_as = "auto",
-    link_text,
-    column: { special_type } = {},
-  }: FormattingOptions = {},
+  { jsx, rich, view_as = "auto", link_text, column }: FormattingOptions = {},
 ) {
   const url = String(value);
-  const urlSpecialType = isa(special_type, TYPE.URL);
+  const urlSpecialType = column && isa(column.special_type, TYPE.URL);
   const protocol = getUrlProtocol(url);
   if (
     jsx &&

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -265,5 +265,14 @@ describe("formatting", () => {
         }),
       ).toEqual("data:text/plain;charset=utf-8,hello%20world");
     });
+    it("should not crash if column is null", () => {
+      expect(
+        formatUrl("foobar", {
+          jsx: true,
+          rich: true,
+          column: null,
+        }),
+      ).toEqual("foobar");
+    });
   });
 });


### PR DESCRIPTION
I broke tooltips in [this commit](https://github.com/metabase/metabase/commit/b11acfd0bd2ca27aaf6e223277984cbaeb2e00f9#diff-8807ab8a8f53830e09a53232f611fcbbR557). This fix allows null columns without crashing. Previously I assumed missing columns would be undefined. 🤦‍♂ 