### PR TITLE
Prevent exception when clicking on embedded dashboards

### DIFF
--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -245,6 +245,10 @@ export default class Visualization extends Component {
     const { rawSeries, metadata } = this.props;
     const seriesIndex = clicked.seriesIndex || 0;
     const card = rawSeries[seriesIndex].card;
+    if (metadata == null) {
+      // embedded visualizations don't have necessary metadata for click actions
+      return [];
+    }
     const question = new Question(metadata, card);
     const mode = question.mode();
     return mode ? mode.actionsForClick(clicked, {}) : [];


### PR DESCRIPTION
Resolves #7641, Resolves #7137

The issues describe this exception breaking tooltips. I can't reproduce that bug, but the exception occurs consistently.

The exception is caused by us assuming the presence of metadata on embedded dashboards. This PR avoids the exception by exiting `getClickActions` if metadata is missing.