### PR TITLE
Fetch field values for dashboard parameters linked to multiple fields

### DIFF
--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -84,7 +84,8 @@ export default class ParameterValueWidget extends Component {
     className: "",
   };
 
-  getField() {
+  // this method assumes the parameter is associated with only one field
+  getSingleField() {
     const { parameter, metadata } = this.props;
     return parameter.field_id != null
       ? metadata.fields[parameter.field_id]
@@ -95,7 +96,7 @@ export default class ParameterValueWidget extends Component {
     const { parameter, values } = this.props;
     if (DATE_WIDGETS[parameter.type]) {
       return DATE_WIDGETS[parameter.type];
-    } else if (this.getField()) {
+    } else if (this.getSingleField()) {
       return ParameterFieldWidget;
     } else if (values && values.length > 0) {
       return CategoryWidget;
@@ -114,19 +115,20 @@ export default class ParameterValueWidget extends Component {
     }
   }
 
+  fieldIds({ parameter: { field_id, field_ids = [] } }) {
+    return field_id ? [field_id] : field_ids;
+  }
+
   componentWillReceiveProps(nextProps) {
-    if (
-      nextProps.parameter.field_id != null &&
-      nextProps.parameter.field_id !== this.props.parameter.field_id
-    ) {
+    if (!_.isEqual(this.fieldIds(this.props), this.fieldIds(nextProps))) {
       this.updateFieldValues(nextProps);
     }
   }
 
   updateFieldValues(props) {
-    if (props.parameter.field_id != null) {
-      props.fetchField(props.parameter.field_id);
-      props.fetchFieldValues(props.parameter.field_id);
+    for (const id of this.fieldIds(props)) {
+      props.fetchField(id);
+      props.fetchFieldValues(id);
     }
   }
 
@@ -229,7 +231,7 @@ export default class ParameterValueWidget extends Component {
             placeholder={placeholder}
             value={value}
             values={values}
-            field={this.getField()}
+            field={this.getSingleField()}
             setValue={setValue}
             isEditing={isEditing}
             commitImmediately={commitImmediately}


### PR DESCRIPTION
Resolves #7640

It took me a while to reproduce this. The bug was due to us not fetching field values when a parameter was linked to multiple fields. When you first add the second question and connect the parameter, the field's values are already loaded. The issue only presents on future loads when we don't already have the field values in the store.

I stopped short of a slightly larger refactor here, but it might be worth it. The `field_id` vs `field_ids` distinction on parameter is awkward to tiptoe around. I think we could just consolidate to `field_ids` which would have zero or more ids.

I started writing some tests for this, but it was going to be pretty ugly since `ParameterValueWidget` is a container. Does that indicate that we should split out the component logic? Or, is there some other way we can more easily test the inner workings of the component?
