### PR TITLE
Avoid race between logging out and refreshing page

### DIFF
--- a/frontend/src/metabase/auth/auth.js
+++ b/frontend/src/metabase/auth/auth.js
@@ -67,7 +67,7 @@ export const loginGoogle = createThunkAction(LOGIN_GOOGLE, function(
       await dispatch(refreshCurrentUser());
       dispatch(push(redirectUrl || "/"));
     } catch (error) {
-      clearGoogleAuthCredentials();
+      await clearGoogleAuthCredentials();
       // If we see a 428 ("Precondition Required") that means we need to show the "No Metabase account exists for this Google Account" page
       if (error.status === 428) {
         dispatch(push("/auth/google_no_mb_account"));
@@ -81,12 +81,12 @@ export const loginGoogle = createThunkAction(LOGIN_GOOGLE, function(
 // logout
 export const LOGOUT = "metabase/auth/LOGOUT";
 export const logout = createThunkAction(LOGOUT, function() {
-  return function(dispatch, getState) {
+  return async function(dispatch, getState) {
     // actively delete the session and remove the cookie
-    SessionApi.delete();
+    await SessionApi.delete();
 
     // clear Google auth credentials if any are present
-    clearGoogleAuthCredentials();
+    await clearGoogleAuthCredentials();
 
     MetabaseAnalytics.trackEvent("Auth", "Logout");
 

--- a/frontend/src/metabase/lib/auth.js
+++ b/frontend/src/metabase/lib/auth.js
@@ -15,5 +15,4 @@ export async function clearGoogleAuthCredentials() {
   } catch (error) {
     console.error("Problem clearing Google Auth credentials", error);
   }
-  console.log("Cleared Google Auth credentials.");
 }

--- a/frontend/src/metabase/lib/auth.js
+++ b/frontend/src/metabase/lib/auth.js
@@ -1,7 +1,7 @@
 /*global gapi*/
 
 /// clear out Google Auth credentials in browser if present
-export function clearGoogleAuthCredentials() {
+export async function clearGoogleAuthCredentials() {
   const googleAuth =
     typeof gapi !== "undefined" && gapi && gapi.auth2
       ? gapi.auth2.getAuthInstance()
@@ -11,10 +11,9 @@ export function clearGoogleAuthCredentials() {
   }
 
   try {
-    googleAuth.signOut().then(function() {
-      console.log("Cleared Google Auth credentials.");
-    });
+    await googleAuth.signOut();
   } catch (error) {
     console.error("Problem clearing Google Auth credentials", error);
   }
+  console.log("Cleared Google Auth credentials.");
 }


### PR DESCRIPTION
Resolves #10039

The bug happened because the logout thunk fired off a few async functions in parallel. If the page refreshed before the logout completed, the user would remain logged in.

It seems like this race should exist in any browser, but I was unable to reproduce it in Chrome. Maybe there's something in Chrome's networking code that blocks a refresh while recently started network calls are in progress?

It's not directly related to the bug, but just to be safe, I also added an `await` for `clearGoogleAuthCredentials`.