### PR TITLE
That's not how you spell "accordion," guys.

### DIFF
--- a/frontend/src/metabase/components/AccordionList.info.js
+++ b/frontend/src/metabase/components/AccordionList.info.js
@@ -1,7 +1,7 @@
 import React from "react";
-import AccordianList from "metabase/components/AccordianList";
+import AccordionList from "metabase/components/AccordionList";
 
-export const component = AccordianList;
+export const component = AccordionList;
 
 // disable snapshot testing due to issue with Popover
 export const noSnapshotTest = true;
@@ -23,14 +23,14 @@ const sections = [
 
 export const examples = {
   Default: (
-    <AccordianList
+    <AccordionList
       className="text-brand full"
       sections={sections}
       itemIsSelected={item => item.name === "Foo"}
     />
   ),
   "Always Expanded": (
-    <AccordianList
+    <AccordionList
       className="text-brand full"
       sections={sections}
       itemIsSelected={item => item.name === "Foo"}
@@ -38,7 +38,7 @@ export const examples = {
     />
   ),
   Searchable: (
-    <AccordianList
+    <AccordionList
       className="text-brand full"
       sections={sections}
       itemIsSelected={item => item.name === "Foo"}
@@ -46,7 +46,7 @@ export const examples = {
     />
   ),
   "Hide Single Section Title": (
-    <AccordianList
+    <AccordionList
       className="text-brand full"
       sections={sections.slice(0, 1)}
       itemIsSelected={item => item.name === "Foo"}

--- a/frontend/src/metabase/components/AccordionList.jsx
+++ b/frontend/src/metabase/components/AccordionList.jsx
@@ -15,7 +15,7 @@ export type RenderItemWrapper = (
   children?: any,
 ) => React$Element;
 
-export default class AccordianList extends Component {
+export default class AccordionList extends Component {
   constructor(props, context) {
     super(props, context);
 
@@ -357,7 +357,7 @@ export default class AccordianList extends Component {
           }}
         >
           {rows.map(row => (
-            <AccordianListCell
+            <AccordionListCell
               {...this.props}
               row={row}
               sections={sections}
@@ -426,7 +426,7 @@ export default class AccordianList extends Component {
               parent={parent}
             >
               {({ measure }) => (
-                <AccordianListCell
+                <AccordionListCell
                   {...this.props}
                   style={style}
                   row={rows[index]}
@@ -454,7 +454,7 @@ export default class AccordianList extends Component {
   }
 }
 
-const AccordianListCell = ({
+const AccordionListCell = ({
   style,
   sections,
   row,

--- a/frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx
@@ -8,7 +8,7 @@ import S from "./DashCardCardParameterMapper.css";
 
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger.jsx";
 import Icon from "metabase/components/Icon.jsx";
-import AccordianList from "metabase/components/AccordianList.jsx";
+import AccordionList from "metabase/components/AccordionList.jsx";
 import Tooltip from "metabase/components/Tooltip.jsx";
 
 import { fetchDatabaseMetadata } from "metabase/redux/metadata";
@@ -208,7 +208,7 @@ export default class DashCardCardParameterMapper extends Component {
             </Tooltip>
           }
         >
-          <AccordianList
+          <AccordionList
             className="text-brand scroll-show scroll-y"
             style={{ maxHeight: 600 }}
             sections={sections}

--- a/frontend/src/metabase/query_builder/components/AggregationPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/AggregationPopover.jsx
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
 import { t } from "ttag";
-import AccordianList from "metabase/components/AccordianList.jsx";
+import AccordionList from "metabase/components/AccordionList.jsx";
 import FieldList from "./FieldList.jsx";
 import QueryDefinitionTooltip from "./QueryDefinitionTooltip.jsx";
 
@@ -428,7 +428,7 @@ export default class AggregationPopover extends Component {
       );
     } else {
       return (
-        <AccordianList
+        <AccordionList
           className="text-green"
           width={this.props.width}
           maxHeight={this.props.maxHeight}

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -5,7 +5,7 @@ import { t } from "ttag";
 import cx from "classnames";
 import Icon from "metabase/components/Icon.jsx";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger.jsx";
-import AccordianList from "metabase/components/AccordianList.jsx";
+import AccordionList from "metabase/components/AccordionList.jsx";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 
 import { isQueryable } from "metabase/lib/table";
@@ -600,7 +600,7 @@ const DatabasePicker = ({
   ];
 
   return (
-    <AccordianList
+    <AccordionList
       id="DatabasePicker"
       key="databasePicker"
       className="text-brand"
@@ -650,7 +650,7 @@ const SegmentAndDatabasePicker = ({
   }
 
   return (
-    <AccordianList
+    <AccordionList
       id="SegmentAndDatabasePicker"
       key="segmentAndDatabasePicker"
       className="text-brand"
@@ -690,7 +690,7 @@ export const SchemaPicker = ({
   ];
   return (
     <div style={{ width: 300 }}>
-      <AccordianList
+      <AccordionList
         id="DatabaseSchemaPicker"
         key="databaseSchemaPicker"
         className="text-brand"
@@ -738,7 +738,7 @@ export const DatabaseSchemaPicker = ({
 
   return (
     <div className="scroll-y">
-      <AccordianList
+      <AccordionList
         id="DatabaseSchemaPicker"
         key="databaseSchemaPicker"
         className="text-brand"
@@ -826,7 +826,7 @@ export const TablePicker = ({
     ];
     return (
       <div style={{ width: 300 }} className="scroll-y">
-        <AccordianList
+        <AccordionList
           id="TablePicker"
           key="tablePicker"
           className="text-brand"
@@ -912,7 +912,7 @@ export class FieldPicker extends Component {
 
     return (
       <div style={{ width: 300 }}>
-        <AccordianList
+        <AccordionList
           id="FieldPicker"
           key="fieldPicker"
           className="text-brand"
@@ -984,7 +984,7 @@ export const SegmentPicker = ({
   ];
 
   return (
-    <AccordianList
+    <AccordionList
       id="SegmentPicker"
       key="segmentPicker"
       className="text-brand"

--- a/frontend/src/metabase/query_builder/components/DimensionList.jsx
+++ b/frontend/src/metabase/query_builder/components/DimensionList.jsx
@@ -4,19 +4,19 @@ import React, { Component } from "react";
 import _ from "underscore";
 import { t } from "ttag";
 
-import AccordianList from "metabase/components/AccordianList";
+import AccordionList from "metabase/components/AccordionList";
 import Icon from "metabase/components/Icon";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
 import Tooltip from "metabase/components/Tooltip";
 
 import Dimension, { BinnedDimension } from "metabase-lib/lib/Dimension";
 
-// import type { Section } from "metabase/components/AccordianList";
-export type AccordianListItem = {};
+// import type { Section } from "metabase/components/AccordionList";
+export type AccordionListItem = {};
 
-export type AccordianListSection = {
+export type AccordionListSection = {
   name: ?string,
-  items: AccordianListItem[],
+  items: AccordionListItem[],
 };
 
 type Props = {
@@ -29,10 +29,10 @@ type Props = {
   onChangeDimension: (dimension: Dimension) => void,
   onChange?: (item: any) => void,
 
-  onAddDimension?: (dimension: Dimension, item: AccordianListItem) => void,
-  onRemoveDimension?: (dimension: Dimension, item: AccordianListItem) => void,
+  onAddDimension?: (dimension: Dimension, item: AccordionListItem) => void,
+  onRemoveDimension?: (dimension: Dimension, item: AccordionListItem) => void,
 
-  sections: AccordianListSection[],
+  sections: AccordionListSection[],
 
   alwaysExpanded?: boolean,
   enableSubDimensions?: boolean,
@@ -40,7 +40,7 @@ type Props = {
 };
 
 type State = {
-  sections: AccordianListSection[],
+  sections: AccordionListSection[],
 };
 
 const SUBMENU_TETHER_OPTIONS = {
@@ -232,7 +232,7 @@ export default class DimensionList extends Component {
 
   render() {
     return (
-      <AccordianList
+      <AccordionList
         {...this.props}
         sections={this.state.sections}
         onChange={this.handleChange}

--- a/frontend/src/metabase/query_builder/components/FieldList.jsx
+++ b/frontend/src/metabase/query_builder/components/FieldList.jsx
@@ -11,12 +11,12 @@ import type { StructuredQuery, ConcreteField } from "metabase/meta/types/Query";
 import type Table from "metabase-lib/lib/metadata/Table";
 import type Metadata from "metabase-lib/lib/metadata/Metadata";
 
-// import type { Section } from "metabase/components/AccordianList";
-export type AccordianListItem = {};
+// import type { Section } from "metabase/components/AccordionList";
+export type AccordionListItem = {};
 
-export type AccordianListSection = {
+export type AccordionListSection = {
   name: ?string,
-  items: AccordianListItem[],
+  items: AccordionListItem[],
 };
 
 type Props = {
@@ -32,7 +32,7 @@ type Props = {
   query?: StructuredQuery,
   metadata?: Metadata,
 
-  // AccordianList props:
+  // AccordionList props:
   className?: string,
   maxHeight?: number,
   width?: number,
@@ -44,7 +44,7 @@ type Props = {
 };
 
 type State = {
-  sections: AccordianListSection[],
+  sections: AccordionListSection[],
 };
 
 // DEPRECATED: use DimensionList directly
@@ -94,7 +94,7 @@ export default class FieldList extends Component {
         dimension={field && Dimension.parseMBQL(field, metadata, query)}
         onChangeDimension={this.handleChangeDimension}
         onChange={this.handleChange}
-        // forward AccordianList props
+        // forward AccordionList props
         className={this.props.className}
         maxHeight={this.props.maxHeight}
         width={this.props.width}

--- a/frontend/test/metabase/components/AccordionList.unit.spec.js
+++ b/frontend/test/metabase/components/AccordionList.unit.spec.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { mount } from "enzyme";
 
-import AccordianList from "metabase/components/AccordianList";
+import AccordionList from "metabase/components/AccordionList";
 import ListSearchField from "metabase/components/ListSearchField";
 
 const SECTIONS = [
@@ -15,38 +15,38 @@ const SECTIONS = [
   },
 ];
 
-describe("AccordianList", () => {
+describe("AccordionList", () => {
   it("should open the first section by default", () => {
-    const wrapper = mount(<AccordianList sections={SECTIONS} />);
+    const wrapper = mount(<AccordionList sections={SECTIONS} />);
     expect(wrapper.find(".List-section-header").length).toBe(2);
     expect(wrapper.find(".List-item").length).toBe(2);
   });
   it("should open the second section if initiallyOpenSection=1", () => {
     const wrapper = mount(
-      <AccordianList sections={SECTIONS} initiallyOpenSection={1} />,
+      <AccordionList sections={SECTIONS} initiallyOpenSection={1} />,
     );
     expect(wrapper.find(".List-item").length).toBe(1);
   });
   it("should not open a section if initiallyOpenSection=null", () => {
     const wrapper = mount(
-      <AccordianList sections={SECTIONS} initiallyOpenSection={null} />,
+      <AccordionList sections={SECTIONS} initiallyOpenSection={null} />,
     );
     expect(wrapper.find(".List-item").length).toBe(0);
   });
   it("should open all sections if alwaysExpanded is set", () => {
-    const wrapper = mount(<AccordianList sections={SECTIONS} alwaysExpanded />);
+    const wrapper = mount(<AccordionList sections={SECTIONS} alwaysExpanded />);
     expect(wrapper.find(".List-item").length).toBe(3);
   });
   it("should not show search field by default", () => {
-    const wrapper = mount(<AccordianList sections={SECTIONS} />);
+    const wrapper = mount(<AccordionList sections={SECTIONS} />);
     expect(wrapper.find(ListSearchField).length).toBe(0);
   });
   it("should show search field is searchable is set", () => {
-    const wrapper = mount(<AccordianList sections={SECTIONS} searchable />);
+    const wrapper = mount(<AccordionList sections={SECTIONS} searchable />);
     expect(wrapper.find(ListSearchField).length).toBe(1);
   });
   it("should close the section when header is clicked", () => {
-    const wrapper = mount(<AccordianList sections={SECTIONS} />);
+    const wrapper = mount(<AccordionList sections={SECTIONS} />);
     expect(wrapper.find(".List-item").length).toBe(2);
     wrapper
       .find(".List-section-header")
@@ -55,7 +55,7 @@ describe("AccordianList", () => {
     expect(wrapper.find(".List-item").length).toBe(0);
   });
   it("should switch sections when another section is clicked", () => {
-    const wrapper = mount(<AccordianList sections={SECTIONS} />);
+    const wrapper = mount(<AccordionList sections={SECTIONS} />);
     expect(wrapper.find(".List-item").length).toBe(2);
     wrapper
       .find(".List-section-header")
@@ -64,7 +64,7 @@ describe("AccordianList", () => {
     expect(wrapper.find(".List-item").length).toBe(1);
   });
   it("should filter items when searched", () => {
-    const wrapper = mount(<AccordianList sections={SECTIONS} searchable />);
+    const wrapper = mount(<AccordionList sections={SECTIONS} searchable />);
     const searchInput = wrapper.find(ListSearchField).find("input");
     expect(wrapper.find(".List-item").length).toBe(2);
     searchInput.simulate("change", { target: { value: "Foo" } });


### PR DESCRIPTION
Front Ned strikes again. A find-and-replace to swap `accordian` with `accordion` throughout.