### PR TITLE
Update ForeignFieldReference

### DIFF
--- a/frontend/src/metabase-lib/lib/Dimension.js
+++ b/frontend/src/metabase-lib/lib/Dimension.js
@@ -395,7 +395,7 @@ export class FieldIDDimension extends FieldDimension {
 }
 
 /**
- * Foreign key-based dimension, `["fk->", fk-field-id, dest-field-id]`
+ * Foreign key-based dimension, `["fk->", ["field-id", fk-field-id], ["field-id", dest-field-id]]`
  */
 export class FKDimension extends FieldDimension {
   static parseMBQL(mbql: ConcreteField, metadata?: ?Metadata): ?Dimension {

--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
@@ -810,7 +810,11 @@ export default class StructuredQuery extends AtomicQuery {
 
   fieldReferenceForColumn(column) {
     if (column.fk_field_id != null) {
-      return ["fk->", column.fk_field_id, column.id];
+      return [
+        "fk->",
+        ["field-id", column.fk_field_id],
+        ["field-id", column.id],
+      ];
     } else if (column.id != null) {
       return ["field-id", column.id];
     } else if (column.expression_name != null) {

--- a/frontend/src/metabase/entities/containers/index.js
+++ b/frontend/src/metabase/entities/containers/index.js
@@ -5,13 +5,8 @@ import EntityObjectLoader, { entityObjectLoader } from "./EntityObjectLoader";
 import EntityName from "./EntityName";
 import EntityForm from "./EntityForm";
 
-import inflection from "inflection";
-
 export function addEntityContainers(entity) {
-  // NOTE: need to use inflection directly here due to circular dependency
-  const ObjectName = inflection.capitalize(
-    entity.nameOne || inflection.singularize(entity.name),
-  );
+  const ObjectName = entity.nameOne;
 
   // Entity.load higher-order component
   entity.load = ({ id, ...props } = {}) =>

--- a/frontend/src/metabase/lib/dataset.js
+++ b/frontend/src/metabase/lib/dataset.js
@@ -53,7 +53,11 @@ export function fieldRefForColumn(
       // $FlowFixMe: sometimes col.id is a field reference (e.x. nested queries), if so just return it
       return column.id;
     } else if (column.fk_field_id != null) {
-      return ["fk->", column.fk_field_id, column.id];
+      return [
+        "fk->",
+        ["field-id", column.fk_field_id],
+        ["field-id", column.id],
+      ];
     } else {
       return ["field-id", column.id];
     }

--- a/frontend/src/metabase/lib/dataset.js
+++ b/frontend/src/metabase/lib/dataset.js
@@ -11,6 +11,8 @@ import type {
 import type { Card } from "metabase/meta/types/Card";
 import type { Field as FieldReference } from "metabase/meta/types/Query";
 
+import Dimension from "metabase-lib/lib/Dimension";
+
 type ColumnSetting = {
   name: ColumnName,
   fieldRef?: FieldReference,
@@ -98,15 +100,21 @@ export function findColumnForColumnSetting(
   }
 }
 
+export function normalizeFieldRef(fieldRef: ?FieldReference): ?FieldReference {
+  const dimension = Dimension.parseMBQL(fieldRef);
+  return dimension && dimension.mbql();
+}
+
 export function findColumnIndexForColumnSetting(
   columns: Column[],
   columnSetting: ColumnSetting,
 ): number {
-  const { fieldRef } = columnSetting;
+  // NOTE: need to normalize field refs because they may be old style [fk->, 1, 2]
+  const fieldRef = normalizeFieldRef(columnSetting.fieldRef);
   // first try to find by fieldRef
   if (fieldRef != null) {
     const index = _.findIndex(columns, col =>
-      _.isEqual(fieldRef, fieldRefForColumn(col)),
+      _.isEqual(fieldRef, normalizeFieldRef(fieldRefForColumn(col))),
     );
     if (index >= 0) {
       return index;

--- a/frontend/src/metabase/lib/entities.js
+++ b/frontend/src/metabase/lib/entities.js
@@ -13,7 +13,9 @@ import {
 import { addUndo } from "metabase/redux/undo";
 
 import { GET, PUT, POST, DELETE } from "metabase/lib/api";
-import { singularize } from "metabase/lib/formatting";
+
+// NOTE: need to use inflection directly here due to circular dependency
+import inflection from "inflection";
 
 import { createSelector } from "reselect";
 import { normalize, denormalize, schema } from "normalizr";
@@ -182,7 +184,7 @@ export function createEntity(def: EntityDefinition): Entity {
   const entity: Entity = { ...def };
 
   if (!entity.nameOne) {
-    entity.nameOne = singularize(entity.name);
+    entity.nameOne = inflection.singularize(entity.name);
   }
   if (!entity.nameMany) {
     entity.nameMany = entity.name;

--- a/frontend/src/metabase/lib/query_time.js
+++ b/frontend/src/metabase/lib/query_time.js
@@ -273,7 +273,7 @@ export function parseFieldTargetId(field) {
       return field[1];
     }
     if (field[0] === "fk->") {
-      return field[1];
+      return parseFieldTargetId(field[1]);
     }
     if (field[0] === "datetime-field") {
       return parseFieldTargetId(field[1]);

--- a/frontend/src/metabase/meta/Dashboard.js
+++ b/frontend/src/metabase/meta/Dashboard.js
@@ -225,8 +225,8 @@ export function getTableDimensions(
             parentName: stripId(field.display_name),
             target: [
               "fk->",
-              field.id,
-              getDimensionTargetFieldId(dimension.target),
+              ["field-id", field.id],
+              ["field-id", getDimensionTargetFieldId(dimension.target)],
             ],
             depth: dimension.depth + 1,
           }),

--- a/frontend/src/metabase/meta/types/Query.js
+++ b/frontend/src/metabase/meta/types/Query.js
@@ -222,7 +222,11 @@ export type ConcreteField =
 
 export type LocalFieldReference = ["field-id", FieldId] | FieldId; // @deprecated: use ["field-id", FieldId]
 
-export type ForeignFieldReference = ["fk->", FieldId, FieldId];
+export type ForeignFieldReference = [
+  "fk->",
+  ["field-id", FieldId],
+  ["field-id", FieldId],
+];
 
 export type ExpressionReference = ["expression", ExpressionName];
 

--- a/frontend/src/metabase/modes/lib/actions.js
+++ b/frontend/src/metabase/modes/lib/actions.js
@@ -75,7 +75,7 @@ export const getFieldRefFromColumn = (
     // NOTE: sometimes col.id is a field reference (e.x. nested queries), if so just return it
     return fieldId;
   } else if (column.fk_field_id != null) {
-    return ["fk->", column.fk_field_id, fieldId];
+    return ["fk->", ["field-id", column.fk_field_id], ["field-id", fieldId]];
   } else {
     return ["field-id", fieldId];
   }

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
@@ -102,16 +102,18 @@ export default class ChartSettingOrderedColumns extends Component {
 
   render() {
     const { value, question, columns } = this.props;
-    const query = question.query();
 
     let additionalFieldOptions = { count: 0 };
-    if (columns && question && query instanceof StructuredQuery) {
-      const fieldRefs = columns.map(column => fieldRefForColumn(column));
-      additionalFieldOptions = query.fieldsOptions(dimension => {
-        return !_.find(fieldRefs, fieldRef =>
-          dimension.isSameBaseDimension(fieldRef),
-        );
-      });
+    if (columns && question) {
+      const query = question.query();
+      if (query instanceof StructuredQuery) {
+        const fieldRefs = columns.map(column => fieldRefForColumn(column));
+        additionalFieldOptions = query.fieldsOptions(dimension => {
+          return !_.find(fieldRefs, fieldRef =>
+            dimension.isSameBaseDimension(fieldRef),
+          );
+        });
+      }
     }
 
     const [enabledColumns, disabledColumns] = _.partition(

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
@@ -102,13 +102,15 @@ export default class ChartSettingOrderedColumns extends Component {
 
   render() {
     const { value, question, columns } = this.props;
+    const query = question.query();
 
     let additionalFieldOptions = { count: 0 };
-    if (columns && question && question.query() instanceof StructuredQuery) {
+    if (columns && question && query instanceof StructuredQuery) {
       const fieldRefs = columns.map(column => fieldRefForColumn(column));
-      additionalFieldOptions = question.query().fieldsOptions(dimension => {
-        const mbql = dimension.mbql();
-        return !_.find(fieldRefs, fieldRef => _.isEqual(fieldRef, mbql));
+      additionalFieldOptions = query.fieldsOptions(dimension => {
+        return !_.find(fieldRefs, fieldRef =>
+          dimension.isSameBaseDimension(fieldRef),
+        );
       });
     }
 

--- a/frontend/src/metabase/visualizations/lib/settings/visualization.js
+++ b/frontend/src/metabase/visualizations/lib/settings/visualization.js
@@ -47,15 +47,17 @@ function getSettingDefintionsForSeries(series: ?Series): SettingDefs {
 }
 
 function normalizeColumnSettings(columnSettings) {
-  return Object.fromEntries(
-    Object.entries(columnSettings).map(([columnKey, columnSettings]) => {
-      const [refOrName, fieldRef] = JSON.parse(columnKey);
-      if (refOrName === "ref") {
-        columnKey = JSON.stringify(["ref", normalizeFieldRef(fieldRef)]);
-      }
-      return [columnKey, columnSettings];
-    }),
-  );
+  const newColumnSettings = {};
+  for (const oldColumnKey of columnSettings) {
+    const [refOrName, fieldRef] = JSON.parse(oldColumnKey);
+    // if the key is a reference, normalize the mbql syntax
+    const newColumnKey =
+      refOrName === "ref"
+        ? JSON.stringify(["ref", normalizeFieldRef(fieldRef)])
+        : oldColumnKey;
+    newColumnSettings[newColumnKey] = columnSettings[oldColumnKey];
+  }
+  return newColumnSettings;
 }
 
 export function getStoredSettingsForSeries(series: ?Series): Settings {

--- a/frontend/src/metabase/visualizations/lib/settings/visualization.js
+++ b/frontend/src/metabase/visualizations/lib/settings/visualization.js
@@ -65,10 +65,9 @@ export function getStoredSettingsForSeries(series: ?Series): Settings {
     (series && series[0] && series[0].card.visualization_settings) || {};
   if (storedSettings.column_settings) {
     // normalize any settings stored under old style keys: [ref, [fk->, 1, 2]]
-    return {
-      ...storedSettings,
-      column_settings: normalizeColumnSettings(storedSettings.column_settings),
-    };
+    storedSettings.column_settings = normalizeColumnSettings(
+      storedSettings.column_settings,
+    );
   }
   return storedSettings;
 }

--- a/frontend/src/metabase/visualizations/lib/settings/visualization.js
+++ b/frontend/src/metabase/visualizations/lib/settings/visualization.js
@@ -48,7 +48,7 @@ function getSettingDefintionsForSeries(series: ?Series): SettingDefs {
 
 function normalizeColumnSettings(columnSettings) {
   const newColumnSettings = {};
-  for (const oldColumnKey of columnSettings) {
+  for (const oldColumnKey of Object.keys(columnSettings)) {
     const [refOrName, fieldRef] = JSON.parse(oldColumnKey);
     // if the key is a reference, normalize the mbql syntax
     const newColumnKey =

--- a/frontend/test/metabase-lib/lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Question.unit.spec.js
@@ -367,7 +367,11 @@ describe("Question", () => {
             "source-table": ORDERS_TABLE_ID,
             filter: [
               "=",
-              ["fk->", ORDERS_PRODUCT_FK_FIELD_ID, PRODUCT_CATEGORY_FIELD_ID],
+              [
+                "fk->",
+                ["field-id", ORDERS_PRODUCT_FK_FIELD_ID],
+                ["field-id", PRODUCT_CATEGORY_FIELD_ID],
+              ],
               "Doohickey",
             ],
           },

--- a/frontend/test/metabase/lib/dataset.unit.spec.js
+++ b/frontend/test/metabase/lib/dataset.unit.spec.js
@@ -1,4 +1,7 @@
-import { fieldRefForColumn } from "metabase/lib/dataset";
+import {
+  fieldRefForColumn,
+  findColumnForColumnSetting,
+} from "metabase/lib/dataset";
 
 const FIELD_COLUMN = { id: 1 };
 const FK_COLUMN = { id: 1, fk_field_id: 2 };
@@ -50,6 +53,30 @@ describe("metabase/util/dataset", () => {
         "field-id",
         3,
       ]);
+    });
+  });
+
+  describe("findColumnForColumnSetting", () => {
+    const columns = [
+      { name: "bar", id: 42 },
+      { name: "foo", id: 1, fk_field_id: 2 },
+      { name: "baz", id: 43 },
+    ];
+    it("should find column with name", () => {
+      const column = findColumnForColumnSetting(columns, { name: "foo" });
+      expect(column).toBe(columns[1]);
+    });
+    it("should find column with normalized fieldRef", () => {
+      const column = findColumnForColumnSetting(columns, {
+        fieldRef: ["fk->", ["field-id", 2], ["field-id", 1]],
+      });
+      expect(column).toBe(columns[1]);
+    });
+    it("should find column with non-normalized fieldRef", () => {
+      const column = findColumnForColumnSetting(columns, {
+        fieldRef: ["fk->", 2, 1],
+      });
+      expect(column).toBe(columns[1]);
     });
   });
 });

--- a/frontend/test/metabase/lib/dataset.unit.spec.js
+++ b/frontend/test/metabase/lib/dataset.unit.spec.js
@@ -11,7 +11,11 @@ describe("metabase/util/dataset", () => {
       expect(fieldRefForColumn(FIELD_COLUMN)).toEqual(["field-id", 1]);
     });
     it('should return `["fk->", 2, 1]` for a fk column', () => {
-      expect(fieldRefForColumn(FK_COLUMN)).toEqual(["fk->", 2, 1]);
+      expect(fieldRefForColumn(FK_COLUMN)).toEqual([
+        "fk->",
+        ["field-id", 2],
+        ["field-id", 1],
+      ]);
     });
     it('should return `["expression", 2, 1]` for a fk column', () => {
       expect(fieldRefForColumn(EXPRESSION_COLUMN)).toEqual([

--- a/frontend/test/metabase/visualizations/lib/settings/visualization.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/settings/visualization.unit.spec.js
@@ -1,7 +1,10 @@
 // NOTE: need to load visualizations first for getSettings to work
 import "metabase/visualizations/index";
 
-import { getComputedSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
+import {
+  getComputedSettingsForSeries,
+  getStoredSettingsForSeries,
+} from "metabase/visualizations/lib/settings/visualization";
 
 import { DateTimeColumn, NumberColumn } from "../../__support__/visualizations";
 
@@ -57,6 +60,30 @@ describe("visualization_settings", () => {
             expect(settings["graph.x_axis._is_histogram"]).toBe(true);
           }),
         ));
+    });
+  });
+  describe("getStoredSettingsForSeries", () => {
+    it("should return an empty object if visualization_settings isn't defined", () => {
+      const settings = getStoredSettingsForSeries([{ card: {} }]);
+      expect(settings).toEqual({});
+    });
+    it("should pull out any saved visualization settings", () => {
+      const settings = getStoredSettingsForSeries([
+        { card: { visualization_settings: { foo: "bar" } } },
+      ]);
+      expect(settings).toEqual({ foo: "bar" });
+    });
+    it("should normalize stored columnSettings keys", () => {
+      const oldKey = `["ref",["fk->",1,2]]`;
+      const newKey = `["ref",["fk->",["field-id",1],["field-id",2]]]`;
+      const settings = getStoredSettingsForSeries([
+        {
+          card: {
+            visualization_settings: { column_settings: { [oldKey]: "blah" } },
+          },
+        },
+      ]);
+      expect(settings.column_settings).toEqual({ [newKey]: "blah" });
     });
   });
 });


### PR DESCRIPTION
This PR updates the definition of `ForeignFieldReference` to match the server.

Old: 
```js
export type ForeignFieldReference = ["fk->", FieldId, FieldId];
```

New:
```js
export type ForeignFieldReference = [
  "fk->",
  ["field-id", FieldId],
  ["field-id", FieldId],
];
```

To make that work:
1. I updated the few places where we create these references.
2. Pulled in [Tom's changes](https://github.com/metabase/metabase/pull/10242) to normalize fk refs.
3. Used that same normalization code to update the keys in saved `column_settings`. This "update" is just done on read though; the new keys aren't persisted automatically.

Resolves #9364, Resolves #9144 