### PR TITLE
In settings, show selected option even when the default is selected

### DIFF
--- a/frontend/src/metabase/admin/settings/components/widgets/SettingSelect.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SettingSelect.jsx
@@ -1,22 +1,30 @@
 import React from "react";
 
-import Select from "metabase/components/Select.jsx";
+import Select, { Option } from "metabase/components/Select.jsx";
 import _ from "underscore";
 
-const SettingSelect = ({ setting, onChange, disabled }) => (
+const SettingSelect = ({
+  setting: { placeholder, value, options, defaultValue },
+  onChange,
+  disabled,
+}) => (
   <Select
     className="full-width"
-    placeholder={setting.placeholder}
-    value={
-      _.findWhere(setting.options, { value: setting.value }) || setting.value
-    }
-    options={setting.options}
-    onChange={onChange}
-    optionNameFn={option => (typeof option === "object" ? option.name : option)}
-    optionValueFn={option =>
-      typeof option === "object" ? option.value : option
-    }
-  />
+    placeholder={placeholder}
+    value={value}
+    defaultValue={defaultValue}
+    onChange={e => onChange(e.target.value)}
+  >
+    {options.map(option => {
+      const name = typeof option === "object" ? option.name : option;
+      const value = typeof option === "object" ? option.value : option;
+      return (
+        <Option key={value} name={name} value={value}>
+          {name}
+        </Option>
+      );
+    })}
+  </Select>
 );
 
 export default SettingSelect;

--- a/frontend/src/metabase/admin/settings/components/widgets/SettingSelect.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SettingSelect.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 
 import Select, { Option } from "metabase/components/Select.jsx";
-import _ from "underscore";
 
 const SettingSelect = ({
   setting: { placeholder, value, options, defaultValue },

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -51,7 +51,6 @@ const SECTIONS = [
           { name: t`Database Default`, value: "" },
           ...MetabaseSettings.get("timezones"),
         ],
-        placeholder: t`Select a timezone`,
         note: t`Not all databases support timezones, in which case this setting won't take effect.`,
         allowValueCollection: true,
       },
@@ -62,7 +61,7 @@ const SECTIONS = [
         options: (MetabaseSettings.get("available_locales") || []).map(
           ([value, name]) => ({ name, value }),
         ),
-        placeholder: t`Select a language`,
+        defaultValue: "en",
         getHidden: () => MetabaseSettings.get("available_locales").length < 2,
       },
       {
@@ -82,9 +81,7 @@ const SECTIONS = [
           },
           { value: "none", name: t`Disabled` },
         ],
-        // this needs to be here because 'advanced' is the default value, so if you select 'advanced' the
-        // widget will always show the placeholder instead of the 'name' defined above :(
-        placeholder: t`Enabled`,
+        defaultValue: "advanced",
       },
       {
         key: "enable-nested-queries",

--- a/frontend/src/metabase/components/Select.jsx
+++ b/frontend/src/metabase/components/Select.jsx
@@ -36,6 +36,7 @@ class BrowserSelect extends Component {
     children: PropTypes.array.isRequired,
     onChange: PropTypes.func.isRequired,
     value: PropTypes.any,
+    defaultValue: PropTypes.any,
 
     searchProp: PropTypes.string,
     searchCaseInsensitive: PropTypes.bool,
@@ -66,14 +67,15 @@ class BrowserSelect extends Component {
   };
 
   isSelected(otherValue) {
-    const { value, multiple } = this.props;
+    const { value, multiple, defaultValue } = this.props;
     if (multiple) {
       return _.any(value, v => v === otherValue);
     } else {
       return (
         value === otherValue ||
         ((value == null || value === "") &&
-          (otherValue == null || otherValue === ""))
+          (otherValue == null || otherValue === "")) ||
+        (value == null && otherValue === defaultValue)
       );
     }
   }

--- a/frontend/test/metabase/components/Select.unit.spec.js
+++ b/frontend/test/metabase/components/Select.unit.spec.js
@@ -1,0 +1,45 @@
+import React from "react";
+import { render, cleanup } from "@testing-library/react";
+
+import Select, { Option } from "metabase/components/Select";
+
+describe("Select", () => {
+  afterEach(cleanup);
+
+  it("should render selected option", () => {
+    const { getByText, queryByText } = render(
+      <Select value="b">
+        <Option value="a">option a</Option>
+        <Option value="b">option b</Option>
+      </Select>,
+    );
+
+    expect(queryByText("option a")).toBe(null);
+    getByText("option b");
+  });
+
+  it("should render the defaultValue if none is selected", () => {
+    const { getByText, queryByText } = render(
+      <Select defaultValue="b">
+        <Option value="a">option a</Option>
+        <Option value="b">option b</Option>
+      </Select>,
+    );
+
+    expect(queryByText("option a")).toBe(null);
+    getByText("option b");
+  });
+
+  it("should render a placeholder if none is selected", () => {
+    const { getByText, queryByText } = render(
+      <Select placeholder="choose an option">
+        <Option value="a">option a</Option>
+        <Option value="b">option b</Option>
+      </Select>,
+    );
+
+    expect(queryByText("option a")).toBe(null);
+    expect(queryByText("option b")).toBe(null);
+    getByText("choose an option");
+  });
+});


### PR DESCRIPTION
Resolves #9098 

## Before

![image](https://user-images.githubusercontent.com/691495/61895818-8e501b80-aee1-11e9-8859-770674cff865.png)

## After

![image](https://user-images.githubusercontent.com/691495/61895834-9740ed00-aee1-11e9-8ff4-c97ef4848fd2.png)

The style changed because I swapped out the `LegacySelect` for `BrowserSelect`.
