### PR TITLE
Remove `--add-modules=java.xml.bind` Java option

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -117,7 +117,6 @@ fi
 JAVA_OPTS="$JAVA_OPTS -XX:+IgnoreUnrecognizedVMOptions" # Don't barf if we see an option we don't understand (e.g. Java 9 option on Java 7/8)
 JAVA_OPTS="$JAVA_OPTS -Djava.awt.headless=true"         # don't try to start AWT. Not sure this does anything but better safe than wasting memory
 JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8"            # Use UTF-8
-JAVA_OPTS="$JAVA_OPTS --add-modules=java.xml.bind"      # Enable access to java.xml.bind module (Java 9)
 
 echo "Using these JAVA_OPTS: ${JAVA_OPTS}"
 


### PR DESCRIPTION
Fixes #10244.

@camsaul confirmed that it is no longer needed.