### PR TITLE
Adding myself (SB) to CODEOWNERS for some parts of the clj codebase

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,11 @@
 
 *.clj @camsaul
+/src/metabase/automagic_dashboards/ @sbelak
+/test/metabase/automagic_dashboards/ @sbelak
+/src/metabase/transform/ @sbelak
+/test/metabase/transform/ @sbelak
+/src/metabase/sync/ @camsaul @sbelak
+/test/metabase/sync/ @camsaul @sbelak
 *.css @kdoh
 /frontend/src @tlrobinson @kdoh
 /frontend/src/metabase/components/ @kdoh


### PR DESCRIPTION
It's useless and annoying for both that I am forced to go through Cam for minor changes to the parts of the codebase he has no context for.