### PR TITLE
Domain entities: distinguish between matching requirements by field name & type

### DIFF
--- a/resources/domain_entity_specs/orders.yaml
+++ b/resources/domain_entity_specs/orders.yaml
@@ -1,8 +1,8 @@
 name: Transactions
 description: Transaction (orders) data
 required_attributes:
-  - field: Income
-  - field: CreationTimestamp
+  - dimension: Income
+  - dimension: CreationTimestamp
 optional_attributes:
   - field: Discount
   - field: Quantity

--- a/src/metabase/domain_entities/core.clj
+++ b/src/metabase/domain_entities/core.clj
@@ -1,7 +1,7 @@
 (ns metabase.domain-entities.core
   (:require [clojure.string :as str]
             [medley.core :as m]
-            [metabase.domain-entities.specs :refer [domain-entity-specs MBQL DomainEntitySpec]]
+            [metabase.domain-entities.specs :refer [domain-entity-specs DomainEntitySpec MBQL]]
             [metabase.mbql.util :as mbql.u]
             [metabase.models
              [card :refer [Card]]

--- a/src/metabase/domain_entities/specs.clj
+++ b/src/metabase/domain_entities/specs.clj
@@ -3,7 +3,9 @@
             [metabase.mbql
              [normalize :as mbql.normalize]
              [util :as mbql.u]]
-            [metabase.util.yaml :as yaml]
+            [metabase.util
+             [schema :as su]
+             [yaml :as yaml]]
             [schema
              [coerce :as sc]
              [core :as s]]))
@@ -12,21 +14,18 @@
   "MBQL clause (ie. a vector starting with a keyword)"
   (s/pred mbql.u/mbql-clause?))
 
