### PR TITLE
Ensure that Metabase JAR is readable by `metabase` container user

### DIFF
--- a/bin/docker/Dockerfile
+++ b/bin/docker/Dockerfile
@@ -8,6 +8,7 @@ RUN apk add --update bash ttf-dejavu fontconfig
 
 # add Metabase jar
 COPY ./metabase.jar /app/
+RUN chmod o+r /app/metabase.jar
 
 # add our run script to the image
 COPY ./run_metabase.sh /app/


### PR DESCRIPTION
If the umask of the user that builds the image is xx7, the JAR will not be world readable in the resulting image.