### PR TITLE
Don't strip options from filter when updating relative date values

### DIFF
--- a/frontend/src/metabase/meta/types/Query.js
+++ b/frontend/src/metabase/meta/types/Query.js
@@ -182,20 +182,13 @@ export type InsideFilter = [
   NumericLiteral,
   NumericLiteral,
 ];
-export type TimeIntervalFilter =
-  | [
-      "time-interval",
-      ConcreteField,
-      RelativeDatetimePeriod,
-      RelativeDatetimeUnit,
-    ]
-  | [
-      "time-interval",
-      ConcreteField,
-      RelativeDatetimePeriod,
-      RelativeDatetimeUnit,
-      FilterOptions,
-    ];
+export type TimeIntervalFilter = [
+  "time-interval",
+  ConcreteField,
+  RelativeDatetimePeriod,
+  RelativeDatetimeUnit,
+  ?TimeIntervalFilterOptions,
+];
 
 export type TimeIntervalFilterOptions = {
   "include-current"?: boolean,

--- a/frontend/src/metabase/meta/types/Query.js
+++ b/frontend/src/metabase/meta/types/Query.js
@@ -182,13 +182,20 @@ export type InsideFilter = [
   NumericLiteral,
   NumericLiteral,
 ];
-export type TimeIntervalFilter = [
-  "time-interval",
-  ConcreteField,
-  RelativeDatetimePeriod,
-  RelativeDatetimeUnit,
-  ?TimeIntervalFilterOptions,
-];
+export type TimeIntervalFilter =
+  | [
+      "time-interval",
+      ConcreteField,
+      RelativeDatetimePeriod,
+      RelativeDatetimeUnit,
+    ]
+  | [
+      "time-interval",
+      ConcreteField,
+      RelativeDatetimePeriod,
+      RelativeDatetimeUnit,
+      TimeIntervalFilterOptions,
+    ];
 
 export type TimeIntervalFilterOptions = {
   "include-current"?: boolean,

--- a/frontend/src/metabase/query_builder/components/filters/pickers/RelativeDatePicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/RelativeDatePicker.jsx
@@ -46,7 +46,7 @@ export default class RelativeDatePicker extends Component {
 
   render() {
     const {
-      filter: [op, field, intervals, unit],
+      filter: [op, field, intervals, unit, options],
       onFilterChange,
       formatter,
     } = this.props;
@@ -66,7 +66,7 @@ export default class RelativeDatePicker extends Component {
             typeof intervals === "number" ? Math.abs(intervals) : intervals
           }
           onChange={value =>
-            onFilterChange([op, field, formatter(value), unit])
+            onFilterChange([op, field, formatter(value), unit, options])
           }
           placeholder="30"
         />
@@ -75,7 +75,7 @@ export default class RelativeDatePicker extends Component {
             open={this.state.showUnits}
             value={unit}
             onChange={value => {
-              onFilterChange([op, field, intervals, value]);
+              onFilterChange([op, field, intervals, value, options]);
               this.setState({ showUnits: false });
             }}
             togglePicker={() =>

--- a/frontend/src/metabase/query_builder/components/filters/pickers/RelativeDatePicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/RelativeDatePicker.jsx
@@ -5,6 +5,8 @@ import React, { Component } from "react";
 import NumericInput from "metabase/components/NumericInput.jsx";
 import DateUnitSelector from "../DateUnitSelector";
 
+import { assoc } from "icepick";
+
 import type {
   TimeIntervalFilter,
   RelativeDatetimeUnit,
@@ -45,11 +47,9 @@ export default class RelativeDatePicker extends Component {
   };
 
   render() {
-    const {
-      filter: [op, field, intervals, unit, options],
-      onFilterChange,
-      formatter,
-    } = this.props;
+    const { filter, onFilterChange, formatter } = this.props;
+    const intervals = filter[2];
+    const unit = filter[3];
     return (
       <div className="flex-full mb2 flex align-center">
         <NumericInput
@@ -65,9 +65,7 @@ export default class RelativeDatePicker extends Component {
           value={
             typeof intervals === "number" ? Math.abs(intervals) : intervals
           }
-          onChange={value =>
-            onFilterChange([op, field, formatter(value), unit, options])
-          }
+          onChange={value => onFilterChange(assoc(filter, 2, formatter(value)))}
           placeholder="30"
         />
         <div className="flex-full mr2">
@@ -75,7 +73,7 @@ export default class RelativeDatePicker extends Component {
             open={this.state.showUnits}
             value={unit}
             onChange={value => {
-              onFilterChange([op, field, intervals, value, options]);
+              onFilterChange(assoc(filter, 3, value));
               this.setState({ showUnits: false });
             }}
             togglePicker={() =>

--- a/frontend/test/metabase/query_builder/components/filters/pickers/DatePicker.unit.spec.js
+++ b/frontend/test/metabase/query_builder/components/filters/pickers/DatePicker.unit.spec.js
@@ -1,6 +1,8 @@
 import React from "react";
 import { mount } from "enzyme";
 
+import { setInputValue } from "__support__/enzyme_utils";
+
 import DatePicker from "metabase/query_builder/components/filters/pickers/DatePicker";
 import DateOperatorSelector from "metabase/query_builder/components/filters/DateOperatorSelector";
 import DateUnitSelector from "metabase/query_builder/components/filters/DateUnitSelector";
@@ -58,6 +60,33 @@ describe("DatePicker", () => {
     expect(picker.find(".Calendar-header").map(t => t.text())).toEqual([
       "January 2020",
       "February 2020",
+    ]);
+  });
+  it("should call onFilterChange with updated filter", () => {
+    const onFilterChange = jest.fn();
+    const picker = mount(
+      <DatePicker
+        filter={[
+          "time-interval",
+          ["field-id", 1],
+          -30,
+          "day",
+          { "include-current": true },
+        ]}
+        onFilterChange={onFilterChange}
+      />,
+    );
+
+    setInputValue(picker.find("input"), "-20");
+
+    const { calls } = onFilterChange.mock;
+    const lastCall = calls[calls.length - 1];
+    expect(lastCall[0]).toEqual([
+      "time-interval",
+      ["field-id", 1],
+      -20,
+      "day",
+      { "include-current": true },
     ]);
   });
 });


### PR DESCRIPTION
Resolves #10249 

I fixed it just by adding the missing arg. Should I instead use [`updateFilter`](https://github.com/metabase/metabase/blob/master/frontend/src/metabase/lib/query/filter.js#L39)?
