### PR TITLE
Transfer log events as JSON objects and allow filtering on front-end

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,6 +16,7 @@ indent_style = tab
 
 [*.clj]
 indent_size = 2
+max_line_length = 120
 
 [*.css]
 indent_size = 2

--- a/frontend/src/metabase/admin/tasks/containers/Logs.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/Logs.jsx
@@ -116,16 +116,6 @@ export default class Logs extends Component {
 
     let processUUIDSelect = null;
     if (processUUIDs.length > 1) {
-      const options = [
-        <Option value="ALL" key="ALL">{t`All Metabase processes`}</Option>,
-      ].concat(
-        processUUIDs.map(uuid => (
-          <Option key={uuid} value={uuid}>
-            <code>{uuid}</code>
-          </Option>
-        )),
-      );
-
       processUUIDSelect = (
         <div className="pb1">
           <label>{t`Select Metabase process`}</label>
@@ -137,7 +127,12 @@ export default class Logs extends Component {
               this.setState({ selectedProcessUUID: e.target.value })
             }
           >
-            {options}
+            <Option value="ALL" key="ALL">{t`All Metabase processes`}</Option>
+            {processUUIDs.map(uuid => (
+              <Option key={uuid} value={uuid}>
+                <code>{uuid}</code>
+              </Option>
+            ))}
           </Select>
         </div>
       );

--- a/frontend/src/metabase/admin/tasks/containers/Logs.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/Logs.jsx
@@ -96,7 +96,7 @@ export default class Logs extends Component {
     });
 
     return (
-      <LoadingAndErrorWrapper loading={!filteredLogs || filteredLogs.length === 0}>
+      <div>
         <div className="Form-field">
           <label className="Form-label">
             Select Metabase process
@@ -114,20 +114,22 @@ export default class Logs extends Component {
           </label>
         </div>
 
-        {() => (
-          <div
-            className="rounded bordered bg-light"
-            style={{
-              fontFamily: '"Lucida Console", Monaco, monospace',
-              fontSize: "14px",
-              whiteSpace: "pre-line",
-              padding: "1em",
-            }}
-          >
-            {reactAnsiStyle(React, renderedLogs.join("\n"))}
-          </div>
-        )}
-      </LoadingAndErrorWrapper>
+        <LoadingAndErrorWrapper loading={!filteredLogs || filteredLogs.length === 0}>
+          {() => (
+            <div
+              className="rounded bordered bg-light"
+              style={{
+                fontFamily: '"Lucida Console", Monaco, monospace',
+                fontSize: "14px",
+                whiteSpace: "pre-line",
+                padding: "1em",
+              }}
+            >
+              {reactAnsiStyle(React, renderedLogs.join("\n"))}
+            </div>
+          )}
+        </LoadingAndErrorWrapper>
+      </div>
     );
   }
 }