-(def FieldType
-  "Field type designator -- a keyword derived from `type/*`"
-  (s/constrained s/Keyword
-                                        ;#(isa? % :type/*)
-                 identity))
-
 (def ^:private DomainEntityReference s/Str)
 
 (def ^:private DomainEntityType (s/isa :DomainEntity/*))
 
 (def ^:private Identifier s/Str)
 
+(def ^:private FieldName s/Str)
+
 (def ^:private Description s/Str)
 
-(def ^:private Attributes [{(s/optional-key :field)         FieldType
+(def ^:private Attributes [{(s/optional-key :field)         FieldName
+                            (s/optional-key :dimension)     su/FieldType
                             (s/optional-key :domain_entity) DomainEntityReference
                             (s/optional-key :has_many)      {:domain_entity DomainEntityReference}}])
 
@@ -76,10 +75,10 @@
                             (for [dimension breakout-dimensions]
                               (if (string? dimension)
                                 (do
-                                  (s/validate FieldType (keyword "type" dimension))
+                                  (s/validate su/FieldType (keyword "type" dimension))
                                   [:dimension dimension])
                                 dimension)))
-    FieldType             (partial keyword "type")
+    su/FieldType          (partial keyword "type")
     ;; Some map keys are names (ie. strings) while the rest are keywords, a distinction lost in YAML
     s/Str                 name}))
 

--- a/src/metabase/transforms/core.clj
+++ b/src/metabase/transforms/core.clj
@@ -140,7 +140,14 @@
   [tableset :- Tableset]
   (into {} (for [{{domain-entity-name :name dimensions :dimensions} :domain_entity :as table} tableset]
              [domain-entity-name
-              {:dimensions (m/map-vals de/mbql-reference dimensions)
+              {:dimensions (let [dimension? (set (vals dimensions))]
+                             (m/map-vals de/mbql-reference
+                                         (merge
+                                          ;; We need all the fields so we can do enrichmets
+                                          (into {} (for [field (:fields table)
+                                                         :when (not (dimension? field))]
+                                                     [(:name field) field]))
+                                          dimensions)))
                :entity     table}])))
 
 (s/defn ^:private apply-transform-to-tableset! :- Bindings

--- a/src/metabase/transforms/specs.clj
+++ b/src/metabase/transforms/specs.clj
@@ -1,6 +1,6 @@
 (ns metabase.transforms.specs
   (:require [medley.core :as m]
-            [metabase.domain-entities.specs :refer [FieldType MBQL]]
+            [metabase.domain-entities.specs :refer [MBQL]]
             [metabase.mbql
              [normalize :as mbql.normalize]
              [schema :as mbql.schema]
@@ -92,7 +92,6 @@
                                  (if (s/check MBQL breakout)
                                    [:dimension breakout]
                                    breakout)))
-    FieldType                (partial keyword "type")
     [DomainEntity]           u/one-or-many
     mbql.schema/JoinStrategy keyword
     ;; Since `Aggregation` and `Expressions` are structurally the same, we can't use them directly

--- a/test/metabase/api/automagic_dashboards_test.clj
+++ b/test/metabase/api/automagic_dashboards_test.clj
@@ -171,9 +171,9 @@
 ;;; ------------------- Transforms -------------------
 
 (expect
-  [[4 1 10.0646 -165.374 "Red Medicine" 3 1 4 3 2 1]
-   [11 2 34.0996 -118.329 "Stout Burgers & Beers" 2 2 11 2 1 1]
-   [11 3 34.0406 -118.428 "The Apple Pan" 2 2 11 2 1 1]]
+  [[1 "Red Medicine" 3 4 -165.374 10.0646 1 4 3 2 1]
+   [2 "Stout Burgers & Beers" 2 11 -118.329 34.0996 2 11 2 1 1]
+   [3 "The Apple Pan" 2 11 -118.428 34.0406 2 11 2 1 1]]
   (test-users/with-test-user :rasta
     (transforms.test/with-test-transform-specs
       (de.test/with-test-domain-entity-specs

--- a/test/metabase/api/automagic_dashboards_test.clj
+++ b/test/metabase/api/automagic_dashboards_test.clj
@@ -171,9 +171,9 @@
 ;;; ------------------- Transforms -------------------
 
 (expect
-  [[1 "Red Medicine" 3 4 -165.374 10.0646 1 4 3 2 1]
-   [2 "Stout Burgers & Beers" 2 11 -118.329 34.0996 2 11 2 1 1]
-   [3 "The Apple Pan" 2 11 -118.428 34.0406 2 11 2 1 1]]
+  [[3 4 -165.374 10.0646 1 "Red Medicine" 1 4 3 2 1]
+   [2 11 -118.329 34.0996 2 "Stout Burgers & Beers" 2 11 2 1 1]
+   [2 11 -118.428 34.0406 3 "The Apple Pan" 2 11 2 1 1]]
   (test-users/with-test-user :rasta
     (transforms.test/with-test-transform-specs
       (de.test/with-test-domain-entity-specs

--- a/test/metabase/api/transform_test.clj
+++ b/test/metabase/api/transform_test.clj
@@ -19,9 +19,9 @@
 
 ;; Run the transform and make sure it produces the correct result
 (expect
-  [[4 1 10.0646 -165.374 "Red Medicine" 3 1 4 3 2 1]
-   [11 2 34.0996 -118.329 "Stout Burgers & Beers" 2 2 11 2 1 1]
-   [11 3 34.0406 -118.428 "The Apple Pan" 2 2 11 2 1 1]]
+  [[1 "Red Medicine" 3 4 -165.374 10.0646 1 4 3 2 1]
+   [2 "Stout Burgers & Beers" 2 11 -118.329 34.0996 2 11 2 1 1]
+   [3 "The Apple Pan" 2 11 -118.428 34.0406 2 11 2 1 1]]
   (test-users/with-test-user :rasta
     (with-test-transform-specs
       (with-test-domain-entity-specs

--- a/test/metabase/api/transform_test.clj
+++ b/test/metabase/api/transform_test.clj
@@ -19,9 +19,9 @@
 
 ;; Run the transform and make sure it produces the correct result
 (expect
-  [[1 "Red Medicine" 3 4 -165.374 10.0646 1 4 3 2 1]
-   [2 "Stout Burgers & Beers" 2 11 -118.329 34.0996 2 11 2 1 1]
-   [3 "The Apple Pan" 2 11 -118.428 34.0406 2 11 2 1 1]]
+  [[3 4 -165.374 10.0646 1 "Red Medicine" 1 4 3 2 1]
+   [2 11 -118.329 34.0996 2 "Stout Burgers & Beers" 2 11 2 1 1]
+   [2 11 -118.428 34.0406 3 "The Apple Pan" 2 11 2 1 1]]
   (test-users/with-test-user :rasta
     (with-test-transform-specs
       (with-test-domain-entity-specs

--- a/test/metabase/test/domain_entities.clj
+++ b/test/metabase/test/domain_entities.clj
@@ -4,17 +4,17 @@
 (def test-domain-entity-specs
   "A test domain specs written against our test DB."
   (->> [{:name                "Venues parent"
-         :required_attributes [{:field "Longitude"}
-                               {:field "Latitude"}]}
+         :required_attributes [{:dimension "Longitude"}
+                               {:dimension "Latitude"}]}
         {:name                "Venues"
-         :required_attributes [{:field "Category"} ; Price
-                               {:field "FK"} ; Category ID
+         :required_attributes [{:field "PRICE"} ; Price
+                               {:dimension "FK"} ; Category ID
                                ;; These are here just for uniquness
-                               {:field "Longitude"}
-                               {:field "Latitude"}]
+                               {:dimension "Longitude"}
+                               {:dimension "Latitude"}]
          :refines             "Venues parent"
          :breakout_dimensions ["FK"]
-         :metrics             {"Avg Price" {:aggregation [:avg [:dimension "Category"]]}}}
+         :metrics             {"Avg Price" {:aggregation [:avg [:dimension "PRICE"]]}}}
         {:name                "VenuesEnhanced"
          :required_attributes [{:field "AvgPrice"}
                                {:field "MinPrice"}

--- a/test/metabase/test/transforms.clj
+++ b/test/metabase/test/transforms.clj
@@ -7,12 +7,12 @@
        :requires "Venues"
        :provides "VenuesEnhanced"
        :steps    {"CategoriesStats" {:source      "Venues"
-                                     :aggregation {"AvgPrice" [:avg [:dimension "Category"]]
-                                                   "MinPrice" [:min [:dimension "Category"]]
-                                                   "MaxPrice" [:max [:dimension "Category"]]}
+                                     :aggregation {"AvgPrice" [:avg [:dimension "PRICE"]]
+                                                   "MinPrice" [:min [:dimension "PRICE"]]
+                                                   "MaxPrice" [:max [:dimension "PRICE"]]}
                                      :breakout    "FK"}
                   "VenuesEnhanced"  {:source      "Venues"
-                                     :expressions {"RelativePrice" [:/ [:dimension "Category"]
+                                     :expressions {"RelativePrice" [:/ [:dimension "PRICE"]
                                                                     [:dimension "CategoriesStats.AvgPrice"]]}
                                      :joins       [{:source    "CategoriesStats"
                                                     :condition [:= [:dimension "FK"]

--- a/test/metabase/transforms/core_test.clj
+++ b/test/metabase/transforms/core_test.clj
@@ -137,9 +137,9 @@
 
 ;; Run the transform and make sure it produces the correct result
 (expect
-  [[1 "Red Medicine" 3 4 -165.374 10.0646 1 4 3 2 1]
-   [2 "Stout Burgers & Beers" 2 11 -118.329 34.0996 2 11 2 1 1]
-   [3 "The Apple Pan" 2 11 -118.428 34.0406 2 11 2 1 1]]
+  [[3 4 -165.374 10.0646 1 "Red Medicine" 1 4 3 2 1]
+   [2 11 -118.329 34.0996 2 "Stout Burgers & Beers" 2 11 2 1 1]
+   [2 11 -118.428 34.0406 3 "The Apple Pan" 2 11 2 1 1]]
   (test-users/with-test-user :rasta
     (with-test-domain-entity-specs
       (tu/with-model-cleanup [Card Collection]

--- a/test/metabase/transforms/core_test.clj
+++ b/test/metabase/transforms/core_test.clj
@@ -4,9 +4,7 @@
             [metabase
              [query-processor :as qp]
              [util :as u]]
-            [metabase.domain-entities
-             [core :as de]
-             [specs :as de.specs]]
+            [metabase.domain-entities.specs :as de.specs]
             [metabase.models
              [card :as card :refer [Card]]
              [collection :refer [Collection]]

--- a/test/metabase/transforms/core_test.clj
+++ b/test/metabase/transforms/core_test.clj
@@ -135,9 +135,9 @@
 
 ;; Run the transform and make sure it produces the correct result
 (expect
-  [[4 1 10.0646 -165.374 "Red Medicine" 3 1 4 3 2 1]
-   [11 2 34.0996 -118.329 "Stout Burgers & Beers" 2 2 11 2 1 1]
-   [11 3 34.0406 -118.428 "The Apple Pan" 2 2 11 2 1 1]]
+  [[1 "Red Medicine" 3 4 -165.374 10.0646 1 4 3 2 1]
+   [2 "Stout Burgers & Beers" 2 11 -118.329 34.0996 2 11 2 1 1]
+   [3 "The Apple Pan" 2 11 -118.428 34.0406 2 11 2 1 1]]
   (test-users/with-test-user :rasta
     (with-test-domain-entity-specs
       (tu/with-model-cleanup [Card Collection]

--- a/test/metabase/transforms/core_test.clj
+++ b/test/metabase/transforms/core_test.clj
@@ -26,9 +26,13 @@
 (def test-bindings
   (delay
    (with-test-domain-entity-specs
-     (let [table (m/find-first (comp #{(data/id :venues)} u/get-id) (#'t/tableset (data/id) "PUBLIC"))]
-       {"Venues" {:dimensions (m/map-vals de/mbql-reference (get-in table [:domain_entity :dimensions]))
-                  :entity     table}}))))
+     {"Venues" {:dimensions {"ID"        [:field-id (data/id :venues :id)],
+                             "NAME"      [:field-id (data/id :venues :name)],
+                             "PRICE"     [:field-id (data/id :venues :price)],
+                             "FK"        [:field-id (data/id :venues :category_id)],
+                             "Longitude" [:field-id (data/id :venues :longitude)],
+                             "Latitude"  [:field-id (data/id :venues :latitude)]}
+                :entity     (m/find-first (comp #{(data/id :venues)} u/get-id) (#'t/tableset (data/id) "PUBLIC"))}})))
 
 ;; Can we accure bindings?
 (let [new-bindings {"D2" [:sum [:field-id 4]]


### PR DESCRIPTION
This introduces 3 changes:
1) domain entities only expose dimensions specified in `required_attributes` or `optional_attributes`
2) adds conflict resolution logic if multiple fields match the same attribute specification
3) [potentially controversial] adds explicit support to bind domains by type (preferred) or name

While matching by name is icky, I think there are cases where it's unavoidable. The two main ones are:
1) outputs from transforms. We can't expect that resulting cols in trasforms will always uniquely map to out types, especially when we do any sort of aggregations (it's reasonable to have a `price` type, much less to cover all the aggregation permutations such as `avg price`, `min price`, ...), and we don't have a good mechanism of extending types on the fly (while you can just drop in new transforms).
2) it makes writing vendor-specific trasforms (ie. the outermost layer of transforms) much easier and more sane as again you don't have to first account for all their particularities in our type system. This one is even nastier than 1) as it would entail also writing classifiers. 