### PR TITLE
Center chart with legend

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartWithLegend.css
+++ b/frontend/src/metabase/visualizations/components/ChartWithLegend.css
@@ -8,6 +8,15 @@
   justify-content: center;
 }
 
+:local .ChartWithLegend .LegendSpacer {
+  flex: 1;
+}
+
+:local .ChartWithLegend .LegendWrapper {
+  flex: 1;
+  display: flex;
+}
+
 :local .ChartWithLegend .Chart {
   flex-shrink: 0;
   position: relative;
@@ -30,6 +39,10 @@
   flex-shrink: 1;
   overflow: hidden;
 }
+:local .ChartWithLegend.vertical .LegendWrapper {
+  flex-direction: column;
+  justify-content: flex-start;
+}
 :local .ChartWithLegend.vertical.flexChart .Legend {
   flex-grow: 0;
   flex-shrink: 0;
@@ -50,6 +63,10 @@
   flex-grow: 0;
   flex-shrink: 1;
   overflow: hidden;
+}
+:local .ChartWithLegend.horizontal .LegendWrapper {
+  flex-direction: row;
+  justify-content: flex-end;
 }
 :local .ChartWithLegend.horizontal.flexChart .Legend {
   flex-grow: 0;

--- a/frontend/src/metabase/visualizations/components/ChartWithLegend.css
+++ b/frontend/src/metabase/visualizations/components/ChartWithLegend.css
@@ -15,6 +15,7 @@
 :local .ChartWithLegend .LegendWrapper {
   flex: 1;
   display: flex;
+  justify-content: center;
 }
 
 :local .ChartWithLegend .Chart {
@@ -41,7 +42,6 @@
 }
 :local .ChartWithLegend.vertical .LegendWrapper {
   flex-direction: column;
-  justify-content: flex-start;
 }
 :local .ChartWithLegend.vertical.flexChart .Legend {
   flex-grow: 0;
@@ -66,7 +66,6 @@
 }
 :local .ChartWithLegend.horizontal .LegendWrapper {
   flex-direction: row;
-  justify-content: flex-end;
 }
 :local .ChartWithLegend.horizontal.flexChart .Legend {
   flex-grow: 0;

--- a/frontend/src/metabase/visualizations/components/ChartWithLegend.css
+++ b/frontend/src/metabase/visualizations/components/ChartWithLegend.css
@@ -46,7 +46,6 @@
 :local .ChartWithLegend.vertical.flexChart .Legend {
   flex-grow: 0;
   flex-shrink: 0;
-  max-height: 25%;
 }
 :local .ChartWithLegend.vertical.flexChart .Chart {
   flex-grow: 1;

--- a/frontend/src/metabase/visualizations/components/ChartWithLegend.css
+++ b/frontend/src/metabase/visualizations/components/ChartWithLegend.css
@@ -1,21 +1,32 @@
 :local .ChartWithLegend {
   display: flex;
-  justify-content: center;
+  justify-content: flex-end;
 }
 
 :local .ChartWithLegend .Legend {
   display: flex;
   justify-content: center;
+  max-width: 100%;
+}
+
+:local .ChartWithLegend .LegendSpacer,
+:local .ChartWithLegend .LegendWrapper {
+  flex-basis: auto;
+  flex-grow: 1;
+  /* allow legend and spacer to shrink */
+  min-width: 0;
+  min-height: 0;
 }
 
 :local .ChartWithLegend .LegendSpacer {
-  flex: 1;
+  visibility: hidden;
+  flex-shrink: 10; /* shrink the spacer much faster than the wrapper */
 }
 
 :local .ChartWithLegend .LegendWrapper {
-  flex: 1;
   display: flex;
   justify-content: center;
+  flex-shrink: 1;
 }
 
 :local .ChartWithLegend .Chart {
@@ -34,7 +45,6 @@
 /* VERTICAL */
 :local .ChartWithLegend.vertical {
   flex-direction: column-reverse;
-  /* justify-content: space-around; */
 }
 :local .ChartWithLegend.vertical .Legend {
   flex-shrink: 1;
@@ -56,7 +66,6 @@
 /* HORIZONTAL */
 :local .ChartWithLegend.horizontal {
   flex-direction: row;
-  justify-content: space-around;
 }
 :local .ChartWithLegend.horizontal .Legend {
   flex-grow: 0;
@@ -69,7 +78,6 @@
 :local .ChartWithLegend.horizontal.flexChart .Legend {
   flex-grow: 0;
   flex-shrink: 0;
-  max-width: 33%;
 }
 :local .ChartWithLegend.horizontal.flexChart .Chart {
   flex-grow: 1;

--- a/frontend/src/metabase/visualizations/components/ChartWithLegend.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartWithLegend.jsx
@@ -95,6 +95,16 @@ export default class ChartWithLegend extends Component {
       type = "small";
     }
 
+    const legend = LegendComponent ? (
+      <LegendComponent
+        className={styles.Legend}
+        titles={legendTitles}
+        colors={legendColors}
+        hovered={hovered}
+        onHoverChange={onHoverChange}
+      />
+    ) : null;
+
     return (
       <div
         className={cx(
@@ -111,17 +121,7 @@ export default class ChartWithLegend extends Component {
           paddingRight: PADDING,
         }}
       >
-        {LegendComponent ? (
-          <div className={cx(styles.LegendWrapper)}>
-            <LegendComponent
-              className={styles.Legend}
-              titles={legendTitles}
-              colors={legendColors}
-              hovered={hovered}
-              onHoverChange={onHoverChange}
-            />
-          </div>
-        ) : null}
+        {legend && <div className={cx(styles.LegendWrapper)}>{legend}</div>}
         <div
           className={cx(styles.Chart)}
           style={{ width: chartWidth, height: chartHeight }}
@@ -129,7 +129,7 @@ export default class ChartWithLegend extends Component {
           {children}
         </div>
         {/* spacer div to balance legend */}
-        {LegendComponent && <div className={cx(styles.LegendSpacer)} />}
+        {legend && <div className={cx(styles.LegendSpacer)}>{legend}</div>}
       </div>
     );
   }

--- a/frontend/src/metabase/visualizations/components/ChartWithLegend.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartWithLegend.jsx
@@ -112,13 +112,15 @@ export default class ChartWithLegend extends Component {
         }}
       >
         {LegendComponent ? (
-          <LegendComponent
-            className={styles.Legend}
-            titles={legendTitles}
-            colors={legendColors}
-            hovered={hovered}
-            onHoverChange={onHoverChange}
-          />
+          <div className={cx(styles.LegendWrapper)}>
+            <LegendComponent
+              className={styles.Legend}
+              titles={legendTitles}
+              colors={legendColors}
+              hovered={hovered}
+              onHoverChange={onHoverChange}
+            />
+          </div>
         ) : null}
         <div
           className={cx(styles.Chart)}
@@ -126,6 +128,8 @@ export default class ChartWithLegend extends Component {
         >
           {children}
         </div>
+        {/* spacer div to balance legend */}
+        {LegendComponent && <div className={cx(styles.LegendSpacer)} />}
       </div>
     );
   }

--- a/frontend/src/metabase/visualizations/visualizations/PieChart.css
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart.css
@@ -16,6 +16,7 @@
 
 :local .Donut {
   flex: 1;
+  height: 100%;
 }
 
 :local .Detail {

--- a/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
@@ -197,7 +197,7 @@ export default class PieChart extends Component {
   componentDidUpdate() {
     const groupElement = ReactDOM.findDOMNode(this.refs.group);
     const detailElement = ReactDOM.findDOMNode(this.refs.detail);
-    if (groupElement.getBoundingClientRect().width < 100) {
+    if (groupElement.getBoundingClientRect().width < 120) {
       detailElement.classList.add("hide");
     } else {
       detailElement.classList.remove("hide");

--- a/frontend/test/metabase/visualizations/components/Visualization-pie.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/Visualization-pie.unit.spec.js
@@ -20,26 +20,24 @@ describe("pie chart", () => {
 
   it("should render correct percentages in legend", () => {
     const rows = [["foo", 1], ["bar", 2], ["baz", 2]];
-    const { getByText, getAllByText } = render(
-      <Visualization rawSeries={series(rows)} />,
-    );
-    getByText("20%");
-    expect(getAllByText("40%").length).toBe(2);
+    const { getAllByText } = render(<Visualization rawSeries={series(rows)} />);
+    getAllByText("20%");
+    getAllByText("40%");
   });
 
   it("should use a consistent number of decimals", () => {
     const rows = [["foo", 0.5], ["bar", 0.499], ["baz", 0.001]];
-    const { getByText } = render(<Visualization rawSeries={series(rows)} />);
-    getByText("50.0%");
-    getByText("49.9%");
-    getByText("0.1%");
+    const { getAllByText } = render(<Visualization rawSeries={series(rows)} />);
+    getAllByText("50.0%");
+    getAllByText("49.9%");
+    getAllByText("0.1%");
   });
 
   it("should squash small slices into 'Other'", () => {
     const rows = [["foo", 0.5], ["bar", 0.49], ["baz", 0.002], ["qux", 0.008]];
-    const { getByText } = render(<Visualization rawSeries={series(rows)} />);
-    getByText("50%");
-    getByText("49%");
-    getByText("1%");
+    const { getAllByText } = render(<Visualization rawSeries={series(rows)} />);
+    getAllByText("50%");
+    getAllByText("49%");
+    getAllByText("1%");
   });
 });


### PR DESCRIPTION
Resolves #10201 

Through some flexbox hackery, I centered chart with the legend to the side. I think this looks good for questions, but I'm iffy on it for cards on dashboards.

Some options:
1. Just keep the prior behavior on dashboards
2. Have some width cutoff where we switch the layout
3. A more clever flexbox solution that gradually moves the chart to the center as the width increases

Another question I had: What's `flexChart` used for? I couldn't seem to find a layout that used it. I haven't tested how it works with this.

Here are the before/after screenshots:

## Question
### Before
<img width="1920" alt="question-before" src="https://user-images.githubusercontent.com/691495/61829688-6e641d80-ae37-11e9-9eae-14819bdfc3bd.png">

### After
<img width="1920" alt="question-after" src="https://user-images.githubusercontent.com/691495/61831001-94d78800-ae3a-11e9-9764-ac548f02678a.png">

## Dashboard
### Before
<img width="875" alt="dashboard-before" src="https://user-images.githubusercontent.com/691495/61829657-6ad09680-ae37-11e9-8966-bd23bc849f92.png">

### After
<img width="875" alt="dashboard-after" src="https://user-images.githubusercontent.com/691495/61831033-a91b8500-ae3a-11e9-8d53-6d7168e845e6.png">