--- a/frontend/src/metabase/admin/tasks/containers/Logs.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/Logs.jsx
@@ -81,6 +81,13 @@ export default class Logs extends Component {
 
   render() {
     const { logs } = this.state;
+    const renderedEvents = logs.map(ev => {
+      if (_.isString(ev)) {
+        return ev;
+      }
+      return `[${ev.site_uuid}] ${ev.timestamp} ${ev.level} ${ev.fqns} ${ev.msg}`;
+    });
+
     return (
       <LoadingAndErrorWrapper loading={!logs || logs.length === 0}>
         {() => (
@@ -93,7 +100,7 @@ export default class Logs extends Component {
               padding: "1em",
             }}
           >
-            {reactAnsiStyle(React, logs.join("\n"))}
+            {reactAnsiStyle(React, renderedEvents.join("\n"))}
           </div>
         )}
       </LoadingAndErrorWrapper>

--- a/frontend/src/metabase/admin/tasks/containers/Logs.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/Logs.jsx
@@ -120,14 +120,15 @@ export default class Logs extends Component {
     if (processUUIDs.length > 1) {
       processUUIDSelect = (
         <div className="pb1">
-          <label>{t`Select Metabase process`}</label>
-
+          <label>{t`Select Metabase process:`}</label>
           <Select
             defaultValue="ALL"
             value={this.state.selectedProcessUUID}
             onChange={e =>
               this.setState({ selectedProcessUUID: e.target.value })
             }
+            className="inline-block ml1"
+            width={400}
           >
             <Option value="ALL" key="ALL">{t`All Metabase processes`}</Option>
             {processUUIDs.map(uuid => (

--- a/frontend/src/metabase/admin/tasks/containers/Logs.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/Logs.jsx
@@ -30,6 +30,16 @@ for (const [name, color] of Object.entries(ANSI_COLORS)) {
   addCSSRule(`.react-ansi-style-${name}`, `color: ${color} !important`);
 }
 
+function logEventUniqueValue(ev) {
+  return `${ev.timestamp}, ${ev.process_uuid}, ${ev.fqns}, ${ev.msg}`;
+}
+
+function mergeLogs(...logArrays) {
+  let logs = Array.prototype.concat(...logArrays);
+  logs = _.sortBy(logs, ev => [ev.timestamp, ev.process_uuid, ev.msg]);
+  return _.uniq(logs, true, logEventUniqueValue);
+}
+
 export default class Logs extends Component {
   constructor() {
     super();
@@ -55,7 +65,7 @@ export default class Logs extends Component {
 
   async fetchLogs() {
     const logs = await UtilApi.logs();
-    this.setState({ logs: logs.reverse() });
+    this.setState({ logs: mergeLogs(this.state.logs, logs.reverse()) });
   }
 
   componentWillMount() {

--- a/frontend/src/metabase/admin/tasks/containers/Logs.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/Logs.jsx
@@ -31,14 +31,18 @@ for (const [name, color] of Object.entries(ANSI_COLORS)) {
   addCSSRule(`.react-ansi-style-${name}`, `color: ${color} !important`);
 }
 
-function logEventUniqueValue(ev) {
+function logEventKey(ev) {
   return `${ev.timestamp}, ${ev.process_uuid}, ${ev.fqns}, ${ev.msg}`;
 }
 
 function mergeLogs(...logArrays) {
-  let logs = Array.prototype.concat(...logArrays);
-  logs = _.sortBy(logs, ev => [ev.timestamp, ev.process_uuid, ev.msg]);
-  return _.uniq(logs, true, logEventUniqueValue);
+  return _.chain(logArrays)
+    .flatten(true)
+    .sortBy(ev => ev.msg)
+    .sortBy(ev => ev.process_uuid)
+    .sortBy(ev => ev.timestamp)
+    .uniq(true, logEventKey)
+    .value();
 }
 
 export default class Logs extends Component {

--- a/frontend/src/metabase/admin/tasks/containers/Logs.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/Logs.jsx
@@ -12,6 +12,7 @@ import _ from "underscore";
 import moment from "moment";
 import { t } from "ttag";
 
+import Select, { Option } from "metabase/components/Select";
 import { addCSSRule } from "metabase/lib/dom";
 import colors from "metabase/lib/colors";
 
@@ -109,30 +110,36 @@ export default class Logs extends Component {
       return `[${uuid}] ${timestamp} ${ev.level} ${ev.fqns} ${ev.msg}`;
     });
 
+    let processUUIDSelect = null;
+    if (processUUIDs.length > 1) {
+      const options = [
+        <Option value="ALL" key="ALL">{t`All Metabase processes`}</Option>
+      ].concat(processUUIDs.map(uuid => (
+        <Option key={uuid} value={uuid}>
+          <code>{uuid}</code>
+        </Option>
+      )));
+
+      processUUIDSelect = (
+        <div className="pb1">
+          <label>{t`Select Metabase process`}</label>
+
+          <Select
+            defaultValue="ALL"
+            value={this.state.selectedProcessUUID}
+            onChange={e =>
+              this.setState({ selectedProcessUUID: e.target.value })
+            }
+          >
+            {options}
+          </Select>
+        </div>
+      );
+    }
+
     return (
       <div>
-        <div className="Form-field">
-          <label className="Form-label">Select Metabase process</label>
-          <label className="Select mt1">
-            <select
-              className="Select"
-              defaultValue="ALL"
-              onChange={e =>
-                this.setState({ selectedProcessUUID: e.target.value })
-              }
-            >
-              <option value="" disabled>
-                {t`Select Metabase process UUID`}
-              </option>
-              <option value="ALL">{t`All Metabase processes`}</option>
-              {processUUIDs.map(uuid => (
-                <option key={uuid} value={uuid}>
-                  {uuid}
-                </option>
-              ))}
-            </select>
-          </label>
-        </div>
+        {processUUIDSelect}
 
         <LoadingAndErrorWrapper
           loading={!filteredLogs || filteredLogs.length === 0}

--- a/frontend/src/metabase/admin/tasks/containers/Logs.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/Logs.jsx
@@ -113,12 +113,14 @@ export default class Logs extends Component {
     let processUUIDSelect = null;
     if (processUUIDs.length > 1) {
       const options = [
-        <Option value="ALL" key="ALL">{t`All Metabase processes`}</Option>
-      ].concat(processUUIDs.map(uuid => (
-        <Option key={uuid} value={uuid}>
-          <code>{uuid}</code>
-        </Option>
-      )));
+        <Option value="ALL" key="ALL">{t`All Metabase processes`}</Option>,
+      ].concat(
+        processUUIDs.map(uuid => (
+          <Option key={uuid} value={uuid}>
+            <code>{uuid}</code>
+          </Option>
+        )),
+      );
 
       processUUIDSelect = (
         <div className="pb1">

--- a/frontend/src/metabase/admin/tasks/containers/Logs.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/Logs.jsx
@@ -9,6 +9,7 @@ import reactAnsiStyle from "react-ansi-style";
 import "react-ansi-style/inject-css";
 
 import _ from "underscore";
+import moment from "moment";
 
 import { addCSSRule } from "metabase/lib/dom";
 import colors from "metabase/lib/colors";
@@ -85,7 +86,9 @@ export default class Logs extends Component {
       if (_.isString(ev)) {
         return ev;
       }
-      return `[${ev.site_uuid}] ${ev.timestamp} ${ev.level} ${ev.fqns} ${ev.msg}`;
+
+      const timestamp = moment(ev.timestamp).format()
+      return `[${ev.process_uuid}] ${timestamp} ${ev.level} ${ev.fqns} ${ev.msg}`;
     });
 
     return (

--- a/frontend/src/metabase/admin/tasks/containers/Logs.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/Logs.jsx
@@ -30,6 +30,7 @@ const ANSI_COLORS = {
 for (const [name, color] of Object.entries(ANSI_COLORS)) {
   addCSSRule(`.react-ansi-style-${name}`, `color: ${color} !important`);
 }
+const MAX_LOGS = 50000;
 
 function logEventKey(ev) {
   return `${ev.timestamp}, ${ev.process_uuid}, ${ev.fqns}, ${ev.msg}`;
@@ -42,6 +43,7 @@ function mergeLogs(...logArrays) {
     .sortBy(ev => ev.process_uuid)
     .sortBy(ev => ev.timestamp)
     .uniq(true, logEventKey)
+    .last(MAX_LOGS)
     .value();
 }
 

--- a/frontend/src/metabase/admin/tasks/containers/Logs.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/Logs.jsx
@@ -85,36 +85,48 @@ export default class Logs extends Component {
   render() {
     const { logs, selectedProcessUUID } = this.state;
     const filteredLogs = logs.filter(
-      ev => !selectedProcessUUID || selectedProcessUUID === "ALL" || ev.process_uuid === selectedProcessUUID
+      ev =>
+        !selectedProcessUUID ||
+        selectedProcessUUID === "ALL" ||
+        ev.process_uuid === selectedProcessUUID,
     );
     const processUUIDs = _.uniq(
-      logs.map(ev => ev.process_uuid).filter(Boolean)
+      logs.map(ev => ev.process_uuid).filter(Boolean),
     ).sort();
     const renderedLogs = filteredLogs.map(ev => {
-      const timestamp = moment(ev.timestamp).format()
-      return `[${ev.process_uuid}] ${timestamp} ${ev.level} ${ev.fqns} ${ev.msg}`;
+      const timestamp = moment(ev.timestamp).format();
+      const uuid = ev.process_uuid || "---";
+      return `[${uuid}] ${timestamp} ${ev.level} ${ev.fqns} ${ev.msg}`;
     });
 
     return (
       <div>
         <div className="Form-field">
-          <label className="Form-label">
-            Select Metabase process
-          </label>
+          <label className="Form-label">Select Metabase process</label>
           <label className="Select mt1">
             <select
               className="Select"
               defaultValue="ALL"
-              onChange={e => this.setState({ selectedProcessUUID: e.target.value })}
+              onChange={e =>
+                this.setState({ selectedProcessUUID: e.target.value })
+              }
             >
-              <option value="" disabled>{t`Select Metabase process UUID`}</option>
+              <option value="" disabled>
+                {t`Select Metabase process UUID`}
+              </option>
               <option value="ALL">{t`All Metabase processes`}</option>
-              {processUUIDs.map(uuid => <option key={uuid} value={uuid}>{uuid}</option>)}
+              {processUUIDs.map(uuid => (
+                <option key={uuid} value={uuid}>
+                  {uuid}
+                </option>
+              ))}
             </select>
           </label>
         </div>
 
-        <LoadingAndErrorWrapper loading={!filteredLogs || filteredLogs.length === 0}>
+        <LoadingAndErrorWrapper
+          loading={!filteredLogs || filteredLogs.length === 0}
+        >
           {() => (
             <div
               className="rounded bordered bg-light"

--- a/frontend/src/metabase/components/Select.jsx
+++ b/frontend/src/metabase/components/Select.jsx
@@ -97,7 +97,7 @@ class BrowserSelect extends Component {
       multiple,
     } = this.props;
 
-    let children = this.props.children;
+    let children = _.flatten(this.props.children);
 
     let selectedNames = children
       .filter(child => this.isSelected(child.props.value))

--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -5,7 +5,8 @@
             [clojure.string :as str]
             [environ.core :as environ]
             [metabase.plugins.classloader :as classloader])
-  (:import clojure.lang.Keyword))
+  (:import clojure.lang.Keyword
+           java.util.UUID))
 
 (def ^Boolean is-windows?
   "Are we running on a Windows machine?"
@@ -100,6 +101,13 @@
    with database connections so admins can identify them as Metabase ones.
    Looks something like `Metabase v0.25.0.RC1`."
   (str "Metabase " (mb-version-info :tag)))
+
+;; This variable used to live at `metabase.metabot.instance/local-process-uuid`
+(defonce ^{:doc "This UUID is randomly-generated upon launch and used to identify this specific Metabase instance during this specifc
+                run. Restarting the server will change this UUID, and each server in a hortizontal cluster will have its own ID,
+                making this different from the `site-uuid` Setting. The local process UUID is used to differentiate different
+                horizontally clustered MB instances so we can determine which of them will handle MetaBot duties."}
+  local-process-uuid (str (UUID/randomUUID)))
 
 
 ;; This only affects dev:

--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -102,12 +102,11 @@
    Looks something like `Metabase v0.25.0.RC1`."
   (str "Metabase " (mb-version-info :tag)))
 
-;; This variable used to live at `metabase.metabot.instance/local-process-uuid`
-(defonce ^{:doc "This UUID is randomly-generated upon launch and used to identify this specific Metabase instance during this specifc
-                run. Restarting the server will change this UUID, and each server in a hortizontal cluster will have its own ID,
-                making this different from the `site-uuid` Setting. The local process UUID is used to differentiate different
-                horizontally clustered MB instances so we can determine which of them will handle MetaBot duties."}
-  local-process-uuid (str (UUID/randomUUID)))
+(defonce ^{:doc "This UUID is randomly-generated upon launch and used to identify this specific Metabase instance during
+                this specifc run. Restarting the server will change this UUID, and each server in a horizontal cluster
+                will have its own ID, making this different from the `site-uuid` Setting."}
+  local-process-uuid
+  (str (UUID/randomUUID)))
 
 
 ;; This only affects dev:

--- a/src/metabase/logger.clj
+++ b/src/metabase/logger.clj
@@ -3,8 +3,7 @@
             [clj-time
              [coerce :as coerce]
              [format :as time]]
-            [clojure.string :as str]
-            [metabase.models.setting :as setting])
+            [metabase.public-settings :refer [local-process-uuid]])
   (:import [org.apache.log4j Appender AppenderSkeleton Logger]
            org.apache.log4j.spi.LoggingEvent))
 
@@ -18,13 +17,13 @@
   (reverse (seq @messages*)))
 
 (defn- event->log-data [^LoggingEvent event]
-  {:timestamp (time/unparse (time/formatter :date-time)
-                            (coerce/from-long (.getTimeStamp event)))
-   :level     (.getLevel event)
-   :fqns      (.getLoggerName event)
-   :msg       (.getMessage event)
-   :exception (.getThrowableStrRep event)
-   :site_uuid (setting/get-string :site-uuid)})
+  {:timestamp    (time/unparse (time/formatter :date-time)
+                               (coerce/from-long (.getTimeStamp event)))
+   :level        (.getLevel event)
+   :fqns         (.getLoggerName event)
+   :msg          (.getMessage event)
+   :exception    (.getThrowableStrRep event)
+   :process_uuid local-process-uuid})
 
 (defn- metabase-appender ^Appender []
   (proxy [AppenderSkeleton] []

--- a/src/metabase/logger.clj
+++ b/src/metabase/logger.clj
@@ -2,7 +2,6 @@
   (:require [amalloy.ring-buffer :refer [ring-buffer]]
             [clj-time
              [coerce :as coerce]
-             [core :as t]
              [format :as time]]
             [clojure.string :as str]
             [metabase.models.setting :as setting])
@@ -18,10 +17,9 @@
   []
   (reverse (seq @messages*)))
 
-(defonce ^:private formatter (time/formatter "MMM dd HH:mm:ss" (t/default-time-zone)))
-
 (defn- event->log-data [^LoggingEvent event]
-  {:timestamp (time/unparse formatter (coerce/from-long (.getTimeStamp event)))
+  {:timestamp (time/unparse (time/formatter :date-time)
+                            (coerce/from-long (.getTimeStamp event)))
    :level     (.getLevel event)
    :fqns      (.getLoggerName event)
    :msg       (.getMessage event)

--- a/src/metabase/logger.clj
+++ b/src/metabase/logger.clj
@@ -18,9 +18,6 @@
   []
   (reverse (seq @messages*)))
 
-(def ^:private ^{:arglists '([])} site-uuid
-  (memoize (fn [] (setting/get-string :site-uuid))))
-
 (defonce ^:private formatter (time/formatter "MMM dd HH:mm:ss" (t/default-time-zone)))
 
 (defn- event->log-data [^LoggingEvent event]
@@ -29,7 +26,7 @@
    :fqns      (.getLoggerName event)
    :msg       (.getMessage event)
    :exception (.getThrowableStrRep event)
-   :site_uuid (site-uuid)})
+   :site_uuid (setting/get-string :site-uuid)})
 
 (defn- metabase-appender ^Appender []
   (proxy [AppenderSkeleton] []

--- a/src/metabase/logger.clj
+++ b/src/metabase/logger.clj
@@ -3,7 +3,7 @@
             [clj-time
              [coerce :as coerce]
              [format :as time]]
-            [metabase.public-settings :refer [local-process-uuid]])
+            [metabase.config :refer [local-process-uuid]])
   (:import [org.apache.log4j Appender AppenderSkeleton Logger]
            org.apache.log4j.spi.LoggingEvent))
 

--- a/src/metabase/metabot/instance.clj
+++ b/src/metabase/metabot/instance.clj
@@ -21,9 +21,10 @@
   MetaBot duties."
   (:require [clojure.tools.logging :as log]
             [honeysql.core :as hsql]
+            [metabase
+             [public-settings :refer [local-process-uuid]]
+             [util :as u]]
             [metabase.models.setting :as setting :refer [defsetting]]
-            [metabase.public-settings :refer [local-process-uuid]]
-            [metabase.util :as u]
             [metabase.util
              [date :as du]
              [i18n :refer [trs]]]

--- a/src/metabase/metabot/instance.clj
+++ b/src/metabase/metabot/instance.clj
@@ -28,8 +28,7 @@
              [date :as du]
              [i18n :refer [trs]]]
             [toucan.db :as db])
-  (:import java.sql.Timestamp
-           java.util.UUID))
+  (:import java.sql.Timestamp))
 
 (defsetting ^:private metabot-instance-uuid
   "UUID of the active MetaBot instance (the Metabase process currently handling MetaBot duties.)"

--- a/src/metabase/metabot/instance.clj
+++ b/src/metabase/metabot/instance.clj
@@ -14,16 +14,15 @@
 
   How do we uniquiely identify each instance?
 
-  `local-process-uuid` is randomly-generated upon launch and used to identify this specific Metabase instance during
-  this specifc run. Restarting the server will change this UUID, and each server in a hortizontal cluster will have
-  its own ID, making this different from the `site-uuid` Setting. The local process UUID is used to differentiate
-  different horizontally clustered MB instances so we can determine which of them will handle MetaBot duties.
-
-  TODO - if we ever want to use this elsewhere, we need to move it to `metabase.config` or somewhere else central like
-  that."
+  `metabase.public-settings/local-process-uuid` is randomly-generated upon launch and used to identify this specific
+  Metabase instance during this specifc run. Restarting the server will change this UUID, and each server in a
+  hortizontal cluster will have its own ID, making this different from the `site-uuid` Setting. The local process UUID
+  is used to differentiate different horizontally clustered MB instances so we can determine which of them will handle
+  MetaBot duties."
   (:require [clojure.tools.logging :as log]
             [honeysql.core :as hsql]
             [metabase.models.setting :as setting :refer [defsetting]]
+            [metabase.public-settings :refer [local-process-uuid]]
             [metabase.util :as u]
             [metabase.util
              [date :as du]
@@ -31,9 +30,6 @@
             [toucan.db :as db])
   (:import java.sql.Timestamp
            java.util.UUID))
-
-(defonce ^:private local-process-uuid
-  (str (UUID/randomUUID)))
 
 (defsetting ^:private metabot-instance-uuid
   "UUID of the active MetaBot instance (the Metabase process currently handling MetaBot duties.)"

--- a/src/metabase/metabot/instance.clj
+++ b/src/metabase/metabot/instance.clj
@@ -22,7 +22,7 @@
   (:require [clojure.tools.logging :as log]
             [honeysql.core :as hsql]
             [metabase
-             [public-settings :refer [local-process-uuid]]
+             [config :refer [local-process-uuid]]
              [util :as u]]
             [metabase.models.setting :as setting :refer [defsetting]]
             [metabase.util

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -232,3 +232,12 @@
    :types                 (types/types->parents :type/*)
    :entities              (types/types->parents :entity/*)
    :version               config/mb-version-info})
+
+;; This UUID is randomly-generated upon launch and used to identify this specific Metabase instance during this specifc
+;; run. Restarting the server will change this UUID, and each server in a hortizontal cluster will have its own ID,
+;; making this different from the `site-uuid` Setting. The local process UUID is used to differentiate different
+;; horizontally clustered MB instances so we can determine which of them will handle MetaBot duties.
+;;
+;; It used to live at `metabase.metabot.instance/local-process-uuid`
+(defonce local-process-uuid
+  (str (UUID/randomUUID)))

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -233,11 +233,9 @@
    :entities              (types/types->parents :entity/*)
    :version               config/mb-version-info})
 
-;; This UUID is randomly-generated upon launch and used to identify this specific Metabase instance during this specifc
-;; run. Restarting the server will change this UUID, and each server in a hortizontal cluster will have its own ID,
-;; making this different from the `site-uuid` Setting. The local process UUID is used to differentiate different
-;; horizontally clustered MB instances so we can determine which of them will handle MetaBot duties.
-;;
-;; It used to live at `metabase.metabot.instance/local-process-uuid`
-(defonce local-process-uuid
-  (str (UUID/randomUUID)))
+;; This variable used to live at `metabase.metabot.instance/local-process-uuid`
+(defonce ^{:doc "This UUID is randomly-generated upon launch and used to identify this specific Metabase instance during this specifc
+                run. Restarting the server will change this UUID, and each server in a hortizontal cluster will have its own ID,
+                making this different from the `site-uuid` Setting. The local process UUID is used to differentiate different
+                horizontally clustered MB instances so we can determine which of them will handle MetaBot duties."}
+  local-process-uuid (str (UUID/randomUUID)))

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -232,10 +232,3 @@
    :types                 (types/types->parents :type/*)
    :entities              (types/types->parents :entity/*)
    :version               config/mb-version-info})
-
-;; This variable used to live at `metabase.metabot.instance/local-process-uuid`
-(defonce ^{:doc "This UUID is randomly-generated upon launch and used to identify this specific Metabase instance during this specifc
-                run. Restarting the server will change this UUID, and each server in a hortizontal cluster will have its own ID,
-                making this different from the `site-uuid` Setting. The local process UUID is used to differentiate different
-                horizontally clustered MB instances so we can determine which of them will handle MetaBot duties."}
-  local-process-uuid (str (UUID/randomUUID)))

--- a/src/metabase/pulse/render/table.clj
+++ b/src/metabase/pulse/render/table.clj
@@ -4,8 +4,12 @@
             [metabase.pulse.render
              [color :as color]
              [style :as style]])
-  (:import jdk.nashorn.api.scripting.JSObject
-           metabase.pulse.render.common.NumericWrapper))
+  (:import jdk.nashorn.api.scripting.JSObject))
+
+;; Our 'helpful' NS declaration linter will complain that common is unused. But we need to require it so
+;; NumericWrapper exists in the first place.
+(require 'metabase.pulse.render.common)
+(import 'metabase.pulse.render.common.NumericWrapper)
 
 (defn- bar-th-style []
   (merge (style/font-style) {:font-size :14.22px


### PR DESCRIPTION
The only visible changes to the UI is the added process `<select>`, and the way in which the log events are rendered. The event rendering could probably be a bit nicer.

![image](https://user-images.githubusercontent.com/23798/62655593-9dfc4500-b962-11e9-889d-c127e903af7d.png)

![image](https://user-images.githubusercontent.com/23798/62655694-d439c480-b962-11e9-8039-7985aa4e7afe.png)

Should the select perhaps be disabled with the available UUID selected, when there is only a single process UUID available? Or maybe auto-selecting _All Metabase processes_ in that case is better...?