### PR TITLE
Wrap d3 range functions to generate ticks in the reporting timezone

### DIFF
--- a/frontend/src/metabase/lib/time.js
+++ b/frontend/src/metabase/lib/time.js
@@ -69,3 +69,18 @@ export function parseTime(value) {
     return moment.utc(value);
   }
 }
+
+// changeOffset takes a datetime and moves it between UTC offsets without
+// changing the date or time.
+//
+// This function is only useful if `d` is missing timezone info (e.g. a
+// javascript Date object). If you have a moment object to begin with, you can
+// just call `.utcOffset(newOffset, true)` directly
+//
+// changeOffset(new Date("2019-08-01T00:00:00-02:00"), -2, 2).format()
+// => "2019-08-01T00:00:00+02:00"
+export function changeOffset(d, oldOffset, newOffset) {
+  return moment(d)
+    .utcOffset(oldOffset, false)
+    .utcOffset(newOffset, true);
+}

--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -7,7 +7,6 @@ import moment from "moment";
 
 import { datasetContainsNoResults } from "metabase/lib/dataset";
 import { formatValue } from "metabase/lib/formatting";
-import { hasHour } from "metabase/lib/formatting/date";
 import { parseTimestamp } from "metabase/lib/time";
 
 import { computeTimeseriesTicksInterval } from "./timeseries";

--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -139,35 +139,13 @@ export function applyChartTimeseriesXAxis(
       }
     }
 
-    chart.xAxis().tickFormat(rawTimestamp => {
-      // `rawTimestamp` is a plain Date object which discards the timezone. If
-      // we're going to display a time, we need to add it back in so it's
-      // formatted correctly.
-      //
-      // An example:
-      // If we're passed "2019-08-15T03:00:00+03:00", but the data offset is -3
-      // then we need to update the UTC offset to get the time in the reporting
-      // timezone. The timestamp is referring to the right "instant" but has the
-      // wrong offset. We want "2019-08-14T21:00:00-03:00" instead.
-      //
-      // However, if there's no time in our display then we don't want to change
-      // the offset. Ticks that dont have time were already snapped to
-      // date/week/etc boundaries by d3. Updating the offset can push them into
-      // another day/week/etc and cause an off-by-one error.
-
-      const timestamp = moment(rawTimestamp);
-      const columnSettings = chart.settings.column(dimensionColumn);
-      const { column: { unit } = {} } = columnSettings;
-      if (hasHour(unit)) {
-        timestamp.utcOffset(dataOffset);
-      }
-
-      return formatValue(timestamp.format(), {
-        ...columnSettings,
+    chart.xAxis().tickFormat(timestamp =>
+      formatValue(timestamp, {
+        ...chart.settings.column(dimensionColumn),
         type: "axis",
         compact: chart.settings["graph.x_axis.axis_enabled"] === "compact",
-      });
-    });
+      }),
+    );
 
     // Compute a sane interval to display based on the data granularity, domain, and chart width
     tickInterval = computeTimeseriesTicksInterval(

--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -7,6 +7,7 @@ import moment from "moment";
 
 import { datasetContainsNoResults } from "metabase/lib/dataset";
 import { formatValue } from "metabase/lib/formatting";
+import { hasHour } from "metabase/lib/formatting/date";
 import { parseTimestamp } from "metabase/lib/time";
 
 import { computeTimeseriesTicksInterval } from "./timeseries";
@@ -138,14 +139,31 @@ export function applyChartTimeseriesXAxis(
       }
     }
 
