### PR TITLE
Fix "saved questions" database behavior in notebook mode + joins

### DIFF
--- a/frontend/src/metabase-lib/lib/metadata/Database.js
+++ b/frontend/src/metabase-lib/lib/metadata/Database.js
@@ -62,4 +62,18 @@ export default class Database extends Base {
   newQuestion(): Question {
     return Question.create({ databaseId: this.id, metadata: this.metadata });
   }
+
+  /** Returns a database containing only the saved questions from the same database, if any */
+  savedQuestionsDatabase(): ?Database {
+    const database = this.metadata
+      .databasesList()
+      .find(db => db.is_saved_questions);
+    if (database) {
+      const tables = database.tables.filter(t => t.db_id === this.id);
+      if (tables.length > 0) {
+        return new Database({ ...database, tables });
+      }
+    }
+    return null;
+  }
 }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -122,11 +122,8 @@ class JoinClause extends React.Component {
         <DatabaseSchemaAndTableDataSelector
           databases={[
             query.database(),
-            ...query
-              .metadata()
-              .databasesList()
-              .filter(db => db.is_saved_questions),
-          ]}
+            query.database().savedQuestionsDatabase(),
+          ].filter(d => d)}
           selectedDatabaseId={query.databaseId()}
           selectedTableId={join.joinSourceTableId()}
           setSourceTableFn={tableId => {

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -10,9 +10,7 @@
              [util :as u]]
             [metabase.api.common :as api]
             [metabase.driver.util :as driver.u]
-            [metabase.mbql
-             [schema :as mbql.s]
-             [util :as mbql.u]]
+            [metabase.mbql.util :as mbql.u]
             [metabase.models
              [card :refer [Card]]
              [field :refer [Field]]

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -266,7 +266,7 @@
   ;; if collection isn't already hydrated then do so
   (let [card (hydrate card :collection)]
     (cond-> {:id           (str "card__" (u/get-id card))
-             :db_id        mbql.s/saved-questions-virtual-database-id
+             :db_id        (:database_id card)
              :display_name (:name card)
              :schema       (get-in card [:collection :name] "Everything else")
              :description  (:description card)}

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -349,7 +349,7 @@
 (defn- virtual-table-for-card [card & {:as kvs}]
   (merge
    {:id           (format "card__%d" (u/get-id card))
-    :db_id        mbql.s/saved-questions-virtual-database-id
+    :db_id        (:database_id card)
     :display_name (:name card)
     :schema       "Everything else"
     :description  nil}

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -10,7 +10,6 @@
              [util :as u]]
             [metabase.api.table :as table-api]
             [metabase.driver.util :as driver.u]
-            [metabase.mbql.schema :as mbql.s]
             [metabase.middleware.util :as middleware.u]
             [metabase.models
              [card :refer [Card]]

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -422,7 +422,7 @@
   (let [card-virtual-table-id (str "card__" (u/get-id card))]
     {:display_name      "Go Dubs!"
      :schema            "Everything else"
-     :db_id             mbql.s/saved-questions-virtual-database-id
+     :db_id             (:database_id card)
      :id                card-virtual-table-id
      :description       nil
      :dimension_options (default-dimension-options)
@@ -470,7 +470,7 @@
   (let [card-virtual-table-id (str "card__" (u/get-id card))]
     {:display_name      "Users"
      :schema            "Everything else"
-     :db_id             mbql.s/saved-questions-virtual-database-id
+     :db_id             (:database_id card)
      :id                card-virtual-table-id
      :description       nil
      :dimension_options (default-dimension-options)


### PR DESCRIPTION
This fixes two problems with the "Saved Questions" database in notebook mode, by switching the `db_id` from the fake `-1337` to the actual underlying database ID:

1. When starting a notebook question based on a "Saved Question" table, we now show the correct actions based on the underlying database capabilities, like join and custom columns. Previously we didn't show anything except the very basics that were supported by all databases (filter, summarize, etc)
2. When joining either to or from a "Saved Question" table we only show the questions (or tables) based on the same underlying database.

Resolves #10440
Resolves #10491