### PR TITLE
Only use compact formatting when standard formatting has >6 characters

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Scalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar.jsx
@@ -177,8 +177,6 @@ export default class Scalar extends Component {
       onVisualizationClick,
     } = this.props;
 
-    const isSmall = gridSize && gridSize.width < 4;
-
     const columnIndex = this._getColumnIndex(cols, settings);
     const value = rows[0] && rows[0][columnIndex];
     const column = cols[columnIndex];
@@ -190,9 +188,14 @@ export default class Scalar extends Component {
     };
 
     const fullScalarValue = formatValue(value, formatOptions);
-    const compactScalarValue = isSmall
-      ? formatValue(value, { ...formatOptions, compact: true })
-      : fullScalarValue;
+    const compactScalarValue = formatValue(value, {
+      ...formatOptions,
+      compact: true,
+    });
+
+    const displayCompact =
+      fullScalarValue.length > 6 && gridSize && gridSize.width < 4;
+    const displayValue = displayCompact ? compactScalarValue : fullScalarValue;
 
     const clicked = { value, column };
     const isClickable = visualizationIsClickable(clicked);
@@ -207,7 +210,7 @@ export default class Scalar extends Component {
             "text-brand-hover cursor-pointer": isClickable,
           })}
           tooltip={fullScalarValue}
-          alwaysShowTooltip={fullScalarValue !== compactScalarValue}
+          alwaysShowTooltip={fullScalarValue !== displayValue}
           style={{ maxWidth: "100%" }}
         >
           <span
@@ -219,7 +222,7 @@ export default class Scalar extends Component {
             }
             ref={scalar => (this._scalar = scalar)}
           >
-            <ScalarValue value={compactScalarValue} />
+            <ScalarValue value={displayValue} />
           </span>
         </Ellipsified>
         {isDashboard && (

--- a/frontend/test/metabase/visualizations/visualizations/Scalar.unit.spec.js
+++ b/frontend/test/metabase/visualizations/visualizations/Scalar.unit.spec.js
@@ -1,0 +1,56 @@
+import React from "react";
+import { render, cleanup } from "@testing-library/react";
+
+import Scalar from "metabase/visualizations/visualizations/Scalar";
+
+const series = (value = 1.23) => [
+  {
+    card: {},
+    data: { rows: [[value]], cols: [{ name: "count" }] },
+  },
+];
+const settings = {
+  "scalar.field": "count",
+  "card.title": "Scalar Title",
+  column: () => ({ column: { base_type: "type/Integer" } }),
+};
+
+describe("MetricForm", () => {
+  afterEach(cleanup);
+
+  it("should render title on dashboards", () => {
+    const { getByText } = render(
+      <Scalar
+        series={series()}
+        settings={settings}
+        isDashboard={true}
+        visualizationIsClickable={() => false}
+      />,
+    );
+    getByText("Scalar Title");
+  });
+
+  it("shouldn't render compact if normal formatting is <=6 characters", () => {
+    const { getByText } = render(
+      <Scalar
+        series={series(12345)}
+        settings={settings}
+        visualizationIsClickable={() => false}
+        gridSize={{ width: 3 }}
+      />,
+    );
+    getByText("12,345"); // with compact formatting, we'd have 1
+  });
+
+  it("should render compact if normal formatting is >6 characters", () => {
+    const { getByText } = render(
+      <Scalar
+        series={series(12345.6)}
+        settings={settings}
+        visualizationIsClickable={() => false}
+        gridSize={{ width: 3 }}
+      />,
+    );
+    getByText("12.3k");
+  });
+});


### PR DESCRIPTION
Resolves #4369 

The old logic used compact formatting rules whenever the scalar occupied three horizontal grid units. This PR adds another criteria: the default formatted value must be over six characters long.

### Before
(viewed at 900px wide)
<img width="380" src="https://user-images.githubusercontent.com/691495/61475683-5aad4880-a959-11e9-93a2-ecb7b74b7d0f.png">

### After
(viewed at 900px wide)
<img width="380" src="https://user-images.githubusercontent.com/691495/61475669-51bc7700-a959-11e9-8f06-8516a83b2a2f.png">

Looking with a larger 1600px width, there's room to show even longer values without compact formatting. A better algorithm would switch formatting based on the actual space surrounding the text, but the simpler approach of counting characters seemed like a good place to start.

(viewed at 1600px wide)
<img width="674" src="https://user-images.githubusercontent.com/691495/61475867-be377600-a959-11e9-90cb-5ef9a2efbd14.png">

This should improve the worst cases where we aggressively switched to compact formatting. If there are still too many cases where we make the wrong choice between compact and standard, we should add an explicit setting to override.
