### PR TITLE
Fetch relevant db's metadata when card is added to a dashboard

### DIFF
--- a/frontend/src/metabase/dashboard/dashboard.js
+++ b/frontend/src/metabase/dashboard/dashboard.js
@@ -188,6 +188,11 @@ export const addCardToDashboard = function({
     };
     dispatch(createAction(ADD_CARD_TO_DASH)(dashcard));
     dispatch(fetchCardData(card, dashcard, { reload: true, clear: true }));
+
+    // guard in case card was filtered
+    if (card.dataset_query && card.dataset_query.database) {
+      dispatch(fetchDatabaseMetadata(card.dataset_query.database));
+    }
   };
 };
 


### PR DESCRIPTION
Resolves #10085 

We weren't showing any valid fields for the new filter because we didn't have any data on the table.

This PR fetches metadata whenever a card is added to a dashboard. This should use a cached fetch and doesn't redundantly pull db metadata.