### PR TITLE
Make permissions edit bar color match top bar

### DIFF
--- a/frontend/src/metabase/css/components/header.css
+++ b/frontend/src/metabase/css/components/header.css
@@ -51,7 +51,7 @@
 }
 
 .EditHeader.EditHeader--admin:after {
-  background-color: var(--color-bg-dark);
+  background-color: var(--color-accent7);
 }
 
 .EditHeader-title {


### PR DESCRIPTION
This was just bugging me.

### Before

![Screen Shot 2019-08-13 at 3 35 00 PM](https://user-images.githubusercontent.com/2223916/62982443-f909be00-bde0-11e9-9f21-a75fe25b2f4a.png)

### After

![Screen Shot 2019-08-13 at 3 40 51 PM](https://user-images.githubusercontent.com/2223916/62982449-ff983580-bde0-11e9-98d9-8891e6873e14.png)
