### PR TITLE
Invalidate "table.columns" if they don't match the data's columns

### DIFF
--- a/frontend/test/metabase/visualizations/lib/settings/visualization.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/settings/visualization.unit.spec.js
@@ -58,6 +58,53 @@ describe("visualization_settings", () => {
           }),
         ));
     });
+    describe("table.columns", () => {
+      it("should populate an empty table.columns based on data columns", () => {
+        const cols = ["foo", "bar", "baz"].map(name => NumberColumn({ name }));
+        const card = { display: "table", visualization_settings: {} };
+        const settings = getComputedSettingsForSeries([
+          { card, data: { cols } },
+        ]);
+        expect(settings["table.columns"].map(c => c.name)).toEqual([
+          "foo",
+          "bar",
+          "baz",
+        ]);
+      });
+      it("should add to table.columns based on new data columns", () => {
+        const cols = ["foo", "bar", "baz"].map(name => NumberColumn({ name }));
+        const card = {
+          display: "table",
+          visualization_settings: {
+            "table.columns": [{ name: "foo" }, { name: "bar" }],
+          },
+        };
+        const settings = getComputedSettingsForSeries([
+          { card, data: { cols } },
+        ]);
+        expect(settings["table.columns"].map(c => c.name)).toEqual([
+          "foo",
+          "bar",
+          "baz",
+        ]);
+      });
+      it("should remove from table.columns if not present in the data's columns", () => {
+        const cols = ["bar", "baz"].map(name => NumberColumn({ name }));
+        const card = {
+          display: "table",
+          visualization_settings: {
+            "table.columns": [{ name: "foo" }, { name: "bar" }],
+          },
+        };
+        const settings = getComputedSettingsForSeries([
+          { card, data: { cols } },
+        ]);
+        expect(settings["table.columns"].map(c => c.name)).toEqual([
+          "bar",
+          "baz",
+        ]);
+      });
+    });
   });
 });
 


### PR DESCRIPTION
Resolves #6670

This bug occurred because adding columns to the dataset wasn't reflected in the stored "table.columns" setting. This PR invalidates "table.columns" whenever the column names don't match the data.

This required an update to how the default names are generated. Instead of just generating them from the table columns, we now also check for any existing settings and use those first.