### PR TITLE
Remove t tag that was causing problems with i18n script

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/structured/Filter.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Filter.js
@@ -63,7 +63,7 @@ export default class Filter extends MBQLClause {
       const dimensionName = dimension && dimension.displayName();
       const operatorName = operator && operator.moreVerboseName;
       const argumentNames = this.formattedArguments().join(" ");
-      return t`${dimensionName || ""} ${operatorName || ""} ${argumentNames}`;
+      return `${dimensionName || ""} ${operatorName || ""} ${argumentNames}`;
     } else {
       return t`Unknown Filter`;
     }


### PR DESCRIPTION
This will be an issue for languages where dimension/operator/args need to be in a different order, but need to remove this ttag in order to fix this script error:

```
➜  metabase git:(release-0.33.x) ./bin/i18n/update-translation-template
SyntaxError: frontend/src/metabase-lib/lib/queries/structured/Filter.js: Can not translate '${dimensionName || ""} ${operatorName || ""} ${argumentNames}'
Error: Can not translate '${dimensionName || ""} ${operatorName || ""} ${argumentNames}'
    at logAction (/Users/maz/workspace/metabase/node_modules/babel-plugin-ttag/dist/context.js:57:13)
    at C3poContext.validationFailureAction (/Users/maz/workspace/metabase/node_modules/babel-plugin-ttag/dist/context.js:231:7)
    at extractOrResolve (/Users/maz/workspace/metabase/node_modules/babel-plugin-ttag/dist/plugin.js:115:19)
    at PluginPass.<anonymous> (/Users/maz/workspace/metabase/node_modules/babel-plugin-ttag/dist/plugin.js:67:7)
    at newFn (/Users/maz/workspace/metabase/node_modules/babel-traverse/lib/visitors.js:276:21)
    at NodePath._call (/Users/maz/workspace/metabase/node_modules/babel-traverse/lib/path/context.js:76:18)
    at NodePath.call (/Users/maz/workspace/metabase/node_modules/babel-traverse/lib/path/context.js:48:17)
    at NodePath.visit (/Users/maz/workspace/metabase/node_modules/babel-traverse/lib/path/context.js:105:12)
    at TraversalContext.visitQueue (/Users/maz/workspace/metabase/node_modules/babel-traverse/lib/context.js:150:16)
    at TraversalContext.visitSingle (/Users/maz/workspace/metabase/node_modules/babel-traverse/lib/context.js:108:19)
  64 |       const operatorName = operator && operator.moreVerboseName;
  65 |       const argumentNames = this.formattedArguments().join(" ");
> 66 |       return t`${dimensionName || ""} ${operatorName || ""} ${argumentNames}`;
     |              ^
  67 |     } else {
  68 |       return t`Unknown Filter`;
  69 |     }
```