-    chart.xAxis().tickFormat(timestamp => {
-      // timestamp is a plain Date object which discards the timezone,
-      // so add it back in so it's formatted correctly
-      const timestampFixed = moment(timestamp)
-        .utcOffset(dataOffset)
-        .format();
-      return formatValue(timestampFixed, {
-        ...chart.settings.column(dimensionColumn),
+    chart.xAxis().tickFormat(rawTimestamp => {
+      // `rawTimestamp` is a plain Date object which discards the timezone. If
+      // we're going to display a time, we need to add it back in so it's
+      // formatted correctly.
+      //
+      // An example:
+      // If we're passed "2019-08-15T03:00:00+03:00", but the data offset is -3
+      // then we need to update the UTC offset to get the time in the reporting
+      // timezone. The timestamp is referring to the right "instant" but has the
+      // wrong offset. We want "2019-08-14T21:00:00-03:00" instead.
+      //
+      // However, if there's no time in our display then we don't want to change
+      // the offset. Ticks that dont have time were already snapped to
+      // date/week/etc boundaries by d3. Updating the offset can push them into
+      // another day/week/etc and cause an off-by-one error.
+
+      const timestamp = moment(rawTimestamp);
+      const columnSettings = chart.settings.column(dimensionColumn);
+      const { column: { unit } = {} } = columnSettings;
+      if (hasHour(unit)) {
+        timestamp.utcOffset(dataOffset);
+      }
+
+      return formatValue(timestamp.format(), {
+        ...columnSettings,
         type: "axis",
         compact: chart.settings["graph.x_axis.axis_enabled"] === "compact",
       });

--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -153,7 +153,8 @@ export function applyChartTimeseriesXAxis(
       tickInterval,
       chart.width(),
     );
-    chart.xAxis().ticks(tickInterval.rangeFn, tickInterval.count);
+    const rangeFn = tickInterval.getRangeFnForOffset(dataOffset);
+    chart.xAxis().ticks(rangeFn, tickInterval.count);
   } else {
     chart.xAxis().ticks(0);
   }

--- a/frontend/test/metabase/lib/time.unit.spec.js
+++ b/frontend/test/metabase/lib/time.unit.spec.js
@@ -1,4 +1,4 @@
-import { parseTime, parseTimestamp } from "metabase/lib/time";
+import { changeOffset, parseTime, parseTimestamp } from "metabase/lib/time";
 import moment from "moment";
 
 describe("time", () => {
@@ -55,6 +55,24 @@ describe("time", () => {
 
       expect(moment.isMoment(result)).toBe(true);
       expect(result.format("h:mm A")).toBe("1:02 AM");
+    });
+  });
+
+  describe("changeOffset", () => {
+    it("should no op for equal offsets", () => {
+      const d = new Date("2019-01-23T12:34:56+10:00");
+
+      const converted = changeOffset(d, 10, 10);
+
+      expect(converted.format()).toBe("2019-01-23T12:34:56+10:00");
+    });
+
+    it("should update only the offset", () => {
+      const d = new Date("2019-01-23T12:34:56-06:00");
+
+      const converted = changeOffset(d, -6, 6);
+
+      expect(converted.format()).toBe("2019-01-23T12:34:56+06:00");
     });
   });
 });

--- a/frontend/test/metabase/visualizations/components/LineAreaBarRenderer.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/LineAreaBarRenderer.unit.spec.js
@@ -66,7 +66,7 @@ describe("LineAreaBarRenderer", () => {
     expect(warnings).toEqual(['We encountered an invalid date: "2019-W53"']);
   });
 
-  ["Z", ...ALL_TZS].forEach(tz =>
+  ["Z", ...ALL_TZS].forEach(tz => {
     it(
       "should display hourly data (in " +
         tz +
@@ -100,8 +100,38 @@ describe("LineAreaBarRenderer", () => {
           expected,
         );
       },
-    ),
-  );
+    );
+
+    it(`should display daily data (in ${tz} timezone) in X axis and tooltip consistently`, () => {
+      const onHoverChange = jest.fn();
+
+      const rows = [
+        ["2016-10-03T00:00:00.000" + tz, 1],
+        ["2016-10-04T00:00:00.000" + tz, 1],
+      ];
+
+      renderTimeseriesLine({
+        rowsOfSeries: [rows],
+        unit: "day",
+        onHoverChange,
+      });
+
+      dispatchUIEvent(qs(".dot"), "mousemove");
+
+      const expected = rows.map(row =>
+        formatValue(row[0], {
+          column: DateTimeColumn({ unit: "day" }),
+        }),
+      );
+      expect(getFormattedTooltips(onHoverChange.mock.calls[0][0])).toEqual([
+        expected[0],
+        "1",
+      ]);
+      expect(qsa(".axis.x .tick text").map(e => e.textContent)).toEqual(
+        expected,
+      );
+    });
+  });
 
   it("should display hourly data (in the browser's timezone) in X axis and tooltip consistently and correctly", () => {
     const onHoverChange = jest.fn();


### PR DESCRIPTION
Resolves #8413

~The comment in the code contains most of the information. Essentially, we were calling `moment#utcOffset` and pushing tick timestamps into a different day before formatting them.~

We used `d3.time[unit]` to generate good locations for ticks. These ticks were on boundaries in local time, but we plotted the data in the reporting timezone. To format the ticks correctly we had to manipulate them.

The new approach taken in this PR is to instead produce ticks in the reporting timezone to begin with (by wrapping the d3 functions). That cleans up the formatting code and prevents issues with tick/data element alignment.

---

Potential issue: 
I'm converting to and from UTC. That might cause some issues when crossing daylight saving boundaries. I'm going to add tests for this before merging.

---

Another approach:
Would it instead make sense to do everything in UTC? (@salsakran floated this idea) The core thing we need is to have ticks match the data we're plotting. This PR tweaks the ticks, but it'd be a bit simpler to convert the data to UTC up front. Would that cause issues elsewhere?