### PR TITLE
Fix field_refs returned for implicit join fields

### DIFF
--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -151,7 +151,7 @@
     ;; TODO - should be able to remove this now
     ;; for FKs where source is a :field-literal don't include `:fk_field_id`
     [:fk-> _ field]
-    (assoc (col-info-for-field-clause field)
+    (assoc (col-info-for-field-clause inner-query field)
       :field_ref &match)
 
     ;; for field literals, look for matching `source-metadata`, and use that if we can find it; otherwise generate

--- a/test/metabase/query_processor/middleware/annotate_test.clj
+++ b/test/metabase/query_processor/middleware/annotate_test.clj
@@ -91,14 +91,14 @@
       {:columns [:name]}))))
 
 ;; we should get `:fk_field_id` and information where possible when using `:joined-field` clauses; display_name should
-;; include the joined table
+;; include the joined table (for IMPLICIT JOINS)
 (expect
   [(data/$ids venues
      (assoc (info-for-field :categories :name)
        :display_name "Venues → Name"
-       :fk_field_id  %category_id
        :source       :fields
-       :field_ref    &CATEGORIES__via__CATEGORY_ID.categories.name))]
+       :field_ref    $category_id->categories.name
+       :fk_field_id  %category_id))]
   (qp.test-util/with-everything-store
     (data/$ids venues
       (doall
@@ -112,14 +112,34 @@
                            :fk-field-id  %category_id}]}}
         {:columns [:name]})))))
 
