### PR TITLE
Null out invalid dates and warn users

### DIFF
--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -31,11 +31,7 @@ import { setupTooltips } from "./apply_tooltips";
 import { getTrendDataPointsFromInsight } from "./trends";
 
 import fillMissingValuesInDatas from "./fill_data";
-import {
-  nullDimensionWarning,
-  NULL_DIMENSION_WARNING,
-  unaggregatedDataWarning,
-} from "./warnings";
+import { NULL_DIMENSION_WARNING, unaggregatedDataWarning } from "./warnings";
 
 import { keyForSingleSeries } from "metabase/visualizations/lib/settings/series";
 

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -31,12 +31,16 @@ import { setupTooltips } from "./apply_tooltips";
 import { getTrendDataPointsFromInsight } from "./trends";
 
 import fillMissingValuesInDatas from "./fill_data";
+import {
+  nullDimensionWarning,
+  NULL_DIMENSION_WARNING,
+  unaggregatedDataWarning,
+} from "./warnings";
 
 import { keyForSingleSeries } from "metabase/visualizations/lib/settings/series";
 
 import {
   HACK_parseTimestamp,
-  NULL_DIMENSION_WARNING,
   forceSortedGroupsOfGroups,
   initChart, // TODO - probably better named something like `initChartParent`
   makeIndexMap,
@@ -71,13 +75,6 @@ import type { VisualizationProps } from "metabase/meta/types/Visualization";
 
 const BAR_PADDING_RATIO = 0.2;
 const DEFAULT_INTERPOLATION = "linear";
-
-const UNAGGREGATED_DATA_WARNING = col => ({
-  key: UNAGGREGATED_DATA_WARNING,
-  text: t`"${getFriendlyName(
-    col,
-  )}" is an unaggregated field: if it has more than one value at a point on the x-axis, the values will be summed.`,
-});
 
 const enableBrush = (series, onChangeCardAndRun) =>
   !!(
@@ -229,7 +226,7 @@ function getDimensionsAndGroupsAndUpdateSeriesDisplayNamesForStackedChart(
   const groups = [
     datas.map((data, seriesIndex) =>
       reduceGroup(dimension.group(), seriesIndex + 1, () =>
-        warn(UNAGGREGATED_DATA_WARNING(props.series[seriesIndex].data.cols[0])),
+        warn(unaggregatedDataWarning(props.series[seriesIndex].data.cols[0])),
       ),
     ),
   ];
@@ -252,7 +249,7 @@ function getDimensionsAndGroupsForOther({ series }, datas, warn) {
       .slice(1)
       .map((_, metricIndex) =>
         reduceGroup(dim.group(), metricIndex + 1, () =>
-          warn(UNAGGREGATED_DATA_WARNING(series[seriesIndex].data.cols[0])),
+          warn(unaggregatedDataWarning(series[seriesIndex].data.cols[0])),
         ),
       );
   });
@@ -877,7 +874,7 @@ export default function lineAreaBar(
 
   // only ordinal axis can display "null" values
   if (isOrdinal(parent.settings)) {
-    delete warnings[NULL_DIMENSION_WARNING.key];
+    delete warnings[NULL_DIMENSION_WARNING];
   }
 
   if (onRender) {

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -72,10 +72,12 @@ import type { VisualizationProps } from "metabase/meta/types/Visualization";
 const BAR_PADDING_RATIO = 0.2;
 const DEFAULT_INTERPOLATION = "linear";
 
-const UNAGGREGATED_DATA_WARNING = col =>
-  t`"${getFriendlyName(
+const UNAGGREGATED_DATA_WARNING = col => ({
+  key: UNAGGREGATED_DATA_WARNING,
+  text: t`"${getFriendlyName(
     col,
-  )}" is an unaggregated field: if it has more than one value at a point on the x-axis, the values will be summed.`;
+  )}" is an unaggregated field: if it has more than one value at a point on the x-axis, the values will be summed.`,
+});
 
 const enableBrush = (series, onChangeCardAndRun) =>
   !!(
@@ -779,8 +781,10 @@ export default function lineAreaBar(
   const { onRender, isScalarSeries, settings, series } = props;
 
   const warnings = {};
-  const warn = id => {
-    warnings[id] = (warnings[id] || 0) + 1;
+  // `text` is displayed to users, but we deduplicate based on `key`
+  // Call `warn` for each row-level issue, but only the first of each type is displayed.
+  const warn = ({ key, text }) => {
+    warnings[key] = warnings[key] || text;
   };
 
   checkSeriesIsValid(props);
@@ -873,13 +877,13 @@ export default function lineAreaBar(
 
   // only ordinal axis can display "null" values
   if (isOrdinal(parent.settings)) {
-    delete warnings[NULL_DIMENSION_WARNING];
+    delete warnings[NULL_DIMENSION_WARNING.key];
   }
 
   if (onRender) {
     onRender({
       yAxisSplit: yAxisProps.yAxisSplit,
-      warnings: Object.keys(warnings),
+      warnings: Object.values(warnings),
     });
   }
 

--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -10,7 +10,14 @@ import { dimensionIsNumeric } from "./numeric";
 import { dimensionIsTimeseries } from "./timeseries";
 import { getAvailableCanvasWidth, getAvailableCanvasHeight } from "./utils";
 
-export const NULL_DIMENSION_WARNING = "Data includes missing dimension values.";
+export const NULL_DIMENSION_WARNING = {
+  key: "NULL_DIMENSION_WARNING",
+  text: "Data includes missing dimension values.",
+};
+const createInvalidDateWarning = value => ({
+  key: "INVALID_DATE_WARNING",
+  text: `We encountered an invalid date: "${value}"`,
+});
 
 export function initChart(chart, element) {
   // set the bounds
@@ -106,11 +113,14 @@ export function HACK_parseTimestamp(value, unit, warn) {
   if (value == null) {
     warn(NULL_DIMENSION_WARNING);
     return null;
-  } else {
-    const m = parseTimestamp(value, unit);
-    m.toString = moment_fast_toString;
-    return m;
   }
+  const m = parseTimestamp(value, unit);
+  if (!m.isValid()) {
+    warn(createInvalidDateWarning(value));
+    return null;
+  }
+  m.toString = moment_fast_toString;
+  return m;
 }
 
 /************************************************************ PROPERTIES ************************************************************/

--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -9,15 +9,7 @@ import { parseTimestamp } from "metabase/lib/time";
 import { dimensionIsNumeric } from "./numeric";
 import { dimensionIsTimeseries } from "./timeseries";
 import { getAvailableCanvasWidth, getAvailableCanvasHeight } from "./utils";
-
-export const NULL_DIMENSION_WARNING = {
-  key: "NULL_DIMENSION_WARNING",
-  text: "Data includes missing dimension values.",
-};
-const createInvalidDateWarning = value => ({
-  key: "INVALID_DATE_WARNING",
-  text: `We encountered an invalid date: "${value}"`,
-});
+import { invalidDateWarning, nullDimensionWarning } from "./warnings";
 
 export function initChart(chart, element) {
   // set the bounds
@@ -111,12 +103,12 @@ function moment_fast_toString() {
 
 export function HACK_parseTimestamp(value, unit, warn) {
   if (value == null) {
-    warn(NULL_DIMENSION_WARNING);
+    warn(nullDimensionWarning());
     return null;
   }
   const m = parseTimestamp(value, unit);
   if (!m.isValid()) {
-    warn(createInvalidDateWarning(value));
+    warn(invalidDateWarning(value));
     return null;
   }
   m.toString = moment_fast_toString;

--- a/frontend/src/metabase/visualizations/lib/warnings.js
+++ b/frontend/src/metabase/visualizations/lib/warnings.js
@@ -1,5 +1,7 @@
 import { getFriendlyName } from "./utils";
 
+import { t } from "ttag";
+
 export const NULL_DIMENSION_WARNING = "NULL_DIMENSION_WARNING";
 export function nullDimensionWarning() {
   return {
@@ -9,7 +11,7 @@ export function nullDimensionWarning() {
 }
 
 export const INVALID_DATE_WARNING = "INVALID_DATE_WARNING";
-export function createInvalidDateWarning(value) {
+export function invalidDateWarning(value) {
   return {
     key: INVALID_DATE_WARNING,
     text: `We encountered an invalid date: "${value}"`,

--- a/frontend/src/metabase/visualizations/lib/warnings.js
+++ b/frontend/src/metabase/visualizations/lib/warnings.js
@@ -1,0 +1,27 @@
+import { getFriendlyName } from "./utils";
+
+export const NULL_DIMENSION_WARNING = "NULL_DIMENSION_WARNING";
+export function nullDimensionWarning() {
+  return {
+    key: NULL_DIMENSION_WARNING,
+    text: "Data includes missing dimension values.",
+  };
+}
+
+export const INVALID_DATE_WARNING = "INVALID_DATE_WARNING";
+export function createInvalidDateWarning(value) {
+  return {
+    key: INVALID_DATE_WARNING,
+    text: `We encountered an invalid date: "${value}"`,
+  };
+}
+
+export const UNAGGREGATED_DATA_WARNING = "UNAGGREGATED_DATA_WARNING";
+export function unaggregatedDataWarning(col) {
+  return {
+    key: UNAGGREGATED_DATA_WARNING,
+    text: t`"${getFriendlyName(
+      col,
+    )}" is an unaggregated field: if it has more than one value at a point on the x-axis, the values will be summed.`,
+  };
+}

--- a/frontend/test/metabase/visualizations/components/LineAreaBarRenderer.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/LineAreaBarRenderer.unit.spec.js
@@ -55,6 +55,17 @@ describe("LineAreaBarRenderer", () => {
     // ]);
   });
 
+  it("should display a warning for invalid dates", () => {
+    const onRender = jest.fn();
+    renderTimeseriesLine({
+      rowsOfSeries: [[["2019-W52", 1], ["2019-W53", 2], ["2019-W01", 3]]],
+      unit: "week",
+      onRender,
+    });
+    const [[{ warnings }]] = onRender.mock.calls;
+    expect(warnings).toEqual(['We encountered an invalid date: "2019-W53"']);
+  });
+
   ["Z", ...ALL_TZS].forEach(tz =>
     it(
       "should display hourly data (in " +
@@ -275,6 +286,7 @@ describe("LineAreaBarRenderer", () => {
   const renderTimeseriesLine = ({
     rowsOfSeries,
     onHoverChange,
+    onRender,
     unit,
     settings,
   }) => {
@@ -297,6 +309,7 @@ describe("LineAreaBarRenderer", () => {
       })),
       {
         onHoverChange,
+        onRender,
       },
     );
   };


### PR DESCRIPTION
Resolves #10020 

The issue occurred because some of the weeks were invalid according to moment.js (e.g. '2019-W00'). Invalid dates would lead to NaNs in crossfilter dimensions which would break things and sum values for distinct weeks.

The core of this PR is to add a warning for invalid dates and null them out to prevent summing their values:
```js
if (!m.isValid()) {
  warn(createInvalidDateWarning(value));
  return null;
}
```

Most of the diff is updating how the warnings work. Previously, we called `warn` with a string that would both dedupe warnings and be displayed to the user. I wanted to include a row-specific example date in the warning but still dedupe by warning type, so I split out `key` and `text` fields. We dedupe by `key`, but only display `text` to the user. The diff is noisy from updating existing warnings.

