### PR TITLE
hide run button in notebook header

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -247,8 +247,8 @@ export class ViewTitleHeader extends React.Component {
           )}
           {isRunnable && (
             <RunButtonWithTooltip
-              className={cx("text-brand-hover hide sm-show", {
-                hide: isShowingNotebook,
+              className={cx("text-brand-hover hide", {
+                "sm-show": !isShowingNotebook,
                 "text-white-hover": isResultDirty && isRunnable,
               })}
               medium


### PR DESCRIPTION
Flip the `sm-show` logic so that the button is hidden unless you're in view mode.