### PR TITLE
Fix hang with autorefreshing dashboard

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard.jsx
@@ -90,7 +90,7 @@ type Props = {
   editingParameter: ?Parameter,
 
   refreshPeriod: number,
-  refreshElapsed: number,
+  setRefreshElapsedHook: Function,
   isFullscreen: boolean,
   isNightMode: boolean,
   hideParameters: ?string,

--- a/frontend/src/metabase/dashboard/components/DashboardActions.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardActions.jsx
@@ -13,7 +13,7 @@ export const getDashboardActions = ({
   onNightModeChange,
   onFullscreenChange,
   refreshPeriod,
-  refreshElapsed,
+  setRefreshElapsedHook,
   onRefreshPeriodChange,
 }) => {
   const buttons = [];
@@ -25,7 +25,7 @@ export const getDashboardActions = ({
         data-metabase-event="Dashboard;Refresh Menu Open"
         className="text-brand-hover"
         period={refreshPeriod}
-        elapsed={refreshElapsed}
+        setRefreshElapsedHook={setRefreshElapsedHook}
         onChangePeriod={onRefreshPeriodChange}
       />,
     );

--- a/frontend/src/metabase/dashboard/components/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader.jsx
@@ -49,7 +49,7 @@ type Props = {
   isNightMode: boolean,
 
   refreshPeriod: ?number,
-  refreshElapsed: ?number,
+  setRefreshElapsedHook: Function,
 
   parametersWidget: React$Element<*>,
 
@@ -90,7 +90,7 @@ export default class DashboardHeader extends Component {
     isNightMode: PropTypes.bool.isRequired,
 
     refreshPeriod: PropTypes.number,
-    refreshElapsed: PropTypes.number,
+    setRefreshElapsedHook: PropTypes.func.isRequired,
 
     addCardToDashboard: PropTypes.func.isRequired,
     addTextDashCardToDashboard: PropTypes.func.isRequired,

--- a/frontend/src/metabase/dashboard/components/RefreshWidget.jsx
+++ b/frontend/src/metabase/dashboard/components/RefreshWidget.jsx
@@ -20,8 +20,28 @@ const OPTIONS = [
 ];
 
 export default class RefreshWidget extends Component {
+  state = { elapsed: null };
+
+  componentWillMount() {
+    const { setRefreshElapsedHook } = this.props;
+    if (setRefreshElapsedHook) {
+      setRefreshElapsedHook(elapsed => this.setState({ elapsed }));
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const { setRefreshElapsedHook } = this.props;
+    if (
+      setRefreshElapsedHook &&
+      prevProps.setRefreshElapsedHook !== setRefreshElapsedHook
+    ) {
+      setRefreshElapsedHook(elapsed => this.setState({ elapsed }));
+    }
+  }
+
   render() {
-    const { period, elapsed, onChangePeriod, className } = this.props;
+    const { period, onChangePeriod, className } = this.props;
+    const { elapsed } = this.state;
     const remaining = period - elapsed;
     return (
       <PopoverWithTrigger


### PR DESCRIPTION
Resolves #9019

To know when we should refresh a dashboard, we've been checking elapsed time every 250ms. The high CPU issues occurred because we were rerendering the dashboard on this interval. This PR changes two things:

1. Change the interval to 1 second
2. Only rerender the refresh widget rather than the entire dashboard

---

Scoping the rerender to just `RefreshWidget` took some hackery.

I first tried to prevent the bulk of unnecessary updates by converting `DashboardGrid` to a `PureComponent` and not passing `refreshElapsed` into it. Unfortunately, this didn't eliminate the slowness.

Instead, I moved `refreshElapsed` from `DashboardControls` state to `RefreshWidget` state. Doing this means nothing unnecessary can be rerendered, but it require more coordination between the two components since `setInterval` still lives in `DashboardControls`. Specifically, I passed down `setRefreshElapsedHook` as a way for `RefreshWidget` to subscribe to updates and set its own state.

It would be more graceful to pass an object that `RefreshWidget` (and others) can bind for updates, but since there's only one thing that needs to be aware of `refreshElapsed` I figured I'd just have a single hook.