+;; for EXPLICIT JOINS (which do not include an `:fk-field-id` in the Join info) the returned `:field_ref` should be a
+;; `joined-field` clause instead of an `fk->` clause
+(expect
+  [(data/$ids venues
+     (assoc (info-for-field :categories :name)
+       :display_name "Venues → Name"
+       :source       :fields
+       :field_ref    &CATEGORIES__via__CATEGORY_ID.categories.name))]
+  (qp.test-util/with-everything-store
+    (data/$ids venues
+      (doall
+       (annotate/column-info
+        {:type  :query
+         :query {:fields [&CATEGORIES__via__CATEGORY_ID.categories.name]
+                 :joins  [{:alias        "CATEGORIES__via__CATEGORY_ID"
+                           :source-table $$venues
+                           :condition    [:= $category_id &CATEGORIES__via__CATEGORY_ID.categories.id]
+                           :strategy     :left-join}]}}
+        {:columns [:name]})))))
+
 ;; we shuld use the `display_name` of a Table instead of its `name` in joined display names
 (expect
   [(data/$ids venues
      (assoc (info-for-field :categories :name)
        :display_name "Geographical locations to share Tips about → Name" ; RIP GeoTips
-       :fk_field_id  %category_id
        :source       :fields
-       :field_ref    &CATEGORIES__via__CATEGORY_ID.categories.name))]
+       :field_ref    $category_id->categories.name
+       :fk_field_id  %category_id))]
   (qp.test-util/with-everything-store
     (data/$ids venues
       (tu/with-temp-vals-in-db Table $$venues {:display_name "Geographical locations to share Tips about"}
@@ -140,9 +160,9 @@
   [(data/$ids venues
      (assoc (info-for-field :categories :name)
        :display_name "cats → Name"
-       :fk_field_id  %category_id
        :source       :fields
-       :field_ref    &cats.categories.name))]
+       :field_ref    $category_id->categories.name
+       :fk_field_id  %category_id))]
   (qp.test-util/with-everything-store
     (data/$ids venues
       (doall
@@ -220,7 +240,7 @@
 
 ;; For fields with parents we should return them with a combined name including parent's name
 (tt/expect-with-temp [Field [parent {:name "parent", :table_id (data/id :venues)}]
-                      Field [child  {:name "child",  :table_id (data/id :venues), :parent_id (u/get-id parent)}]]
+                      Field [child  {:name "child", :table_id (data/id :venues), :parent_id (u/get-id parent)}]]
   {:description     nil
    :table_id        (data/id :venues)
    :special_type    nil
@@ -231,14 +251,15 @@
    :visibility_type :normal
    :display_name    "Child"
    :fingerprint     nil
+   :field_ref       [:field-id (u/get-id child)]
    :base_type       :type/Text}
   (qp.test-util/with-everything-store
     (#'annotate/col-info-for-field-clause {} [:field-id (u/get-id child)])))
 
 ;; nested-nested fields should include grandparent name (etc)
 (tt/expect-with-temp [Field [grandparent {:name "grandparent", :table_id (data/id :venues)}]
-                      Field [parent      {:name "parent",      :table_id (data/id :venues), :parent_id (u/get-id grandparent)}]
-                      Field [child       {:name "child",       :table_id (data/id :venues), :parent_id (u/get-id parent)}]]
+                      Field [parent      {:name "parent", :table_id (data/id :venues), :parent_id (u/get-id grandparent)}]
+                      Field [child       {:name "child", :table_id (data/id :venues), :parent_id (u/get-id parent)}]]
   {:description     nil
    :table_id        (data/id :venues)
    :special_type    nil
@@ -249,6 +270,7 @@
    :visibility_type :normal
    :display_name    "Child"
    :fingerprint     nil
+   :field_ref       [:field-id (u/get-id child)]
    :base_type       :type/Text}
   (qp.test-util/with-everything-store
     (#'annotate/col-info-for-field-clause {} [:field-id (u/get-id child)])))
@@ -258,10 +280,11 @@
   {:name         "sum"
    :display_name "sum of User ID"
    :base_type    :type/Integer
+   :field_ref    [:field-literal "sum" :type/Integer]
    :special_type :type/FK}
   (qp.test-util/with-everything-store
     (#'annotate/col-info-for-field-clause
-     {:source-metadata [{:name "abc", :display_name "another Field",  :base_type :type/Integer, :special_type :type/FK}
+     {:source-metadata [{:name "abc", :display_name "another Field", :base_type :type/Integer, :special_type :type/FK}
                         {:name "sum", :display_name "sum of User ID", :base_type :type/Integer, :special_type :type/FK}]}
      [:field-literal "sum" :type/Integer])))
 

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -12,7 +12,6 @@
             [metabase.models
              [field :refer [Field]]
              [table :refer [Table]]]
-            [metabase.query-processor.middleware.add-implicit-joins :as add-implicit-joins]
             [metabase.test.data :as data]
             [metabase.test.data
              [datasets :as datasets]

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -172,11 +172,10 @@
   (let [source-col              (col source-table-kw source-field-kw)
         dest-col                (col dest-table-kw dest-field-kw)
         dest-table-display-name (db/select-one-field :display_name Table :id (data/id dest-table-kw))
-        dest-table-name         (db/select-one-field :name Table :id (data/id dest-table-kw))
-        join-alias              (#'add-implicit-joins/join-alias dest-table-name (:name source-col))]
+        dest-table-name         (db/select-one-field :name Table :id (data/id dest-table-kw))]
     (-> dest-col
         (update :display_name (partial format "%s → %s" (or dest-table-display-name dest-table-name)))
-        (assoc :field_ref   [:joined-field join-alias [:field-id (:id dest-col)]]
+        (assoc :field_ref   [:fk-> [:field-id (:id source-col)] [:field-id (:id dest-col)]]
                :fk_field_id (:id source-col)))))
 
 (declare cols)

--- a/test/metabase/query_processor_test/implicit_joins_test.clj
+++ b/test/metabase/query_processor_test/implicit_joins_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.query-processor-test.implicit-joins-test
   "Test for JOIN behavior."
-  (:require [metabase
+  (:require [expectations :refer [expect]]
+            [metabase
              [driver :as driver]
              [query-processor-test :as qp.test]]
             [metabase.test.data :as data]
@@ -107,6 +108,17 @@
                    [:asc $id]]
         :limit    10}))
    [:status :error]))
+
+;; Implicit joins should come back with `:fk->` field refs
+(expect
+  (data/$ids venues $category_id->categories.name)
+  (-> (qp.test/cols
+        (data/run-mbql-query :venues
+          {:fields   [$category_id->categories.name]
+           :order-by [[:asc $id]]
+           :limit    1}))
+      first
+      :field_ref))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/test/metabase/query_processor_test/remapping_test.clj
+++ b/test/metabase/query_processor_test/remapping_test.clj
@@ -59,9 +59,7 @@
               :display_name  "Foo"
               :name          (data/format-name "name_2")
               :remapped_from (data/format-name "category_id")
-              :field_ref     [:joined-field
-                              (qp.test-util/fk-table-alias-name $$categories %category_id)
-                              $categories.name]))]}
+              :field_ref     $category_id->categories.name))]}
   (data/with-temp-objects
     (data/create-venue-category-fk-remapping "Foo")
     (select-columns (set (map data/format-name ["name" "price" "name_2"]))
@@ -84,9 +82,7 @@
                      :display_name  "Foo"
                      :name          (data/format-name "name_2")
                      :remapped_from (data/format-name "category_id")
-                     :field_ref     [:joined-field
-                                     (qp.test-util/fk-table-alias-name $$categories %category_id)
-                                     $categories.name]))]}
+                     :field_ref     $category_id->categories.name))]}
   (data/with-temp-objects
     (data/create-venue-category-fk-remapping "Foo")
     (select-columns (set (map data/format-name ["name" "price" "name_2"]))

--- a/test/metabase/query_processor_test/remapping_test.clj
+++ b/test/metabase/query_processor_test/remapping_test.clj
@@ -7,7 +7,6 @@
              [dimension :refer [Dimension]]
              [field :refer [Field]]]
             [metabase.query-processor.middleware.add-dimension-projections :as add-dimension-projections]
-            [metabase.query-processor.test-util :as qp.test-util]
             [metabase.test.data :as data]
             [metabase.test.data.datasets :as datasets]
             [toucan.db :as db]))


### PR DESCRIPTION
Return original `fk->` form instead of the `joined-field` form used internally.
