### PR TITLE
Factor out test for access to localStorage

### DIFF
--- a/frontend/src/metabase/app.js
+++ b/frontend/src/metabase/app.js
@@ -49,6 +49,14 @@ const BASENAME = window.MetabaseRoot.replace(/\/+$/, "");
 
 api.basename = BASENAME;
 
+try {
+  window.localStorage; // This will trigger an exception if access is denied.
+  window.hasLocalStorage = true;
+} catch (e) {
+  console.warn("localStorage not available:", e);
+  window.hasLocalStorage = false;
+}
+
 const browserHistory = useRouterHistory(createHistory)({
   basename: BASENAME,
 });

--- a/frontend/src/metabase/app.js
+++ b/frontend/src/metabase/app.js
@@ -49,14 +49,6 @@ const BASENAME = window.MetabaseRoot.replace(/\/+$/, "");
 
 api.basename = BASENAME;
 
-try {
-  window.localStorage; // This will trigger an exception if access is denied.
-  window.hasLocalStorage = true;
-} catch (e) {
-  console.warn("localStorage not available:", e);
-  window.hasLocalStorage = false;
-}
-
 const browserHistory = useRouterHistory(createHistory)({
   basename: BASENAME,
 });

--- a/frontend/src/metabase/lib/debug.js
+++ b/frontend/src/metabase/lib/debug.js
@@ -2,7 +2,7 @@ let debug;
 if (
   typeof window === "object" &&
   ((window.location && window.location.hash === "#debug") ||
-    (window.localStorage && window.localStorage.getItem("debug")))
+    (window.hasLocalStorage && window.localStorage.getItem("debug")))
 ) {
   debug = true;
 } else {

--- a/frontend/src/metabase/lib/debug.js
+++ b/frontend/src/metabase/lib/debug.js
@@ -1,8 +1,10 @@
+import { HAS_LOCAL_STORAGE } from "metabase/lib/dom";
+
 let debug;
 if (
   typeof window === "object" &&
   ((window.location && window.location.hash === "#debug") ||
-    (window.hasLocalStorage && window.localStorage.getItem("debug")))
+    (HAS_LOCAL_STORAGE && window.localStorage.getItem("debug")))
 ) {
   debug = true;
 } else {

--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -26,6 +26,18 @@ export const IFRAMED_IN_SELF = (function() {
   }
 })();
 
+// check if we have access to localStorage to avoid handling "access denied"
+// exceptions
+export const HAS_LOCAL_STORAGE = (function() {
+  try {
+    window.localStorage; // This will trigger an exception if access is denied.
+    return true;
+  } catch (e) {
+    console.warn("localStorage not available:", e);
+    return false;
+  }
+})();
+
 export function isObscured(element, offset) {
   if (!document.elementFromPoint) {
     return false;

--- a/frontend/src/metabase/lib/i18n-debug.js
+++ b/frontend/src/metabase/lib/i18n-debug.js
@@ -1,5 +1,7 @@
 import React from "react";
 
+import { HAS_LOCAL_STORAGE } from "metabase/lib/dom";
+
 // If enabled this monkeypatches `t` and `jt` to return blacked out
 // strings/elements to assist in finding untranslated strings.
 //
@@ -52,6 +54,6 @@ export function enableTranslatedStringReplacement() {
   };
 }
 
-if (window.hasLocalStorage && window.localStorage["metabase-i18n-debug"]) {
+if (HAS_LOCAL_STORAGE && window.localStorage["metabase-i18n-debug"]) {
   enableTranslatedStringReplacement();
 }

--- a/frontend/src/metabase/lib/i18n-debug.js
+++ b/frontend/src/metabase/lib/i18n-debug.js
@@ -52,6 +52,6 @@ export function enableTranslatedStringReplacement() {
   };
 }
 
-if (window.localStorage && window.localStorage["metabase-i18n-debug"]) {
+if (window.hasLocalStorage && window.localStorage["metabase-i18n-debug"]) {
   enableTranslatedStringReplacement();
 }


### PR DESCRIPTION
This allows code that uses localStorage to test against `window.hasLocalStorage`, in stead of handling exceptions generated when access to localStorage is denied.

Fixes #8873.

I'm sure there's a better place to put the initialization of `window.hasLocalStorage`. Any preferences, @tlrobinson? Somewhere in `metabase/lib/`?