### PR TITLE
Fix query cleaning when switching out of notebook mode

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
@@ -1428,8 +1428,4 @@ class NestedStructuredQuery extends StructuredQuery {
   parentQuery() {
     return this._parent.setSourceQuery(this.query());
   }
-  question() {
-    // FIXME: this is incorrect
-    return this.parentQuery().question();
-  }
 }

--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
@@ -1429,6 +1429,7 @@ class NestedStructuredQuery extends StructuredQuery {
     return this._parent.setSourceQuery(this.query());
   }
   question() {
+    // FIXME: this is incorrect
     return this.parentQuery().question();
   }
 }

--- a/frontend/src/metabase/query_builder/components/notebook/Notebook.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/Notebook.jsx
@@ -25,10 +25,7 @@ export default function Notebook({ className, ...props }) {
           primary
           style={{ minWidth: 220 }}
           onClick={async () => {
-            let cleanQuestion = question
-              .query()
-              .clean()
-              .question();
+            let cleanQuestion = question.setQuery(question.query().clean());
             if (cleanQuestion.display() === "table") {
               cleanQuestion = cleanQuestion.setDisplayDefault();
             }

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery-clean.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery-clean.unit.spec.js
@@ -270,12 +270,12 @@ describe("StructuredQuery", () => {
         expect(q.clean() === q).toBe(true);
       });
 
-      it("should remove unecessary layers of nesting", () => {
+      it("should remove unecessary layers of nesting via query()", () => {
         const q = makeStructuredQuery().nest();
         expect(q.clean().query()).toEqual({ "source-table": ORDERS_TABLE_ID });
       });
 
-      xit("should remove unecessary layers of nesting", () => {
+      it("should remove unecessary layers of nesting via question()", () => {
         const q = makeStructuredQuery().nest();
         expect(
           q

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery-clean.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery-clean.unit.spec.js
@@ -275,6 +275,16 @@ describe("StructuredQuery", () => {
         expect(q.clean().query()).toEqual({ "source-table": ORDERS_TABLE_ID });
       });
 
+      xit("should remove unecessary layers of nesting", () => {
+        const q = makeStructuredQuery().nest();
+        expect(
+          q
+            .clean()
+            .question()
+            .card().dataset_query.query,
+        ).toEqual({ "source-table": ORDERS_TABLE_ID });
+      });
+
       it("should remove clauses dependent on removed clauses in the parent", () => {
         const q = makeStructuredQuery()
           .addBreakout(["field-id", ORDERS_PRODUCT_FK_FIELD_ID])


### PR DESCRIPTION
Partial fix for #10445, but requires a backend change to work with post aggregation filters or otherwise nested queries with duplicate column names. Issue here #10511