### PR TITLE
Don't create API callback if no database is associated with card

### DIFF
--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -63,6 +63,10 @@ import { MetabaseApi } from "metabase/services";
 
 function autocompleteResults(card, prefix) {
   const databaseId = card && card.dataset_query && card.dataset_query.database;
+  if (!databaseId) {
+    return null;
+  }
+
   const apiCall = MetabaseApi.db_autocomplete_suggestions({
     dbId: databaseId,
     prefix: prefix,

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -64,7 +64,7 @@ import { MetabaseApi } from "metabase/services";
 function autocompleteResults(card, prefix) {
   const databaseId = card && card.dataset_query && card.dataset_query.database;
   if (!databaseId) {
-    return null;
+    return [];
   }
 
   const apiCall = MetabaseApi.db_autocomplete_suggestions({


### PR DESCRIPTION
@tlrobinson I'm not sure why this does _not_ cause a `Cannot read property 'map' of null` error [here](https://github.com/metabase/metabase/blob/fix-10538/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx#L243), but it has the desired effect.

Fixes #10538