### PR TITLE
Fix dashboard filter reordering/renaming

### DIFF
--- a/frontend/src/metabase/meta/Dashboard.js
+++ b/frontend/src/metabase/meta/Dashboard.js
@@ -382,6 +382,9 @@ export function setParameterName(
   parameter: Parameter,
   name: string,
 ): Parameter {
+  if (!name) {
+    name = "unnamed";
+  }
   const slug = slugify(name);
   return {
     ...parameter,

--- a/frontend/src/metabase/parameters/components/ParameterWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterWidget.jsx
@@ -15,6 +15,7 @@ import { KEYCODE_ENTER, KEYCODE_ESCAPE } from "metabase/lib/keyboard";
 export default class ParameterWidget extends Component {
   state = {
     isEditingName: false,
+    editingNameValue: undefined,
     isFocused: false,
   };
 

--- a/frontend/src/metabase/parameters/components/ParameterWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterWidget.jsx
@@ -111,9 +111,15 @@ export default class ParameterWidget extends Component {
                 p => p.name === parameter.name && p.id !== parameter.id,
               ),
             })}
-            value={parameter.name}
-            onChange={e => setName(e.target.value)}
-            onBlur={() => this.setState({ isEditingName: false })}
+            value={this.state.editingNameValue}
+            onChange={e => this.setState({ editingNameValue: e.target.value })}
+            onBlur={() => {
+              setName(this.state.editingNameValue);
+              this.setState({
+                isEditingName: false,
+                editingNameValue: undefined,
+              });
+            }}
             onKeyUp={e => {
               if (e.keyCode === KEYCODE_ESCAPE || e.keyCode === KEYCODE_ENTER) {
                 e.target.blur();
@@ -133,7 +139,12 @@ export default class ParameterWidget extends Component {
             name="pencil"
             size={12}
             className="text-brand cursor-pointer"
-            onClick={() => this.setState({ isEditingName: true })}
+            onClick={() => {
+              this.setState({
+                isEditingName: true,
+                editingNameValue: parameter.name,
+              });
+            }}
           />
         </span>
       );

--- a/frontend/src/metabase/parameters/components/Parameters.jsx
+++ b/frontend/src/metabase/parameters/components/Parameters.jsx
@@ -175,6 +175,7 @@ export default class Parameters extends Component {
               parameters={parameters}
               editingParameter={editingParameter}
               setEditingParameter={setEditingParameter}
+              index={index}
               setName={
                 setParameterName &&
                 (name => setParameterName(parameter.id, name))


### PR DESCRIPTION
Resolves #10001 

That issue describes two problems:

1. Filters can't be dragged without disappearing.

There was a missing `index` prop. Adding that back fixes it.

2. Removing the filter name while editing removes filter

I moved the name into component state while editing. If onBlur, the name is still blank, it's replaced with "unnamed".

I think the issue with blank name was actually due to the slug rather than name, but it felt like it should be solved for name itself.

Resolves #10299 