### PR TITLE
Load memberships after creating a user

### DIFF
--- a/frontend/src/metabase/entities/users.js
+++ b/frontend/src/metabase/entities/users.js
@@ -23,6 +23,11 @@ export const PASSWORD_RESET_MANUAL =
   "metabase/entities/users/RESET_PASSWORD_MANUAL";
 export const RESEND_INVITE = "metabase/entities/users/RESEND_INVITE";
 
+// TODO: It'd be nice to import loadMemberships, but we need to resolve a circular dependency
+function loadMemberships() {
+  return require("metabase/admin/people/people").loadMemberships();
+}
+
 const BASE_FORM_FIELDS: FormFieldDefinition[] = [
   {
     name: "first_name",
@@ -74,6 +79,8 @@ const Users = createEntity({
         };
       }
       const result = await thunkCreator(user)(dispatch, getState);
+
+      dispatch(loadMemberships());
       return {
         // HACK: include user ID and password for temporaryPasswords reducer
         id: result.result,
@@ -85,7 +92,7 @@ const Users = createEntity({
       const result = await thunkCreator(...args)(dispatch, getState);
       // HACK: reload memberships when updating a user
       // TODO: only do this if group_ids changes
-      dispatch(require("metabase/admin/people/people").loadMemberships());
+      dispatch(loadMemberships());
       return result;
     },
   },


### PR DESCRIPTION
Resolves #9857

We create memberships while creating a user, but we need to explicitly retrieve those after the user has been created or updated.

---

There's an icky "require" in here for `loadMemberships`. I tried to remove it as I added another use of `loadMemberships`, but the circular dependency that caused it was a bit too entangled. Removing it would require restructuring our temporary password state/code.