### PR TITLE
tweak scroll behavior to prevent jumping the whole window

### DIFF
--- a/frontend/src/metabase/components/TokenField.jsx
+++ b/frontend/src/metabase/components/TokenField.jsx
@@ -482,14 +482,14 @@ export default class TokenField extends Component {
     ) {
       const element = findDOMNode(this.scrollElement);
       if (element && isObscured(element)) {
-        element.scrollIntoView(element);
+        element.scrollIntoView({ block: "nearest" });
       }
     }
-    // if we added a valkue then scroll to the last item (the input)
+    // if we added a value then scroll to the last item (the input)
     if (this.props.value.length > prevProps.value.length) {
       const input = findDOMNode(this.refs.input);
       if (input && isObscured(input)) {
-        input.scrollIntoView(input);
+        input.scrollIntoView({ block: "nearest" });
       }
     }
   }


### PR DESCRIPTION
Resolves #10162 

After reading MDN and StackOverflow, I'm still not sure I understand _why_ this fixes the jumping, but it does.🤷‍♂️

I couldn't find our previous usage of passing the element to `scrollIntoView` documented. This options object allows you to customize scrolling. The "block" option customizes vertical alignment. The "nearest" option behaves like we'd want it to with minimal scrolling.