### PR TITLE
Change sync log levels from DEBUG to INFO

### DIFF
--- a/resources/log4j.properties
+++ b/resources/log4j.properties
@@ -14,23 +14,16 @@ log4j.appender.file.MaxBackupIndex=2
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
 log4j.appender.file.layout.ConversionPattern=%d [%t] %-5p%c - %m%n
 
-# customizations to logging by package
-
-log4j.logger.metabase.driver=INFO
+# Default log level for all metabase namespaces is INFO. Default log level for everything else is WARN (see top of file)
+log4j.logger.metabase=INFO
+# For some other Metabase namespaces we want slightly higher log levels for newer/more critical code
 log4j.logger.metabase.plugins=DEBUG
 log4j.logger.metabase.middleware=DEBUG
-log4j.logger.metabase.models.permissions=INFO
-log4j.logger.metabase.query-processor.permissions=INFO
-log4j.logger.metabase.query-processor=INFO
-log4j.logger.metabase.sync=DEBUG
-log4j.logger.metabase.models.field-values=INFO
 
 # TODO - we can dial these back a bit once we are satisfied the async stuff isn't so new (0.33.0+)
 log4j.logger.metabase.async.util=DEBUG
 log4j.logger.metabase.middleware.async=DEBUG
 log4j.logger.metabase.query-processor.async=DEBUG
-
-log4j.logger.metabase=INFO
 
 # c3p0 connection pools tend to log useless warnings way too often; only log actual errors
 log4j.logger.com.mchange=ERROR


### PR DESCRIPTION
We don't really need all the noise in the logs like anymore since the code is stable/mature now so reduce the sync log level to `INFO`

```
08-14 12:11:33 DEBUG analyze.fingerprint :: Saving fingerprint for Field 122 'name'
```