### PR TITLE
fixup "medium" button horizontal spacing

### DIFF
--- a/frontend/src/metabase/css/components/buttons.css
+++ b/frontend/src/metabase/css/components/buttons.css
@@ -36,7 +36,7 @@
 }
 
 .Button--medium {
-  padding: 0.5rem 1rem;
+  padding: 0.5rem 0.75rem;
   font-size: 0.8rem;
 }
 


### PR DESCRIPTION
The horizontal spacing being double the size of the vertical was making me itchy. It very subtly helps clean up a lot of the buttons in the new query interface, I think the biggest example of this is in the footer.  

**Before**
---
![Screen Shot 2019-08-06 at 5 49 48 PM](https://user-images.githubusercontent.com/5248953/62586572-023fdb80-b873-11e9-9c3c-970d11abfb5b.png)

**After**
---
![Screen Shot 2019-08-06 at 5 49 22 PM](https://user-images.githubusercontent.com/5248953/62586571-023fdb80-b873-11e9-9ce3-f37af2281440.png)
