### PR TITLE
Perform startOf/endOf manipulation in "en" locale

### DIFF
--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -381,8 +381,20 @@ export function formatDateTimeRangeWithUnit(
     options.type === "tooltip" ? "MMMM" : getMonthFormat(options);
   const condensed = options.compact || options.type === "tooltip";
 
-  const start = m.clone().startOf(unit);
-  const end = m.clone().endOf(unit);
+  // The startOf/endOf transition needs to happen in "en" rather than the
+  // current locale. Other locales define week boundaries differently, and they
+  // don't line up with the server's grouping logic.
+  const start = m
+    .clone()
+    .locale("en")
+    .startOf(unit)
+    .locale(false);
+  const end = m
+    .clone()
+    .locale("en")
+    .endOf(unit)
+    .locale(false);
+
   if (start.isValid() && end.isValid()) {
     if (!condensed || start.year() !== end.year()) {
       // January 1, 2018 - January 2, 2019

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -1,6 +1,12 @@
 import { isElementOfType } from "react-dom/test-utils";
+import moment from "moment";
 
-import { formatNumber, formatValue, formatUrl } from "metabase/lib/formatting";
+import {
+  formatNumber,
+  formatValue,
+  formatUrl,
+  formatDateTimeWithUnit,
+} from "metabase/lib/formatting";
 import ExternalLink from "metabase/components/ExternalLink.jsx";
 import { TYPE } from "metabase/lib/types";
 
@@ -273,6 +279,31 @@ describe("formatting", () => {
           column: null,
         }),
       ).toEqual("foobar");
+    });
+  });
+
+  describe("formatDateTimeWithUnit", () => {
+    it("should format week ranges", () => {
+      expect(
+        formatDateTimeWithUnit("2019-07-07T00:00:00.000Z", "week", {
+          type: "cell",
+        }),
+      ).toEqual("July 7, 2019 – July 13, 2019");
+    });
+
+    it("should always format week ranges in en locale", () => {
+      try {
+        // globally set locale to es
+        moment.locale("es");
+        expect(
+          formatDateTimeWithUnit("2019-07-07T00:00:00.000Z", "week", {
+            type: "cell",
+          }),
+        ).toEqual("julio 7, 2019 – julio 13, 2019");
+      } finally {
+        // globally reset locale
+        moment.locale(false);
+      }
     });
   });
 });


### PR DESCRIPTION
Resolves #9892

Different locales have variable definitions of week boundaries. Moment.js respects this when you call `startOf('week')` and `endOf('week')`, which breaks our date range formatting.

The issue had simple repro steps.

<img width="780" src="https://user-images.githubusercontent.com/691495/61496787-44b87b80-a98b-11e9-8c8d-1e4397c67c04.png">

In that screenshot, the server returns the following data:

```
"2019-06-30T00:00:00.000-04:00", 121
"2019-07-07T00:00:00.000-04:00", 129
```

With a local of "en" rather than "es", that would incorrectly display shifted by one week:

<img width="780" src="https://user-images.githubusercontent.com/691495/61496875-99f48d00-a98b-11e9-8362-beceb15a9201.png">


This PR switches locale to 'en' before calling `startOf` and `endOf` so that the date math is always consistent.

<img width="780" src="https://user-images.githubusercontent.com/691495/61496878-9eb94100-a98b-11e9-97ed-eb454afb5c30.png">


I think another approach would be to stop using locale-aware `startOf`/`endOf` and do the date manipulation directly. Both seemed like fine options, so I went with the smaller change.
