### PR TITLE
Fix timezone issue with overwriting data while filling zeros

### DIFF
--- a/frontend/src/metabase/visualizations/lib/fill_data.js
+++ b/frontend/src/metabase/visualizations/lib/fill_data.js
@@ -59,10 +59,13 @@ function fillMissingValuesInData(
       // $FlowFixMe
       const { interval, count } = xInterval;
       if (count <= MAX_FILL_COUNT) {
-        // replace xValues with
+        // d3.time[interval].range always uses local time by default
+        // We save the offset here to reset it after creating the range
+        const timeZoneOffset = moment(xDomain[0]).utcOffset();
+        // replace xValues with this range
         xValues = d3.time[interval]
           .range(xDomain[0], moment(xDomain[1]).add(1, "ms"), count)
-          .map(d => moment(d));
+          .map(d => moment(d).utcOffset(timeZoneOffset, true));
         return fillMissingValues(
           rows,
           xValues,

--- a/frontend/src/metabase/visualizations/lib/fill_data.js
+++ b/frontend/src/metabase/visualizations/lib/fill_data.js
@@ -64,7 +64,16 @@ function fillMissingValuesInData(
         const timeZoneOffset = moment(xDomain[0]).utcOffset();
         // replace xValues with this range
         xValues = d3.time[interval]
-          .range(xDomain[0], moment(xDomain[1]).add(1, "ms"), count)
+          .range(
+            xDomain[0],
+            // `range` returns all interval boundaries. To make sure we capture
+            // the end of the range even, we move it over just less than one
+            // full interval.
+            moment(xDomain[1])
+              .add(1, interval)
+              .add(-1, "ms"),
+            count,
+          )
           .map(d => moment(d).utcOffset(timeZoneOffset, true));
         return fillMissingValues(
           rows,

--- a/frontend/test/metabase/visualizations/lib/fill_data.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/fill_data.unit.spec.js
@@ -24,7 +24,35 @@ describe("fillMissingValuesInDatas", () => {
     );
 
     expect(filledData.length).toEqual(31);
+    expect(filledData[0][1]).toEqual(1);
     expect(filledData[1][1]).toEqual(null);
+    expect(filledData[30][1]).toEqual(2);
+  });
+
+  it("should fill missing hours", () => {
+    const time1 = moment("2018-01-01");
+    const time2 = moment("2018-01-05");
+    const rows = [[time1, 1], [time2, 2]];
+    const [filledData] = fillMissingValuesInDatas(
+      {
+        series: [{}],
+        settings: {
+          "graph.x_axis.scale": "timeseries",
+          series: () => ({ "line.missing": "none" }),
+        },
+      },
+      {
+        xValues: [time1, time2],
+        xDomain: [time1, time2],
+        xInterval: { interval: "hour", count: 1 },
+      },
+      [rows],
+    );
+
+    expect(filledData.length).toEqual(97);
+    expect(filledData[0][1]).toEqual(1);
+    expect(filledData[1][1]).toEqual(null);
+    expect(filledData[96][1]).toEqual(2);
   });
 
   it("should work with data in a different timezone", () => {
@@ -53,7 +81,40 @@ describe("fillMissingValuesInDatas", () => {
       [rows],
     );
 
-    // ensure that it
+    // ensure that it didn't zero out provided values
+    expect(filledData.length).toEqual(31);
+    expect(filledData[0][1]).toEqual(1);
     expect(filledData[1][1]).toEqual(2);
+    expect(filledData[2][1]).toEqual(0);
+    expect(filledData[30][1]).toEqual(3);
+  });
+
+  it("should work with data in a different when passing through a DST boundary", () => {
+    const offset = (moment().utcOffset() + 60) % (12 * 60);
+    const time1 = moment("2019-03-01").utcOffset(offset, true);
+    const time2 = moment("2019-03-30").utcOffset(offset, true);
+    const time3 = moment("2019-03-31").utcOffset(offset, true);
+    const rows = [[time1, 1], [time2, 2], [time3, 3]];
+    const [filledData] = fillMissingValuesInDatas(
+      {
+        series: [{}],
+        settings: {
+          "graph.x_axis.scale": "timeseries",
+          series: () => ({ "line.missing": "zero" }),
+        },
+      },
+      {
+        xValues: [time1, time2, time3],
+        xDomain: [time1, time3],
+        xInterval: { interval: "day", count: 1 },
+      },
+      [rows],
+    );
+
+    expect(filledData.length).toEqual(31);
+    expect(filledData[0][1]).toEqual(1);
+    expect(filledData[1][1]).toEqual(0);
+    expect(filledData[29][1]).toEqual(2);
+    expect(filledData[30][1]).toEqual(3);
   });
 });

--- a/frontend/test/metabase/visualizations/lib/fill_data.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/fill_data.unit.spec.js
@@ -1,0 +1,59 @@
+import moment from "moment";
+
+import fillMissingValuesInDatas from "metabase/visualizations/lib/fill_data";
+
+describe("fillMissingValuesInDatas", () => {
+  it("should fill missing days", () => {
+    const time1 = moment("2018-01-01");
+    const time2 = moment("2018-01-31");
+    const rows = [[time1, 1], [time2, 2]];
+    const [filledData] = fillMissingValuesInDatas(
+      {
+        series: [{}],
+        settings: {
+          "graph.x_axis.scale": "timeseries",
+          series: () => ({ "line.missing": "none" }),
+        },
+      },
+      {
+        xValues: [time1, time2],
+        xDomain: [time1, time2],
+        xInterval: { interval: "day", count: 1 },
+      },
+      [rows],
+    );
+
+    expect(filledData.length).toEqual(31);
+    expect(filledData[1][1]).toEqual(null);
+  });
+
+  it("should work with data in a different timezone", () => {
+    // This is somewhat awkward. The test wants to check that we're correcting
+    // for the local time default in `d3.time[interval].range`. The important
+    // thing is to have offset not match the timezone where the test is being
+    // run. We get the current offset and move it by one hour.
+    const offset = (moment().utcOffset() + 60) % (12 * 60);
+    const time1 = moment("2018-01-01").utcOffset(offset, true);
+    const time2 = moment("2018-01-02").utcOffset(offset, true);
+    const time3 = moment("2018-01-31").utcOffset(offset, true);
+    const rows = [[time1, 1], [time2, 2], [time3, 3]];
+    const [filledData] = fillMissingValuesInDatas(
+      {
+        series: [{}],
+        settings: {
+          "graph.x_axis.scale": "timeseries",
+          series: () => ({ "line.missing": "zero" }),
+        },
+      },
+      {
+        xValues: [time1, time2, time3],
+        xDomain: [time1, time3],
+        xInterval: { interval: "day", count: 1 },
+      },
+      [rows],
+    );
+
+    // ensure that it
+    expect(filledData[1][1]).toEqual(2);
+  });
+});


### PR DESCRIPTION
Resolves #4802

To reproduce I changed my computer timzone and followed these steps: https://github.com/metabase/metabase/issues/4802#issuecomment-426017298

# Before
<img width="870" src="https://user-images.githubusercontent.com/691495/61915061-d76b9400-af10-11e9-83da-1979b2954c9f.png">


# After

<img width="870" src="https://user-images.githubusercontent.com/691495/61915064-db97b180-af10-11e9-82cc-1a7491dc2c5f.png">
